### PR TITLE
Make specialized error for I/O errors

### DIFF
--- a/cli/zli.cpp
+++ b/cli/zli.cpp
@@ -21,6 +21,7 @@
 
 #include "tools/arg/ParseException.h"
 #include "tools/arg/arg_parser.h"
+#include "tools/io/IOException.h"
 #include "tools/logger/Logger.h"
 
 #include "openzl/common/logging.h"
@@ -145,6 +146,9 @@ int main(int argc, char** argv)
         return 1;
     } catch (const CLIException& ce) {
         Logger::log(ERRORS, "CLI Exception:\n\t", ce.what());
+        return 1;
+    } catch (const tools::io::IOException& ioe) {
+        Logger::log(ERRORS, "I/O Exception:\n\t", ioe.what());
         return 1;
     } catch (const openzl::Exception& oe) {
         Logger::log(ERRORS, "OpenZL Library Exception:\n\t", oe.what());

--- a/doc/mkdocs/doc/getting-started/examples/cli/protobuf.md
+++ b/doc/mkdocs/doc/getting-started/examples/cli/protobuf.md
@@ -1,0 +1,28 @@
+# Protobuf Serialization
+OpenZL supports serialization and deserialization of Protobuf messages directly into a compressed format.
+
+## Experimenting with Protobuf Serialization
+All protobuf-related code is located in the `tools/protobuf` directory. You can experiment with OpenZL's Protobuf support using the `protobuf_cli` tool.
+
+### Adding Your Schema
+The first step is to add your Protobuf schema to the `tools/protobuf/schema.proto` file. You should replace the existing schema with your own.
+
+### Building the Protobuf CLI
+Once you have added your Protobuf schema, you should re-build the `protobuf_cli` tool. This can be done by running the following commands from the root of the OpenZL repository:
+```
+cmake -DOPENZL_BUILD_PROTOBUF_TOOLS=ON
+make
+```
+
+### Using the Protobuf CLI
+The `protobuf_cli` tool can be used to serialize Protobuf messages. You can serialize a Protobuf message by running the following command:
+```
+protobuf_cli serialize --input <input_file> --output <output_file>
+```
+
+By default, the input is expected to be a proto serialized message and the output will be in the OpenZL format. You can change these defaults using the `--input-protocol` and `--output-protocol` flags. The supported protocols are `zl`, `proto`, and `json`.
+
+For example, if your input file is in the OpenZL format and you want your output to be protobuf, you can run the following command:
+```
+protobuf_cli serialize --input <input_file> --output <output_file> --input-protocol zl --output-protocol proto
+```

--- a/doc/mkdocs/mkdocs.yml
+++ b/doc/mkdocs/mkdocs.yml
@@ -27,6 +27,7 @@ nav:
         - Parsing: getting-started/examples/py/parsing.md
       - CLI:
         - Parquet: getting-started/examples/cli/parquet.md
+        - Protobuf: getting-started/examples/cli/protobuf.md
     - CLI: getting-started/cli.md
     - Advanced Build Settings: getting-started/advanced-build.md
   - API Reference:

--- a/tools/io/IOException.h
+++ b/tools/io/IOException.h
@@ -1,0 +1,18 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#pragma once
+
+#include <stdexcept>
+#include <string>
+
+namespace openzl::tools::io {
+
+/**
+ * Exception thrown when an I/O operation fails.
+ */
+class IOException : public std::runtime_error {
+   public:
+    explicit IOException(const std::string& msg) : std::runtime_error(msg) {}
+};
+
+} // namespace openzl::tools::io

--- a/tools/io/InputFile.cpp
+++ b/tools/io/InputFile.cpp
@@ -1,6 +1,7 @@
 // Copyright (c) Meta Platforms, Inc. and affiliates.
 
 #include "tools/io/InputFile.h"
+#include "tools/io/IOException.h"
 
 #include <cerrno>
 #include <filesystem>
@@ -9,8 +10,6 @@
 #include <system_error>
 
 #include "tools/logger/Logger.h"
-
-#include "openzl/cpp/Exception.hpp"
 
 namespace openzl::tools::io {
 
@@ -49,7 +48,7 @@ void InputFile::read()
 
     std::filesystem::path path(filename_);
     if (std::filesystem::exists(path) && std::filesystem::is_directory(path)) {
-        throw Exception(
+        throw IOException(
                 "Input path '" + filename_
                 + "' is a directory, but a file is required.");
     }
@@ -60,7 +59,7 @@ void InputFile::read()
     try {
         in.open(filename_, std::ios::binary);
     } catch (const std::system_error&) {
-        throw Exception(
+        throw IOException(
                 "Failed to open input file '" + filename_
                 + "': " + std::system_category().message(errno));
     }
@@ -70,7 +69,7 @@ void InputFile::read()
         ss << in.rdbuf();
         contents_ = std::move(ss).str();
     } catch (const std::system_error& err) {
-        throw Exception(
+        throw IOException(
                 "Failed to read input file '" + filename_
                 + "': " + err.code().message());
     }

--- a/tools/io/InputSetLogger.cpp
+++ b/tools/io/InputSetLogger.cpp
@@ -1,6 +1,7 @@
 // Copyright (c) Meta Platforms, Inc. and affiliates.
 
 #include "tools/io/InputSetLogger.h"
+#include "tools/io/IOException.h"
 
 #include <iostream>
 
@@ -109,7 +110,7 @@ InputSetLogger::InputSetLogger(
         : input_set_(std::move(input_set)), verbosity_(verbosity)
 {
     if (!input_set_) {
-        throw std::runtime_error(
+        throw IOException(
                 "InputSet passed into InputSetLogger() cannot be nullptr!");
     }
 }

--- a/tools/io/OutputFile.cpp
+++ b/tools/io/OutputFile.cpp
@@ -1,13 +1,12 @@
 // Copyright (c) Meta Platforms, Inc. and affiliates.
 
 #include "tools/io/OutputFile.h"
+#include "tools/io/IOException.h"
 #include "tools/logger/Logger.h"
 
 #include <cerrno>
 #include <fstream>
 #include <system_error>
-
-#include "openzl/cpp/Exception.hpp"
 
 namespace openzl::tools::io {
 
@@ -30,7 +29,7 @@ void OutputFile::open()
         os_->open(filename_, std::ios::binary);
     } catch (const std::system_error&) {
         os_.reset();
-        throw Exception(
+        throw IOException(
                 "Failed to open output file '" + filename_
                 + "': " + std::system_category().message(errno));
     }
@@ -41,7 +40,7 @@ void OutputFile::close()
     try {
         os_.reset();
     } catch (const std::system_error&) {
-        throw Exception(
+        throw IOException(
                 "Failed to close output file '" + filename_
                 + "': " + std::system_category().message(errno));
     }
@@ -59,7 +58,7 @@ void OutputFile::write(poly::string_view contents)
     } catch (const std::system_error& err) {
         // It's not clear that errno is set during failed write() calls.
         // But err.code().message() sucks.
-        throw Exception(
+        throw IOException(
                 "Failed to write to output file '" + filename_
                 + "': " + err.code().message());
     }


### PR DESCRIPTION
Summary: Add specialized Error for I/O exceptions in `tools/io`. We previously used OpenZL library exceptions for this.

Differential Revision: D83590858


