### PR TITLE
Make the std::exception message much more generic

### DIFF
--- a/CODING_STYLE
+++ b/CODING_STYLE
@@ -1,2 +1,0 @@
-This project conforms to a coding style described here:
-https://our.intern.facebook.com/intern/wiki/Data_Compression/C99_Style_Guide/

--- a/cli/zli.cpp
+++ b/cli/zli.cpp
@@ -150,13 +150,7 @@ int main(int argc, char** argv)
         Logger::log(ERRORS, "OpenZL Library Exception:\n\t", oe.what());
         return 1;
     } catch (const std::exception& e) {
-        Logger::log(
-                ERRORS,
-                "Unexpected runtime error. This may mean that your inputs are "
-                "invalid (eg your file is invalid, the compressor is invalid, or "
-                "the compressor doesn't match the file format), or it may be a bug. "
-                "Please report bugs to the OpenZL developers!\n\t",
-                e.what());
+        Logger::log(ERRORS, "Unhandled Exception:\n\t", e.what());
         return 1;
     }
     return 1;

--- a/doc/mkdocs/doc/getting-started/quick-start.md
+++ b/doc/mkdocs/doc/getting-started/quick-start.md
@@ -153,6 +153,14 @@ cp sra0 /tmp/sampleDir
 ./zli train --profile le-u64 /tmp/sampleDir --output sra0.zlc
 ```
 
+??? note "Setting max training time"
+    The trainer is multi-threaded, and machines with less cores will take longer
+    to train. If it is taking too long, the `--max-time-secs` flag can be used to
+    limit the training time. It currently limits the time spent in each step of
+    training, not the total time. But, the trained result may be worse given less
+    time to train.
+
+
 The training session will generate some messages on the consoles.
 The last lines should look something like that:
 


### PR DESCRIPTION
Summary: We aren't that confident that this is a bug today. There are other reasons we may not catch a more specific exception. For now, just classify it as an unhandled exception.

Differential Revision: D83591457


