### PR TITLE
Limit FieldLZ to content size of 4B

### DIFF
--- a/CODING_STYLE
+++ b/CODING_STYLE
@@ -1,2 +1,0 @@
-This project conforms to a coding style described here:
-https://our.intern.facebook.com/intern/wiki/Data_Compression/C99_Style_Guide/

--- a/doc/mkdocs/doc/getting-started/quick-start.md
+++ b/doc/mkdocs/doc/getting-started/quick-start.md
@@ -153,6 +153,14 @@ cp sra0 /tmp/sampleDir
 ./zli train --profile le-u64 /tmp/sampleDir --output sra0.zlc
 ```
 
+??? note "Setting max training time"
+    The trainer is multi-threaded, and machines with less cores will take longer
+    to train. If it is taking too long, the `--max-time-secs` flag can be used to
+    limit the training time. It currently limits the time spent in each step of
+    training, not the total time. But, the trained result may be worse given less
+    time to train.
+
+
 The training session will generate some messages on the consoles.
 The last lines should look something like that:
 


### PR DESCRIPTION
Summary: Cleanly error when the input size would overflow the 32-bit indices. Choose 4,000,000,000 as the maximum to avoid getting too close to 2^32-1.

Differential Revision: D83591456


