### PR TITLE
bump chunking requirement in the CLI to 2GB

### DIFF
--- a/cli/commands/cmd_benchmark.cpp
+++ b/cli/commands/cmd_benchmark.cpp
@@ -125,9 +125,9 @@ BenchmarkResult runCompressionBenchmarks(const BenchmarkArgs& args)
             uncompressed_size += input.contentSize();
         }
         // TODO: Size limitations should be a library feature
-        if (uncompressed_size > 1 * BYTES_TO_GiB) {
+        if (uncompressed_size > 2 * BYTES_TO_GiB) {
             throw std::runtime_error(
-                    "Chunking support is required for compressing inputs larger than 1 GiB. ");
+                    "Chunking support is required for compressing inputs larger than 2 GiB. ");
         }
         // get the compressed size
         const auto compressed = cctx.compress(inputVec);

--- a/cli/commands/cmd_compress.cpp
+++ b/cli/commands/cmd_compress.cpp
@@ -145,9 +145,9 @@ int performCompression(const CompressArgs& args)
     // ahead of time.
     const auto inputSize = input.size().value();
     // TODO: Size limitations should be a library feature
-    if (inputSize > 1 * BYTES_TO_GiB) {
+    if (inputSize > 2 * BYTES_TO_GiB) {
         throw std::runtime_error(
-                "Chunking support is required for compressing inputs larger than 1 GiB. ");
+                "Chunking support is required for compressing inputs larger than 2 GiB. ");
     }
     Logger::log(VERBOSE1, "Input size: ", inputSize);
 


### PR DESCRIPTION
Summary: It's a requirement to reproduce the experiment results. For now.

Differential Revision: D83605585


