### PR TITLE
Standardize on KB, MB, GB

### DIFF
--- a/cli/commands/cmd_benchmark.cpp
+++ b/cli/commands/cmd_benchmark.cpp
@@ -21,8 +21,8 @@ namespace openzl::cli {
 using namespace openzl::tools::logger;
 
 namespace {
-constexpr size_t BYTES_TO_MB  = 1000 * 1000;
-constexpr size_t BYTES_TO_GiB = 1024 * 1024 * 1024;
+constexpr size_t BYTES_TO_MB = 1000 * 1000;
+constexpr size_t BYTES_TO_GB = BYTES_TO_MB * 1000;
 
 /// Updates the printed line of benchmarks based on the new parameters provided.
 /// @return The BenchmarkResult structure containing ratio and speeds
@@ -125,9 +125,9 @@ BenchmarkResult runCompressionBenchmarks(const BenchmarkArgs& args)
             uncompressed_size += input.contentSize();
         }
         // TODO: Size limitations should be a library feature
-        if (uncompressed_size > 2 * BYTES_TO_GiB) {
+        if (uncompressed_size > 2 * BYTES_TO_GB) {
             throw std::runtime_error(
-                    "Chunking support is required for compressing inputs larger than 2 GiB. ");
+                    "Chunking support is required for compressing inputs larger than 2 GB. ");
         }
         // get the compressed size
         const auto compressed = cctx.compress(inputVec);

--- a/cli/commands/cmd_compress.cpp
+++ b/cli/commands/cmd_compress.cpp
@@ -23,8 +23,8 @@ using namespace openzl::tools;
 using namespace logger;
 
 namespace openzl::cli {
-constexpr size_t BYTES_TO_MiB = 1024 * 1024;
-constexpr size_t BYTES_TO_GiB = 1024 * 1024 * 1024;
+constexpr size_t BYTES_TO_MB = 1000 * 1000;
+constexpr size_t BYTES_TO_GB = BYTES_TO_MB * 1000;
 
 namespace {
 
@@ -145,9 +145,9 @@ int performCompression(const CompressArgs& args)
     // ahead of time.
     const auto inputSize = input.size().value();
     // TODO: Size limitations should be a library feature
-    if (inputSize > 2 * BYTES_TO_GiB) {
+    if (inputSize > 2 * BYTES_TO_GB) {
         throw std::runtime_error(
-                "Chunking support is required for compressing inputs larger than 2 GiB. ");
+                "Chunking support is required for compressing inputs larger than 2 GB. ");
     }
     Logger::log(VERBOSE1, "Input size: ", inputSize);
 
@@ -175,16 +175,16 @@ int performCompression(const CompressArgs& args)
     const auto end     = std::chrono::steady_clock::now();
     const auto time_ms = std::chrono::duration<double, std::milli>(end - start);
 
-    const auto time_s        = time_ms.count() / 1000.0;
-    const auto inputSize_mib = (double)inputSize / BYTES_TO_MiB;
+    const auto time_s       = time_ms.count() / 1000.0;
+    const auto inputSize_mb = (double)inputSize / BYTES_TO_MB;
 
-    const auto compressionSpeed = inputSize_mib / time_s;
+    const auto compressionSpeed = inputSize_mb / time_s;
 
     // write output
     dstBuffer.resize(compressedSize);
     Logger::log_c(
             INFO,
-            "Compressed %zu -> %zu (%.2fx) in %.3f ms, %.2f MiB/s",
+            "Compressed %zu -> %zu (%.2fx) in %.3f ms, %.2f MB/s",
             srcBuffer.size(),
             dstBuffer.size(),
             (double)srcBuffer.size() / dstBuffer.size(),

--- a/cli/commands/cmd_decompress.cpp
+++ b/cli/commands/cmd_decompress.cpp
@@ -12,7 +12,7 @@
 #include "openzl/zl_decompress.h"
 
 namespace openzl::cli {
-constexpr size_t BYTES_TO_MiB = 1024 * 1024;
+constexpr size_t BYTES_TO_MB = 1000 * 1000;
 
 using namespace tools::logger;
 
@@ -49,14 +49,14 @@ int cmdDecompress(const DecompressArgs& args)
     const auto end     = std::chrono::steady_clock::now();
     const auto time_ms = std::chrono::duration<double, std::milli>(end - start);
 
-    const auto time_s               = time_ms.count() / 1000.0;
-    const auto decompressedSize_mib = (double)dstBuffer.size() / BYTES_TO_MiB;
+    const auto time_s              = time_ms.count() / 1000.0;
+    const auto decompressedSize_mb = (double)dstBuffer.size() / BYTES_TO_MB;
 
-    const auto compressionSpeed = decompressedSize_mib / time_s;
+    const auto compressionSpeed = decompressedSize_mb / time_s;
 
     Logger::log_c(
             INFO,
-            "Decompressed: %2.2f%% (%s -> %s) in %.3f ms, %.2f MiB/s",
+            "Decompressed: %2.2f%% (%s -> %s) in %.3f ms, %.2f MB/s",
             (double)srcBuffer.size() / dstBuffer.size() * 100,
             util::sizeString(srcBuffer.size()).c_str(),
             util::sizeString(dstBuffer.size()).c_str(),

--- a/cli/utils/util.cpp
+++ b/cli/utils/util.cpp
@@ -15,8 +15,8 @@ using namespace std::string_view_literals;
 
 namespace openzl::cli::util {
 
-static constexpr std::array suffix{ "B"sv, "KiB"sv, "MiB"sv, "GiB"sv, "TiB"sv };
-static constexpr double kilo = 1024.0;
+static constexpr std::array suffix{ "B"sv, "KB"sv, "MB"sv, "GB"sv, "TB"sv };
+static constexpr double kilo = 1000.0;
 static constexpr double tenK = 10000.0;
 std::string sizeString(size_t sz)
 {


### PR DESCRIPTION
Summary: In D82965045 we changed the `benchmark` command to report `MB/s` to match `lzbench` and `zstd`. This diff changes all the other places we are currently reporting `MiB` to report `MB` instead.

Reviewed By: Victor-C-Zhang

Differential Revision: D83606545


