### PR TITLE
Add dataset management test scripts

### DIFF
--- a/contrib/reproducibility/dataset_manager/BUCK
+++ b/contrib/reproducibility/dataset_manager/BUCK
@@ -17,6 +17,7 @@ python_binary(
     typing = True,
     deps = [
         ":base_dataset_builder",
+        "//data_compression/experimental/zstrong/contrib/reproducibility/dataset_manager/dataset_builders:__init__",
     ],
 )
 

--- a/contrib/reproducibility/dataset_manager/BUCK
+++ b/contrib/reproducibility/dataset_manager/BUCK
@@ -1,0 +1,45 @@
+load("@fbcode_macros//build_defs:python_binary.bzl", "python_binary")
+load("@fbcode_macros//build_defs:python_library.bzl", "python_library")
+
+oncall("data_compression")
+
+python_library(
+    name = "__init__",
+    srcs = ["__init__.py"],
+    labels = ["autodeps2_generated"],
+    deps = [],
+)
+
+python_binary(
+    name = "dataset_manager",
+    srcs = ["dataset_manager.py"],
+    main_function = "data_compression.experimental.zstrong.contrib.reproducibility.dataset_manager.dataset_manager.main",
+    typing = True,
+    deps = [
+        ":base_dataset_builder",
+    ],
+)
+
+python_library(
+    name = "dataset_utils",
+    srcs = ["dataset_utils.py"],
+    labels = ["autodeps2_generated"],
+    deps = [
+        "fbsource//third-party/pypi/kaggle:kaggle",
+        "fbsource//third-party/pypi/numpy:numpy",
+        "fbsource//third-party/pypi/pandas:pandas",
+        "fbsource//third-party/pypi/pyarrow:pyarrow",
+        "fbsource//third-party/pypi/rasterio:rasterio",
+        "fbsource//third-party/pypi/requests:requests",
+        "fbsource//third-party/pypi/xarray:xarray",
+    ],
+)
+
+python_library(
+    name = "base_dataset_builder",
+    srcs = ["base_dataset_builder.py"],
+    labels = ["autodeps2_generated"],
+    deps = [
+        ":dataset_utils",
+    ],
+)

--- a/contrib/reproducibility/dataset_manager/README.md
+++ b/contrib/reproducibility/dataset_manager/README.md
@@ -1,15 +1,34 @@
 # Dataset Manager
 
 ## Setup
+For `.parquet` files (`binance` datasets), run the following commands to compile binary files:
+
+```bash
+mkdir -p cmakebuild
+cmake -S . -B cmakebuild -DOPENZL_BUILD_PARQUET_TOOLS=ON
+cmake --build cmakebuild
+```
+If you choose to compile binary files in separate location, please pass in the path to the `make_canonical_parquet` binary with the `--binary-path` command
+
 Run the following command inside the `dataset_manager` directory to install required packages:
 ```bash
 pip install -r requirements.txt
 ```
 
+Some datasets require API keys for access. Set up the following keys as needed:
+
+**For Kaggle datasets:**
+- Follow the instructions under `Authentication`: https://www.kaggle.com/docs/api
+
 ## Usage
 Navigate to the `reproducibility` directory and use the following sample command to download all available datasets:
 ```bash
 python -m dataset_manager.dataset_manager download -o /tmp/datasets/ -a
+```
+
+A specific dataset can be downloaded with `-d` and parquet binary can be passed in with `--binary-path`. Below is a sample command:
+```bash
+python -m dataset_manager.dataset_manager download -o /tmp/datasets -d binance --binary-path=$HOME/openzl/cmakebuild/tools/parquet/make_canonical_parquet
 ```
 
 The following command lets you view all available datasets:

--- a/contrib/reproducibility/dataset_manager/README.md
+++ b/contrib/reproducibility/dataset_manager/README.md
@@ -1,0 +1,20 @@
+# Dataset Manager
+
+## Setup
+Run the following command inside the `dataset_manager` directory to install required packages:
+```bash
+pip install -r requirements.txt
+```
+
+## Usage
+Navigate to the `reproducibility` directory and use the following sample command to download all available datasets:
+```bash
+python -m dataset_manager.dataset_manager download -o /tmp/datasets/ -a
+```
+
+The following command lets you view all available datasets:
+```bash
+python -m dataset_manager.dataset_manager list
+```
+
+Use `-h` to explore all command options.

--- a/contrib/reproducibility/dataset_manager/base_dataset_builder.py
+++ b/contrib/reproducibility/dataset_manager/base_dataset_builder.py
@@ -1,0 +1,41 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+import json
+import os
+from abc import ABC, abstractmethod
+
+from .dataset_utils import DownloadUtils
+
+
+class BaseDatasetBuilder(ABC):
+    """Base class for all dataset builders"""
+
+    def __init__(self, manifest_path: str | None = None) -> None:
+        self.download_utils = DownloadUtils()
+        self.name = ""
+        self.manifest_data = {}
+
+        if manifest_path:
+            self._parse_manifest(manifest_path)
+
+    def _parse_manifest(self, manifest_path: str | None = None) -> None:
+        """Parse the manifest file and set dataset metadata"""
+        if not os.path.exists(manifest_path):
+            raise FileNotFoundError(f"Dataset manifest file not found: {manifest_path}")
+
+        with open(manifest_path, "r") as f:
+            self.manifest_data = json.load(f)
+
+        self.name = self.manifest_data["name"]
+
+    @abstractmethod
+    def download(
+        self,
+        download_dir: str,
+        **kwargs,
+    ) -> bool:
+        """Download dataset to specified directory"""
+        pass
+
+    def post_download_processing(self, download_dir: str, kwargs: dict) -> bool:
+        """Override this for custom post-processing"""
+        return True

--- a/contrib/reproducibility/dataset_manager/dataset_builders/BUCK
+++ b/contrib/reproducibility/dataset_manager/dataset_builders/BUCK
@@ -1,0 +1,12 @@
+load("@fbcode_macros//build_defs:python_library.bzl", "python_library")
+
+oncall("data_compression")
+
+python_library(
+    name = "__init__",
+    srcs = ["__init__.py"],
+    labels = ["autodeps2_generated"],
+    deps = [
+        "//data_compression/experimental/zstrong/contrib/reproducibility/dataset_manager/dataset_builders/binance:__init__",
+    ],
+)

--- a/contrib/reproducibility/dataset_manager/dataset_builders/__init__.py
+++ b/contrib/reproducibility/dataset_manager/dataset_builders/__init__.py
@@ -1,0 +1,7 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+from .binance import BinanceDatasetBuilder
+
+
+__all__ = [
+    "BinanceDatasetBuilder",
+]

--- a/contrib/reproducibility/dataset_manager/dataset_builders/binance/BUCK
+++ b/contrib/reproducibility/dataset_manager/dataset_builders/binance/BUCK
@@ -1,0 +1,22 @@
+load("@fbcode_macros//build_defs:python_library.bzl", "python_library")
+
+oncall("data_compression")
+
+python_library(
+    name = "binance_dataset_builder_py_lib",
+    srcs = ["binance_dataset_builder.py"],
+    labels = ["autodeps2_generated"],
+    resources = ["binance_manifest.json"],
+    deps = [
+        "//data_compression/experimental/zstrong/contrib/reproducibility/dataset_manager:base_dataset_builder",
+    ],
+)
+
+python_library(
+    name = "__init__",
+    srcs = ["__init__.py"],
+    labels = ["autodeps2_generated"],
+    deps = [
+        ":binance_dataset_builder_py_lib",
+    ],
+)

--- a/contrib/reproducibility/dataset_manager/dataset_builders/binance/__init__.py
+++ b/contrib/reproducibility/dataset_manager/dataset_builders/binance/__init__.py
@@ -1,0 +1,4 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+from .binance_dataset_builder import BinanceDatasetBuilder
+
+__all__ = ["BinanceDatasetBuilder"]

--- a/contrib/reproducibility/dataset_manager/dataset_builders/binance/binance_dataset_builder.py
+++ b/contrib/reproducibility/dataset_manager/dataset_builders/binance/binance_dataset_builder.py
@@ -1,0 +1,65 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+
+import os
+
+from ...base_dataset_builder import BaseDatasetBuilder
+
+
+class BinanceDatasetBuilder(BaseDatasetBuilder):
+    """Dataset builder for cryptocurrency pairs data on Binance.com"""
+
+    def __init__(self) -> None:
+        current_dir = os.path.dirname(os.path.abspath(__file__))
+        manifest_path = os.path.join(current_dir, "binance_manifest.json")
+        super().__init__(manifest_path)
+
+    def download(
+        self,
+        download_dir: str,
+        **kwargs,
+    ) -> bool:
+        """Download Binance dataset to specified directory
+
+        Args:
+            download_dir: Directory to download files to
+            **kwargs: Additional arguments
+
+        Returns:
+            bool: True if download successful, False otherwise
+        """
+        if not self.download_utils.download_file_from_kaggle(
+            self.manifest_data["download_config"]["kaggle_slug"],
+            self.manifest_data["download_config"]["kaggle_files"],
+            download_dir,
+            self.name,
+        ):
+            print("Failed to download Binance dataset")
+            return False
+
+        if not self.post_download_processing(download_dir, kwargs):
+            print("Failed to post-process Binance dataset")
+            return False
+
+        print("Binance dataset downloaded and post processed successfully")
+        return True
+
+    def post_download_processing(self, download_dir: str, kwargs: dict) -> bool:
+        """Verify parquet files are "canonical" (i.e no compression, no encoding)
+
+        Args:
+            download_dir: Directory where files were downloaded
+            **kwargs: Additional arguments
+
+        Returns:
+            bool: True if post-processing successful, False otherwise
+        """
+        if self.download_utils.verify_parquet_canonical(
+            os.path.join(download_dir, self.name),
+            os.path.join(download_dir, f"{self.name}_canonical"),
+            kwargs.get("binary_path"),
+        ):
+            print("Binance dataset post-processing successful")
+            return True
+        else:
+            print("Failed to post-process Binance dataset")
+            return False

--- a/contrib/reproducibility/dataset_manager/dataset_builders/binance/binance_manifest.json
+++ b/contrib/reproducibility/dataset_manager/dataset_builders/binance/binance_manifest.json
@@ -1,0 +1,31 @@
+{
+  "name": "binance",
+  "description": "cryptocurrency pairs data from Binance.com",
+  "format": "parquet",
+  "source_url": "https://www.kaggle.com/datasets/jorijnsmit/binance-full-history",
+  "download_method": "kaggle",
+  "download_config": {
+    "kaggle_slug": "jorijnsmit/binance-full-history",
+    "kaggle_files": [
+      "BTC-AUD.parquet",
+      "BTC-BIDR.parquet",
+      "BTC-BRL.parquet",
+      "BTC-BUSD.parquet",
+      "BTC-DAI.parquet",
+      "BTC-EUR.parquet",
+      "BTC-GBP.parquet",
+      "BTC-NGN.parquet",
+      "BTC-PAX.parquet",
+      "BTC-RUB.parquet",
+      "BTC-TRY.parquet",
+      "BTC-TUSD.parquet",
+      "BTC-UAH.parquet",
+      "BTC-USDC.parquet",
+      "BTC-USDT.parquet"
+    ]
+  },
+  "tags": [
+    "crypto",
+    "parquet"
+  ]
+}

--- a/contrib/reproducibility/dataset_manager/dataset_manager.py
+++ b/contrib/reproducibility/dataset_manager/dataset_manager.py
@@ -5,13 +5,16 @@ import sys
 from typing import Dict
 
 from .base_dataset_builder import BaseDatasetBuilder
+from .dataset_builders import BinanceDatasetBuilder
 
 
 class DatasetManager:
     """Central manager for dataset downloading and catalog generation"""
 
     def __init__(self):
-        self.available_datasets: Dict[str, BaseDatasetBuilder] = {}
+        self.available_datasets: Dict[str, BaseDatasetBuilder] = {
+            "binance": BinanceDatasetBuilder
+        }
 
     def list_datasets(self):
         """List all available datasets"""

--- a/contrib/reproducibility/dataset_manager/dataset_manager.py
+++ b/contrib/reproducibility/dataset_manager/dataset_manager.py
@@ -1,0 +1,112 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+
+import argparse
+import sys
+from typing import Dict
+
+from .base_dataset_builder import BaseDatasetBuilder
+
+
+class DatasetManager:
+    """Central manager for dataset downloading and catalog generation"""
+
+    def __init__(self):
+        self.available_datasets: Dict[str, BaseDatasetBuilder] = {}
+
+    def list_datasets(self):
+        """List all available datasets"""
+        print("Available datasets:")
+        for k, v in self.available_datasets.items():
+            print(f"  {k:<10} - {v.manifest_data['description']}")
+
+    def generate_catalog(
+        self, output_file: str = "catalog.yaml", include_stats: bool = True
+    ) -> None:
+        """Generate a comprehensive catalog of all available datasets"""
+        # todo
+        pass
+
+
+def create_argParser():
+    """Create and configure argument parser"""
+
+    parser = argparse.ArgumentParser(
+        description="Download datasets",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+
+    # Create subcommands
+    subparsers = parser.add_subparsers(dest="command", help="Available commands")
+
+    # List command - no arguments needed
+    subparsers.add_parser("list", help="List available datasets")
+
+    # Download command - requires dataset_name and output_dir
+    download_parser = subparsers.add_parser(
+        "download", help="Download one or more datasets"
+    )
+    download_parser.add_argument(
+        "-o", "--output-dir", dest="output_dir", required=True, help="Output directory"
+    )
+
+    group_parser = download_parser.add_mutually_exclusive_group(required=True)
+    group_parser.add_argument(
+        "-a", "--all", action="store_true", help="Download all datasets"
+    )
+    group_parser.add_argument(
+        "-d", "--dataset", dest="dataset_name", help="Name of dataset to download"
+    )
+
+    download_parser.add_argument(
+        "--binary-path",
+        dest="binary_path",
+        help="Path for binary file needed to convert parquet datasets to canonical",
+        required=False,
+    )
+    return parser
+
+
+def main():
+    parser = create_argParser()
+    args = parser.parse_args()
+
+    # Show help if no command provided
+    if not args.command:
+        parser.print_help()
+        sys.exit(1)
+
+    manager = DatasetManager()
+
+    try:
+        if args.command == "download":
+            if args.all:
+                failed_downloads = []
+                for name, dataset in manager.available_datasets.items():
+                    if not dataset.download(args.output_dir):
+                        failed_downloads.append(name)
+                print("Summary of downloads:")
+                for fd in failed_downloads:
+                    print(f"Failed to download {fd}")
+                if len(failed_downloads) == 0:
+                    print("All datasets downloaded successfully")
+
+            else:
+                if args.dataset_name in manager.available_datasets:
+                    manager.available_datasets[args.dataset_name].download(
+                        args.output_dir,
+                        binary_path=args.binary_path,
+                    )
+                else:
+                    print(
+                        f"Dataset {args.dataset_name} not found. Use 'list' to see available datasets."
+                    )
+        else:
+            manager.list_datasets()
+
+    except Exception as e:
+        print(f"Error: {e}")
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/contrib/reproducibility/dataset_manager/dataset_utils.py
+++ b/contrib/reproducibility/dataset_manager/dataset_utils.py
@@ -1,0 +1,7 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+
+class DownloadUtils:
+    """Shared download utilities for all datasets"""
+
+    def __init__(self) -> None:
+        pass

--- a/contrib/reproducibility/dataset_manager/dataset_utils.py
+++ b/contrib/reproducibility/dataset_manager/dataset_utils.py
@@ -1,7 +1,120 @@
 # Copyright (c) Meta Platforms, Inc. and affiliates.
+import os
+import shutil
+import subprocess
+from pathlib import Path
+from typing import List, Optional
+
+from kaggle.api.kaggle_api_extended import KaggleApi
 
 class DownloadUtils:
     """Shared download utilities for all datasets"""
 
     def __init__(self) -> None:
         pass
+
+    @staticmethod
+    def download_file_from_kaggle(
+        kaggle_slug: str,
+        files: List[str],
+        output_path: str,
+        dataset_name: str = None,
+    ) -> bool:
+        """Download a single file from Kaggle"""
+        try:
+
+            dataset_dir = os.path.join(output_path, kaggle_slug.split("/")[-1])
+
+            for file in files:
+                print(f"Downloading {kaggle_slug} - {file}")
+                api = KaggleApi()
+                api.authenticate()
+
+                api.dataset_download_file(kaggle_slug, file, path=dataset_dir)
+
+                if DownloadUtils.extract_data(
+                    os.path.join(dataset_dir, file),
+                    os.path.join(output_path, dataset_name),
+                ):
+                    os.remove(os.path.join(dataset_dir, file))
+                else:
+                    os.remove(os.path.join(dataset_dir, file))
+                    os.rmdir(dataset_dir)
+                    return False
+
+            os.rmdir(dataset_dir)
+            print(f"Finished Downloading: {os.path.basename(dataset_dir)}")
+            return True
+        except Exception as e:
+            if "Unauthorized" in str(e):
+                print(e)
+                print("kaggle.json API key is not set up correctly")
+                return False
+            print(f"Unexpected error: {e}")
+            return False
+
+
+    @staticmethod
+    def find_openzl_root(max_levels: int = 10) -> Optional[Path]:
+        """Get the path to the binary file"""
+        current_dir = Path(__file__).parent
+        for _ in range(max_levels):
+            if current_dir.name == "openzl":
+                openzl_root = current_dir
+                return openzl_root
+
+            # Go up one level
+            parent = current_dir.parent
+            if parent == current_dir:
+                # Hit filesystem root - stop searching
+                break
+            current_dir = parent
+        return None
+
+    @staticmethod
+    def verify_parquet_canonical(
+        input_dir: str, output_dir: str, binary_path: Optional[str] = None
+    ) -> bool:
+
+        try:
+            files = os.listdir(input_dir)
+            os.makedirs(output_dir, exist_ok=True)
+
+            for file in files:
+                if file.endswith(".parquet"):
+                    print(f"Verifying and converting {os.path.join(input_dir, file)}")
+
+                    input_file_path = os.path.join(input_dir, file)
+                    output_file_path = os.path.join(output_dir, file)
+
+                    bin_path = (
+                        Path(binary_path)
+                        if binary_path is not None
+                        else os.path.join(
+                            DownloadUtils.find_openzl_root(),
+                            "cmakebuild/tools/parquet/make_canonical_parquet",
+                        )
+                    )
+                    # Temporarily copy original parquet file to output dir
+                    shutil.copy2(input_file_path, output_file_path)
+
+                    # Turn parquet file canonical
+                    subprocess.run(
+                        [
+                            str(
+                                bin_path,
+                            ),
+                            "--input",
+                            output_file_path,
+                        ],
+                        capture_output=False,
+                        text=True,
+                    )
+
+                    # Remove non canonical parquet file (canonical version is saved with .canonical)
+                    os.remove(output_file_path)
+
+            return True
+        except Exception as e:
+            print(f"Failed to verify and convert parquet file to canonical: {e}")
+            return False

--- a/contrib/reproducibility/dataset_manager/requirements.txt
+++ b/contrib/reproducibility/dataset_manager/requirements.txt
@@ -1,0 +1,7 @@
+requests
+kaggle
+cdsapi>=0.7.4
+numpy
+pyarrow~=18.0.0
+pandas
+zstandard

--- a/contrib/reproducibility/dataset_manager/tests/BUCK
+++ b/contrib/reproducibility/dataset_manager/tests/BUCK
@@ -1,0 +1,13 @@
+load("@fbcode_macros//build_defs:python_binary.bzl", "python_binary")
+
+oncall("data_compression")
+
+python_binary(
+    name = "verify_datasets",
+    srcs = ["verify_datasets.py"],
+    main_module = "data_compression.experimental.zstrong.contrib.reproducibility.dataset_manager.tests.verify_datasets",
+    deps = [
+        "fbsource//third-party/pypi/pyarrow:pyarrow",
+        "fbsource//third-party/pypi/zstandard:zstandard",
+    ],
+)

--- a/contrib/reproducibility/dataset_manager/tests/verify_datasets.py
+++ b/contrib/reproducibility/dataset_manager/tests/verify_datasets.py
@@ -1,0 +1,151 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+
+import hashlib
+import os
+import random
+import subprocess
+import tempfile
+from io import BytesIO
+from pathlib import Path
+from typing import Optional
+
+import pyarrow.parquet as pq
+import zstandard as zstd
+
+
+def get_file_sha(file_path: Path) -> str:
+    """Calculate SHA256 hash of a local file."""
+    with open(file_path, "rb") as f:
+        return hashlib.sha256(f.read()).hexdigest()
+
+
+def download_manifold_file(manifold_path: str, corpus: str) -> Optional[str]:
+    """Download file from manifold to temp file. Returns temp file path or None."""
+    try:
+        with tempfile.NamedTemporaryFile(delete=False) as temp_file:
+            cmd = ["manifold", "--vip", "get", f"{corpus}/{manifold_path}"]
+            _ = subprocess.run(
+                cmd,
+                stdout=temp_file,
+                check=True,
+                timeout=30,
+            )
+            return temp_file.name
+    except Exception as e:
+        if "cannot find the file" in str(e):
+            print("\tSKIP: File not on manifold")
+        else:
+            print(f"Error downloading {manifold_path}: {e}")
+        return None
+
+
+def get_manifold_sha(file_path: Path) -> str:
+    """Get SHA256 hash of file from manifold"""
+    with open(file_path, "rb") as f:
+        compressed_data = f.read()
+        decompressor = zstd.ZstdDecompressor()
+        decompressed_data = decompressor.decompress(compressed_data)
+        return hashlib.sha256(decompressed_data).hexdigest()
+
+
+def verify_files(directory: Path, corpus: str, num_files_to_check: int) -> None:
+    """Verify n random files from each subdirectory against manifold."""
+    non_matching_files = {}
+    for subdir in directory.iterdir():
+        if not subdir.is_dir():
+            continue
+
+        subdir_name = subdir.name.lower()
+
+        files = [f for f in subdir.iterdir() if f.is_file()]
+        random_files = random.sample(files, min(num_files_to_check, len(files)))
+
+        for file_path in random_files:
+            manifold_path = f"tree/{subdir_name}/{file_path.name}.zst"
+
+            print(f"Checking: {file_path}")
+
+            manifold_file_path = download_manifold_file(manifold_path, corpus)
+            if manifold_file_path:
+                try:
+
+                    if str(file_path).endswith(".parquet.canonical"):
+                        # Compare data table directly since metadata for canonical file can be different
+                        decompressor = zstd.ZstdDecompressor()
+                        with open(manifold_file_path, "rb") as f:
+                            compressed_data = f.read()
+                            decompressed_data = decompressor.decompress(compressed_data)
+
+                            local_table = pq.read_table(file_path)
+                            manifold_table = pq.read_table(BytesIO(decompressed_data))
+
+                            if local_table.equals(manifold_table):
+                                print("\tMATCH: Parquet files are identical")
+
+                            else:
+                                print("\tMISMATCH: Parquet files differ")
+                                print(f"\tManifold path: {manifold_path}")
+                                if subdir_name not in non_matching_files:
+                                    non_matching_files[subdir_name] = []
+                                non_matching_files[subdir_name].append(file_path.name)
+                    else:
+                        # Regular file comparison using SHA
+                        local_sha = get_file_sha(file_path)
+                        manifold_sha = get_manifold_sha(manifold_file_path)
+                        if local_sha == manifold_sha:
+                            print("\tMATCH: SHA256 hashes are identical")
+                        else:
+                            print("\tMISMATCH: SHA256 hashes differ")
+                            print(f"\tLocal SHA: {local_sha}")
+                            print(f"\tManifold SHA: {manifold_sha}")
+                            print(f"\tManifold path: {manifold_path}")
+                            if subdir_name not in non_matching_files:
+                                non_matching_files[subdir_name] = []
+                            non_matching_files[subdir_name].append(file_path.name)
+                except Exception as e:
+                    print(f"\tERROR: Error verifying {file_path}: {e}")
+
+                finally:
+                    os.remove(manifold_file_path)
+    print("Summary:")
+    for folder, files in non_matching_files.items():
+        print(f"The following files in {folder} are not matching:")
+        for file in files:
+            print(f" - {file}")
+    if not non_matching_files:
+        print("All files match!")
+
+
+def main(directory: str, corpus: str, num_files: int) -> None:
+    """Main function to verify dataset directory against manifold corpus."""
+    directory_path = Path(directory)
+    verify_files(directory_path, corpus, num_files)
+
+
+if __name__ == "__main__":
+    import sys
+
+    if len(sys.argv) < 3 or len(sys.argv) > 4:
+        print(
+            "Usage: python verify_dataset.py <directory> <manifold_corpus> [num_files]"
+        )
+        print(
+            "  num_files: Number of random files to check per subdirectory (default: 3). Choose large number to check all (e.g. 4000)"
+        )
+        sys.exit(1)
+
+    directory = sys.argv[1]
+    corpus = sys.argv[2]
+
+    num_files = 3  # default
+    if len(sys.argv) == 4:
+        try:
+            num_files = int(sys.argv[3])
+            if num_files <= 0:
+                print("Error: num_files must be a positive integer")
+                sys.exit(1)
+        except ValueError:
+            print("Error: num_files must be a valid integer")
+            sys.exit(1)
+
+    main(directory, corpus, num_files)


### PR DESCRIPTION
Summary: Adds test script to make sure that data pulled from data management python scripts match the ones on Manifold. Pulls data from Manifold through CLI and compare SHA or data (if file is canonical parquet since metadata can be different)

Differential Revision: D83766939
