### PR TITLE
SDDL Compiler: Support Arrays of Indeterminate Length (#2355)

### DIFF
--- a/src/openzl/compress/graphs/simple_data_description_language.c
+++ b/src/openzl/compress/graphs/simple_data_description_language.c
@@ -2394,9 +2394,7 @@ static ZL_RESULT_OF(ZL_SDDL_Expr) ZL_SDDL_State_execExpr_op_inner(
             ZL_ERR_IF_NE(args[1].type, ZL_SDDL_ExprType_num, corruption);
             ZL_ERR_IF_EQ(
                     args[1].num.val, 0, corruption, "Modulus can't be zero.");
-            result.type    = ZL_SDDL_ExprType_num;
-            result.num.val = args[0].num.val % args[1].num.val;
-            result = ZL_SDDL_Expr_makeNum(args[0].num.val == args[1].num.val);
+            result = ZL_SDDL_Expr_makeNum(args[0].num.val % args[1].num.val);
             break;
         }
 

--- a/tests/codecs/test_sddl.cpp
+++ b/tests/codecs/test_sddl.cpp
@@ -524,6 +524,17 @@ TEST_F(SimpleDataDescriptionLanguageTest, avoidScopeCopiesInTemporaryFunctions)
     roundtrip(prog, input);
 }
 
+TEST_F(SimpleDataDescriptionLanguageTest, directlyUseAggregateFieldDecls)
+{
+    const auto prog  = R"(
+        : {}[1][1]
+        : {Byte}[1][1]
+        : {{Byte}}[1][1]
+    )";
+    const auto input = iota(2);
+    roundtrip(prog, input);
+}
+
 TEST_F(SimpleDataDescriptionLanguageTest, consumeTooMuch)
 {
     const auto program = R"(

--- a/tests/codecs/test_sddl.cpp
+++ b/tests/codecs/test_sddl.cpp
@@ -570,6 +570,24 @@ TEST_F(SimpleDataDescriptionLanguageTest, consumeTooMuch)
             << err_str;
 }
 
+TEST_F(SimpleDataDescriptionLanguageTest, indeterminateArrayLength)
+{
+    const auto program = R"(
+        : UInt32LE[]
+        expect _rem == 0
+    )";
+
+    for (size_t i = 4; i < 33; i++) {
+        exec(program,
+             iota(i),
+             (i % 4) ? Expected::FAIL_TO_EXECUTE : Expected::SUCCEED);
+    }
+
+    // Zero-sized objects can't be expanded.
+    exec(": {}[]; :Byte[3]", iota(3), Expected::FAIL_TO_EXECUTE);
+    exec(": Byte[0][]; :Byte[3]", iota(3), Expected::FAIL_TO_EXECUTE);
+}
+
 class SimpleDataDescriptionLanguageSourceCodePrettyPrintingTest : public Test {
    protected:
     void SetUp() override

--- a/tools/sddl/compiler/Grammar.cpp
+++ b/tools/sddl/compiler/Grammar.cpp
@@ -278,9 +278,11 @@ poly::optional<ASTPtr> GrammarRule::match_lhs(const ASTPtr& op, ASTPtr arg)
                 return poly::nullopt;
             }
             break;
-        case ArgType::LIST_PAREN:
         case ArgType::LIST_SQUARE:
-        case ArgType::LIST_CURLY: {
+        case ArgType::LIST_CURLY:
+            arg = unwrap_parens(std::move(arg));
+            ZL_FALLTHROUGH;
+        case ArgType::LIST_PAREN: {
             const auto* const list = some(arg).as_list();
             if (list == nullptr) {
                 return poly::nullopt;
@@ -296,6 +298,9 @@ poly::optional<ASTPtr> GrammarRule::match_lhs(const ASTPtr& op, ASTPtr arg)
                 return poly::nullopt;
             }
             arg = unwrap_parens(std::move(arg));
+            if (some(arg).as_list() != nullptr) {
+                return poly::nullopt;
+            }
             break;
         }
         default:
@@ -316,9 +321,11 @@ poly::optional<ASTPtr> GrammarRule::match_rhs(const ASTPtr& op, ASTPtr arg)
                 return poly::nullopt;
             }
             break;
-        case ArgType::LIST_PAREN:
         case ArgType::LIST_SQUARE:
-        case ArgType::LIST_CURLY: {
+        case ArgType::LIST_CURLY:
+            arg = unwrap_parens(std::move(arg));
+            ZL_FALLTHROUGH;
+        case ArgType::LIST_PAREN: {
             const auto* const list = some(arg).as_list();
             if (list == nullptr) {
                 return poly::nullopt;
@@ -334,6 +341,9 @@ poly::optional<ASTPtr> GrammarRule::match_rhs(const ASTPtr& op, ASTPtr arg)
                 return poly::nullopt;
             }
             arg = unwrap_parens(arg);
+            if (some(arg).as_list() != nullptr) {
+                return poly::nullopt;
+            }
             break;
         }
         default:


### PR DESCRIPTION
Summary:

This diff translates syntax like `field[]`, where a length isn't given, into
underlying ops that compute the correct length and resolve the expression to
an array of that length.

See the comment in the code for the code this expression expands into.

Reviewed By: terrelln

Differential Revision: D83539780


