### PR TITLE
Fix typos in docs (#2340)

### DIFF
--- a/doc/mkdocs/doc/getting-started/cli.md
+++ b/doc/mkdocs/doc/getting-started/cli.md
@@ -16,29 +16,29 @@ todo
 The input file names in the code snippets correspond to files in the `openzl_corpus/getting_started` folder.
 
 # Basic usage
-### ZStd in OpenZL
-Let's start with a simple example. We will use the CLI to compress a file named `myfile.txt` using ZStd.
+### Serial data in OpenZL
+Let's start with a simple example. We will use the CLI to compress a file named `myfile.txt` using the serial compression profile.
 ```
-zli compress --profile zstd myfile.txt --output myfile.zs2
+zli compress --profile serial myfile.txt --output myfile.zs2
 ```
-The `--profile` option allows you to select a predefined **compression profile**. In this case, we are using the `zstd` profile, which is a wrapper around a ZStd compression call.
+The `--profile` option allows you to select a predefined **compression profile**. In this case, we are using the `serial` profile, which is suited for serial data.
 
-> **More about profiles:** Under the hood, a `profile` is simply a pre-configured OpenZL **graph**. In this case, the graph just contains one node: the Zstd node. Other profiles contain more complex graphs, as we will see later.
+> **More about profiles:** Under the hood, a `profile` is simply a pre-configured OpenZL **graph**. Since we did not do any [ACE](./using-openzl.md#ace-training) training, the graph contains a single Zstd node. Other profiles contain more complex graphs, as we will see later.
 
-### Field LZ for numeric data
-Now let's try to compress a file of numbers. We have preconfigured a graph called `field_lz` that takes advantage of fixed-width structure of integer data to compress better than byte-wise LZ.
-
-```
-zli compress --profile field_lz ints.txt --output ints.field_lz.zs2
-```
-
-For comparison, we can try compressing the same output with Zstd.
+### Numeric data in OpenZL
+Now let's try to compress a file of numbers. We have preconfigured profile called `le-i32` that takes advantage of fixed-width structure of integer data to compress better than byte-wise LZ.
 
 ```
-zli compress --profile zstd ints.txt --output ints.zstd.zs2
+zli compress --profile le-i32 ints.txt --output ints.le_i32.zs2
 ```
 
-We can see the immediate benefit of moving from Zstd to Field LZ.
+For comparison, we can try compressing the same output with serial.
+
+```
+zli compress --profile serial ints.txt --output ints.serial.zs2
+```
+
+We can see the immediate benefit of moving from serial to le-i32.
 
 > **Tip:** The more you know about your data, the better you can tune your compression. Simply knowing that your data is integral dramatically improves compression.
 

--- a/doc/mkdocs/doc/getting-started/concepts.md
+++ b/doc/mkdocs/doc/getting-started/concepts.md
@@ -57,9 +57,7 @@ The typical usage pattern is for users to insert a small number of codecs or use
 
 ### Static Graph
 
-A static graph is a graph that takes one input, and that consists of a head node, whose outputs are passed to other graphs.
-This graph does not make any dynamic decisions during compression; it always passes the input to the head node.
-However, the graphs that compress the output of the head node may make dynamic decisions.
+A static graph is a graph with fixed routing behavior. It accepts a single input via a head node whose output is passed to other graphs. During compression, the static graph does not make any dynamic routing decisions. The graphs that receive output from the head node, however, may still make dynamic decisions about how to compress the data.
 
 ### Selector Graph
 
@@ -71,16 +69,18 @@ If the data is sorted, it may pass it to a specialized compression graph for sor
 
 ### Function Graph
 
-A function graph is a graph that takes one or more input, and passes it to a user defined input that defines the graph at compression time.
+A function graph is a graph that takes one or more inputs, and passes it to a user defined function that defines the graph at compression time.
 This function may:
 
 * Inspect the data of any edge it has access to (including all input data).
 * Run [codecs][codecs] directly on any edge, and customize the configuration of codecs that get run.
 * Dynamically select the output graph for any edge.
 
-The function graph starts with a set of unterminated edges which is the inputs.
-It can update the set by running a node, which removes the inputs passed to that node, and adds its outputs.
-It can remove from the set by setting the output graph for an edge.
+The function graph starts with a set of unterminated edges which is the inputs. The set can change in two ways:
+
+* Running a node removes the inputs passed to that node and adds its outputs to the set.
+* Setting the output graph for an edge removes it from the set.
+
 The set of unterminated edges must be empty before the function graph finishes.
 
 The function graph is very powerful, but in exchange it gives up ease of use.
@@ -91,4 +91,4 @@ It is recommended to make each function graph as small as possible, and prefer s
 The store graph is the "base" graph that takes a single input and produces no outputs.
 Passing data to this graph denotes that the data should be written as-is into the compressed output.
 All other graphs must eventually terminate all of their edges with store.
-However, it may not be written into the graph directly, because e.g. it terminates an edge in a standard graph, which itself eventually terminates all edges in store.
+However, graphs don't always terminate explicitly with the store graph. For example, a graph might terminate their edges with a standard graph, which eventually routes all edges to the store graph.

--- a/doc/mkdocs/doc/getting-started/examples/c/benchmarking.md
+++ b/doc/mkdocs/doc/getting-started/examples/c/benchmarking.md
@@ -2,10 +2,8 @@
 A lightweight benchmarking tool `unitBench` is provided in the codebase as a helper to benchmark some common compression use cases.
 
 ## Build and Use
-Toggle the `DOPENZL_BUILD_BENCHMARKS` CMake option to enable benchmarking.
 ```bash
-cmake .. -DCMAKE_BUILD_TYPE=Release -DOPENZL_BUILD_BENCHMARKS=ON
-make -j unitBench
+make unitBench
 ```
 The `unitBench` binary expects a scenario and some number of input files. Here is a sample command to benchmark Zstd compression on a few files
 ```bash

--- a/doc/mkdocs/doc/getting-started/examples/c/custom-formats.md
+++ b/doc/mkdocs/doc/getting-started/examples/c/custom-formats.md
@@ -2,11 +2,17 @@
 A simple way to enhance generic compressors is to parse the input data before compression. Furthermore, if the data is homogeneous training can also be done. After parsing into structured outputs, OpenZL offers a training tool that clusters these outputs to exploit correlations and tries multiple compression strategies per cluster to create a good compressor.
 
 ## Running the example
-First generate some data using `parsing_data_generator_correlated.py`. This is in its own [custom format](#the-data-format). We will use `/tmp/openzl` as the working directory for this exercise and generate a single file to compress. [Trainining Orchestration](training-orchestration.md) will properly set up a test/train split for your data. For now, we will train and test on the single file. Run:
+First generate some data using `parsing_data_generator_correlated.py` (which can be found in `openzl/examples` folder). This is in its own [custom format](#the-data-format). We will use `/tmp/openzl` as the working directory for this exercise and generate a single file to compress. [Training Orchestration](training-orchestration.md) will properly set up a test/train split for your data. For now, we will train and test on the single file. Inside `/tmp/openzl`, create a `train` directory and an empty file called `correlated`. The following command will populate the file with data:
+
+Run:
 ```
 python3 parsing_data_generator_correlated.py /tmp/openzl/train/correlated
 ```
-Next, run cmake and go to the build directory. Then run the training binary:
+Next, run cmake. If you used [these cmake steps](../../quick-start.md#building-the-openzl-cli) to build `zli` you can run the following command to run cmake.
+```
+cmake --build cmakebuild --target training
+```
+Then go to the `cmakebuild/examples` directory and run the training binary:
 ```
 ./training train /tmp/openzl/train /tmp/openzl/compressor.zlc
 ```
@@ -171,7 +177,7 @@ The next step is to paramaterize the graph with the required parameters. In our 
 --8<-- "src/examples/training.cpp:register-parser-parameterize"
 ```
 
-After creating a generic registration function for the parser, we must create a specialized compressor profile for the parser. The compressor profile allows you to specify successors, and optionally clustering codecs. Good successors to pick here depends on the parsed data. For example, time series data will work well with compressors which have `ZL_NODE_DELTA`. A reasonable set of successors can be found in "custom_parsers/shared_components/clustering.cpp". We have also built a [graph builder]()(Documentation under construction) that can be used at this stage of successor selection.
+After creating a generic registration function for the parser, we must create a specialized compressor profile for the parser. The compressor profile allows you to specify successors, and optionally clustering codecs. Good successors to pick here depends on the parsed data. For example, time series data will work well with compressors which have `ZL_NODE_DELTA`. A reasonable set of successors can be found in `custom_parsers/shared_components/clustering.cpp`. We have also built a [graph builder]()(Documentation under construction) that can be used at this stage of successor selection.
 
 ## Running training and compression
  After handling I/O, create a compressor, register the new compressor profile built and set the starting graph for the compressor as this graph. Then we can can train directly by calling `train` with the appropriate parameters.

--- a/doc/mkdocs/doc/getting-started/examples/c/training-orchestration.md
+++ b/doc/mkdocs/doc/getting-started/examples/c/training-orchestration.md
@@ -19,7 +19,7 @@ Using this trained compressor, we can now benchmark the test set. It is first ne
 ```
 Deserialization requires all dependencies to be registered in the compressor. In this example, we register the compressor profile we used in training with `registerGraph_ParsingCompressor`. This enables the compressor to be deserialized by calling `compressor.deserialize` and passing in the serialized compressor.
 
-Even though we have built a custom compressor, to decompress, there are no requirements other than the the format version of the compressor set to a version less than or equal to the library's format version on the decompressor side. The following two lines of code are all that is necessary to decompress.
+Decompression only requires that the compressor's configured format version to be less than or equal to the decompressor's format version. The following two lines of code are all that is necessary to decompress.
 ```cpp
 --8<-- "src/examples/training.cpp:decompression"
 ```

--- a/doc/mkdocs/doc/getting-started/examples/py/parsing.md
+++ b/doc/mkdocs/doc/getting-started/examples/py/parsing.md
@@ -51,6 +51,7 @@ It is a trivial example, but it is enough to show that you can improve compressi
 OpenZL allows constructing graphs at runtime, similar to the [Selector][openzl.ext.Selector] that we saw in the [quick start example](./quick-start.md), but more powerful.
 This is done through [`FunctionGraph`s][openzl.ext.FunctionGraph].
 Inside a function graph you can:
+
 * Inspect the input edge, and the data attached to that edge.
 * Run a node on any edge, and get the resulting edges back.
 * Send an edge to a destination graph.

--- a/doc/mkdocs/doc/getting-started/introduction.md
+++ b/doc/mkdocs/doc/getting-started/introduction.md
@@ -40,19 +40,23 @@ Although OpenZL is a toolkit of components that can be arbitrarily composed into
 
 ``` mermaid
 graph LR
-    classDef hidden display: none;
-
-    input:::hidden --> Parse;
-    Parse --> Group;
-    Group --> Transform;
-    Transform --> Compress;
+  input["input"] --> Parse["Parse"]
+  subgraph s1["Frontend"]
+    Parse --> Group["Group"]
+  end
+  subgraph s2["Backend"]
+    Group --> Transform["Transform"]
+    Transform --> Compress["Compress"]
+  end
+  input:::hidden
+  classDef hidden display: none
 ```
 
 This is because OpenZL's components that are actually good at compressing data—its suite of transforms and compressors—work best on homogenous streams of data. For inputs that aren't already organized that way, those backend components require a frontend to parse and group the input into streams, which the backend can then compress effectively.
 
 OpenZL offers a number of options for accomplishing that organization of your data:
 
-1. **Pre-Built Profiles**: Use a profile that has already been built to compress a particular format. (TODO: link?)
+1. **Pre-Built Profiles**: Use a profile that has already been built to compress a [particular format](quick-start.md#compress-with-trained-profile).
 
 2. **Describe Your Data**: The [Simple Data Description Language](../api/c/graphs/sddl.md) profile lets you describe the format of your input with a simple syntax, which OpenZL uses to split your input into component streams.
 

--- a/doc/mkdocs/doc/getting-started/using-openzl.md
+++ b/doc/mkdocs/doc/getting-started/using-openzl.md
@@ -35,7 +35,8 @@ graph TD
 Most data formats can benefit from parsing although to different extents. Csv and json are both highly structured and repetitive and are representative examples as formats that benefit significantly from parsing correctly. On the other hand, html is structured but not repetitive and will therefore not benefit much from parsing.
 
 ### SDDL Compatibility
-While SDDL has the capability to describe any data format, some formats are easier to describe. The following properties are:
+While SDDL has the capability to describe any data format, some formats are easier to describe. Simpler formats have the following properties:
+
 * No nested structures
 * No variably sized structures
 

--- a/tools/visualization_app/src/components/StreamdumpGraph.tsx
+++ b/tools/visualization_app/src/components/StreamdumpGraph.tsx
@@ -8,7 +8,7 @@ import {StreamdumpGraphView} from '../graphVisualization/views/StreamdumpGraphVi
 import {ReactFlowProvider} from '@xyflow/react';
 import {Box, Code, CodeBlock, Float, IconButton, Text, Tabs, useTabs, Heading, Span} from '@chakra-ui/react';
 
-const cliInvocation = 'zli compress --trace /tmp/streamdump.cbor -p zstd -o /dev/null myfile.txt';
+const cliInvocation = 'zli compress --trace /tmp/streamdump.cbor -p serial -o /dev/null myfile.txt';
 const files = [
   {
     language: 'C++',


### PR DESCRIPTION
Summary:

- Updated graph inside Introduction
- Updated Concepts and Examples sections for clarity
- Updated bullet points format in Using OpenZL and Parser so they displayed correctly
- Updated sample commands to use `serial` instead of `zstd` profile

Reviewed By: terrelln, kevinjzhang

Differential Revision: D83360242


