### PR TITLE
add instructions to generate language server information

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,6 +1,6 @@
 {
     "cmake.copyCompileCommands": "${workspaceFolder}/compile_commands.json",
-    "cmake.buildDirectory": "${workspaceFolder}/build",
+    "cmake.buildDirectory": "${workspaceFolder}/cmakebuild",
     "cmake.useCMakePresets": "always",
     "files.associations": {
         "array": "cpp",
@@ -9,5 +9,13 @@
         "vector": "cpp",
         "*.make": "makefile"
     },
-    "files.trimTrailingWhitespace": true
+    "files.trimTrailingWhitespace": true,
+    "C_Cpp.default.compileCommands": "${workspaceFolder}/compile_commands.json",
+    "C_Cpp.default.configurationProvider": "ms-vscode.cmake-tools",
+    "C_Cpp.intelliSenseEngine": "default",
+    "C_Cpp.codeAnalysis.runAutomatically": true,
+    "clangd.arguments": [
+        "--compile-commands-dir=${workspaceFolder}",
+        "--header-insertion=iwyu"
+    ]
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,7 +1,10 @@
 {
     "cmake.copyCompileCommands": "${workspaceFolder}/compile_commands.json",
     "cmake.buildDirectory": "${workspaceFolder}/cmakebuild",
-    "cmake.useCMakePresets": "always",
+    "cmake.useCMakePresets": "auto",
+    "cmake.configureArgs": [
+        "-DOPENZL_BUILD_TESTS=ON"
+    ],
     "files.associations": {
         "array": "cpp",
         "string_view": "cpp",

--- a/README.md
+++ b/README.md
@@ -75,6 +75,24 @@ OpenZL ships with settings to configure VSCode to work with the cmake build syst
 1. cmake-tools
 2. clangd (or any other C++ language server that works with compile_commands.json)
 
+**Important:** For proper C++ language server support, you need to generate `compile_commands.json`:
+
+```bash
+mkdir cmakebuild
+cd cmakebuild
+cmake -DOPENZL_BUILD_TESTS=ON -DCMAKE_EXPORT_COMPILE_COMMANDS=ON ..
+cp compile_commands.json ..
+```
+
+This creates a compilation database in `cmakebuild/compile_commands.json` that provides compilation information to the C++ language server.
+It needs to be copied to the root of the project for VSCode to pick it up.
+Note: If using CMake Tools extension commands (like "CMake: Configure"): The file is automatically copied to the workspace root.
+
+**When to regenerate:**
+- After cloning the repository (first-time setup)
+- When adding/removing source files
+- When modifying CMakeLists.txt
+
 
 ### CMake Variables
 

--- a/README.md
+++ b/README.md
@@ -77,22 +77,21 @@ OpenZL ships with settings to configure VSCode to work with the cmake build syst
 
 **Important:** For proper C++ language server support, you need to generate `compile_commands.json`:
 
+The preferred method is to use the CMake Tools extension command `"CMake: Configure"`.
+
+If it doesn't work, or is too difficult to setup, you can use the manual setup:
+
 ```bash
-mkdir cmakebuild
-cd cmakebuild
-cmake -DOPENZL_BUILD_TESTS=ON -DCMAKE_EXPORT_COMPILE_COMMANDS=ON ..
-cp compile_commands.json ..
+mkdir -p cmakebuild
+cmake -B cmakebuild -DOPENZL_BUILD_TESTS=ON -DCMAKE_EXPORT_COMPILE_COMMANDS=ON .
+cp cmakebuild/compile_commands.json .
 ```
 
-This creates a compilation database in `cmakebuild/compile_commands.json` that provides compilation information to the C++ language server.
-It needs to be copied to the root of the project for VSCode to pick it up.
-Note: If using CMake Tools extension commands (like "CMake: Configure"): The file is automatically copied to the workspace root.
-
 **When to regenerate:**
-- After cloning the repository (first-time setup)
-- When adding/removing source files
-- When modifying CMakeLists.txt
 
+* After cloning the repository (first-time setup)
+* When adding/removing source files
+* When modifying `CMakeLists.txt`
 
 ### CMake Variables
 


### PR DESCRIPTION
After struggling too long to get `code-fb` editor running correctly on openzl (outside of fbcode), these instructions should prove helpful for users with similar issues.

Also: fixed instructions passed to VSCode extension, so that generating a "good" `compile_commands.json` is more  straightforward.