### PR TITLE
Selectors can select Segmenters

### DIFF
--- a/include/openzl/zl_selector.h
+++ b/include/openzl/zl_selector.h
@@ -154,8 +154,8 @@ ZL_GraphID ZL_Compressor_registerSerialSelectorGraph(
  */
 
 typedef ZL_GraphID (*ZL_SelectorFn)(
-        const ZL_Selector* selCtx,
-        const ZL_Input* inputStream,
+        const ZL_Selector* selectorAPI,
+        const ZL_Input* input,
         const ZL_GraphID*
                 customGraphs, // list custom Graphs that the selector may choose
                               // as successor. Can be NULL when none needed.

--- a/src/openzl/compress/cctx.c
+++ b/src/openzl/compress/cctx.c
@@ -1186,7 +1186,9 @@ ZL_Report CCTX_runSuccessor(
 {
     ZL_RESULT_DECLARE_SCOPE_REPORT(cctx);
     ZL_DLOG(BLOCK, "CCTX_runSuccessor (graphid=%u)", graphid.gid);
-    int const isSegmentable = (rtInputs[0].rtsid == 0 && nbInputs == cctx->nbInputs && !cctx->segmenterStarted);
+    int const isSegmentable =
+            (rtInputs[0].rtsid == 0 && nbInputs == cctx->nbInputs
+             && !cctx->segmenterStarted);
 
     // Segmenter
     if (CGRAPH_graphType(cctx->cgraph, graphid) == gt_segmenter) {

--- a/src/openzl/compress/cctx.c
+++ b/src/openzl/compress/cctx.c
@@ -1100,9 +1100,10 @@ static ZL_Report CCTX_triggerBackupMode(
 }
 
 /* Implementation note:
- * CCTX_runSuccessor_internal(), invoked by CCTX_runSuccessor(), features
- * multiple exit points. This 2-stages design ensures that Stream cleaning
- * cannot be skipped.
+ * CCTX_runSuccessor_internal(), invoked by CCTX_runSuccessor().
+ * This 2-stages design ensures that Stream cleaning cannot be skipped despite
+ * multiple exit points. Will invoke CCTX_runSupervisedGraph(). Is also in
+ * charge of Permissive (backup) mode.
  */
 static ZL_Report CCTX_runSuccessor_internal(
         ZL_CCtx* cctx,
@@ -1172,8 +1173,9 @@ static ZL_Report CCTX_runSuccessor_internal(
 }
 
 /* Invoked from: CCTX_startGraph(), CCTX_runSuccessors()
- * Upper echelon, will invoke CCTX_runSupervisedGraph(),
- * is also in charge of Permissive (backup) mode */
+ * Upper echelon, acts as a graph type dispatcher,
+ * routing between segmenter and normal graphs.
+ * Is also in charge of Stream cleaning */
 ZL_Report CCTX_runSuccessor(
         ZL_CCtx* cctx,
         ZL_GraphID graphid,
@@ -1184,19 +1186,15 @@ ZL_Report CCTX_runSuccessor(
 {
     ZL_RESULT_DECLARE_SCOPE_REPORT(cctx);
     ZL_DLOG(BLOCK, "CCTX_runSuccessor (graphid=%u)", graphid.gid);
-    if (rtInputs[0].rtsid == 0 && nbInputs == cctx->nbInputs
-        && !cctx->segmenterStarted) {
-        // Original input
-        if (CGRAPH_graphType(cctx->cgraph, graphid) == gt_segmenter) {
+    int const isSegmentable = (rtInputs[0].rtsid == 0 && nbInputs == cctx->nbInputs && !cctx->segmenterStarted);
+
+    // Segmenter
+    if (CGRAPH_graphType(cctx->cgraph, graphid) == gt_segmenter) {
+        if (isSegmentable) {
             return CCTX_runSegmenter(cctx, graphid, rgp, rtInputs, nbInputs);
         }
+        ZL_ERR(graph_invalid, "Segmenter can only be used on full input");
     }
-
-    ZL_ERR_IF_EQ(
-            CGRAPH_graphType(cctx->cgraph, graphid),
-            gt_segmenter,
-            GENERIC,
-            "Invalid usage of Segmenter: can only be employed on full input");
 
     // Normal Graph
     for (size_t n = 0; n < nbInputs; n++) {
@@ -1204,8 +1202,10 @@ ZL_Report CCTX_runSuccessor(
     }
     ZL_Report const r = CCTX_runSuccessor_internal(
             cctx, graphid, rgp, rtInputs, nbInputs, depth);
-    for (size_t n = 0; n < nbInputs; n++) {
-        RTGM_clearRTStream(&cctx->rtgraph, rtInputs[n], depth);
+    if (!isSegmentable) {
+        for (size_t n = 0; n < nbInputs; n++) {
+            RTGM_clearRTStream(&cctx->rtgraph, rtInputs[n], depth);
+        }
     }
     return r;
 }

--- a/src/openzl/compress/dyngraph_interface.c
+++ b/src/openzl/compress/dyngraph_interface.c
@@ -342,17 +342,39 @@ ZL_Report ZL_Edge_setParameterizedDestination(
     ZL_ASSERT_NN(gctx);
     ZL_RESULT_DECLARE_SCOPE_REPORT(gctx->cctx);
 
+    // === Phase 1: Basic Input Sanitization ===
     ZL_ERR_IF_NULL(
             nbInputs,
             successor_invalidNumInputs,
             "A Graph Successor must have at least 1 Input.");
 
+    // === Phase 2: Graph Descriptor Lookup ===
     const ZL_Compressor* const compressor = CCTX_getCGraph(gctx->cctx);
-    const ZL_FunctionGraphDesc* const migd =
-            CGRAPH_getMultiInputGraphDesc(compressor, gid);
+    ZL_FunctionGraphDesc localMigd;
+    const ZL_FunctionGraphDesc* migd = NULL;
+    ZL_DLOG(SEQ,
+            "CGRAPH_graphType(compressor, gid) = %i",
+            CGRAPH_graphType(compressor, gid));
+    if (CGRAPH_graphType(compressor, gid) == gt_segmenter) {
+        const ZL_SegmenterDesc* const segd =
+                CGRAPH_getSegmenterDesc(compressor, gid);
+        localMigd = (ZL_FunctionGraphDesc){
+            .name                = segd->name,
+            .inputTypeMasks      = segd->inputTypeMasks,
+            .nbInputs            = segd->numInputs,
+            .lastInputIsVariable = segd->lastInputIsVariable,
+        };
+        migd = &localMigd;
+    } else {
+        migd = CGRAPH_getMultiInputGraphDesc(compressor, gid);
+    };
+
     ZL_ERR_IF_NULL(migd, graph_invalid);
+
+    // === Phase 3: Validate number of inputs ===
     if (migd->lastInputIsVariable) {
         // Variable Input: last Input can be present [0-N] times
+        // Must provide at least (required_inputs - 1) since last is optional
         ZL_ASSERT_GE(migd->nbInputs, 1);
         ZL_ERR_IF_LT(nbInputs, migd->nbInputs - 1, successor_invalidNumInputs);
     } else {
@@ -366,6 +388,8 @@ ZL_Report ZL_Edge_setParameterizedDestination(
                 migd->nbInputs,
                 nbInputs);
     }
+
+    // === Phase 4: Process Each Input Edge ===
     for (size_t n = 0; n < nbInputs; n++) {
         ZL_ASSERT_NN(inputs[n]);
         DG_StreamCtx* const sctx =
@@ -384,15 +408,22 @@ ZL_Report ZL_Edge_setParameterizedDestination(
     }
     ZL_ASSERT_GE(VECTOR_SIZE(gctx->rtsids), nbInputs);
 
-    // Transfer optional Graph parameters in Session memory
+    // === Phase 5: Transfer Runtime Parameters to Session Memory ===
     rGraphParams =
             ZL_transferRuntimeGraphParams(gctx->chunkArena, rGraphParams);
+
+    // === Phase 6: Create and Store Destination Graph Descriptor ===
+    // This descriptor is stored for deferred execution - not used immediately
+    // 1. When the current graph completes execution (in CCTX_runGraph_internal)
+    // 2. GCTX_getSuccessors() will iterate through stored descriptors
+    // 3. For each "trigger" stream, it extracts the stored descriptor
+    // 4. The SuccessorInfo array is passed to CCTX_runSuccessors()
     DestGraphDesc const sd = {
         gid, rGraphParams, nbInputs, VECTOR_SIZE(gctx->rtsids) - nbInputs
     };
     ZL_ERR_IF_NOT(VECTOR_PUSHBACK(gctx->dstGraphDescs, sd), allocation);
 
-    // note : Input Type compatibility is checked when starting Successor Graph
+    // note: Input Type compatibility is checked on starting the Successor Graph
     return ZL_returnSuccess();
 }
 

--- a/src/openzl/compress/dyngraph_interface.c
+++ b/src/openzl/compress/dyngraph_interface.c
@@ -348,44 +348,54 @@ ZL_Report ZL_Edge_setParameterizedDestination(
             successor_invalidNumInputs,
             "A Graph Successor must have at least 1 Input.");
 
-    // === Phase 2: Graph Descriptor Lookup ===
+    // === Phase 2: Input Descriptor Lookup ===
+    typedef struct {
+        const char* name;
+        size_t numInputs;
+        bool lastInputIsVariable;
+    } InputGraphDesc;
+
     const ZL_Compressor* const compressor = CCTX_getCGraph(gctx->cctx);
-    ZL_FunctionGraphDesc localMigd;
-    const ZL_FunctionGraphDesc* migd = NULL;
     ZL_DLOG(SEQ,
             "CGRAPH_graphType(compressor, gid) = %i",
             CGRAPH_graphType(compressor, gid));
+    InputGraphDesc inputGD;
     if (CGRAPH_graphType(compressor, gid) == gt_segmenter) {
         const ZL_SegmenterDesc* const segd =
                 CGRAPH_getSegmenterDesc(compressor, gid);
-        localMigd = (ZL_FunctionGraphDesc){
+        ZL_ASSERT_NN(segd);
+        inputGD = (InputGraphDesc){
             .name                = segd->name,
-            .inputTypeMasks      = segd->inputTypeMasks,
-            .nbInputs            = segd->numInputs,
+            .numInputs           = segd->numInputs,
             .lastInputIsVariable = segd->lastInputIsVariable,
         };
-        migd = &localMigd;
     } else {
-        migd = CGRAPH_getMultiInputGraphDesc(compressor, gid);
+        const ZL_FunctionGraphDesc* const fgd =
+                CGRAPH_getMultiInputGraphDesc(compressor, gid);
+        ZL_ERR_IF_NULL(fgd, graph_invalid);
+        inputGD = (InputGraphDesc){
+            .name                = fgd->name,
+            .numInputs           = fgd->nbInputs,
+            .lastInputIsVariable = fgd->lastInputIsVariable,
+        };
     };
 
-    ZL_ERR_IF_NULL(migd, graph_invalid);
-
     // === Phase 3: Validate number of inputs ===
-    if (migd->lastInputIsVariable) {
+    if (inputGD.lastInputIsVariable) {
         // Variable Input: last Input can be present [0-N] times
         // Must provide at least (required_inputs - 1) since last is optional
-        ZL_ASSERT_GE(migd->nbInputs, 1);
-        ZL_ERR_IF_LT(nbInputs, migd->nbInputs - 1, successor_invalidNumInputs);
+        ZL_ASSERT_GE(inputGD.numInputs, 1);
+        ZL_ERR_IF_LT(
+                nbInputs, inputGD.numInputs - 1, successor_invalidNumInputs);
     } else {
         // Only Singular Inputs: count must be exact
         ZL_ERR_IF_NE(
                 nbInputs,
-                migd->nbInputs,
+                inputGD.numInputs,
                 successor_invalidNumInputs,
                 "Graph '%s' should have received %zu Inputs (!= %zu)",
-                STR_REPLACE_NULL(migd->name),
-                migd->nbInputs,
+                STR_REPLACE_NULL(inputGD.name),
+                inputGD.numInputs,
                 nbInputs);
     }
 

--- a/src/openzl/compress/encode_frameheader.c
+++ b/src/openzl/compress/encode_frameheader.c
@@ -846,7 +846,9 @@ static ZL_Report writeChunkHeaderV8orMore(
         }
     }
     EFH_Workspace_destroy(&wksp);
-    ZL_DLOG(SEQ, "ZL_isError(ret) = %i", ZL_isError(ret));
+    if (ZL_isError(ret)) {
+        ZL_DLOG(ERROR, "writeChunkHeaderV8orMore() error");
+    }
     return ret;
 }
 

--- a/src/openzl/compress/graphmgr.c
+++ b/src/openzl/compress/graphmgr.c
@@ -754,8 +754,13 @@ const ZL_FunctionGraphDesc* GM_getMultiInputGraphDesc(
     ZL_DLOG(BLOCK, "GM_getMultiInputGraphDesc (graphid=%u)", lgid);
     ZL_IDType const lid = GM_GraphID_to_lgid(graphid);
     ZL_ASSERT_NN(gm);
-    if (lid >= VECTOR_SIZE(gm->gdv))
+    if (lid >= VECTOR_SIZE(gm->gdv)) {
+        ZL_DLOG(ERROR,
+                "requested graphid=%u is invalid (too large, >= %zu max)",
+                lgid,
+                VECTOR_SIZE(gm->gdv));
         return NULL;
+    }
     if (VECTOR_AT(gm->gdv, lid).originalGraphType == ZL_GraphType_segmenter)
         return NULL;
     return &VECTOR_AT(gm->gdv, lid).migd;

--- a/src/openzl/compress/rtgraphs.c
+++ b/src/openzl/compress/rtgraphs.c
@@ -419,10 +419,14 @@ const ZL_Data* RTGM_getRStream(const RTGraph* rtgraph, RTStreamID rtstreamid)
  * but requires the state to be writable in order to receive the reference */
 ZL_Data* RTGM_getWStream(RTGraph* rtgraph, RTStreamID rtstreamid)
 {
+    ZL_DLOG(SEQ, "RTGM_getWStream (streamid==%u)", rtstreamid.rtsid);
     ZL_ASSERT_NN(rtgraph);
     ZL_IDType const rtsid = rtstreamid.rtsid;
-    ZL_Data* stream       = VECTOR_AT(rtgraph->streams, rtsid).stream;
+    ZL_Data* const stream = VECTOR_AT(rtgraph->streams, rtsid).stream;
 
+    if (stream == NULL) {
+        ZL_DLOG(ERROR, "streamID=%u is invalid", rtsid);
+    }
     ZL_ASSERT_NN(stream); // should be valid
     return stream;
 }
@@ -468,6 +472,10 @@ void RTGM_guardRTStream(
         RTStreamID rtstream,
         unsigned protectRank)
 {
+    ZL_DLOG(SEQ,
+            "RTGM_guardRTStream (rtstream=%u, protectRank=%u)",
+            rtstream.rtsid,
+            protectRank);
     if (protectRank == 0)
         return;
     ZL_IDType const rtsid = rtstream.rtsid;
@@ -489,6 +497,10 @@ void RTGM_clearRTStream(
         RTStreamID rtstream,
         unsigned protectRank)
 {
+    ZL_DLOG(SEQ,
+            "RTGM_clearRTStream (rtstream=%u, protectRank=%u)",
+            rtstream.rtsid,
+            protectRank);
     ZL_ASSERT_NN(rtgraph);
     ZL_IDType const rtsid  = rtstream.rtsid;
     RT_CStream* const rtcs = &VECTOR_AT(rtgraph->streams, rtsid);

--- a/src/openzl/compress/segmenter.c
+++ b/src/openzl/compress/segmenter.c
@@ -89,17 +89,10 @@ ZL_Segmenter* SEGM_init(
 /* ===   internal actions   === */
 
 /**
- * Implementation Notes for SEGM_runSegmenter():
- *
- * Delegation Strategy: This function acts as a thin wrapper around the
- * user-provided segmenter function, handling validation and error checking
- * while delegating the actual chunking logic to the registered callback.
- *
- * Consumption Validation: Only accets complete input consumption on
- * successful execution.
- *
- * Error Propagation: Preserves the original error from the segmenter function.
- * This ensures the root cause of failures is visible to callers.
+ * SEGM_runSegmenter(): acts as a thin wrapper around the user-provided
+ * segmenter callback. User code is in charge of actual chunking logic. The
+ * wrapper just checks that all conditions are correctly respected. In current
+ * implementation, it enforces that input is entirely consumed.
  */
 ZL_Report SEGM_runSegmenter(ZL_Segmenter* segCtx)
 {
@@ -107,6 +100,8 @@ ZL_Report SEGM_runSegmenter(ZL_Segmenter* segCtx)
     ZL_SegmenterFn const segfn = segCtx->segDesc->segmenterFn;
     ZL_ASSERT_NN(segfn);
     ZL_Report const r = segfn(segCtx);
+
+    // if successful, check that all inputs were consumed
     if (!ZL_isError(r)) {
         for (size_t n = 0; n < segCtx->nbInputs; n++) {
             ZL_RET_R_IF_LT(

--- a/tests/round_trip/test_segmenter.cpp
+++ b/tests/round_trip/test_segmenter.cpp
@@ -555,6 +555,54 @@ TEST(Segmenter, selectorThenSegmenter)
             "selector then segmenter");
 }
 
+/* =======   Segmenter after a Function Graph that only selects   ======== */
+
+static ZL_Report graphSelectFirst(
+        ZL_Graph* graph,
+        ZL_Edge* inputs[],
+        size_t nbInputs) ZL_NOEXCEPT_FUNC_PTR
+{
+    printf("Graph 'graphSelectFirst'\n");
+    assert(nbInputs == 1);
+    assert(inputs != NULL);
+    const ZL_GraphIDList gids = ZL_Graph_getCustomGraphs(graph);
+    assert(gids.nbGraphIDs >= 1);
+    assert(gids.graphids != NULL);
+    return ZL_Edge_setDestination(inputs[0], gids.graphids[0]);
+}
+
+static ZL_GraphID registerGraphAndSegmenter(ZL_Compressor* compressor) noexcept
+{
+    ZL_Report const setr = ZL_Compressor_setParameter(
+            compressor, ZL_CParam_formatVersion, g_testVersion);
+    if (ZL_isError(setr))
+        abort();
+
+    ZL_GraphID const segid =
+            ZL_Compressor_registerSegmenter(compressor, g_segmenterDescPtr);
+
+    const ZL_Type inType                 = ZL_Type_serial;
+    ZL_FunctionGraphDesc const graphDesc = {
+        .name           = "Graph justSelectFirst",
+        .graph_f        = graphSelectFirst,
+        .inputTypeMasks = &inType,
+        .nbInputs       = 1,
+        .customGraphs   = &segid,
+        .nbCustomGraphs = 1,
+    };
+
+    return ZL_Compressor_registerFunctionGraph(compressor, &graphDesc);
+}
+
+TEST(Segmenter, graphThenSegmenter)
+{
+    if (g_testVersion < ZL_CHUNK_VERSION_MIN)
+        return;
+    g_segmenterDescPtr = &serialSegmenter;
+    (void)roundTripGen(
+            ZL_Type_serial, registerGraphAndSegmenter, "graph then segmenter");
+}
+
 /* *********************************************** */
 /* =======   Expected clean failure tests ======== */
 /* *********************************************** */

--- a/tests/round_trip/test_segmenter.cpp
+++ b/tests/round_trip/test_segmenter.cpp
@@ -534,11 +534,11 @@ static ZL_GraphID registerSelectorAndSegmenter(
             ZL_Compressor_registerSegmenter(compressor, g_segmenterDescPtr);
 
     ZL_SelectorDesc const selectorDesc = {
-        .name           = "Selector justSelectFirst",
         .selector_f     = justSelectFirst,
         .inStreamType   = ZL_Type_serial,
         .customGraphs   = &segid,
         .nbCustomGraphs = 1,
+        .name           = "Selector justSelectFirst",
     };
 
     return ZL_Compressor_registerSelectorGraph(compressor, &selectorDesc);

--- a/tests/round_trip/test_segmenter.cpp
+++ b/tests/round_trip/test_segmenter.cpp
@@ -17,6 +17,7 @@
 #include "openzl/zl_input.h"
 #include "openzl/zl_opaque_types.h"
 #include "openzl/zl_segmenter.h"
+#include "openzl/zl_selector.h"
 #include "openzl/zl_version.h" // ZL_MIN_FORMAT_VERSION
 
 namespace {
@@ -505,6 +506,55 @@ TEST(Segmenter, string)
             ZL_Type_string, registerSegmenter, g_segmenterDescPtr->name);
 }
 
+/* =======   Segmenter after a Selector   ======== */
+
+static ZL_GraphID justSelectFirst(
+        const ZL_Selector* selectorAPI,
+        const ZL_Input* input,
+        const ZL_GraphID* gids,
+        size_t nbGids) ZL_NOEXCEPT_FUNC_PTR
+{
+    printf("Selector 'justSelectFirst'\n");
+    (void)selectorAPI;
+    (void)input;
+    assert(nbGids == 1);
+    assert(gids != NULL);
+    return gids[0];
+}
+
+static ZL_GraphID registerSelectorAndSegmenter(
+        ZL_Compressor* compressor) noexcept
+{
+    ZL_Report const setr = ZL_Compressor_setParameter(
+            compressor, ZL_CParam_formatVersion, g_testVersion);
+    if (ZL_isError(setr))
+        abort();
+
+    ZL_GraphID const segid =
+            ZL_Compressor_registerSegmenter(compressor, g_segmenterDescPtr);
+
+    ZL_SelectorDesc const selectorDesc = {
+        .name           = "Selector justSelectFirst",
+        .selector_f     = justSelectFirst,
+        .inStreamType   = ZL_Type_serial,
+        .customGraphs   = &segid,
+        .nbCustomGraphs = 1,
+    };
+
+    return ZL_Compressor_registerSelectorGraph(compressor, &selectorDesc);
+}
+
+TEST(Segmenter, selectorThenSegmenter)
+{
+    if (g_testVersion < ZL_CHUNK_VERSION_MIN)
+        return;
+    g_segmenterDescPtr = &serialSegmenter;
+    (void)roundTripGen(
+            ZL_Type_serial,
+            registerSelectorAndSegmenter,
+            "selector then segmenter");
+}
+
 /* *********************************************** */
 /* =======   Expected clean failure tests ======== */
 /* *********************************************** */
@@ -532,7 +582,7 @@ TEST(Segmenter, input_incomplete)
     (void)cFailTest(registerSegmenter, g_segmenterDescPtr->name);
 }
 
-/* =======   Codec precedes segmenter   ======== */
+/* =======   Codec precedes segmenter (must fail)  ======== */
 
 ZL_GraphID registerInvalidGraph(ZL_Compressor* compressor) noexcept
 {


### PR DESCRIPTION
`Segmenters` **must** operate on *the entire* user `inputs`. For this reason, they are meant to run first, before any other `graph` or `node`.

However, "other `graphs`" include `selectors`.
Now, `selectors` don't modify `inputs`. Therefore, it should be possible for a `selector` to run first, in order to select which `segmenter` to invoke. This property can be extended to any function graph that in fine only select.
This capability is important for a future in which a ML-driven `selector` could detect which kind of `input` is being processed in order to select the proper `segmenter` to deal with it.

This patch makes this scenario possible.