### PR TITLE
Solve constraint sat in with an improved algorithm (#15)

### DIFF
--- a/tools/training/ace/BUCK
+++ b/tools/training/ace/BUCK
@@ -9,6 +9,7 @@ cpp_library(
     name = "automated_compressor_explorer",
     srcs = [
         "ace.cpp",
+        "ace_combination.cpp",
         "ace_compressor.cpp",
         "ace_compressors.cpp",
         "ace_utils.cpp",
@@ -16,6 +17,7 @@ cpp_library(
     ],
     headers = [
         "ace.h",
+        "ace_combination.h",
         "ace_compressor.h",
         "ace_compressors.h",
         "ace_crossover.h",

--- a/tools/training/ace/ace_combination.cpp
+++ b/tools/training/ace/ace_combination.cpp
@@ -1,0 +1,265 @@
+#include "tools/training/ace/ace_combination.h"
+#include "openzl/zl_reflection.h"
+#include "tools/logger/Logger.h"
+#include "tools/training/graph_mutation/graph_mutation_utils.h"
+#include "tools/training/utils/genetic_algorithm.h"
+#include "tools/training/utils/thread_pool.h"
+
+namespace openzl::training {
+
+// TODO: Make these hyperparameters training args
+const size_t kNumIntermediateFrontierCandidates = 1000;
+const size_t kNumFinalParetoCandidates          = 100;
+
+using namespace openzl::tools::logger;
+using namespace openzl::training::graph_mutation;
+
+namespace {
+/**
+ * @returns A serialized compressor of @p compressor where each backend graph is
+ * replaced by the given `ACECompressor`.
+ */
+std::shared_ptr<const std::string_view> runReplacements(
+        Compressor& compressor,
+        const std::unordered_map<std::string, ACECompressor>& replacements)
+{
+    // Add each graph to the compressor
+    std::unordered_map<std::string, ZL_GraphID> newGraphIds;
+    newGraphIds.reserve(replacements.size());
+    for (const auto& [backendGraph, aceCompressor] : replacements) {
+        newGraphIds.emplace(backendGraph, aceCompressor.build(compressor));
+    }
+
+    // Replace each backend graph with the new GraphID
+    std::string serializedForReplacements = compressor.serialize();
+    for (const auto& [backendGraph, newGraphId] : newGraphIds) {
+        auto result = replaceBaseGraphInCompressor(
+                serializedForReplacements,
+                backendGraph,
+                ZL_Compressor_Graph_getName(compressor.get(), newGraphId));
+
+        serializedForReplacements = std::string(result.begin(), result.end());
+    }
+
+    auto json = Compressor::convertSerializedToJson(serializedForReplacements);
+    Logger::log(VERBOSE3, "Graph with trained ACE successors: ", json);
+
+    return graph_mutation::createSharedStringView(
+            std::move(serializedForReplacements));
+}
+
+/** Filters @param candidates down to its Pareto Frontier and returns it.
+ */
+std::vector<CandidateSelection> filterParetoFrontier(
+        std::vector<CandidateSelection>&& candidates,
+        ThreadPool& threadPool)
+{
+    // TODO: Filter pareto optimal candidates out in a better way (divide and
+    // conquer is O(n log^2 n) as opposed to the current O(n^2) runtime).
+    std::vector<std::future<bool>> futures;
+    std::vector<CandidateSelection> frontier;
+    futures.reserve(candidates.size());
+    for (size_t i = 0; i < candidates.size(); i++) {
+        auto task = [i, &candidates]() {
+            bool isDominated = false;
+            for (size_t j = 0; j < candidates.size(); j++) {
+                if (candidates[j].dominates(candidates[i])) {
+                    isDominated = true;
+                    break;
+                }
+            }
+            return isDominated;
+        };
+        futures.emplace_back(threadPool.run(task));
+    }
+    for (size_t i = 0; i < candidates.size(); i++) {
+        if (!futures[i].get()) {
+            frontier.emplace_back(std::move(candidates[i]));
+        }
+    }
+    return frontier;
+}
+
+/** Prunes the list of candidates provided in @param candidates based on
+ * crowdingDistance and returns it. Picks the  @param numCandidates number of
+ * candidates with the highest crowdingDistance.
+ */
+std::vector<CandidateSelection> pruneCandidates(
+        std::vector<CandidateSelection>&& candidates,
+        size_t numCandidates)
+{
+    std::vector<std::vector<float>> fitness;
+    std::vector<size_t> indices;
+    fitness.reserve(candidates.size());
+    indices.reserve(candidates.size());
+    size_t candidateIdx = 0;
+    for (const auto& candidate : candidates) {
+        fitness.emplace_back(candidate.fitness());
+        indices.emplace_back(candidateIdx++);
+    }
+    auto crowdingDistances = crowdingDistance(fitness, indices);
+    detail::sortByKey(
+            indices, [&](size_t idx) { return -crowdingDistances[idx]; });
+    numCandidates = std::min(numCandidates, candidates.size());
+    std::vector<CandidateSelection> prunedCandidates;
+    prunedCandidates.reserve(numCandidates);
+    for (size_t i = 0; i < numCandidates; i++) {
+        prunedCandidates.emplace_back(std::move(candidates[indices[i]]));
+    }
+    return prunedCandidates;
+}
+
+/**
+ * Merges 2 vectors of candidates getting all combinations. Then filters out
+ * only pareto optimal points followed by pruning to a limit of the number of
+ * candidates.
+ */
+std::vector<CandidateSelection> mergeParetoFrontier(
+        ThreadPool& threadPool,
+        const std::vector<CandidateSelection>& currentFrontier,
+        const std::vector<CandidateSelection>& nextFrontier,
+        size_t maxNumCandidates)
+{
+    std::vector<CandidateSelection> newFrontier;
+    newFrontier.reserve(currentFrontier.size() * nextFrontier.size());
+    for (const auto& candidate : currentFrontier) {
+        for (const auto& candidateToMerge : nextFrontier) {
+            auto newCandidate = candidate;
+            newCandidate.merge(candidateToMerge);
+            newFrontier.emplace_back(newCandidate);
+        }
+    }
+    newFrontier = filterParetoFrontier(std::move(newFrontier), threadPool);
+    newFrontier = pruneCandidates(std::move(newFrontier), maxNumCandidates);
+    return newFrontier;
+}
+
+/**
+ * @returns The compressor for each backend graph that has the best ratio, which
+ * is just the first compressor because they are sorted by compressed size.
+ */
+std::shared_ptr<const std::string_view> getSmallestCandidate(
+        const std::function<Compressor()>& makeCompressor,
+        const std::unordered_map<
+                std::string,
+                std::vector<std::pair<ACECompressor, ACECompressionResult>>>&
+                allCandidates)
+{
+    auto compressor = makeCompressor();
+    std::unordered_map<std::string, ACECompressor> replacements;
+    replacements.reserve(allCandidates.size());
+    for (const auto& [backendGraph, candidates] : allCandidates) {
+        replacements.emplace(backendGraph, candidates[0].first);
+    }
+    return runReplacements(compressor, replacements);
+}
+
+/**
+ * @returns A vector of CandidateSelection constructed from the @p
+ * candidateInfo such that one CandidateSelection is produced for each
+ * associated compressor.
+ */
+std::vector<CandidateSelection> candidatesFromVec(
+        const std::string& name,
+        const std::vector<std::pair<ACECompressor, ACECompressionResult>>&
+                candidateInfo)
+{
+    std::vector<CandidateSelection> candidates;
+    size_t candidateIdx = 0;
+    candidates.reserve(candidateInfo.size());
+    for (const auto& [compressor, result] : candidateInfo) {
+        candidates.emplace_back(name, result, candidateIdx++);
+    }
+    return candidates;
+}
+
+/**
+ * Requires that a choice has been made for every subcompressor in @param
+ * allCandidates for the given @param candidate.
+ * @returns the overall serialized compressor from the choices with ACE
+ * graphs replaced of @param candidate.
+ */
+std::shared_ptr<const std::string_view> makeCombinedCompressor(
+        const CandidateSelection& candidate,
+        const std::function<Compressor()>& makeCompressor,
+        const std::unordered_map<
+                std::string,
+                std::vector<std::pair<ACECompressor, ACECompressionResult>>>&
+                allCandidates)
+{
+    const auto& choices = candidate.choices();
+    if (allCandidates.size() != choices.size()) {
+        throw Exception("A subcompressor was not chosen for every input.");
+    }
+    std::unordered_map<std::string, ACECompressor> replacements;
+    for (const auto& [name, compressorIdx] : choices) {
+        if (allCandidates.count(name) == 0) {
+            throw Exception(
+                    "The candidate has a name not contained in the map of name to subcompressors.");
+        }
+        auto compressor = allCandidates.at(name)[compressorIdx].first;
+        replacements.emplace(name, compressor);
+    }
+    auto compressor = makeCompressor();
+    return runReplacements(compressor, replacements);
+}
+} // namespace
+
+std::vector<CandidateSelection> combineCandidates(
+        const std::vector<std::vector<CandidateSelection>>& candidates,
+        const TrainParams& trainParams)
+{
+    ThreadPool threadPool(trainParams.threads.value_or(
+            std::thread::hardware_concurrency() / 2));
+    size_t count = 0;
+    std::vector<CandidateSelection> currentFrontier;
+    for (auto& candidate : candidates) {
+        Logger::logProgress(
+                INFO,
+                (double)count / candidates.size(),
+                "Computing overall Pareto Frontier: %zu / %zu",
+                count,
+                candidates.size());
+        count++;
+        if (currentFrontier.empty()) {
+            currentFrontier = candidate;
+        } else {
+            currentFrontier = mergeParetoFrontier(
+                    threadPool,
+                    currentFrontier,
+                    candidate,
+                    kNumIntermediateFrontierCandidates);
+        }
+    }
+    return currentFrontier;
+}
+
+std::vector<std::shared_ptr<const std::string_view>> getCombinedCompressors(
+        const std::function<Compressor()>& makeCompressor,
+        const std::unordered_map<
+                std::string,
+                std::vector<std::pair<ACECompressor, ACECompressionResult>>>&
+                allCandidates,
+        const TrainParams& trainParams)
+{
+    if (!trainParams.paretoFrontier) {
+        return { getSmallestCandidate(makeCompressor, allCandidates) };
+    }
+    std::vector<std::vector<CandidateSelection>> candidates;
+    candidates.reserve(allCandidates.size());
+    for (const auto& [name, subCompressors] : allCandidates) {
+        candidates.emplace_back(candidatesFromVec(name, subCompressors));
+    }
+    auto frontier = combineCandidates(candidates, trainParams);
+    /* TODO: Alternative pruning for surfacing candidates to users*/
+    frontier = pruneCandidates(std::move(frontier), kNumFinalParetoCandidates);
+    std::sort(frontier.begin(), frontier.end());
+    std::vector<std::shared_ptr<const std::string_view>> paretoOptimalResults;
+    paretoOptimalResults.reserve(frontier.size());
+    for (auto& candidate : frontier) {
+        paretoOptimalResults.push_back(makeCombinedCompressor(
+                candidate, makeCompressor, allCandidates));
+    }
+    return paretoOptimalResults;
+}
+} // namespace openzl::training

--- a/tools/training/ace/ace_combination.h
+++ b/tools/training/ace/ace_combination.h
@@ -1,0 +1,123 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#pragma once
+
+#include <functional>
+#include <memory>
+#include <unordered_map>
+#include <vector>
+
+#include "openzl/cpp/Compressor.hpp"
+
+#include "tools/training/ace/ace_compressor.h"
+#include "tools/training/train_params.h"
+
+namespace openzl::training {
+
+class CandidateSelection {
+   public:
+    CandidateSelection(
+            const std::string& name,
+            const ACECompressionResult& result,
+            size_t index)
+    {
+        choices_[name] = index;
+        mergedResult_  = result;
+    }
+
+    bool operator<(const CandidateSelection& other) const
+    {
+        return mergedResult_ < other.mergedResult_;
+    }
+
+    /** Returns true if strictly dominates @p other. The fitness parameters in
+     * ACECompressionResult are compared against @p other.
+     */
+    bool dominates(const CandidateSelection& other) const
+    {
+        if (mergedResult_.compressedSize == other.mergedResult_.compressedSize
+            && mergedResult_.compressionTime
+                    == other.mergedResult_.compressionTime
+            && mergedResult_.decompressionTime
+                    == other.mergedResult_.decompressionTime) {
+            return false;
+        }
+        return mergedResult_.compressedSize
+                <= other.mergedResult_.compressedSize
+                && mergedResult_.compressionTime
+                <= other.mergedResult_.compressionTime
+                && mergedResult_.decompressionTime
+                <= other.mergedResult_.decompressionTime;
+    }
+
+    /**
+     * Adds all choices from the candidate @p toMerge to the map as well as
+     * adding the total time taken and compressed size of the associated
+     * sub-compressors
+     */
+    void merge(const CandidateSelection& toMerge)
+    {
+        for (const auto& choice : toMerge.choices_) {
+            if (choices_.count(choice.first) != 0) {
+                throw Exception(
+                        "Subcompressor in candidate to merge has already been chosen");
+            }
+            choices_.emplace(choice);
+        }
+        mergedResult_ += toMerge.mergedResult_;
+    }
+
+    /**
+     * Computes the fitness based on size and times.
+     */
+    std::vector<float> fitness() const
+    {
+        std::vector<float> fitness(3);
+        fitness[0] = mergedResult_.compressedSize;
+        fitness[1] = mergedResult_.compressionTime.count();
+        fitness[2] = mergedResult_.decompressionTime.count();
+        return fitness;
+    }
+
+    std::unordered_map<std::string, size_t> choices() const
+    {
+        return choices_;
+    }
+
+   private:
+    // A mapping from subCompressor name to the index of the
+    // chosen compressor
+    std::unordered_map<std::string, size_t> choices_;
+    // The combined compression ratio/ speeds the
+    // combined compressor is expected to produce
+    ACECompressionResult mergedResult_;
+};
+
+/**
+ * Takes the Pareto Frontier of solutions for all sub-compressor, and produces a
+ * Pareto-optimal vector of solutions for the entire compressor. Returns each
+ * solution as a serialized compressor.
+ *
+ * @param makeCompressor A function used to create new compressors that have
+ * processed dependencies.
+ * @param allCandidates A map of sub-compressor names to the vector of
+ * subcompressors and their benchmarks.
+ * @param trainParams The training parameters to use for the algorithm.
+ */
+std::vector<std::shared_ptr<const std::string_view>> getCombinedCompressors(
+        const std::function<Compressor()>& makeCompressor,
+        const std::unordered_map<
+                std::string,
+                std::vector<std::pair<ACECompressor, ACECompressionResult>>>&
+                allCandidates,
+        const TrainParams& trainParams);
+
+/**
+ * Given a vector of choices for each subcompressor, returns the overall pareto
+ * frontier obtained from choosing one candidate from each subcompressor.
+ */
+std::vector<CandidateSelection> combineCandidates(
+        const std::vector<std::vector<CandidateSelection>>& candidates,
+        const TrainParams& trainParams);
+
+} // namespace openzl::training

--- a/tools/training/tests/BUCK
+++ b/tools/training/tests/BUCK
@@ -9,6 +9,7 @@ cpp_unittest(
     name = "test_training",
     srcs = [
         "test_ace.cpp",
+        "test_ace_combination.cpp",
         "test_clustering.cpp",
         "test_clustering_benchmarks.cpp",
         "test_clustering_config_builder.cpp",

--- a/tools/training/tests/test_ace_combination.cpp
+++ b/tools/training/tests/test_ace_combination.cpp
@@ -1,0 +1,100 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#include <gtest/gtest.h>
+#include <random>
+#include "tools/training/ace/ace_combination.h"
+
+namespace openzl {
+namespace training {
+namespace tests {
+
+class ACECombinationTest : public testing::Test {
+   public:
+    void SetUp() override
+    {
+        candidates_.clear();
+        params_.threads                = 1;
+        std::mt19937::result_type seed = 0;
+        gen_                           = std::mt19937(seed);
+    }
+
+    void setUpRandomFitnessCandidates(
+            size_t numCandidates,
+            size_t numSubcompressors)
+    {
+        candidates_.reserve(numCandidates);
+        for (size_t i = 0; i < numCandidates; ++i) {
+            std::vector<std::vector<size_t>> fitness;
+            fitness.reserve(numSubcompressors);
+            for (size_t j = 0; j < numSubcompressors; ++j) {
+                fitness.push_back(getRandomFitness());
+            }
+            candidates_.push_back(getCandidates(std::to_string(i), fitness));
+        }
+    }
+
+    std::vector<size_t> getRandomFitness()
+    {
+        std::vector<size_t> fitness(3);
+        for (size_t i = 0; i < 3; ++i) {
+            fitness[i] = distribution_(gen_);
+        }
+        return fitness;
+    }
+
+    std::vector<CandidateSelection> getCandidates(
+            const std::string& name,
+            std::vector<std::vector<size_t>> fitness)
+    {
+        std::vector<CandidateSelection> candidates;
+        for (size_t i = 0; i < fitness.size(); ++i) {
+            if (fitness[i].size() != 3) {
+                throw std::runtime_error("Invalid fitness vector size");
+            }
+            ACECompressionResult result;
+            result.compressedSize  = fitness[i][0];
+            result.compressionTime = std::chrono::nanoseconds{ fitness[i][1] };
+            result.decompressionTime =
+                    std::chrono::nanoseconds{ fitness[i][2] };
+            CandidateSelection cs(name, result, i);
+            candidates.push_back(std::move(cs));
+        }
+        return candidates;
+    }
+
+    bool isPareto(std::vector<CandidateSelection> frontier)
+    {
+        for (size_t i = 0; i < frontier.size(); ++i) {
+            for (size_t j = 0; j < frontier.size(); ++j) {
+                if (frontier[i].dominates(frontier[j])) {
+                    return false;
+                }
+            }
+        }
+        return true;
+    }
+
+   protected:
+    TrainParams params_;
+    std::vector<std::vector<CandidateSelection>> candidates_;
+    std::mt19937 gen_;
+    std::uniform_int_distribution<unsigned> distribution_{ 1, 10000 };
+};
+
+TEST_F(ACECombinationTest, CombinationSizeIsLimited)
+{
+    setUpRandomFitnessCandidates(10, 40);
+    auto frontier = combineCandidates(candidates_, params_);
+    EXPECT_LE(frontier.size(), 1000);
+}
+
+TEST_F(ACECombinationTest, ProducesParetoOptimalCombination)
+{
+    setUpRandomFitnessCandidates(10, 40);
+    auto frontier = combineCandidates(candidates_, params_);
+    EXPECT_TRUE(isPareto(frontier));
+}
+
+} // namespace tests
+} // namespace training
+} // namespace openzl


### PR DESCRIPTION
Summary:

Changes the algorithm used to create the pareto frontier. The new algorithm on a high level doing the following:
1. Merges 2 sub-compressors at a time iteratively in a brute force manner. Repeats for all sub-compressors until a full selection is made.
2. During the merging stages - filters out the pareto frontier after merge
3.  Prunes the pareto frontier to ensure there are not too many candidates in the pareto frontier

Stage 1 is provably optimal as the pareto frontier after merging a pareto frontier of size m and size n can be of size mn.

Stage 2 is done in `O(n^2)` time currently which can be improved.

Stage 3 reduces the time complexity appropriately by limiting the sizes of the pareto frontiers operated on. This affects final results generated as it prunes each pareto frontier found iteratively.

Followups:
1. It is clear that the noisy nature of compression and decompression time make the crowding distance metric less valuable. This metric only makes sense on a Pareto frontier and such noise results in slightly degraded final candidates. We should investigate more an alternative.
2. It is expensive to explore the latter stage of pareto frontier generation when earlier stages are non-deterministic and time consuming. We should add a way to load from this stage.
3. We should generate a more meaningful final set of points for the user. This can be done by replacing the final prune stage with an alternative. It may also be useful to provide all the candidates available at the last stage prior to pruning.

Differential Revision: D83378367


