### PR TITLE
SDDL: Add `peek` Instruction

### DIFF
--- a/src/openzl/compress/graphs/simple_data_description_language.c
+++ b/src/openzl/compress/graphs/simple_data_description_language.c
@@ -175,6 +175,8 @@ typedef struct {
 typedef enum {
     ZL_SDDL_OpCode_die,
     ZL_SDDL_OpCode_expect,
+    ZL_SDDL_OpCode_log,
+
     ZL_SDDL_OpCode_consume,
     ZL_SDDL_OpCode_sizeof,
     ZL_SDDL_OpCode_send,
@@ -297,6 +299,8 @@ static const char* ZL_SDDL_OpCode_toString(ZL_SDDL_OpCode opcode)
             return "die";
         case ZL_SDDL_OpCode_expect:
             return "expect";
+        case ZL_SDDL_OpCode_log:
+            return "log";
         case ZL_SDDL_OpCode_consume:
             return "consume";
         case ZL_SDDL_OpCode_sizeof:
@@ -366,28 +370,28 @@ static const char* ZL_SDDL_ExprType_toString(ZL_SDDL_ExprType type)
 
 static void log_expr(const ZL_SDDL_Expr* const expr)
 {
-    ZL_LOG(ALWAYS,
-           "expr %p: type = %s",
-           expr,
-           ZL_SDDL_ExprType_toString(expr->type));
+    ZL_RLOG(ALWAYS,
+            "Logging value of expr %p:\n  type: %s\n",
+            expr,
+            ZL_SDDL_ExprType_toString(expr->type));
     switch (expr->type) {
         case ZL_SDDL_ExprType_null:
             break;
         case ZL_SDDL_ExprType_op:
-            ZL_LOG(ALWAYS, "op = %s", ZL_SDDL_OpCode_toString(expr->op.op));
+            ZL_RLOG(ALWAYS, "  op: %s\n", ZL_SDDL_OpCode_toString(expr->op.op));
             break;
         case ZL_SDDL_ExprType_num:
-            ZL_LOG(ALWAYS, "val = %lld", (long long)expr->num.val);
+            ZL_RLOG(ALWAYS, "  val: %lld\n", (long long)expr->num.val);
             break;
         case ZL_SDDL_ExprType_field:
             break;
         case ZL_SDDL_ExprType_dest:
             break;
         case ZL_SDDL_ExprType_var:
-            ZL_LOG(ALWAYS,
-                   "name = '%.*s'",
-                   expr->var.name.size,
-                   expr->var.name.data);
+            ZL_RLOG(ALWAYS,
+                    "  name: '%.*s'\n",
+                    expr->var.name.size,
+                    expr->var.name.data);
             break;
         case ZL_SDDL_ExprType_scope:
             break;
@@ -470,6 +474,7 @@ static size_t ZL_SDDL_OpCode_numArgs(const ZL_SDDL_OpCode opcode)
         case ZL_SDDL_OpCode_die:
             return 0;
         case ZL_SDDL_OpCode_expect:
+        case ZL_SDDL_OpCode_log:
         case ZL_SDDL_OpCode_consume:
         case ZL_SDDL_OpCode_sizeof:
             return 1;
@@ -984,6 +989,9 @@ static ZL_Report ZL_SDDL_Program_decodeExprType(
     } else if (StringView_eqCStr(&type_sv, "expect")) {
         expr->type  = ZL_SDDL_ExprType_op;
         expr->op.op = ZL_SDDL_OpCode_expect;
+    } else if (StringView_eqCStr(&type_sv, "log")) {
+        expr->type  = ZL_SDDL_ExprType_op;
+        expr->op.op = ZL_SDDL_OpCode_log;
     } else if (StringView_eqCStr(&type_sv, "consume")) {
         expr->type  = ZL_SDDL_ExprType_op;
         expr->op.op = ZL_SDDL_OpCode_consume;
@@ -2440,6 +2448,37 @@ static ZL_RESULT_OF(ZL_SDDL_Expr) ZL_SDDL_State_execExpr_op_inner(
                     0,
                     corruption,
                     "Expect op got 0-valued argument. Failing the parse.");
+            break;
+        }
+        case ZL_SDDL_OpCode_log: {
+            // #ifndef NDEBUG
+
+            log_expr(&args[0]);
+
+            const ZL_RESULT_OF(ZL_SDDL_SourceLocationPrettyString) pstr_res =
+                    ZL_SDDL_SourceLocationPrettyString_create(
+                            ZL_ERR_CTX_PTR,
+                            state->arena,
+                            &state->prog->source_code,
+                            &state->cur_src_loc,
+                            2);
+
+            ZL_ASSERT(
+                    !ZL_RES_isError(pstr_res),
+                    "Error in ZL_SDDL_SourceLocationPrettyString_create(): %s",
+                    ZL_E_str(ZL_RES_error(pstr_res)));
+
+            if (!ZL_RES_isError(pstr_res)) {
+                const ZL_SDDL_SourceLocationPrettyString pstr =
+                        ZL_RES_value(pstr_res);
+                if (pstr.str.data != NULL) {
+                    ZL_RLOG(ALWAYS, "at %.*s", pstr.str.size, pstr.str.data);
+                }
+
+                ZL_SDDL_SourceLocationPrettyString_destroy(state->arena, &pstr);
+            }
+            // #endif
+            result = args[0];
             break;
         }
         case ZL_SDDL_OpCode_consume: {

--- a/src/openzl/compress/graphs/simple_data_description_language.c
+++ b/src/openzl/compress/graphs/simple_data_description_language.c
@@ -185,6 +185,8 @@ typedef enum {
 
     ZL_SDDL_OpCode_bind,
 
+    ZL_SDDL_OpCode_while,
+
     // Unary arithmetic operations
     ZL_SDDL_OpCode_neg,
 
@@ -313,6 +315,8 @@ static const char* ZL_SDDL_OpCode_toString(ZL_SDDL_OpCode opcode)
             return "member";
         case ZL_SDDL_OpCode_bind:
             return "bind";
+        case ZL_SDDL_OpCode_while:
+            return "while";
         case ZL_SDDL_OpCode_neg:
             return "neg";
         case ZL_SDDL_OpCode_eq:
@@ -482,6 +486,7 @@ static size_t ZL_SDDL_OpCode_numArgs(const ZL_SDDL_OpCode opcode)
         case ZL_SDDL_OpCode_assign:
         case ZL_SDDL_OpCode_member:
         case ZL_SDDL_OpCode_bind:
+        case ZL_SDDL_OpCode_while:
             return 2;
         case ZL_SDDL_OpCode_neg:
             return 1;
@@ -1010,6 +1015,9 @@ static ZL_Report ZL_SDDL_Program_decodeExprType(
     } else if (StringView_eqCStr(&type_sv, "bind")) {
         expr->type  = ZL_SDDL_ExprType_op;
         expr->op.op = ZL_SDDL_OpCode_bind;
+    } else if (StringView_eqCStr(&type_sv, "while")) {
+        expr->type  = ZL_SDDL_ExprType_op;
+        expr->op.op = ZL_SDDL_OpCode_while;
     } else if (StringView_eqCStr(&type_sv, "neg")) {
         expr->type  = ZL_SDDL_ExprType_op;
         expr->op.op = ZL_SDDL_OpCode_neg;
@@ -2535,6 +2543,9 @@ static ZL_RESULT_OF(ZL_SDDL_Expr) ZL_SDDL_State_execExpr_op_inner(
                             state, scope, &args[0], &args[1]));
             break;
         }
+        case ZL_SDDL_OpCode_while:
+            ZL_ERR(GENERIC,
+                   "Should be unreachable; 'while' op handled elsewhere.");
         case ZL_SDDL_OpCode_neg: {
             ZL_ERR_IF_NE(args[0].type, ZL_SDDL_ExprType_num, corruption);
             result = ZL_SDDL_Expr_makeNum(-args[0].num.val);
@@ -2620,12 +2631,55 @@ static ZL_RESULT_OF(ZL_SDDL_Expr) ZL_SDDL_State_execExpr_op_inner(
     return ZL_WRAP_VALUE(result);
 }
 
+static ZL_RESULT_OF(ZL_SDDL_Expr) ZL_SDDL_State_execExpr_while(
+        ZL_SDDL_State* const state,
+        ZL_SDDL_Scope* const scope,
+        const ZL_SDDL_Op* const op)
+{
+    ZL_RESULT_DECLARE_SCOPE(ZL_SDDL_Expr, state->opCtx);
+
+    const ZL_SDDL_Expr* const cond_expr = op->args[0];
+    const ZL_SDDL_Expr* const body_expr = op->args[1];
+
+    ZL_ERR_IF_NULL(cond_expr, corruption);
+    ZL_ERR_IF_NULL(body_expr, corruption);
+    ZL_ERR_IF_NE(body_expr->type, ZL_SDDL_ExprType_tuple, corruption);
+
+    while (true) {
+        ZL_TRY_LET(
+                ZL_SDDL_Expr,
+                cond_eval,
+                ZL_SDDL_State_execExpr(state, scope, cond_expr));
+        ZL_ERR_IF_NE(cond_eval.type, ZL_SDDL_ExprType_num, corruption);
+        const ZL_SDDL_IntT cond_val = cond_eval.num.val;
+        ZL_SDDL_Expr_decref(state, &cond_eval);
+        if (cond_val == 0) {
+            break;
+        }
+
+        for (size_t i = 0; i < body_expr->tuple.num_exprs; i++) {
+            ZL_TRY_LET(
+                    ZL_SDDL_Expr,
+                    body_eval,
+                    ZL_SDDL_State_execExpr(
+                            state, scope, &body_expr->tuple.exprs[i]));
+            ZL_SDDL_Expr_decref(state, &body_eval);
+        }
+    }
+
+    return ZL_WRAP_VALUE(ZL_SDDL_Expr_makeNull());
+}
+
 static ZL_RESULT_OF(ZL_SDDL_Expr) ZL_SDDL_State_execExpr_op(
         ZL_SDDL_State* const state,
         ZL_SDDL_Scope* const scope,
         const ZL_SDDL_Op* const op)
 {
     ZL_RESULT_DECLARE_SCOPE(ZL_SDDL_Expr, state->opCtx);
+
+    if (op->op == ZL_SDDL_OpCode_while) {
+        return ZL_SDDL_State_execExpr_while(state, scope, op);
+    }
 
     const size_t num_args = ZL_SDDL_OpCode_numArgs(op->op);
     ZL_SDDL_Expr args[ZL_SDDL_OP_ARG_COUNT];

--- a/src/openzl/compress/graphs/simple_data_description_language.c
+++ b/src/openzl/compress/graphs/simple_data_description_language.c
@@ -1789,6 +1789,11 @@ static ZL_RESULT_OF(ZL_SDDL_Expr) ZL_SDDL_State_execExpr(
         const ZL_SDDL_Expr* const expr);
 
 // Forward declaration
+static ZL_RESULT_OF(ZL_SDDL_Expr) ZL_SDDL_State_consume(
+        ZL_SDDL_State* const state,
+        const ZL_SDDL_Expr* const expr);
+
+// Forward declaration
 static ZL_RESULT_OF(ZL_SDDL_Expr) ZL_SDDL_State_consumeField(
         ZL_SDDL_State* const state,
         const ZL_SDDL_Field* const field);
@@ -2139,44 +2144,51 @@ static ZL_RESULT_OF(ZL_SDDL_Expr) ZL_SDDL_State_consumeArray(
     ZL_ERR_IF_NULL(dyn, GENERIC);
     const ZL_SDDL_Expr* const inner_expr = &dyn->exprs[0];
     const ZL_SDDL_Expr* const len_expr   = &dyn->exprs[1];
-    ZL_ERR_IF_NE(inner_expr->type, ZL_SDDL_ExprType_field, corruption);
+    ZL_ERR_IF(
+            inner_expr->type != ZL_SDDL_ExprType_field
+                    && inner_expr->type != ZL_SDDL_ExprType_func,
+            corruption);
     ZL_ERR_IF_NE(len_expr->type, ZL_SDDL_ExprType_num, corruption);
     ZL_ERR_IF_LT(len_expr->num.val, 0, corruption);
     const size_t len = (size_t)len_expr->num.val;
 
-    if (inner_expr->field.type == ZL_SDDL_FieldType_atom) {
-        // Optimization
-        return ZL_SDDL_State_consumeArray_ofAtoms(
-                state, &inner_expr->field.atom, len);
-    }
-
-    if (inner_expr->field.type == ZL_SDDL_FieldType_record && len > 1) {
-        // Optimization
-        ZL_ERR_IF_ERR(ZL_SDDL_State_consumeRecord_noScope(
-                state, &inner_expr->field.record, true));
-
-        const size_t instr_count = inner_expr->field.record.dyn->instrs->count;
-
-        // As an optimization, these reserves are allowed to fail.
-        (void)VECTOR_RESERVE(
-                state->segment_sizes,
-                VECTOR_SIZE(state->segment_sizes) + instr_count * (len - 1));
-        (void)VECTOR_RESERVE(
-                state->segment_tags,
-                VECTOR_SIZE(state->segment_tags) + instr_count * (len - 1));
-
-        for (size_t i = 1; i < len; i++) {
-            ZL_ERR_IF_ERR(ZL_SDDL_State_consumeRecord_noScope(
-                    state, &inner_expr->field.record, false));
+    if (inner_expr->type == ZL_SDDL_ExprType_field) {
+        if (inner_expr->field.type == ZL_SDDL_FieldType_atom) {
+            // Optimization
+            return ZL_SDDL_State_consumeArray_ofAtoms(
+                    state, &inner_expr->field.atom, len);
         }
-        return ZL_WRAP_VALUE(ZL_SDDL_Expr_makeNull());
+
+        if (inner_expr->field.type == ZL_SDDL_FieldType_record && len > 1) {
+            // Optimization
+            ZL_ERR_IF_ERR(ZL_SDDL_State_consumeRecord_noScope(
+                    state, &inner_expr->field.record, true));
+
+            const size_t instr_count =
+                    inner_expr->field.record.dyn->instrs->count;
+
+            // As an optimization, these reserves are allowed to fail.
+            (void)VECTOR_RESERVE(
+                    state->segment_sizes,
+                    VECTOR_SIZE(state->segment_sizes)
+                            + instr_count * (len - 1));
+            (void)VECTOR_RESERVE(
+                    state->segment_tags,
+                    VECTOR_SIZE(state->segment_tags) + instr_count * (len - 1));
+
+            for (size_t i = 1; i < len; i++) {
+                ZL_ERR_IF_ERR(ZL_SDDL_State_consumeRecord_noScope(
+                        state, &inner_expr->field.record, false));
+            }
+            return ZL_WRAP_VALUE(ZL_SDDL_Expr_makeNull());
+        }
     }
 
     for (size_t i = 0; i < len; i++) {
         ZL_TRY_LET(
                 ZL_SDDL_Expr,
                 field_result,
-                ZL_SDDL_State_consumeField(state, &inner_expr->field));
+                ZL_SDDL_State_consume(state, inner_expr));
         ZL_SDDL_Expr_decref(state, &field_result);
     }
     return ZL_WRAP_VALUE(ZL_SDDL_Expr_makeNull());

--- a/src/openzl/compress/graphs/simple_data_description_language.c
+++ b/src/openzl/compress/graphs/simple_data_description_language.c
@@ -178,6 +178,7 @@ typedef enum {
     ZL_SDDL_OpCode_log,
 
     ZL_SDDL_OpCode_consume,
+    ZL_SDDL_OpCode_peek,
     ZL_SDDL_OpCode_sizeof,
     ZL_SDDL_OpCode_send,
     ZL_SDDL_OpCode_assign,
@@ -305,6 +306,8 @@ static const char* ZL_SDDL_OpCode_toString(ZL_SDDL_OpCode opcode)
             return "log";
         case ZL_SDDL_OpCode_consume:
             return "consume";
+        case ZL_SDDL_OpCode_peek:
+            return "peek";
         case ZL_SDDL_OpCode_sizeof:
             return "sizeof";
         case ZL_SDDL_OpCode_send:
@@ -480,6 +483,7 @@ static size_t ZL_SDDL_OpCode_numArgs(const ZL_SDDL_OpCode opcode)
         case ZL_SDDL_OpCode_expect:
         case ZL_SDDL_OpCode_log:
         case ZL_SDDL_OpCode_consume:
+        case ZL_SDDL_OpCode_peek:
         case ZL_SDDL_OpCode_sizeof:
             return 1;
         case ZL_SDDL_OpCode_send:
@@ -1000,6 +1004,9 @@ static ZL_Report ZL_SDDL_Program_decodeExprType(
     } else if (StringView_eqCStr(&type_sv, "consume")) {
         expr->type  = ZL_SDDL_ExprType_op;
         expr->op.op = ZL_SDDL_OpCode_consume;
+    } else if (StringView_eqCStr(&type_sv, "peek")) {
+        expr->type  = ZL_SDDL_ExprType_op;
+        expr->op.op = ZL_SDDL_OpCode_peek;
     } else if (StringView_eqCStr(&type_sv, "sizeof")) {
         expr->type  = ZL_SDDL_ExprType_op;
         expr->op.op = ZL_SDDL_OpCode_sizeof;
@@ -2494,6 +2501,17 @@ static ZL_RESULT_OF(ZL_SDDL_Expr) ZL_SDDL_State_execExpr_op_inner(
                     ZL_SDDL_Expr,
                     result,
                     ZL_SDDL_State_consume(state, &args[0]));
+            break;
+        }
+        case ZL_SDDL_OpCode_peek: {
+            ZL_ERR_IF_NE(args[0].type, ZL_SDDL_ExprType_field, corruption);
+            // TODO: extend peeking to compound types??
+            ZL_ERR_IF_NE(
+                    args[0].field.type, ZL_SDDL_FieldType_atom, corruption);
+            const ZL_SDDL_Field_Atom* const atom = &args[0].field.atom;
+            const size_t width                   = atom->width;
+            ZL_ERR_IF_GT(state->pos + width, state->size, srcSize_tooSmall);
+            result = ZL_SDDL_State_readAtom(state, atom);
             break;
         }
         case ZL_SDDL_OpCode_sizeof: {

--- a/src/openzl/compress/graphs/simple_data_description_language.c
+++ b/src/openzl/compress/graphs/simple_data_description_language.c
@@ -2748,6 +2748,9 @@ static ZL_RESULT_OF(ZL_SDDL_Expr) ZL_SDDL_State_execExpr_var(
         return ZL_WRAP_VALUE(ZL_SDDL_Expr_makeNum(
                 (ZL_SDDL_IntT)state->size - (ZL_SDDL_IntT)state->pos));
     }
+    if (StringView_eqCStr(&var->name, "_pos")) {
+        return ZL_WRAP_VALUE(ZL_SDDL_Expr_makeNum((ZL_SDDL_IntT)state->pos));
+    }
 
     return ZL_SDDL_Scope_get(state, scope, var);
 }

--- a/src/openzl/compress/graphs/simple_data_description_language.h
+++ b/src/openzl/compress/graphs/simple_data_description_language.h
@@ -55,6 +55,7 @@ ZL_BEGIN_C_DECLS
  * +---------+-----------+
  * | die     | Op        |
  * | expect  | Op        |
+ * | log     | Op        |
  * | consume | Op        |
  * | sizeof  | Op        |
  * | send    | Op        |
@@ -97,6 +98,7 @@ ZL_BEGIN_C_DECLS
  * +---------+------+------+-----+-------+--------
  * | die     | 0    | N    |     |       | Unconditionally fail
  * | expect  | 1    | N    | IV  |       | Fail the parse if arg is 0
+ * | log     | 1    | *    | *   |       | Logs the arg to stderr for debug
  * | consume | 1    | INS  | FV  |       | Consumes a field, see below
  * | sizeof  | 1    | I    | FV  |       | (Recursize) size of given field
  * | send    | 2    | F    | FV  | DV    | New field assoc'ed w/ dest

--- a/src/openzl/compress/graphs/simple_data_description_language.h
+++ b/src/openzl/compress/graphs/simple_data_description_language.h
@@ -192,6 +192,14 @@ ZL_BEGIN_C_DECLS
  * context other than as the left-hand argument to the assignment operator, it
  * resolves to the expression that was most recently assigned into that var.
  *
+ * There are some built-in variables which can be read but which can't be
+ * assigned to:
+ *
+ * | Variable | Type | Evaluates To           |
+ * +----------+------+------------------------+
+ * | `_pos`   | Int  | Bytes consumed so far. |
+ * | `_rem`   | Int  | Bytes remaining.       |
+ *
  * ### Tuple:
  *
  * A Tuple expression is just a list of expressions, used by the bind op to

--- a/src/openzl/shared/a1cbor.h
+++ b/src/openzl/shared/a1cbor.h
@@ -220,7 +220,7 @@ void A1C_LimitedArena_reset(A1C_LimitedArena* limitedArena);
 // Decoder
 ////////////////////////////////////////
 
-#define A1C_MAX_DEPTH_DEFAULT 32
+#define A1C_MAX_DEPTH_DEFAULT 128
 
 typedef struct {
     /**

--- a/tests/codecs/test_sddl.cpp
+++ b/tests/codecs/test_sddl.cpp
@@ -495,6 +495,136 @@ TEST_F(SimpleDataDescriptionLanguageTest, consumeFloats)
     roundtrip(prog, input);
 }
 
+TEST_F(SimpleDataDescriptionLanguageTest, peekVals)
+{
+    const auto prog  = R"(
+        B = Byte
+        I1L = Int8
+        I1B = Int8
+        U1L = UInt8
+        U1B = UInt8
+        I2L = Int16LE
+        I2B = Int16BE
+        U2L = UInt16LE
+        U2B = UInt16BE
+        I4L = Int32LE
+        I4B = Int32BE
+        U4L = UInt32LE
+        U4B = UInt32BE
+        I8L = Int64LE
+        I8B = Int64BE
+        U8L = UInt64LE
+        U8B = UInt64BE
+
+        expect (*B) == 1
+        expect (:B) == 1
+        expect (*B) == 254
+        expect (:B) == 254
+
+        expect (*I1L) == 1
+        expect (:I1L) == 1
+        expect (*I1L) == -2
+        expect (:I1L) == -2
+        expect (*I1B) == 1
+        expect (:I1B) == 1
+        expect (*I1B) == -2
+        expect (:I1B) == -2
+        expect (*U1L) == 1
+        expect (:U1L) == 1
+        expect (*U1L) == 239
+        expect (:U1L) == 239
+        expect (*U1B) == 1
+        expect (:U1B) == 1
+        expect (*U1B) == 239
+        expect (:U1B) == 239
+        expect (*I2L) == 291
+        expect (:I2L) == 291
+        expect (*I2L) == -292
+        expect (:I2L) == -292
+        expect (*I2B) == 291
+        expect (:I2B) == 291
+        expect (*I2B) == -292
+        expect (:I2B) == -292
+        expect (*U2L) == 291
+        expect (:U2L) == 291
+        expect (*U2L) == 61389
+        expect (:U2L) == 61389
+        expect (*U2B) == 291
+        expect (:U2B) == 291
+        expect (*U2B) == 61389
+        expect (:U2B) == 61389
+        expect (*I4L) == 19088743
+        expect (:I4L) == 19088743
+        expect (*I4L) == -19088744
+        expect (:I4L) == -19088744
+        expect (*I4B) == 19088743
+        expect (:I4B) == 19088743
+        expect (*I4B) == -19088744
+        expect (:I4B) == -19088744
+        expect (*U4L) == 19088743
+        expect (:U4L) == 19088743
+        expect (*U4L) == 4023233417
+        expect (:U4L) == 4023233417
+        expect (*U4B) == 19088743
+        expect (:U4B) == 19088743
+        expect (*U4B) == 4023233417
+        expect (:U4B) == 4023233417
+        expect (*I8L) == 81985529216486895
+        expect (:I8L) == 81985529216486895
+        expect (*I8L) == -81985529216486896
+        expect (:I8L) == -81985529216486896
+        expect (*I8B) == 81985529216486895
+        expect (:I8B) == 81985529216486895
+        expect (*I8B) == -81985529216486896
+        expect (:I8B) == -81985529216486896
+        expect (*U8L) == 81985529216486895
+        expect (:U8L) == 81985529216486895
+        expect (*U8L) == 8056283915067138817
+        expect (:U8L) == 8056283915067138817
+        expect (*U8B) == 81985529216486895
+        expect (:U8B) == 81985529216486895
+        expect (*U8B) == 8056283915067138817
+        expect (:U8B) == 8056283915067138817
+    )";
+    const auto input = std::string{
+        "\x01"
+        "\xfe"
+        "\x01"
+        "\xfe"
+        "\x01"
+        "\xfe"
+        "\x01"
+        "\xef"
+        "\x01"
+        "\xef"
+        "\x23\x01"
+        "\xdc\xfe"
+        "\x01\x23"
+        "\xfe\xdc"
+        "\x23\x01"
+        "\xcd\xef"
+        "\x01\x23"
+        "\xef\xcd"
+        "\x67\x45\x23\x01"
+        "\x98\xba\xdc\xfe"
+        "\x01\x23\x45\x67"
+        "\xfe\xdc\xba\x98"
+        "\x67\x45\x23\x01"
+        "\x89\xab\xcd\xef"
+        "\x01\x23\x45\x67"
+        "\xef\xcd\xab\x89"
+        "\xef\xcd\xab\x89\x67\x45\x23\x01"
+        "\x10\x32\x54\x76\x98\xba\xdc\xfe"
+        "\x01\x23\x45\x67\x89\xab\xcd\xef"
+        "\xfe\xdc\xba\x98\x76\x54\x32\x10"
+        "\xef\xcd\xab\x89\x67\x45\x23\x01"
+        "\x01\x23\x45\x67\x89\xab\xcd\x6f"
+        "\x01\x23\x45\x67\x89\xab\xcd\xef"
+        "\x6f\xcd\xab\x89\x67\x45\x23\x01"
+    };
+    roundtrip(prog, input);
+}
+
 TEST_F(SimpleDataDescriptionLanguageTest, arithmetic)
 {
     const auto prog  = R"(

--- a/tools/sddl/compiler/AST.cpp
+++ b/tools/sddl/compiler/AST.cpp
@@ -663,10 +663,45 @@ ASTVec ASTTuple::extract_exprs(
         throw InvariantViolation(
                 loc, "Tuple declaration must be given a list as argument.");
     }
-    if (list->list_type() != ListType::PAREN) {
-        throw InvariantViolation(
-                loc, "Tuple declaration argument list must be curly-braced.");
-    }
     return unwrap_parens(list->nodes());
+}
+
+ASTWhile::ASTWhile(ASTPtr cond, ASTPtr body)
+        : ASTConverted(maybe_loc(cond) + maybe_loc(body)),
+          cond_(std::move(cond)),
+          body_(std::move(body))
+{
+}
+
+void ASTWhile::print(std::ostream& os, size_t indent) const
+{
+    os << std::string(indent, ' ') << "While:" << std::endl;
+    os << std::string(indent + 2, ' ') << "Cond:" << std::endl;
+    some(cond_).print(os, indent + 4);
+    os << std::string(indent + 2, ' ') << "Body:" << std::endl;
+    some(body_).print(os, indent + 4);
+}
+
+A1C_Item ASTWhile::serialize(const SerializationOptions& opts) const
+{
+    auto* const arena = opts.arena;
+    A1C_Item map;
+    const auto builder = A1C_Item_map_builder(&map, 2, arena);
+    auto* const pair   = A1C_MapBuilder_add(builder);
+    if (pair == nullptr) {
+        throw SerializationError(loc(), "Failed to allocate A1C_Item map.");
+    }
+    A1C_Item_string_refCStr(&pair->key, "while");
+
+    auto* const val_items = A1C_Item_array(&pair->val, 2, arena);
+    if (val_items == nullptr) {
+        throw SerializationError(loc(), "Failed to allocate A1C_Item array.");
+    }
+
+    val_items[0] = some(cond_).serialize(opts);
+    val_items[1] = some(body_).serialize(opts);
+
+    add_debug_info(*this, opts, builder);
+    return map;
 }
 } // namespace openzl::sddl

--- a/tools/sddl/compiler/AST.h
+++ b/tools/sddl/compiler/AST.h
@@ -280,4 +280,17 @@ class ASTTuple : public ASTConverted {
     const ASTVec tuple_;
 };
 
+class ASTWhile : public ASTConverted {
+   public:
+    explicit ASTWhile(ASTPtr cond, ASTPtr body);
+
+    void print(std::ostream& os, size_t indent) const override;
+
+    A1C_Item serialize(const SerializationOptions& opts) const override;
+
+   private:
+    const ASTPtr cond_;
+    const ASTPtr body_;
+};
+
 } // namespace openzl::sddl

--- a/tools/sddl/compiler/Grammar.cpp
+++ b/tools/sddl/compiler/Grammar.cpp
@@ -824,6 +824,18 @@ class NegationRule : public UnaryOpRule {
     }
 };
 
+class PeekRule : public UnaryOpRule {
+   public:
+    explicit PeekRule() : UnaryOpRule(Symbol::MUL, Precedence::UNARY) {}
+
+    ASTPtr do_gen(ASTPtr op, ASTPtr, ASTPtr rhs) const override
+    {
+        ASTVec args{ std::move(rhs) };
+        return std::make_shared<ASTOp>(
+                Token{ some(op).loc(), Symbol::PEEK }, std::move(args));
+    }
+};
+
 class BindRule : public OpRule {
    public:
     explicit BindRule()
@@ -891,6 +903,7 @@ const std::vector<std::unique_ptr<const GrammarRule>> grammar_rules{ []() {
     add_rule<UnaryOpRule>(r, Symbol::LOG);
 
     add_rule<UnaryOpRule>(r, Symbol::CONSUME);
+    add_rule<PeekRule>(r);
     add_rule<UnaryOpRule>(r, Symbol::SIZEOF);
 
     add_rule<WhileRule>(r);

--- a/tools/sddl/compiler/Grammar.cpp
+++ b/tools/sddl/compiler/Grammar.cpp
@@ -47,12 +47,14 @@ constexpr Associativity LTR = Associativity::LEFT_TO_RIGHT;
 constexpr Associativity RTL = Associativity::RIGHT_TO_LEFT;
 
 const std::map<Precedence, Associativity> associativities{
+    { Precedence::CONTROL_FLOW, LTR },
+
     { Precedence::ACCESS, LTR },
 
-    { Precedence::UNARY, RTL },       { Precedence::NULLARY, LTR },
+    { Precedence::UNARY, RTL },        { Precedence::NULLARY, LTR },
 
-    { Precedence::MUL_DIV_MOD, LTR }, { Precedence::ADD_SUB, LTR },
-    { Precedence::RELATION, LTR },    { Precedence::EQUALITY, LTR },
+    { Precedence::MUL_DIV_MOD, LTR },  { Precedence::ADD_SUB, LTR },
+    { Precedence::RELATION, LTR },     { Precedence::EQUALITY, LTR },
 
     { Precedence::ASSIGNMENT, RTL },
 };
@@ -70,6 +72,8 @@ std::string enum_to_str_of_int(T e)
 }
 
 const std::map<Precedence, std::string> precedences_to_strs{
+    { Precedence::CONTROL_FLOW,
+      "CONTROL_FLOW(" + enum_to_str_of_int(Precedence::CONTROL_FLOW) + ")" },
     { Precedence::UNARY,
       "UNARY(" + enum_to_str_of_int(Precedence::UNARY) + ")" },
     { Precedence::NULLARY,
@@ -735,9 +739,32 @@ class UnaryOpRule : public OpRule {
 
 class BinaryOpRule : public OpRule {
    public:
-    explicit BinaryOpRule(Symbol op, Precedence precedence)
-            : OpRule(op, precedence, ArgType::EXPR, ArgType::EXPR)
+    explicit BinaryOpRule(
+            Symbol op,
+            Precedence precedence,
+            ArgType lhs_type = ArgType::EXPR,
+            ArgType rhs_type = ArgType::EXPR)
+            : OpRule(op, precedence, lhs_type, rhs_type)
     {
+    }
+};
+
+class WhileRule : public BinaryOpRule {
+   public:
+    explicit WhileRule()
+            : BinaryOpRule(
+                      Symbol::WHILE,
+                      Precedence::CONTROL_FLOW,
+                      ArgType::LIST_CURLY,
+                      ArgType::LIST_PAREN)
+    {
+    }
+
+    ASTPtr do_gen(ASTPtr op, ASTPtr lhs, ASTPtr rhs) const override
+    {
+        auto cond = unwrap_parens(std::move(rhs));
+        auto body = std::make_shared<ASTTuple>(std::move(lhs));
+        return std::make_shared<ASTWhile>(std::move(cond), std::move(body));
     }
 };
 
@@ -865,6 +892,8 @@ const std::vector<std::unique_ptr<const GrammarRule>> grammar_rules{ []() {
 
     add_rule<UnaryOpRule>(r, Symbol::CONSUME);
     add_rule<UnaryOpRule>(r, Symbol::SIZEOF);
+
+    add_rule<WhileRule>(r);
 
     add_rule<NegationRule>(r);
 

--- a/tools/sddl/compiler/Grammar.cpp
+++ b/tools/sddl/compiler/Grammar.cpp
@@ -861,6 +861,8 @@ const std::vector<std::unique_ptr<const GrammarRule>> grammar_rules{ []() {
     add_rule<NullaryOpRule>(r, Symbol::DIE);
 
     add_rule<UnaryOpRule>(r, Symbol::EXPECT, Precedence::ASSIGNMENT);
+    add_rule<UnaryOpRule>(r, Symbol::LOG);
+
     add_rule<UnaryOpRule>(r, Symbol::CONSUME);
     add_rule<UnaryOpRule>(r, Symbol::SIZEOF);
 

--- a/tools/sddl/compiler/Grammar.h
+++ b/tools/sddl/compiler/Grammar.h
@@ -18,6 +18,8 @@ namespace openzl::sddl {
  */
 
 enum class Precedence : size_t {
+    CONTROL_FLOW,
+
     NULLARY,
 
     ACCESS,

--- a/tools/sddl/compiler/Syntax.cpp
+++ b/tools/sddl/compiler/Syntax.cpp
@@ -66,6 +66,7 @@ static const std::map<Symbol, SymbolType> sym_types{
     { Symbol::LOG, SymbolType::OPERATOR },
 
     { Symbol::CONSUME, SymbolType::OPERATOR },
+    { Symbol::PEEK, SymbolType::OPERATOR },
     { Symbol::SIZEOF, SymbolType::OPERATOR },
     { Symbol::SEND, SymbolType::OPERATOR },
     { Symbol::ASSIGN, SymbolType::OPERATOR },
@@ -154,6 +155,7 @@ static const std::map<Symbol, poly::string_view> syms_to_debug_strs{
     { Symbol::LOG, "LOG" },
 
     { Symbol::CONSUME, "CONSUME" },
+    { Symbol::CONSUME, "PEEK" },
     { Symbol::SIZEOF, "SIZEOF" },
     { Symbol::SEND, "SEND" },
     { Symbol::ASSIGN, "ASSIGN" },
@@ -293,10 +295,10 @@ const std::vector<std::pair<poly::string_view, Symbol>> strs_to_syms{
 /* These symbols can't actually be accessed via these names. */
 static const std::vector<std::pair<poly::string_view, Symbol>>
         addl_strs_to_syms{
-            { "\\n", Symbol::NL },        { "Atom", Symbol::ATOM },
-            { "Record", Symbol::RECORD }, { "Array", Symbol::ARRAY },
-            { "Dest", Symbol::DEST },     { "bind", Symbol::BIND },
-            { "-", Symbol::NEG },
+            { "\\n", Symbol::NL },      { "*", Symbol::PEEK },
+            { "Atom", Symbol::ATOM },   { "Record", Symbol::RECORD },
+            { "Array", Symbol::ARRAY }, { "Dest", Symbol::DEST },
+            { "bind", Symbol::BIND },   { "-", Symbol::NEG },
         };
 
 static const std::map<Symbol, poly::string_view> syms_to_repr_strs{ []() {
@@ -332,11 +334,11 @@ static const std::map<Symbol, poly::string_view> syms_to_ser_strs{
     { Symbol::DIE, "die" },         { Symbol::EXPECT, "expect" },
     { Symbol::LOG, "log" },
 
-    { Symbol::CONSUME, "consume" }, { Symbol::SIZEOF, "sizeof" },
-    { Symbol::SEND, "send" },       { Symbol::ASSIGN, "assign" },
-    { Symbol::ASSUME, "assume" },   { Symbol::MEMBER, "member" },
-    { Symbol::BIND, "bind" },       { Symbol::WHILE, "while" },
-    { Symbol::NEG, "neg" },
+    { Symbol::CONSUME, "consume" }, { Symbol::PEEK, "peek" },
+    { Symbol::SIZEOF, "sizeof" },   { Symbol::SEND, "send" },
+    { Symbol::ASSIGN, "assign" },   { Symbol::ASSUME, "assume" },
+    { Symbol::MEMBER, "member" },   { Symbol::BIND, "bind" },
+    { Symbol::WHILE, "while" },     { Symbol::NEG, "neg" },
 
     { Symbol::BYTE, "byte" },       { Symbol::U8, "u1" },
     { Symbol::I8, "i1" },           { Symbol::U16LE, "u2l" },

--- a/tools/sddl/compiler/Syntax.cpp
+++ b/tools/sddl/compiler/Syntax.cpp
@@ -72,6 +72,7 @@ static const std::map<Symbol, SymbolType> sym_types{
     { Symbol::ASSUME, SymbolType::OPERATOR },
     { Symbol::MEMBER, SymbolType::OPERATOR },
     { Symbol::BIND, SymbolType::OPERATOR },
+    { Symbol::WHILE, SymbolType::OPERATOR },
 
     { Symbol::NEG, SymbolType::OPERATOR },
 
@@ -160,6 +161,7 @@ static const std::map<Symbol, poly::string_view> syms_to_debug_strs{
     { Symbol::ASSUME, "ASSUME" },
     { Symbol::MEMBER, "MEMBER" },
     { Symbol::BIND, "BIND" },
+    { Symbol::WHILE, "WHILE" },
 
     { Symbol::NEG, "NEG" },
 
@@ -255,6 +257,7 @@ const std::vector<std::pair<poly::string_view, Symbol>> strs_to_syms{
     { "consume", Symbol::CONSUME },
     { "sizeof", Symbol::SIZEOF },
     { "sendto", Symbol::SEND },
+    { "while", Symbol::WHILE },
     { "Byte", Symbol::BYTE },
     { "UInt8", Symbol::U8 },
     { "Int8", Symbol::I8 },
@@ -332,7 +335,8 @@ static const std::map<Symbol, poly::string_view> syms_to_ser_strs{
     { Symbol::CONSUME, "consume" }, { Symbol::SIZEOF, "sizeof" },
     { Symbol::SEND, "send" },       { Symbol::ASSIGN, "assign" },
     { Symbol::ASSUME, "assume" },   { Symbol::MEMBER, "member" },
-    { Symbol::BIND, "bind" },       { Symbol::NEG, "neg" },
+    { Symbol::BIND, "bind" },       { Symbol::WHILE, "while" },
+    { Symbol::NEG, "neg" },
 
     { Symbol::BYTE, "byte" },       { Symbol::U8, "u1" },
     { Symbol::I8, "i1" },           { Symbol::U16LE, "u2l" },

--- a/tools/sddl/compiler/Syntax.cpp
+++ b/tools/sddl/compiler/Syntax.cpp
@@ -63,6 +63,8 @@ static const std::map<Symbol, SymbolType> sym_types{
 
     { Symbol::DIE, SymbolType::OPERATOR },
     { Symbol::EXPECT, SymbolType::OPERATOR },
+    { Symbol::LOG, SymbolType::OPERATOR },
+
     { Symbol::CONSUME, SymbolType::OPERATOR },
     { Symbol::SIZEOF, SymbolType::OPERATOR },
     { Symbol::SEND, SymbolType::OPERATOR },
@@ -148,6 +150,8 @@ static const std::map<Symbol, poly::string_view> syms_to_debug_strs{
 
     { Symbol::DIE, "DIE" },
     { Symbol::EXPECT, "EXPECT" },
+    { Symbol::LOG, "LOG" },
+
     { Symbol::CONSUME, "CONSUME" },
     { Symbol::SIZEOF, "SIZEOF" },
     { Symbol::SEND, "SEND" },
@@ -247,6 +251,7 @@ const std::vector<std::pair<poly::string_view, Symbol>> strs_to_syms{
     { ".", Symbol::MEMBER },
     { "die", Symbol::DIE },
     { "expect", Symbol::EXPECT },
+    { "log", Symbol::LOG },
     { "consume", Symbol::CONSUME },
     { "sizeof", Symbol::SIZEOF },
     { "sendto", Symbol::SEND },
@@ -322,6 +327,8 @@ static const std::map<Symbol, poly::string_view> syms_to_ser_strs{
     { Symbol::MOD, "mod" },
 
     { Symbol::DIE, "die" },         { Symbol::EXPECT, "expect" },
+    { Symbol::LOG, "log" },
+
     { Symbol::CONSUME, "consume" }, { Symbol::SIZEOF, "sizeof" },
     { Symbol::SEND, "send" },       { Symbol::ASSIGN, "assign" },
     { Symbol::ASSUME, "assume" },   { Symbol::MEMBER, "member" },

--- a/tools/sddl/compiler/Syntax.h
+++ b/tools/sddl/compiler/Syntax.h
@@ -25,6 +25,8 @@ enum class Symbol {
     // Operators
     DIE,
     EXPECT,
+    LOG,
+
     CONSUME,
     SIZEOF,
     SEND,

--- a/tools/sddl/compiler/Syntax.h
+++ b/tools/sddl/compiler/Syntax.h
@@ -28,6 +28,8 @@ enum class Symbol {
     LOG,
 
     CONSUME,
+    PEEK, // `*` is tokenized as MUL, but the unary form is converted into this
+          // during parsing.
     SIZEOF,
     SEND,
     ASSIGN,

--- a/tools/sddl/compiler/Syntax.h
+++ b/tools/sddl/compiler/Syntax.h
@@ -38,6 +38,8 @@ enum class Symbol {
 
     BIND,
 
+    WHILE,
+
     NEG, // `-` is tokenized as SUB, but the unary form is converted into this
          // during parsing.
 


### PR DESCRIPTION
Summary:
This instruction lets you retrieve the value that consuming an atom *would*
produce, without actually consuming that value. It lets you do lookahead.

Differential Revision: D84071336


