### PR TITLE
Pruning maximizing minimum crowding distance

### DIFF
--- a/tools/training/ace/BUCK
+++ b/tools/training/ace/BUCK
@@ -14,6 +14,7 @@ cpp_library(
         "ace_compressors.cpp",
         "ace_utils.cpp",
         "automated_compressor_explorer.cpp",
+        "crowding_distance_selector.cpp",
     ],
     headers = [
         "ace.h",

--- a/tools/training/ace/ace_combination.h
+++ b/tools/training/ace/ace_combination.h
@@ -4,6 +4,7 @@
 
 #include <functional>
 #include <memory>
+#include <set>
 #include <unordered_map>
 #include <vector>
 
@@ -11,6 +12,7 @@
 
 #include "tools/training/ace/ace_compressor.h"
 #include "tools/training/train_params.h"
+#include "tools/training/utils/thread_pool.h"
 
 namespace openzl::training {
 
@@ -92,7 +94,6 @@ class CandidateSelection {
     // combined compressor is expected to produce
     ACECompressionResult mergedResult_;
 };
-
 /**
  * Takes the Pareto Frontier of solutions for all sub-compressor, and produces a
  * Pareto-optimal vector of solutions for the entire compressor. Returns each
@@ -120,4 +121,17 @@ std::vector<CandidateSelection> combineCandidates(
         const std::vector<std::vector<CandidateSelection>>& candidates,
         const TrainParams& trainParams);
 
+/** Prunes the list of candidates provided in @param candidates based on
+ * crowdingDistance and returns it. Picks the  @param numCandidates number of
+ * candidates and tries to maximize minimum crowding distance.
+ */
+std::vector<CandidateSelection> pruneCandidates(
+        std::vector<CandidateSelection>&& candidates,
+        size_t numCandidates);
+
+/** Filters @param candidates down to its Pareto Frontier and returns it.
+ */
+std::vector<CandidateSelection> filterParetoFrontier(
+        std::vector<CandidateSelection>&& candidates,
+        ThreadPool& threadPool);
 } // namespace openzl::training

--- a/tools/training/ace/crowding_distance_selector.cpp
+++ b/tools/training/ace/crowding_distance_selector.cpp
@@ -1,0 +1,154 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#include "tools/training/ace/crowding_distance_selector.h"
+#include "openzl/cpp/Exception.hpp"
+
+#include <set>
+
+namespace openzl::training {
+
+namespace {
+class CrowdingDistanceSelector {
+   public:
+    std::vector<size_t> selectLeastCrowded(
+            poly::span<const std::vector<float>> fitness,
+            poly::span<const float> crowdingDistance,
+            size_t numCandidates)
+    {
+        init(fitness, crowdingDistance, numCandidates);
+        numCandidates = std::min(numCandidates, fitness.size());
+        // Remove candidates starting with smallest crowding distance
+        while (crowdingDistanceIndexSet_.size() > numCandidates) {
+            // Remove the most crowded point from the list
+            auto it    = crowdingDistanceIndexSet_.begin();
+            auto index = it->second;
+            crowdingDistanceIndexSet_.erase(it);
+            // For each dimension, the neighbor's crowding distance will be
+            // increased by removing it
+            for (size_t n = 0; n < nDims_; n++) {
+                auto fitnessDim = indexToInfo_[index].fitness[n];
+                auto adjFitness = getAdjacentFitness(index, n);
+                for (auto adj : adjFitness) {
+                    auto delta =
+                            std::abs(adj.first - fitnessDim) / dimRanges_[n];
+                    updateCrowdingDistance(
+                            indexToInfo_[adj.second].crowdingDistance,
+                            adj.second,
+                            delta);
+                }
+                // Erase after updating crowding distances
+                dimIndexSets_[n].erase({ fitnessDim, index });
+            }
+        }
+
+        std::vector<size_t> indices;
+        indices.reserve(crowdingDistanceIndexSet_.size());
+        for (const auto& [_crowdingDistance, index] :
+             crowdingDistanceIndexSet_) {
+            indices.emplace_back(index);
+        }
+        return indices;
+    }
+
+   private:
+    void init(
+            poly::span<const std::vector<float>> fitness,
+            poly::span<const float> crowdingDistance,
+            size_t numCandidates)
+    {
+        if (fitness.size() == 0) {
+            throw Exception("Cannot select candidates with size 0 fitness");
+        }
+        nDims_ = fitness[0].size();
+        if (numCandidates < nDims_ * 2) {
+            throw Exception(
+                    "Cannot prune candidates that have infinite crowding distance. There must be at least 2 * nDims_ candidates.");
+        }
+        for (size_t n = 0; n < nDims_; n++) {
+            std::set<std::pair<float, size_t>> dimIndexSet;
+            for (size_t i = 0; i < fitness.size(); i++) {
+                dimIndexSet.emplace(fitness[i][n], i);
+            }
+            dimIndexSets_.emplace_back(std::move(dimIndexSet));
+        }
+        indexToInfo_.reserve(fitness.size());
+        for (size_t i = 0; i < fitness.size(); i++) {
+            crowdingDistanceIndexSet_.emplace(crowdingDistance[i], i);
+            indexToInfo_.emplace_back(crowdingDistance[i], fitness[i]);
+        }
+        // The ranges will not change since crowding distance is infinite at
+        // extremities.
+        dimRanges_.reserve(nDims_);
+        for (size_t n = 0; n < nDims_; n++) {
+            dimRanges_.emplace_back(
+                    dimIndexSets_[n].rbegin()->first
+                    - dimIndexSets_[n].begin()->first);
+        }
+    }
+
+    std::vector<std::pair<float, size_t>> getAdjacentFitness(
+            size_t index,
+            size_t dim) const
+    {
+        std::vector<std::pair<float, size_t>> adjacentFitness;
+        auto fitnessDim = indexToInfo_[index].fitness[dim];
+        // Since there can be duplicates we must find the one that has
+        // matching index
+        auto it = dimIndexSets_[dim].find({ fitnessDim, index });
+        if (it == dimIndexSets_[dim].end()) {
+            throw Exception(
+                    "Unexpected algorithm error: matching fitness not found");
+        }
+        // It is possible for the maximum of a dimension to not have
+        // infinite CD when there are duplicates with the same fitness
+        // in that dimension
+        if (it != dimIndexSets_[dim].begin()) {
+            adjacentFitness.emplace_back(*std::prev(it));
+        }
+        auto next = std::next(it);
+        if (next != dimIndexSets_[dim].end()) {
+            adjacentFitness.emplace_back(*next);
+        }
+        return adjacentFitness;
+    }
+
+    void updateCrowdingDistance(float oldCD, size_t index, float delta)
+    {
+        auto it = crowdingDistanceIndexSet_.find({ oldCD, index });
+        if (it == crowdingDistanceIndexSet_.end()) {
+            throw Exception(
+                    "Unexpected algorithm error: crowding distance mismatch");
+        }
+        crowdingDistanceIndexSet_.erase(it);
+        indexToInfo_[index].crowdingDistance += delta;
+        crowdingDistanceIndexSet_.emplace(oldCD + delta, index);
+    }
+
+    struct CrowdingInfo {
+        float crowdingDistance;
+        std::vector<float> fitness;
+
+        CrowdingInfo(float cd, std::vector<float> f)
+                : crowdingDistance(cd), fitness(std::move(f))
+        {
+        }
+    };
+
+    std::vector<float> dimRanges_;
+    size_t nDims_;
+    std::set<std::pair<float, size_t>> crowdingDistanceIndexSet_;
+    std::vector<std::set<std::pair<float, size_t>>> dimIndexSets_;
+    std::vector<CrowdingInfo> indexToInfo_;
+};
+} // namespace
+
+std::vector<size_t> selectLeastCrowded(
+        poly::span<const std::vector<float>> fitness,
+        poly::span<const float> crowdingDistance,
+        size_t numCandidates)
+{
+    return CrowdingDistanceSelector{}.selectLeastCrowded(
+            fitness, crowdingDistance, numCandidates);
+}
+
+} // namespace openzl::training

--- a/tools/training/ace/crowding_distance_selector.h
+++ b/tools/training/ace/crowding_distance_selector.h
@@ -1,0 +1,29 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#pragma once
+
+#include <vector>
+#include "openzl/cpp/poly/Span.hpp"
+
+namespace openzl::training {
+
+/**
+ * The algorithm works by sorting the candidates by crowding distance and
+ * greedily removing the candidates with the lowest crowding distance then
+ * recalculating crowding distance until @param numCandidates is reached.
+ * Since removing a point only affects the crowding distance of neighbors in
+ * each dimension, the algorithm updates these crowding distances after each
+ * removal. This allows it to run in O(lg n) time per removal.
+ *
+ * @returns a vector of indices that maximizes the minimum crowding distance
+ * of any point.
+ * @param fitness is a vector of fitness values for each candidate.
+ * @param crowdingDistance is a vector of crowding distances for each
+ * candidate.
+ */
+std::vector<size_t> selectLeastCrowded(
+        poly::span<const std::vector<float>> fitness,
+        poly::span<const float> crowdingDistance,
+        size_t numCandidates);
+
+} // namespace openzl::training

--- a/tools/training/utils/genetic_algorithm.cpp
+++ b/tools/training/utils/genetic_algorithm.cpp
@@ -21,7 +21,9 @@ std::vector<float> crowdingDistance(
 
     const size_t numDims = fitness[0].size();
     for (size_t dim = 0; dim < numDims; ++dim) {
-        auto metric = [&](size_t idx) { return fitness[subset[idx]][dim]; };
+        auto metric = [&](size_t idx) {
+            return std::make_pair(fitness[subset[idx]][dim], idx);
+        };
 
         detail::sortByKey(indices, metric);
         dist[indices.front()] = std::numeric_limits<float>::infinity();
@@ -30,8 +32,8 @@ std::vector<float> crowdingDistance(
         float minMetric = std::numeric_limits<float>::infinity();
         float maxMetric = -std::numeric_limits<float>::infinity();
         for (auto idx : indices) {
-            minMetric = std::min(minMetric, metric(idx));
-            maxMetric = std::max(maxMetric, metric(idx));
+            minMetric = std::min(minMetric, metric(idx).first);
+            maxMetric = std::max(maxMetric, metric(idx).first);
         }
         const float metricRange = maxMetric - minMetric;
         if (!std::isnormal(metricRange)) {
@@ -40,8 +42,8 @@ std::vector<float> crowdingDistance(
         }
         assert(minMetric <= maxMetric);
         for (size_t i = 1; i < indices.size() - 1; ++i) {
-            const auto prevMetric = metric(indices[i - 1]);
-            const auto nextMetric = metric(indices[i + 1]);
+            const auto prevMetric = metric(indices[i - 1]).first;
+            const auto nextMetric = metric(indices[i + 1]).first;
             assert(nextMetric >= prevMetric);
             dist[indices[i]] += (nextMetric - prevMetric) / metricRange;
         }


### PR DESCRIPTION
Summary:
Introduces an alternative pruning strategy. Does greedy pruning (removing the elements with lower crowding distance first) - then recalculates the crowding distance. 

While this algorithm does not find the optimal maximum minimum crowding distance, removing a single point only affects the crowding distance of two points per dimension, hence is a greedy algorithm is a good choice. It is also fast running in `O(lg n)` time per removal.

Also moves a few functions so that they can be more easily tested and adds more tests.

Differential Revision: D83869261


