### PR TITLE
Add training usage section

### DIFF
--- a/doc/mkdocs/doc/getting-started/cli.md
+++ b/doc/mkdocs/doc/getting-started/cli.md
@@ -59,7 +59,7 @@ Let's see what happens when we run a compression using the trained graph. In thi
 ```
 The difference is stark. Training is able to net us a 10% ratio win at no other cost. (Technically, if we wanted to be rigorous we should have split our data into train and test directories. But the result is very similar.)
 
-> **Training effectively:** The typical training workflow is to collect a small number of representative samples, train on those samples, and use the trained compressor on the entire dataset. In production settings, data may evolve over time. So it is useful to collect new samples at designated intervals (maybe daily or weekly) and replace the trained compressor with the newly trained one.
+> **Training effectively:** The typical training workflow is to collect a small number of representative samples, train on those samples, and use the trained compressor on the entire dataset. For more details on sizing training inputs, see [training usage](examples/cli/training-usage.md). In production settings, data may evolve over time. So it is useful to collect new samples at designated intervals (maybe daily or weekly) and replace the trained compressor with the newly trained one.
 
 ### Inline Training
 Because the impact of training is so stark, the CLI requires that trainable compressors be trained in some form before using them. The typical way to do this is by first training then compressing with the trained `.zsc` compressor, but **inline training** is also supported.

--- a/doc/mkdocs/doc/getting-started/examples/cli/training-usage.md
+++ b/doc/mkdocs/doc/getting-started/examples/cli/training-usage.md
@@ -1,0 +1,18 @@
+## CPU Requirements
+Training can be CPU intensive, but is expected to work for even laptop cpus for smaller workloads. The following tests are done using a Intel(R) Xeon(R) Gold 6138 CPU @ 2.00GHz.
+
+## Training Times
+
+!!! note "Note"
+    The times below are very approximate given runtime depends on the input and therefore may not be representative of exact runtimes but are intended to help guide file sizing for training.
+
+It is recommended to train to completion, however the flag `--max-time-secs` will pause training and return the best result found within the time frame provided. Training to completion on a 100Mb file using 40 threads takes for the following stages:
+
+Clustering Training: 480s
+- The clustering trainer is not always able to use all the threads, typically able to fully utilize ~5-10 threads. Clustering training time scales linearly with file size, but is also dependent on many other factors.
+
+ACE Training: 3000s
+- Ace training time scales linearly with the file input size, and time spent is inversely proportional to the number of threads used. It is possible to decrease the time spent by tuning hyperparameters such as `maxGenerations` at the cost of worse results.
+
+## Recommended usage
+It is recommended to initially train/ test on a single smaller file to verify correctness. A very small subset of the data can typically be provided to the trainer to train compressors, such as 3 files out of 1000 files, however this depends on the properties of the dataset.

--- a/doc/mkdocs/mkdocs.yml
+++ b/doc/mkdocs/mkdocs.yml
@@ -28,6 +28,7 @@ nav:
       - CLI:
         - Parquet: getting-started/examples/cli/parquet.md
         - Protobuf: getting-started/examples/cli/protobuf.md
+        - Training usage: getting-started/examples/cli/training-usage.md
     - CLI: getting-started/cli.md
     - Advanced Build Settings: getting-started/advanced-build.md
   - API Reference:


### PR DESCRIPTION
Summary: Adds a section under `CLI/examples` to help with sizing when using training.

Reviewed By: Cyan4973

Differential Revision: D84089872


