### PR TITLE
Simplify and fix clone instructions in quick start

### DIFF
--- a/doc/mkdocs/doc/getting-started/quick-start.md
+++ b/doc/mkdocs/doc/getting-started/quick-start.md
@@ -13,9 +13,8 @@ This 15 minute exercise will teach you:
 ## Clone OpenZL
 
 ```sh
-git clone --depth 1 https://github.com/facebook/openzl.git
+git clone --depth 1 -b release https://github.com/facebook/openzl.git
 cd openzl
-git checkout release
 ```
 
 ## Building the OpenZL CLI
@@ -148,7 +147,6 @@ Now train a compressor using the `sra0` sample:
     limit the training time. It currently limits the time spent in each step of
     training, not the total time. But, the trained result may be worse given less
     time to train.
-
 
 The training session will generate some messages on the consoles.
 The last lines should look something like that:


### PR DESCRIPTION
## Summary
The git clone instructions in the Clone OpenZL section of the [Quick Start](https://openzl.org/getting-started/quick-start/) guide do not work because of the -depth 1 option. That's because the latest commit does not belong to the release branch.

Updated the checkout instruction to 
Fixes #91 

## Type of Change
Documentation update

## Test Plan

Copied and executed the new Quick Start clone instructions.
Verified that the branch is correctly `release` with

```
> git branch
* release
```

Verified only a single commit has been checked out:

```
> git log --decorate
commit 48b31632516d3ce135924f6783a6e7514e7f2f61 (grafted, HEAD -> release, tag: v0.0.23, origin/release)
Author: Nick Terrell <terrelln@meta.com>
Date:   Tue Sep 30 21:01:51 2025 -0700

    Check in Pareto optimal results (#11)
....
```

### Test Configuration
- Compiler: n/a
- Build type: git version 2.51.0
- Platform(s): Mac
