### PR TITLE
tools: add missing STL includes for Windows/clang-cl (bugfix)

### DIFF
--- a/tools/io/InputSet.cpp
+++ b/tools/io/InputSet.cpp
@@ -3,78 +3,60 @@
 #include "tools/io/InputSet.h"
 #include <stdexcept>
 
-
 namespace openzl::tools::io {
 
-InputSet::Iterator InputSet::begin() const
-{
-    return Iterator{ begin_state() };
-}
+InputSet::Iterator InputSet::begin() const { return Iterator{begin_state()}; }
 
-InputSet::Iterator InputSet::end() const
-{
-    return Iterator{};
-}
+InputSet::Iterator InputSet::end() const { return Iterator{}; }
 
 // end()
 InputSet::Iterator::Iterator() : state_() {}
 
 // begin()
 InputSet::Iterator::Iterator(std::unique_ptr<IteratorState> state)
-        : state_((state && **state) ? std::move(state)
-                                    : std::unique_ptr<IteratorState>{})
-{
+    : state_((state && **state) ? std::move(state)
+                                : std::unique_ptr<IteratorState>{}) {}
+
+InputSet::Iterator::Iterator(const Iterator &o)
+    : state_(o.state_ ? o.state_->copy() : std::unique_ptr<IteratorState>{}) {}
+
+InputSet::Iterator &InputSet::Iterator::operator=(const Iterator &o) {
+  state_ = o.state_ ? o.state_->copy() : std::unique_ptr<IteratorState>{};
+  return *this;
 }
 
-InputSet::Iterator::Iterator(const Iterator& o)
-        : state_(o.state_ ? o.state_->copy() : std::unique_ptr<IteratorState>{})
-{
+const std::shared_ptr<Input> &InputSet::Iterator::operator*() const {
+  static const std::shared_ptr<Input> null_input{};
+  if (!state_) {
+    throw std::runtime_error("Can't deref end InputSet::Iterator.");
+  }
+  return **state_;
 }
 
-InputSet::Iterator& InputSet::Iterator::operator=(const Iterator& o)
-{
-    state_ = o.state_ ? o.state_->copy() : std::unique_ptr<IteratorState>{};
-    return *this;
+InputSet::Iterator &InputSet::Iterator::operator++() {
+  if (!state_) {
+    throw std::runtime_error(
+        "Can't advance InputSet::Iterator past the end of the InputSet.");
+  }
+  ++(*state_);
+  if (!**state_) {
+    state_.reset();
+  }
+  return *this;
 }
 
-const std::shared_ptr<Input>& InputSet::Iterator::operator*() const
-{
-    static const std::shared_ptr<Input> null_input{};
-    if (!state_) {
-        throw std::runtime_error("Can't deref end InputSet::Iterator.");
-    }
-    return **state_;
+InputSet::Iterator InputSet::Iterator::operator++(int) const {
+  Iterator new_it{*this};
+  ++new_it;
+  return new_it;
 }
 
-InputSet::Iterator& InputSet::Iterator::operator++()
-{
-    if (!state_) {
-        throw std::runtime_error(
-                "Can't advance InputSet::Iterator past the end of the InputSet.");
-    }
-    ++(*state_);
-    if (!**state_) {
-        state_.reset();
-    }
-    return *this;
+bool InputSet::Iterator::operator==(const Iterator &o) const {
+  return (!state_ && !o.state_) || (state_ && o.state_ && *state_ == *o.state_);
 }
 
-InputSet::Iterator InputSet::Iterator::operator++(int) const
-{
-    Iterator new_it{ *this };
-    ++new_it;
-    return new_it;
-}
-
-bool InputSet::Iterator::operator==(const Iterator& o) const
-{
-    return (!state_ && !o.state_)
-            || (state_ && o.state_ && *state_ == *o.state_);
-}
-
-bool InputSet::Iterator::operator!=(const Iterator& o) const
-{
-    return !(*this == o);
+bool InputSet::Iterator::operator!=(const Iterator &o) const {
+  return !(*this == o);
 }
 
 } // namespace openzl::tools::io

--- a/tools/io/InputSet.cpp
+++ b/tools/io/InputSet.cpp
@@ -1,6 +1,8 @@
 // Copyright (c) Meta Platforms, Inc. and affiliates.
 
 #include "tools/io/InputSet.h"
+#include <stdexcept>
+
 
 namespace openzl::tools::io {
 

--- a/tools/io/InputSetBuilder.h
+++ b/tools/io/InputSetBuilder.h
@@ -4,6 +4,10 @@
 
 #include <memory>
 #include <vector>
+#include <string>
+#include <optional>
+#include <stdexcept>
+
 
 #include "tools/io/InputSet.h"
 

--- a/tools/io/InputSetBuilder.h
+++ b/tools/io/InputSetBuilder.h
@@ -3,11 +3,10 @@
 #pragma once
 
 #include <memory>
-#include <vector>
-#include <string>
 #include <optional>
 #include <stdexcept>
-
+#include <string>
+#include <vector>
 
 #include "tools/io/InputSet.h"
 
@@ -17,23 +16,23 @@ namespace openzl::tools::io {
  * Helper class to build up an input set from a bunch of path arguments.
  */
 class InputSetBuilder {
-   public:
-    explicit InputSetBuilder(bool recursive, bool verbose = false);
+public:
+  explicit InputSetBuilder(bool recursive, bool verbose = false);
 
-    InputSetBuilder& add_path(std::string path) &;
-    InputSetBuilder&& add_path(std::string path) &&;
+  InputSetBuilder &add_path(std::string path) &;
+  InputSetBuilder &&add_path(std::string path) &&;
 
-    InputSetBuilder& add_path(std::optional<std::string> path_opt) &;
-    InputSetBuilder&& add_path(std::optional<std::string> path_opt) &&;
+  InputSetBuilder &add_path(std::optional<std::string> path_opt) &;
+  InputSetBuilder &&add_path(std::optional<std::string> path_opt) &&;
 
-    std::unique_ptr<InputSet> build() &&;
+  std::unique_ptr<InputSet> build() &&;
 
-    std::unique_ptr<InputSet> build_static() &&;
+  std::unique_ptr<InputSet> build_static() &&;
 
-   private:
-    const bool recursive_;
-    const bool verbose_;
+private:
+  const bool recursive_;
+  const bool verbose_;
 
-    std::vector<std::unique_ptr<InputSet>> input_sets_;
+  std::vector<std::unique_ptr<InputSet>> input_sets_;
 };
 } // namespace openzl::tools::io

--- a/tools/io/InputSetDir.cpp
+++ b/tools/io/InputSetDir.cpp
@@ -3,6 +3,8 @@
 #include "tools/io/InputSetDir.h"
 
 #include <filesystem>
+#include <stdexcept>
+
 
 #include "tools/io/InputFile.h"
 

--- a/tools/io/InputSetDir.cpp
+++ b/tools/io/InputSetDir.cpp
@@ -5,93 +5,83 @@
 #include <filesystem>
 #include <stdexcept>
 
-
 #include "tools/io/InputFile.h"
 
 namespace openzl::tools::io {
 
 template <typename IterT>
 class InputSetDir::IteratorStateDir : public InputSet::IteratorState {
-   public:
-    IteratorStateDir(const InputSetDir& isd, const std::string& path)
-            : isd_(isd), it_(path)
-    {
-        advance_to_next_regular_file();
-    }
+public:
+  IteratorStateDir(const InputSetDir &isd, const std::string &path)
+      : isd_(isd), it_(path) {
+    advance_to_next_regular_file();
+  }
 
-    std::unique_ptr<IteratorState> copy() const override
-    {
-        return std::make_unique<IteratorStateDir>(*this);
-    }
+  std::unique_ptr<IteratorState> copy() const override {
+    return std::make_unique<IteratorStateDir>(*this);
+  }
 
-    // Advance to the next regular file.
-    IteratorState& operator++() override
-    {
-        input_.reset();
-        if (it_ == IterT{}) {
-            throw std::runtime_error(
-                    "Can't advance iterator past the end of the InputSet.");
-        }
-        ++it_;
-        advance_to_next_regular_file();
-        return *this;
+  // Advance to the next regular file.
+  IteratorState &operator++() override {
+    input_.reset();
+    if (it_ == IterT{}) {
+      throw std::runtime_error(
+          "Can't advance iterator past the end of the InputSet.");
     }
+    ++it_;
+    advance_to_next_regular_file();
+    return *this;
+  }
 
-    const std::shared_ptr<Input>& operator*() const override
-    {
-        if (input_) {
-            return input_;
-        }
-        if (it_ == IterT{}) {
-            return input_;
-        }
-        input_ = std::make_shared<InputFile>(it_->path().string());
-        return input_;
+  const std::shared_ptr<Input> &operator*() const override {
+    if (input_) {
+      return input_;
     }
-
-    bool operator==(const IteratorState& o) const override
-    {
-        auto ptr = dynamic_cast<const IteratorStateDir*>(&o);
-        if (ptr == nullptr) {
-            return false;
-        }
-        return (&isd_ == &ptr->isd_) && (it_ == ptr->it_);
+    if (it_ == IterT{}) {
+      return input_;
     }
+    input_ = std::make_shared<InputFile>(it_->path().string());
+    return input_;
+  }
 
-   private:
-    void advance_to_next_regular_file()
-    {
-        while (true) {
-            if (it_ == IterT{}) {
-                break;
-            }
-            if (it_->is_regular_file()) {
-                break;
-            }
-            ++it_;
-        }
+  bool operator==(const IteratorState &o) const override {
+    auto ptr = dynamic_cast<const IteratorStateDir *>(&o);
+    if (ptr == nullptr) {
+      return false;
     }
+    return (&isd_ == &ptr->isd_) && (it_ == ptr->it_);
+  }
 
-    const InputSetDir& isd_;
-    IterT it_;
-    mutable std::shared_ptr<Input> input_;
+private:
+  void advance_to_next_regular_file() {
+    while (true) {
+      if (it_ == IterT{}) {
+        break;
+      }
+      if (it_->is_regular_file()) {
+        break;
+      }
+      ++it_;
+    }
+  }
+
+  const InputSetDir &isd_;
+  IterT it_;
+  mutable std::shared_ptr<Input> input_;
 };
 
 InputSetDir::InputSetDir(std::string path, bool recursive)
-        : path_(std::move(path)), recursive_(recursive)
-{
-}
+    : path_(std::move(path)), recursive_(recursive) {}
 
-std::unique_ptr<InputSet::IteratorState> InputSetDir::begin_state() const
-{
-    if (recursive_) {
-        return std::make_unique<IteratorStateDir<
-                std::filesystem::recursive_directory_iterator>>(*this, path_);
-    } else {
-        return std::make_unique<
-                IteratorStateDir<std::filesystem::directory_iterator>>(
-                *this, path_);
-    }
+std::unique_ptr<InputSet::IteratorState> InputSetDir::begin_state() const {
+  if (recursive_) {
+    return std::make_unique<
+        IteratorStateDir<std::filesystem::recursive_directory_iterator>>(*this,
+                                                                         path_);
+  } else {
+    return std::make_unique<
+        IteratorStateDir<std::filesystem::directory_iterator>>(*this, path_);
+  }
 }
 
 } // namespace openzl::tools::io

--- a/tools/io/InputSetMulti.cpp
+++ b/tools/io/InputSetMulti.cpp
@@ -3,105 +3,94 @@
 #include "tools/io/InputSetMulti.h"
 #include <stdexcept>
 
-
 namespace openzl::tools::io {
 
 class InputSetMulti::IteratorStateMulti : public InputSet::IteratorState {
-   public:
-    explicit IteratorStateMulti(const InputSetMulti& ism)
-            : ism_(ism), idx_(0), size_(ism.input_sets_.size())
-    {
-        if (idx_ != size_) {
-            inner_it_  = ism_[idx_].begin();
-            inner_end_ = ism_[idx_].end();
-        }
-        advance_to_next_nonempty();
+public:
+  explicit IteratorStateMulti(const InputSetMulti &ism)
+      : ism_(ism), idx_(0), size_(ism.input_sets_.size()) {
+    if (idx_ != size_) {
+      inner_it_ = ism_[idx_].begin();
+      inner_end_ = ism_[idx_].end();
     }
+    advance_to_next_nonempty();
+  }
 
-    std::unique_ptr<IteratorState> copy() const override
-    {
-        return std::make_unique<IteratorStateMulti>(*this);
+  std::unique_ptr<IteratorState> copy() const override {
+    return std::make_unique<IteratorStateMulti>(*this);
+  }
+
+  IteratorState &operator++() override {
+    if (idx_ == size_) {
+      throw std::runtime_error(
+          "Can't advance iterator past the end of the InputSet.");
     }
-
-    IteratorState& operator++() override
-    {
-        if (idx_ == size_) {
-            throw std::runtime_error(
-                    "Can't advance iterator past the end of the InputSet.");
-        }
-        if (inner_it_ != inner_end_) {
-            ++inner_it_;
-        }
-        if (inner_it_ == inner_end_) {
-            idx_++;
-            if (idx_ != size_) {
-                inner_it_  = ism_[idx_].begin();
-                inner_end_ = ism_[idx_].end();
-            }
-            advance_to_next_nonempty();
-        }
-        return *this;
+    if (inner_it_ != inner_end_) {
+      ++inner_it_;
     }
-
-    const std::shared_ptr<Input>& operator*() const override
-    {
-        static const std::shared_ptr<Input> null_input{};
-        if (idx_ == ism_.input_sets_.size()) {
-            return null_input;
-        }
-        if (inner_it_ == inner_end_) {
-            return null_input;
-        }
-        return *inner_it_;
+    if (inner_it_ == inner_end_) {
+      idx_++;
+      if (idx_ != size_) {
+        inner_it_ = ism_[idx_].begin();
+        inner_end_ = ism_[idx_].end();
+      }
+      advance_to_next_nonempty();
     }
+    return *this;
+  }
 
-    bool operator==(const IteratorState& o) const override
-    {
-        auto ptr = dynamic_cast<const IteratorStateMulti*>(&o);
-        if (ptr == nullptr) {
-            return false;
-        }
-        return (&ism_ == &ptr->ism_) && (idx_ == ptr->idx_)
-                && (inner_it_ == ptr->inner_it_);
+  const std::shared_ptr<Input> &operator*() const override {
+    static const std::shared_ptr<Input> null_input{};
+    if (idx_ == ism_.input_sets_.size()) {
+      return null_input;
     }
-
-   private:
-    void advance_to_next_nonempty()
-    {
-        if (idx_ == size_) {
-            return;
-        }
-        while (inner_it_ == inner_end_) {
-            idx_++;
-            if (idx_ == size_) {
-                break;
-            }
-            inner_it_  = ism_[idx_].begin();
-            inner_end_ = ism_[idx_].end();
-        }
+    if (inner_it_ == inner_end_) {
+      return null_input;
     }
+    return *inner_it_;
+  }
 
-    const InputSetMulti& ism_;
-    size_t idx_;
-    const size_t size_;
+  bool operator==(const IteratorState &o) const override {
+    auto ptr = dynamic_cast<const IteratorStateMulti *>(&o);
+    if (ptr == nullptr) {
+      return false;
+    }
+    return (&ism_ == &ptr->ism_) && (idx_ == ptr->idx_) &&
+           (inner_it_ == ptr->inner_it_);
+  }
 
-    InputSet::Iterator inner_it_;
-    InputSet::Iterator inner_end_;
+private:
+  void advance_to_next_nonempty() {
+    if (idx_ == size_) {
+      return;
+    }
+    while (inner_it_ == inner_end_) {
+      idx_++;
+      if (idx_ == size_) {
+        break;
+      }
+      inner_it_ = ism_[idx_].begin();
+      inner_end_ = ism_[idx_].end();
+    }
+  }
+
+  const InputSetMulti &ism_;
+  size_t idx_;
+  const size_t size_;
+
+  InputSet::Iterator inner_it_;
+  InputSet::Iterator inner_end_;
 };
 
 InputSetMulti::InputSetMulti(std::vector<std::unique_ptr<InputSet>> input_sets)
-        : input_sets_(std::move(input_sets))
-{
+    : input_sets_(std::move(input_sets)) {}
+
+const InputSet &InputSetMulti::operator[](size_t idx) const {
+  return *input_sets_[idx];
 }
 
-const InputSet& InputSetMulti::operator[](size_t idx) const
-{
-    return *input_sets_[idx];
-}
-
-std::unique_ptr<InputSet::IteratorState> InputSetMulti::begin_state() const
-{
-    return std::make_unique<IteratorStateMulti>(*this);
+std::unique_ptr<InputSet::IteratorState> InputSetMulti::begin_state() const {
+  return std::make_unique<IteratorStateMulti>(*this);
 }
 
 } // namespace openzl::tools::io

--- a/tools/io/InputSetMulti.cpp
+++ b/tools/io/InputSetMulti.cpp
@@ -1,6 +1,8 @@
 // Copyright (c) Meta Platforms, Inc. and affiliates.
 
 #include "tools/io/InputSetMulti.h"
+#include <stdexcept>
+
 
 namespace openzl::tools::io {
 

--- a/tools/io/InputSetStatic.cpp
+++ b/tools/io/InputSetStatic.cpp
@@ -1,6 +1,8 @@
 // Copyright (c) Meta Platforms, Inc. and affiliates.
 
 #include "tools/io/InputSetStatic.h"
+#include <stdexcept>
+
 
 namespace openzl::tools::io {
 

--- a/tools/io/InputSetStatic.cpp
+++ b/tools/io/InputSetStatic.cpp
@@ -3,80 +3,66 @@
 #include "tools/io/InputSetStatic.h"
 #include <stdexcept>
 
-
 namespace openzl::tools::io {
 
 class InputSetStatic::IteratorStateStatic : public InputSet::IteratorState {
-   public:
-    explicit IteratorStateStatic(const InputSetStatic& iss, size_t idx)
-            : iss_(iss), idx_(idx)
-    {
-    }
+public:
+  explicit IteratorStateStatic(const InputSetStatic &iss, size_t idx)
+      : iss_(iss), idx_(idx) {}
 
-    std::unique_ptr<IteratorState> copy() const override
-    {
-        return std::make_unique<IteratorStateStatic>(iss_, idx_);
-    }
+  std::unique_ptr<IteratorState> copy() const override {
+    return std::make_unique<IteratorStateStatic>(iss_, idx_);
+  }
 
-    IteratorState& operator++() override
-    {
-        idx_++;
-        return *this;
-    }
+  IteratorState &operator++() override {
+    idx_++;
+    return *this;
+  }
 
-    const std::shared_ptr<Input>& operator*() const override
-    {
-        return iss_[idx_];
-    }
+  const std::shared_ptr<Input> &operator*() const override {
+    return iss_[idx_];
+  }
 
-    bool operator==(const IteratorState& o) const override
-    {
-        auto ptr = dynamic_cast<const IteratorStateStatic*>(&o);
-        if (ptr == nullptr) {
-            return false;
-        }
-        return (&iss_ == &ptr->iss_) && (idx_ == ptr->idx_);
+  bool operator==(const IteratorState &o) const override {
+    auto ptr = dynamic_cast<const IteratorStateStatic *>(&o);
+    if (ptr == nullptr) {
+      return false;
     }
+    return (&iss_ == &ptr->iss_) && (idx_ == ptr->idx_);
+  }
 
-   private:
-    const InputSetStatic& iss_;
-    size_t idx_{ 0 };
+private:
+  const InputSetStatic &iss_;
+  size_t idx_{0};
 };
 
 InputSetStatic::InputSetStatic(std::vector<std::shared_ptr<Input>> inputs)
-        : inputs_(std::move(inputs))
-{
-    for (const auto& input : inputs_) {
-        if (!input) {
-            throw std::runtime_error("InputSetStatic cannot hold a nullptr.");
-        }
+    : inputs_(std::move(inputs)) {
+  for (const auto &input : inputs_) {
+    if (!input) {
+      throw std::runtime_error("InputSetStatic cannot hold a nullptr.");
     }
+  }
 }
 
-InputSetStatic InputSetStatic::from_input_set(InputSet& input_set)
-{
-    std::vector<std::shared_ptr<Input>> inputs{ input_set.begin(),
-                                                input_set.end() };
-    return InputSetStatic{ std::move(inputs) };
+InputSetStatic InputSetStatic::from_input_set(InputSet &input_set) {
+  std::vector<std::shared_ptr<Input>> inputs{input_set.begin(),
+                                             input_set.end()};
+  return InputSetStatic{std::move(inputs)};
 }
 
-size_t InputSetStatic::size() const
-{
-    return inputs_.size();
+size_t InputSetStatic::size() const { return inputs_.size(); }
+
+const std::shared_ptr<Input> &InputSetStatic::operator[](size_t idx) const {
+  static const std::shared_ptr<Input> null_input{};
+  if (idx < inputs_.size()) {
+    return inputs_[idx];
+  }
+  return null_input;
 }
 
-const std::shared_ptr<Input>& InputSetStatic::operator[](size_t idx) const
-{
-    static const std::shared_ptr<Input> null_input{};
-    if (idx < inputs_.size()) {
-        return inputs_[idx];
-    }
-    return null_input;
-}
-
-std::unique_ptr<InputSet::IteratorState> InputSetStatic::begin_state() const
-{
-    return std::make_unique<IteratorStateStatic>(*this, 0);
+std::unique_ptr<InputSet::IteratorState> InputSetStatic::begin_state() const {
+  return std::make_unique<IteratorStateStatic>(*this, 0);
 }
 
 } // namespace openzl::tools::io

--- a/tools/logger/Logger.h
+++ b/tools/logger/Logger.h
@@ -5,22 +5,22 @@
 #include <cstdio>
 #include <iostream>
 #include <ostream>
-#include <string>
 #include <stdexcept>
+#include <string>
 #include <vector>
 
 namespace openzl::tools::logger {
 
 // Global verbosity functions
 enum LogLevel {
-    ALWAYS     = 0,
-    ERRORS     = 1,
-    WARNINGS   = 2,
-    INFO       = 3,
-    VERBOSE1   = 4,
-    VERBOSE2   = 5,
-    VERBOSE3   = 6,
-    EVERYTHING = 7,
+  ALWAYS = 0,
+  ERRORS = 1,
+  WARNINGS = 2,
+  INFO = 3,
+  VERBOSE1 = 4,
+  VERBOSE2 = 5,
+  VERBOSE3 = 6,
+  EVERYTHING = 7,
 };
 
 const int progressBarWidth = 50;
@@ -29,200 +29,176 @@ const int progressBarWidth = 50;
  * Logger class for CLI and training
  */
 class Logger {
-   public:
-    static Logger& instance()
-    {
-        static Logger instance_;
-        return instance_;
+public:
+  static Logger &instance() {
+    static Logger instance_;
+    return instance_;
+  }
+
+  int global_verbosity;      // TODO where to set this by default?
+  bool progress_line_active; // Track if we have an active progress line
+
+  // Store current progress information for re-printing
+  LogLevel progress_level;
+  double progress_value;
+  std::string progress_message;
+
+  void setGlobalLoggerVerbosity(int verbosity) {
+    if (verbosity < static_cast<int>(ALWAYS) ||
+        verbosity > static_cast<int>(EVERYTHING)) {
+      throw std::invalid_argument(
+          "Invalid log level: " + std::to_string(verbosity) +
+          ". Valid levels are " + std::to_string(static_cast<int>(ALWAYS)) +
+          " (ALWAYS) to " + std::to_string(static_cast<int>(EVERYTHING)) +
+          " (EVERYTHING).");
+    }
+    global_verbosity = verbosity;
+  }
+  int getGlobalLoggerVerbosity() { return global_verbosity; }
+
+private:
+  Logger()
+      : global_verbosity(INFO), progress_line_active(false),
+        progress_level(INFO), progress_value(0.0), progress_message("") {}
+  Logger(const Logger &) = delete;
+  Logger &operator=(const Logger &) = delete;
+
+  template <typename Arg>
+  static void log_inner(std::ostream &os, const Arg &arg) {
+    os << arg;
+  }
+  template <typename Arg, typename... Args>
+  static void log_inner(std::ostream &os, const Arg &arg, const Args &...args) {
+    log_inner(os << arg, args...);
+  }
+
+public:
+  template <typename... Args>
+  static void log(LogLevel level, const Args &...args) {
+    if (shouldLog(level)) {
+      finalizeProgressIfActive();
+      log_inner(std::cerr, args...);
+      std::cerr << '\n';
+      reprintProgressIfActive();
+    }
+  }
+
+public:
+  template <typename... Args>
+  static void log_c(LogLevel level, const char *format, const Args &...args) {
+    if (!shouldLog(level)) {
+      return;
     }
 
-    int global_verbosity;      // TODO where to set this by default?
-    bool progress_line_active; // Track if we have an active progress line
+    finalizeProgressIfActive();
+
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wformat-nonliteral"
+    fprintf(stderr, format, args...);
+    fprintf(stderr, "\n");
+#pragma GCC diagnostic pop
+
+    reprintProgressIfActive();
+  }
+
+public:
+  template <typename... Args>
+  static void update(LogLevel level, const char *format, const Args &...args) {
+    if (!shouldLog(level)) {
+      return;
+    }
+
+    // Move to beginning of line
+    // TODO remove control characters when printing to non-tty
+    fprintf(stderr, "\r");
+
+    // Print the formatted message
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wformat-nonliteral"
+    fprintf(stderr, format, args...);
+#pragma GCC diagnostic pop
+
+    // Clear to end of line to remove any remaining characters
+    // TODO remove control characters when printing to non-tty
+    fprintf(stderr, "%s", CLEAR_TO_EOL);
+
+    fflush(stderr);
+  }
+
+  template <typename... Args>
+  static void logProgress(LogLevel level, double progress, const char *format,
+                          Args &&...args) {
+    if (!shouldLog(level)) {
+      return;
+    }
+
+    if (progress > 1.0) {
+      throw std::invalid_argument("Progress percentage must be <= 1.0, got: " +
+                                  std::to_string(progress) + ".");
+    }
+
+    instance().progress_line_active = true;
 
     // Store current progress information for re-printing
-    LogLevel progress_level;
-    double progress_value;
-    std::string progress_message;
+    instance().progress_level = level;
+    instance().progress_value = progress;
 
-    void setGlobalLoggerVerbosity(int verbosity)
-    {
-        if (verbosity < static_cast<int>(ALWAYS)
-            || verbosity > static_cast<int>(EVERYTHING)) {
-            throw std::invalid_argument(
-                    "Invalid log level: " + std::to_string(verbosity)
-                    + ". Valid levels are "
-                    + std::to_string(static_cast<int>(ALWAYS)) + " (ALWAYS) to "
-                    + std::to_string(static_cast<int>(EVERYTHING))
-                    + " (EVERYTHING).");
-        }
-        global_verbosity = verbosity;
-    }
-    int getGlobalLoggerVerbosity()
-    {
-        return global_verbosity;
-    }
-
-   private:
-    Logger()
-            : global_verbosity(INFO),
-              progress_line_active(false),
-              progress_level(INFO),
-              progress_value(0.0),
-              progress_message("")
-    {
-    }
-    Logger(const Logger&)            = delete;
-    Logger& operator=(const Logger&) = delete;
-
-    template <typename Arg>
-    static void log_inner(std::ostream& os, const Arg& arg)
-    {
-        os << arg;
-    }
-    template <typename Arg, typename... Args>
-    static void log_inner(std::ostream& os, const Arg& arg, const Args&... args)
-    {
-        log_inner(os << arg, args...);
-    }
-
-   public:
-    template <typename... Args>
-    static void log(LogLevel level, const Args&... args)
-    {
-        if (shouldLog(level)) {
-            finalizeProgressIfActive();
-            log_inner(std::cerr, args...);
-            std::cerr << '\n';
-            reprintProgressIfActive();
-        }
-    }
-
-   public:
-    template <typename... Args>
-    static void log_c(LogLevel level, const char* format, const Args&... args)
-    {
-        if (!shouldLog(level)) {
-            return;
-        }
-
-        finalizeProgressIfActive();
-
+    // Build the user message part
+    std::string userMsg;
+    if (format && format[0] != '\0') {
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wformat-nonliteral"
-        fprintf(stderr, format, args...);
-        fprintf(stderr, "\n");
+      int required_size = snprintf(nullptr, 0, format, args...);
+      if (required_size > 0) {
+        std::vector<char> buffer(required_size + 1); // +1 for null terminator
+        snprintf(buffer.data(), buffer.size(), format, args...);
+        userMsg = std::string(buffer.data());
+      }
 #pragma GCC diagnostic pop
-
-        reprintProgressIfActive();
     }
 
-   public:
-    template <typename... Args>
-    static void update(LogLevel level, const char* format, const Args&... args)
-    {
-        if (!shouldLog(level)) {
-            return;
-        }
+    // Build the progress message
+    int filled = (int)(progress * progressBarWidth);
+    char progressBar[progressBarWidth + 3]; // progressBarWidth + 2 for ends
+                                            // + 1 for null terminator
+    progressBar[0] = '[';
+    for (int i = 0; i < progressBarWidth; ++i) {
+      progressBar[i + 1] = (i < filled) ? '=' : '-';
+    }
+    progressBar[progressBarWidth + 1] = ']';
+    progressBar[progressBarWidth + 2] = '\0';
+    instance().progress_message = std::string(progressBar) + " " + userMsg;
 
-        // Move to beginning of line
-        // TODO remove control characters when printing to non-tty
-        fprintf(stderr, "\r");
+    update(level, "%s", instance().progress_message.c_str());
+  }
 
-        // Print the formatted message
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wformat-nonliteral"
-        fprintf(stderr, format, args...);
-#pragma GCC diagnostic pop
-
-        // Clear to end of line to remove any remaining characters
-        // TODO remove control characters when printing to non-tty
-        fprintf(stderr, "%s", CLEAR_TO_EOL);
-
-        fflush(stderr);
+  // Finalize an update line by adding a newline
+public:
+  static void finalizeUpdate(LogLevel level) {
+    if (!shouldLog(level)) {
+      return;
     }
 
-    template <typename... Args>
-    static void logProgress(
-            LogLevel level,
-            double progress,
-            const char* format,
-            Args&&... args)
-    {
-        if (!shouldLog(level)) {
-            return;
-        }
+    // Add newline
+    fprintf(stderr, "\n");
+  }
 
-        if (progress > 1.0) {
-            throw std::invalid_argument(
-                    "Progress percentage must be <= 1.0, got: "
-                    + std::to_string(progress) + ".");
-        }
+  // Finalize an UPDATE line by adding a newline
+  static void finalizeProgress(LogLevel level) {
+    finalizeUpdate(level);
+    instance().progress_line_active = false;
+  }
 
-        instance().progress_line_active = true;
+private:
+  // ANSI terminal control sequences
+  static constexpr const char *CLEAR_TO_EOL = "\033[K";
 
-        // Store current progress information for re-printing
-        instance().progress_level = level;
-        instance().progress_value = progress;
+  static constexpr int PADDING_SIZE = 80;
 
-        // Build the user message part
-        std::string userMsg;
-        if (format && format[0] != '\0') {
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wformat-nonliteral"
-            int required_size = snprintf(nullptr, 0, format, args...);
-            if (required_size > 0) {
-                std::vector<char> buffer(
-                        required_size + 1); // +1 for null terminator
-                snprintf(buffer.data(), buffer.size(), format, args...);
-                userMsg = std::string(buffer.data());
-            }
-#pragma GCC diagnostic pop
-        }
-
-        // Build the progress message
-        int filled = (int)(progress * progressBarWidth);
-        char progressBar[progressBarWidth + 3]; // progressBarWidth + 2 for ends
-                                                // + 1 for null terminator
-        progressBar[0] = '[';
-        for (int i = 0; i < progressBarWidth; ++i) {
-            progressBar[i + 1] = (i < filled) ? '=' : '-';
-        }
-        progressBar[progressBarWidth + 1] = ']';
-        progressBar[progressBarWidth + 2] = '\0';
-        instance().progress_message = std::string(progressBar) + " " + userMsg;
-
-        update(level, "%s", instance().progress_message.c_str());
-    }
-
-    // Finalize an update line by adding a newline
-   public:
-    static void finalizeUpdate(LogLevel level)
-    {
-        if (!shouldLog(level)) {
-            return;
-        }
-
-        // Add newline
-        fprintf(stderr, "\n");
-    }
-
-    // Finalize an UPDATE line by adding a newline
-    static void finalizeProgress(LogLevel level)
-    {
-        finalizeUpdate(level);
-        instance().progress_line_active = false;
-    }
-
-   private:
-    // ANSI terminal control sequences
-    static constexpr const char* CLEAR_TO_EOL = "\033[K";
-
-    static constexpr int PADDING_SIZE = 80;
-
-    static bool shouldLog(LogLevel level);
-    static void clearLine();
-    static void finalizeProgressIfActive();
-    static void reprintProgressIfActive();
+  static bool shouldLog(LogLevel level);
+  static void clearLine();
+  static void finalizeProgressIfActive();
+  static void reprintProgressIfActive();
 };
 
 } // namespace openzl::tools::logger

--- a/tools/logger/Logger.h
+++ b/tools/logger/Logger.h
@@ -5,6 +5,7 @@
 #include <cstdio>
 #include <iostream>
 #include <ostream>
+#include <string>
 #include <stdexcept>
 #include <vector>
 

--- a/tools/training/clustering/trainers/bottom_up_trainer.cpp
+++ b/tools/training/clustering/trainers/bottom_up_trainer.cpp
@@ -1,5 +1,7 @@
 // Copyright (c) Meta Platforms, Inc. and affiliates.
 
+#include <chrono>
+
 #include "tools/training/clustering/trainers/bottom_up_trainer.h"
 #include "tools/logger/Logger.h"
 #include "tools/training/clustering/clustering_config_builder.h"

--- a/tools/training/clustering/trainers/bottom_up_trainer.cpp
+++ b/tools/training/clustering/trainers/bottom_up_trainer.cpp
@@ -2,174 +2,144 @@
 
 #include <chrono>
 
-#include "tools/training/clustering/trainers/bottom_up_trainer.h"
 #include "tools/logger/Logger.h"
 #include "tools/training/clustering/clustering_config_builder.h"
+#include "tools/training/clustering/trainers/bottom_up_trainer.h"
 
 namespace openzl::training {
 
 using namespace openzl::tools::logger;
 
 ClusteringConfigBuilder BottomUpTrainer::buildTrainedFullSplitConfig(
-        const CompressionUtils& cUtils,
-        const ColumnMetadata& metadata,
-        const std::map<std::pair<ZL_Type, size_t>, size_t>&
-                typeToDefaultSuccessorIdxMap)
-{
-    auto config = ClusteringConfigBuilder::buildFullSplitConfig(
-            metadata,
-            typeToDefaultSuccessorIdxMap,
-            cUtils.getTypeToClusteringCodecIdxsMap());
+    const CompressionUtils &cUtils, const ColumnMetadata &metadata,
+    const std::map<std::pair<ZL_Type, size_t>, size_t>
+        &typeToDefaultSuccessorIdxMap) {
+  auto config = ClusteringConfigBuilder::buildFullSplitConfig(
+      metadata, typeToDefaultSuccessorIdxMap,
+      cUtils.getTypeToClusteringCodecIdxsMap());
 
-    // Pick successor and clustering codec for each cluster in full split
-    std::vector<std::future<ClusterInfo>> futures;
-    futures.reserve(config.clusters().size());
-    const auto& clusters = config.clusters();
-    for (const auto& cluster : clusters) {
-        const auto& tags = cluster.memberTags;
-        auto type        = cluster.typeSuccessor.type;
-        auto width       = cluster.typeSuccessor.eltWidth;
-        auto task        = [&cUtils, &metadata, tags, type, width]() {
-            auto clusterInfo =
-                    cUtils.getBestClusterInfo(tags, type, width, metadata);
-            return clusterInfo;
-        };
-        futures.emplace_back(this->threadPool_->run(task));
-    }
-    size_t clusterIdx = 0;
-    for (auto& future : futures) {
-        auto clusterInfo = future.get();
-        config.setClusterSuccessor(clusterIdx, clusterInfo.successorIdx);
-        config.setClusteringCodec(clusterIdx, clusterInfo.clusteringCodecIdx);
-        clusterIdx++;
-    }
-    return config;
+  // Pick successor and clustering codec for each cluster in full split
+  std::vector<std::future<ClusterInfo>> futures;
+  futures.reserve(config.clusters().size());
+  const auto &clusters = config.clusters();
+  for (const auto &cluster : clusters) {
+    const auto &tags = cluster.memberTags;
+    auto type = cluster.typeSuccessor.type;
+    auto width = cluster.typeSuccessor.eltWidth;
+    auto task = [&cUtils, &metadata, tags, type, width]() {
+      auto clusterInfo = cUtils.getBestClusterInfo(tags, type, width, metadata);
+      return clusterInfo;
+    };
+    futures.emplace_back(this->threadPool_->run(task));
+  }
+  size_t clusterIdx = 0;
+  for (auto &future : futures) {
+    auto clusterInfo = future.get();
+    config.setClusterSuccessor(clusterIdx, clusterInfo.successorIdx);
+    config.setClusteringCodec(clusterIdx, clusterInfo.clusteringCodecIdx);
+    clusterIdx++;
+  }
+  return config;
 }
 
 ClusteringConfigBuilder BottomUpTrainer::buildTrainedConfigAddInputToCluster(
-        const CompressionUtils& cUtils,
-        const ColumnMetadata& metadata,
-        const ClusteringConfigBuilder& config,
-        int tag,
-        ZL_Type type,
-        size_t eltWidth,
-        size_t clusterIdx)
-{
-    auto candidate = config.buildConfigAddInputToCluster(
-            tag, type, eltWidth, clusterIdx);
-    auto clusterInfo = cUtils.getBestClusterInfo(
-            candidate.clusters()[clusterIdx].memberTags,
-            type,
-            eltWidth,
-            metadata);
-    candidate.setClusterSuccessor(clusterIdx, clusterInfo.successorIdx);
-    candidate.setClusteringCodec(clusterIdx, clusterInfo.clusteringCodecIdx);
-    return candidate;
+    const CompressionUtils &cUtils, const ColumnMetadata &metadata,
+    const ClusteringConfigBuilder &config, int tag, ZL_Type type,
+    size_t eltWidth, size_t clusterIdx) {
+  auto candidate =
+      config.buildConfigAddInputToCluster(tag, type, eltWidth, clusterIdx);
+  auto clusterInfo = cUtils.getBestClusterInfo(
+      candidate.clusters()[clusterIdx].memberTags, type, eltWidth, metadata);
+  candidate.setClusterSuccessor(clusterIdx, clusterInfo.successorIdx);
+  candidate.setClusteringCodec(clusterIdx, clusterInfo.clusteringCodecIdx);
+  return candidate;
 }
 
 ClusteringConfigBuilder BottomUpTrainer::getTrainedClusteringConfig(
-        const ZL_Compressor* compressor,
-        const std::vector<MultiInput>& samples,
-        const std::vector<ZL_GraphID>& successors,
-        const std::vector<ZL_NodeID>& clusteringCodecs,
-        const std::map<std::pair<ZL_Type, size_t>, size_t>&
-                typeToDefaultSuccessorIdxMap)
-{
-    auto start  = std::chrono::high_resolution_clock::now();
-    auto cUtils = CompressionUtils(
-            compressor,
-            samples,
-            successors,
-            clusteringCodecs,
-            this->threadPool_);
-    auto metadata = cUtils.aggregateInputMetadata();
-    auto config   = buildTrainedFullSplitConfig(
-            cUtils, metadata, typeToDefaultSuccessorIdxMap);
-    Logger::log_c(
-            INFO,
-            "Created trained full split config with %zu inputs",
-            metadata.size());
+    const ZL_Compressor *compressor, const std::vector<MultiInput> &samples,
+    const std::vector<ZL_GraphID> &successors,
+    const std::vector<ZL_NodeID> &clusteringCodecs,
+    const std::map<std::pair<ZL_Type, size_t>, size_t>
+        &typeToDefaultSuccessorIdxMap) {
+  auto start = std::chrono::high_resolution_clock::now();
+  auto cUtils = CompressionUtils(compressor, samples, successors,
+                                 clusteringCodecs, this->threadPool_);
+  auto metadata = cUtils.aggregateInputMetadata();
+  auto config = buildTrainedFullSplitConfig(cUtils, metadata,
+                                            typeToDefaultSuccessorIdxMap);
+  Logger::log_c(INFO, "Created trained full split config with %zu inputs",
+                metadata.size());
 
-    // Build clusters up iteratively from full split state
-    size_t nbClusters = 0;
-    auto bestCost     = cUtils.tryCompress(config.build()).get();
-    for (const auto& data : metadata) {
-        if (nbClusters == 0) {
-            // No cluster has been built yet for the first tag. Track it in the
-            // set of clusters
-            nbClusters++;
-            continue;
-        }
-        auto now = std::chrono::high_resolution_clock::now();
-        auto duration =
-                std::chrono::duration_cast<std::chrono::seconds>(now - start);
-        if (maxTimeSecs_.has_value()
-            && (size_t)duration.count() > maxTimeSecs_.value()) {
-            Logger::log_c(
-                    INFO,
-                    "Stopping training early after %zu s. Exceeded max time of %zu s.",
-                    duration.count(),
-                    maxTimeSecs_.value());
-            return config;
-        }
-        auto tag            = data.tag;
-        auto typeInfo       = std::make_pair(data.type, data.width);
-        bool hasImprovement = false;
-        // Try add tag to existing clusters only if it hasn't been visited
-        std::vector<std::future<ClusteringConfigBuilder>> candidateFutures;
-        candidateFutures.reserve(nbClusters);
-        for (size_t i = 0; i < nbClusters; i++) {
-            if (!config.typeIsCompatibleWithClusterIdx(
-                        data.type, data.width, (int)i)) {
-                continue;
-            }
-            auto task =
-                    [this, &cUtils, &metadata, &config, tag, typeInfo, i]() {
-                        return buildTrainedConfigAddInputToCluster(
-                                cUtils,
-                                metadata,
-                                config,
-                                tag,
-                                typeInfo.first,
-                                typeInfo.second,
-                                i);
-                    };
-            candidateFutures.emplace_back(this->threadPool_->run(task));
-        }
-        std::vector<std::future<SizeTimePair>> costFutures;
-        std::vector<ClusteringConfigBuilder> candidates;
-        costFutures.reserve(candidateFutures.size());
-        candidates.reserve(candidateFutures.size());
-        for (auto& candidateFuture : candidateFutures) {
-            auto res = candidateFuture.get();
-            costFutures.emplace_back(cUtils.tryCompress(res.build()));
-            candidates.emplace_back(std::move(res));
-        }
-        for (size_t i = 0; i < candidates.size(); i++) {
-            assert(i < costFutures.size());
-            auto cost = costFutures[i].get();
-            if (cost < bestCost) {
-                bestCost       = cost;
-                config         = std::move(candidates[i]);
-                hasImprovement = true;
-            }
-        }
-
-        if (hasImprovement) {
-            // A candidate has been found that adds to a tracked cluster.
-            // Therefore we do not increment the number of clusters.
-            Logger::log_c(VERBOSE1, "New cost: %zu", bestCost.compressedSize);
-        } else {
-            // Increment the number of clusters to track the new tag as its own
-            // cluster
-            nbClusters++;
-            Logger::log_c(VERBOSE1, "No improvement found using tag: %zu", tag);
-        }
+  // Build clusters up iteratively from full split state
+  size_t nbClusters = 0;
+  auto bestCost = cUtils.tryCompress(config.build()).get();
+  for (const auto &data : metadata) {
+    if (nbClusters == 0) {
+      // No cluster has been built yet for the first tag. Track it in the
+      // set of clusters
+      nbClusters++;
+      continue;
     }
-    Logger::log_c(
-            VERBOSE1,
-            "Final config found with cost: ",
-            bestCost.compressedSize);
-    return config;
+    auto now = std::chrono::high_resolution_clock::now();
+    auto duration =
+        std::chrono::duration_cast<std::chrono::seconds>(now - start);
+    if (maxTimeSecs_.has_value() &&
+        (size_t)duration.count() > maxTimeSecs_.value()) {
+      Logger::log_c(
+          INFO,
+          "Stopping training early after %zu s. Exceeded max time of %zu s.",
+          duration.count(), maxTimeSecs_.value());
+      return config;
+    }
+    auto tag = data.tag;
+    auto typeInfo = std::make_pair(data.type, data.width);
+    bool hasImprovement = false;
+    // Try add tag to existing clusters only if it hasn't been visited
+    std::vector<std::future<ClusteringConfigBuilder>> candidateFutures;
+    candidateFutures.reserve(nbClusters);
+    for (size_t i = 0; i < nbClusters; i++) {
+      if (!config.typeIsCompatibleWithClusterIdx(data.type, data.width,
+                                                 (int)i)) {
+        continue;
+      }
+      auto task = [this, &cUtils, &metadata, &config, tag, typeInfo, i]() {
+        return buildTrainedConfigAddInputToCluster(
+            cUtils, metadata, config, tag, typeInfo.first, typeInfo.second, i);
+      };
+      candidateFutures.emplace_back(this->threadPool_->run(task));
+    }
+    std::vector<std::future<SizeTimePair>> costFutures;
+    std::vector<ClusteringConfigBuilder> candidates;
+    costFutures.reserve(candidateFutures.size());
+    candidates.reserve(candidateFutures.size());
+    for (auto &candidateFuture : candidateFutures) {
+      auto res = candidateFuture.get();
+      costFutures.emplace_back(cUtils.tryCompress(res.build()));
+      candidates.emplace_back(std::move(res));
+    }
+    for (size_t i = 0; i < candidates.size(); i++) {
+      assert(i < costFutures.size());
+      auto cost = costFutures[i].get();
+      if (cost < bestCost) {
+        bestCost = cost;
+        config = std::move(candidates[i]);
+        hasImprovement = true;
+      }
+    }
+
+    if (hasImprovement) {
+      // A candidate has been found that adds to a tracked cluster.
+      // Therefore we do not increment the number of clusters.
+      Logger::log_c(VERBOSE1, "New cost: %zu", bestCost.compressedSize);
+    } else {
+      // Increment the number of clusters to track the new tag as its own
+      // cluster
+      nbClusters++;
+      Logger::log_c(VERBOSE1, "No improvement found using tag: %zu", tag);
+    }
+  }
+  Logger::log_c(VERBOSE1,
+                "Final config found with cost: ", bestCost.compressedSize);
+  return config;
 }
 } // namespace openzl::training

--- a/tools/training/clustering/trainers/greedy_trainer.cpp
+++ b/tools/training/clustering/trainers/greedy_trainer.cpp
@@ -3,6 +3,7 @@
 #include "tools/training/clustering/trainers/greedy_trainer.h"
 
 #include <algorithm>
+#include <chrono>
 #include "tools/logger/Logger.h"
 
 #include "tools/training/clustering/clustering_config_builder.h"

--- a/tools/training/utils/genetic_algorithm.cpp
+++ b/tools/training/utils/genetic_algorithm.cpp
@@ -1,5 +1,7 @@
 // Copyright (c) Meta Platforms, Inc. and affiliates.
 
+#include <numeric>
+
 #include "tools/training/utils/genetic_algorithm.h"
 
 namespace openzl {


### PR DESCRIPTION
part of #95

Building the tools/ targets on Windows with LLVM clang-cl fails due to missing STL headers (that Linux setups probably get transitively) 

This PR adds includes where symbols are used, no behavior change