### PR TITLE
derive edge label from the edge itself, rather than a hardcoding

### DIFF
--- a/tools/visualization_app/eslint.config.js
+++ b/tools/visualization_app/eslint.config.js
@@ -25,12 +25,20 @@ export default defineConfig([
   {...pluginReact.configs.flat['jsx-runtime'], files: ['**/*.{jsx,tsx}']},
   {
     files: ['**/*.json'],
-    ignores: ['package.json'],
+    ignores: ['package.json', 'tsconfig.app.json', 'tsconfig.node.json'],
     plugins: {json},
     language: 'json/json',
     extends: ['json/recommended'],
   },
-  {files: ['**/*.css'], plugins: {css}, language: 'css/css', extends: ['css/recommended']},
+  {
+    files: ['**/*.css'],
+    plugins: {css},
+    language: 'css/css',
+    rules: {
+      'css/no-invalid-properties': 'off',
+    },
+    extends: ['css/recommended'],
+  },
   // prettier needs to be at the bottom
   pluginPrettier,
 ]);

--- a/tools/visualization_app/src/components/StreamdumpGraph.tsx
+++ b/tools/visualization_app/src/components/StreamdumpGraph.tsx
@@ -53,9 +53,9 @@ function NoDataHelper() {
       </Heading>
       <Text className="no-data-helper-text">
         This is on by default for CMake builds.{' '}
-        <b>You do not need to worry about this step if you don't see any errors!</b> If you've disabled introspection in
-        your CMake build, you can re-enable it by adding the following flag to your CMake configure command:{' '}
-        <Code>{`-DOPENZL_ALLOW_INTROSPECTION=ON`}</Code>
+        <b>You do not need to worry about this step if you don&apos;t see any errors!</b> If you&apos;ve disabled
+        introspection in your CMake build, you can re-enable it by adding the following flag to your CMake configure
+        command: <Code>{`-DOPENZL_ALLOW_INTROSPECTION=ON`}</Code>
       </Text>
       <br />
 
@@ -66,7 +66,8 @@ function NoDataHelper() {
         Using the CLI
       </Heading>
       <Text className="no-data-helper-text">
-        Specify the 'trace' option when compressing, and provide a .cbor path to write the trace to. For example:
+        Specify the &lsquo;trace&rsquo; option when compressing, and provide a .cbor path to write the trace to. For
+        example:
       </Text>
       <CodeBlock.Root code={cliInvocation} language={'bash'} display="inline-flex">
         <CodeBlock.Content>
@@ -126,10 +127,10 @@ function NoDataHelper() {
         2. Upload the trace
       </Heading>
       <Text className="no-data-helper-text">
-        Navigate to this website (hooray! you've already done it!) and upload the CBOR file.
+        Navigate to this website (hooray! you&apos;ve already done it!) and upload the CBOR file.
       </Text>
       <Text className="no-data-helper-text" fontWeight="bold">
-        That's it!
+        That&apos;s it!
       </Text>
     </Box>
   );

--- a/tools/visualization_app/src/components/Toolbar.tsx
+++ b/tools/visualization_app/src/components/Toolbar.tsx
@@ -5,9 +5,9 @@ import {Legend} from './Legend';
 import logoUrl from '/OpenZL_logo.png?url';
 import {Box, Flex, HStack, VStack, Heading} from '@chakra-ui/react';
 
-type ToolbarProps = {
+interface ToolbarProps {
   onUploadCborFile: () => void;
-};
+}
 
 interface Props {
   key: string;
@@ -35,7 +35,7 @@ const NavLink = (props: Props) => {
   );
 };
 
-const Toolbar: React.FC<ToolbarProps> = ({onUploadCborFile}) => {
+const Toolbar: React.FC<ToolbarProps> = (props: ToolbarProps) => {
   return (
     <Box bg="#23554a" px={4}>
       <VStack align="left" gap={0}>
@@ -58,7 +58,7 @@ const Toolbar: React.FC<ToolbarProps> = ({onUploadCborFile}) => {
               <NavLink key={link.name} name={link.name} link={link.link} />
             ))}
           </HStack>
-          <Box as="button" className="toolbar-button" onClick={onUploadCborFile}>
+          <Box as="button" className="toolbar-button" onClick={props.onUploadCborFile}>
             <p className="toolbar-button-text">UPLOAD CBOR FILE</p>
           </Box>
         </Flex>

--- a/tools/visualization_app/src/graphVisualization/controllers/LayoutController.ts
+++ b/tools/visualization_app/src/graphVisualization/controllers/LayoutController.ts
@@ -50,7 +50,7 @@ export class LayoutController {
       target: edge.target.rfid,
       sourceHandle: 'source',
       targetHandle: 'target',
-      label: edge.label,
+      label: edge.genLabel(),
       type: 'custom',
       style: {stroke: 'black', strokeWidth: 2},
       data: {

--- a/tools/visualization_app/src/graphVisualization/models/InteractiveStreamdumpGraph.ts
+++ b/tools/visualization_app/src/graphVisualization/models/InteractiveStreamdumpGraph.ts
@@ -134,20 +134,10 @@ export class InteractiveStreamdumpGraph {
       }
       const sourceCodec = this.codecs[stream.sourceCodec];
       const targetCodec = this.codecs[stream.targetCodec];
-      const label =
-        `#${stream.outputIdx} (${stream.rfId}) | ${stream.streamTypeToString()}\n` +
-        `${stream.cSize} [${stream.share.toFixed(2)}%]\n` +
-        `${stream.numElts} [${stream.eltWidth}]`;
       // Make edge
       this.edgeViewModels.set(
         stream.rfId,
-        InternalEdge.constructFromStream(
-          stream.rfId,
-          this.codecs[sourceCodec.id],
-          this.codecs[targetCodec.id],
-          label,
-          stream,
-        ),
+        InternalEdge.constructFromStream(stream.rfId, this.codecs[sourceCodec.id], this.codecs[targetCodec.id], stream),
       );
     }
 
@@ -204,7 +194,6 @@ export class InteractiveStreamdumpGraph {
               proxyId as RF_edgeId,
               sourceGraph,
               targetGraph,
-              originalEdge.label,
               originalEdge,
             );
             sourceGraph.outgoingEdges.push(proxyEdge);
@@ -213,51 +202,27 @@ export class InteractiveStreamdumpGraph {
           {
             const proxyId = `proxy-${sourceGraph.rfid}-${stream.rfId}-${targetCodec.rfid}`;
             sourceGraph.outgoingEdges.push(
-              InternalEdge.constructFromInternalEdge(
-                proxyId as RF_edgeId,
-                sourceGraph,
-                targetCodec,
-                originalEdge.label,
-                originalEdge,
-              ),
+              InternalEdge.constructFromInternalEdge(proxyId as RF_edgeId, sourceGraph, targetCodec, originalEdge),
             );
           }
           {
             const proxyId = `proxy-${sourceCodec.rfid}-${stream.rfId}-${targetGraph.rfid}`;
             targetGraph.incomingEdges.push(
-              InternalEdge.constructFromInternalEdge(
-                proxyId as RF_edgeId,
-                sourceCodec,
-                targetGraph,
-                originalEdge.label,
-                originalEdge,
-              ),
+              InternalEdge.constructFromInternalEdge(proxyId as RF_edgeId, sourceCodec, targetGraph, originalEdge),
             );
           }
         }
       } else if (sourceGraph != null) {
         const proxyId = `proxy-${sourceGraph.rfid}-${stream.rfId}-${targetCodec.rfid}`;
         sourceGraph.outgoingEdges.push(
-          InternalEdge.constructFromInternalEdge(
-            proxyId as RF_edgeId,
-            sourceGraph,
-            targetCodec,
-            originalEdge.label,
-            originalEdge,
-          ),
+          InternalEdge.constructFromInternalEdge(proxyId as RF_edgeId, sourceGraph, targetCodec, originalEdge),
         );
       } else if (targetGraph != null) {
         // const sourceCodecRfId = this.codecs[sourceCodecId].rfId;
         // const targetGraphRfId = this.graphs[targetGraphId].rfId;
         const proxyId = `proxy-${sourceCodec.rfid}-${stream.rfId}-${targetGraph.rfid}`;
         targetGraph.incomingEdges.push(
-          InternalEdge.constructFromInternalEdge(
-            proxyId as RF_edgeId,
-            sourceCodec,
-            targetGraph,
-            originalEdge.label,
-            originalEdge,
-          ),
+          InternalEdge.constructFromInternalEdge(proxyId as RF_edgeId, sourceCodec, targetGraph, originalEdge),
         );
       }
     });
@@ -332,12 +297,18 @@ export class InteractiveStreamdumpGraph {
       } else {
         const totShare = edges.reduce((acc, item) => acc + item.share, 0);
         const totCSize = edges.reduce((acc, item) => acc + item.cSize, 0);
-        const coalescedEdge = InternalEdge.constructFromInternalEdge(
-          edges[0].rfid,
+        const coalescedEdge = new InternalEdge(
+          '-' as RF_edgeId,
+          edges[0].streamId,
+          edges[0].type,
+          -1,
+          -1,
+          -1,
+          totCSize,
+          totShare,
+          -1,
           edges[0].source,
           edges[0].target,
-          `#- (-) | Multiple edges\n${totCSize} [${totShare.toFixed(2)}%]\n- [-]`,
-          edges[0],
         );
         dedupedEdges.push(coalescedEdge);
       }

--- a/tools/visualization_app/src/graphVisualization/models/InternalEdge.ts
+++ b/tools/visualization_app/src/graphVisualization/models/InternalEdge.ts
@@ -18,9 +18,6 @@ export class InternalEdge {
   readonly share: number;
   readonly contentSize: number;
 
-  // derived properties
-  readonly label: string;
-
   // graph properties
   readonly source: InternalNode;
   readonly target: InternalNode;
@@ -29,7 +26,6 @@ export class InternalEdge {
 
   constructor(
     rfid: RF_edgeId,
-    // stream: Stream,
     streamId: StreamID,
     type: ZL_Type,
     outputIdx: number,
@@ -40,7 +36,6 @@ export class InternalEdge {
     contentSize: number,
     source: InternalNode,
     target: InternalNode,
-    label: string,
   ) {
     this.rfid = rfid;
     this.streamId = streamId;
@@ -54,14 +49,12 @@ export class InternalEdge {
 
     this.source = source;
     this.target = target;
-    this.label = label;
   }
 
   static constructFromStream(
     rfid: RF_edgeId,
     source: InternalNode,
     target: InternalNode,
-    label: string,
     stream: Stream,
   ): InternalEdge {
     return new InternalEdge(
@@ -76,7 +69,6 @@ export class InternalEdge {
       stream.contentSize,
       source,
       target,
-      label,
     );
   }
 
@@ -84,7 +76,6 @@ export class InternalEdge {
     rfid: RF_edgeId,
     source: InternalNode,
     target: InternalNode,
-    label: string,
     edge: InternalEdge,
   ): InternalEdge {
     return new InternalEdge(
@@ -99,7 +90,6 @@ export class InternalEdge {
       edge.contentSize,
       source,
       target,
-      label,
     );
   }
 
@@ -116,5 +106,13 @@ export class InternalEdge {
       default:
         return 'default';
     }
+  }
+
+  genLabel(): string {
+    return (
+      `#${this.outputIdx} (${this.rfid}) | ${this.streamTypeToString()}\n` +
+      `${this.cSize} [${this.share.toFixed(2)}%]\n` +
+      `${this.numElts} [${this.eltWidth}]`
+    );
   }
 }

--- a/tools/visualization_app/src/graphVisualization/views/EdgeView.tsx
+++ b/tools/visualization_app/src/graphVisualization/views/EdgeView.tsx
@@ -1,0 +1,31 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+import {Handle, Position} from '@xyflow/react';
+import type {InternalEdge} from '../models/InternalEdge';
+import '../../styles/streamdumpGraph.css';
+
+interface EdgeViewProps {
+  data: {
+    internalNode: InternalEdge;
+  };
+}
+
+export function EdgeView({data}: EdgeViewProps) {
+  const edge = data.internalNode;
+  return (
+    <div style={edge.inLargestCompressionPath ? {border: '7px solid #2ed78b'} : {}}>
+      <Handle type="target" position={Position.Top} id="target" style={{background: '#555'}} />
+      <Handle type="source" position={Position.Bottom} id="source" style={{background: '#555'}} />
+      <div
+        style={{
+          borderStyle: 'solid',
+          borderColor: 'black',
+          borderWidth: '1px',
+          padding: '5px',
+        }}
+        className="edge-label">
+        {edge.genLabel()}
+      </div>
+    </div>
+  );
+}

--- a/tools/visualization_app/src/graphVisualization/views/LocalParamsView.tsx
+++ b/tools/visualization_app/src/graphVisualization/views/LocalParamsView.tsx
@@ -5,9 +5,9 @@ import {useState} from 'react';
 import {useFloating, autoUpdate} from '@floating-ui/react';
 import {CiCircleMore} from '../../icons/TablerIcons';
 
-type LocalParamsPopoverProps = {
+interface LocalParamsPopoverProps {
   localParams: LocalParamInfo;
-};
+}
 
 // Display local params
 export function renderLocalParams(localParams: LocalParamInfo) {

--- a/tools/visualization_app/src/graphVisualization/views/ScrollablePopover.tsx
+++ b/tools/visualization_app/src/graphVisualization/views/ScrollablePopover.tsx
@@ -3,10 +3,10 @@
 import {ScrollArea} from '@chakra-ui/react';
 import type {PropsWithChildren} from 'react';
 
-type ScrollablePopoverProps = {
+interface ScrollablePopoverProps {
   className: string;
   maxHeight: string;
-};
+}
 
 export const ScrollablePopover = (props: PropsWithChildren<ScrollablePopoverProps>) => {
   return (

--- a/tools/visualization_app/src/graphVisualization/views/StreamdumpGraphView.tsx
+++ b/tools/visualization_app/src/graphVisualization/views/StreamdumpGraphView.tsx
@@ -10,6 +10,8 @@ import {Box} from '@chakra-ui/react/box';
 import {Button} from '@chakra-ui/react/button';
 import {HStack} from '@chakra-ui/react/stack';
 
+const showExpansionButton = false;
+
 interface StreamdumpGraphViewProps {
   nodes: Node[];
   edges: Edge[];
@@ -27,9 +29,6 @@ export function StreamdumpGraphView({
   handleAllStandardGraphsCollapse,
   areStandardGraphsCollapsed,
 }: StreamdumpGraphViewProps) {
-  areStandardGraphsCollapsed as unknown;
-  handleAllStandardGraphsCollapse as unknown;
-
   const [isTrackpadMode, setIsTrackpadMode] = useState<boolean>(false);
   const reactFlowInstance = useReactFlow();
 
@@ -66,9 +65,11 @@ export function StreamdumpGraphView({
               {isTrackpadMode ? 'Switch to Mouse Controls' : 'Switch to Trackpad Controls'}
             </Button>
             {/* TODO: re-enable once expansion is fixed */}
-            {/* <Button onClick={handleAllStandardGraphsCollapse}>
-              {areStandardGraphsCollapsed ? 'Expand all standard graphs' : 'Collapse all standard graphs'}
-            </Button> */}
+            {showExpansionButton && (
+              <Button onClick={handleAllStandardGraphsCollapse}>
+                {areStandardGraphsCollapsed ? 'Expand all standard graphs' : 'Collapse all standard graphs'}
+              </Button>
+            )}
           </HStack>
         </Panel>
       </ReactFlow>

--- a/tools/visualization_app/src/index.css
+++ b/tools/visualization_app/src/index.css
@@ -37,7 +37,9 @@
   }
 }
 
-html, body, #root {
+html,
+body,
+#root {
   position: fixed;
   height: 100%;
   width: 100%;

--- a/tools/visualization_app/src/interfaces/NullableStreamdump.ts
+++ b/tools/visualization_app/src/interfaces/NullableStreamdump.ts
@@ -3,6 +3,6 @@
 import {Streamdump} from '../models/Streamdump';
 
 // Useful for functions that wait for streamdump data to do something
-export type NullableStreamdump = {
+export interface NullableStreamdump {
   data: Streamdump | null;
-};
+}

--- a/tools/visualization_app/src/interfaces/SerializedCodec.ts
+++ b/tools/visualization_app/src/interfaces/SerializedCodec.ts
@@ -3,7 +3,7 @@
 import type {ZL_IDType, StreamID} from '../models/idTypes';
 import type {SerializedLocalParamInfo} from './SerializedLocalParamInfo';
 
-export type SerializedCodec = {
+export interface SerializedCodec {
   name: string;
   cType: boolean;
   cID: ZL_IDType;
@@ -12,4 +12,4 @@ export type SerializedCodec = {
   cLocalParams: SerializedLocalParamInfo;
   inputStreams: StreamID[];
   outputStreams: StreamID[];
-};
+}

--- a/tools/visualization_app/src/interfaces/SerializedCopyParamInfo.ts
+++ b/tools/visualization_app/src/interfaces/SerializedCopyParamInfo.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Meta Platforms, Inc. and affiliates.
 
-export type SerializedCopyParamInfo = {
+export interface SerializedCopyParamInfo {
   paramId: number;
   paramSize: number;
   paramData: Uint8Array;
-};
+}

--- a/tools/visualization_app/src/interfaces/SerializedGraph.ts
+++ b/tools/visualization_app/src/interfaces/SerializedGraph.ts
@@ -3,10 +3,10 @@
 import {ZL_GraphType} from '../models/idTypes';
 import type {SerializedLocalParamInfo} from './SerializedLocalParamInfo';
 
-export type SerializedGraph = {
+export interface SerializedGraph {
   gType: ZL_GraphType;
   gName: string;
   gFailureString: string;
   gLocalParams: SerializedLocalParamInfo;
   codecIDs: number[];
-};
+}

--- a/tools/visualization_app/src/interfaces/SerializedIntParamInfo.ts
+++ b/tools/visualization_app/src/interfaces/SerializedIntParamInfo.ts
@@ -1,6 +1,6 @@
 // Copyright (c) Meta Platforms, Inc. and affiliates.
 
-export type SerializedIntParamInfo = {
+export interface SerializedIntParamInfo {
   paramId: number;
   paramValue: number;
-};
+}

--- a/tools/visualization_app/src/interfaces/SerializedLocalParamInfo.ts
+++ b/tools/visualization_app/src/interfaces/SerializedLocalParamInfo.ts
@@ -4,8 +4,8 @@ import type {SerializedIntParamInfo} from './SerializedIntParamInfo';
 import type {SerializedCopyParamInfo} from './SerializedCopyParamInfo';
 import type {SerializedRefParamInfo} from './SerializedRefParamInfo';
 
-export type SerializedLocalParamInfo = {
+export interface SerializedLocalParamInfo {
   intParams: SerializedIntParamInfo[];
   copyParams: SerializedCopyParamInfo[];
   refParams: SerializedRefParamInfo[];
-};
+}

--- a/tools/visualization_app/src/interfaces/SerializedRefParamInfo.ts
+++ b/tools/visualization_app/src/interfaces/SerializedRefParamInfo.ts
@@ -1,5 +1,5 @@
 // Copyright (c) Meta Platforms, Inc. and affiliates.
 
-export type SerializedRefParamInfo = {
+export interface SerializedRefParamInfo {
   paramId: number;
-};
+}

--- a/tools/visualization_app/src/interfaces/SerializedStream.ts
+++ b/tools/visualization_app/src/interfaces/SerializedStream.ts
@@ -2,7 +2,7 @@
 
 import {ZL_Type} from '../models/idTypes';
 
-export type SerializedStream = {
+export interface SerializedStream {
   type: ZL_Type;
   outputIdx: number;
   eltWidth: number;
@@ -10,4 +10,4 @@ export type SerializedStream = {
   cSize: number;
   share: number;
   contentSize: number;
-};
+}

--- a/tools/visualization_app/src/main.tsx
+++ b/tools/visualization_app/src/main.tsx
@@ -7,6 +7,7 @@ import {system} from '@chakra-ui/react/preset';
 import './index.css';
 import App from './App.tsx';
 
+// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
 ReactDOM.createRoot(document.getElementById('root')!).render(
   <React.StrictMode>
     <ChakraProvider value={system}>

--- a/tools/visualization_app/src/styles/streamdumpGraph.css
+++ b/tools/visualization_app/src/styles/streamdumpGraph.css
@@ -1,5 +1,7 @@
 /* Copyright (c) Meta Platforms, Inc. and affiliates. */
 
+@import '../index.css';
+
 /* Usage hints for when no data is provided */
 .no-data-helper {
   text-align: left;

--- a/tools/visualization_app/tests/createTestModels.ts
+++ b/tools/visualization_app/tests/createTestModels.ts
@@ -12,7 +12,7 @@ import {ZL_Type, ZL_GraphType} from '../src/models/idTypes';
 export function createTestStream(
   id: number,
   type: ZL_Type = ZL_Type.ZL_Type_numeric,
-  eltWidth: number = 4,
+  eltWidth = 4,
   numElts: number,
   cSize: number,
   share: number,
@@ -24,9 +24,9 @@ export function createTestStream(
 export function createTestCodec(
   id: number,
   name: string,
-  cType: boolean = true,
-  headerSize: number = 1,
-  localParamsSize: number = 16,
+  cType = true,
+  headerSize = 1,
+  localParamsSize = 16,
   localParams: LocalParamInfo = new LocalParamInfo([], [], []),
   inputStreams: number[] = [],
   outputStreams: number[] = [],
@@ -46,7 +46,7 @@ export function createTestGraph(
 }
 
 // Create a simple tree with a graph: A->B->C->D where B and C are in a graph
-export function createSimpleTreeWithGraph(isDefaultCollapsed: boolean = false) {
+export function createSimpleTreeWithGraph(isDefaultCollapsed = false) {
   const emptyLocalParams = new LocalParamInfo([], [], []);
 
   // Create streams
@@ -70,7 +70,7 @@ export function createSimpleTreeWithGraph(isDefaultCollapsed: boolean = false) {
 }
 
 // Create a branching tree with two paths: A->B->C/D and A->E->F
-export function createBranchingTreeWithGraph(isDefaultCollapsed: boolean = false) {
+export function createBranchingTreeWithGraph(isDefaultCollapsed = false) {
   const emptyLocalParams = new LocalParamInfo([], [], []);
 
   // Create streams

--- a/tools/visualization_app/tests/interactiveStreamdumpGraph.test.ts
+++ b/tools/visualization_app/tests/interactiveStreamdumpGraph.test.ts
@@ -14,7 +14,7 @@ import {createSimpleTreeWithGraph, createBranchingTreeWithGraph} from './createT
 
 describe('Test interactive streamdump graph creation', () => {
   it('Should initialize with a chain of codecs A->B->C->D where B and C are in a graph', () => {
-    let interactiveGraph = createSimpleTreeWithGraph();
+    const interactiveGraph = createSimpleTreeWithGraph();
     // Test that thge model graph was created properly
     const {nodes, edges, graphs} = interactiveGraph.getVisibleStreamdumpGraph();
     expect(nodes.length).toBe(4);
@@ -46,7 +46,7 @@ describe('Test interactive streamdump graph creation', () => {
 
 describe('Test collapsing and expanding a graph', () => {
   it('Should collapse and expand a graph, preserving its successors upon collapse and preserving its codecs upon expand', () => {
-    let interactiveGraph = createSimpleTreeWithGraph();
+    const interactiveGraph = createSimpleTreeWithGraph();
     const {nodes, edges, graphs} = interactiveGraph.getVisibleStreamdumpGraph();
 
     // Test collapsing the graph
@@ -79,7 +79,7 @@ describe('Test collapsing and expanding a graph', () => {
 
 describe('Test preserving collapsed descendant node', () => {
   it('Should collapse a node, collapse an ancestor of the collapsed node, and upon expanding the ancestor, the descendant should be collapse', () => {
-    let interactiveGraph = createSimpleTreeWithGraph();
+    const interactiveGraph = createSimpleTreeWithGraph();
     const {nodes, edges, graphs} = interactiveGraph.getVisibleStreamdumpGraph();
 
     // collapse a node with an ancestor
@@ -113,7 +113,7 @@ describe('Test preserving collapsed descendant node', () => {
 
 describe('Test preserving collapsed descendant graph', () => {
   it('Should collapse a graph, collapse an ancestor of the graph, and upon expanding the ancestor, the graph should still be collapsed', () => {
-    let interactiveGraph = createSimpleTreeWithGraph();
+    const interactiveGraph = createSimpleTreeWithGraph();
     const {nodes, edges, graphs} = interactiveGraph.getVisibleStreamdumpGraph();
 
     // collapse the graph
@@ -141,7 +141,7 @@ describe('Test preserving collapsed descendant graph', () => {
 
 describe('Test preserving collapsed node in collapsed graph', () => {
   it('Should collapse a node within a graph, collapse and expand the graph, and see if the internal collapsed node is still collapsed', () => {
-    let interactiveGraph = createSimpleTreeWithGraph();
+    const interactiveGraph = createSimpleTreeWithGraph();
     const {nodes, edges, graphs} = interactiveGraph.getVisibleStreamdumpGraph();
 
     // Collapse a node within the graph
@@ -170,7 +170,7 @@ describe('Test preserving collapsed node in collapsed graph', () => {
 
 describe('Test expanding 1 level of a graph', () => {
   it('Should expand a graph by just 1 level', () => {
-    let interactiveGraph = createSimpleTreeWithGraph();
+    const interactiveGraph = createSimpleTreeWithGraph();
     const {nodes, edges, graphs} = interactiveGraph.getVisibleStreamdumpGraph();
 
     // Collapse child to root node
@@ -194,7 +194,7 @@ describe('Test expanding 1 level of a graph', () => {
 
 describe('Test expanding 1 level of a graph with child collapsed graph', () => {
   it('Should expand a graph by just 1 level, amd the child codec is in a collapsed graph, so the level expansion should should the collapsed graph', () => {
-    let interactiveGraph = createSimpleTreeWithGraph();
+    const interactiveGraph = createSimpleTreeWithGraph();
     const {nodes, edges, graphs} = interactiveGraph.getVisibleStreamdumpGraph();
     // Collapse the graph
     interactiveGraph.toggleGraphCollapse(graphs[0]);
@@ -230,7 +230,7 @@ describe('Test expanding 1 level of a graph with child collapsed graph', () => {
 
 describe('Collapse/Expanding all standard graphs', () => {
   it('Should test default standard graph collapsed state, where successors are also hidden', () => {
-    let interactiveGraph = createSimpleTreeWithGraph(true); // Default collapse all standard graphs
+    const interactiveGraph = createSimpleTreeWithGraph(true); // Default collapse all standard graphs
     const {nodes, edges, graphs} = interactiveGraph.getVisibleStreamdumpGraph();
     expect(nodes.length).toBe(1);
     expect(edges.length).toBe(1);
@@ -252,7 +252,7 @@ describe('Collapse/Expanding all standard graphs', () => {
 
 describe('Collapse/Expanding all standard graphs with all hidden', () => {
   it('Attempts to collapse/expand all standard graphs when they are all hidden, should do nothing', () => {
-    let interactiveGraph = createSimpleTreeWithGraph();
+    const interactiveGraph = createSimpleTreeWithGraph();
     const {nodes, edges, graphs} = interactiveGraph.getVisibleStreamdumpGraph();
     // Collapse root node to hide standard graph
     interactiveGraph.toggleSubgraphCollapse(nodes[0]);
@@ -277,7 +277,7 @@ describe('Collapse/Expanding all standard graphs with all hidden', () => {
 
 describe('Collapse/Expanding all standard graphs with no standard graphs', () => {
   it('Attempts to collapse/expand all standard graphs when there are no standard graphs, should do nothing', () => {
-    let interactiveGraph = createBranchingTreeWithGraph();
+    const interactiveGraph = createBranchingTreeWithGraph();
     // Collapse all standard graphs
     interactiveGraph.toggleAllStandardGraphs(true);
     const {nodes, edges, graphs} = interactiveGraph.getVisibleStreamdumpGraph();
@@ -288,7 +288,7 @@ describe('Collapse/Expanding all standard graphs with no standard graphs', () =>
 
 describe('Test the largest compression path', () => {
   it('Creates a graph, and ensures that the largest compression path is the correct path', () => {
-    let interactiveGraph = createBranchingTreeWithGraph();
+    const interactiveGraph = createBranchingTreeWithGraph();
     const {nodes, edges, graphs} = interactiveGraph.getVisibleStreamdumpGraph();
     // A -> B -> C is the largest compression path
     expect(nodes[0].inLargestCompressionPath).toBe(true); // A

--- a/tools/visualization_app/tsconfig.app.json
+++ b/tools/visualization_app/tsconfig.app.json
@@ -7,7 +7,7 @@
     "module": "ESNext",
     "skipLibCheck": true,
 
-    /* Bundler mode */
+    // Bundler mode
     "moduleResolution": "bundler",
     "allowImportingTsExtensions": true,
     "verbatimModuleSyntax": true,
@@ -15,7 +15,7 @@
     "noEmit": true,
     "jsx": "react-jsx",
 
-    /* Linting */
+    // Linting
     "strict": true,
     "noUnusedLocals": true,
     "noUnusedParameters": true,

--- a/tools/visualization_app/tsconfig.json
+++ b/tools/visualization_app/tsconfig.json
@@ -1,9 +1,6 @@
 {
   "files": [],
-  "references": [
-    { "path": "./tsconfig.app.json" },
-    { "path": "./tsconfig.node.json" }
-  ],
+  "references": [{"path": "./tsconfig.app.json"}, {"path": "./tsconfig.node.json"}],
   "compilerOptions": {
     "jsx": "react-jsx"
   }

--- a/tools/visualization_app/tsconfig.node.json
+++ b/tools/visualization_app/tsconfig.node.json
@@ -6,14 +6,14 @@
     "module": "ESNext",
     "skipLibCheck": true,
 
-    /* Bundler mode */
+    // Bundler mode
     "moduleResolution": "bundler",
     "allowImportingTsExtensions": true,
     "verbatimModuleSyntax": true,
     "moduleDetection": "force",
     "noEmit": true,
 
-    /* Linting */
+    // Linting
     "strict": true,
     "noUnusedLocals": true,
     "noUnusedParameters": true,


### PR DESCRIPTION
Summary:
The `InternalEdge` has essentially all the info necessary to regenerate the label at any time. Thus, there's no reason for this duplication.

This undoes the multiple edge hack somewhat, but that will go away in the next diff anyways.

Reviewed By: kevinjzhang

Differential Revision: D84166479


