### PR TITLE
hide internal trace hooks detail from CCtx.hpp

### DIFF
--- a/cpp/include/openzl/cpp/CCtx.hpp
+++ b/cpp/include/openzl/cpp/CCtx.hpp
@@ -4,6 +4,7 @@
 
 #include <map>
 #include "openzl/cpp/CParam.hpp"
+#include "openzl/cpp/CompressIntrospectionHooks.hpp"
 #include "openzl/cpp/Compressor.hpp"
 #include "openzl/cpp/Exception.hpp"
 #include "openzl/cpp/Input.hpp"
@@ -107,7 +108,7 @@ class CCtx {
 
    private:
     detail::NonNullUniqueCPtr<ZL_CCtx> cctx_;
-    std::unique_ptr<visualizer::CompressionTraceHooks> hooks_{ nullptr };
+    std::unique_ptr<CompressIntrospectionHooks> visHooks_{ nullptr };
 };
 
 class CCtxRef : public CCtx {

--- a/cpp/src/openzl/cpp/CCtx.cpp
+++ b/cpp/src/openzl/cpp/CCtx.cpp
@@ -151,15 +151,16 @@ void CCtx::selectStartingGraph(
 
 void CCtx::writeTraces(bool enabled)
 {
-    if ((bool)hooks_ == enabled) {
+    if ((bool)visHooks_ == enabled) {
         return; // no need to re-create or re-destroy the hooks
     }
     if (enabled) {
-        hooks_ = std::make_unique<visualizer::CompressionTraceHooks>();
-        unwrap(ZL_CCtx_attachIntrospectionHooks(get(), hooks_->getRawHooks()));
+        visHooks_ = std::make_unique<visualizer::CompressionTraceHooks>();
+        unwrap(ZL_CCtx_attachIntrospectionHooks(
+                get(), visHooks_->getRawHooks()));
     } else {
         unwrap(ZL_CCtx_detachAllIntrospectionHooks(get()));
-        hooks_.reset();
+        visHooks_.reset();
     }
 }
 
@@ -168,10 +169,11 @@ std::pair<
         std::map<size_t, std::pair<poly::string_view, poly::string_view>>>
 CCtx::getLatestTrace()
 {
-    if (!hooks_) {
+    if (!visHooks_) {
         throw Exception("Tracing is not enabled");
     }
-    return hooks_->getLatestTrace();
+    return (static_cast<visualizer::CompressionTraceHooks*>(visHooks_.get()))
+            ->getLatestTrace();
 }
 
 } // namespace openzl


### PR DESCRIPTION
Summary:
The `CompressTraceHooks` class is an internal experimental class and not meant to be exposed via the API. Previously, the `CCtx.hpp` had a unique pointer to this class, leading to build failures.

This diff instead declares an unique_ptr to `CompressIntrospectionHooks`, which *is* declared in the public API. Internally, the trace hooks are still used, because it is a derived class of the introspection hooks.

Differential Revision: D84366736


