### PR TITLE
update readme and quick-start to reflect current requirements for C11, C++17, and CMake 3.20.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,9 @@ Despite the big scary warnings above, we consider the core to have reached produ
 
 ## Building OpenZL
 
+### Prerequisites
+OpenZL requires a compiler that supports C11 and C++17. When building with `cmake`, `cmake 3.20.2` or newer is required. There is ongoing work to relax these restrictions. As that happens, this section will be updated.
+
 ### Build with `make`
 
 The OpenZL library and essential tools can be built using `make`:

--- a/cpp/include/openzl/cpp/CCtx.hpp
+++ b/cpp/include/openzl/cpp/CCtx.hpp
@@ -4,6 +4,7 @@
 
 #include <map>
 #include "openzl/cpp/CParam.hpp"
+#include "openzl/cpp/CompressIntrospectionHooks.hpp"
 #include "openzl/cpp/Compressor.hpp"
 #include "openzl/cpp/Exception.hpp"
 #include "openzl/cpp/Input.hpp"
@@ -107,7 +108,7 @@ class CCtx {
 
    private:
     detail::NonNullUniqueCPtr<ZL_CCtx> cctx_;
-    std::unique_ptr<visualizer::CompressionTraceHooks> hooks_{ nullptr };
+    std::unique_ptr<CompressIntrospectionHooks> visHooks_{ nullptr };
 };
 
 class CCtxRef : public CCtx {

--- a/cpp/src/openzl/cpp/CCtx.cpp
+++ b/cpp/src/openzl/cpp/CCtx.cpp
@@ -151,15 +151,16 @@ void CCtx::selectStartingGraph(
 
 void CCtx::writeTraces(bool enabled)
 {
-    if ((bool)hooks_ == enabled) {
+    if ((bool)visHooks_ == enabled) {
         return; // no need to re-create or re-destroy the hooks
     }
     if (enabled) {
-        hooks_ = std::make_unique<visualizer::CompressionTraceHooks>();
-        unwrap(ZL_CCtx_attachIntrospectionHooks(get(), hooks_->getRawHooks()));
+        visHooks_ = std::make_unique<visualizer::CompressionTraceHooks>();
+        unwrap(ZL_CCtx_attachIntrospectionHooks(
+                get(), visHooks_->getRawHooks()));
     } else {
         unwrap(ZL_CCtx_detachAllIntrospectionHooks(get()));
-        hooks_.reset();
+        visHooks_.reset();
     }
 }
 
@@ -168,10 +169,11 @@ std::pair<
         std::map<size_t, std::pair<poly::string_view, poly::string_view>>>
 CCtx::getLatestTrace()
 {
-    if (!hooks_) {
+    if (!visHooks_) {
         throw Exception("Tracing is not enabled");
     }
-    return hooks_->getLatestTrace();
+    return (static_cast<visualizer::CompressionTraceHooks*>(visHooks_.get()))
+            ->getLatestTrace();
 }
 
 } // namespace openzl

--- a/doc/mkdocs/doc/getting-started/quick-start.md
+++ b/doc/mkdocs/doc/getting-started/quick-start.md
@@ -20,13 +20,17 @@ cd openzl
 ## Building the OpenZL CLI
 
 OpenZL consists of a core library and a set of tools, each of which can be compiled independently. However, for usage simplicity, many of them are bundled into a CLI called `zli`.
-Compile it; it will be your main tool for the next sections.
+It will be your main tool for the next sections.
+
+???+ important "System requirements"
+    OpenZL uses modern C11 and C++17 features. Ensure your compiler has full support. GCC 9+ and Clang 13+ are known to be supported.
 
 ```sh
 make zli
 ```
 
 ??? note "Alternative: Using cmake instead of make"
+    Use CMake 3.20.2+ when generating:
     ```bash
     mkdir -p cmakebuild
     cmake -S . -B cmakebuild


### PR DESCRIPTION
Summary:
C11 and C++17 are required but not enforced in the Makefile. Thus, older compiler versions may choke and fail.
The CMake requirement will throw an error at generation time, but is an easy bird to hit with the stone we're already throwing in this diff.

Differential Revision: D84514503


