### PR TITLE
Fix protobuf training

### DIFF
--- a/tools/protobuf/BUCK
+++ b/tools/protobuf/BUCK
@@ -40,6 +40,7 @@ zs_cxxbinary(
         "fbsource//third-party/protobuf:libprotobuf",
         ":schema-cpp",
         ":serializer",
+        "//data_compression/experimental/zstrong/custom_parsers:custom_parsers",
         "//data_compression/experimental/zstrong/tools:arg",
         "//data_compression/experimental/zstrong/tools:io",
         "//data_compression/experimental/zstrong/tools/training:train",

--- a/tools/protobuf/cli.cpp
+++ b/tools/protobuf/cli.cpp
@@ -5,6 +5,7 @@
 #include <google/protobuf/util/message_differencer.h>
 #include <filesystem>
 #include <iomanip>
+#include "custom_parsers/dependency_registration.h"
 #include "openzl/common/assertion.h"
 #include "openzl/common/logging.h"
 #include "tools/arg/arg_parser.h"
@@ -320,6 +321,8 @@ int handleTrain(TrainArgs args)
     auto compressor = args.serializer.getCompressor();
 
     auto params = training::TrainParams();
+    params.compressorGenFunc =
+            openzl::custom_parsers::createCompressorFromSerialized;
 
     auto serialized = training::train(samples, *compressor, params)[0];
 


### PR DESCRIPTION
Summary: Training now requires `compressorGenFunc` to be set, which handles dependency registration.

Differential Revision: D84544879


