### PR TITLE
Make --output actually affect the output path

### DIFF
--- a/tools/protobuf/BUCK
+++ b/tools/protobuf/BUCK
@@ -40,6 +40,7 @@ zs_cxxbinary(
         "fbsource//third-party/protobuf:libprotobuf",
         ":schema-cpp",
         ":serializer",
+        "//data_compression/experimental/zstrong/custom_parsers:custom_parsers",
         "//data_compression/experimental/zstrong/tools:arg",
         "//data_compression/experimental/zstrong/tools:io",
         "//data_compression/experimental/zstrong/tools/training:train",

--- a/tools/protobuf/cli.cpp
+++ b/tools/protobuf/cli.cpp
@@ -176,11 +176,13 @@ class SerializeArgs : public Args {
         outputType = parseProtocol(
                 args.cmdFlag(Cmd::SERIALIZE, kOutputType).value_or("zl"));
 
-        check = args.cmdHasFlag(Cmd::SERIALIZE, kCheck);
+        check  = args.cmdHasFlag(Cmd::SERIALIZE, kCheck);
+        output = args.cmdFlag(Cmd::SERIALIZE, kOutput);
     }
 
     Protocol outputType;
     bool check;
+    std::optional<std::string> output;
 };
 
 class TrainArgs : public Args {
@@ -296,8 +298,13 @@ int handleSerialize(SerializeArgs args)
         };
 
         // Write the serialized object to a file
-        auto path = std::filesystem::path(input->name());
-        path.replace_extension(ext(args.outputType));
+        std::filesystem::path path;
+        if (!args.output) {
+            path = std::filesystem::path(input->name());
+            path.replace_extension(ext(args.outputType));
+        } else {
+            path = std::filesystem::path(args.output.value());
+        }
         std::make_unique<tools::io::OutputFile>(path)->write(serialized);
     }
     return 0;

--- a/tools/protobuf/cli.cpp
+++ b/tools/protobuf/cli.cpp
@@ -5,6 +5,7 @@
 #include <google/protobuf/util/message_differencer.h>
 #include <filesystem>
 #include <iomanip>
+#include "custom_parsers/dependency_registration.h"
 #include "openzl/common/assertion.h"
 #include "openzl/common/logging.h"
 #include "tools/arg/arg_parser.h"
@@ -320,6 +321,8 @@ int handleTrain(TrainArgs args)
     auto compressor = args.serializer.getCompressor();
 
     auto params = training::TrainParams();
+    params.compressorGenFunc =
+            openzl::custom_parsers::createCompressorFromSerialized;
 
     auto serialized = training::train(samples, *compressor, params)[0];
 


### PR DESCRIPTION
Summary: There is currently a bug where setting `--output` does not change the output of the protobuf serializet

Differential Revision: D84547721


