### PR TITLE
Ensure training fails if file size too large

### DIFF
--- a/cli/commands/cmd_benchmark.cpp
+++ b/cli/commands/cmd_benchmark.cpp
@@ -125,9 +125,9 @@ BenchmarkResult runCompressionBenchmarks(const BenchmarkArgs& args)
             uncompressed_size += input.contentSize();
         }
         // TODO: Size limitations should be a library feature
-        if (uncompressed_size > 2 * BYTES_TO_GB) {
+        if (uncompressed_size > BYTES_TO_GB / 2) {
             throw std::runtime_error(
-                    "Chunking support is required for compressing inputs larger than 2 GB. ");
+                    "Chunking support is required for compressing inputs larger than 500 MB. ");
         }
         // get the compressed size
         const auto compressed = cctx.compress(inputVec);

--- a/cli/commands/cmd_compress.cpp
+++ b/cli/commands/cmd_compress.cpp
@@ -145,9 +145,9 @@ int performCompression(const CompressArgs& args)
     // ahead of time.
     const auto inputSize = input.size().value();
     // TODO: Size limitations should be a library feature
-    if (inputSize > 2 * BYTES_TO_GB) {
+    if (inputSize > BYTES_TO_GB / 2) {
         throw std::runtime_error(
-                "Chunking support is required for compressing inputs larger than 2 GB. ");
+                "Chunking support is required for compressing inputs larger than 500 MB. ");
     }
     Logger::log(VERBOSE1, "Input size: ", inputSize);
 

--- a/cli/commands/cmd_train.cpp
+++ b/cli/commands/cmd_train.cpp
@@ -17,6 +17,7 @@ using namespace tools::logger;
 
 const uint64_t kDefaultMaxSingleSampleSize = 150 * 1024 * 1024; /* 150MiB */
 const uint64_t kDefaultMaxTotalSize        = 300 * 1024 * 1024; /* 300MiB */
+constexpr size_t BYTES_TO_GB               = 1000 * 1000 * 1000;
 
 int cmdTrain(const TrainArgs& args)
 {
@@ -74,6 +75,11 @@ int cmdTrain(const TrainArgs& args)
     auto maxTotalSize = args.trainParams.maxTotalSizeMb.has_value()
             ? args.trainParams.maxTotalSizeMb.value() * 1024 * 1024
             : kDefaultMaxTotalSize;
+
+    if (maxFileSize > BYTES_TO_GB / 2) {
+        throw InvalidArgsException(
+                "Max file size must be less than 500MB. Chunking support is required for compressing inputs larger than 2 GB.");
+    }
 
     // Get samples for training
     auto limiter =


### PR DESCRIPTION
Summary: By default, training will have a max file size of 150Mb. This can be overwritten by the flag `--max-file-size-mb`. When passing in a value greater than 500Mb, this should also error.

Differential Revision: D84366852


