### PR TITLE
Make OpenZl Python wrapper package version dynamic

### DIFF
--- a/py/pyproject.toml
+++ b/py/pyproject.toml
@@ -4,10 +4,9 @@
 requires = ["scikit-build-core >=0.11.5", "nanobind >=2.7.0"]
 build-backend = "scikit_build_core.build"
 
-# TODO: Figure out how to get the version from zl_version.h
 [project]
 name = "openzl"
-version = "0.1.0"
+dynamic = ["version"]
 requires-python = ">=3.8"
 
 [project.urls]
@@ -30,6 +29,19 @@ wheel.py-api = "cp312"
 
 # Point it at the project build directory
 cmake.source-dir = ".."
+
+[tool.scikit-build.metadata.version]
+# https://scikit-build-core.readthedocs.io/en/stable/configuration/dynamic.html#regex
+provider = "scikit_build_core.metadata.regex"
+input = "../include/openzl/zl_version.h"
+regex = '''(?sx)
+\#define \s+ ZL_LIBRARY_VERSION_MAJOR \s+ (?P<major>\d+) .*?
+\#define \s+ ZL_LIBRARY_VERSION_MINOR \s+ (?P<minor>\d+) .*?
+\#define \s+ ZL_LIBRARY_VERSION_PATCH \s+ (?P<patch>\d+) .*?
+\#define \s+ ZL_FBCODE_IS_RELEASE \s+ (?P<dev>\d+) .*?
+'''
+result = "{major}.{minor}.{patch}dev{dev}"
+remove = "dev1"
 
 [tool.scikit-build.cmake.define]
 # Build the Python extension, but don't install OpenZL.


### PR DESCRIPTION
## Summary
This PR modifies the version field for the Python wrapper package of OpenZl by making it dynamic. The version values will now be obtained from the `include/openzl/zl_version.h` file.

## Type of Change
Build/CI changes (update how version of pyproject.toml is set)

## Test Plan
Validation:
- On local copy, modified `ZL_LIBRARY_VERSION_PATCH` from 0 -> 1
- Ran pip install
- Confirmed version now reflects values in `zl_version.h`

Output:
```bash
> pip install .
Processing /data/openzl/py
  Installing build dependencies ... done
  Getting requirements to build wheel ... done
  Installing backend dependencies ... done
  Preparing metadata (pyproject.toml) ... done
Building wheels for collected packages: openzl
  Building wheel for openzl (pyproject.toml) ... done
  Created wheel for openzl: filename=openzl-0.1.1.dev0-cp312-abi3-linux_x86_64.whl size=5683742 sha256=3169b521b1aafffb437201597f1575e443ff7c7a6db83555ba08dc5dbbc7dfa4
  Stored in directory: /tmp/pip-ephem-wheel-cache-fg9ff8b8/wheels/a7/2d/36/abbf0c966eef96fc386ad984a19e8201825d1f42816b0e0a7d
Successfully built openzl
Installing collected packages: openzl
Successfully installed openzl-0.1.1.dev0
```

### Test Configuration
Not really relevant