### PR TITLE
limit training time for integration tests

### DIFF
--- a/cli/args/CompressArgs.h
+++ b/cli/args/CompressArgs.h
@@ -51,6 +51,14 @@ struct CompressArgs : public GlobalArgs {
                 "Train the compressor on the input file before compressing.");
         parser.addCommandFlag(
                 cmd(),
+                kTrainInlineTestLimit,
+                0,
+                true,
+                // "Lime limit spent on inline training, in seconds, for
+                // testing."
+                "");
+        parser.addCommandFlag(
+                cmd(),
                 kTrace,
                 0,
                 true,
@@ -80,6 +88,10 @@ struct CompressArgs : public GlobalArgs {
         output = std::make_unique<tools::io::OutputFile>(std::move(outputPath));
 
         trainInline = parsed.cmdHasFlag(cmd(), kTrainInline);
+        if (parsed.cmdHasFlag(cmd(), kTrainInlineTestLimit)) {
+            trainInlineTestLimit = std::stoul(
+                    parsed.cmdFlag(cmd(), kTrainInlineTestLimit).value());
+        }
 
         if (parsed.cmdHasFlag(cmd(), kTrace)) {
             auto path   = parsed.cmdFlag(cmd(), kTrace).value();
@@ -100,6 +112,8 @@ struct CompressArgs : public GlobalArgs {
     std::shared_ptr<tools::io::Output> output;
 
     bool trainInline{};
+    poly::optional<size_t> trainInlineTestLimit;
+
     std::shared_ptr<tools::io::Output> traceOutput;
     std::optional<std::string> traceStreamsDir;
 
@@ -112,9 +126,11 @@ struct CompressArgs : public GlobalArgs {
     inline static const std::string kProfileArg = "profile-arg";
     inline static const std::string kCompressor = "compressor";
 
-    inline static const std::string kVerbose         = "verbose";
-    inline static const std::string kRecursive       = "recursive";
-    inline static const std::string kTrainInline     = "train-inline";
+    inline static const std::string kVerbose     = "verbose";
+    inline static const std::string kRecursive   = "recursive";
+    inline static const std::string kTrainInline = "train-inline";
+    inline static const std::string kTrainInlineTestLimit =
+            "train-inline-test-limit";
     inline static const std::string kTrace           = "trace";
     inline static const std::string kTraceStreamsDir = "trace-streams-dir";
 };

--- a/cli/commands/cmd_compress.cpp
+++ b/cli/commands/cmd_compress.cpp
@@ -69,6 +69,9 @@ int trainCompressorOnSampleFile(CompressArgs& args)
             std::make_unique<tools::io::InputSetStatic>(std::move(inputVec));
     trainArgs.output     = compressorOutput;
     trainArgs.compressor = args.compressor;
+    if (args.trainInlineTestLimit) {
+        trainArgs.trainParams.maxTimeSecs = args.trainInlineTestLimit.value();
+    }
 
     // Train the compressor
     int result = cmdTrain(trainArgs);

--- a/cli/tests/command_utils.py
+++ b/cli/tests/command_utils.py
@@ -210,7 +210,7 @@ def execute_train(
     cstr = compressor_info.compressor_str
     cflag = compressor_info.compressor_type.value
 
-    train_args = f"train --{cflag} {cstr} {str(uncompressed_dir)} -o {str(trained_compressor_path)}"
+    train_args = f"train --max-time-secs 1 --{cflag} {cstr} {str(uncompressed_dir)} -o {str(trained_compressor_path)}"
     if trainer_name:
         train_args += f" -t {trainer_name}"
 
@@ -233,7 +233,7 @@ def execute_train_inline(
     cstr = compressor_info.compressor_str
     cflag = compressor_info.compressor_type.value
 
-    train_args = f"compress --train-inline --{cflag} {cstr} {str(uncompressed_file)} -o {str(compressed_file_path)}"
+    train_args = f"compress --train-inline --train-inline-test-limit 1 --{cflag} {cstr} {str(uncompressed_file)} -o {str(compressed_file_path)}"
 
     if execute_command(train_args) != 0:
         raise ValueError("Executing train command failed")


### PR DESCRIPTION
Summary: Limit training tests to 1 second via `--max-time-secs`. Limit inline-training tests to 1 second via a new trampoline compress arg `--train-inline-test-limit`.

Reviewed By: terrelln

Differential Revision: D84753134


