### PR TITLE
add a button to manually start CI tests from any feature branch

### DIFF
--- a/.github/workflows/cmake-ci.yml
+++ b/.github/workflows/cmake-ci.yml
@@ -7,6 +7,7 @@ on:
     branches: [dev]
   pull_request:
     branches: [dev, master, actionsTest]
+  workflow_dispatch: {}
 
 env:
   # Common environment variables

--- a/.github/workflows/cross-platform-ci.yml
+++ b/.github/workflows/cross-platform-ci.yml
@@ -7,6 +7,7 @@ on:
     branches: [dev]
   pull_request:
     branches: [dev, master, actionsTest]
+  workflow_dispatch: {}
 
 env:
   # Common environment variables

--- a/.github/workflows/dev-ci.yml
+++ b/.github/workflows/dev-ci.yml
@@ -7,6 +7,7 @@ on:
     branches: [dev]
   pull_request:
     branches: [dev, master, actionsTest]
+  workflow_dispatch: {}
 
 env:
   # Common environment variables

--- a/.github/workflows/windows-ci.yml
+++ b/.github/workflows/windows-ci.yml
@@ -7,6 +7,7 @@ on:
     branches: [dev]
   pull_request:
     branches: [dev, master, actionsTest]
+  workflow_dispatch: {}
 
 env:
   # Common environment variables


### PR DESCRIPTION
Currently, CI tests are run on `dev` or `release` branches only.

This makes it difficult to do CI tests on one's local fork before creating a PR.
Such ability would be useful to trigger "good" PRs, where CI tests are expected to be good because they were previously successfully tested from the fork.

This PR is expected to create a new button in the `Actions` tab once it's merged, that would make it possible to manually start CI tests on any branch.
