### PR TITLE
migrate prod fuzzers to use datagen instead of FDP directly

### DIFF
--- a/custom_parsers/parquet/tests/BUCK
+++ b/custom_parsers/parquet/tests/BUCK
@@ -21,7 +21,6 @@ zs_cxxlibrary(
     exported_deps = [
         "fbsource//third-party/apache-arrow:arrow",
         "//data_compression/experimental/zstrong/custom_parsers/parquet:parquet_metadata",
-        "//data_compression/experimental/zstrong/tests:fuzz_utils",
     ],
 )
 
@@ -47,14 +46,17 @@ zs_fuzzers(
     srcs = [
         "fuzz_parquet_lexer.cpp",
     ],
+    headers = [
+        "fuzz_utils.h",
+    ],
     ftest_names = [
         ("ParquetLexerTest", "FuzzLexerRandomInput"),
         ("ParquetLexerTest", "FuzzLexerValidInput"),
     ],
     deps = [
-        "fbsource//xplat/security/lionhead/utils/lib_ftest:lib",
         ":test_utils",
         "//data_compression/experimental/zstrong:zstronglib",
         "//data_compression/experimental/zstrong/custom_parsers/parquet:parquet_lexer",
+        "//data_compression/experimental/zstrong/tests:fuzz_utils",
     ],
 )

--- a/custom_parsers/parquet/tests/fuzz_parquet_lexer.cpp
+++ b/custom_parsers/parquet/tests/fuzz_parquet_lexer.cpp
@@ -1,8 +1,9 @@
 // Copyright (c) Meta Platforms, Inc. and affiliates.
 #include "custom_parsers/parquet/parquet_lexer.h"
+#include "custom_parsers/parquet/tests/fuzz_utils.h"
 #include "custom_parsers/parquet/tests/test_utils.h"
 #include "openzl/common/errors_internal.h"
-#include "security/lionhead/utils/lib_ftest/ftest.h"
+
 namespace zstrong {
 namespace parquet {
 namespace testing {

--- a/custom_parsers/parquet/tests/fuzz_utils.h
+++ b/custom_parsers/parquet/tests/fuzz_utils.h
@@ -1,0 +1,162 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#pragma once
+
+#include <arrow/api.h>
+#include <parquet/exception.h>
+#include <string>
+#include <vector>
+
+#include "custom_parsers/parquet/tests/test_utils.h"
+#include "tests/fuzz_utils.h"
+
+namespace zstrong {
+namespace parquet {
+namespace testing {
+using namespace facebook::security::lionhead::fdp;
+
+template <typename Mode>
+std::shared_ptr<arrow::Field> gen_arrow_field(
+        StructuredFDP<Mode>& f,
+        size_t maxDepth,
+        size_t depth,
+        size_t idx)
+{
+    bool isLeaf = maxDepth == depth ? true : f.coin("is_leaf");
+    // Hack to enforce unique names for the same struct
+    auto name = tests::gen_str(f, "field_name", Range<size_t>(1, 10));
+    name += std::to_string(name.size()) + std::to_string(idx);
+
+    std::shared_ptr<arrow::DataType> type;
+
+    if (isLeaf) {
+        auto fixed = arrow::fixed_size_binary(1);
+        type       = f.choices(
+                "data_type",
+                { arrow::boolean(),
+                        arrow::int32(),
+                        arrow::int64(),
+                        arrow::float32(),
+                        arrow::float64(),
+                        arrow::utf8(),
+                        fixed });
+        if (type == fixed) {
+            type = arrow::fixed_size_binary(
+                    f.u16_range("fixed_len_byte_array_width", 1, 32));
+        }
+    } else {
+        size_t numChildren = f.u16_range("num_children", 1, 10);
+        std::vector<std::shared_ptr<arrow::Field>> fields(numChildren);
+        for (size_t i = 0; i < numChildren; ++i) {
+            fields[i] = gen_arrow_field(f, maxDepth, depth + 1, i);
+        }
+        type = arrow::struct_(fields);
+    }
+
+    return arrow::field(std::move(name), std::move(type));
+};
+
+template <typename Mode>
+std::shared_ptr<arrow::Schema> gen_arrow_schema(
+        StructuredFDP<Mode>& f,
+        size_t maxDepth = 0)
+{
+    // Recursively generate children
+    size_t numChildren = f.u8_range("num_children", 1, 20);
+    std::vector<std::shared_ptr<arrow::Field>> fields(numChildren);
+    for (size_t i = 0; i < numChildren; ++i) {
+        fields[i] = gen_arrow_field(f, maxDepth, 0, i);
+    }
+    return arrow::schema(std::move(fields));
+};
+
+template <typename Mode, typename T>
+std::vector<std::optional<T>>
+gen_vec(StructuredFDP<Mode>& f, std::string& name, size_t numElts)
+{
+    std::vector<std::optional<T>> vec(numElts);
+    for (size_t i = 0; i < numElts; ++i) {
+        if (!f.has_more_data() || f.coin("null")) {
+            vec[i] = std::nullopt;
+        } else {
+            vec[i] = Uniform<T>().gen(name, f);
+        }
+    }
+    return vec;
+}
+
+template <typename Mode, typename LenDist>
+std::vector<std::optional<std::string>> gen_str_vec(
+        StructuredFDP<Mode>& f,
+        std::string& name,
+        size_t numElts,
+        LenDist lenDist)
+{
+    std::vector<std::optional<std::string>> vec(numElts);
+    for (size_t i = 0; i < numElts; ++i) {
+        if (!f.has_more_data() || f.coin("null")) {
+            vec[i] = std::nullopt;
+        } else {
+            vec[i] = tests::gen_str(f, name, lenDist);
+        }
+    }
+    return vec;
+}
+
+template <typename Mode>
+std::shared_ptr<arrow::Array> gen_array_from_field(
+        StructuredFDP<Mode>& f,
+        const std::shared_ptr<arrow::Field>& field,
+        size_t numElts)
+{
+    auto type     = field->type();
+    auto typeName = type->name();
+
+    if (typeName == "bool") {
+        return to_arrow_array(gen_vec<Mode, bool>(f, typeName, numElts));
+    } else if (typeName == "int32") {
+        return to_arrow_array(gen_vec<Mode, int32_t>(f, typeName, numElts));
+    } else if (typeName == "int64") {
+        return to_arrow_array(gen_vec<Mode, int64_t>(f, typeName, numElts));
+    } else if (typeName == "float") {
+        return to_arrow_array(gen_vec<Mode, float>(f, typeName, numElts));
+    } else if (typeName == "double") {
+        return to_arrow_array(gen_vec<Mode, double>(f, typeName, numElts));
+    } else if (typeName == "utf8") {
+        return to_arrow_array(
+                gen_str_vec(f, typeName, numElts, Range<size_t>(1, 100)));
+    } else if (typeName == "fixed_size_binary") {
+        auto width = type->byte_width();
+        return to_arrow_array(
+                gen_str_vec(f, typeName, numElts, Const<size_t>(width)), width);
+    } else if (typeName == "struct") {
+        std::vector<std::shared_ptr<arrow::Array>> arrays;
+        for (const auto& field : field->type()->fields()) {
+            arrays.push_back(gen_array_from_field(f, field, numElts));
+        }
+        return std::make_shared<arrow::StructArray>(
+                arrow::StructArray(type, numElts, arrays, nullptr, 0, 0));
+    } else {
+        throw std::runtime_error("Unsupported type: " + typeName);
+    }
+};
+
+template <typename Mode>
+std::string gen_parquet_from_schema(
+        StructuredFDP<Mode>& f,
+        const std::shared_ptr<arrow::Schema>& schema)
+{
+    size_t numFields = schema->fields().size();
+    std::vector<std::shared_ptr<arrow::Array>> arrays(numFields);
+
+    size_t numElts = f.u32_range("num_elts", 1, 5000);
+
+    for (size_t i = 0; i < numFields; i++) {
+        arrays[i] = gen_array_from_field(f, schema->fields()[i], numElts);
+    }
+    return to_canonical_parquet(arrow::Table::Make(schema, arrays));
+};
+
+} // namespace testing
+} // namespace parquet
+} // namespace zstrong

--- a/custom_parsers/parquet/tests/test_utils.h
+++ b/custom_parsers/parquet/tests/test_utils.h
@@ -6,13 +6,10 @@
 #include <parquet/exception.h>
 #include <string>
 #include <vector>
-#include "security/lionhead/utils/lib_ftest/fdp/fdp/fdp_impl.h"
-#include "tests/fuzz_utils.h"
 
 namespace zstrong {
 namespace parquet {
 namespace testing {
-using namespace facebook::security::lionhead::fdp;
 
 std::string to_canonical_parquet(
         const std::shared_ptr<arrow::Table> table,
@@ -64,148 +61,6 @@ std::shared_ptr<arrow::Array> to_arrow_array(
     PARQUET_THROW_NOT_OK(builder.Finish(&result));
     return result;
 }
-
-template <typename Mode>
-std::shared_ptr<arrow::Field> gen_arrow_field(
-        StructuredFDP<Mode>& f,
-        size_t maxDepth,
-        size_t depth,
-        size_t idx)
-{
-    bool isLeaf = maxDepth == depth ? true : f.coin("is_leaf");
-    // Hack to enforce unique names for the same struct
-    auto name = tests::gen_str(f, "field_name", Range<size_t>(1, 10));
-    name += std::to_string(name.size()) + std::to_string(idx);
-
-    std::shared_ptr<arrow::DataType> type;
-
-    if (isLeaf) {
-        auto fixed = arrow::fixed_size_binary(1);
-        type       = f.choices(
-                "data_type",
-                { arrow::boolean(),
-                        arrow::int32(),
-                        arrow::int64(),
-                        arrow::float32(),
-                        arrow::float64(),
-                        arrow::utf8(),
-                        fixed });
-        if (type == fixed) {
-            type = arrow::fixed_size_binary(
-                    f.u16_range("fixed_len_byte_array_width", 1, 32));
-        }
-    } else {
-        size_t numChildren = f.u16_range("num_children", 1, 10);
-        std::vector<std::shared_ptr<arrow::Field>> fields(numChildren);
-        for (size_t i = 0; i < numChildren; ++i) {
-            fields[i] = gen_arrow_field(f, maxDepth, depth + 1, i);
-        }
-        type = arrow::struct_(fields);
-    }
-
-    return arrow::field(std::move(name), std::move(type));
-};
-
-template <typename Mode>
-std::shared_ptr<arrow::Schema> gen_arrow_schema(
-        StructuredFDP<Mode>& f,
-        size_t maxDepth = 0)
-{
-    // Recursively generate children
-    size_t numChildren = f.u8_range("num_children", 1, 20);
-    std::vector<std::shared_ptr<arrow::Field>> fields(numChildren);
-    for (size_t i = 0; i < numChildren; ++i) {
-        fields[i] = gen_arrow_field(f, maxDepth, 0, i);
-    }
-    return arrow::schema(std::move(fields));
-};
-
-template <typename Mode, typename T>
-std::vector<std::optional<T>>
-gen_vec(StructuredFDP<Mode>& f, std::string& name, size_t numElts)
-{
-    std::vector<std::optional<T>> vec(numElts);
-    for (size_t i = 0; i < numElts; ++i) {
-        if (!f.has_more_data() || f.coin("null")) {
-            vec[i] = std::nullopt;
-        } else {
-            vec[i] = Uniform<T>().gen(name, f);
-        }
-    }
-    return vec;
-}
-
-template <typename Mode, typename LenDist>
-std::vector<std::optional<std::string>> gen_str_vec(
-        StructuredFDP<Mode>& f,
-        std::string& name,
-        size_t numElts,
-        LenDist lenDist)
-{
-    std::vector<std::optional<std::string>> vec(numElts);
-    for (size_t i = 0; i < numElts; ++i) {
-        if (!f.has_more_data() || f.coin("null")) {
-            vec[i] = std::nullopt;
-        } else {
-            vec[i] = tests::gen_str(f, name, lenDist);
-        }
-    }
-    return vec;
-}
-
-template <typename Mode>
-std::shared_ptr<arrow::Array> gen_array_from_field(
-        StructuredFDP<Mode>& f,
-        const std::shared_ptr<arrow::Field>& field,
-        size_t numElts)
-{
-    auto type     = field->type();
-    auto typeName = type->name();
-
-    if (typeName == "bool") {
-        return to_arrow_array(gen_vec<Mode, bool>(f, typeName, numElts));
-    } else if (typeName == "int32") {
-        return to_arrow_array(gen_vec<Mode, int32_t>(f, typeName, numElts));
-    } else if (typeName == "int64") {
-        return to_arrow_array(gen_vec<Mode, int64_t>(f, typeName, numElts));
-    } else if (typeName == "float") {
-        return to_arrow_array(gen_vec<Mode, float>(f, typeName, numElts));
-    } else if (typeName == "double") {
-        return to_arrow_array(gen_vec<Mode, double>(f, typeName, numElts));
-    } else if (typeName == "utf8") {
-        return to_arrow_array(
-                gen_str_vec(f, typeName, numElts, Range<size_t>(1, 100)));
-    } else if (typeName == "fixed_size_binary") {
-        auto width = type->byte_width();
-        return to_arrow_array(
-                gen_str_vec(f, typeName, numElts, Const<size_t>(width)), width);
-    } else if (typeName == "struct") {
-        std::vector<std::shared_ptr<arrow::Array>> arrays;
-        for (const auto& field : field->type()->fields()) {
-            arrays.push_back(gen_array_from_field(f, field, numElts));
-        }
-        return std::make_shared<arrow::StructArray>(
-                arrow::StructArray(type, numElts, arrays, nullptr, 0, 0));
-    } else {
-        throw std::runtime_error("Unsupported type: " + typeName);
-    }
-};
-
-template <typename Mode>
-std::string gen_parquet_from_schema(
-        StructuredFDP<Mode>& f,
-        const std::shared_ptr<arrow::Schema>& schema)
-{
-    size_t numFields = schema->fields().size();
-    std::vector<std::shared_ptr<arrow::Array>> arrays(numFields);
-
-    size_t numElts = f.u32_range("num_elts", 1, 5000);
-
-    for (size_t i = 0; i < numFields; i++) {
-        arrays[i] = gen_array_from_field(f, schema->fields()[i], numElts);
-    }
-    return to_canonical_parquet(arrow::Table::Make(schema, arrays));
-};
 
 } // namespace testing
 } // namespace parquet

--- a/tests/BUCK
+++ b/tests/BUCK
@@ -172,13 +172,13 @@ zs_cxxlibrary(
     name = "fuzz_utils",
     headers = ["fuzz_utils.h"],
     exported_deps = [
+        "fbsource//xplat/security/lionhead/utils/lib_ftest:lib",
         "fbsource//xplat/security/lionhead/utils/lib_ftest/fdp:lib",
         "//data_compression/experimental/zstrong/tests/datagen:datagen",
     ],
 )
 
 FUZZER_DEPS = [
-    "fbsource//xplat/security/lionhead/utils/lib_ftest:lib",
     ":constants",
     ":fuzz_utils",
     ":test_zstrong_fixtures",

--- a/tests/datagen/DataGen.h
+++ b/tests/datagen/DataGen.h
@@ -2,6 +2,7 @@
 
 #pragma once
 
+#include <cassert>
 #include <iostream>
 #include <random>
 
@@ -177,6 +178,17 @@ class DataGen {
     double f64_range(RandWrapper::NameType name, double min, double max)
     {
         return UniformDistribution<double>(rw_, min, max)(name);
+    }
+
+    // convenience functions for fuzzer inputs
+    bool has_more_data()
+    {
+        return rw_->has_more_data();
+    }
+
+    std::vector<uint8_t> all_remaining_bytes()
+    {
+        return rw_->all_remaining_bytes();
     }
 
    private:

--- a/tests/datagen/random_producer/LionheadFDPWrapper.h
+++ b/tests/datagen/random_producer/LionheadFDPWrapper.h
@@ -34,7 +34,7 @@ class LionheadFDPWrapper : public RandWrapper {
     {
         return fdp_->remaining_input_length();
     }
-    std::vector<uint8_t> all_remaining_bytes()
+    std::vector<uint8_t> all_remaining_bytes() override
     {
         return fdp_->all_remaining_bytes();
     }

--- a/tests/datagen/random_producer/PRNGWrapper.h
+++ b/tests/datagen/random_producer/PRNGWrapper.h
@@ -105,6 +105,12 @@ class PRNGWrapper : public RandWrapper {
         return true;
     }
 
+    std::vector<uint8_t> all_remaining_bytes() override
+    {
+        throw std::runtime_error(
+                "all_remaining_bytes() only available for fuzzers");
+    }
+
    private:
     std::shared_ptr<std::mt19937> generator_;
     std::uniform_int_distribution<uint8_t> u8dist_;

--- a/tests/datagen/random_producer/RandWrapper.h
+++ b/tests/datagen/random_producer/RandWrapper.h
@@ -5,6 +5,7 @@
 #include <cstddef>
 #include <cstdint>
 #include <type_traits>
+#include <vector>
 
 namespace zstrong::tests::datagen {
 
@@ -45,7 +46,9 @@ class RandWrapper {
     virtual float f32_range(NameType name, float min, float max)          = 0;
     virtual double f64_range(NameType name, double min, double max)       = 0;
 
-    virtual bool has_more_data() = 0;
+    // only applicable to fuzzers
+    virtual bool has_more_data()                       = 0;
+    virtual std::vector<uint8_t> all_remaining_bytes() = 0;
 
     virtual bool boolean(NameType name)
     {

--- a/tests/fuzz_utils.h
+++ b/tests/fuzz_utils.h
@@ -3,7 +3,9 @@
 #pragma once
 
 #include <stddef.h>
+
 #include "security/lionhead/utils/lib_ftest/fdp/fdp/fdp_impl.h"
+#include "security/lionhead/utils/lib_ftest/ftest.h" // FUZZ_F
 
 #include "tests/datagen/DataGen.h"
 #include "tests/datagen/random_producer/LionheadFDPWrapper.h"

--- a/tests/zstrong/InterleaveFuzzer.cpp
+++ b/tests/zstrong/InterleaveFuzzer.cpp
@@ -1,7 +1,5 @@
 // Copyright (c) Meta Platforms, Inc. and affiliates.
 
-#include "security/lionhead/utils/lib_ftest/ftest.h"
-
 #include "tests/datagen/DataGen.h"
 #include "tests/datagen/structures/openzl/StringInputProducer.h"
 #include "tests/fuzz_utils.h"

--- a/tests/zstrong/fuzz_alloc_failure.cpp
+++ b/tests/zstrong/fuzz_alloc_failure.cpp
@@ -12,8 +12,8 @@
 #include "openzl/zl_decompress.h"
 #include "openzl/zl_errors.h"
 #include "openzl/zl_reflection.h"
-#include "security/lionhead/utils/lib_ftest/ftest.h"
 #include "tests/constants.h"
+#include "tests/datagen/DataGen.h"
 #include "tests/fuzz_utils.h"
 
 #include <algorithm>
@@ -86,9 +86,8 @@ size_t findFirstAfter(size_t start, size_t size, F const& fn)
     return (size_t)-1;
 }
 
-template <typename FDP>
 ZL_GraphID buildGraph(
-        FDP& f,
+        datagen::DataGen& dg,
         ZL_Compressor* cgraph,
         size_t* nodesInGraph,
         std::vector<ZL_NodeID> const& nodes,
@@ -105,19 +104,19 @@ ZL_GraphID buildGraph(
     ++*nodesInGraph;
 
     // Give some chance to stop the graph with store immediately
-    bool const stop = f.coin("use_store", 0.1)
+    bool const stop = dg.coin("use_store", 0.1)
             || (graphs.size() == 0 && nodes.size() == 0);
     if (stop) {
         return ZL_GRAPH_STORE;
     }
 
     // Choose between a graph or a node
-    bool const useGraph =
-            (f.boolean("use_graph") && graphs.size() != 0) || nodes.size() == 0;
+    bool const useGraph = (dg.boolean("use_graph") && graphs.size() != 0)
+            || nodes.size() == 0;
     if (useGraph) {
         // Pick an index, then pick the first graph after that index
         // that has a compatible type
-        size_t graphIdx = f.index("graph_index", graphs.size());
+        size_t graphIdx = dg.usize_range("graph_index", 0, graphs.size() - 1);
         graphIdx = findFirstAfter(graphIdx, graphs.size(), [&](size_t idx) {
             auto const graphType =
                     ZL_Compressor_Graph_getInput0Mask(cgraph, graphs[idx]);
@@ -131,7 +130,7 @@ ZL_GraphID buildGraph(
 
     // Pick an index, then pick the first node after that index
     // that has a compatible type
-    size_t nodeIdx = f.index("node_index", nodes.size());
+    size_t nodeIdx = dg.usize_range("node_index", 0, nodes.size() - 1);
     nodeIdx        = findFirstAfter(nodeIdx, nodes.size(), [&](size_t idx) {
         auto const nodeType =
                 ZL_Compressor_Node_getInput0Type(cgraph, nodes[idx]);
@@ -148,7 +147,7 @@ ZL_GraphID buildGraph(
     for (size_t i = 0; i < successors.size(); ++i) {
         auto const outType = ZL_Compressor_Node_getOutputType(cgraph, node, i);
         successors[i]      = buildGraph(
-                f, cgraph, nodesInGraph, nodes, graphs, outType, maxDepth - 1);
+                dg, cgraph, nodesInGraph, nodes, graphs, outType, maxDepth - 1);
     }
 
     return ZL_Compressor_registerStaticGraph_fromNode(
@@ -202,16 +201,17 @@ extern "C" bool ZS2_malloc_should_fail(size_t size)
 
 FUZZ(AllocFailureTest, FuzzAllocFailure)
 {
-    gAllocState = AllocState{};
+    datagen::DataGen dg = fromFDP(f);
+    gAllocState         = AllocState{};
     // declare these before allocation failures are toggled
     openzl::Compressor compressor;
     openzl::CCtx myCctx;
 
     bool allowAllocFailuresInConstruction =
-            f.coin("allow_alloc_failures_in_graph_construction", 0.1);
+            dg.coin("allow_alloc_failures_in_graph_construction", 0.1);
     auto localAllocState =
-            AllocState{ f.u32_range("fail_every_n_allocs", 1, 10000),
-                        f.u32_range("num_allocs_offset", 0, 10000) };
+            AllocState{ dg.u32_range("fail_every_n_allocs", 1, 10000),
+                        dg.u32_range("num_allocs_offset", 0, 10000) };
     if (allowAllocFailuresInConstruction) {
         // Focus fuzzing energy on fuzzing (de)compression, rather than
         // allocation failures during graph construction.
@@ -227,7 +227,7 @@ FUZZ(AllocFailureTest, FuzzAllocFailure)
             ZL_CParam_permissiveCompression,
             ZL_TernaryParam_enable));
     // Set the format version to a random version.
-    uint32_t const formatVersion = f.u32_range(
+    uint32_t const formatVersion = dg.u32_range(
             "format_version", ZL_MIN_FORMAT_VERSION, ZL_MAX_FORMAT_VERSION);
     ZL_REQUIRE_SUCCESS(ZL_Compressor_setParameter(
             compressor.get(), ZL_CParam_formatVersion, formatVersion));
@@ -235,7 +235,7 @@ FUZZ(AllocFailureTest, FuzzAllocFailure)
     // Build a random graph
     size_t nodesInGraph    = 0;
     ZL_GraphID const graph = buildGraph(
-            f,
+            dg,
             compressor.get(),
             &nodesInGraph,
             getAllNodes(formatVersion),
@@ -253,7 +253,7 @@ FUZZ(AllocFailureTest, FuzzAllocFailure)
         gAllocState = std::move(localAllocState);
     }
 
-    std::string input = gen_str(f, "input_str", InputLengthInBytes(1));
+    std::string input = dg.randString("input_str");
 
     // TODO(terrelln): ZL_compressBound() doesn't provide a tight bound
     // on compressed size. And it is impossible to provide in the general case

--- a/tests/zstrong/fuzz_compress_reuse.cpp
+++ b/tests/zstrong/fuzz_compress_reuse.cpp
@@ -2,7 +2,7 @@
 
 #include <memory>
 
-#include "security/lionhead/utils/lib_ftest/ftest.h"
+#include "tests/datagen/DataGen.h"
 #include "tests/fuzz_utils.h"
 
 #include "openzl/common/assertion.h"
@@ -106,8 +106,9 @@ ZL_GraphID setCopyGraph(ZL_Compressor* cgraph)
 
 FUZZ(CompressTest, ReuseCCtx)
 {
-    ZL_g_logLevel       = ZL_LOG_LVL_ALWAYS;
-    ZL_CCtx* const cctx = ZL_CCtx_create();
+    zstrong::tests::datagen::DataGen dg = zstrong::tests::fromFDP(f);
+    ZL_g_logLevel                       = ZL_LOG_LVL_ALWAYS;
+    ZL_CCtx* const cctx                 = ZL_CCtx_create();
     ZL_REQUIRE_NN(cctx);
     ZL_Compressor* const cgraph1 = ZL_Compressor_create();
     ZL_REQUIRE_NN(cgraph1);
@@ -133,15 +134,16 @@ FUZZ(CompressTest, ReuseCCtx)
                 ZL_Compressor_selectStartingGraphID(cgraph3, sgid);
         EXPECT_EQ(ZL_isError(gssr), 0) << "setting cgraph3 failed\n";
     }
-    while (f.has_more_data()) {
-        std::string input =
-                gen_str(f, "input_data", zstrong::tests::InputLengthInBytes(1));
+
+    while (dg.has_more_data()) {
+        std::string input        = dg.randString("input_data");
         const char* const data   = input.c_str();
         size_t const isize       = input.length();
         size_t const dstCapacity = ZL_compressBound(isize);
         auto dst                 = std::make_unique<uint8_t[]>(dstCapacity);
-        const ZL_Compressor* const cgraph =
-                f.choices("cgraph", { cgraph1, cgraph2, cgraph3 });
+        const ZL_Compressor* const cgraph = dg.choices(
+                "cgraph",
+                std::vector<const ZL_Compressor*>{ cgraph1, cgraph2, cgraph3 });
         ZL_Report const cgr = ZL_CCtx_refCompressor(cctx, cgraph);
         EXPECT_EQ(ZL_isError(cgr), 0) << "CGraph reference failed\n";
         ZL_Report const creport =

--- a/tests/zstrong/fuzz_decompress_reuse.cpp
+++ b/tests/zstrong/fuzz_decompress_reuse.cpp
@@ -3,7 +3,7 @@
 #include <algorithm>
 #include <memory>
 
-#include "security/lionhead/utils/lib_ftest/ftest.h"
+#include "tests/datagen/DataGen.h"
 #include "tests/fuzz_utils.h"
 
 #include "openzl/common/assertion.h"
@@ -35,12 +35,12 @@ constexpr ZL_TypedDecoderDesc kTransform = {
 
 FUZZ(DecompressTest, ReuseDCtx)
 {
-    ZL_g_logLevel       = ZL_LOG_LVL_ALWAYS;
-    ZL_DCtx* const dctx = ZL_DCtx_create();
+    zstrong::tests::datagen::DataGen dg = zstrong::tests::fromFDP(f);
+    ZL_g_logLevel                       = ZL_LOG_LVL_ALWAYS;
+    ZL_DCtx* const dctx                 = ZL_DCtx_create();
     ZL_REQUIRE_NN(dctx);
-    while (f.has_more_data()) {
-        std::string input =
-                gen_str(f, "input_data", zstrong::tests::InputLengthInBytes(1));
+    while (dg.has_more_data()) {
+        std::string input      = dg.randString("input_data");
         const char* const data = input.c_str();
         size_t const size      = input.length();
         ZL_REQUIRE_SUCCESS(ZL_DCtx_registerTypedDecoder(dctx, &kTransform));

--- a/tests/zstrong/fuzz_fixed.cpp
+++ b/tests/zstrong/fuzz_fixed.cpp
@@ -2,8 +2,6 @@
 
 #include <limits.h>
 
-#include "security/lionhead/utils/lib_ftest/ftest.h"
-
 #include "openzl/compress/private_nodes.h"
 #include "tests/datagen/DataGen.h"
 #include "tests/fuzz_utils.h"

--- a/tests/zstrong/fuzz_graph.cpp
+++ b/tests/zstrong/fuzz_graph.cpp
@@ -11,8 +11,8 @@
 #include "openzl/zl_decompress.h"
 #include "openzl/zl_errors.h"
 #include "openzl/zl_reflection.h"
-#include "security/lionhead/utils/lib_ftest/ftest.h"
 #include "tests/constants.h"
+#include "tests/datagen/DataGen.h"
 #include "tests/fuzz_utils.h"
 
 #include <algorithm>
@@ -87,9 +87,8 @@ ZL_GraphID buildStoreGraph(ZL_Compressor* cgraph, ZL_Type inType)
     return ZL_GRAPH_STORE;
 }
 
-template <typename FDP>
 ZL_GraphID buildGraph(
-        FDP& f,
+        datagen::DataGen& dg,
         ZL_Compressor* cgraph,
         size_t* nodesInGraph,
         std::vector<ZL_NodeID> const& nodes,
@@ -106,17 +105,17 @@ ZL_GraphID buildGraph(
     ++*nodesInGraph;
 
     // Give some chance to stop the graph with store immediately
-    bool const stop = f.coin("use_store", 0.1);
+    bool const stop = dg.coin("use_store", 0.1);
     if (stop) {
         return buildStoreGraph(cgraph, inType);
     }
 
     // Choose between a graph or a node
-    bool const useGraph = f.boolean("use_graph");
+    bool const useGraph = dg.boolean("use_graph");
     if (useGraph) {
         // Pick an index, then pick the first graph after that index
         // that has a compatible type
-        size_t graphIdx = f.index("graph_index", graphs.size());
+        size_t graphIdx = dg.usize_range("graph_index", 0, graphs.size() - 1);
         graphIdx = findFirstAfter(graphIdx, graphs.size(), [&](size_t idx) {
             auto const graphType =
                     ZL_Compressor_Graph_getInput0Mask(cgraph, graphs[idx]);
@@ -127,7 +126,7 @@ ZL_GraphID buildGraph(
 
     // Pick an index, then pick the first node after that index
     // that has a compatible type
-    size_t nodeIdx  = f.index("node_index", nodes.size());
+    size_t nodeIdx  = dg.usize_range("node_index", 0, nodes.size() - 1);
     nodeIdx         = findFirstAfter(nodeIdx, nodes.size(), [&](size_t idx) {
         auto const nodeType =
                 ZL_Compressor_Node_getInput0Type(cgraph, nodes[idx]);
@@ -141,7 +140,7 @@ ZL_GraphID buildGraph(
     for (size_t i = 0; i < successors.size(); ++i) {
         auto const outType = ZL_Compressor_Node_getOutputType(cgraph, node, i);
         successors[i]      = buildGraph(
-                f, cgraph, nodesInGraph, nodes, graphs, outType, maxDepth - 1);
+                dg, cgraph, nodesInGraph, nodes, graphs, outType, maxDepth - 1);
     }
 
     return ZL_Compressor_registerStaticGraph_fromNode(
@@ -150,6 +149,7 @@ ZL_GraphID buildGraph(
 
 FUZZ(GraphTest, FuzzGraphRoundTrip)
 {
+    datagen::DataGen dg   = fromFDP(f);
     ZL_Compressor* cgraph = ZL_Compressor_create();
     ASSERT_NE(cgraph, nullptr);
 
@@ -160,7 +160,7 @@ FUZZ(GraphTest, FuzzGraphRoundTrip)
     ZL_REQUIRE_SUCCESS(ZL_Compressor_setParameter(
             cgraph, ZL_CParam_permissiveCompression, ZL_TernaryParam_enable));
     // Set the format version to a random version.
-    uint32_t const formatVersion = f.u32_range(
+    uint32_t const formatVersion = dg.u32_range(
             "format_version", ZL_MIN_FORMAT_VERSION, ZL_MAX_FORMAT_VERSION);
     ZL_REQUIRE_SUCCESS(ZL_Compressor_setParameter(
             cgraph, ZL_CParam_formatVersion, formatVersion));
@@ -168,7 +168,7 @@ FUZZ(GraphTest, FuzzGraphRoundTrip)
     // Build a random graph
     size_t nodesInGraph    = 0;
     ZL_GraphID const graph = buildGraph(
-            f,
+            dg,
             cgraph,
             &nodesInGraph,
             getAllNodes(formatVersion),
@@ -177,7 +177,7 @@ FUZZ(GraphTest, FuzzGraphRoundTrip)
             kMaxGraphDepth);
     ZL_REQUIRE_SUCCESS(ZL_Compressor_selectStartingGraphID(cgraph, graph));
 
-    std::string input = gen_str(f, "input_str", InputLengthInBytes(1));
+    std::string input = dg.randStringWithQuantizedLength("input_str", 1);
 
     // TODO(terrelln): ZL_compressBound() doesn't provide a tight bound
     // on compressed size. And it is impossible to provide in the general case

--- a/tests/zstrong/fuzz_integer.cpp
+++ b/tests/zstrong/fuzz_integer.cpp
@@ -1,9 +1,8 @@
 // Copyright (c) Meta Platforms, Inc. and affiliates.
 
-#include "security/lionhead/utils/lib_ftest/ftest.h"
-
 #include "openzl/compress/private_nodes.h"
 #include "openzl/shared/mem.h"
+#include "tests/datagen/DataGen.h"
 #include "tests/fuzz_utils.h"
 #include "tests/zstrong/test_integer_fixture.h"
 
@@ -15,26 +14,29 @@ namespace {
 
 FUZZ_F(IntegerTest, FuzzConvertIntToTokenRoundTrip)
 {
-    size_t const eltWidth = f.choices("elt_width", { 1, 2, 4, 8 });
+    datagen::DataGen dg = fromFDP(f);
+    auto const eltWidth =
+            dg.choices("elt_width", std::vector<size_t>{ 1, 2, 4, 8 });
     std::string input =
-            gen_str(f, "input_data", ShortInputLengthInBytes(eltWidth));
+            dg.randStringWithQuantizedLength("input_data", eltWidth);
     testNodeOnInput(ZL_NODE_CONVERT_NUM_TO_TOKEN, eltWidth, input);
 }
 
 FUZZ_F(IntegerTest, FuzzConvertIntToSerialRoundTrip)
 {
-    size_t const eltWidth = f.choices("elt_width", { 1, 2, 4, 8 });
+    datagen::DataGen dg = fromFDP(f);
+    auto const eltWidth =
+            dg.choices("elt_width", std::vector<size_t>{ 1, 2, 4, 8 });
     std::string input =
-            gen_str(f, "input_data", ShortInputLengthInBytes(eltWidth));
+            dg.randStringWithQuantizedLength("input_data", eltWidth);
     testNodeOnInput(ZL_NODE_CONVERT_NUM_TO_SERIAL, eltWidth, input);
 }
 
 FUZZ_F(IntegerTest, FuzzQuantizeOffsetsRoundTrip)
 {
-    auto input = f.vec_args(
-            "input_data",
-            d_range_u32(1, (uint32_t)-1),
-            InputLengthInElts(sizeof(uint32_t)));
+    datagen::DataGen dg = fromFDP(f);
+    auto input =
+            dg.randLongVector<uint32_t>("input_data", 1, (uint32_t)-1, 0, 512);
     // TODO(terrelln): This hack is here to avoid null input pointers.
     // But we should fix the engine to accept NULL empty inputs.
     if (input.capacity() == 0)
@@ -46,43 +48,59 @@ FUZZ_F(IntegerTest, FuzzQuantizeOffsetsRoundTrip)
 
 FUZZ_F(IntegerTest, FuzzQuantizeLengthsRoundTrip)
 {
+    datagen::DataGen dg   = fromFDP(f);
     const size_t eltWidth = 4;
-    std::string input = gen_str(f, "input_data", InputLengthInBytes(eltWidth));
+    std::string input =
+            dg.randStringWithQuantizedLength("input_data", eltWidth);
     testNodeOnInput(ZL_NODE_QUANTIZE_LENGTHS, eltWidth, input);
 }
 
 FUZZ_F(IntegerTest, FuzzDeltaRoundTrip)
 {
-    size_t const eltWidth = f.choices("elt_width", { 1, 2, 4, 8 });
-    std::string input = gen_str(f, "input_data", InputLengthInBytes(eltWidth));
+    datagen::DataGen dg = fromFDP(f);
+    auto const eltWidth =
+            dg.choices("elt_width", std::vector<size_t>{ 1, 2, 4, 8 });
+    std::string input =
+            dg.randStringWithQuantizedLength("input_data", eltWidth);
     testNodeOnInput(ZL_NODE_DELTA_INT, eltWidth, input);
 }
 
 FUZZ_F(IntegerTest, FuzzZigzagRoundTrip)
 {
-    size_t const eltWidth = f.choices("elt_width", { 1, 2, 4, 8 });
-    std::string input = gen_str(f, "input_data", InputLengthInBytes(eltWidth));
+    datagen::DataGen dg = fromFDP(f);
+    auto const eltWidth =
+            dg.choices("elt_width", std::vector<size_t>{ 1, 2, 4, 8 });
+    std::string input =
+            dg.randStringWithQuantizedLength("input_data", eltWidth);
     testNodeOnInput(ZL_NODE_ZIGZAG, eltWidth, input);
 }
 
 FUZZ_F(IntegerTest, FuzzBitpackRoundTrip)
 {
-    size_t const eltWidth = f.choices("elt_width", { 1, 2, 4, 8 });
-    std::string input = gen_str(f, "input_data", InputLengthInBytes(eltWidth));
+    datagen::DataGen dg = fromFDP(f);
+    auto const eltWidth =
+            dg.choices("elt_width", std::vector<size_t>{ 1, 2, 4, 8 });
+    std::string input =
+            dg.randStringWithQuantizedLength("input_data", eltWidth);
     testNodeOnInput(ZL_NODE_BITPACK_INT, eltWidth, input);
 }
 
 FUZZ_F(IntegerTest, FuzzRangePackRoundTrip)
 {
-    size_t const eltWidth = f.choices("elt_width", { 1, 2, 4, 8 });
-    std::string input = gen_str(f, "input_data", InputLengthInBytes(eltWidth));
+    datagen::DataGen dg = fromFDP(f);
+    auto const eltWidth =
+            dg.choices("elt_width", std::vector<size_t>{ 1, 2, 4, 8 });
+    std::string input =
+            dg.randStringWithQuantizedLength("input_data", eltWidth);
     testNodeOnInput(ZL_NODE_RANGE_PACK, eltWidth, input);
 }
 
 FUZZ_F(IntegerTest, FuzzMergeSortedRoundTrip)
 {
+    datagen::DataGen dg   = fromFDP(f);
     size_t const eltWidth = 4;
-    std::string input = gen_str(f, "input_data", InputLengthInBytes(eltWidth));
+    std::string input =
+            dg.randStringWithQuantizedLength("input_data", eltWidth);
     reset();
     ZL_GraphID graph = ZL_Compressor_registerMergeSortedGraph(
             cgraph_, ZL_GRAPH_STORE, ZL_GRAPH_STORE, ZL_GRAPH_STORE);
@@ -93,13 +111,15 @@ FUZZ_F(IntegerTest, FuzzMergeSortedRoundTrip)
 
 FUZZ_F(IntegerTest, FuzzSplitNRoundTrip)
 {
-    size_t const eltWidth = f.choices("elt_width", { 1, 2, 4, 8 });
-    std::string input = gen_str(f, "input_str", InputLengthInBytes(eltWidth));
+    datagen::DataGen dg = fromFDP(f);
+    auto const eltWidth =
+            dg.choices("elt_width", std::vector<size_t>{ 1, 2, 4, 8 });
+    std::string input = dg.randStringWithQuantizedLength("input_str", eltWidth);
 
     StructuredFDP<HarnessMode>* fPtr = &f;
 
     reset();
-    if (f.u8("split_by_param") >= 128) {
+    if (dg.u8("split_by_param") >= 128) {
         auto segmentSizes = getSplitNSegments(f, input.size() / eltWidth);
         std::vector<ZL_GraphID> successors(segmentSizes.size(), ZL_GRAPH_STORE);
         auto graph = ZL_Compressor_registerSplitGraph(
@@ -136,9 +156,10 @@ FUZZ_F(IntegerTest, FuzzSplitNRoundTrip)
 
 FUZZ_F(IntegerTest, FuzzFSENCountRoundTrip)
 {
+    datagen::DataGen dg   = fromFDP(f);
     size_t const eltWidth = 2;
     std::string input =
-            gen_str(f, "input_data", ShortInputLengthInBytes(eltWidth));
+            dg.randStringWithQuantizedLength("input_data", eltWidth);
     reset();
     finalizeGraph({ ZL_PrivateStandardGraphID_fse_ncount }, eltWidth);
     testRoundTripCompressionMayFail(input);
@@ -146,9 +167,11 @@ FUZZ_F(IntegerTest, FuzzFSENCountRoundTrip)
 
 FUZZ_F(IntegerTest, FuzzIntegerSelector)
 {
-    size_t const eltWidth = f.choices("elt_width", { 1, 2, 4, 8 });
+    datagen::DataGen dg = fromFDP(f);
+    auto const eltWidth =
+            dg.choices("elt_width", std::vector<size_t>{ 1, 2, 4, 8 });
     std::string input =
-            gen_str(f, "input_data", ShortInputLengthInBytes(eltWidth));
+            dg.randStringWithQuantizedLength("input_data", eltWidth);
     reset();
     finalizeGraph(ZL_GRAPH_NUMERIC, eltWidth);
     testRoundTrip(input);
@@ -156,12 +179,14 @@ FUZZ_F(IntegerTest, FuzzIntegerSelector)
 
 FUZZ_F(IntegerTest, FuzzIntegerDivideBy)
 {
-    size_t const eltWidth = f.choices("elt_width", { 1, 2, 4, 8 });
+    datagen::DataGen dg = fromFDP(f);
+    auto const eltWidth =
+            dg.choices("elt_width", std::vector<size_t>{ 1, 2, 4, 8 });
     std::string input =
-            gen_str(f, "input_data", ShortInputLengthInBytes(eltWidth));
+            dg.randStringWithQuantizedLength("input_data", eltWidth);
     reset();
-    if (f.boolean("set_divisor")) {
-        const auto divisor = f.u64("divisor");
+    if (dg.boolean("set_divisor")) {
+        const auto divisor = dg.u64("divisor");
         ZL_GraphID const graphDivideBy =
                 ZL_Compressor_registerStaticGraph_fromNode1o(
                         cgraph_,

--- a/tests/zstrong/fuzz_large.cpp
+++ b/tests/zstrong/fuzz_large.cpp
@@ -1,7 +1,6 @@
 // Copyright (c) Meta Platforms, Inc. and affiliates.
 
-#include "security/lionhead/utils/lib_ftest/ftest.h"
-
+#include "tests/datagen/DataGen.h"
 #include "tests/datagen/InputExpander.h"
 #include "tests/datagen/random_producer/LionheadFDPWrapper.h"
 #include "tests/datagen/test_registry/CustomNodes.h"
@@ -51,10 +50,11 @@ FUZZ_F(LargeInputTest, FuzzSerialTransform)
 
 FUZZ_F(LargeInputTest, FuzzSerialGraph)
 {
+    datagen::DataGen dg = fromFDP(f);
     using datagen::test_registry::TransformID;
 
     // transposeSplit and fieldLZ both take serial input
-    const auto coin = f.coin("transform_id");
+    const auto coin = dg.coin("transform_id");
     TransformID trId;
     if (coin) {
         trId = TransformID::TransposeSplit;
@@ -64,7 +64,7 @@ FUZZ_F(LargeInputTest, FuzzSerialGraph)
     const auto& customGraph =
             datagen::test_registry::getCustomGraphs().at(trId);
 
-    const auto inputVec = f.all_remaining_bytes();
+    const auto inputVec = dg.all_remaining_bytes();
     const auto input    = std::string(inputVec.begin(), inputVec.end());
     if (input.size() == 0) {
         return;

--- a/tests/zstrong/fuzz_multi_input.cpp
+++ b/tests/zstrong/fuzz_multi_input.cpp
@@ -1,5 +1,4 @@
 // Copyright (c) Meta Platforms, Inc. and affiliates.
-#include "security/lionhead/utils/lib_ftest/ftest.h"
 
 #include "openzl/codecs/zl_concat.h"
 #include "openzl/compress/graphs/generic_clustering_graph.h"
@@ -9,17 +8,19 @@
 namespace zstrong {
 namespace tests {
 namespace {
-template <typename FDP>
-std::vector<uint32_t>
-getSegments(FDP& f, size_t const srcSize, size_t maxSegments = 512)
+
+std::vector<uint32_t> getSegments(
+        datagen::DataGen& dg,
+        size_t const srcSize,
+        size_t maxSegments = 512)
 {
-    size_t const numSegments = f.usize_range("num_segments", 0, maxSegments);
+    size_t const numSegments = dg.usize_range("num_segments", 0, maxSegments);
     std::vector<uint32_t> segmentSizes;
     size_t totalSize = 0;
     segmentSizes.reserve(numSegments);
     for (size_t i = 0; i < numSegments; ++i) {
         size_t const segmentSize =
-                f.usize_range("segment_size", 0, srcSize - totalSize);
+                dg.usize_range("segment_size", 0, srcSize - totalSize);
         segmentSizes.push_back(segmentSize);
         totalSize += segmentSize;
     }
@@ -31,30 +32,31 @@ getSegments(FDP& f, size_t const srcSize, size_t maxSegments = 512)
 
 FUZZ_F(MultiInputTest, FuzzConcatRoundTrip)
 {
+    datagen::DataGen dg = fromFDP(f);
     reset();
     setLargeCompressBound(2);
-    auto concat = f.choices(
+    auto concat = dg.choices(
             "concat",
-            { ZL_NODE_CONCAT_SERIAL,
-              ZL_NODE_CONCAT_NUMERIC,
-              ZL_NODE_CONCAT_STRUCT,
-              ZL_NODE_CONCAT_STRING });
+            std::vector<ZL_NodeID>{ ZL_NODE_CONCAT_SERIAL,
+                                    ZL_NODE_CONCAT_NUMERIC,
+                                    ZL_NODE_CONCAT_STRUCT,
+                                    ZL_NODE_CONCAT_STRING });
     const ZL_GraphID successors[2] = { ZL_GRAPH_STORE, ZL_GRAPH_STORE };
     auto graph                     = ZL_Compressor_registerStaticGraph_fromNode(
             cgraph_, concat, successors, 2);
     ZL_REQUIRE_SUCCESS(ZL_Compressor_selectStartingGraphID(cgraph_, graph));
-    size_t numInputs = f.usize_range("num_inputs", 1, 512);
+    size_t numInputs = dg.usize_range("num_inputs", 1, 512);
     std::vector<std::unique_ptr<ZL_TypedRef, ZS2_TypedRef_Deleter>> inputs;
     std::vector<TypedInputDesc> inputDescs;
     inputs.reserve(numInputs);
     inputDescs.reserve(numInputs);
     for (size_t i = 0; i < numInputs; ++i) {
-        ZL_Type type = f.choices(
+        ZL_Type type = dg.choices(
                 "type",
-                { ZL_Type_serial,
-                  ZL_Type_struct,
-                  ZL_Type_numeric,
-                  ZL_Type_string });
+                std::vector<ZL_Type>{ ZL_Type_serial,
+                                      ZL_Type_struct,
+                                      ZL_Type_numeric,
+                                      ZL_Type_string });
         std::string input;
         size_t eltWidth = 1;
         std::vector<uint32_t> strLens;
@@ -62,17 +64,19 @@ FUZZ_F(MultiInputTest, FuzzConcatRoundTrip)
             case ZL_Type_serial:
                 break;
             case ZL_Type_struct:
-                eltWidth = f.choices("elt_width", { 1, 2, 4, 8 });
+                eltWidth = dg.choices(
+                        "elt_width", std::vector<size_t>{ 1, 2, 4, 8 });
                 break;
             case ZL_Type_numeric:
-                eltWidth = f.choices("elt_width", { 1, 2, 4, 8 });
+                eltWidth = dg.choices(
+                        "elt_width", std::vector<size_t>{ 1, 2, 4, 8 });
                 break;
             case ZL_Type_string:
                 break;
         }
-        input = gen_str(f, "input_str", InputLengthInBytes(eltWidth));
+        input = dg.randStringWithQuantizedLength("input_str", eltWidth);
         if (type == ZL_Type_string) {
-            strLens = getSegments(f, input.size(), false);
+            strLens = getSegments(dg, input.size(), false);
         }
         inputDescs.emplace_back(
                 std::move(input), type, eltWidth, std::move(strLens));
@@ -123,6 +127,7 @@ FUZZ_F(MultiInputTest, FuzzConcatRoundTrip)
 
 FUZZ_F(MultiInputTest, FuzzClusterRoundTrip)
 {
+    datagen::DataGen dg = fromFDP(f);
     reset();
     setLargeCompressBound(2);
     const ZL_GraphID successors[3] = { ZL_GRAPH_STORE,
@@ -132,14 +137,16 @@ FUZZ_F(MultiInputTest, FuzzClusterRoundTrip)
                                        ZL_NODE_CONCAT_NUMERIC,
                                        ZL_NODE_CONCAT_STRING };
 
-    size_t numInputs = f.usize_range("num_inputs", 1, 512);
+    size_t numInputs = dg.usize_range("num_inputs", 1, 512);
     std::vector<std::unique_ptr<ZL_TypedRef, ZS2_TypedRef_Deleter>> inputs;
     std::vector<TypedInputDesc> inputDescs;
     inputs.reserve(numInputs);
     inputDescs.reserve(numInputs);
     for (size_t i = 0; i < numInputs; ++i) {
-        ZL_Type type = f.choices(
-                "type", { ZL_Type_serial, ZL_Type_numeric, ZL_Type_string });
+        ZL_Type type = dg.choices(
+                "type",
+                std::vector<ZL_Type>{
+                        ZL_Type_serial, ZL_Type_numeric, ZL_Type_string });
         std::string input;
         size_t eltWidth = 1;
         std::vector<uint32_t> strLens;
@@ -154,14 +161,14 @@ FUZZ_F(MultiInputTest, FuzzClusterRoundTrip)
             default:
                 throw std::runtime_error("Unsupported type");
         }
-        input = gen_str(f, "input_str", InputLengthInBytes(eltWidth));
+        input = dg.randStringWithQuantizedLength("input_str", eltWidth);
         if (type == ZL_Type_string) {
-            strLens = getSegments(f, input.size(), false);
+            strLens = getSegments(dg, input.size(), false);
         }
         inputDescs.emplace_back(
                 std::move(input), type, eltWidth, std::move(strLens));
         inputs.emplace_back(getTypedInput(inputDescs[i]));
-        int metadata = f.usize_range("num_inputs", 1, 1024);
+        int metadata = dg.usize_range("num_inputs", 1, 1024);
         if (ZL_isError(ZL_Input_setIntMetadata(inputs[i].get(), 0, metadata))) {
             throw std::runtime_error("Failed to set metadata");
         }
@@ -184,24 +191,26 @@ FUZZ_F(MultiInputTest, FuzzClusterRoundTrip)
                             .successorIdx       = 2,
                             .clusteringCodecIdx = 2 };
     config.typeDefaults = defaultSuccs;
-    config.nbClusters   = f.usize_range("num_inputs", 1, 512);
+    config.nbClusters   = dg.usize_range("num_inputs", 1, 512);
     config.clusters     = (ZL_ClusteringConfig_Cluster*)malloc(
             sizeof(ZL_ClusteringConfig_Cluster) * config.nbClusters);
     for (size_t i = 0; i < config.nbClusters; i++) {
         // Member tag
-        auto nbMemberTags               = f.usize_range("members", 1, 10);
+        auto nbMemberTags               = dg.usize_range("members", 1, 10);
         config.clusters[i].nbMemberTags = nbMemberTags;
         config.clusters[i].memberTags =
                 (int*)malloc(sizeof(int) * nbMemberTags);
         for (size_t j = 0; j < nbMemberTags; j++) {
-            config.clusters[i].memberTags[j] = f.usize_range("tags", 1, 1024);
+            config.clusters[i].memberTags[j] = dg.usize_range("tags", 1, 1024);
         }
         // Type successor
         // TODO: Allow the fuzzer to generate out of range successor indices
         config.clusters[i].typeSuccessor.successorIdx =
-                f.usize_range("num_inputs", 0, 2);
-        config.clusters[i].typeSuccessor.type = f.choices(
-                "type", { ZL_Type_serial, ZL_Type_numeric, ZL_Type_string });
+                dg.usize_range("num_inputs", 0, 2);
+        config.clusters[i].typeSuccessor.type = dg.choices(
+                "type",
+                std::vector<ZL_Type>{
+                        ZL_Type_serial, ZL_Type_numeric, ZL_Type_string });
         switch (config.clusters[i].typeSuccessor.type) {
             case ZL_Type_serial:
                 config.clusters[i].typeSuccessor.eltWidth = 1;
@@ -218,7 +227,7 @@ FUZZ_F(MultiInputTest, FuzzClusterRoundTrip)
         // Clustering codec
         // TODO: Allow the fuzzer to generate out of range codec indices
         config.clusters[i].typeSuccessor.clusteringCodecIdx =
-                f.usize_range("cluster_codec_idx", 0, 2);
+                dg.usize_range("cluster_codec_idx", 0, 2);
     }
 
     auto graph = ZL_Clustering_registerGraphWithCustomClusteringCodecs(

--- a/tests/zstrong/fuzz_serialized.cpp
+++ b/tests/zstrong/fuzz_serialized.cpp
@@ -1,8 +1,8 @@
 // Copyright (c) Meta Platforms, Inc. and affiliates.
 
-#include "security/lionhead/utils/lib_ftest/ftest.h"
-
 #include "openzl/compress/private_nodes.h"
+#include "tests/datagen/DataGen.h"
+#include "tests/datagen/distributions/VecLengthDistribution.h"
 #include "tests/fuzz_utils.h"
 #include "tests/zstrong/test_serialized_fixture.h"
 
@@ -32,9 +32,11 @@ ZL_NodeID selectNode(
 
 FUZZ_F(SerializedTest, FuzzInterpretSerializedAsLEIntRoundTrip)
 {
-    size_t const eltWidth = f.choices("elt_width", { 1, 2, 4, 8 });
+    datagen::DataGen dg = fromFDP(f);
+    size_t const eltWidth =
+            dg.choices("elt_width", std::vector<size_t>{ 1, 2, 4, 8 });
     std::string input =
-            gen_str(f, "input_data", ShortInputLengthInBytes(eltWidth));
+            dg.randStringWithQuantizedLength("input_data", eltWidth);
     ZL_NodeID const node = selectNode(
             eltWidth,
             ZL_NODE_INTERPRET_AS_LE8,
@@ -46,9 +48,11 @@ FUZZ_F(SerializedTest, FuzzInterpretSerializedAsLEIntRoundTrip)
 
 FUZZ_F(SerializedTest, FuzzConvertSerialToTokenRoundTrip)
 {
-    size_t const eltWidth = f.choices("elt_width", { 4, 8 });
+    datagen::DataGen dg = fromFDP(f);
+    size_t const eltWidth =
+            dg.choices("elt_width", std::vector<size_t>{ 4, 8 });
     std::string input =
-            gen_str(f, "input_data", ShortInputLengthInBytes(eltWidth));
+            dg.randStringWithQuantizedLength("input_data", eltWidth);
     ZL_NodeID const node = selectNode(
             eltWidth,
             {},
@@ -60,8 +64,9 @@ FUZZ_F(SerializedTest, FuzzConvertSerialToTokenRoundTrip)
 
 FUZZ_F(SerializedTest, FuzzHuffmanRoundTrip)
 {
-    bool const useNode = f.coin("use_node");
-    std::string input  = gen_str(f, "input_data", InputLengthInBytes(1));
+    datagen::DataGen dg = fromFDP(f);
+    bool const useNode  = dg.coin("use_node");
+    std::string input   = dg.randString("input_data");
     reset();
     if (useNode) {
         setLargeCompressBound(8);
@@ -79,8 +84,9 @@ FUZZ_F(SerializedTest, FuzzHuffmanRoundTrip)
 
 FUZZ_F(SerializedTest, FuzzFSERoundTrip)
 {
-    bool const useNode = f.coin("use_node");
-    std::string input  = gen_str(f, "input_data", InputLengthInBytes(1));
+    datagen::DataGen dg = fromFDP(f);
+    bool const useNode  = dg.coin("use_node");
+    std::string input   = dg.randString("input_data");
     reset();
     // Only the graph guarantees that copmression succeeds on every input
     if (useNode) {
@@ -96,27 +102,31 @@ FUZZ_F(SerializedTest, FuzzFSERoundTrip)
 
 FUZZ_F(SerializedTest, FuzzZstdRoundTrip)
 {
-    std::string input = gen_str(f, "input_data", InputLengthInBytes(1));
+    datagen::DataGen dg = fromFDP(f);
+    std::string input   = dg.randString("input_data");
     testNodeOnInput(ZL_NODE_ZSTD, input);
 }
 
 FUZZ_F(SerializedTest, FuzzBitpackRoundTrip)
 {
-    std::string input = gen_str(f, "input_data", InputLengthInBytes(1));
+    datagen::DataGen dg = fromFDP(f);
+    std::string input   = dg.randString("input_data");
     testNodeOnInput(ZL_NODE_BITPACK_SERIAL, input);
 }
 
 FUZZ_F(SerializedTest, FuzzFlatpackRoundTrip)
 {
-    std::string input = gen_str(f, "input_data", InputLengthInBytes(1));
+    datagen::DataGen dg = fromFDP(f);
+    std::string input   = dg.randString("input_data");
     testNodeOnInput(ZL_NODE_FLATPACK, input);
 }
 
 FUZZ_F(SerializedTest, FuzzBitunpackRoundTrip)
 {
-    size_t integerBitWidth = f.i32_range("integer_bit_width", 1, 64);
+    datagen::DataGen dg    = fromFDP(f);
+    size_t integerBitWidth = dg.i32_range("integer_bit_width", 1, 64);
     std::string input =
-            gen_str(f, "input_str", InputLengthInBytes(integerBitWidth));
+            dg.randStringWithQuantizedLength("input_str", integerBitWidth);
     ASSERT_LT((input.size() * 8) % integerBitWidth, 8);
     ZL_IntParam intParam  = { ZL_Bitunpack_numBits, (int)integerBitWidth };
     ZL_LocalParams params = { { &intParam, 1 }, { NULL, 0 }, { NULL, 0 } };
@@ -126,14 +136,15 @@ FUZZ_F(SerializedTest, FuzzBitunpackRoundTrip)
 
 FUZZ_F(SerializedTest, FuzzSplitByStructRoundTrip)
 {
-    std::string input = gen_str(f, "input_str", InputLengthInBytes(1));
-    size_t numFields  = f.usize_range("num_fields", 1, 16);
+    datagen::DataGen dg = fromFDP(f);
+    std::string input   = dg.randString("input_str");
+    size_t numFields    = dg.usize_range("num_fields", 1, 16);
     std::vector<size_t> fieldSizes;
     size_t structSize = 0;
     fieldSizes.reserve(numFields);
     for (size_t i = 0; i < numFields && structSize < input.size(); ++i) {
         size_t const fieldSize =
-                f.usize_range("field_size", 1, input.size() - structSize);
+                dg.usize_range("field_size", 1, input.size() - structSize);
         fieldSizes.push_back(fieldSize);
         structSize += fieldSize;
     }
@@ -153,12 +164,13 @@ FUZZ_F(SerializedTest, FuzzSplitByStructRoundTrip)
 
 FUZZ_F(SerializedTest, FuzzSplitNRoundTrip)
 {
-    std::string input = gen_str(f, "input_str", InputLengthInBytes(1));
+    datagen::DataGen dg = fromFDP(f);
+    std::string input   = dg.randString("input_str");
 
     StructuredFDP<HarnessMode>* fPtr = &f;
 
     reset();
-    if (f.u8("split_by_param") >= 128) {
+    if (dg.u8("split_by_param") >= 128) {
         auto segmentSizes = getSplitNSegments(f, input.size());
         std::vector<ZL_GraphID> successors(segmentSizes.size(), ZL_GRAPH_STORE);
         auto graph = ZL_Compressor_registerSplitGraph(
@@ -195,7 +207,8 @@ FUZZ_F(SerializedTest, FuzzSplitNRoundTrip)
 
 FUZZ_F(SerializedTest, FuzzDispatchNByTagRoundTrip)
 {
-    std::string input = gen_str(f, "input_str", InputLengthInBytes(1));
+    datagen::DataGen dg = fromFDP(f);
+    std::string input   = dg.randString("input_str");
 
     reset();
     StructuredFDP<HarnessMode>* fPtr = &f;
@@ -248,7 +261,8 @@ FUZZ_F(SerializedTest, FuzzDispatchNByTagRoundTrip)
 
 FUZZ_F(SerializedTest, FuzzSetStringSizesRoundTrip)
 {
-    std::string input = gen_str(f, "input_str", InputLengthInBytes(1));
+    datagen::DataGen dg = fromFDP(f);
+    std::string input   = dg.randString("input_str");
 
     StructuredFDP<HarnessMode>* fPtr = &f;
 
@@ -279,8 +293,10 @@ FUZZ_F(SerializedTest, FuzzSetStringSizesRoundTrip)
 
 FUZZ_F(SerializedTest, FuzzConstantRoundTrip)
 {
-    uint8_t const rptChr = f.u8_range("rptChr", 0, 255);
-    size_t const nbRpts  = InputLengthInBytes(1).gen("nbRpts", f);
+    datagen::DataGen dg  = fromFDP(f);
+    uint8_t const rptChr = dg.u8_range("rptChr", 0, 255);
+    datagen::VecLengthDistribution lengthDist(dg.getRandWrapper(), 1);
+    size_t const nbRpts = lengthDist("nbRpts");
     const std::string input(nbRpts == 0 ? 1 : nbRpts, rptChr);
 
     testNodeOnInput(ZL_NODE_CONSTANT_SERIAL, input, 1);

--- a/tests/zstrong/fuzz_sort.cpp
+++ b/tests/zstrong/fuzz_sort.cpp
@@ -1,21 +1,22 @@
 // Copyright (c) Meta Platforms, Inc. and affiliates.
+
 #include <algorithm>
 
-#include "security/lionhead/utils/lib_ftest/ftest.h"
+#include "tests/datagen/DataGen.h"
+#include "tests/fuzz_utils.h"
 
 #include "openzl/shared/pdqsort.h"
-#include "tests/fuzz_utils.h"
 
 namespace zstrong {
 namespace tests {
 namespace {
 
-template <typename T, typename F>
-void fuzzPdqsort_inner(F& f)
+template <typename T>
+void fuzzPdqsort_inner(datagen::DataGen& dg)
 {
     size_t const eltWidth = sizeof(T);
-    std::vector<T> input =
-            gen_vec<T>(f, "input_data", InputLengthInElts(eltWidth));
+    std::vector<T> input  = dg.randVector<T>(
+            "input_data", T(0), std::numeric_limits<T>::max(), 1000);
     std::vector<T> verification = input;
     ASSERT_EQ(input, verification);
     pdqsort(input.data(), input.size(), eltWidth);
@@ -26,19 +27,21 @@ void fuzzPdqsort_inner(F& f)
 
 FUZZ(SortTest, FuzzPDQsort)
 {
-    size_t const eltWidth = f.choices("elt_width", { 1, 2, 4, 8 });
+    datagen::DataGen dg = fromFDP(f);
+    size_t const eltWidth =
+            dg.choices("elt_width", std::vector<size_t>{ 1, 2, 4, 8 });
     switch (eltWidth) {
         case 1:
-            fuzzPdqsort_inner<uint8_t>(f);
+            fuzzPdqsort_inner<uint8_t>(dg);
             break;
         case 2:
-            fuzzPdqsort_inner<uint16_t>(f);
+            fuzzPdqsort_inner<uint16_t>(dg);
             break;
         case 4:
-            fuzzPdqsort_inner<uint32_t>(f);
+            fuzzPdqsort_inner<uint32_t>(dg);
             break;
         case 8:
-            fuzzPdqsort_inner<uint64_t>(f);
+            fuzzPdqsort_inner<uint64_t>(dg);
             break;
     }
 }

--- a/tests/zstrong/fuzz_variable.cpp
+++ b/tests/zstrong/fuzz_variable.cpp
@@ -1,11 +1,11 @@
 // Copyright (c) Meta Platforms, Inc. and affiliates.
 
 #include <algorithm>
-#include "security/lionhead/utils/lib_ftest/ftest.h"
 
 #include "openzl/codecs/zl_parse_int.h"
 #include "openzl/compress/private_nodes.h"
 #include "openzl/zl_data.h"
+#include "tests/datagen/DataGen.h"
 #include "tests/datagen/random_producer/LionheadFDPWrapper.h"
 #include "tests/datagen/random_producer/RandWrapper.h"
 #include "tests/datagen/structures/IntegerStringProducer.h"
@@ -48,7 +48,8 @@ std::vector<size_t> getSegments(
 
 FUZZ_F(VariableTest, FuzzPrefixRoundTrip)
 {
-    std::string input = gen_str(f, "input_str", InputLengthInBytes(1));
+    datagen::DataGen dg = fromFDP(f);
+    std::string input   = dg.randString("input_str");
 
     StructuredFDP<HarnessMode>* fPtr = &f;
 
@@ -85,7 +86,8 @@ FUZZ_F(VariableTest, FuzzPrefixRoundTrip)
 
 FUZZ_F(VariableTest, FuzzTokenizeRoundTrip)
 {
-    std::string input = gen_str(f, "input_str", InputLengthInBytes(1));
+    datagen::DataGen dg = fromFDP(f);
+    std::string input   = dg.randString("input_str");
 
     StructuredFDP<HarnessMode>* fPtr = &f;
 
@@ -123,7 +125,8 @@ FUZZ_F(VariableTest, FuzzTokenizeRoundTrip)
 
 FUZZ_F(VariableTest, FuzzTokenizeSortedRoundTrip)
 {
-    std::string input = gen_str(f, "input_str", InputLengthInBytes(1));
+    datagen::DataGen dg = fromFDP(f);
+    std::string input   = dg.randString("input_str");
 
     StructuredFDP<HarnessMode>* fPtr = &f;
 
@@ -161,14 +164,15 @@ FUZZ_F(VariableTest, FuzzTokenizeSortedRoundTrip)
 
 FUZZ_F(VariableTest, FuzzDispatchStringRoundTrip)
 {
-    std::string input = gen_str(f, "inputStr", InputLengthInBytes(1));
+    datagen::DataGen dg = fromFDP(f);
+    std::string input   = dg.randString("inputStr");
 
     reset();
 
     const auto tmpSegments = getSegments(f, input.size(), false);
     const std::vector<uint32_t> segments(
             tmpSegments.begin(), tmpSegments.end());
-    uint16_t nbOutputs = f.u16_range("nbOutputs", 0, 2048);
+    uint16_t nbOutputs = dg.u16_range("nbOutputs", 0, 2048);
     const auto indices = VecDistribution<Range<uint16_t>, Const<size_t>>(
                                  Range<uint16_t>(0, nbOutputs),
                                  Const<size_t>(segments.size()))
@@ -240,7 +244,8 @@ FUZZ_F(VariableTest, FuzzParseIntRoundTrip)
 
 FUZZ_F(VariableTest, FuzzParseIntSafeRoundTrip)
 {
-    std::string input = gen_str(f, "inputStr", InputLengthInBytes(1));
+    datagen::DataGen dg = fromFDP(f);
+    std::string input   = dg.randString("inputStr");
 
     reset();
     const auto tmpSegments = getSegments(f, input.size(), false);


### PR DESCRIPTION
Summary:
This is a continuation of the datagen project. Instead of using the FDP directly, use the datagen shim layer for more controlled and expressive data structures. Along the way, this also hoists `all_remaining_bytes()` to the `RandWrapper` API.

## What's next?
- Migrate version fuzzer after the next release
- Remove extraneous functions from `fuzz_utils.h` now that they're no longer needed

Differential Revision: D84266467


