### PR TITLE
Standard numeric segmenter

### DIFF
--- a/include/openzl/codecs/zl_generic.h
+++ b/include/openzl/codecs/zl_generic.h
@@ -31,6 +31,12 @@ extern "C" {
         ZL_StandardGraphID_select_numeric \
     }
 
+#define ZL_GRAPH_SEGMENT_NUMERIC           \
+    (ZL_GraphID)                           \
+    {                                      \
+        ZL_StandardGraphID_segment_numeric \
+    }
+
 #if defined(__cplusplus)
 }
 #endif

--- a/include/openzl/zl_graphs.h
+++ b/include/openzl/zl_graphs.h
@@ -25,6 +25,7 @@ typedef enum {
 
     ZL_StandardGraphID_compress_generic,
     ZL_StandardGraphID_select_generic_lz_backend,
+    ZL_StandardGraphID_segment_numeric,
     ZL_StandardGraphID_select_numeric,
     ZL_StandardGraphID_clustering,
     ZL_StandardGraphID_try_parse_int,

--- a/src/openzl/compress/cgraph.c
+++ b/src/openzl/compress/cgraph.c
@@ -924,6 +924,7 @@ const ZL_FunctionGraphDesc* CGRAPH_getMultiInputGraphDesc(
         const ZL_Compressor* compressor,
         ZL_GraphID graphid)
 {
+    ZL_DLOG(SEQ, "CGRAPH_getMultiInputGraphDesc (gid=%u)", graphid.gid);
     ZL_ASSERT_NN(compressor);
     return GM_getMultiInputGraphDesc(compressor->gm, graphid);
 }

--- a/src/openzl/compress/dyngraph_interface.c
+++ b/src/openzl/compress/dyngraph_interface.c
@@ -341,6 +341,7 @@ ZL_Report ZL_Edge_setParameterizedDestination(
     ZL_Graph* const gctx = inputs[0]->gctx;
     ZL_ASSERT_NN(gctx);
     ZL_RESULT_DECLARE_SCOPE_REPORT(gctx->cctx);
+    ZL_DLOG(SEQ, "ZL_Edge_setDestination(%zu inputs => gid=%u)", nbInputs, gid);
 
     // === Phase 1: Basic Input Sanitization ===
     ZL_ERR_IF_NULL(

--- a/src/openzl/compress/graph_registry.c
+++ b/src/openzl/compress/graph_registry.c
@@ -95,6 +95,15 @@
         },                                    \
     }
 
+#define REGISTER_SEGMENTER(id, _sdesc) \
+    [id] = {                                 \
+        .type = GR_segmenter,                \
+        .gdi  = {                            \
+            .segDesc = _sdesc,               \
+            .baseGraphID = ZL_GRAPH_ILLEGAL, \
+        },                                   \
+    }
+
 #define REGISTER_SPECIAL(id, _name, _type) \
     [id] = {                                                              \
         .type = _type,                                                    \

--- a/src/openzl/compress/graph_registry.c
+++ b/src/openzl/compress/graph_registry.c
@@ -1,32 +1,32 @@
 // Copyright (c) Meta Platforms, Inc. and affiliates.
 
-#include "openzl/compress/graph_registry.h"
+#include "openzl/compress/graph_registry.h" // InternalGraphDesc, GR_standardGraphs declarations
 #include "openzl/codecs/bitpack/encode_bitpack_binding.h" // SI_selector_bitpack
-#include "openzl/codecs/encoder_registry.h"               // ER_standardNodes
-#include "openzl/codecs/entropy/encode_entropy_binding.h"
-#include "openzl/codecs/lz/encode_lz_binding.h"
+#include "openzl/codecs/encoder_registry.h" // ER_standardNodes, CNode definitions
+#include "openzl/codecs/entropy/encode_entropy_binding.h" // EI_fseDynamicGraph, EI_huffmanDynamicGraph, EI_entropyDynamicGraph
+#include "openzl/codecs/lz/encode_lz_binding.h" // EI_fieldLzDynGraph, EI_fieldLzLiteralsDynGraph, SI_fieldLzLiteralsChannelSelector
 #include "openzl/codecs/parse_int/encode_parse_int_binding.h" // MIGRAPH_TRY_PARSE_INT
-#include "openzl/common/assertion.h"
-#include "openzl/common/logging.h"
-#include "openzl/compress/compress_types.h"
-#include "openzl/compress/dyngraph_interface.h" // ZL_Graph definition
-#include "openzl/compress/graphs/generic_clustering_graph.h" // graph_compressClustered
-#include "openzl/compress/graphs/simple_data_description_language.h"
-#include "openzl/compress/graphs/split_graph.h"
-#include "openzl/compress/implicit_conversion.h" // ICONV_*
-#include "openzl/compress/private_nodes.h" // ZL_PrivateStandardGraphID_end
-#include "openzl/compress/selector.h"      // SelectorCtx
-#include "openzl/compress/selectors/selector_compress.h"
-#include "openzl/compress/selectors/selector_constant.h"
-#include "openzl/compress/selectors/selector_genericLZ.h"
-#include "openzl/compress/selectors/selector_numeric.h"
-#include "openzl/compress/selectors/selector_store.h"
-#include "openzl/shared/utils.h" // ZL_ARRAY_SIZE
-#include "openzl/zl_data.h"
-#include "openzl/zl_errors.h"    // ZL_TRY_LET_T
-#include "openzl/zl_graph_api.h" // ZS2_Graph_*
-#include "openzl/zl_localParams.h"
-#include "openzl/zl_opaque_types.h"
+#include "openzl/common/assertion.h" // ZL_ASSERT_* macros for runtime checks
+#include "openzl/common/logging.h"   // STR_REPLACE_NULL, logging utilities
+#include "openzl/compress/compress_types.h" // Compression-related type definitions
+#include "openzl/compress/dyngraph_interface.h" // ZL_Graph definition and graph context functions
+#include "openzl/compress/graphs/generic_clustering_graph.h" // MIGRAPH_CLUSTERING
+#include "openzl/compress/graphs/simple_data_description_language.h" // ZL_SDDL_dynGraph
+#include "openzl/compress/graphs/split_graph.h" // ZL_splitFnGraph
+#include "openzl/compress/implicit_conversion.h" // ICONV_isCompatible for type checking
+#include "openzl/compress/private_nodes.h" // ZL_PrivateStandardGraphID_end, private node ID definitions
+#include "openzl/compress/selector.h" // SelectorCtx, ZL_SelectorFn, SelCtx_* functions
+#include "openzl/compress/selectors/selector_compress.h" // SI_selector_compress, SI_selector_compress_* functions
+#include "openzl/compress/selectors/selector_constant.h" // SI_selector_constant
+#include "openzl/compress/selectors/selector_genericLZ.h" // SI_selector_genericLZ
+#include "openzl/compress/selectors/selector_numeric.h"   // SI_selector_numeric
+#include "openzl/compress/selectors/selector_store.h" // SI_selector_store, MIGRAPH_STORE
+#include "openzl/shared/utils.h"                      // ZL_ARRAY_SIZE macro
+#include "openzl/zl_data.h"   // ZL_Type definitions and data structures
+#include "openzl/zl_errors.h" // ZL_TRY_LET_T, ZL_RET_R_IF_* error handling macros
+#include "openzl/zl_graph_api.h"    // ZL_Graph_*, ZL_Edge_* API functions
+#include "openzl/zl_localParams.h"  // ZL_LocalParams structure and functions
+#include "openzl/zl_opaque_types.h" // Opaque type definitions used by the API
 
 #define _1_SUCCESSOR(s) (const ZL_GraphID[]){ { s } }, 1
 #define _2_SUCCESSORS(s1, s2) (const ZL_GraphID[]){ { s1 }, { s2 } }, 2

--- a/src/openzl/compress/graph_registry.c
+++ b/src/openzl/compress/graph_registry.c
@@ -15,6 +15,7 @@
 #include "openzl/compress/graphs/split_graph.h" // ZL_splitFnGraph
 #include "openzl/compress/implicit_conversion.h" // ICONV_isCompatible for type checking
 #include "openzl/compress/private_nodes.h" // ZL_PrivateStandardGraphID_end, private node ID definitions
+#include "openzl/compress/segmenters/segmenter_numeric.h" // SEGM_numeric_desc
 #include "openzl/compress/selector.h" // SelectorCtx, ZL_SelectorFn, SelCtx_* functions
 #include "openzl/compress/selectors/selector_compress.h" // SI_selector_compress, SI_selector_compress_* functions
 #include "openzl/compress/selectors/selector_constant.h" // SI_selector_constant
@@ -134,6 +135,7 @@ const InternalGraphDesc GR_standardGraphs[ZL_PrivateStandardGraphID_end] = {
     REGISTER_DYNAMIC_GRAPH(ZL_StandardGraphID_field_lz, "!zl.field_lz", ZL_Type_struct | ZL_Type_numeric, EI_fieldLzDynGraph),
     REGISTER_MIGRAPH(ZL_StandardGraphID_compress_generic, MIGRAPH_COMPRESS),
     REGISTER_SELECTOR(ZL_StandardGraphID_select_generic_lz_backend, "!zl.select_generic_lz_backend", SI_selector_genericLZ, ZL_Type_serial),
+    REGISTER_SEGMENTER(ZL_StandardGraphID_segment_numeric, SEGM_NUMERIC_DESC),
     REGISTER_SELECTOR(ZL_StandardGraphID_select_numeric, "!zl.select_numeric", SI_selector_numeric, ZL_Type_numeric),
     REGISTER_MIGRAPH(ZL_StandardGraphID_clustering, MIGRAPH_CLUSTERING),
     REGISTER_DYNAMIC_GRAPH(ZL_StandardGraphID_simple_data_description_language, "!zl.sddl", ZL_Type_serial, ZL_SDDL_dynGraph),

--- a/src/openzl/compress/graph_registry.h
+++ b/src/openzl/compress/graph_registry.h
@@ -14,7 +14,12 @@
 
 ZL_BEGIN_C_DECLS
 
-typedef enum { GR_illegal = 0, GR_store, GR_dynamicGraph } GraphFunctionType_e;
+typedef enum {
+    GR_illegal = 0,
+    GR_store,
+    GR_dynamicGraph,
+    GR_segmenter
+} GraphFunctionType_e;
 
 typedef struct {
     union {

--- a/src/openzl/compress/graphmgr.c
+++ b/src/openzl/compress/graphmgr.c
@@ -744,44 +744,52 @@ const ZL_FunctionGraphDesc* GM_getMultiInputGraphDesc(
         const GraphsMgr* gm,
         ZL_GraphID graphid)
 {
+    ZL_IDType const ggid = graphid.gid;
+    ZL_DLOG(BLOCK, "GM_getMultiInputGraphDesc (graphid=%u)", ggid);
     if (GR_isStandardGraph(graphid)) {
-        if (GR_standardGraphs[graphid.gid].type == GR_illegal) {
-            return NULL;
+        switch(GR_standardGraphs[ggid].type) {
+            case GR_store:
+            case GR_dynamicGraph:
+                return &GR_standardGraphs[ggid].gdi.migd;
+            case GR_illegal:
+            case GR_segmenter:
+            default:
+                return NULL;
         }
-        return &GR_standardGraphs[graphid.gid].gdi.migd;
     }
-    ZL_IDType const lgid = graphid.gid;
-    ZL_DLOG(BLOCK, "GM_getMultiInputGraphDesc (graphid=%u)", lgid);
-    ZL_IDType const lid = GM_GraphID_to_lgid(graphid);
+    ZL_IDType const lgid = GM_GraphID_to_lgid(graphid);
     ZL_ASSERT_NN(gm);
-    if (lid >= VECTOR_SIZE(gm->gdv)) {
+    if (lgid >= VECTOR_SIZE(gm->gdv)) {
         ZL_DLOG(ERROR,
                 "requested graphid=%u is invalid (too large, >= %zu max)",
-                lgid,
+                ggid,
                 VECTOR_SIZE(gm->gdv));
         return NULL;
     }
-    if (VECTOR_AT(gm->gdv, lid).originalGraphType == ZL_GraphType_segmenter)
+    if (VECTOR_AT(gm->gdv, lgid).originalGraphType == ZL_GraphType_segmenter)
         return NULL;
-    return &VECTOR_AT(gm->gdv, lid).migd;
+    return &VECTOR_AT(gm->gdv, lgid).migd;
 }
 
 const ZL_SegmenterDesc* GM_getSegmenterDesc(
         const GraphsMgr* gm,
         ZL_GraphID graphid)
 {
+    ZL_IDType const ggid = graphid.gid;
+    ZL_DLOG(BLOCK, "GM_getSelectorDesc (graphid=%u)", ggid);
     if (GR_isStandardGraph(graphid)) {
-        return NULL; // not supported yet
+        if (GR_standardGraphs[graphid.gid].type != GR_segmenter) {
+            return NULL;
+        }
+        return &GR_standardGraphs[graphid.gid].gdi.segDesc;
     }
-    ZL_IDType const lgid = graphid.gid;
-    ZL_DLOG(BLOCK, "GM_getSelectorDesc (graphid=%u)", lgid);
-    ZL_IDType const lid = GM_GraphID_to_lgid(graphid);
+    ZL_IDType const lgid = GM_GraphID_to_lgid(graphid);
     ZL_ASSERT_NN(gm);
-    if (lid >= VECTOR_SIZE(gm->gdv))
+    if (lgid >= VECTOR_SIZE(gm->gdv))
         return NULL;
-    ZL_ASSERT_EQ(
-            VECTOR_AT(gm->gdv, lid).originalGraphType, ZL_GraphType_segmenter);
-    return &VECTOR_AT(gm->gdv, lid).segDesc;
+    if (VECTOR_AT(gm->gdv, lgid).originalGraphType != ZL_GraphType_segmenter)
+        return NULL;
+    return &VECTOR_AT(gm->gdv, lgid).segDesc;
 }
 
 GraphType_e GM_graphType(const GraphsMgr* gm, ZL_GraphID graphid)

--- a/src/openzl/compress/graphmgr.c
+++ b/src/openzl/compress/graphmgr.c
@@ -747,7 +747,7 @@ const ZL_FunctionGraphDesc* GM_getMultiInputGraphDesc(
     ZL_IDType const ggid = graphid.gid;
     ZL_DLOG(BLOCK, "GM_getMultiInputGraphDesc (graphid=%u)", ggid);
     if (GR_isStandardGraph(graphid)) {
-        switch(GR_standardGraphs[ggid].type) {
+        switch (GR_standardGraphs[ggid].type) {
             case GR_store:
             case GR_dynamicGraph:
                 return &GR_standardGraphs[ggid].gdi.migd;

--- a/src/openzl/compress/graphmgr.c
+++ b/src/openzl/compress/graphmgr.c
@@ -1,21 +1,21 @@
 // Copyright (c) Meta Platforms, Inc. and affiliates.
 
-#include "openzl/compress/graphmgr.h"
-#include "openzl/common/allocation.h"
-#include "openzl/common/assertion.h"
-#include "openzl/common/limits.h"
-#include "openzl/common/logging.h"
-#include "openzl/common/map.h"
-#include "openzl/common/opaque.h"
-#include "openzl/compress/cgraph.h"
-#include "openzl/compress/graph_registry.h" // ZL_PrivateStandardGraphID_end, DynGraph_Desc_internal
-#include "openzl/compress/implicit_conversion.h" // ICONV_isCompatible
-#include "openzl/compress/localparams.h"         // LP_*
-#include "openzl/compress/name.h"
-#include "openzl/shared/mem.h"
-#include "openzl/shared/overflow.h"
-#include "openzl/zl_opaque_types.h"
-#include "openzl/zl_reflection.h"
+#include "openzl/compress/graphmgr.h" // GraphsMgr interface and GM_* function declarations
+#include "openzl/common/allocation.h" // ALLOC_Arena_malloc, ALLOC_HeapArena_create, arena memory management
+#include "openzl/common/assertion.h" // ZL_ASSERT_* macros for runtime checks
+#include "openzl/common/limits.h"    // ZL_ENCODER_GRAPH_LIMIT constant
+#include "openzl/common/logging.h" // ZL_DLOG, STR_REPLACE_NULL for logging and debugging
+#include "openzl/common/map.h" // ZL_DECLARE_PREDEF_MAP_TYPE, GraphMap for name-to-GraphID mapping
+#include "openzl/common/opaque.h" // ZL_OpaquePtrRegistry for managing opaque pointers
+#include "openzl/compress/cgraph.h" // CNODE_getName, CNode definitions, graph context functions
+#include "openzl/compress/graph_registry.h" // ZL_PrivateStandardGraphID_end, GR_standardGraphs, InternalGraphDesc
+#include "openzl/compress/implicit_conversion.h" // ICONV_isCompatible for type checking
+#include "openzl/compress/localparams.h" // LP_transferLocalParams for parameter management
+#include "openzl/compress/name.h" // ZL_Name_*, ZS2_Name_* for graph name handling
+#include "openzl/shared/mem.h" // ZL_malloc, ZL_free, ZL_memcpy memory utilities
+#include "openzl/shared/overflow.h" // ZL_overflowMulST for integer overflow checks
+#include "openzl/zl_opaque_types.h" // Opaque type definitions used by the API
+#include "openzl/zl_reflection.h" // ZL_MIGraphDesc and type reflection utilities
 
 /* ===   State Management   === */
 
@@ -792,6 +792,8 @@ GraphType_e GM_graphType(const GraphsMgr* gm, ZL_GraphID graphid)
                 return gt_store;
             case GR_dynamicGraph:
                 return gt_miGraph;
+            case GR_segmenter:
+                return gt_segmenter;
             case GR_illegal:
             default:
                 return gt_illegal;

--- a/src/openzl/compress/graphmgr.c
+++ b/src/openzl/compress/graphmgr.c
@@ -109,6 +109,7 @@ static ZL_GraphID GM_lgid_to_zgid(ZL_IDType lgid)
 
 bool GM_isValidGraphID(const GraphsMgr* gm, ZL_GraphID gid)
 {
+    ZL_DLOG(SEQ, "GM_isValidGraphID(%u)", gid.gid);
     ZL_IDType const cid   = gid.gid;
     size_t const nbGraphs = VECTOR_SIZE(gm->gdv);
     return ZL_StandardGraphID_illegal < cid
@@ -477,6 +478,9 @@ GM_registerParameterizedGraph(
     ZL_RESULT_DECLARE_SCOPE(ZL_GraphID, gm->opCtx);
     ZL_ASSERT_NN(gm);
     ZL_ASSERT_NN(desc);
+    ZL_DLOG(SEQ,
+            "GM_registerParameterizedGraph (name=%s)",
+            STR_REPLACE_NULL(desc->name));
 
     const ZL_FunctionGraphDesc* miDescPtr =
             GM_getMultiInputGraphDesc(gm, desc->graph);
@@ -631,13 +635,16 @@ static GM_GraphMetadata GM_getSegmenterMetadata(
         ZL_GraphID gid)
 {
     ZL_ASSERT(GM_isValidGraphID(gm, gid));
-    ZL_ASSERT(!GR_isStandardGraph(gid));
     GM_GraphMetadata meta;
+    ZL_DLOG(SEQ, "GM_getSegmenterMetadata (graphid=%u)", gid.gid);
 
     // graphType
-    ZL_IDType const lgid = GM_GraphID_to_lgid(gid);
-    ZL_ASSERT_EQ(
-            VECTOR_AT(gm->gdv, lgid).originalGraphType, ZL_GraphType_segmenter);
+    if (!GR_isStandardGraph(gid)) {
+        ZL_IDType const lgid = GM_GraphID_to_lgid(gid);
+        ZL_ASSERT_EQ(
+                VECTOR_AT(gm->gdv, lgid).originalGraphType,
+                ZL_GraphType_segmenter);
+    }
     meta.graphType = ZL_GraphType_segmenter;
 
     const ZL_SegmenterDesc* desc = GM_getSegmenterDesc(gm, gid);
@@ -647,12 +654,18 @@ static GM_GraphMetadata GM_getSegmenterMetadata(
     meta.baseGraphID = ZL_GRAPH_ILLEGAL;
 
     // name
-    meta.name = VECTOR_AT(gm->gdv, lgid).maybeName;
-    ZL_ASSERT_EQ(
-            strcmp(ZL_Name_unique(&meta.name), desc->name),
-            0,
-            "Name mismatch in %s",
-            desc->name);
+    ZL_ASSERT_NN(desc);
+    if (GR_isStandardGraph(gid)) {
+        meta.name = ZS2_Name_wrapStandard(desc->name);
+    } else {
+        ZL_IDType const lgid = GM_GraphID_to_lgid(gid);
+        meta.name            = VECTOR_AT(gm->gdv, lgid).maybeName;
+        ZL_ASSERT_EQ(
+                strcmp(ZL_Name_unique(&meta.name), desc->name),
+                0,
+                "Name mismatch in %s",
+                desc->name);
+    }
     ZL_ASSERT(!ZL_Name_isEmpty(&meta.name));
 
     meta.inputTypeMasks      = desc->inputTypeMasks;
@@ -672,10 +685,13 @@ GM_GraphMetadata GM_getGraphMetadata(const GraphsMgr* gm, ZL_GraphID gid)
 {
     ZL_ASSERT(GM_isValidGraphID(gm, gid));
     GM_GraphMetadata meta;
+    ZL_DLOG(SEQ, "GM_getGraphMetadata (graphid=%u)", gid.gid);
 
     // graphType
     if (GR_isStandardGraph(gid)) {
         meta.graphType = ZL_GraphType_standard;
+        if (GR_standardGraphs[gid.gid].type == GR_segmenter)
+            meta.graphType = ZL_GraphType_segmenter;
     } else {
         ZL_IDType const lgid = GM_GraphID_to_lgid(gid);
         meta.graphType       = VECTOR_AT(gm->gdv, lgid).originalGraphType;
@@ -695,6 +711,7 @@ GM_GraphMetadata GM_getGraphMetadata(const GraphsMgr* gm, ZL_GraphID gid)
     }
 
     // name
+    ZL_ASSERT_NN(desc);
     if (GR_isStandardGraph(gid)) {
         meta.name = ZS2_Name_wrapStandard(desc->name);
     } else {

--- a/src/openzl/compress/segmenters/segmenter_numeric.c
+++ b/src/openzl/compress/segmenters/segmenter_numeric.c
@@ -1,8 +1,8 @@
 // Copyright (c) Meta Platforms, Inc. and affiliates.
 
 #include "openzl/compress/segmenters/segmenter_numeric.h"
-#include "openzl/compress/private_nodes.h"
 #include "openzl/common/assertion.h"
+#include "openzl/compress/private_nodes.h"
 
 ZL_Report SEGM_numeric(ZL_Segmenter* sctx)
 {
@@ -16,7 +16,7 @@ ZL_Report SEGM_numeric(ZL_Segmenter* sctx)
     // Note: Currently, static chunk size.
     // Tomorrow: global parameter, then local parameter.
     size_t const chunkByteSizeMax = 16 << 20;
-    size_t const chunkEltSizeMax = chunkByteSizeMax / width;
+    size_t const chunkEltSizeMax  = chunkByteSizeMax / width;
 
     // Note: Currently, static head graph.
     // Tomorrow: selectable
@@ -24,11 +24,13 @@ ZL_Report SEGM_numeric(ZL_Segmenter* sctx)
 
     size_t numElts = ZL_Input_numElts(input);
     while (numElts > chunkEltSizeMax) {
-        ZL_RET_R_IF_ERR(ZL_Segmenter_processChunk(sctx, &chunkEltSizeMax,1, headGraph, NULL));
+        ZL_RET_R_IF_ERR(ZL_Segmenter_processChunk(
+                sctx, &chunkEltSizeMax, 1, headGraph, NULL));
         numElts -= chunkEltSizeMax;
     }
     ZL_ASSERT_LE(numElts, chunkEltSizeMax);
-    ZL_RET_R_IF_ERR(ZL_Segmenter_processChunk(sctx, &numElts,1, headGraph, NULL));
+    ZL_RET_R_IF_ERR(
+            ZL_Segmenter_processChunk(sctx, &numElts, 1, headGraph, NULL));
 
     return ZL_returnSuccess();
 }

--- a/src/openzl/compress/segmenters/segmenter_numeric.c
+++ b/src/openzl/compress/segmenters/segmenter_numeric.c
@@ -1,0 +1,34 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#include "openzl/compress/segmenters/segmenter_numeric.h"
+#include "openzl/compress/private_nodes.h"
+#include "openzl/common/assertion.h"
+
+ZL_Report SEGM_numeric(ZL_Segmenter* sctx)
+{
+    size_t const numInputs = ZL_Segmenter_numInputs(sctx);
+    ZL_ASSERT_EQ(numInputs, 1);
+    const ZL_Input* const input = ZL_Segmenter_getInput(sctx, 0);
+    ZL_ASSERT_NN(input);
+    size_t const width = ZL_Input_eltWidth(input);
+    ZL_ASSERT(width == 1 || width == 2 || width == 4 || width == 8);
+
+    // Note: Currently, static chunk size.
+    // Tomorrow: global parameter, then local parameter.
+    size_t const chunkByteSizeMax = 16 << 20;
+    size_t const chunkEltSizeMax = chunkByteSizeMax / width;
+
+    // Note: Currently, static head graph.
+    // Tomorrow: selectable
+    ZL_GraphID const headGraph = ZL_GRAPH_NUMERIC_COMPRESS;
+
+    size_t numElts = ZL_Input_numElts(input);
+    while (numElts > chunkEltSizeMax) {
+        ZL_RET_R_IF_ERR(ZL_Segmenter_processChunk(sctx, &chunkEltSizeMax,1, headGraph, NULL));
+        numElts -= chunkEltSizeMax;
+    }
+    ZL_ASSERT_LE(numElts, chunkEltSizeMax);
+    ZL_RET_R_IF_ERR(ZL_Segmenter_processChunk(sctx, &numElts,1, headGraph, NULL));
+
+    return ZL_returnSuccess();
+}

--- a/src/openzl/compress/segmenters/segmenter_numeric.h
+++ b/src/openzl/compress/segmenters/segmenter_numeric.h
@@ -10,13 +10,14 @@ ZL_BEGIN_C_DECLS
 
 ZL_Report SEGM_numeric(ZL_Segmenter* sctx);
 
-const ZL_SegmenterDesc SEGM_numeric_desc = {
-    .name                = "segmenter_numeric",
-    .segmenterFn         = SEGM_numeric,
-    .inputTypeMasks      = &(const ZL_Type){ ZL_Type_numeric },
-    .numInputs           = 1,
-    .lastInputIsVariable = false,
-};
+#define SEGM_NUMERIC_DESC                                           \
+    {                                                               \
+        .name                = "!zl.segmenter_numeric",             \
+        .segmenterFn         = SEGM_numeric,                        \
+        .inputTypeMasks      = &(const ZL_Type){ ZL_Type_numeric }, \
+        .numInputs           = 1,                                   \
+        .lastInputIsVariable = false,                               \
+    }
 
 ZL_END_C_DECLS
 

--- a/src/openzl/compress/segmenters/segmenter_numeric.h
+++ b/src/openzl/compress/segmenters/segmenter_numeric.h
@@ -1,0 +1,23 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#ifndef ZSTRONG_COMPRESS_SEGMENTERS_NUMERIC_H
+#define ZSTRONG_COMPRESS_SEGMENTERS_NUMERIC_H
+
+#include "openzl/shared/portability.h"
+#include "openzl/zl_segmenter.h"
+
+ZL_BEGIN_C_DECLS
+
+ZL_Report SEGM_numeric(ZL_Segmenter* sctx);
+
+const ZL_SegmenterDesc SEGM_numeric_desc = {
+    .name                = "segmenter_numeric",
+    .segmenterFn         = SEGM_numeric,
+    .inputTypeMasks      = &(const ZL_Type){ ZL_Type_numeric },
+    .numInputs           = 1,
+    .lastInputIsVariable = false,
+};
+
+ZL_END_C_DECLS
+
+#endif // ZSTRONG_COMPRESS_SEGMENTERS_NUMERIC_H

--- a/src/openzl/compress/segmenters/segmenter_numeric.h
+++ b/src/openzl/compress/segmenters/segmenter_numeric.h
@@ -10,13 +10,11 @@ ZL_BEGIN_C_DECLS
 
 ZL_Report SEGM_numeric(ZL_Segmenter* sctx);
 
-#define SEGM_NUMERIC_DESC                                           \
-    {                                                               \
-        .name                = "!zl.segmenter_numeric",             \
-        .segmenterFn         = SEGM_numeric,                        \
-        .inputTypeMasks      = &(const ZL_Type){ ZL_Type_numeric }, \
-        .numInputs           = 1,                                   \
-        .lastInputIsVariable = false,                               \
+#define SEGM_NUMERIC_DESC                                                      \
+    {                                                                          \
+        .name = "!zl.segmenter_numeric", .segmenterFn = SEGM_numeric,          \
+        .inputTypeMasks = &(const ZL_Type){ ZL_Type_numeric }, .numInputs = 1, \
+        .lastInputIsVariable = false,                                          \
     }
 
 ZL_END_C_DECLS

--- a/src/openzl/compress/selectors/selector_numeric.h
+++ b/src/openzl/compress/selectors/selector_numeric.h
@@ -18,4 +18,4 @@ ZL_GraphID SI_selector_numeric(
 
 ZL_END_C_DECLS
 
-#endif
+#endif // ZSTRONG_COMPRESS_SELECTORS_SELECTOR_NUMERIC_H

--- a/tests/round_trip/test_segmenter.cpp
+++ b/tests/round_trip/test_segmenter.cpp
@@ -35,23 +35,7 @@ void printHexa(const void* p, size_t size)
 }
 #endif
 
-/* ------   create the compressor   -------- */
-
-// This graph function follows the ZL_GraphFn definition
-// It's in charge of registering custom graphs and nodes
-// and the one passed via unit-wide variable @g_dynGraph_dgdPtr.
-static const ZL_FunctionGraphDesc* g_dynGraph_dgdPtr = nullptr;
-static ZL_GraphID registerDynGraph(ZL_Compressor* cgraph) noexcept
-{
-    ZL_Report const setr = ZL_Compressor_setParameter(
-            cgraph, ZL_CParam_formatVersion, g_testVersion);
-    if (ZL_isError(setr))
-        abort();
-
-    return ZL_Compressor_registerFunctionGraph(cgraph, g_dynGraph_dgdPtr);
-}
-
-/* ------   compress, using provided graph function   -------- */
+/* ------   compress, using provided compressor generator   -------- */
 
 static size_t compress(
         void* dst,
@@ -601,6 +585,27 @@ TEST(Segmenter, graphThenSegmenter)
     g_segmenterDescPtr = &serialSegmenter;
     (void)roundTripGen(
             ZL_Type_serial, registerGraphAndSegmenter, "graph then segmenter");
+}
+
+/* ======   Default segmenter   ======= */
+ZL_GraphID default_numeric_segmenter(ZL_Compressor* compressor) noexcept
+{
+    ZL_Report const setr = ZL_Compressor_setParameter(
+            compressor, ZL_CParam_formatVersion, g_testVersion);
+    if (ZL_isError(setr))
+        abort();
+
+    return ZL_GRAPH_SEGMENT_NUMERIC;
+}
+
+TEST(Segmenter, default_numeric_segmenter)
+{
+    if (g_testVersion < ZL_CHUNK_VERSION_MIN)
+        return;
+    (void)roundTripGen(
+            ZL_Type_numeric,
+            default_numeric_segmenter,
+            "use the default numeric segmenter");
 }
 
 /* *********************************************** */


### PR DESCRIPTION
This PR creates a standard segmenter for numeric data (only).
Importantly, it makes it possible to have Segmenters as part of the standard set.

The provided Numeric Segmenter is pretty bare bone, notably:
- Chunk size is static: a future update will make it programmable, both with a global and a local parameter
- The follow-up graph is also static: a future update will make it programmable 
