### PR TITLE
disable yarn tests while vitest is not installed

### DIFF
--- a/tools/visualization_app/BUCK
+++ b/tools/visualization_app/BUCK
@@ -1,7 +1,7 @@
 # Copyright (c) Meta Platforms, Inc. and affiliates.
 
 load("@bazel_skylib//lib:shell.bzl", "shell")
-load("@fbcode_macros//build_defs:native_rules.bzl", "buck_filegroup", "buck_genrule", "buck_sh_binary", "buck_sh_test")
+load("@fbcode_macros//build_defs:native_rules.bzl", "buck_filegroup", "buck_genrule", "buck_sh_binary")
 
 oncall("data_compression")
 
@@ -44,7 +44,9 @@ buck_genrule(
     ),
 )
 
-buck_sh_test(
-    name = "visualization-app-tests",
-    test = ":yarn-test",
-)
+# disabled for now. vitest 3.2.4 has a security vulnerability that prevents us from using it.
+# vitest 4.0.0 is in beta. This test will be re-enabled when it becomes generally available.
+# buck_sh_test(
+#     name = "visualization-app-tests",
+#     test = ":yarn-test",
+# )


### PR DESCRIPTION
Summary: vitest 3.2.4 has a security vulnerability that prevents us from using it. vitest 4.0.0 is still in beta and not fit for general use. This diff disables testing (which uses vitest) while 4.0.0 is unreleased.

Differential Revision: D85059940


