### PR TITLE
SDDL Engine: Fix Assertion of Output Stream Count

### DIFF
--- a/src/openzl/codecs/dispatchN_byTag/encode_dispatchN_byTag_binding.c
+++ b/src/openzl/codecs/dispatchN_byTag/encode_dispatchN_byTag_binding.c
@@ -115,7 +115,8 @@ EI_dispatchN_byTag(ZL_Encoder* eictx, const ZL_Input* ins[], size_t nbIns)
     ZL_ASSERT_EQ(ZL_Input_type(in), ZL_Type_serial);
     ZL_ASSERT_NN(eictx);
 
-    ZL_TRY_LET_T(ZL_DispatchInstructions, si, getSplitInstructions(eictx, in));
+    ZL_TRY_LET_CONST_T(
+            ZL_DispatchInstructions, si, getSplitInstructions(eictx, in));
 
     ZL_DLOG(BLOCK,
             "EI_dispatchN_byTag: splitting %zu segments into %zu streams",

--- a/src/openzl/compress/graphs/simple_data_description_language.c
+++ b/src/openzl/compress/graphs/simple_data_description_language.c
@@ -2897,7 +2897,10 @@ ZL_SDDL_State_exec(
 
     instructions.dispatch_instructions.nbSegments =
             VECTOR_SIZE(state->segment_sizes);
-    instructions.dispatch_instructions.nbTags = state->num_tags;
+    ZL_ERR_IF_GT(
+            VECTOR_SIZE(state->dests), UINT_MAX, nodeExecution_invalidOutputs);
+    instructions.dispatch_instructions.nbTags =
+            (uint32_t)VECTOR_SIZE(state->dests);
 
     instructions.dispatch_instructions.segmentSizes =
             VECTOR_DATA(state->segment_sizes);

--- a/tests/codecs/test_sddl.cpp
+++ b/tests/codecs/test_sddl.cpp
@@ -755,6 +755,7 @@ TEST_F(SimpleDataDescriptionLanguageTest, unusedFields)
         C = UInt32LE
         D = UInt64LE
         E = UInt32LE
+        F = UInt64LE
 
         : A[5]
         : C[7]
@@ -767,6 +768,8 @@ TEST_F(SimpleDataDescriptionLanguageTest, unusedFields)
     const auto instrs = exec(prog, input, Expected::SUCCEED);
     ASSERT_TRUE(instrs);
     EXPECT_EQ(instrs->numOutputs, 5);
+
+    roundtrip(prog, input);
 }
 
 TEST_F(SimpleDataDescriptionLanguageTest, multipleDeclsInFunction)


### PR DESCRIPTION
Summary:
Use the dynamic count of destinations actually created (which is what is used
in the call to dispatch) rather than the static count of all dests in the
SDDL program.

Note that this still doesn't fix the abuse of the dispatch API. (Its docs
require that all tags in the interval `[0, nbTags)` are used, which is not
true for our use of it.) But it seems like it works under these conditions.

This should address the bug identified in [#136](https://github.com/facebook/openzl/issues/136)

Differential Revision: D85186115


