### PR TITLE
Add logical operators

### DIFF
--- a/src/openzl/compress/graphs/simple_data_description_language.c
+++ b/src/openzl/compress/graphs/simple_data_description_language.c
@@ -200,6 +200,12 @@ typedef enum {
     ZL_SDDL_OpCode_mul,
     ZL_SDDL_OpCode_div,
     ZL_SDDL_OpCode_mod,
+
+    // Logical operations
+    ZL_SDDL_OpCode_log_and,
+    ZL_SDDL_OpCode_log_or,
+    ZL_SDDL_OpCode_log_not,
+
 } ZL_SDDL_OpCode;
 
 #define ZL_SDDL_OP_ARG_COUNT 2
@@ -337,6 +343,12 @@ static const char* ZL_SDDL_OpCode_toString(ZL_SDDL_OpCode opcode)
             return "div";
         case ZL_SDDL_OpCode_mod:
             return "mod";
+        case ZL_SDDL_OpCode_log_and:
+            return "log_and";
+        case ZL_SDDL_OpCode_log_or:
+            return "log_or";
+        case ZL_SDDL_OpCode_log_not:
+            return "log_not";
         default:
             return "unknown";
     }
@@ -496,6 +508,11 @@ static size_t ZL_SDDL_OpCode_numArgs(const ZL_SDDL_OpCode opcode)
         case ZL_SDDL_OpCode_mul:
         case ZL_SDDL_OpCode_div:
         case ZL_SDDL_OpCode_mod:
+            return 2;
+        case ZL_SDDL_OpCode_log_not:
+            return 1;
+        case ZL_SDDL_OpCode_log_and:
+        case ZL_SDDL_OpCode_log_or:
             return 2;
         default:
             return 0;
@@ -1046,6 +1063,15 @@ static ZL_Report ZL_SDDL_Program_decodeExprType(
     } else if (StringView_eqCStr(&type_sv, "mod")) {
         expr->type  = ZL_SDDL_ExprType_op;
         expr->op.op = ZL_SDDL_OpCode_mod;
+    } else if (StringView_eqCStr(&type_sv, "log_and")) {
+        expr->type  = ZL_SDDL_ExprType_op;
+        expr->op.op = ZL_SDDL_OpCode_log_and;
+    } else if (StringView_eqCStr(&type_sv, "log_or")) {
+        expr->type  = ZL_SDDL_ExprType_op;
+        expr->op.op = ZL_SDDL_OpCode_log_or;
+    } else if (StringView_eqCStr(&type_sv, "log_not")) {
+        expr->type  = ZL_SDDL_ExprType_op;
+        expr->op.op = ZL_SDDL_OpCode_log_not;
     }
     // Num
     else if (StringView_eqCStr(&type_sv, "int")) {
@@ -2610,7 +2636,23 @@ static ZL_RESULT_OF(ZL_SDDL_Expr) ZL_SDDL_State_execExpr_op_inner(
             result = ZL_SDDL_Expr_makeNum(args[0].num.val % args[1].num.val);
             break;
         }
-
+        case ZL_SDDL_OpCode_log_and: {
+            ZL_ERR_IF_NE(args[0].type, ZL_SDDL_ExprType_num, corruption);
+            ZL_ERR_IF_NE(args[1].type, ZL_SDDL_ExprType_num, corruption);
+            result = ZL_SDDL_Expr_makeNum(args[0].num.val && args[1].num.val);
+            break;
+        }
+        case ZL_SDDL_OpCode_log_or: {
+            ZL_ERR_IF_NE(args[0].type, ZL_SDDL_ExprType_num, corruption);
+            ZL_ERR_IF_NE(args[1].type, ZL_SDDL_ExprType_num, corruption);
+            result = ZL_SDDL_Expr_makeNum(args[0].num.val || args[1].num.val);
+            break;
+        }
+        case ZL_SDDL_OpCode_log_not: {
+            ZL_ERR_IF_NE(args[0].type, ZL_SDDL_ExprType_num, corruption);
+            result = ZL_SDDL_Expr_makeNum(!args[0].num.val);
+            break;
+        }
         default:
             ZL_ERR(corruption, "Unknown opcode %d", op->op);
     }

--- a/src/openzl/compress/graphs/simple_data_description_language.h
+++ b/src/openzl/compress/graphs/simple_data_description_language.h
@@ -74,6 +74,9 @@ ZL_BEGIN_C_DECLS
  * | mul     | Op        |
  * | div     | Op        |
  * | mod     | Op        |
+ * | log_and | Op        |
+ * | log_or  | Op        |
+ * | log_not | Op        |
  * | int     | Num       |
  * | poison  | Field     |
  * | atom    | Field     |
@@ -117,6 +120,9 @@ ZL_BEGIN_C_DECLS
  * | mul     | 2    | I    | IV  | IV    | eval(lhs) * eval(rhs)
  * | div     | 2    | I    | IV  | IV    | eval(lhs) / eval(rhs)
  * | mod     | 2    | I    | IV  | IV    | eval(lhs) % eval(rhs)
+ * | log_and | 2    | I    | IV  | IV    | eval(lhs) && eval(rhs)
+ * | log_or  | 2    | I    | IV  | IV    | eval(lhs) || eval(rhs)
+ * | log_not | 1    | I    | IV  |       | !eval(arg)
  *
  * ### Num
  *

--- a/tests/codecs/test_sddl.cpp
+++ b/tests/codecs/test_sddl.cpp
@@ -539,6 +539,46 @@ TEST_F(SimpleDataDescriptionLanguageTest, arithmetic)
     roundtrip(prog, input);
 }
 
+TEST_F(SimpleDataDescriptionLanguageTest, logical_ops)
+{
+    const auto prog = R"(
+        expect 1 && 1
+        expect (1 && 1) == 1
+        expect !(1 && 0)
+        expect (1 && 0) == 0
+        expect !(0 && 1)
+        expect (0 && 1) == 0
+        expect !(0 && 0)
+        expect (0 && 0) == 0
+
+        expect 1 || 1
+        expect (1 || 1) == 1
+        expect 1 || 0
+        expect (1 || 0) == 1
+        expect 0 || 1
+        expect (0 || 1) == 1
+        expect !(0 || 0)
+        expect (0 || 0) == 0
+
+        expect !0
+        expect !0 == 1
+        expect !1 == 0
+        expect !!1
+
+        expect !2 == 0
+        expect 4 && 5
+        expect (4 && 5) == 1
+        expect 4 || 5
+        expect (4 || 5) == 1
+        expect !(4 && 0)
+
+        : Byte[]
+    )";
+
+    const auto input = iota(10);
+    roundtrip(prog, input);
+}
+
 TEST_F(SimpleDataDescriptionLanguageTest, mildlyVexingParses)
 {
     const auto prog  = R"(

--- a/tools/sddl/compiler/Grammar.cpp
+++ b/tools/sddl/compiler/Grammar.cpp
@@ -53,6 +53,7 @@ const std::map<Precedence, Associativity> associativities{
 
     { Precedence::MUL_DIV_MOD, LTR }, { Precedence::ADD_SUB, LTR },
     { Precedence::RELATION, LTR },    { Precedence::EQUALITY, LTR },
+    { Precedence::LOG_AND, LTR },     { Precedence::LOG_OR, LTR },
 
     { Precedence::ASSIGNMENT, RTL },
 };
@@ -84,6 +85,10 @@ const std::map<Precedence, std::string> precedences_to_strs{
       "RELATION(" + enum_to_str_of_int(Precedence::RELATION) + ")" },
     { Precedence::EQUALITY,
       "EQUALITY(" + enum_to_str_of_int(Precedence::EQUALITY) + ")" },
+    { Precedence::LOG_AND,
+      "LOG_AND(" + enum_to_str_of_int(Precedence::LOG_AND) + ")" },
+    { Precedence::LOG_OR,
+      "LOG_OR(" + enum_to_str_of_int(Precedence::LOG_OR) + ")" },
     { Precedence::ASSIGNMENT,
       "ASSIGNMENT(" + enum_to_str_of_int(Precedence::ASSIGNMENT) + ")" },
 };
@@ -888,6 +893,10 @@ const std::vector<std::unique_ptr<const GrammarRule>> grammar_rules{ []() {
     add_rule<BinaryOpRule>(r, Symbol::MUL, Precedence::MUL_DIV_MOD);
     add_rule<BinaryOpRule>(r, Symbol::DIV, Precedence::MUL_DIV_MOD);
     add_rule<BinaryOpRule>(r, Symbol::MOD, Precedence::MUL_DIV_MOD);
+
+    add_rule<BinaryOpRule>(r, Symbol::LOG_AND, Precedence::LOG_AND);
+    add_rule<BinaryOpRule>(r, Symbol::LOG_OR, Precedence::LOG_OR);
+    add_rule<UnaryOpRule>(r, Symbol::LOG_NOT);
 
     // TODO: check that all ops have rules
 

--- a/tools/sddl/compiler/Grammar.h
+++ b/tools/sddl/compiler/Grammar.h
@@ -29,6 +29,9 @@ enum class Precedence : size_t {
     RELATION,
     EQUALITY,
 
+    LOG_AND,
+    LOG_OR,
+
     ASSIGNMENT,
 };
 

--- a/tools/sddl/compiler/Syntax.cpp
+++ b/tools/sddl/compiler/Syntax.cpp
@@ -87,6 +87,10 @@ static const std::map<Symbol, SymbolType> sym_types{
     { Symbol::DIV, SymbolType::OPERATOR },
     { Symbol::MOD, SymbolType::OPERATOR },
 
+    { Symbol::LOG_AND, SymbolType::OPERATOR },
+    { Symbol::LOG_OR, SymbolType::OPERATOR },
+    { Symbol::LOG_NOT, SymbolType::OPERATOR },
+
     { Symbol::BYTE, SymbolType::KEYWORD },
     { Symbol::U8, SymbolType::KEYWORD },
     { Symbol::I8, SymbolType::KEYWORD },
@@ -175,6 +179,10 @@ static const std::map<Symbol, poly::string_view> syms_to_debug_strs{
     { Symbol::DIV, "DIV" },
     { Symbol::MOD, "MOD" },
 
+    { Symbol::LOG_AND, "LOG_AND" },
+    { Symbol::LOG_OR, "LOG_OR" },
+    { Symbol::LOG_NOT, "LOG_NOT" },
+
     { Symbol::BYTE, "BYTE" },
     { Symbol::U8, "U8" },
     { Symbol::I8, "I8" },
@@ -247,6 +255,9 @@ const std::vector<std::pair<poly::string_view, Symbol>> strs_to_syms{
     { "*", Symbol::MUL },
     { "/", Symbol::DIV },
     { "%", Symbol::MOD },
+    { "&&", Symbol::LOG_AND },
+    { "||", Symbol::LOG_OR },
+    { "!", Symbol::LOG_NOT },
     { ":", Symbol::ASSUME },
     { ".", Symbol::MEMBER },
     { "die", Symbol::DIE },
@@ -325,6 +336,9 @@ static const std::map<Symbol, poly::string_view> syms_to_ser_strs{
     { Symbol::ADD, "add" },         { Symbol::SUB, "sub" },
     { Symbol::MUL, "mul" },         { Symbol::DIV, "div" },
     { Symbol::MOD, "mod" },
+
+    { Symbol::LOG_AND, "log_and" }, { Symbol::LOG_OR, "log_or" },
+    { Symbol::LOG_NOT, "log_not" },
 
     { Symbol::DIE, "die" },         { Symbol::EXPECT, "expect" },
     { Symbol::LOG, "log" },

--- a/tools/sddl/compiler/Syntax.h
+++ b/tools/sddl/compiler/Syntax.h
@@ -53,6 +53,10 @@ enum class Symbol {
     DIV,
     MOD,
 
+    LOG_AND,
+    LOG_OR,
+    LOG_NOT,
+
     // Keywords
 
     // Integer Numeric Types


### PR DESCRIPTION
Summary: This diff adds the logical operators `&&`, `||`, and `!` to SDDL.

Differential Revision: D85271536
