### PR TITLE
Add bitwise operators

### DIFF
--- a/src/openzl/compress/graphs/simple_data_description_language.c
+++ b/src/openzl/compress/graphs/simple_data_description_language.c
@@ -201,6 +201,12 @@ typedef enum {
     ZL_SDDL_OpCode_div,
     ZL_SDDL_OpCode_mod,
 
+    // Bitwise operations
+    ZL_SDDL_OpCode_bit_and,
+    ZL_SDDL_OpCode_bit_or,
+    ZL_SDDL_OpCode_bit_xor,
+    ZL_SDDL_OpCode_bit_not,
+
     // Logical operations
     ZL_SDDL_OpCode_log_and,
     ZL_SDDL_OpCode_log_or,
@@ -343,6 +349,14 @@ static const char* ZL_SDDL_OpCode_toString(ZL_SDDL_OpCode opcode)
             return "div";
         case ZL_SDDL_OpCode_mod:
             return "mod";
+        case ZL_SDDL_OpCode_bit_and:
+            return "bit_and";
+        case ZL_SDDL_OpCode_bit_or:
+            return "bit_or";
+        case ZL_SDDL_OpCode_bit_xor:
+            return "bit_xor";
+        case ZL_SDDL_OpCode_bit_not:
+            return "bit_not";
         case ZL_SDDL_OpCode_log_and:
             return "log_and";
         case ZL_SDDL_OpCode_log_or:
@@ -508,6 +522,12 @@ static size_t ZL_SDDL_OpCode_numArgs(const ZL_SDDL_OpCode opcode)
         case ZL_SDDL_OpCode_mul:
         case ZL_SDDL_OpCode_div:
         case ZL_SDDL_OpCode_mod:
+            return 2;
+        case ZL_SDDL_OpCode_bit_not:
+            return 1;
+        case ZL_SDDL_OpCode_bit_and:
+        case ZL_SDDL_OpCode_bit_or:
+        case ZL_SDDL_OpCode_bit_xor:
             return 2;
         case ZL_SDDL_OpCode_log_not:
             return 1;
@@ -1063,6 +1083,18 @@ static ZL_Report ZL_SDDL_Program_decodeExprType(
     } else if (StringView_eqCStr(&type_sv, "mod")) {
         expr->type  = ZL_SDDL_ExprType_op;
         expr->op.op = ZL_SDDL_OpCode_mod;
+    } else if (StringView_eqCStr(&type_sv, "bit_and")) {
+        expr->type  = ZL_SDDL_ExprType_op;
+        expr->op.op = ZL_SDDL_OpCode_bit_and;
+    } else if (StringView_eqCStr(&type_sv, "bit_or")) {
+        expr->type  = ZL_SDDL_ExprType_op;
+        expr->op.op = ZL_SDDL_OpCode_bit_or;
+    } else if (StringView_eqCStr(&type_sv, "bit_xor")) {
+        expr->type  = ZL_SDDL_ExprType_op;
+        expr->op.op = ZL_SDDL_OpCode_bit_xor;
+    } else if (StringView_eqCStr(&type_sv, "bit_not")) {
+        expr->type  = ZL_SDDL_ExprType_op;
+        expr->op.op = ZL_SDDL_OpCode_bit_not;
     } else if (StringView_eqCStr(&type_sv, "log_and")) {
         expr->type  = ZL_SDDL_ExprType_op;
         expr->op.op = ZL_SDDL_OpCode_log_and;
@@ -2634,6 +2666,29 @@ static ZL_RESULT_OF(ZL_SDDL_Expr) ZL_SDDL_State_execExpr_op_inner(
             ZL_ERR_IF_EQ(
                     args[1].num.val, 0, corruption, "Modulus can't be zero.");
             result = ZL_SDDL_Expr_makeNum(args[0].num.val % args[1].num.val);
+            break;
+        }
+        case ZL_SDDL_OpCode_bit_and: {
+            ZL_ERR_IF_NE(args[0].type, ZL_SDDL_ExprType_num, corruption);
+            ZL_ERR_IF_NE(args[1].type, ZL_SDDL_ExprType_num, corruption);
+            result = ZL_SDDL_Expr_makeNum(args[0].num.val & args[1].num.val);
+            break;
+        }
+        case ZL_SDDL_OpCode_bit_or: {
+            ZL_ERR_IF_NE(args[0].type, ZL_SDDL_ExprType_num, corruption);
+            ZL_ERR_IF_NE(args[1].type, ZL_SDDL_ExprType_num, corruption);
+            result = ZL_SDDL_Expr_makeNum(args[0].num.val | args[1].num.val);
+            break;
+        }
+        case ZL_SDDL_OpCode_bit_xor: {
+            ZL_ERR_IF_NE(args[0].type, ZL_SDDL_ExprType_num, corruption);
+            ZL_ERR_IF_NE(args[1].type, ZL_SDDL_ExprType_num, corruption);
+            result = ZL_SDDL_Expr_makeNum(args[0].num.val ^ args[1].num.val);
+            break;
+        }
+        case ZL_SDDL_OpCode_bit_not: {
+            ZL_ERR_IF_NE(args[0].type, ZL_SDDL_ExprType_num, corruption);
+            result = ZL_SDDL_Expr_makeNum(~args[0].num.val);
             break;
         }
         case ZL_SDDL_OpCode_log_and: {

--- a/src/openzl/compress/graphs/simple_data_description_language.h
+++ b/src/openzl/compress/graphs/simple_data_description_language.h
@@ -74,6 +74,10 @@ ZL_BEGIN_C_DECLS
  * | mul     | Op        |
  * | div     | Op        |
  * | mod     | Op        |
+ * | bit_and | Op        |
+ * | bit_or  | Op        |
+ * | bit_xor | Op        |
+ * | bit_not | Op        |
  * | log_and | Op        |
  * | log_or  | Op        |
  * | log_not | Op        |
@@ -120,6 +124,10 @@ ZL_BEGIN_C_DECLS
  * | mul     | 2    | I    | IV  | IV    | eval(lhs) * eval(rhs)
  * | div     | 2    | I    | IV  | IV    | eval(lhs) / eval(rhs)
  * | mod     | 2    | I    | IV  | IV    | eval(lhs) % eval(rhs)
+ * | bit_and | 2    | I    | IV  | IV    | eval(lhs) & eval(rhs)
+ * | bit_or  | 2    | I    | IV  | IV    | eval(lhs) | eval(rhs)
+ * | bit_xor | 2    | I    | IV  | IV    | eval(lhs) ^ eval(rhs)
+ * | bit_not | 1    | I    | IV  |       | ~eval(arg)
  * | log_and | 2    | I    | IV  | IV    | eval(lhs) && eval(rhs)
  * | log_or  | 2    | I    | IV  | IV    | eval(lhs) || eval(rhs)
  * | log_not | 1    | I    | IV  |       | !eval(arg)

--- a/tests/codecs/test_sddl.cpp
+++ b/tests/codecs/test_sddl.cpp
@@ -539,6 +539,35 @@ TEST_F(SimpleDataDescriptionLanguageTest, arithmetic)
     roundtrip(prog, input);
 }
 
+TEST_F(SimpleDataDescriptionLanguageTest, bitwise_ops)
+{
+    const auto prog  = R"(
+        expect (1 & 2) == 0
+        expect (1 & 2) == (2 & 1)
+        expect (1 | 2) == 3
+        expect (1 | 2) == (2 | 1)
+        expect (1 ^ 2) == 3
+        expect (1 ^ 2) == (2 ^ 1)
+        expect ~1 == -2
+
+        expect (1 & 2) == 0 == 1
+        expect (4 & 8) == 0
+        expect (4 | 8) == 12
+        expect (4 ^ 8) == 12
+        expect ~4 == -5
+
+        expect (0xFF & 0x00) == 0x00
+        expect (0xFF | 0x00) == 0xFF
+        expect (0xFF ^ 0x00) == 0xFF
+        expect ~0x00 == -1
+        expect ~0xFF == -256
+
+        : Byte[]
+    )";
+    const auto input = iota(10);
+    roundtrip(prog, input);
+}
+
 TEST_F(SimpleDataDescriptionLanguageTest, logical_ops)
 {
     const auto prog = R"(

--- a/tools/sddl/compiler/Grammar.cpp
+++ b/tools/sddl/compiler/Grammar.cpp
@@ -53,6 +53,10 @@ const std::map<Precedence, Associativity> associativities{
 
     { Precedence::MUL_DIV_MOD, LTR }, { Precedence::ADD_SUB, LTR },
     { Precedence::RELATION, LTR },    { Precedence::EQUALITY, LTR },
+
+    { Precedence::BIT_AND, LTR },     { Precedence::BIT_XOR, LTR },
+    { Precedence::BIT_OR, LTR },
+
     { Precedence::LOG_AND, LTR },     { Precedence::LOG_OR, LTR },
 
     { Precedence::ASSIGNMENT, RTL },
@@ -85,6 +89,12 @@ const std::map<Precedence, std::string> precedences_to_strs{
       "RELATION(" + enum_to_str_of_int(Precedence::RELATION) + ")" },
     { Precedence::EQUALITY,
       "EQUALITY(" + enum_to_str_of_int(Precedence::EQUALITY) + ")" },
+    { Precedence::BIT_AND,
+      "BIT_AND(" + enum_to_str_of_int(Precedence::BIT_AND) + ")" },
+    { Precedence::BIT_XOR,
+      "BIT_XOR(" + enum_to_str_of_int(Precedence::BIT_XOR) + ")" },
+    { Precedence::BIT_OR,
+      "BIT_OR(" + enum_to_str_of_int(Precedence::BIT_OR) + ")" },
     { Precedence::LOG_AND,
       "LOG_AND(" + enum_to_str_of_int(Precedence::LOG_AND) + ")" },
     { Precedence::LOG_OR,
@@ -920,6 +930,11 @@ const std::vector<std::unique_ptr<const GrammarRule>> grammar_rules{ []() {
     add_rule<BinaryOpRule>(r, Symbol::MUL, Precedence::MUL_DIV_MOD);
     add_rule<BinaryOpRule>(r, Symbol::DIV, Precedence::MUL_DIV_MOD);
     add_rule<BinaryOpRule>(r, Symbol::MOD, Precedence::MUL_DIV_MOD);
+
+    add_rule<BinaryOpRule>(r, Symbol::BIT_AND, Precedence::BIT_AND);
+    add_rule<BinaryOpRule>(r, Symbol::BIT_OR, Precedence::BIT_OR);
+    add_rule<BinaryOpRule>(r, Symbol::BIT_XOR, Precedence::BIT_XOR);
+    add_rule<UnaryOpRule>(r, Symbol::BIT_NOT);
 
     add_rule<BinaryOpRule>(r, Symbol::LOG_AND, Precedence::LOG_AND);
     add_rule<BinaryOpRule>(r, Symbol::LOG_OR, Precedence::LOG_OR);

--- a/tools/sddl/compiler/Grammar.h
+++ b/tools/sddl/compiler/Grammar.h
@@ -29,6 +29,10 @@ enum class Precedence : size_t {
     RELATION,
     EQUALITY,
 
+    BIT_AND,
+    BIT_XOR,
+    BIT_OR,
+
     LOG_AND,
     LOG_OR,
 

--- a/tools/sddl/compiler/Syntax.cpp
+++ b/tools/sddl/compiler/Syntax.cpp
@@ -87,6 +87,11 @@ static const std::map<Symbol, SymbolType> sym_types{
     { Symbol::DIV, SymbolType::OPERATOR },
     { Symbol::MOD, SymbolType::OPERATOR },
 
+    { Symbol::BIT_AND, SymbolType::OPERATOR },
+    { Symbol::BIT_OR, SymbolType::OPERATOR },
+    { Symbol::BIT_XOR, SymbolType::OPERATOR },
+    { Symbol::BIT_NOT, SymbolType::OPERATOR },
+
     { Symbol::LOG_AND, SymbolType::OPERATOR },
     { Symbol::LOG_OR, SymbolType::OPERATOR },
     { Symbol::LOG_NOT, SymbolType::OPERATOR },
@@ -179,6 +184,11 @@ static const std::map<Symbol, poly::string_view> syms_to_debug_strs{
     { Symbol::DIV, "DIV" },
     { Symbol::MOD, "MOD" },
 
+    { Symbol::BIT_AND, "BIT_AND" },
+    { Symbol::BIT_OR, "BIT_OR" },
+    { Symbol::BIT_XOR, "BIT_XOR" },
+    { Symbol::BIT_NOT, "BIT_NOT" },
+
     { Symbol::LOG_AND, "LOG_AND" },
     { Symbol::LOG_OR, "LOG_OR" },
     { Symbol::LOG_NOT, "LOG_NOT" },
@@ -258,6 +268,10 @@ const std::vector<std::pair<poly::string_view, Symbol>> strs_to_syms{
     { "&&", Symbol::LOG_AND },
     { "||", Symbol::LOG_OR },
     { "!", Symbol::LOG_NOT },
+    { "&", Symbol::BIT_AND },
+    { "|", Symbol::BIT_OR },
+    { "^", Symbol::BIT_XOR },
+    { "~", Symbol::BIT_NOT },
     { ":", Symbol::ASSUME },
     { ".", Symbol::MEMBER },
     { "die", Symbol::DIE },
@@ -336,6 +350,9 @@ static const std::map<Symbol, poly::string_view> syms_to_ser_strs{
     { Symbol::ADD, "add" },         { Symbol::SUB, "sub" },
     { Symbol::MUL, "mul" },         { Symbol::DIV, "div" },
     { Symbol::MOD, "mod" },
+
+    { Symbol::BIT_AND, "bit_and" }, { Symbol::BIT_OR, "bit_or" },
+    { Symbol::BIT_XOR, "bit_xor" }, { Symbol::BIT_NOT, "bit_not" },
 
     { Symbol::LOG_AND, "log_and" }, { Symbol::LOG_OR, "log_or" },
     { Symbol::LOG_NOT, "log_not" },

--- a/tools/sddl/compiler/Syntax.h
+++ b/tools/sddl/compiler/Syntax.h
@@ -53,6 +53,11 @@ enum class Symbol {
     DIV,
     MOD,
 
+    BIT_AND,
+    BIT_OR,
+    BIT_XOR,
+    BIT_NOT,
+
     LOG_AND,
     LOG_OR,
     LOG_NOT,


### PR DESCRIPTION
Summary: This diff adds the bitwise operators `&`, `|`, `^` and `~` to SDDL.

Reviewed By: felixhandte

Differential Revision: D85344280
