### PR TITLE
Intentionally introduce non-formatted code

### DIFF
--- a/.github/workflows/dev-ci.yml
+++ b/.github/workflows/dev-ci.yml
@@ -217,18 +217,18 @@ jobs:
           CC: ${{ matrix.cc || 'cc' }}
         run: make test
 
-  # Code quality checks
-  test-quality:
-    name: Code Quality (clang-format)
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - name: Run clang-format style check
-        uses: jidicula/clang-format-action@1ca6f2218b4d8a56817f3654c4a7f47d34117251 # v4.8.0
-        with:
-          clang-format-version: '18'
-          check-path: '.'
-          exclude-regex: '.*/fbcode_builder/.*'
+  # # Code quality checks
+  # test-quality:
+  #   name: Code Quality (clang-format)
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #     - uses: actions/checkout@v4
+  #     - name: Run clang-format style check
+  #       uses: jidicula/clang-format-action@1ca6f2218b4d8a56817f3654c4a7f47d34117251 # v4.8.0
+  #       with:
+  #         clang-format-version: '18'
+  #         check-path: '.'
+  #         exclude-regex: '.*/fbcode_builder/.*'
 
   # Static analysis
   test-static-analysis:

--- a/src/openzl/common/speed.h
+++ b/src/openzl/common/speed.h
@@ -19,7 +19,7 @@ ZL_BEGIN_C_DECLS
  */
 
 // slowest -> fastest
-typedef enum {
+typedef enum  {
     ZL_DecodeSpeedBaseline_any     = 0, // No decoding speed constraints
     ZL_DecodeSpeedBaseline_zlib    = 1, // Aim for ZLIB speeds
     ZL_DecodeSpeedBaseline_zstd    = 2, // Aim for ZSTD speeds


### PR DESCRIPTION
Summary:
To see:
1. If I can override a formatting lint failure & commit
2. If the daily codemod job correctly formats the code

Differential Revision: D85675144


