### PR TITLE
Disable GitHub CI clang-format check

### DIFF
--- a/.github/workflows/dev-ci.yml
+++ b/.github/workflows/dev-ci.yml
@@ -217,18 +217,18 @@ jobs:
           CC: ${{ matrix.cc || 'cc' }}
         run: make test
 
-  # Code quality checks
-  test-quality:
-    name: Code Quality (clang-format)
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - name: Run clang-format style check
-        uses: jidicula/clang-format-action@1ca6f2218b4d8a56817f3654c4a7f47d34117251 # v4.8.0
-        with:
-          clang-format-version: '18'
-          check-path: '.'
-          exclude-regex: '.*/fbcode_builder/.*'
+  # # Code quality checks
+  # test-quality:
+  #   name: Code Quality (clang-format)
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #     - uses: actions/checkout@v4
+  #     - name: Run clang-format style check
+  #       uses: jidicula/clang-format-action@1ca6f2218b4d8a56817f3654c4a7f47d34117251 # v4.8.0
+  #       with:
+  #         clang-format-version: '18'
+  #         check-path: '.'
+  #         exclude-regex: '.*/fbcode_builder/.*'
 
   # Static analysis
   test-static-analysis:


### PR DESCRIPTION
Summary:
* We will rely on internal signal
* Allow bypassing the internal signal for external contributions, and rely on the daily codemod to format to fixup the diffs

Differential Revision: D85682513


