### PR TITLE
Reject transforms with 0 inputs or outputs

### DIFF
--- a/src/openzl/compress/cnodes.c
+++ b/src/openzl/compress/cnodes.c
@@ -170,8 +170,6 @@ static ZL_RESULT_OF(CNodeID) CTM_registerCNode(
                     CNodeID,
                     CTM_transferStreamTypes(
                             ctm, &trDesc->gd.inputTypes, trDesc->gd.nbInputs));
-            // A valid transform must have at least one output or outcome
-            ZL_ASSERT_GT(CNODE_getNbOutcomes(cnode), 0);
             ZL_RET_T_IF_ERR(
                     CNodeID,
                     CTM_transferStreamTypes(

--- a/src/openzl/compress/graphmgr.c
+++ b/src/openzl/compress/graphmgr.c
@@ -58,19 +58,20 @@ static ZL_Report GM_fillStandardGraphs(GraphsMgr* gm)
 
 GraphsMgr* GM_create(const Nodes_manager* nmgr)
 {
-    GraphsMgr* const gm = ZL_malloc(sizeof(*gm));
+    GraphsMgr* const gm = ZL_calloc(sizeof(*gm));
     if (!gm)
         return NULL;
     ZL_OpaquePtrRegistry_init(&gm->opaquePtrs);
     gm->nmgr      = nmgr;
     gm->allocator = ALLOC_HeapArena_create();
     if (gm->allocator == NULL) {
-        ZL_free(gm);
+        GM_free(gm);
         return NULL;
     }
     VECTOR_INIT(gm->gdv, ZL_ENCODER_GRAPH_LIMIT);
     gm->nameMap = GraphMap_create(ZL_ENCODER_GRAPH_LIMIT);
     if (ZL_isError(GM_fillStandardGraphs(gm))) {
+        GM_free(gm);
         return NULL;
     }
     gm->opCtx = nmgr->opCtx;

--- a/src/openzl/decompress/decompress2.c
+++ b/src/openzl/decompress/decompress2.c
@@ -704,6 +704,11 @@ static ZL_Report fillStoredStreams(
                 inputEndIdx,
                 firstOutputIdx,
                 "Graph inconsistency: Output stream depends on another output stream");
+        ZL_RET_R_IF_EQ(
+                corruption,
+                node->nbRegens,
+                0,
+                "Graph inconsistency: Transform has no regenerated streams");
 
         for (size_t n = 0; n < node->nbRegens; n++) {
             size_t const outputStreamIdx =
@@ -1051,7 +1056,6 @@ static ZL_Report processStream(
             streamID + (ZL_IDType)nbInStreams - 1,
             trName,
             nodeInfo->trpid.trid);
-    ZL_ASSERT_GT(dt->miGraphDesc.nbSOs + dt->miGraphDesc.nbVOs, 0);
     if (dctx->dfh.formatVersion < 9) {
         ZL_RET_R_IF_EQ(
                 formatVersion_unsupported,

--- a/src/openzl/decompress/dtransforms.c
+++ b/src/openzl/decompress/dtransforms.c
@@ -486,11 +486,12 @@ ZL_Report DT_miTransformWrapper(
 {
     size_t const nbO1s = transform->miGraphDesc.nbSOs;
     ZL_ASSERT(nbIns >= nbO1s);
+    ZL_Input const** inputs = ZL_codemodDatasAsInputs(ins);
     return transform->implDesc.dmi.transform_f(
             dictx,
-            ZL_codemodDatasAsInputs(ins),
+            inputs,
             nbO1s,
-            ZL_codemodDatasAsInputs(ins) + nbO1s,
+            nbO1s == 0 ? inputs : inputs + nbO1s,
             nbIns - nbO1s);
 }
 

--- a/tests/round_trip/test_custom_transform.cpp
+++ b/tests/round_trip/test_custom_transform.cpp
@@ -3,6 +3,7 @@
 #include <gtest/gtest.h>
 #include <initializer_list>
 
+#include "openzl/openzl.hpp"
 #include "openzl/zl_compressor.h"
 #include "openzl/zl_ctransform.h"
 #include "openzl/zl_data.h"
@@ -353,5 +354,74 @@ TEST_F(TestCustomTransform, TwoSimpleVOTransforms)
     roundTripTest(kLoremTestInput, graph2);
     roundTripTest(kAudioPCMS32LETestInput, graph2);
 }
+
+TEST_F(TestCustomTransform, ZeroOutputTransform)
+{
+    using namespace openzl;
+    class ZeroEncoder : public CustomEncoder {
+       public:
+        SimpleCodecDescription simpleCodecDescription() const override
+        {
+            return SimpleCodecDescription{
+                .id          = 0,
+                .inputType   = Type::Serial,
+                .outputTypes = {},
+            };
+        }
+
+        void encode(EncoderState& encoder) const override
+        {
+            const auto& input = encoder.inputs()[0];
+            if (input.contentSize() != 1 || *(const uint8_t*)input.ptr() != 0) {
+                throw std::runtime_error("Invalid input");
+            }
+        }
+
+        ~ZeroEncoder() override = default;
+    };
+
+    class ZeroDecoder : public CustomDecoder {
+       public:
+        SimpleCodecDescription simpleCodecDescription() const override
+        {
+            return SimpleCodecDescription{
+                .id          = 0,
+                .inputType   = Type::Serial,
+                .outputTypes = {},
+            };
+        }
+
+        void decode(DecoderState& decoder) const override
+        {
+            auto out   = decoder.createOutput(0, 1, 1);
+            uint8_t* p = (uint8_t*)out.ptr();
+            p[0]       = 0;
+            out.commit(1);
+        }
+
+        ~ZeroDecoder() override = default;
+    };
+
+    Compressor compressor;
+    auto node =
+            compressor.registerCustomEncoder(std::make_unique<ZeroEncoder>());
+    auto graph = compressor.buildStaticGraph(node, {});
+    compressor.selectStartingGraph(graph);
+    compressor.setParameter(CParam::FormatVersion, ZL_MAX_FORMAT_VERSION);
+    compressor.setParameter(CParam::MinStreamSize, -1);
+
+    CCtx cctx;
+    cctx.refCompressor(compressor);
+
+    auto compressed = cctx.compressSerial({ "", 1 });
+
+    DCtx dctx;
+    dctx.registerCustomDecoder(std::make_unique<ZeroDecoder>());
+    auto decompressed = dctx.decompressSerial(compressed);
+
+    ASSERT_EQ(decompressed.size(), 1);
+    ASSERT_EQ(decompressed[0], 0);
+}
+
 } // namespace
 } // namespace zstrong::tests


### PR DESCRIPTION
Summary:
OpenZL doesn't expect to handle transforms with 0 inputs / outputs today. This breaks logic later down the chain, which causes assertion failures. So validate that transforms have at least one input & output when building the decompression graph.

NOTE: This change impacts both dev & release

Differential Revision: D85700591


