### PR TITLE
Add segmenter opctx

### DIFF
--- a/include/openzl/detail/zl_error_context.h
+++ b/include/openzl/detail/zl_error_context.h
@@ -49,6 +49,8 @@ ZL_CONST_FN ZL_OperationContext* ZL_CompressorSerializer_getOperationContext(
         ZL_CompressorSerializer* ctx);
 ZL_CONST_FN ZL_OperationContext* ZL_CompressorDeserializer_getOperationContext(
         ZL_CompressorDeserializer* ctx);
+ZL_CONST_FN ZL_OperationContext* ZL_Segmenter_getOperationContext(
+        ZL_Segmenter* ctx);
 ZL_CONST_FN ZL_OperationContext* ZL_ErrorContext_getOperationContext(
         ZL_ErrorContext* ctx);
 ZL_CONST_FN ZL_OperationContext* ZL_NULL_getOperationContext(void* ctx);
@@ -102,6 +104,11 @@ ZL_INLINE ZL_CONST_FN ZL_OperationContext* ZL_getOperationContextImpl(
     return ZL_CompressorDeserializer_getOperationContext(ctx);
 }
 ZL_INLINE ZL_CONST_FN ZL_OperationContext* ZL_getOperationContextImpl(
+        ZL_Segmenter* ctx)
+{
+    return ZL_Segmenter_getOperationContext(ctx);
+}
+ZL_INLINE ZL_CONST_FN ZL_OperationContext* ZL_getOperationContextImpl(
         ZL_ErrorContext* ctx)
 {
     return ZL_ErrorContext_getOperationContext(ctx);
@@ -138,6 +145,7 @@ extern "C" {
                         (void*)(ctx)),                                                     \
                 ZL_CompressorDeserializer*: ZL_CompressorDeserializer_getOperationContext( \
                         (void*)(ctx)),                                                     \
+                ZL_Segmenter*: ZL_Segmenter_getOperationContext((void*)(ctx)),             \
                 ZL_ErrorContext*: ZL_ErrorContext_getOperationContext(                     \
                         (void*)(ctx)),                                                     \
                 ZL_OperationContext*: (ctx),                                               \

--- a/include/openzl/zl_errors.h
+++ b/include/openzl/zl_errors.h
@@ -300,6 +300,7 @@ ZL_Report ZL_reportError(
  * - ZL_Edge
  * - ZL_CompressorSerializer
  * - ZL_CompressorDeserializer
+ * - ZL_Segmenter
  *
  * It will return `NULL` if the provided @p context is `NULL`.
  */
@@ -320,6 +321,7 @@ ZL_Report ZL_reportError(
  * - ZL_Edge
  * - ZL_CompressorSerializer
  * - ZL_CompressorDeserializer
+ * - ZL_Segmenter
  *
  * It will return `NULL` if the provided @p context is `NULL`.
  */

--- a/include/openzl/zl_opaque_types.h
+++ b/include/openzl/zl_opaque_types.h
@@ -49,6 +49,7 @@ typedef struct ZL_Decoder_s ZL_Decoder;
 typedef struct ZL_Selector_s ZL_Selector;
 typedef struct ZL_Graph_s ZL_Graph;
 typedef struct ZL_Edge_s ZL_Edge;
+typedef struct ZL_Segmenter_s ZL_Segmenter;
 
 // Generic List construction macro (C99)
 #define ZL_LIST_SIZE(_type, ...) \

--- a/src/openzl/compress/segmenter.c
+++ b/src/openzl/compress/segmenter.c
@@ -320,3 +320,12 @@ ZL_Report ZL_Segmenter_processChunk(
     CCTX_cleanChunk(cctx);
     return r;
 }
+
+ZL_CONST_FN
+ZL_OperationContext* ZL_Segmenter_getOperationContext(ZL_Segmenter* sctx)
+{
+    if (sctx == NULL) {
+        return NULL;
+    }
+    return ZL_CCtx_getOperationContext(sctx->cctx);
+}


### PR DESCRIPTION
Summary: Add function to macro to get opctx for segmenter.

Reviewed By: terrelln

Differential Revision: D85364795


