### PR TITLE
fix error in quote parsing in CSV lexer

### DIFF
--- a/custom_parsers/csv/csv_lexer.c
+++ b/custom_parsers/csv/csv_lexer.c
@@ -54,13 +54,17 @@ static ZL_Report parseFirstRow(
             "CSV file not well formed. No newline character found anywhere in the file");
 }
 
-static size_t countNbNewlines(const char* content, const size_t length)
+static ZL_Report countNbNewlines(const char* content, const size_t length)
 {
     size_t nbNewlines = 0;
     for (uint32_t i = 0; i < length; i++) {
         nbNewlines += (content[i] == '\n');
     }
-    return nbNewlines;
+    ZL_RET_R_IF(
+            node_invalid_input,
+            nbNewlines == 0 && length > 0,
+            "No newline character found in a non-empty CSV body");
+    return ZL_returnValue(nbNewlines);
 }
 
 /**
@@ -274,7 +278,9 @@ ZL_Report ZL_CSV_lex(
             rowsByteSize = byteSize;
         }
     }
-    const size_t maxNbRows = countNbNewlines(rowsStart, rowsByteSize);
+    const ZL_Report maxNbRowsReport = countNbNewlines(rowsStart, rowsByteSize);
+    ZL_RET_R_IF_ERR(maxNbRowsReport);
+    const size_t maxNbRows = ZL_validResult(maxNbRowsReport);
 
     // Given 'n' columns, there are 'n' content strings and 'n' separator
     // strings per row. This is because we count the newline separator as well
@@ -335,7 +341,9 @@ ZL_Report ZL_CSV_lexNullAware(
             rowsByteSize = byteSize;
         }
     }
-    const size_t maxNbRows = countNbNewlines(rowsStart, rowsByteSize);
+    const ZL_Report maxNbRowsReport = countNbNewlines(rowsStart, rowsByteSize);
+    ZL_RET_R_IF_ERR(maxNbRowsReport);
+    const size_t maxNbRows = ZL_validResult(maxNbRowsReport);
 
     // Given 'n' columns, there are up to 'n' content strings and 'n' separator
     // strings per row. This is because we count the newline separator as well

--- a/custom_parsers/csv/csv_lexer.c
+++ b/custom_parsers/csv/csv_lexer.c
@@ -114,7 +114,7 @@ static ZL_Report createCsvDispatchIndices(
     return ZL_returnSuccess();
 }
 
-static ZL_Report createParsedCsv(
+ZL_Report createParsedCsv(
         uint32_t* stringLens,
         const char* content,
         const size_t length,
@@ -127,7 +127,7 @@ static ZL_Report createParsedCsv(
 
     for (uint32_t i = 0; i < length; ++i) {
         // skip past all quoted strings
-        if (content[i] == '"') {
+        while (content[i] == '"') {
             do {
                 ++i;
             } while (i < length && content[i] != '"');
@@ -203,7 +203,7 @@ ZL_Report createNullAwareLexAndDispatch(
 
     for (uint32_t i = 0; i < length;) {
         // skip past all quoted strings
-        if (content[i] == '"') {
+        while (content[i] == '"') {
             do {
                 ++i;
             } while (i < length && content[i] != '"');

--- a/custom_parsers/csv/csv_lexer.h
+++ b/custom_parsers/csv/csv_lexer.h
@@ -39,6 +39,13 @@ ZL_Report ZL_CSV_lexNullAware(
         char sep,
         ZL_CSV_lexResult* retLexResult);
 
+ZL_Report createParsedCsv(
+        uint32_t* stringLens,
+        const char* content,
+        const size_t length,
+        char sep,
+        size_t nbColumns);
+
 ZL_Report createNullAwareLexAndDispatch(
         uint32_t* stringLens,
         uint16_t* dispatchIndices,

--- a/custom_parsers/csv/tests/lex_test.cpp
+++ b/custom_parsers/csv/tests/lex_test.cpp
@@ -90,3 +90,37 @@ TEST(LexTest, singleLine)
         EXPECT_EQ(expectedDispatchIndicess[i], dispatchIndices[i]);
     }
 }
+
+TEST(LexTest, singlePairOfQuotes)
+{
+    std::string input                        = "aaa,\"\",\"\"\n";
+    std::vector<uint32_t> expectedStringLens = { 3, 1, 2, 1, 2, 1 };
+    std::vector<uint32_t> stringLens(100, 0);
+
+    auto e = createParsedCsv(
+            stringLens.data(), input.data(), input.size(), ',', 3);
+    EXPECT_FALSE(ZL_isError(e));
+    size_t nbStrs = ZL_validResult(e);
+    EXPECT_EQ(nbStrs, expectedStringLens.size());
+    for (size_t i = 0; i < nbStrs; ++i) {
+        EXPECT_EQ(expectedStringLens[i], stringLens[i]);
+    }
+}
+
+TEST(LexTest, multiplePairsOfQuotes)
+{
+    std::string input =
+            "aaa,\"\",\"\",\"\",\"\",\"\",\"\"\"\",\"\",\"\"\"\"\",\"\n";
+    std::vector<uint32_t> expectedStringLens = { 3, 1, 2, 1, 2, 1, 2, 1, 2,
+                                                 1, 2, 1, 4, 1, 2, 1, 7, 1 };
+    std::vector<uint32_t> stringLens(100, 0);
+
+    auto e = createParsedCsv(
+            stringLens.data(), input.data(), input.size(), ',', 9);
+    EXPECT_FALSE(ZL_isError(e));
+    size_t nbStrs = ZL_validResult(e);
+    EXPECT_EQ(nbStrs, expectedStringLens.size());
+    for (size_t i = 0; i < nbStrs; ++i) {
+        EXPECT_EQ(expectedStringLens[i], stringLens[i]);
+    }
+}


### PR DESCRIPTION
Summary:
There was a bug where multiply-quoted column strings weren't parsed correctly. Things like
`,,"""",,`.

Note: if you're trying to follow along from the stack trace, it won't be clear at all. The problem is not in realloc() at all, that's a red herring. The real symptom is just that the test takes a long time on the input. Among other potential reasons, the quote parsing issue meant that this specific input was not throwing an exception when it should be. Does this mean there's no problem with parsing at all? Maybe not. But we'll get there when we get there...

Differential Revision: D85724735


