### PR TITLE
Add comment field to frame header

### DIFF
--- a/include/openzl/zl_common_types.h
+++ b/include/openzl/zl_common_types.h
@@ -57,6 +57,14 @@ typedef struct {
     size_t nbNodeIDs;
 } ZL_NodeIDList;
 
+/**
+ * @brief Data layout for comment contained in the frame header.
+ */
+typedef struct {
+    const void* data;
+    size_t size;
+} ZL_Comment;
+
 #if defined(__cplusplus)
 } // extern "C"
 #endif

--- a/include/openzl/zl_compress.h
+++ b/include/openzl/zl_compress.h
@@ -369,6 +369,22 @@ ZL_TypedRef* ZL_TypedRef_createString(
         size_t nbStrings);
 
 /**
+ * Adds header comment to the compressed frame for the following compression.
+ * The message will be overridden if added a second time. The message is erased
+ * from the cctx at the end of each compression.
+ *
+ * @note A comment of size 0 clears the comment field.
+ *
+ * @param comment The comment to add. The comment is copied and stored in the
+ * cctx.
+ * @param commentSize The size of the comment or 0 to clear the comment.
+ */
+ZL_Report ZL_CCtx_addHeaderComment(
+        ZL_CCtx* cctx,
+        const void* comment,
+        size_t commentSize);
+
+/**
  * Frees the given `ZL_TypedRef`.
  *
  * @param tref the object to free

--- a/include/openzl/zl_decompress.h
+++ b/include/openzl/zl_decompress.h
@@ -4,6 +4,7 @@
 #define ZSTRONG_ZS2_DECOMPRESS_H
 
 // basic definitions
+#include "openzl/zl_common_types.h"
 #include "openzl/zl_errors.h" // ZL_Report, ZL_isError()
 #include "openzl/zl_output.h"
 
@@ -339,6 +340,16 @@ ZL_Report ZL_FrameInfo_getDecompressedSize(
  * @return Number of elements in specified output, or error code
  */
 ZL_Report ZL_FrameInfo_getNumElts(const ZL_FrameInfo* fi, int outputID);
+
+ZL_RESULT_DECLARE_TYPE(ZL_Comment);
+
+/**
+ * @brief Gets the comment stored in the FrameInfo.
+ *
+ * @returns The comment or an error. If no comment is present it
+ * returns a comment with `size == 0`. The buffer returned is owned by @p zfi
+ */
+ZL_RESULT_OF(ZL_Comment) ZL_FrameInfo_getComment(const ZL_FrameInfo* zfi);
 
 // ----------------------------------------------------
 // Decompression of Typed content

--- a/include/openzl/zl_version.h
+++ b/include/openzl/zl_version.h
@@ -60,7 +60,7 @@ extern "C" {
 /// format changes. But note that once a library with
 /// max format version X is released, we must support X
 /// through our support window.
-#define ZL_MAX_FORMAT_VERSION (21)
+#define ZL_MAX_FORMAT_VERSION (22)
 
 /// Minimum wire format version required to support chunking.
 #define ZL_CHUNK_VERSION_MIN (21)

--- a/src/openzl/common/limits.h
+++ b/src/openzl/common/limits.h
@@ -63,6 +63,9 @@ size_t ZL_transformOutStreamsLimit(unsigned formatVersion);
 /// there's any risk.
 #define ZL_CONTAINER_SIZE_LIMIT (1024 * 1024)
 
+/// Size limit for the variable sized comment field
+#define ZL_MAX_HEADER_COMMENT_SIZE_LIMIT 10000
+
 ////////////////////////////////////////
 // Compressor Serialization Limits
 ////////////////////////////////////////

--- a/src/openzl/common/wire_format.h
+++ b/src/openzl/common/wire_format.h
@@ -20,6 +20,7 @@
  * - v21+: Frame property flags: 1 byte
  *   + bit0: checksum of decoded data
  *   + bit1: checksum of encoded data (also control frame header checksum)
+ *   + bit2: presence of a comment field
  * - Input Type :
  *   + v13-: 0-byte , 1 Input assumed to be Serial
  *   + v14 : 1-byte, single Input, selectable type
@@ -41,6 +42,9 @@
  *              Organized as a single large BM-bytes Little Endian number
  *              scanned from its lowest bits (shift >> 2 for each Input).
  *              Note: Format 1 stores the first 2 types in 1st byte.
+ *  + v22+: VarInt format: Number of bytes of comment field
+ *          Length x 1-byte: Arbitrary buffer of up to 10000 bytes (defined in
+ *                           limits.h) containing a comment.
  *
  * Size of Inputs
  * v20-: NbInputs x LE_U32: decompressed size of each input, in bytes
@@ -183,9 +187,13 @@ uint32_t ZL_getMagicNumber(uint32_t version);
 #define FRAME_HEADER_SIZE_MIN \
     (4 /*magic*/ + 4 /*dec.Size*/ + 1 /*eof marker*/) // Just core elts
 
+/// Minimum wire format version required to support extra comment field
+#define ZL_COMMENT_VERSION_MIN (22)
+
 typedef struct {
     bool hasContentChecksum;
     bool hasCompressedChecksum;
+    bool hasComment;
 } ZL_FrameProperties;
 
 typedef enum { trt_standard, trt_custom } TransformType_e;

--- a/src/openzl/compress/cctx.c
+++ b/src/openzl/compress/cctx.c
@@ -133,6 +133,8 @@ struct ZL_CCtx_s {
     GCParams requestedGCParams;     // User selection, at CCtx level
     GCParams appliedGCParams;       // Employed at compression time;
                                     // CCtx > Compressor > default
+    /// Comment to be added to the header. Is not added when size is 0.
+    ZL_Comment comment;
     CCTX_TransformHeaders trHeaders;
     /* These Arenas presume single-thread execution.
      * For parallel execution, it will have to be replaced by Arena Pools */
@@ -197,6 +199,8 @@ void CCTX_clean(ZL_CCtx* cctx)
 {
     CCTX_cleanChunk(cctx);
     ALLOC_Arena_freeAll(cctx->sessionArena);
+    cctx->comment.size = 0;
+    cctx->comment.data = NULL;
     ZL_ASSERT_EQ(ALLOC_Arena_memUsed(cctx->codecArena), 0);
     ZL_ASSERT_EQ(ALLOC_Arena_memUsed(cctx->graphArena), 0);
     ZL_ASSERT_EQ(ALLOC_Arena_memUsed(cctx->chunkArena), 0);
@@ -301,7 +305,9 @@ ZL_Report ZL_CCtx_resetParameters(ZL_CCtx* cctx)
     // something else. In `zstd`, there are different levels of reset
     // (parameters, session, or both). Maybe the same would be needed here ?
     ZL_zeroes(&cctx->requestedGCParams, sizeof(cctx->requestedGCParams));
-    cctx->cgraph = NULL;
+    cctx->cgraph       = NULL;
+    cctx->comment.size = 0;
+    cctx->comment.data = NULL;
     ZL_Compressor_free(cctx->internal_cgraph);
     cctx->internal_cgraph = NULL;
     return ZL_returnSuccess();
@@ -1852,4 +1858,26 @@ CCTX_tryGraph(
     CCTX_free(cctx);
 
     return result;
+}
+
+ZL_Report
+CCTX_setHeaderComment(ZL_CCtx* cctx, const void* comment, size_t commentSize)
+{
+    ZL_RESULT_DECLARE_SCOPE_REPORT(cctx);
+    ZL_ASSERT_NN(cctx);
+    if (commentSize == 0) {
+        cctx->comment.size = 0;
+        return ZL_returnSuccess();
+    }
+    void* buff = ALLOC_Arena_malloc(cctx->sessionArena, commentSize);
+    ZL_ERR_IF_NULL(buff, allocation);
+    cctx->comment.size = commentSize;
+    memcpy(buff, comment, commentSize);
+    cctx->comment.data = buff;
+    return ZL_returnSuccess();
+}
+
+ZL_Comment CCTX_getHeaderComment(const ZL_CCtx* cctx)
+{
+    return cctx->comment;
 }

--- a/src/openzl/compress/cctx.h
+++ b/src/openzl/compress/cctx.h
@@ -786,6 +786,17 @@ CCTX_tryGraph(
         ZL_GraphID graph,
         const ZL_RuntimeGraphParameters* params);
 
+/**
+ * @return The comment stored in the cctx.
+ */
+ZL_Comment CCTX_getHeaderComment(const ZL_CCtx* cctx);
+
+/**
+ * Writes @p comment into a field of the cctx.
+ */
+ZL_Report
+CCTX_setHeaderComment(ZL_CCtx* cctx, const void* comment, size_t commentSize);
+
 ZL_END_C_DECLS
 
 #endif // ZSTRONG_COMPRESS_CCTX_H

--- a/src/openzl/compress/compress2.c
+++ b/src/openzl/compress/compress2.c
@@ -60,6 +60,7 @@ static ZL_Report writeFrameHeader(
         inputDescs[n].numElts  = ZL_Data_numElts(inputs[n]);
     }
 
+    ZL_Comment comment = CCTX_getHeaderComment(cctx);
     // Requested frame properties (checksum)
     ZL_FrameProperties const fprop = {
         .hasContentChecksum =
@@ -68,12 +69,14 @@ static ZL_Report writeFrameHeader(
         .hasCompressedChecksum =
                 CCTX_getAppliedGParam(cctx, ZL_CParam_compressedChecksum)
                 != ZL_TernaryParam_disable,
+        .hasComment = (comment.size != 0),
     };
 
     EFH_FrameInfo const fi = {
         .inputDescs = inputDescs,
         .numInputs  = numInputs,
         .fprop      = &fprop,
+        .comment    = comment,
     };
 
     ZL_Report const r =
@@ -374,4 +377,16 @@ ZL_Report ZL_CCtx_compress(
     // No graph set => use default
     return ZL_CCtx_compress_usingGraphID(
             cctx, dst, dstCapacity, src, srcSize, ZL_GRAPH_SERIAL_COMPRESS);
+}
+
+ZL_Report
+ZL_CCtx_addHeaderComment(ZL_CCtx* cctx, const void* comment, size_t commentSize)
+{
+    ZL_RESULT_DECLARE_SCOPE_REPORT(cctx);
+    ZL_ERR_IF_GT(
+            commentSize,
+            ZL_MAX_HEADER_COMMENT_SIZE_LIMIT,
+            parameter_invalid,
+            "Max header comment size limit exceeded");
+    return CCTX_setHeaderComment(cctx, comment, commentSize);
 }

--- a/src/openzl/compress/encode_frameheader.c
+++ b/src/openzl/compress/encode_frameheader.c
@@ -445,11 +445,13 @@ static ZL_Report writeFrameHeader_internal(
         const EFH_FrameInfo* fip)
 {
     ZL_TRY_LET_R(hsBound, computeFHBound(fip->numInputs, 0, 0, 0));
+    // Add comment bytes relaxing header bound
+    hsBound += fip->comment.size ? 4 + fip->comment.size : 0;
     ZL_DLOG(FRAME,
             "writeFrameHeader_internal (nbInputs=%zu, maxBound=%zu bytes)",
             fip->numInputs,
             hsBound);
-    ZL_RET_R_IF_LT(internalBuffer_tooSmall, dstCapacity, hsBound);
+    ZL_RET_R_IF_LT(dstCapacity_tooSmall, dstCapacity, hsBound);
 
     ZL_WC out = ZL_WC_wrap(dst, dstCapacity);
 
@@ -465,6 +467,9 @@ static ZL_Report writeFrameHeader_internal(
             flags |= 1 << 0;
         if (fip->fprop->hasCompressedChecksum)
             flags |= 1 << 1;
+        if (encoder->formatVersion >= ZL_COMMENT_VERSION_MIN
+            && fip->fprop->hasComment)
+            flags |= 1 << 2;
         ZL_WC_push(&out, flags);
     }
 
@@ -604,6 +609,17 @@ static ZL_Report writeFrameHeader_internal(
     // @note (@cyan): currently, input size is presumed always known
     ZL_RET_R_IF_ERR(EFH_encodeInputSizes(
             &out, fip->inputDescs, fip->numInputs, encoder->formatVersion));
+
+    // Store variable-length comment
+    if (encoder->formatVersion >= ZL_COMMENT_VERSION_MIN
+        && fip->fprop->hasComment) {
+        ZL_RET_R_IF_GT(
+                graph_invalid,
+                fip->comment.size,
+                ZL_MAX_HEADER_COMMENT_SIZE_LIMIT);
+        ZL_WC_pushVarint(&out, fip->comment.size);
+        ZL_WC_shove(&out, (const uint8_t*)fip->comment.data, fip->comment.size);
+    }
 
     if ((encoder->formatVersion >= ZL_CHUNK_VERSION_MIN)
         && fip->fprop->hasCompressedChecksum) {

--- a/src/openzl/compress/encode_frameheader.h
+++ b/src/openzl/compress/encode_frameheader.h
@@ -6,6 +6,7 @@
 #include "openzl/common/wire_format.h" // ZL_FrameHeaderInfo
 #include "openzl/shared/portability.h"
 #include "openzl/zl_buffer.h" // ZL_RBuffer
+#include "openzl/zl_common_types.h"
 #include "openzl/zl_data.h"   // ZL_Type
 #include "openzl/zl_errors.h" // ZL_Report
 
@@ -29,6 +30,7 @@ typedef struct {
     const ZL_FrameProperties* fprop;
     const InputDesc* inputDescs; /**< Array of input stream's properties */
     size_t numInputs;
+    ZL_Comment comment;
 } EFH_FrameInfo;
 
 /**

--- a/src/openzl/decompress/decode_frameheader.c
+++ b/src/openzl/decompress/decode_frameheader.c
@@ -34,6 +34,8 @@ struct ZL_FrameInfo {
     uint64_t* decompressedSizes;
     uint64_t* numElts;
     size_t frameHeaderSize;
+    void* comment;
+    size_t commentSize;
 };
 
 static ZL_Type decodeType(uint8_t et)
@@ -273,13 +275,15 @@ static ZL_Report DFH_FrameInfo_decodeFrameHeader(
     ZL_ASSERT_NN(zfi);
     zfi->formatVersion = formatVersion;
     size_t consumed    = 4;
+    const uint8_t* ptr = (const uint8_t*)cSrc;
 
     /* frame properties, such as checksums */
     if (zfi->formatVersion >= ZL_CHUNK_VERSION_MIN) {
         ZL_RET_R_IF_LE(srcSize_tooSmall, cSize, consumed);
-        uint8_t const flags                = ((const uint8_t*)cSrc)[consumed++];
-        zfi->properties.hasContentChecksum = ((flags & (1 << 0)) != 0);
+        uint8_t const flags                   = ptr[consumed++];
+        zfi->properties.hasContentChecksum    = ((flags & (1 << 0)) != 0);
         zfi->properties.hasCompressedChecksum = ((flags & (1 << 1)) != 0);
+        zfi->properties.hasComment            = ((flags & (1 << 2)) != 0);
     }
 
     /* nb of outputs */
@@ -316,7 +320,7 @@ static ZL_Report DFH_FrameInfo_decodeFrameHeader(
             DFH_decodeOutputSizes(
                     dSizes,
                     numElts,
-                    (const char*)cSrc + consumed,
+                    ptr + consumed,
                     cSize - consumed,
                     types,
                     zfi->nbOutputs,
@@ -325,6 +329,30 @@ static ZL_Report DFH_FrameInfo_decodeFrameHeader(
     ZL_DLOG(BLOCK,
             "DFH_FrameInfo_decodeFrameHeader consumed %zu bytes from header",
             consumed);
+
+    // Decode Comment
+    if (formatVersion >= ZL_COMMENT_VERSION_MIN && zfi->properties.hasComment) {
+        const uint8_t* cSrcCur = ptr + consumed;
+        ZL_TRY_LET_CONST_T(
+                uint64_t, commentSize, ZL_varintDecode(&cSrcCur, ptr + cSize));
+        ZL_RET_R_IF_EQ(
+                corruption,
+                commentSize,
+                0,
+                "Invalid frame header: comment size cannot be 0 when flag is set.");
+        ZL_RET_R_IF_GT(
+                corruption,
+                commentSize,
+                ZL_MAX_HEADER_COMMENT_SIZE_LIMIT,
+                "Invalid frame header: frame max comment size exceeded.");
+        zfi->commentSize = commentSize;
+        consumed += (size_t)(cSrcCur - (ptr + consumed));
+        zfi->comment = ZL_malloc(commentSize);
+        ZL_RET_R_IF_NULL(allocation, zfi->comment);
+        ZL_RET_R_IF_GT(corruption, consumed + commentSize, cSize);
+        memcpy(zfi->comment, ptr + consumed, commentSize);
+        consumed += commentSize;
+    }
 
     if ((formatVersion >= ZL_CHUNK_VERSION_MIN)
         && zfi->properties.hasCompressedChecksum) {
@@ -363,6 +391,7 @@ void ZL_FrameInfo_free(ZL_FrameInfo* zfi)
     ZL_free(zfi->types);
     ZL_free(zfi->decompressedSizes);
     ZL_free(zfi->numElts);
+    ZL_free(zfi->comment);
     ZL_free(zfi);
 }
 
@@ -439,6 +468,22 @@ ZL_Report ZL_FrameInfo_getNumElts(const ZL_FrameInfo* zfi, int outputID)
 
     ZL_ASSERT_NN(zfi->numElts);
     return ZL_returnValue(zfi->numElts[outputID]);
+}
+
+ZL_RESULT_OF(ZL_Comment) ZL_FrameInfo_getComment(const ZL_FrameInfo* zfi)
+{
+    ZL_Comment comment;
+    ZL_ASSERT_NN(zfi);
+    ZL_RET_T_IF_LT(
+            ZL_Comment,
+            GENERIC,
+            zfi->formatVersion,
+            ZL_COMMENT_VERSION_MIN,
+            "This method only works on frames with version >= %zu",
+            ZL_COMMENT_VERSION_MIN);
+    comment.data = zfi->comment;
+    comment.size = zfi->commentSize;
+    return ZL_RESULT_WRAP_VALUE(ZL_Comment, comment);
 }
 
 // --------------------------

--- a/tests/compress/test_compress.cpp
+++ b/tests/compress/test_compress.cpp
@@ -6,16 +6,32 @@
 
 #include "openzl/common/assertion.h"
 #include "openzl/common/errors_internal.h"
+#include "openzl/common/limits.h"
+#include "openzl/common/wire_format.h"
+#include "openzl/compress/cctx.h"
+#include "openzl/cpp/CCtx.hpp"
+#include "openzl/cpp/Compressor.hpp"
 #include "openzl/zl_compress.h"
 #include "openzl/zl_compressor.h"
 #include "openzl/zl_public_nodes.h"
 
+#include "tests/utils.h"
+
 using namespace ::testing;
+using namespace ::openzl;
 
 namespace {
 
 class CompressTest : public Test {
    protected:
+    void SetUp() override
+    {
+        cctx_.setParameter(CParam::StickyParameters, 1);
+        cctx_.setParameter(CParam::FormatVersion, ZL_MAX_FORMAT_VERSION);
+        compressor_.selectStartingGraph(ZL_GRAPH_COMPRESS_GENERIC);
+        cctx_.refCompressor(compressor_);
+    }
+
     size_t compress(
             void* dst,
             size_t dstCapacity,
@@ -38,6 +54,9 @@ class CompressTest : public Test {
 
         return ZL_validResult(report);
     }
+
+    CCtx cctx_;
+    Compressor compressor_;
 };
 
 TEST_F(CompressTest, CompressionSucceedsWithSmallDstBuffer)
@@ -55,4 +74,123 @@ TEST_F(CompressTest, CompressionSucceedsWithSmallDstBuffer)
             dst.data(), cSize0, data.data(), data.size(), ZL_GRAPH_CONSTANT);
     ASSERT_EQ(cSize0, cSize1);
 }
+
+TEST_F(CompressTest, CompressionZeroLengthCommentIsNotSent)
+{
+    std::string data(1000, 'a');
+    std::string comment = "";
+    auto d1             = cctx_.compressSerial(data);
+    EXPECT_ZS_VALID(ZL_CCtx_addHeaderComment(
+            cctx_.get(), (const uint8_t*)comment.data(), comment.size()));
+    auto d2 = cctx_.compressSerial(data);
+    EXPECT_EQ(d1, d2);
+}
+TEST_F(CompressTest, CompressionCommentReadCorrectly)
+{
+    std::string data(1000, 'a');
+    std::string comment = "comment";
+    EXPECT_ZS_VALID(ZL_CCtx_addHeaderComment(
+            cctx_.get(), (const uint8_t*)comment.data(), comment.size()));
+    EXPECT_ZS_VALID(ZL_CCtx_addHeaderComment(cctx_.get(), NULL, 0));
+    auto dst = cctx_.compressSerial(data);
+    auto zfi = ZL_FrameInfo_create(dst.data(), dst.size());
+    auto r   = ZL_RES_value(ZL_FrameInfo_getComment(zfi));
+    std::string reconstructed((const char*)r.data, r.size);
+    EXPECT_EQ(r.size, 0);
+    ZL_FrameInfo_free(zfi);
+}
+
+TEST_F(CompressTest, CompressionZeroLengthCommentClearsField)
+{
+    std::string data(1000, 'a');
+    std::string comment = "comment";
+    EXPECT_ZS_VALID(ZL_CCtx_addHeaderComment(
+            cctx_.get(), (const uint8_t*)comment.data(), comment.size()));
+    auto dst = cctx_.compressSerial(data);
+    auto zfi = ZL_FrameInfo_create(dst.data(), dst.size());
+    auto r   = ZL_RES_value(ZL_FrameInfo_getComment(zfi));
+    std::string reconstructed((const char*)r.data, r.size);
+    EXPECT_EQ(comment, reconstructed);
+    ZL_FrameInfo_free(zfi);
+}
+
+TEST_F(CompressTest, CompressionCommentSentIsOverriden)
+{
+    std::string data(1000, 'a');
+    std::string comment1 = "comment1";
+    std::string comment2 = "comment2";
+
+    EXPECT_ZS_VALID(ZL_CCtx_addHeaderComment(
+            cctx_.get(), comment1.data(), comment1.size()));
+    EXPECT_ZS_VALID(ZL_CCtx_addHeaderComment(
+            cctx_.get(), comment2.data(), comment2.size()));
+    auto dst = cctx_.compressSerial(data);
+    auto zfi = ZL_FrameInfo_create(dst.data(), dst.size());
+    auto r   = ZL_RES_value(ZL_FrameInfo_getComment(zfi));
+    std::string reconstructed((const char*)r.data, r.size);
+    EXPECT_EQ(comment2, reconstructed);
+    ZL_FrameInfo_free(zfi);
+}
+
+TEST_F(CompressTest, CompressMultipleTimesCommentRead)
+{
+    std::string data(1000, 'a');
+    std::string comment = "comment";
+
+    EXPECT_ZS_VALID(ZL_CCtx_addHeaderComment(
+            cctx_.get(), comment.data(), comment.size()));
+    // Compressing clears the comment in the cctx
+    auto dst = cctx_.compressSerial(data);
+    auto zfi = ZL_FrameInfo_create(dst.data(), dst.size());
+    auto r   = ZL_RES_value(ZL_FrameInfo_getComment(zfi));
+    std::string reconstructed((const char*)r.data, r.size);
+    EXPECT_EQ(comment, reconstructed);
+    ZL_FrameInfo_free(zfi);
+    // Try again after message has been cleared
+    dst = cctx_.compressSerial(data);
+    zfi = ZL_FrameInfo_create(dst.data(), dst.size());
+    r   = ZL_RES_value(ZL_FrameInfo_getComment(zfi));
+    std::string emptyComment((const char*)r.data, r.size);
+    // Expect no comment since sticky parameters are disabled
+    EXPECT_EQ(emptyComment.size(), 0);
+    ZL_FrameInfo_free(zfi);
+}
+
+TEST_F(CompressTest, CompressCommentIsZeroedInCctxAfterCompression)
+{
+    std::string data(1000, 'a');
+    std::string comment = "comment";
+
+    EXPECT_ZS_VALID(ZL_CCtx_addHeaderComment(
+            cctx_.get(), comment.data(), comment.size()));
+    // Compressing clears the comment in the cctx
+    auto dst = cctx_.compressSerial(data);
+    auto r   = CCTX_getHeaderComment(cctx_.get());
+    EXPECT_EQ(r.size, 0);
+}
+
+TEST_F(CompressTest, CompressTooLongCommentFails)
+{
+    std::string comment(ZL_MAX_HEADER_COMMENT_SIZE_LIMIT + 1, 'a');
+    EXPECT_ZS_ERROR(ZL_CCtx_addHeaderComment(
+            cctx_.get(), comment.data(), comment.size()));
+}
+
+TEST_F(CompressTest, OlderFormatVersionCommentDoesNotChangeFrameHeader)
+{
+    std::string data(1000, 'a');
+    std::string comment      = "comment";
+    std::string emptyComment = "";
+    cctx_.setParameter(CParam::FormatVersion, ZL_COMMENT_VERSION_MIN - 1);
+    EXPECT_ZS_VALID(ZL_CCtx_addHeaderComment(
+            cctx_.get(), comment.data(), comment.size()));
+    auto dst = cctx_.compressSerial(data);
+    // Clear comment
+    EXPECT_ZS_VALID(ZL_CCtx_addHeaderComment(
+            cctx_.get(), emptyComment.data(), emptyComment.size()));
+    auto dst2 = cctx_.compressSerial(data);
+    // Ensure that the frame is identical regardless of the comment
+    EXPECT_EQ(dst, dst2);
+}
+
 } // namespace

--- a/tests/unittest/common/test_wire_format.cpp
+++ b/tests/unittest/common/test_wire_format.cpp
@@ -3,8 +3,13 @@
 #include <gtest/gtest.h>
 
 #include "openzl/common/errors_internal.h"
+#include "openzl/common/limits.h"
 #include "openzl/common/wire_format.h"
+#include "openzl/compress/encode_frameheader.h"
+#include "openzl/decompress/decode_frameheader.h"
 #include "openzl/shared/mem.h"
+
+#include "tests/utils.h"
 
 namespace {
 uint32_t constexpr kMinVersion = ZL_MIN_FORMAT_VERSION;
@@ -66,4 +71,111 @@ TEST(WireFormatTest, InvalidMagicNumberFrameFormat)
 TEST(WireFormatTest, DefaultEncodingVersion)
 {
     ASSERT_TRUE(ZL_isFormatVersionSupported(ZL_getDefaultEncodingVersion()));
+}
+
+TEST(WireFormatTest, CommentFrameFormat)
+{
+    Arena* arena      = ALLOC_StackArena_create();
+    uint16_t configId = 300;
+    EFH_FrameInfo fi;
+    fi.comment.data          = (uint8_t*)&configId;
+    fi.comment.size          = 2;
+    fi.numInputs             = 1;
+    ZL_FrameProperties fprop = {
+        .hasContentChecksum    = false,
+        .hasCompressedChecksum = false,
+        .hasComment            = true,
+    };
+    InputDesc inputDesc;
+    inputDesc.type     = ZL_Type_serial;
+    inputDesc.numElts  = 100;
+    inputDesc.byteSize = 100;
+    fi.fprop           = &fprop;
+    fi.inputDescs      = &inputDesc;
+
+    size_t dstCapacity = 1000;
+
+    void* dst = ALLOC_Arena_malloc(arena, dstCapacity);
+
+    EXPECT_ZS_VALID(EFH_writeFrameHeader(
+            dst, dstCapacity, &fi, ZL_COMMENT_VERSION_MIN));
+    // Decode
+    DFH_Struct* dfh =
+            (DFH_Struct*)ALLOC_Arena_malloc(arena, sizeof(DFH_Struct));
+    DFH_init(dfh);
+    dfh->formatVersion = ZL_COMMENT_VERSION_MIN;
+    EXPECT_ZS_VALID(DFH_decodeFrameHeader(dfh, dst, dstCapacity));
+    auto comment = ZL_RES_value(ZL_FrameInfo_getComment(dfh->frameinfo));
+    EXPECT_EQ(comment.size, 2);
+    uint16_t result = *(const uint16_t*)(const void*)comment.data;
+    EXPECT_EQ(result, configId);
+    DFH_destroy(dfh);
+    ALLOC_Arena_freeArena(arena);
+}
+
+TEST(WireFormatTest, DecodeOldFrameFormatWithComment)
+{
+    Arena* arena      = ALLOC_StackArena_create();
+    uint16_t configId = 300;
+    EFH_FrameInfo fi;
+    fi.comment.data          = (uint8_t*)&configId;
+    fi.comment.size          = 2;
+    fi.numInputs             = 1;
+    ZL_FrameProperties fprop = {
+        .hasContentChecksum    = false,
+        .hasCompressedChecksum = false,
+        .hasComment            = true,
+    };
+    InputDesc inputDesc;
+    inputDesc.type     = ZL_Type_serial;
+    inputDesc.numElts  = 100;
+    inputDesc.byteSize = 100;
+    fi.fprop           = &fprop;
+    fi.inputDescs      = &inputDesc;
+
+    size_t dstCapacity = 1000;
+
+    void* dst = ALLOC_Arena_malloc(arena, dstCapacity);
+
+    EXPECT_ZS_VALID(EFH_writeFrameHeader(
+            dst, dstCapacity, &fi, ZL_COMMENT_VERSION_MIN - 1));
+
+    DFH_Struct* dfh =
+            (DFH_Struct*)ALLOC_Arena_malloc(arena, sizeof(DFH_Struct));
+    // Decode with newer version
+    DFH_init(dfh);
+    dfh->formatVersion = ZL_COMMENT_VERSION_MIN;
+    EXPECT_ZS_VALID(DFH_decodeFrameHeader(dfh, dst, dstCapacity));
+    EXPECT_ZS_ERROR(ZL_FrameInfo_getComment(dfh->frameinfo));
+    // Decode with old version
+    dfh->formatVersion = ZL_COMMENT_VERSION_MIN - 1;
+    EXPECT_ZS_VALID(DFH_decodeFrameHeader(dfh, dst, dstCapacity));
+    DFH_destroy(dfh);
+    ALLOC_Arena_freeArena(arena);
+}
+
+TEST(WireFormatTest, CommentExceedingSizeLimitCannotBeEncoded)
+{
+    Arena* arena = ALLOC_StackArena_create();
+
+    EFH_FrameInfo fi;
+    fi.comment.size          = ZL_MAX_HEADER_COMMENT_SIZE_LIMIT + 1;
+    fi.numInputs             = 1;
+    ZL_FrameProperties fprop = {
+        .hasContentChecksum    = false,
+        .hasCompressedChecksum = false,
+        .hasComment            = true,
+    };
+    InputDesc inputDesc;
+    inputDesc.type     = ZL_Type_serial;
+    inputDesc.numElts  = 100;
+    inputDesc.byteSize = 100;
+    fi.fprop           = &fprop;
+    fi.inputDescs      = &inputDesc;
+    size_t dstCapacity = 1000;
+    void* dst          = ALLOC_Arena_malloc(arena, dstCapacity);
+
+    EXPECT_ZS_ERROR(EFH_writeFrameHeader(
+            dst, dstCapacity, &fi, ZL_COMMENT_VERSION_MIN - 1));
+    ALLOC_Arena_freeArena(arena);
 }


### PR DESCRIPTION
Summary:
Adds a method that enables adding a comment field to the frame header sent. A flag bit is set to indicate this comment field is enabled.

The change involves:
- Adding comment stored in the session arena of the cctx
- Encode/ decode changes for frame headers.

Differential Revision: D85364780


