### PR TITLE
Add API to mutate graph params in library

### DIFF
--- a/src/openzl/compress/cgraph.c
+++ b/src/openzl/compress/cgraph.c
@@ -807,6 +807,21 @@ ZL_Compressor_parameterizeGraph(
     return GM_registerParameterizedGraph(compressor->gm, &desc);
 }
 
+ZL_Report ZL_Compressor_overrideGraphParams(
+        ZL_Compressor* compressor,
+        ZL_GraphID graph,
+        const ZL_GraphParameters* gp)
+{
+    ZL_RESULT_DECLARE_SCOPE(size_t, compressor);
+    ZL_ERR_IF_NOT(
+            CGRAPH_checkGraphIDExists(compressor, graph),
+            graph_invalid,
+            "Graph must be registered in compressor");
+
+    ZL_ERR_IF_ERR(GM_overrideGraphParams(compressor->gm, graph, gp));
+    return ZL_returnSuccess();
+}
+
 ZL_GraphID ZL_Compressor_registerParameterizedGraph(
         ZL_Compressor* compressor,
         const ZL_ParameterizedGraphDesc* desc)

--- a/src/openzl/compress/cgraph.h
+++ b/src/openzl/compress/cgraph.h
@@ -74,6 +74,23 @@ ZL_NodeID CGraph_registerStandardMITransform(
         unsigned minFormatVersion,
         unsigned maxFormatVersion);
 
+/* =====   Private actions on Compressor   ===== */
+
+/**
+ * Warning: This is part of experimental API for compressor mutation.
+ *
+ * Requires that:
+ * @p graph is a parameterized graph registered in @p compressor
+ *
+ * Replaces the parameters of @p graph with @p gp.
+ * @note: This function does not validate there are no dependency cycles within
+ * the compressor.
+ */
+ZL_Report ZL_Compressor_overrideGraphParams(
+        ZL_Compressor* compressor,
+        ZL_GraphID graph,
+        const ZL_GraphParameters* gp);
+
 ZL_END_C_DECLS
 
 #endif // ZSTRONG_COMPRESS_CGRAPH_H

--- a/src/openzl/compress/graphmgr.c
+++ b/src/openzl/compress/graphmgr.c
@@ -480,6 +480,62 @@ GM_registerStaticGraph(GraphsMgr* gm, const ZL_StaticGraphDesc* sgDesc)
             sizeof(nsParam));
 }
 
+ZL_Report GM_overrideGraphParams(
+        GraphsMgr* const gm,
+        ZL_GraphID targetGraph,
+        const ZL_GraphParameters* gp)
+{
+    ZL_RESULT_DECLARE_SCOPE(size_t, gm->opCtx);
+    ZL_ASSERT_NN(gm);
+
+    ZL_ERR_IF(
+            GR_isStandardGraph(targetGraph),
+            graph_invalid,
+            "Cannot replace standard graph");
+
+    ZL_IDType const lid = GM_GraphID_to_lgid(targetGraph);
+    ZL_ERR_IF_GE(lid, VECTOR_SIZE(gm->gdv), internalBuffer_tooSmall);
+    // Check that the graphs is a parameterized graph
+    ZL_ERR_IF_NE(
+            VECTOR_AT(gm->gdv, lid).originalGraphType,
+            ZL_GraphType_parameterized,
+            graph_invalid);
+    ZL_FunctionGraphDesc* const migd = &VECTOR_AT(gm->gdv, lid).migd;
+
+    // Validate custom graphs
+    for (size_t i = 0; i < gp->nbCustomGraphs; ++i) {
+        // TODO(T219759022): Should this be allowed?
+        if (gp->customGraphs[i].gid == ZL_GRAPH_ILLEGAL.gid) {
+            continue;
+        }
+        ZL_ERR_IF_NOT(
+                GM_isValidGraphID(gm, gp->customGraphs[i]),
+                graph_invalid,
+                "Custom GraphID at idx=%zu is invalid!",
+                i);
+    }
+
+    // Validate custom nodes
+    // TODO(T219759022): Should ZL_NODE_ILLEGAL be allowed?
+    // It currently is, because NM_getCNode() returns non-null.
+    for (size_t i = 0; i < gp->nbCustomNodes; ++i) {
+        const CNode* cnode = NM_getCNode(gm->nmgr, gp->customNodes[i]);
+        ZL_ERR_IF_NULL(
+                cnode,
+                graph_invalid,
+                "Custom NodeID at idx=%zu is invalid!",
+                i);
+    }
+
+    ZL_ERR_IF_ERR(GM_transferCustomGIDs(
+            gm, gp->customGraphs, gp->nbCustomGraphs, &migd->customGraphs));
+    ZL_ERR_IF_ERR(GM_transferCustomNIDs(
+            gm, gp->customNodes, gp->nbCustomNodes, &migd->customNodes));
+    migd->localParams = *gp->localParams;
+    ZL_ERR_IF_ERR(GM_transferLocalParameters(gm, &migd->localParams));
+    return ZL_returnSuccess();
+}
+
 ZL_RESULT_OF(ZL_GraphID)
 GM_registerParameterizedGraph(
         GraphsMgr* gm,

--- a/src/openzl/compress/graphmgr.h
+++ b/src/openzl/compress/graphmgr.h
@@ -129,6 +129,16 @@ ZL_Report GM_forEachGraph(
         void* opaque,
         const ZL_Compressor* compressor);
 
+// Warning: This is part of experimental API for graph mutation on the
+// compressor.
+//
+// Replaces all the parameters of the target graph with @p gp. If there is a
+// cycle in the graph as a result of this operation, it is UB.
+ZL_Report GM_overrideGraphParams(
+        GraphsMgr* const gm,
+        ZL_GraphID targetGraph,
+        const ZL_GraphParameters* gp);
+
 ZL_END_C_DECLS
 
 #endif // ZSTRONG_COMPRESS_GRAPHMGR_H

--- a/tests/compress/test_cgraph.cpp
+++ b/tests/compress/test_cgraph.cpp
@@ -4,14 +4,21 @@
 
 #include <gtest/gtest.h>
 
+#include "openzl/compress/cgraph.h"
+#include "openzl/cpp/CCtx.hpp"
+#include "openzl/cpp/DCtx.hpp"
 #include "openzl/zl_opaque_types.h"
 #include "openzl/zl_public_nodes.h"
 #include "openzl/zl_reflection.h"
 #include "openzl/zl_selector.h" // ZL_SelectorDesc
 
+#include "tests/datagen/random_producer/PRNGWrapper.h"
+#include "tests/datagen/structures/CompressorProducer.h"
 #include "tests/utils.h"
 
 using namespace ::testing;
+using namespace ::zstrong::tests;
+using namespace ::zstrong::tests::datagen;
 
 namespace {
 
@@ -19,8 +26,15 @@ class CGraphTest : public Test {
    protected:
     void SetUp() override
     {
+        // TODO: replace with impl with C++ bindings
         cgraph_ = ZL_Compressor_create();
+
+        // Set up cctx, and input
+        cctx_.setParameter(
+                openzl::CParam::FormatVersion, ZL_MAX_FORMAT_VERSION);
+        cctx_.setParameter(openzl::CParam::StickyParameters, 1);
     }
+
     void TearDown() override
     {
         ZL_Compressor_free(cgraph_);
@@ -46,6 +60,10 @@ class CGraphTest : public Test {
     }
 
     ZL_Compressor* cgraph_{ nullptr };
+
+    openzl::Compressor compressor_;
+    openzl::CCtx cctx_;
+    openzl::DCtx dctx_;
 };
 
 TEST_F(CGraphTest, referencingUnfinishedCGraphWithoutStartingGraphID)
@@ -386,6 +404,47 @@ TEST_F(CGraphTest, baseGraphDynamic)
     cloneAndCheckGetBaseGraphID(compressor, gid);
 
     ZL_Compressor_free(compressor);
+}
+
+TEST_F(CGraphTest, replaceGraphParams)
+{
+    openzl::LocalParams nullParams;
+    openzl::LocalParams intParams;
+    intParams.addIntParam(1, 1);
+    // Set up cctx, compressor and input
+    auto params        = (openzl::GraphParameters){ .localParams = nullParams };
+    const auto rparams = (ZL_GraphParameters){ .localParams = intParams.get() };
+
+    auto customStore = compressor_.parameterizeGraph(ZL_GRAPH_STORE, params);
+    EXPECT_ZS_VALID(ZL_Compressor_overrideGraphParams(
+            compressor_.get(), customStore, &rparams));
+    auto r = ZL_Compressor_Graph_getLocalParams(compressor_.get(), customStore);
+    EXPECT_EQ(r.intParams.intParams[0].paramId, 1);
+    EXPECT_EQ(r.intParams.intParams[0].paramValue, 1);
+}
+
+TEST_F(CGraphTest, cannotReplaceWhenGraphIsNotParameterized)
+{
+    auto params           = (ZL_GraphParameters){ .name = "zstdalt" };
+    const auto graph_func = [](ZL_Graph*, ZL_Edge*[], size_t) noexcept {
+        ZL_RET_R_ERR(GENERIC, "Unimplemented! Can't actually run.");
+    };
+    ZL_FunctionGraphDesc desc = {
+        .name    = "testBase",
+        .graph_f = graph_func,
+    };
+    auto newBaseGraph =
+            ZL_Compressor_registerFunctionGraph(compressor_.get(), &desc);
+    EXPECT_NE(newBaseGraph.gid, ZL_GRAPH_ILLEGAL.gid);
+
+    EXPECT_ZS_ERROR(ZL_Compressor_overrideGraphParams(
+            compressor_.get(), ZL_GRAPH_ILLEGAL, &params));
+
+    EXPECT_ZS_ERROR(ZL_Compressor_overrideGraphParams(
+            compressor_.get(), ZL_GRAPH_ZSTD, &params));
+
+    EXPECT_ZS_ERROR(ZL_Compressor_overrideGraphParams(
+            compressor_.get(), newBaseGraph, &params));
 }
 
 } // namespace


### PR DESCRIPTION
Summary:
Adds a new private API that allows replacement of graph parameters. This is a advanced library API intended to support training workflows to be experimented with.


Currently:
- Only parametrizable graphs can be modified with this API
- Does not check for dangers of cycles

Reviewed By: terrelln

Differential Revision: D85101264


