### PR TITLE
Modify introspection hooks

### DIFF
--- a/tools/training/sample_collection/introspection_hooks.cpp
+++ b/tools/training/sample_collection/introspection_hooks.cpp
@@ -44,12 +44,9 @@ void UntrainedGraphHook::on_migraphEncode_start(
             nbInputs,
             graphName.c_str());
 
-    // If this is the first time we're seeing this graph, initialize an empty
-    // vector
-    if (inputs_.find(graphName) == inputs_.end()) {
-        inputs_[graphName] = MultiInput();
-    }
-
+    // Each time a graph is called, we should record a separate set of inputs
+    // for that graph.
+    auto encodeInputs = MultiInput();
     for (size_t i = 0; i < nbInputs; ++i) {
         if (!inputs[i]) {
             errorMessage_ = "Input is null at index " + std::to_string(i);
@@ -63,11 +60,13 @@ void UntrainedGraphHook::on_migraphEncode_start(
             Logger::log(ERRORS, errorMessage_);
             return;
         }
-        inputs_[graphName].add(InputCopy(edgeInputData));
+        encodeInputs.add(InputCopy(edgeInputData));
     }
+    inputs_[graphName].push_back(std::move(encodeInputs));
 }
 
-const std::map<std::string, MultiInput>& UntrainedGraphHook::getInputs() const
+const std::map<std::string, std::vector<MultiInput>>&
+UntrainedGraphHook::getInputs() const
 {
     if (!errorMessage_.empty()) {
         Logger::log(ERRORS, "Error message present: ", errorMessage_);

--- a/tools/training/sample_collection/introspection_hooks.h
+++ b/tools/training/sample_collection/introspection_hooks.h
@@ -26,11 +26,11 @@ class UntrainedGraphHook : public openzl::CompressIntrospectionHooks {
             ZL_Edge* inputs[],
             size_t nbInputs) override;
 
-    const std::map<std::string, MultiInput>& getInputs() const;
+    const std::map<std::string, std::vector<MultiInput>>& getInputs() const;
 
    private:
     std::vector<std::string> targetGraphNames_;
-    std::map<std::string, MultiInput> inputs_{};
+    std::map<std::string, std::vector<MultiInput>> inputs_{};
     std::string errorMessage_{};
 };
 

--- a/tools/training/sample_collection/training_sample_collector.cpp
+++ b/tools/training/sample_collection/training_sample_collector.cpp
@@ -53,10 +53,10 @@ void captureInputs(
     cctx.compress(*input);
     const auto& captured = hooks.getInputs();
 
-    for (const auto& [graphName, sample] : captured) {
-        if (!captured.empty()) {
-            auto [it, _] = samplesPerGraph.emplace(
-                    graphName, std::vector<MultiInput>());
+    for (const auto& [graphName, samples] : captured) {
+        auto [it, _] =
+                samplesPerGraph.emplace(graphName, std::vector<MultiInput>());
+        for (auto& sample : samples) {
             it->second.push_back(sample);
         }
     }


### PR DESCRIPTION
Summary: Modify introspection hooks such that each new invocation of `on_migraphEncode_start` for a graph is treated as a separate sample.

Reviewed By: terrelln

Differential Revision: D86339023


