### PR TITLE
Add csv segmenter

### DIFF
--- a/cli/utils/compress_profiles.cpp
+++ b/cli/utils/compress_profiles.cpp
@@ -180,7 +180,11 @@ compressProfiles()
                         }
                         return openzl::custom_parsers::
                                 ZL_createGraph_genericCSVCompressorWithOptions(
-                                        comp, true, str[0], false);
+                                        comp,
+                                        custom_parsers::kDefaultChunkSize,
+                                        true,
+                                        str[0],
+                                        false);
                     }
                     return openzl::custom_parsers::
                             ZL_createGraph_genericCSVCompressor(comp);

--- a/custom_parsers/csv/csv_lexer.c
+++ b/custom_parsers/csv/csv_lexer.c
@@ -6,7 +6,7 @@
 
 #include "openzl/codecs/zl_dispatch.h"
 #include "openzl/common/logging.h"
-#include "openzl/zl_graph_api.h"
+#include "openzl/zl_segmenter.h"
 
 // Parses the CSV file to get the number of columns, separated by @p sep, and
 // the length of the first row, including the ending `\n`.
@@ -115,14 +115,15 @@ static ZL_Report createCsvDispatchIndices(
 }
 
 ZL_Report createParsedCsv(
-        uint32_t* stringLens,
+        ZL_CSV_lexResult* retLexResult,
         const char* content,
         const size_t length,
-        char sep,
-        size_t nbColumns)
+        char sep)
 {
+    size_t nbColumns    = retLexResult->nbColumns;
     uint32_t fieldStart = 0;
-    size_t nbStrs       = 0;
+    size_t nbStrs       = 1; // Header has been added
+    size_t nbRows       = 0;
     size_t col          = 1;
 
     for (uint32_t i = 0; i < length; ++i) {
@@ -162,12 +163,13 @@ ZL_Report createParsedCsv(
                             nbColumns,
                             col);
                 }
-                col = 1;
+                col                                    = 1;
+                retLexResult->newlineIndices[nbRows++] = nbStrs + 1;
             }
 
-            stringLens[nbStrs] = i - fieldStart;
+            retLexResult->stringLens[nbStrs] = i - fieldStart;
             ++nbStrs;
-            stringLens[nbStrs] = 1;
+            retLexResult->stringLens[nbStrs] = 1;
             ++nbStrs;
             fieldStart = i + 1;
         }
@@ -184,22 +186,23 @@ ZL_Report createParsedCsv(
             fieldStart,
             length,
             "CSV file not well formed. No newline character at the end of the last line");
+    retLexResult->nbStrs     = nbStrs;
+    retLexResult->nbNewlines = nbRows;
     ZL_LOG(V, "createParsedCsv nbStrs: %zu", nbStrs);
     return ZL_returnValue(nbStrs);
 }
 
 // returns number of strings processed
 ZL_Report createNullAwareLexAndDispatch(
-        uint32_t* stringLens,
-        uint16_t* dispatchIndices,
+        ZL_CSV_lexResult* retLexResult,
         const char* content,
         const size_t length,
-        uint8_t nbColumns,
         char sep)
 {
     uint32_t fieldStart = 0;
     uint8_t colIdx      = 0;
-    size_t nbStrs       = 0;
+    size_t nbStrs       = 1; // Header has been added
+    size_t nbRows       = 0;
 
     for (uint32_t i = 0; i < length;) {
         // skip past all quoted strings
@@ -215,8 +218,8 @@ ZL_Report createNullAwareLexAndDispatch(
             ++i;
         }
         if (content[i] == sep) {
-            stringLens[nbStrs]      = i - fieldStart;
-            dispatchIndices[nbStrs] = colIdx;
+            retLexResult->stringLens[nbStrs]      = i - fieldStart;
+            retLexResult->dispatchIndices[nbStrs] = colIdx;
             ++nbStrs;
             fieldStart = i;
             // coalesce all contiguous separators, e.g. ',,,,,,'
@@ -224,24 +227,29 @@ ZL_Report createNullAwareLexAndDispatch(
                 ++colIdx;
                 ++i;
             }
-            stringLens[nbStrs]      = i - fieldStart;
-            dispatchIndices[nbStrs] = nbColumns;
+            retLexResult->stringLens[nbStrs] = i - fieldStart;
+            retLexResult->dispatchIndices[nbStrs] =
+                    (uint16_t)retLexResult->nbColumns;
             ++nbStrs;
             fieldStart = i;
             continue;
         }
         if (content[i] == '\n') {
-            stringLens[nbStrs]      = i - fieldStart;
-            dispatchIndices[nbStrs] = colIdx;
+            retLexResult->stringLens[nbStrs]      = i - fieldStart;
+            retLexResult->dispatchIndices[nbStrs] = colIdx;
             ++nbStrs;
-            stringLens[nbStrs]      = 1;
-            dispatchIndices[nbStrs] = nbColumns;
+            retLexResult->stringLens[nbStrs] = 1;
+            retLexResult->dispatchIndices[nbStrs] =
+                    (uint16_t)retLexResult->nbColumns;
+            retLexResult->newlineIndices[nbRows++] = nbStrs;
             ++nbStrs;
             fieldStart = i + 1;
             colIdx     = 0;
         }
         ++i;
     }
+    retLexResult->nbStrs     = nbStrs;
+    retLexResult->nbNewlines = nbRows;
     ZL_RET_R_IF_NE(
             node_invalid_input,
             fieldStart,
@@ -252,7 +260,7 @@ ZL_Report createNullAwareLexAndDispatch(
 }
 
 ZL_Report ZL_CSV_lex(
-        ZL_Graph* gctx,
+        ZL_Segmenter* sctx,
         const char* const content,
         size_t byteSize,
         bool hasHeader,
@@ -289,33 +297,31 @@ ZL_Report ZL_CSV_lex(
     const size_t maxNbStrings = 2 * nbColumns * maxNbRows + 1;
 
     uint32_t* stringLens =
-            ZL_Graph_getScratchSpace(gctx, maxNbStrings * sizeof(uint32_t));
+            ZL_Segmenter_getScratchSpace(sctx, maxNbStrings * sizeof(uint32_t));
+    size_t* newlineIndices =
+            ZL_Segmenter_getScratchSpace(sctx, maxNbRows * sizeof(size_t));
     ZL_RET_R_IF_NULL(allocation, stringLens);
     stringLens[0] = (uint32_t)(rowsStart - content); // 0 if there is no header
-    ZL_Report rep = createParsedCsv(
-            stringLens + 1, rowsStart, rowsByteSize, sep, nbColumns);
-    ZL_RET_R_IF_ERR(rep);
-    size_t actualNbStrs = ZL_validResult(rep);
-    size_t actualNbRows = actualNbStrs / (2 * nbColumns);
-    actualNbStrs += 1; // +1 for header
+    retLexResult->stringLens     = stringLens;
+    retLexResult->nbColumns      = nbColumns;
+    retLexResult->newlineIndices = newlineIndices;
 
-    uint16_t* dispatchIndices =
-            ZL_Graph_getScratchSpace(gctx, actualNbStrs * sizeof(uint16_t));
+    ZL_RET_R_IF_ERR(
+            createParsedCsv(retLexResult, rowsStart, rowsByteSize, sep));
+    size_t actualNbRows = retLexResult->nbStrs / (2 * nbColumns);
+
+    uint16_t* dispatchIndices = ZL_Segmenter_getScratchSpace(
+            sctx, retLexResult->nbStrs * sizeof(uint16_t));
     ZL_RET_R_IF_NULL(allocation, dispatchIndices);
     ZL_RET_R_IF_ERR(createCsvDispatchIndices(
             dispatchIndices, actualNbRows, nbColumns, stringLens));
 
-    // return
-    retLexResult->stringLens      = stringLens;
     retLexResult->dispatchIndices = dispatchIndices;
-    retLexResult->nbStrs          = actualNbStrs;
-    retLexResult->nbColumns       = nbColumns;
-
     return ZL_returnSuccess();
 }
 
 ZL_Report ZL_CSV_lexNullAware(
-        ZL_Graph* gctx,
+        ZL_Segmenter* sctx,
         const char* const content,
         size_t byteSize,
         bool hasHeader,
@@ -351,31 +357,21 @@ ZL_Report ZL_CSV_lexNullAware(
     // extraneous quoted newlines is possible.
     const size_t maxNbStrings = 2 * nbColumns * maxNbRows + 1;
 
+    size_t* newlineIndices =
+            ZL_Segmenter_getScratchSpace(sctx, maxNbRows * sizeof(size_t));
     uint32_t* stringLens =
-            ZL_Graph_getScratchSpace(gctx, maxNbStrings * sizeof(uint32_t));
+            ZL_Segmenter_getScratchSpace(sctx, maxNbStrings * sizeof(uint32_t));
     ZL_RET_R_IF_NULL(allocation, stringLens);
     uint16_t* dispatchIndices =
-            ZL_Graph_getScratchSpace(gctx, maxNbStrings * sizeof(uint16_t));
+            ZL_Segmenter_getScratchSpace(sctx, maxNbStrings * sizeof(uint16_t));
     ZL_RET_R_IF_NULL(allocation, dispatchIndices);
     stringLens[0] = (uint32_t)(rowsStart - content); // 0 if there is no header
-
-    ZL_Report rep = createNullAwareLexAndDispatch(
-            stringLens + 1,
-            dispatchIndices + 1,
-            rowsStart,
-            rowsByteSize,
-            (uint8_t)nbColumns,
-            sep);
-    ZL_RET_R_IF_ERR(rep);
-    size_t actualNbStrs = ZL_validResult(rep);
-    actualNbStrs += 1;                            // +1 for header
-    dispatchIndices[0] = (uint16_t)nbColumns + 1; // header
-
-    // return
+    dispatchIndices[0]            = (uint16_t)nbColumns + 1; // header
     retLexResult->stringLens      = stringLens;
     retLexResult->dispatchIndices = dispatchIndices;
-    retLexResult->nbStrs          = actualNbStrs;
     retLexResult->nbColumns       = nbColumns;
-
+    retLexResult->newlineIndices  = newlineIndices;
+    ZL_RET_R_IF_ERR(createNullAwareLexAndDispatch(
+            retLexResult, rowsStart, rowsByteSize, sep));
     return ZL_returnSuccess();
 }

--- a/custom_parsers/csv/csv_lexer.h
+++ b/custom_parsers/csv/csv_lexer.h
@@ -14,14 +14,18 @@ extern "C" {
 #endif
 
 typedef struct {
-    size_t nbStrs;
+    // Inputs
     size_t nbColumns;
     uint32_t* stringLens;
     uint16_t* dispatchIndices;
+    size_t* newlineIndices;
+    // Outputs
+    size_t nbNewlines;
+    size_t nbStrs;
 } ZL_CSV_lexResult;
 
 ZL_Report ZL_CSV_lex(
-        ZL_Graph* gctx,
+        ZL_Segmenter* sctx,
         const char* const content,
         size_t byteSize,
         bool hasHeader,
@@ -32,7 +36,7 @@ ZL_Report ZL_CSV_lex(
 // is empty and coalesce the separators together. So we have a result with
 // uneven columns, depending on how many empty values are in each column.
 ZL_Report ZL_CSV_lexNullAware(
-        ZL_Graph* gctx,
+        ZL_Segmenter* sctx,
         const char* const content,
         size_t byteSize,
         bool hasHeader,
@@ -40,18 +44,15 @@ ZL_Report ZL_CSV_lexNullAware(
         ZL_CSV_lexResult* retLexResult);
 
 ZL_Report createParsedCsv(
-        uint32_t* stringLens,
+        ZL_CSV_lexResult* retLexResult,
         const char* content,
         const size_t length,
-        char sep,
-        size_t nbColumns);
+        char sep);
 
 ZL_Report createNullAwareLexAndDispatch(
-        uint32_t* stringLens,
-        uint16_t* dispatchIndices,
+        ZL_CSV_lexResult* retLexResult,
         const char* content,
         const size_t length,
-        uint8_t nbColumns,
         char sep);
 
 #if defined(__cplusplus)

--- a/custom_parsers/csv/csv_parser.c
+++ b/custom_parsers/csv/csv_parser.c
@@ -35,9 +35,6 @@ csvParserGraphFn(ZL_Graph* gctx, ZL_Edge* inputs[], size_t nbInputs)
      * multiple types of line end characters. */
     const ZL_Input* input = ZL_Edge_getData(inputs[0]);
     ZL_RET_R_IF_NE(node_invalid_input, ZL_Input_type(input), ZL_Type_serial);
-    const size_t byteSize     = ZL_Input_contentSize(input);
-    const char* const content = (const char* const)ZL_Input_ptr(input);
-
     // Clustering graph is registered inside as a custom graph
     // Expecting 3 custom graphs right now: clustering, delimiters, header
     // Clustering - (self explanatory)
@@ -46,38 +43,18 @@ csvParserGraphFn(ZL_Graph* gctx, ZL_Edge* inputs[], size_t nbInputs)
     ZL_GraphIDList customGraphs = ZL_Graph_getCustomGraphs(gctx);
     ZL_RET_R_IF_NE(node_invalid_input, customGraphs.nbGraphIDs, 3);
 
-    int hasHeader = ZL_Graph_getLocalIntParam(gctx, ZL_PARSER_HAS_HEADER_PID)
-                            .paramValue;
-    int intSep =
-            ZL_Graph_getLocalIntParam(gctx, ZL_PARSER_SEPARATOR_PID).paramValue;
-    ZL_RET_R_IF(
-            node_invalid_input,
-            (intSep > 255) || (intSep < 0),
-            "Separator must be a char value");
-    char sep = (char)intSep;
-    int useNullAwareParse =
-            ZL_Graph_getLocalIntParam(gctx, ZL_PARSER_USE_NULL_AWARE_PID)
-                    .paramValue;
-    ZL_RET_R_IF(
-            node_invalid_input,
-            (useNullAwareParse != 0) && (useNullAwareParse != 1),
-            "UseNullAware must be 0 or 1");
-
-    ZL_CSV_lexResult lexed = {};
-    ZL_Report lexRes       = (useNullAwareParse)
-                  ? ZL_CSV_lexNullAware(
-                      gctx, content, byteSize, hasHeader, sep, &lexed)
-                  : ZL_CSV_lex(gctx, content, byteSize, hasHeader, sep, &lexed);
-    ZL_RET_R_IF_ERR(lexRes);
+    ZL_RefParam refParam =
+            ZL_Graph_getLocalRefParam(gctx, ZL_CSV_CHUNKED_LEXED_RESULT_ID);
+    const ZL_CSV_lexResult* lexed = (const ZL_CSV_lexResult*)refParam.paramRef;
     // +1 for delimiters and newlines; +1 for header
-    size_t nbOutputs = lexed.nbColumns + 2;
+    size_t nbOutputs = lexed->nbColumns + 2;
 
     // Run newly created Node, collect outputs at intermediate output
     ZL_TRY_LET_T(
             ZL_EdgeList,
             io,
             ZL_Edge_runConvertSerialToStringNode(
-                    inputs[0], lexed.stringLens, lexed.nbStrs));
+                    inputs[0], lexed->stringLens, lexed->nbStrs));
 
     if (0) { // dump these streams for debugging
         const ZL_Input* data = ZL_Edge_getData(io.edges[0]);
@@ -87,18 +64,18 @@ csvParserGraphFn(ZL_Graph* gctx, ZL_Edge* inputs[], size_t nbInputs)
         print(ZL_Input_stringLens(data),
               ZL_Input_numElts(data),
               "/tmp/sdd/psam.streams.strLens");
-        print(lexed.dispatchIndices,
-              lexed.nbStrs,
+        print(lexed->dispatchIndices,
+              lexed->nbStrs,
               "/tmp/sdd/psam.streams.dispatchIndices");
     }
     ZL_TRY_LET_T(
             ZL_EdgeList,
             so,
             ZL_Edge_runDispatchStringNode(
-                    io.edges[0], (int)nbOutputs, lexed.dispatchIndices));
+                    io.edges[0], (int)nbOutputs, lexed->dispatchIndices));
 
     // Set edge tag metadata for identification for clustering to the column
-    for (size_t n = 0; n < lexed.nbColumns; n++) {
+    for (size_t n = 0; n < lexed->nbColumns; n++) {
         ZL_RET_R_IF_ERR(ZL_Edge_setIntMetadata(
                 so.edges[n + 1], ZL_CLUSTERING_TAG_METADATA_ID, (int)n));
     }
@@ -107,42 +84,23 @@ csvParserGraphFn(ZL_Graph* gctx, ZL_Edge* inputs[], size_t nbInputs)
             ZL_Edge_setDestination(so.edges[0], ZL_GRAPH_COMPRESS_GENERIC));
     // columns go to clustering
     ZL_RET_R_IF_ERR(ZL_Edge_setParameterizedDestination(
-            so.edges + 1, lexed.nbColumns, customGraphs.graphids[0], NULL));
+            so.edges + 1, lexed->nbColumns, customGraphs.graphids[0], NULL));
     // Successor for delimiters, whitespace, and newlines
     ZL_RET_R_IF_ERR(ZL_Edge_setDestination(
-            so.edges[lexed.nbColumns + 1], customGraphs.graphids[1]));
+            so.edges[lexed->nbColumns + 1], customGraphs.graphids[1]));
     // Successor for header
     ZL_RET_R_IF_ERR(ZL_Edge_setDestination(
-            so.edges[lexed.nbColumns + 2], customGraphs.graphids[2]));
+            so.edges[lexed->nbColumns + 2], customGraphs.graphids[2]));
     return ZL_returnSuccess();
 }
 
 ZL_GraphID ZL_CsvParser_registerGraph(
         ZL_Compressor* compressor,
-        bool hasHeader,
-        char sep,
-        bool useNullAware,
         const ZL_GraphID clusteringGraph)
 {
     ZL_GraphID* successors = (ZL_GraphID[]){ clusteringGraph,
                                              ZL_GRAPH_COMPRESS_GENERIC,
                                              ZL_GRAPH_COMPRESS_GENERIC };
-    ZL_IntParam* intParams =
-            (ZL_IntParam[]){ {
-                                     .paramId    = ZL_PARSER_HAS_HEADER_PID,
-                                     .paramValue = hasHeader,
-                             },
-                             {
-                                     .paramId    = ZL_PARSER_SEPARATOR_PID,
-                                     .paramValue = sep,
-                             },
-                             {
-                                     .paramId    = ZL_PARSER_USE_NULL_AWARE_PID,
-                                     .paramValue = useNullAware,
-                             } };
-    ZL_LocalParams csvParams = (ZL_LocalParams){
-        .intParams = { .intParams = intParams, .nbIntParams = 3 },
-    };
 
     ZL_GraphID csvParserGraph =
             ZL_Compressor_getGraph(compressor, "CSV Parser");
@@ -164,7 +122,6 @@ ZL_GraphID ZL_CsvParser_registerGraph(
         .graph          = csvParserGraph,
         .customGraphs   = successors,
         .nbCustomGraphs = 3,
-        .localParams    = &csvParams,
     };
     return ZL_Compressor_registerParameterizedGraph(
             compressor, &csvParserGraphDesc);

--- a/custom_parsers/csv/csv_parser.h
+++ b/custom_parsers/csv/csv_parser.h
@@ -10,13 +10,8 @@
 extern "C" {
 #endif
 
-// Parameters for ZL_CsvParser_registerGraph:
-// Set to 1 if the first line is a header line, 0 otherwise
-#define ZL_PARSER_HAS_HEADER_PID 225
-// The character separator between columns. e.g. `,` for comma `|` for pipe
-#define ZL_PARSER_SEPARATOR_PID 226
-// Whether to use the null-aware parser (1) or not (0)
-#define ZL_PARSER_USE_NULL_AWARE_PID 227
+// The parameter for the lexed result to be used
+#define ZL_CSV_CHUNKED_LEXED_RESULT_ID 101
 
 /**
  * @brief Registers the csv parser graph. This graph takes a serialized input
@@ -41,9 +36,6 @@ extern "C" {
  */
 ZL_GraphID ZL_CsvParser_registerGraph(
         ZL_Compressor* compressor,
-        bool hasHeader,
-        char sep,
-        bool useNullAware,
         const ZL_GraphID clusteringGraph);
 
 #if defined(__cplusplus)

--- a/custom_parsers/csv/csv_profile.cpp
+++ b/custom_parsers/csv/csv_profile.cpp
@@ -1,7 +1,7 @@
 // Copyright (c) Meta Platforms, Inc. and affiliates.
 
 #include "custom_parsers/csv/csv_profile.h"
-#include "custom_parsers/csv/csv_parser.h"
+#include "custom_parsers/csv/csv_segmenter.h"
 #include "custom_parsers/shared_components/numeric_graphs.h"
 #include "custom_parsers/shared_components/string_graphs.h"
 #include "openzl/codecs/zl_clustering.h"
@@ -25,11 +25,12 @@ ZL_GraphID ZL_createGraph_genericCSVCompressor(
         ZL_Compressor* compressor) noexcept
 {
     return ZL_createGraph_genericCSVCompressorWithOptions(
-            compressor, true, ',', false);
+            compressor, kDefaultChunkSize, true, ',', false);
 }
 
 ZL_GraphID ZL_createGraph_genericCSVCompressorWithOptions(
         ZL_Compressor* compressor,
+        size_t chunkByteSizeMax,
         bool hasHeader,
         char separator,
         bool useNullAware) noexcept
@@ -115,8 +116,13 @@ ZL_GraphID ZL_createGraph_genericCSVCompressorWithOptions(
                     clusteringCodecs.size());
 
     // TODO support non-comma separators
-    return ZL_CsvParser_registerGraph(
-            compressor, hasHeader, separator, useNullAware, clusteringGraph);
+    return ZL_RES_value(ZL_CsvSegmenter_registerSegmenter(
+            compressor,
+            chunkByteSizeMax,
+            hasHeader,
+            separator,
+            useNullAware,
+            clusteringGraph));
 }
 
 } // namespace openzl::custom_parsers

--- a/custom_parsers/csv/csv_profile.h
+++ b/custom_parsers/csv/csv_profile.h
@@ -7,6 +7,8 @@
 
 namespace openzl::custom_parsers {
 
+const size_t kDefaultChunkSize = 20 * 1000 * 1000;
+
 /**
  * @brief Registers a generic CSV graph where the clustering of the columns is
  * still unconfigured.
@@ -31,6 +33,7 @@ ZL_GraphID ZL_createGraph_genericCSVCompressor(
  */
 ZL_GraphID ZL_createGraph_genericCSVCompressorWithOptions(
         ZL_Compressor* compressor,
+        size_t chunkByteSizeMax,
         bool hasHeader,
         char separator,
         bool useNullAware) noexcept;

--- a/custom_parsers/csv/csv_segmenter.c
+++ b/custom_parsers/csv/csv_segmenter.c
@@ -1,0 +1,206 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#include "custom_parsers/csv/csv_segmenter.h"
+#include "custom_parsers/csv/csv_lexer.h"
+#include "custom_parsers/csv/csv_parser.h"
+#include "openzl/common/assertion.h"
+
+// Parameter to set the chunk size desired during chunking
+#define ZL_CSV_CHUNK_BYTE_SIZE_MAX_ID 100
+// Parameters for ZL_CsvParser_registerGraph:
+// Set to 1 if the first line is a header line, 0 otherwise
+#define ZL_PARSER_HAS_HEADER_PID 225
+// The character separator between columns. e.g. `,` for comma `|` for pipe
+#define ZL_PARSER_SEPARATOR_PID 226
+// Whether to use the null-aware parser (1) or not (0)
+#define ZL_PARSER_USE_NULL_AWARE_PID 227
+
+static ZL_Report SEGM_csvProcessChunk(
+        ZL_Segmenter* sctx,
+        const ZL_CSV_lexResult* lexed,
+        ZL_GraphID headGraph,
+        size_t currentChunkByteSize)
+{
+    ZL_RESULT_DECLARE_SCOPE_REPORT(sctx);
+    ZL_CopyParam cParam = {
+        .paramId   = ZL_CSV_CHUNKED_LEXED_RESULT_ID,
+        .paramPtr  = lexed,
+        .paramSize = sizeof(ZL_CSV_lexResult),
+    };
+    ZL_LocalParams chunkParams = { .copyParams = { .copyParams   = &cParam,
+                                                   .nbCopyParams = 1 } };
+    const ZL_RuntimeGraphParameters gparams = {
+        .localParams = &chunkParams,
+    };
+    ZL_ERR_IF_ERR(ZL_Segmenter_processChunk(
+            sctx, &currentChunkByteSize, 1, headGraph, &gparams));
+    return ZL_returnSuccess();
+}
+
+static ZL_Report SEGM_csv(ZL_Segmenter* sctx)
+{
+    ZL_RESULT_DECLARE_SCOPE_REPORT(sctx);
+    size_t const numInputs = ZL_Segmenter_numInputs(sctx);
+    ZL_ERR_IF_NE(numInputs, 1, node_invalid_input);
+    const ZL_Input* const input = ZL_Segmenter_getInput(sctx, 0);
+    ZL_ASSERT_NN(input);
+    ZL_ERR_IF_NE(ZL_Input_type(input), ZL_Type_serial, node_invalid_input);
+    const size_t byteSize     = ZL_Input_contentSize(input);
+    const char* const content = (const char* const)ZL_Input_ptr(input);
+
+    ZL_GraphIDList const customGraphs = ZL_Segmenter_getCustomGraphs(sctx);
+    ZL_ASSERT_EQ(customGraphs.nbGraphIDs, 1);
+    ZL_GraphID const headGraph = customGraphs.graphids[0];
+    // Note: assumes a positive chunkByteSizeMax is passed in.
+    size_t chunkByteSizeMax = (size_t)ZL_Segmenter_getLocalIntParam(
+                                      sctx, ZL_CSV_CHUNK_BYTE_SIZE_MAX_ID)
+                                      .paramValue;
+    int hasHeader =
+            ZL_Segmenter_getLocalIntParam(sctx, ZL_PARSER_HAS_HEADER_PID)
+                    .paramValue;
+    int intSep = ZL_Segmenter_getLocalIntParam(sctx, ZL_PARSER_SEPARATOR_PID)
+                         .paramValue;
+    ZL_ERR_IF(
+            (intSep > 255) || (intSep < 0),
+            node_invalid_input,
+            "Separator must be a char value");
+    char sep = (char)intSep;
+    int useNullAwareParse =
+            ZL_Segmenter_getLocalIntParam(sctx, ZL_PARSER_USE_NULL_AWARE_PID)
+                    .paramValue;
+    ZL_ERR_IF(
+            (useNullAwareParse != 0) && (useNullAwareParse != 1),
+            node_invalid_input,
+            "UseNullAware must be 0 or 1");
+
+    ZL_CSV_lexResult lexed = {};
+    ZL_Report lexRes       = (useNullAwareParse)
+                  ? ZL_CSV_lexNullAware(
+                      sctx, content, byteSize, hasHeader, sep, &lexed)
+                  : ZL_CSV_lex(sctx, content, byteSize, hasHeader, sep, &lexed);
+    ZL_ERR_IF_ERR(lexRes);
+
+    // Can pick a subset of lexed result to pass in as local params
+    size_t numElts     = ZL_Input_numElts(input);
+    size_t prevIdx     = 0;
+    size_t rowByteSize = 0;
+    if (lexed.nbNewlines > 0) { // Can do chunking
+        // Chunk must contain at least one row
+        for (size_t start = 0; start <= lexed.newlineIndices[0]; start++) {
+            rowByteSize += lexed.stringLens[start];
+        }
+        size_t currentChunkByteSize = rowByteSize;
+        for (size_t row = 1; row < lexed.nbNewlines; row++) {
+            rowByteSize = 0;
+            for (size_t start = lexed.newlineIndices[row - 1] + 1;
+                 start <= lexed.newlineIndices[row];
+                 start++) {
+                rowByteSize += lexed.stringLens[start];
+            }
+            if (currentChunkByteSize + rowByteSize > chunkByteSizeMax) {
+                ZL_CSV_lexResult chunkedLex = {
+                    .nbStrs     = lexed.newlineIndices[row - 1] - prevIdx + 1,
+                    .nbColumns  = lexed.nbColumns,
+                    .stringLens = lexed.stringLens + prevIdx,
+                    .dispatchIndices = lexed.dispatchIndices + prevIdx,
+                };
+                ZL_ERR_IF_ERR(SEGM_csvProcessChunk(
+                        sctx, &chunkedLex, headGraph, currentChunkByteSize));
+                numElts -= currentChunkByteSize;
+                currentChunkByteSize = 0;
+                prevIdx              = lexed.newlineIndices[row - 1] + 1;
+            }
+            currentChunkByteSize += rowByteSize;
+        }
+    }
+    ZL_CSV_lexResult chunkedLex = {
+        .nbStrs          = lexed.nbStrs - prevIdx,
+        .nbColumns       = lexed.nbColumns,
+        .stringLens      = lexed.stringLens + prevIdx,
+        .dispatchIndices = lexed.dispatchIndices + prevIdx,
+    };
+    ZL_ERR_IF_ERR(SEGM_csvProcessChunk(sctx, &chunkedLex, headGraph, numElts));
+    return ZL_returnSuccess();
+}
+
+ZL_RESULT_OF(ZL_GraphID)
+ZL_CsvSegmenter_registerSegmenter(
+        ZL_Compressor* compressor,
+        size_t chunkByteSizeMax,
+        bool hasHeader,
+        char sep,
+        bool useNullAware,
+        const ZL_GraphID clusteringGraph)
+{
+    ZL_RESULT_DECLARE_SCOPE(ZL_GraphID, compressor);
+    ZL_GraphID csvGraph =
+            ZL_CsvParser_registerGraph(compressor, clusteringGraph);
+
+    ZL_IntParam intParams[]  = { {
+                                         .paramId    = ZL_PARSER_HAS_HEADER_PID,
+                                         .paramValue = hasHeader,
+                                },
+                                 {
+                                         .paramId    = ZL_PARSER_SEPARATOR_PID,
+                                         .paramValue = sep,
+                                },
+                                 {
+                                         .paramId = ZL_PARSER_USE_NULL_AWARE_PID,
+                                         .paramValue = useNullAware,
+                                },
+                                 {
+                                         .paramId =
+                                                ZL_CSV_CHUNK_BYTE_SIZE_MAX_ID,
+                                         .paramValue = (int)chunkByteSizeMax,
+                                } };
+    ZL_LocalParams csvParams = (ZL_LocalParams){
+        .intParams = { .intParams = intParams, .nbIntParams = 4 },
+    };
+    ZL_Type inputType = ZL_Type_serial;
+    ZL_GraphID segmenterBase =
+            ZL_Compressor_getGraph(compressor, "CSV Segmenter");
+    if (segmenterBase.gid == ZL_GRAPH_ILLEGAL.gid) {
+        ZL_SegmenterDesc desc = {
+            .name                = "!CSV Segmenter",
+            .segmenterFn         = SEGM_csv,
+            .inputTypeMasks      = &inputType,
+            .numInputs           = 1,
+            .lastInputIsVariable = false,
+            .customGraphs        = NULL,
+            .numCustomGraphs     = 0,
+            .localParams         = {},
+        };
+        segmenterBase = ZL_Compressor_registerSegmenter(compressor, &desc);
+    }
+    ZL_ParameterizedGraphDesc const csvGraphDesc = {
+        .graph          = segmenterBase,
+        .localParams    = &csvParams,
+        .customGraphs   = &csvGraph,
+        .nbCustomGraphs = 1,
+    };
+    ZL_GraphID segmenter =
+            ZL_Compressor_registerParameterizedGraph(compressor, &csvGraphDesc);
+    ZL_ERR_IF_EQ(
+            segmenter.gid,
+            ZL_GRAPH_ILLEGAL.gid,
+            GENERIC,
+            "Graph parameterization failed");
+    return ZL_RESULT_WRAP_VALUE(ZL_GraphID, segmenter);
+}
+
+ZL_RESULT_OF(ZL_GraphID)
+ZL_CsvSegmenter_registerSegmenterNoChunks(
+        ZL_Compressor* compressor,
+        bool hasHeader,
+        char sep,
+        bool useNullAware,
+        const ZL_GraphID clusteringGraph)
+{
+    return ZL_CsvSegmenter_registerSegmenter(
+            compressor,
+            SIZE_MAX,
+            hasHeader,
+            sep,
+            useNullAware,
+            clusteringGraph);
+}

--- a/custom_parsers/csv/csv_segmenter.h
+++ b/custom_parsers/csv/csv_segmenter.h
@@ -1,0 +1,37 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#ifndef ZSTRONG_COMPRESS_SEGMENTERS_CSV_H
+#define ZSTRONG_COMPRESS_SEGMENTERS_CSV_H
+
+#include "openzl/shared/portability.h"
+#include "openzl/zl_segmenter.h"
+
+ZL_BEGIN_C_DECLS
+
+/**
+ * Registers the csv graph with a segmenter and returns the graph ID or error if
+ * failed.
+ *
+ * @param chunkByteSizeMax The maximum size of a chunk in bytes requested.
+ * @param clusterGraph The graph ID of the clustering graph to use.
+ */
+ZL_RESULT_OF(ZL_GraphID)
+ZL_CsvSegmenter_registerSegmenter(
+        ZL_Compressor* compressor,
+        size_t chunkByteSizeMax,
+        bool hasHeader,
+        char sep,
+        bool useNullAware,
+        const ZL_GraphID clusteringGraph);
+
+ZL_RESULT_OF(ZL_GraphID)
+ZL_CsvSegmenter_registerSegmenterNoChunks(
+        ZL_Compressor* compressor,
+        bool hasHeader,
+        char sep,
+        bool useNullAware,
+        const ZL_GraphID clusteringGraph);
+
+ZL_END_C_DECLS
+
+#endif // ZSTRONG_COMPRESS_SEGMENTERS_CSV_H

--- a/custom_parsers/csv/tests/BUCK
+++ b/custom_parsers/csv/tests/BUCK
@@ -6,9 +6,14 @@ oncall("data_compression")
 
 zs_unittest(
     name = "test",
-    srcs = ["lex_test.cpp"],
+    srcs = [
+        "lex_test.cpp",
+        "segmenter_test.cpp",
+    ],
     deps = [
+        "//data_compression/experimental/zstrong/cpp:openzl_cpp",
         "//data_compression/experimental/zstrong/custom_parsers/csv:csv_parser",
+        "//data_compression/experimental/zstrong/tests:utils",
     ],
 )
 
@@ -18,6 +23,21 @@ zs_fuzzers(
     ],
     ftest_names = [
         ("CsvLexerTest", "RandomInputFuzzer"),
+    ],
+    deps = [
+        "fbsource//xplat/security/lionhead/utils/lib_ftest:lib",
+        "//data_compression/experimental/zstrong/cpp:openzl_cpp",
+        "//data_compression/experimental/zstrong/custom_parsers/csv:csv_parser",
+        "//data_compression/experimental/zstrong/tests/datagen:datagen",
+    ],
+)
+
+zs_fuzzers(
+    srcs = [
+        "CsvSegmenterFuzzer.cpp",
+    ],
+    ftest_names = [
+        ("CsvSegmenterTest", "RandomInputFuzzer"),
     ],
     deps = [
         "fbsource//xplat/security/lionhead/utils/lib_ftest:lib",

--- a/custom_parsers/csv/tests/CsvSegmenterFuzzer.cpp
+++ b/custom_parsers/csv/tests/CsvSegmenterFuzzer.cpp
@@ -1,0 +1,56 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#include <gtest/gtest.h>
+#include "security/lionhead/utils/lib_ftest/fdp/fdp/fdp_impl.h"
+#include "security/lionhead/utils/lib_ftest/ftest.h"
+
+#include "custom_parsers/csv/csv_profile.h"
+#include "openzl/openzl.hpp"
+#include "tests/datagen/random_producer/LionheadFDPWrapper.h"
+
+using namespace ::testing;
+using namespace facebook::security::lionhead::fdp;
+using zstrong::tests::datagen::LionheadFDPWrapper;
+
+namespace openzl::custom_parsers {
+
+class CsvSegmenterTest : public ::testing::Test {
+   protected:
+    void roundtrip(std::string_view input)
+    {
+        std::string compressed;
+        try {
+            compressed = cctx_.compressSerial(input);
+        } catch (openzl::Exception&) {
+            return;
+        }
+        auto regen = dctx_.decompressSerial(compressed);
+        ASSERT_EQ(regen, input);
+    }
+
+    CCtx cctx_{};
+    DCtx dctx_{};
+    Compressor compressor_{};
+};
+
+template <class HarnessMode>
+LionheadFDPWrapper<StructuredFDP<HarnessMode>> rwFromFDP(
+        StructuredFDP<HarnessMode>& fdp)
+{
+    return LionheadFDPWrapper<StructuredFDP<HarnessMode>>(fdp);
+}
+
+FUZZ_F(CsvSegmenterTest, RandomInputFuzzer)
+{
+    auto rw        = rwFromFDP(f);
+    auto chunkSize = rw.u32_range("chunkSize", 200, 50000);
+    auto input     = rw.all_remaining_bytes();
+    auto gid       = ZL_createGraph_genericCSVCompressorWithOptions(
+            compressor_.get(), chunkSize, false, ',', false);
+    compressor_.selectStartingGraph(gid);
+    cctx_.setParameter(CParam::FormatVersion, ZL_MAX_FORMAT_VERSION);
+    cctx_.refCompressor(compressor_);
+    roundtrip(std::string_view((const char*)input.data(), input.size()));
+}
+
+} // namespace openzl::custom_parsers

--- a/custom_parsers/csv/tests/lex_test.cpp
+++ b/custom_parsers/csv/tests/lex_test.cpp
@@ -4,6 +4,7 @@
 
 #include "custom_parsers/csv/csv_lexer.h"
 #include "openzl/zl_errors.h"
+#include "tests/utils.h"
 
 using namespace ::testing;
 
@@ -16,7 +17,9 @@ H,2019GQ0000153,6,00800,3,01,1195583,1207712,0,1,3,,,,,,,,,,,,,2,,,,,,,,,,,,,,,,
 )";
 
     // clang-format off
-    constexpr std::array<uint32_t, 558> expectedStrLens = {
+    constexpr std::array<uint32_t, 559> expectedStrLens = { 
+    // Header
+    0,
     // row 1
     1, 1, 13, 1, 1, 1, 5, 1, 1, 1, 2, 1, 7, 1, 7, 1, 1, 1, 1, 1, 1, 13, 1, 91, 1, 43, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
     // row 2
@@ -25,25 +28,27 @@ H,2019GQ0000153,6,00800,3,01,1195583,1207712,0,1,3,,,,,,,,,,,,,2,,,,,,,,,,,,,,,,
     1, 1, 13, 1, 1, 1, 5, 1, 1, 1, 2, 1, 7, 1, 7, 1, 1, 1, 1, 1, 1, 13, 1, 91, 1, 43, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
     };
 
-    constexpr std::array<uint16_t, 558> expectedDispatchIndices = {
-    0, 237, 1, 237, 2, 237, 3, 237, 4, 237, 5, 237, 6, 237, 7, 237, 8, 237, 9, 237, 10, 237, 23, 237, 114, 237, 157, 237, 158, 237, 159, 237, 160, 237, 161, 237, 162, 237, 163, 237, 164, 237, 165, 237, 166, 237, 167, 237, 168, 237, 169, 237, 170, 237, 171, 237, 172, 237, 173, 237, 174, 237, 175, 237, 176, 237, 177, 237, 178, 237, 179, 237, 180, 237, 181, 237, 182, 237, 183, 237, 184, 237, 185, 237, 186, 237, 187, 237, 188, 237, 189, 237, 190, 237, 191, 237, 192, 237, 193, 237, 194, 237, 195, 237, 196, 237, 197, 237, 198, 237, 199, 237, 200, 237, 201, 237, 202, 237, 203, 237, 204, 237, 205, 237, 206, 237, 207, 237, 208, 237, 209, 237, 210, 237, 211, 237, 212, 237, 213, 237, 214, 237, 215, 237, 216, 237, 217, 237, 218, 237, 219, 237, 220, 237, 221, 237, 222, 237, 223, 237, 224, 237, 225, 237, 226, 237, 227, 237, 228, 237, 229, 237, 230, 237, 231, 237, 232, 237, 233, 237, 234, 237, 235, 237, 236, 237,
+    constexpr std::array<uint16_t, 559> expectedDispatchIndices = {
+    0, 0, 237, 1, 237, 2, 237, 3, 237, 4, 237, 5, 237, 6, 237, 7, 237, 8, 237, 9, 237, 10, 237, 23, 237, 114, 237, 157, 237, 158, 237, 159, 237, 160, 237, 161, 237, 162, 237, 163, 237, 164, 237, 165, 237, 166, 237, 167, 237, 168, 237, 169, 237, 170, 237, 171, 237, 172, 237, 173, 237, 174, 237, 175, 237, 176, 237, 177, 237, 178, 237, 179, 237, 180, 237, 181, 237, 182, 237, 183, 237, 184, 237, 185, 237, 186, 237, 187, 237, 188, 237, 189, 237, 190, 237, 191, 237, 192, 237, 193, 237, 194, 237, 195, 237, 196, 237, 197, 237, 198, 237, 199, 237, 200, 237, 201, 237, 202, 237, 203, 237, 204, 237, 205, 237, 206, 237, 207, 237, 208, 237, 209, 237, 210, 237, 211, 237, 212, 237, 213, 237, 214, 237, 215, 237, 216, 237, 217, 237, 218, 237, 219, 237, 220, 237, 221, 237, 222, 237, 223, 237, 224, 237, 225, 237, 226, 237, 227, 237, 228, 237, 229, 237, 230, 237, 231, 237, 232, 237, 233, 237, 234, 237, 235, 237, 236, 237,
     0, 237, 1, 237, 2, 237, 3, 237, 4, 237, 5, 237, 6, 237, 7, 237, 8, 237, 9, 237, 10, 237, 23, 237, 114, 237, 157, 237, 158, 237, 159, 237, 160, 237, 161, 237, 162, 237, 163, 237, 164, 237, 165, 237, 166, 237, 167, 237, 168, 237, 169, 237, 170, 237, 171, 237, 172, 237, 173, 237, 174, 237, 175, 237, 176, 237, 177, 237, 178, 237, 179, 237, 180, 237, 181, 237, 182, 237, 183, 237, 184, 237, 185, 237, 186, 237, 187, 237, 188, 237, 189, 237, 190, 237, 191, 237, 192, 237, 193, 237, 194, 237, 195, 237, 196, 237, 197, 237, 198, 237, 199, 237, 200, 237, 201, 237, 202, 237, 203, 237, 204, 237, 205, 237, 206, 237, 207, 237, 208, 237, 209, 237, 210, 237, 211, 237, 212, 237, 213, 237, 214, 237, 215, 237, 216, 237, 217, 237, 218, 237, 219, 237, 220, 237, 221, 237, 222, 237, 223, 237, 224, 237, 225, 237, 226, 237, 227, 237, 228, 237, 229, 237, 230, 237, 231, 237, 232, 237, 233, 237, 234, 237, 235, 237, 236, 237,
     0, 237, 1, 237, 2, 237, 3, 237, 4, 237, 5, 237, 6, 237, 7, 237, 8, 237, 9, 237, 10, 237, 23, 237, 114, 237, 157, 237, 158, 237, 159, 237, 160, 237, 161, 237, 162, 237, 163, 237, 164, 237, 165, 237, 166, 237, 167, 237, 168, 237, 169, 237, 170, 237, 171, 237, 172, 237, 173, 237, 174, 237, 175, 237, 176, 237, 177, 237, 178, 237, 179, 237, 180, 237, 181, 237, 182, 237, 183, 237, 184, 237, 185, 237, 186, 237, 187, 237, 188, 237, 189, 237, 190, 237, 191, 237, 192, 237, 193, 237, 194, 237, 195, 237, 196, 237, 197, 237, 198, 237, 199, 237, 200, 237, 201, 237, 202, 237, 203, 237, 204, 237, 205, 237, 206, 237, 207, 237, 208, 237, 209, 237, 210, 237, 211, 237, 212, 237, 213, 237, 214, 237, 215, 237, 216, 237, 217, 237, 218, 237, 219, 237, 220, 237, 221, 237, 222, 237, 223, 237, 224, 237, 225, 237, 226, 237, 227, 237, 228, 237, 229, 237, 230, 237, 231, 237, 232, 237, 233, 237, 234, 237, 235, 237, 236, 237,
     };
 
+    std::vector<size_t> expectedNewlines = { 186, 372, 558 };
     // clang-format on
     std::vector<uint32_t> stringLens(1100, 0);
     std::vector<uint16_t> dispatchIndices(1100, 0);
     uint8_t nbColumns = 237;
     char sep          = ',';
 
-    auto e = createNullAwareLexAndDispatch(
-            stringLens.data(),
-            dispatchIndices.data(),
-            str.data(),
-            str.length(),
-            nbColumns,
-            sep);
+    std::vector<size_t> newLines(1100, 0);
+    ZL_CSV_lexResult lexResult;
+    lexResult.stringLens      = stringLens.data();
+    lexResult.dispatchIndices = dispatchIndices.data();
+    lexResult.nbColumns       = nbColumns;
+    lexResult.newlineIndices  = newLines.data();
+    auto e                    = createNullAwareLexAndDispatch(
+            &lexResult, str.data(), str.length(), sep);
     EXPECT_FALSE(ZL_isError(e));
     size_t nbStrs = ZL_validResult(e);
     EXPECT_EQ(nbStrs, expectedStrLens.size());
@@ -53,33 +58,33 @@ H,2019GQ0000153,6,00800,3,01,1195583,1207712,0,1,3,,,,,,,,,,,,,2,,,,,,,,,,,,,,,,
     for (size_t i = 0; i < nbStrs; ++i) {
         EXPECT_EQ(expectedDispatchIndices[i], dispatchIndices[i]);
     }
+    newLines.resize(lexResult.nbNewlines);
+    EXPECT_EQ(expectedNewlines, newLines);
 }
 
 TEST(LexTest, singleLine)
 {
-    std::string inputNoNewline                     = "aaa,bb,c,\"d\"";
-    std::string input                              = inputNoNewline + "\n";
-    std::vector<uint32_t> expectedStringLens       = { 3, 1, 2, 1, 1, 1, 3, 1 };
-    std::vector<uint16_t> expectedDispatchIndicess = { 0, 4, 1, 4, 2, 4, 3, 4 };
+    std::string inputNoNewline               = "aaa,bb,c,\"d\"";
+    std::string input                        = inputNoNewline + "\n";
+    std::vector<uint32_t> expectedStringLens = { 0, 3, 1, 2, 1, 1, 1, 3, 1 };
+    std::vector<uint16_t> expectedDispatchIndicess = {
+        0, 0, 4, 1, 4, 2, 4, 3, 4
+    };
     std::vector<uint32_t> stringLens(100, 0);
     std::vector<uint16_t> dispatchIndices(100, 0);
+    std::vector<size_t> newLines(1100, 0);
+    ZL_CSV_lexResult lexResult;
+    lexResult.stringLens      = stringLens.data();
+    lexResult.dispatchIndices = dispatchIndices.data();
+    lexResult.nbColumns       = 4;
+    lexResult.newlineIndices  = newLines.data();
 
     auto e = createNullAwareLexAndDispatch(
-            stringLens.data(),
-            dispatchIndices.data(),
-            inputNoNewline.data(),
-            inputNoNewline.size(),
-            4,
-            ',');
+            &lexResult, inputNoNewline.data(), inputNoNewline.size(), ',');
     EXPECT_TRUE(ZL_isError(e));
 
     e = createNullAwareLexAndDispatch(
-            stringLens.data(),
-            dispatchIndices.data(),
-            input.data(),
-            input.size(),
-            4,
-            ',');
+            &lexResult, input.data(), input.size(), ',');
     EXPECT_FALSE(ZL_isError(e));
     size_t nbStrs = ZL_validResult(e);
     EXPECT_EQ(nbStrs, expectedStringLens.size());
@@ -94,11 +99,16 @@ TEST(LexTest, singleLine)
 TEST(LexTest, singlePairOfQuotes)
 {
     std::string input                        = "aaa,\"\",\"\"\n";
-    std::vector<uint32_t> expectedStringLens = { 3, 1, 2, 1, 2, 1 };
+    std::vector<uint32_t> expectedStringLens = { 0, 3, 1, 2, 1, 2, 1 };
     std::vector<uint32_t> stringLens(100, 0);
+    std::vector<size_t> newLines(100, 0);
 
-    auto e = createParsedCsv(
-            stringLens.data(), input.data(), input.size(), ',', 3);
+    ZL_CSV_lexResult lexResult;
+    lexResult.stringLens     = stringLens.data();
+    lexResult.nbColumns      = 3;
+    lexResult.newlineIndices = newLines.data();
+
+    auto e = createParsedCsv(&lexResult, input.data(), input.size(), ',');
     EXPECT_FALSE(ZL_isError(e));
     size_t nbStrs = ZL_validResult(e);
     EXPECT_EQ(nbStrs, expectedStringLens.size());
@@ -111,16 +121,37 @@ TEST(LexTest, multiplePairsOfQuotes)
 {
     std::string input =
             "aaa,\"\",\"\",\"\",\"\",\"\",\"\"\"\",\"\",\"\"\"\"\",\"\n";
-    std::vector<uint32_t> expectedStringLens = { 3, 1, 2, 1, 2, 1, 2, 1, 2,
+    std::vector<uint32_t> expectedStringLens = { 0, 3, 1, 2, 1, 2, 1, 2, 1, 2,
                                                  1, 2, 1, 4, 1, 2, 1, 7, 1 };
     std::vector<uint32_t> stringLens(100, 0);
+    std::vector<size_t> newLines(100, 0);
 
-    auto e = createParsedCsv(
-            stringLens.data(), input.data(), input.size(), ',', 9);
+    ZL_CSV_lexResult lexResult;
+    lexResult.stringLens     = stringLens.data();
+    lexResult.nbColumns      = 9;
+    lexResult.newlineIndices = newLines.data();
+
+    auto e = createParsedCsv(&lexResult, input.data(), input.size(), ',');
     EXPECT_FALSE(ZL_isError(e));
     size_t nbStrs = ZL_validResult(e);
     EXPECT_EQ(nbStrs, expectedStringLens.size());
     for (size_t i = 0; i < nbStrs; ++i) {
         EXPECT_EQ(expectedStringLens[i], stringLens[i]);
     }
+}
+
+TEST(LexTest, newLineInQuotes)
+{
+    std::string input                    = "a, ,\"\n\",a \n b, , ,b \n";
+    std::vector<size_t> expectedNewLines = { 8, 16 };
+    std::vector<size_t> newLines(100, 0);
+    std::vector<uint32_t> stringLens(100, 0);
+    ZL_CSV_lexResult lexResult;
+    lexResult.stringLens     = stringLens.data();
+    lexResult.nbColumns      = 4;
+    lexResult.newlineIndices = newLines.data();
+    EXPECT_ZS_VALID(
+            createParsedCsv(&lexResult, input.data(), input.size(), ','));
+    newLines.resize(lexResult.nbNewlines);
+    EXPECT_EQ(newLines, expectedNewLines);
 }

--- a/custom_parsers/csv/tests/segmenter_test.cpp
+++ b/custom_parsers/csv/tests/segmenter_test.cpp
@@ -1,0 +1,125 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#include <gtest/gtest.h>
+
+#include "custom_parsers/csv/csv_profile.h"
+#include "openzl/openzl.hpp"
+#include "openzl/zl_errors.h"
+#include "openzl/zl_reflection.h"
+
+#include "openzl/cpp/CompressIntrospectionHooks.hpp"
+
+using namespace ::testing;
+
+namespace openzl::custom_parsers {
+class CsvSegmenterUnitTest : public ::testing::Test {
+   public:
+    void SetUp() override
+    {
+        auto gid = ZL_createGraph_genericCSVCompressorWithOptions(
+                compressor_.get(), kChunkSize, true, ',', true);
+        compressor_.selectStartingGraph(gid);
+        cctx_.setParameter(CParam::FormatVersion, ZL_MAX_FORMAT_VERSION);
+        cctx_.refCompressor(compressor_);
+    }
+
+    void roundtrip(std::string_view input)
+    {
+        std::string compressed(10000, '\0');
+        auto csize = cctx_.compressSerial(compressed, input);
+        compressed.resize(csize);
+        auto regen = dctx_.decompressSerial(compressed);
+        ASSERT_EQ(regen, input);
+    }
+
+   protected:
+    const size_t kChunkSize = 500;
+    CCtx cctx_{};
+    DCtx dctx_{};
+    Compressor compressor_{};
+};
+
+class CsvSegmentTestingReaderHook : public CompressIntrospectionHooks {
+   public:
+    explicit CsvSegmentTestingReaderHook(std::string_view targetName)
+            : CompressIntrospectionHooks(), targetName_(targetName)
+    {
+    }
+
+    void on_migraphEncode_start(
+            ZL_Graph* gctx,
+            const ZL_Compressor* compressor,
+            ZL_GraphID gid,
+            ZL_Edge* inputs[],
+            size_t nbInputs) override
+    {
+        std::string graphName = ZL_Compressor_Graph_getName(compressor, gid);
+        if (graphName.size() == 0 || graphName != targetName_) {
+            return;
+        }
+        EXPECT_EQ(nbInputs, 1);
+        auto input = ZL_Edge_getData(inputs[0]);
+        inputs_.emplace_back(
+                (const char*)ZL_Input_ptr(input), ZL_Input_numElts(input));
+    }
+
+    std::vector<std::string> getInputs() const
+    {
+        return inputs_;
+    }
+
+   private:
+    std::string_view targetName_;
+    std::vector<std::string> inputs_;
+};
+
+TEST_F(CsvSegmenterUnitTest, FixedCsvInputRoundTrip)
+{
+    constexpr std::string_view str =
+            R"(H,2019GQ0000088,6,02600,3,01,1195583,1207712,0,1,3,,,,,,,,,,,,,1,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,0,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0
+H,2019GQ0000096,6,00700,3,01,1195583,1207712,0,1,2,,,,,,,,,,,,,2,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,0,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0
+H,2019GQ0000153,6,00800,3,01,1195583,1207712,0,1,3,,,,,,,,,,,,,2,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,0,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0
+)";
+    roundtrip(str);
+}
+
+TEST_F(CsvSegmenterUnitTest, SegmenterGraphIsSerializable)
+{
+    auto serialized = compressor_.serialize();
+    Compressor newCompressor;
+    // Make it so that the graph ID is different from originally
+    newCompressor.parameterizeGraph(ZL_GRAPH_CONSTANT, {});
+    ZL_createGraph_genericCSVCompressor(newCompressor.get());
+    newCompressor.deserialize(serialized);
+}
+
+TEST_F(CsvSegmenterUnitTest, SegmenterDividesInputAsExpected)
+{
+    constexpr std::string_view str =
+            R"(H,2019GQ0000088,6,02600,3,01,1195583,1207712,0,1,3,,,,,,,,,,,,,1,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,0,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0
+H,2019GQ0000096,6,00700,3,01,1195583,1207712,0,1,2,,,,,,,,,,,,,2,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,0,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0
+H,2019GQ0000153,6,00800,3,01,1195583,1207712,0,1,3,,,,,,,,,,,,,2,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,0,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0
+)";
+    constexpr std::string_view chunk1 =
+            R"(H,2019GQ0000088,6,02600,3,01,1195583,1207712,0,1,3,,,,,,,,,,,,,1,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,0,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0
+H,2019GQ0000096,6,00700,3,01,1195583,1207712,0,1,2,,,,,,,,,,,,,2,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,0,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0
+)";
+    constexpr std::string_view chunk2 =
+            R"(H,2019GQ0000153,6,00800,3,01,1195583,1207712,0,1,3,,,,,,,,,,,,,2,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,0,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0
+)";
+    // We want to read what is passed in the csv parser. The name happens to
+    // have suffix #12 based on registration ordering.
+    CsvSegmentTestingReaderHook hook("CSV Parser#12");
+    ZL_CompressIntrospectionHooks* rawHooks = hook.getRawHooks();
+    openzl::unwrap(
+            ZL_CCtx_attachIntrospectionHooks(cctx_.get(), rawHooks),
+            "Failed to attach introspection hooks",
+            cctx_.get());
+    std::string compressed(10000, '\0');
+    cctx_.compressSerial(compressed, str);
+    auto chunks = hook.getInputs();
+    EXPECT_EQ(chunks[0], chunk1);
+    EXPECT_EQ(chunks[1], chunk2);
+}
+
+} // namespace openzl::custom_parsers

--- a/custom_parsers/tests/csv_main.cpp
+++ b/custom_parsers/tests/csv_main.cpp
@@ -6,7 +6,7 @@
 #include <map>
 #include <sstream>
 #include <vector>
-#include "custom_parsers/csv/csv_parser.h"
+#include "custom_parsers/csv/csv_segmenter.h"
 #include "custom_parsers/shared_components/numeric_graphs.h"
 #include "custom_parsers/shared_components/string_graphs.h"
 #include "custom_parsers/tests/DebugIntrospectionHooks.h"
@@ -102,8 +102,8 @@ class TPC_H_lineitem : public Config {
                 &clusteringConfig,
                 successors.data(),
                 successors.size());
-        return ZL_CsvParser_registerGraph(
-                compressor, true, '|', false, clusteringGraph);
+        return ZL_RES_value(ZL_CsvSegmenter_registerSegmenterNoChunks(
+                compressor, true, '|', false, clusteringGraph));
     }
 };
 
@@ -390,8 +390,8 @@ class PsamH01 : public Config {
                 &clusteringConfig,
                 successors.data(),
                 successors.size());
-        auto ee = ZL_CsvParser_registerGraph(
-                compressor, true, ',', UseNullAware, clusteringGraph);
+        auto ee = ZL_RES_value(ZL_CsvSegmenter_registerSegmenterNoChunks(
+                compressor, true, ',', UseNullAware, clusteringGraph));
         if (ee.gid == ZL_GRAPH_ILLEGAL.gid) {
             std::cerr << "illegal graph!" << std::endl;
             exit(1);
@@ -530,8 +530,8 @@ class PPMF_Unit : public Config {
                 &clusteringConfig,
                 successors.data(),
                 successors.size());
-        auto ee = ZL_CsvParser_registerGraph(
-                compressor, true, ',', false, clusteringGraph);
+        auto ee = ZL_RES_value(ZL_CsvSegmenter_registerSegmenterNoChunks(
+                compressor, true, ',', false, clusteringGraph));
         if (ee.gid == ZL_GRAPH_ILLEGAL.gid) {
             std::cerr << "illegal graph!" << std::endl;
             exit(1);
@@ -662,8 +662,8 @@ class PPMF_Person : public Config {
                 &clusteringConfig,
                 successors.data(),
                 successors.size());
-        auto ee = ZL_CsvParser_registerGraph(
-                compressor, true, ',', false, clusteringGraph);
+        auto ee = ZL_RES_value(ZL_CsvSegmenter_registerSegmenterNoChunks(
+                compressor, true, ',', false, clusteringGraph));
         if (ee.gid == ZL_GRAPH_ILLEGAL.gid) {
             std::cerr << "illegal graph!" << std::endl;
             exit(1);

--- a/custom_parsers/tests/test_clustering.cpp
+++ b/custom_parsers/tests/test_clustering.cpp
@@ -2,7 +2,7 @@
 
 #include <gtest/gtest.h>
 
-#include "custom_parsers/csv/csv_parser.h"
+#include "custom_parsers/csv/csv_segmenter.h"
 #include "custom_parsers/tests/DebugIntrospectionHooks.h"
 #include "openzl/common/a1cbor_helpers.h"
 #include "openzl/common/assertion.h"
@@ -53,8 +53,8 @@ class TestClusteringGraph : public testing::Test {
                 successors_.data(),
                 successors_.size());
 
-        return ZL_CsvParser_registerGraph(
-                cgraph, true, ',', false, clusteringGraph);
+        return ZL_RES_value(ZL_CsvSegmenter_registerSegmenterNoChunks(
+                cgraph, true, ',', false, clusteringGraph));
     }
 
     size_t compress(


### PR DESCRIPTION
Summary:
Create csv segmenter and add this into tests. This can be added into cli after some fuzzing has been run.

Followup:
- Allow users to choose a chunk size instead of defaulting to 20MB in zli

Reviewed By: terrelln

Differential Revision: D85455810


