### PR TITLE
Add chunk size as an argument for training

### DIFF
--- a/cli/args/ArgsUtils.cpp
+++ b/cli/args/ArgsUtils.cpp
@@ -36,20 +36,19 @@ void checkOutput(const std::string& path, bool force)
 }
 
 std::unique_ptr<Compressor> createCompressorFromArgs(
-        const std::optional<std::string>& profileName,
-        const std::optional<std::string>& profileArg,
+        const ProfileArgs& profileArgs,
         const std::optional<std::string>& compressorPath)
 {
-    if (profileName && compressorPath) {
+    if (profileArgs.name() && compressorPath) {
         throw InvalidArgsException(
                 "Both compressor profile and serialized compressor specified. Please provide only one.");
     }
 
-    if (profileName) {
-        ProfileArgs profileArgs;
-        profileArgs.name = profileName.value();
-        if (profileArg) {
-            profileArgs.argmap.emplace("TBD", profileArg.value());
+    if (profileArgs.name()) {
+        if (profileArgs.chunkSize()) {
+            Logger::log(
+                    INFO,
+                    "Chunking is not currently implemented for all profiles. Ignoring size parameter if unimplemented.\nChunking is implemented for the following profiles: csv");
         }
         return util::createCompressorFromProfile(profileArgs);
     }

--- a/cli/args/ArgsUtils.h
+++ b/cli/args/ArgsUtils.h
@@ -4,6 +4,7 @@
 
 #include <string>
 
+#include "cli/utils/compress_profiles.h"
 #include "openzl/cpp/Compressor.hpp"
 
 namespace openzl {
@@ -18,8 +19,7 @@ void checkOutput(const std::string& path, bool force);
  * created compressor.
  */
 std::unique_ptr<Compressor> createCompressorFromArgs(
-        const std::optional<std::string>& profileName,
-        const std::optional<std::string>& profileArg,
+        const ProfileArgs& profileArgs,
         const std::optional<std::string>& compressorPath);
 
 } // namespace cli

--- a/cli/args/BenchmarkArgs.h
+++ b/cli/args/BenchmarkArgs.h
@@ -17,7 +17,7 @@
 
 namespace openzl::cli {
 
-struct BenchmarkArgs : public GlobalArgs {
+struct BenchmarkArgs : public GlobalArgs, public ProfileArgs {
     static void addArgs(arg::ArgParser& parser)
     {
         // Add the command
@@ -31,14 +31,6 @@ struct BenchmarkArgs : public GlobalArgs {
                 0,
                 true,
                 "Output file path for CSV-formatted sumamry statistic.");
-        parser.addCommandFlag(
-                cmd(), kProfile, 'p', true, "Benchmark the given profile.");
-        parser.addCommandFlag(
-                cmd(),
-                kProfileArg,
-                0,
-                true,
-                "Pass the given value as an argument to constructing the profile.");
         parser.addCommandFlag(
                 cmd(),
                 kCompressor,
@@ -62,12 +54,12 @@ struct BenchmarkArgs : public GlobalArgs {
                 "Enforce strict mode compression. This will fail the compression in cases of errors, instead of falling back.");
     }
 
-    explicit BenchmarkArgs(const arg::ParsedArgs& parsed) : GlobalArgs(parsed)
+    explicit BenchmarkArgs(const arg::ParsedArgs& parsed)
+            : GlobalArgs(parsed), ProfileArgs(parsed)
     {
-        compressor = createCompressorFromArgs(
-                parsed.cmdFlag(cmd(), kProfile),
-                parsed.cmdFlag(cmd(), kProfileArg),
-                parsed.cmdFlag(cmd(), kCompressor));
+        // Create the compressor
+        setCompressor(createCompressorFromArgs(
+                *this, parsed.cmdFlag(cmd(), kCompressor)));
         auto inputPath = parsed.cmdPositional(Cmd::BENCHMARK, kInput);
 
         auto input_set = tools::io::InputSetBuilder(recursive)
@@ -92,8 +84,10 @@ struct BenchmarkArgs : public GlobalArgs {
         strict = parsed.cmdHasFlag(Cmd::BENCHMARK, kStrict);
     }
 
-    explicit BenchmarkArgs(const GlobalArgs& globalArgs)
-            : GlobalArgs(globalArgs)
+    explicit BenchmarkArgs(
+            const GlobalArgs& globalArgs,
+            const std::shared_ptr<Compressor>& compressor)
+            : GlobalArgs(globalArgs), ProfileArgs(compressor)
     {
     }
 
@@ -101,8 +95,6 @@ struct BenchmarkArgs : public GlobalArgs {
     {
         return Cmd::BENCHMARK;
     }
-
-    std::shared_ptr<Compressor> compressor;
 
     std::vector<training::MultiInput> inputs;
     std::unique_ptr<tools::io::Output> outputCsv;
@@ -113,11 +105,8 @@ struct BenchmarkArgs : public GlobalArgs {
     bool strict     = false;
 
    private:
-    inline static const std::string kInput     = "input";
-    inline static const std::string kOutputCsv = "output-csv";
-
-    inline static const std::string kProfile    = "profile";
-    inline static const std::string kProfileArg = "profile-arg";
+    inline static const std::string kInput      = "input";
+    inline static const std::string kOutputCsv  = "output-csv";
     inline static const std::string kCompressor = "compressor";
 
     inline static const std::string kLevel    = "level";

--- a/cli/args/CompressArgs.h
+++ b/cli/args/CompressArgs.h
@@ -18,7 +18,7 @@
 
 namespace openzl::cli {
 
-struct CompressArgs : public GlobalArgs {
+struct CompressArgs : public GlobalArgs, public ProfileArgs {
     static void addArgs(arg::ArgParser& parser)
     {
         // Add the command
@@ -29,14 +29,6 @@ struct CompressArgs : public GlobalArgs {
         parser.addCommandFlag(cmd(), kOutput, 'o', true, "Output file path.");
         parser.addCommandFlag(
                 cmd(), kForce, 'f', false, "Overwrite output file.");
-        parser.addCommandFlag(
-                cmd(), kProfile, 'p', true, "Compress with the given profile.");
-        parser.addCommandFlag(
-                cmd(),
-                kProfileArg,
-                0,
-                true,
-                "Pass the given value as an argument to constructing the profile.");
         parser.addCommandFlag(
                 cmd(),
                 kCompressor,
@@ -71,13 +63,12 @@ struct CompressArgs : public GlobalArgs {
                 "Directory to write trace streamdump to.");
     }
 
-    explicit CompressArgs(const arg::ParsedArgs& parsed) : GlobalArgs(parsed)
+    explicit CompressArgs(const arg::ParsedArgs& parsed)
+            : GlobalArgs(parsed), ProfileArgs(parsed)
     {
         // Create the compressor
-        compressor = createCompressorFromArgs(
-                parsed.cmdFlag(cmd(), kProfile),
-                parsed.cmdFlag(cmd(), kProfileArg),
-                parsed.cmdFlag(cmd(), kCompressor));
+        setCompressor(createCompressorFromArgs(
+                *this, parsed.cmdFlag(cmd(), kCompressor)));
 
         // Get the input and output files
         auto inputPath = parsed.cmdPositional(cmd(), kInput);
@@ -106,8 +97,6 @@ struct CompressArgs : public GlobalArgs {
         return Cmd::COMPRESS;
     };
 
-    std::shared_ptr<Compressor> compressor;
-
     std::shared_ptr<tools::io::Input> input;
     std::shared_ptr<tools::io::Output> output;
 
@@ -118,12 +107,9 @@ struct CompressArgs : public GlobalArgs {
     std::optional<std::string> traceStreamsDir;
 
    private:
-    inline static const std::string kInput  = "input";
-    inline static const std::string kOutput = "output";
-    inline static const std::string kForce  = "force";
-
-    inline static const std::string kProfile    = "profile";
-    inline static const std::string kProfileArg = "profile-arg";
+    inline static const std::string kInput      = "input";
+    inline static const std::string kOutput     = "output";
+    inline static const std::string kForce      = "force";
     inline static const std::string kCompressor = "compressor";
 
     inline static const std::string kVerbose     = "verbose";

--- a/cli/args/TrainArgs.h
+++ b/cli/args/TrainArgs.h
@@ -17,7 +17,7 @@
 
 namespace openzl::cli {
 
-class TrainArgs : public GlobalArgs {
+class TrainArgs : public GlobalArgs, public ProfileArgs {
    public:
     static void addArgs(arg::ArgParser& parser)
     {
@@ -27,14 +27,6 @@ class TrainArgs : public GlobalArgs {
         // Add the top-level flags
         parser.addCommandPositional(
                 cmd(), kSampleDir, "Directory containing samples to train on.");
-        parser.addCommandFlag(
-                cmd(), kProfile, 'p', true, "Train with the given profile.");
-        parser.addCommandFlag(
-                cmd(),
-                kProfileArg,
-                0,
-                true,
-                "Pass the given value as an argument to constructing the profile.");
         parser.addCommandFlag(
                 cmd(),
                 kCompressor,
@@ -117,12 +109,12 @@ class TrainArgs : public GlobalArgs {
                 "Enables pareto frontier training. This will output a directory containing all compressors in the pareto frontier.");
     }
 
-    explicit TrainArgs(const arg::ParsedArgs& parsed) : GlobalArgs(parsed)
+    explicit TrainArgs(const arg::ParsedArgs& parsed)
+            : GlobalArgs(parsed), ProfileArgs(parsed)
     {
-        compressor = createCompressorFromArgs(
-                parsed.cmdFlag(cmd(), kProfile),
-                parsed.cmdFlag(cmd(), kProfileArg),
-                parsed.cmdFlag(cmd(), kCompressor));
+        // Create the compressor
+        setCompressor(createCompressorFromArgs(
+                *this, parsed.cmdFlag(cmd(), kCompressor)));
         auto outputPath = parsed.cmdFlag(cmd(), kOutput);
         if (outputPath) {
             checkOutput(outputPath.value(), parsed.cmdHasFlag(cmd(), kForce));
@@ -193,7 +185,10 @@ class TrainArgs : public GlobalArgs {
                 custom_parsers::createCompressorFromSerialized;
     }
 
-    explicit TrainArgs(const GlobalArgs& globalArgs) : GlobalArgs(globalArgs)
+    explicit TrainArgs(
+            const GlobalArgs& globalArgs,
+            const std::shared_ptr<Compressor>& compressor)
+            : GlobalArgs(globalArgs), ProfileArgs(compressor)
     {
         trainParams.compressorGenFunc =
                 custom_parsers::createCompressorFromSerialized;
@@ -204,7 +199,6 @@ class TrainArgs : public GlobalArgs {
         return Cmd::TRAIN;
     }
 
-    std::shared_ptr<Compressor> compressor;
     std::shared_ptr<tools::io::InputSet> inputs;
     std::shared_ptr<tools::io::Output> output;
 
@@ -213,8 +207,6 @@ class TrainArgs : public GlobalArgs {
 
    private:
     inline static const std::string kSampleDir  = "sample-dir";
-    inline static const std::string kProfile    = "profile";
-    inline static const std::string kProfileArg = "profile-arg";
     inline static const std::string kCompressor = "compressor";
 
     inline static const std::string kOutput = "output";

--- a/cli/commands/cmd_benchmark.cpp
+++ b/cli/commands/cmd_benchmark.cpp
@@ -98,8 +98,8 @@ BenchmarkResult runCompressionBenchmarks(const BenchmarkArgs& args)
     const auto iters = args.numIters;
 
     // create compressor, context, and decompression context
-    auto cctx =
-            createCompressionContext(*args.compressor, args.level, args.strict);
+    auto cctx = createCompressionContext(
+            *args.compressor(), args.level, args.strict);
     DCtx dctx;
 
     // if output is not specified, don't write csv-formatted summary statistics

--- a/cli/commands/cmd_compress.cpp
+++ b/cli/commands/cmd_compress.cpp
@@ -63,11 +63,10 @@ int trainCompressorOnSampleFile(CompressArgs& args)
             std::make_shared<tools::io::OutputBuffer>(compressorData);
 
     // Construct args for training
-    TrainArgs trainArgs(args);
+    TrainArgs trainArgs(args, args.compressor());
     trainArgs.inputs =
             std::make_unique<tools::io::InputSetStatic>(std::move(inputVec));
-    trainArgs.output     = compressorOutput;
-    trainArgs.compressor = args.compressor;
+    trainArgs.output = compressorOutput;
     if (args.trainInlineTestLimit) {
         trainArgs.trainParams.maxTimeSecs = args.trainInlineTestLimit.value();
     }
@@ -79,8 +78,9 @@ int trainCompressorOnSampleFile(CompressArgs& args)
     }
 
     // Save the trained compressor
-    args.compressor = custom_parsers::createCompressorFromSerialized(
-            compressorOutput->to_input()->contents());
+    args.setCompressor(
+            custom_parsers::createCompressorFromSerialized(
+                    compressorOutput->to_input()->contents()));
 
     return result;
 }
@@ -131,7 +131,7 @@ int performCompression(const CompressArgs& args)
     // create compressor and context
     CCtx cctx;
     cctx.setParameter(CParam::FormatVersion, ZL_MAX_FORMAT_VERSION);
-    cctx.refCompressor(*args.compressor);
+    cctx.refCompressor(*args.compressor());
     if (args.traceOutput) {
         args.traceOutput->open();
         Logger::log(

--- a/cli/commands/cmd_train.cpp
+++ b/cli/commands/cmd_train.cpp
@@ -81,15 +81,14 @@ int cmdTrain(const TrainArgs& args)
     auto filteredInputsPtr = limiter.getFilteredInputsPtr(inputs);
 
     // Benchmark the untrained compressor
-    BenchmarkArgs benchmarkArgs(args);
-    benchmarkArgs.compressor = args.compressor;
+    BenchmarkArgs benchmarkArgs(args, args.compressor());
     benchmarkArgs.inputs = training::inputSetToMultiInputs(*filteredInputsPtr);
     Logger::log(INFO, "Benchmarking untrained compressor...");
     auto untrainedBenchmark = runCompressionBenchmarks(benchmarkArgs);
 
     std::vector<std::shared_ptr<const std::string_view>>
             serializedTrainedCompressors = openzl::training::train(
-                    benchmarkArgs.inputs, *args.compressor, args.trainParams);
+                    benchmarkArgs.inputs, *args.compressor(), args.trainParams);
 
     poly::optional<tools::io::OutputFile> resultsCsv;
     if (args.trainParams.paretoFrontier) {
@@ -110,9 +109,9 @@ int cmdTrain(const TrainArgs& args)
     for (size_t i = 0; i < serializedTrainedCompressors.size(); ++i) {
         auto& serializedTrainedCompressor = serializedTrainedCompressors[i];
         // Benchmark the trained compressor
-        benchmarkArgs.compressor =
+        benchmarkArgs.setCompressor(
                 custom_parsers::createCompressorFromSerialized(
-                        *serializedTrainedCompressor);
+                        *serializedTrainedCompressor));
         if (!args.trainParams.paretoFrontier) {
             Logger::log(INFO, "Benchmarking trained compressor...");
         }

--- a/cli/tests/BUCK
+++ b/cli/tests/BUCK
@@ -105,6 +105,20 @@ custom_unittest(
 )
 
 custom_unittest(
+    name = "csv_chunked_test",
+    command = [
+        "$(location :integration_test_bin)",
+        "$(location ..:zli)",
+        "CsvChunkedTest.test_train_compress_decompress",
+    ],
+    type = "simple",
+    deps = [
+        "..:zli",
+        ":integration_test_bin",
+    ],
+)
+
+custom_unittest(
     name = "parquet_test",
     command = [
         "$(location :integration_test_bin)",

--- a/cli/tests/cli_integration_tests.py
+++ b/cli/tests/cli_integration_tests.py
@@ -164,6 +164,34 @@ class CsvBottomUpTest(_CsvBaseTest):
         self.train_compress_decompress()
 
 
+class CsvChunkedTest(_CsvBaseTest):
+    """
+    Test case for CSV training and compression using the trainer with chunking.
+
+    This test demonstrates the train-compress-decompress workflow for CSV files
+    using including chunking the input data.
+
+    Sample files are located in cli/tests/sample_files/csv/
+    Output files are stored in {output_dir_path}
+    """
+
+    @property
+    def extra_args(self) -> str | None:
+        return "--chunk-size-mb 1"
+
+    def test_train_compress_decompress(self):
+        """
+        Test the train, compress, and decompress workflow for CSV files using the greedy trainer.
+
+        This test:
+        1. Trains a compressor on the CSV files in cli/tests/sample_files/csv/ using the greedy trainer
+        2. Saves the trained compressor to {output_dir_path}/trained_compressor.zlc
+        3. Uses the trained compressor to compress and decompress the CSV files
+        4. Verifies that the decompressed files match the originals
+        """
+        self.train_compress_decompress()
+
+
 class ParquetTest(_TrainBaseTest):
     """
     Parquet compression tests with training.

--- a/cli/utils/BUCK
+++ b/cli/utils/BUCK
@@ -23,6 +23,7 @@ zs_cxxlibrary(
         "../../custom_parsers/parquet:parquet_graph",
         "../../custom_parsers/sddl:profile",
         "../../custom_parsers/shared_components:clustering",
+        "../../tools:arg",
         "../../tools:io",
         "../../tools:logger",
         "../../tools/sddl/compiler:lib",

--- a/cli/utils/compress_profiles.cpp
+++ b/cli/utils/compress_profiles.cpp
@@ -171,23 +171,22 @@ compressProfiles()
                 kCsvName,
                 "CSV. Pass optional non-comma separator with --profile-arg <char>.",
                 [](ZL_Compressor* comp, void*, const ProfileArgs& args) {
-                    auto it = args.argmap.find("TBD");
-                    if (it != args.argmap.end()) {
+                    char sep             = ',';
+                    const auto chunkSize = args.chunkSize().value_or(
+                            custom_parsers::kDefaultChunkSize);
+                    auto argmap = args.map();
+                    auto it     = argmap.find("TBD");
+                    if (it != argmap.end()) {
                         auto str = it->second;
                         if (str.size() != 1) {
                             throw InvalidArgsException(
                                     "The CSV profile separator must be a single character. Pass it with --profile-arg <char>.");
                         }
-                        return openzl::custom_parsers::
-                                ZL_createGraph_genericCSVCompressorWithOptions(
-                                        comp,
-                                        custom_parsers::kDefaultChunkSize,
-                                        true,
-                                        str[0],
-                                        false);
+                        sep = str[0];
                     }
                     return openzl::custom_parsers::
-                            ZL_createGraph_genericCSVCompressor(comp);
+                            ZL_createGraph_genericCSVCompressorWithOptions(
+                                    comp, chunkSize, true, sep, false);
                 });
 
         addLEintProfile(mp, true, 16);
@@ -214,8 +213,9 @@ compressProfiles()
                 kSDDLName,
                 "Data that can be parsed using the Simple Data Description Language. Pass a path to the data description file with --profile-arg.",
                 [](ZL_Compressor* comp, void*, const ProfileArgs& args) {
-                    auto it = args.argmap.find("TBD");
-                    if (it == args.argmap.end()) {
+                    auto argmap = args.map();
+                    auto it     = argmap.find("TBD");
+                    if (it == argmap.end()) {
                         throw InvalidArgsException(
                                 "The Simple Data Description Language profile requires a data description. Pass a path to the description file with --profile-arg.");
                     }
@@ -234,8 +234,9 @@ compressProfiles()
                 kSDDL2Name,
                 "Data that can be parsed using Simple Data Description Language v2. Pass a path to the pre-compiled bytecode file with --profile-arg.",
                 [](ZL_Compressor* comp, void*, const ProfileArgs& args) {
-                    auto it = args.argmap.find("TBD");
-                    if (it == args.argmap.end()) {
+                    auto argmap = args.map();
+                    auto it     = argmap.find("TBD");
+                    if (it == argmap.end()) {
                         throw InvalidArgsException(
                                 "The Simple Data Description Language v2 profile requires pre-compiled bytecode. Pass a path to the bytecode file with --profile-arg.");
                     }

--- a/cli/utils/compress_profiles.h
+++ b/cli/utils/compress_profiles.h
@@ -8,15 +8,91 @@
 #include <string>
 #include <vector>
 
+#include "openzl/cpp/Compressor.hpp"
+#include "openzl/cpp/poly/Optional.hpp"
+
 #include "openzl/zl_compressor.h"
+#include "tools/arg/arg_parser.h"
+#include "tools/arg/parsed_args.h"
 
 namespace openzl::cli {
 
-struct ProfileArgs {
-    std::string name;
+class ProfileArgs {
+   public:
+    static void addArgs(arg::ArgParser& parser)
+    {
+        parser.addGlobalFlag(kProfile, 'p', true, "Select the given profile.");
+        parser.addGlobalFlag(
+                kProfileArg,
+                0,
+                true,
+                "Pass the given value as an argument to constructing the profile.");
+        parser.addGlobalFlag(
+                kChunkSize,
+                0,
+                true,
+                "The chunk size in MB for the input to be separated into. This reduces the memory usage to a multiplicative factor of the chunk size instead of the whole input. Defaults to 20MB if segmenter exists for profile.");
+    }
 
+    explicit ProfileArgs(const arg::ParsedArgs& parsed)
+    {
+        auto chunkSize = parsed.globalFlag(kChunkSize);
+        if (chunkSize.has_value()) {
+            chunkSize_ = std::stoull(chunkSize.value()) * 1000 * 1000;
+        } else {
+            chunkSize_ = poly::nullopt;
+        }
+        auto profileArg = parsed.globalFlag(kProfileArg);
+        if (profileArg) {
+            argmap_.emplace("TBD", profileArg.value());
+        }
+        auto profile = parsed.globalFlag(kProfile);
+        if (profile) {
+            name_ = std::move(profile);
+        }
+    }
+
+    explicit ProfileArgs(const std::shared_ptr<Compressor>& compressor)
+            : compressor_(compressor)
+    {
+    }
+
+    const poly::optional<size_t>& chunkSize() const
+    {
+        return chunkSize_;
+    }
+
+    const poly::optional<std::string>& name() const
+    {
+        return name_;
+    }
+
+    const std::map<std::string, std::string>& map() const
+    {
+        return argmap_;
+    }
+
+    const std::shared_ptr<Compressor>& compressor() const
+    {
+        return compressor_;
+    }
+
+    void setCompressor(const std::shared_ptr<Compressor>& compressor)
+    {
+        compressor_ = compressor;
+    }
+
+   private:
+    std::shared_ptr<Compressor> compressor_;
+
+    inline static const std::string kProfileArg = "profile-arg";
+    inline static const std::string kChunkSize  = "chunk-size-mb";
+    inline static const std::string kProfile    = "profile";
+
+    poly::optional<std::string> name_;
+    poly::optional<size_t> chunkSize_;
     // Arbitrary (K,V) arguments provided on the command line.
-    std::map<std::string, std::string> argmap;
+    std::map<std::string, std::string> argmap_;
 };
 
 class CompressProfile {
@@ -42,8 +118,8 @@ class CompressProfile {
     std::string name;
     std::string description; // useful for documentation as well as printing
     GenFunc gen;
-    std::shared_ptr<void> opaque; // an optional opaque helper pointer that's
-                                  // passed to the gen function
+    std::shared_ptr<void> opaque; // an optional opaque helper pointer
+                                  // that's passed to the gen function
 };
 
 const std::map<std::string, std::shared_ptr<CompressProfile>>&

--- a/cli/utils/util.cpp
+++ b/cli/utils/util.cpp
@@ -39,15 +39,15 @@ std::unique_ptr<Compressor> createCompressorFromProfile(const ProfileArgs& args)
 {
     auto compressor = std::make_unique<Compressor>();
 
-    if (args.name.empty()) {
+    if (args.name().value_or("").empty()) {
         throw InvalidArgsException(
                 "Please provide a profile. See `zli list-profiles` for a list of supported profiles.");
     }
-
-    auto profile = compressProfiles().find(args.name);
+    auto name    = args.name().value();
+    auto profile = compressProfiles().find(name);
     if (profile == compressProfiles().end()) {
         throw InvalidArgsException(
-                "Profile not found: '" + args.name
+                "Profile not found: '" + name
                 + "'. See `zli list-profiles` for a list of supported profiles.");
     }
 

--- a/cli/zli.cpp
+++ b/cli/zli.cpp
@@ -40,6 +40,7 @@ int impl(int argc, char** argv)
 
     // set command-line arguments
     GlobalArgs::addArgs(argParser);
+    ProfileArgs::addArgs(argParser);
     CompressArgs::addArgs(argParser);
     DecompressArgs::addArgs(argParser);
     TrainArgs::addArgs(argParser);


### PR DESCRIPTION
Summary:
Refactors parsing such that it is more streamlined to add parameters to a profile.

Adds chunk size via profile args `chunk-size-mb=*`. This always displays:
```
Chunking is not currently implemented for all profiles. Ignoring parameter if unimplemented.
Chunking is implemented for the following profiles: csv
```

Differential Revision: D86459877


