### PR TITLE
Pin Ubuntu to fix GCC

### DIFF
--- a/.github/workflows/dev-ci.yml
+++ b/.github/workflows/dev-ci.yml
@@ -131,6 +131,10 @@ jobs:
             flags: "-Werror -Wgnu-anonymous-struct -DZS_ENABLE_CLANG_PRAGMA -Wno-implicit-fallthrough"
     steps:
       - uses: actions/checkout@v4
+      - name: Install GCC-9
+        if: ${{ matrix.cc == 'gcc-9' }}
+        run: |
+          sudo apt install gcc-9 g++-9
       - name: Build
         env:
           CC: ${{ matrix.cc }}


### PR DESCRIPTION
Summary: Change ubuntu version to 20.04 (which has gcc 9 as default)

Differential Revision: D86990419


