### PR TITLE
add versioning to traces

### DIFF
--- a/cpp/src/openzl/cpp/experimental/trace/Tracer.cpp
+++ b/cpp/src/openzl/cpp/experimental/trace/Tracer.cpp
@@ -6,6 +6,7 @@
 #include "openzl/common/logging.h"
 #include "openzl/compress/dyngraph_interface.h"
 #include "openzl/cpp/Exception.hpp"
+#include "openzl/cpp/experimental/trace/CborHelpers.hpp"
 #include "openzl/cpp/experimental/trace/Codec.hpp"
 #include "openzl/cpp/experimental/trace/StreamVisualizer.hpp"
 #include "openzl/zl_data.h"
@@ -272,6 +273,7 @@ void Tracer::on_ZL_CCtx_compressMultiTypedRef_start(
         ZL_TypedRef const* const inputs[],
         size_t const nbInputs)
 {
+    frameVersion = ZL_CCtx_getParameter(cctx, ZL_CParam_formatVersion);
     // Create a "placeholder" node representing compression start, so the first
     // streams are not orphaned
     Codec compressionStart = {
@@ -566,8 +568,13 @@ ZL_Report Tracer::serializeStreamdumpToCbor(
      * 3. graph info, specifically, which codecs and edges are within a
      * graph
      */
-    A1C_MapBuilder rootBuilder = A1C_Item_map_builder(root, 3, a1c_arena);
+    A1C_MapBuilder rootBuilder = A1C_Item_map_builder(root, 6, a1c_arena);
+
     ZL_RET_R_IF_NULL(allocation, rootBuilder.map);
+
+    ZL_RET_R_IF_ERR(addIntValue(rootBuilder, "libraryVersion", libraryVersion));
+    ZL_RET_R_IF_ERR(addIntValue(rootBuilder, "frameVersion", frameVersion));
+    ZL_RET_R_IF_ERR(addIntValue(rootBuilder, "traceVersion", traceVersion));
 
     // 1. Make the streams map
     A1C_MAP_TRY_ADD_R(streamsPair, rootBuilder);

--- a/cpp/src/openzl/cpp/experimental/trace/Tracer.hpp
+++ b/cpp/src/openzl/cpp/experimental/trace/Tracer.hpp
@@ -109,6 +109,9 @@ class Tracer {
     };
 
     const ZL_CCtx* cctx_{};
+    static constexpr uint32_t libraryVersion = ZL_LIBRARY_VERSION_NUMBER;
+    uint32_t frameVersion;
+    static constexpr uint32_t traceVersion = 1;
     size_t compressedSize_{};
     size_t currCodecNum_ = 0;
     std::map<ZL_DataID, Stream, ZL_DataIDCustomComparator> streamInfo_;

--- a/cpp/src/openzl/cpp/experimental/trace/wire_format.md
+++ b/cpp/src/openzl/cpp/experimental/trace/wire_format.md
@@ -1,0 +1,70 @@
+# Trace CBOR Wire Format
+!!! WARNING
+    The format is evolving and the following description is liable to be out of date if not maintained.
+    This is provided as a convenience, not a prescription.
+
+## Version 1 (dev)
+The wire format of the CBOR file is as follows:
+```
+Trace = {
+    libraryVersion: Int32LE; # ZL_LIBRARY_VERSION_NUMBER from zl_version.h
+    frameVersion: Int32LE;   # The frame version used for the trace
+    traceVersion: Int32LE;   # A specific version number for the trace CBOR
+    streams: StreamVisualizer[];
+    codecs: Codec[];
+    graphs: Graph[];
+}
+
+StreamVisualizer = {
+    type: Int64LE; # ZL_Type
+    outputIdx: Int64LE;
+    eltWidth: Int64LE;
+    numElts: Int64LE;
+    cSize: Int64LE;
+    share: Float64LE;
+    contentSize: Int64LE;
+}
+
+Codec = {
+    name: String;
+    cType: Boolean; # Standard vs Custom
+    cID: Int64LE;
+    cHeaderSize: Int64LE;
+    cFailureString: String | null;
+    cLocalParams: LocalParamInfo;
+    inputStreams: Int64LE[];
+    outputStreams: Int64LE[];
+}
+
+Graph = {
+    gType: Int64LE; # ZL_GraphType
+    gName: String;
+    gFailureString: String | null;
+    gLocalParams: LocalParamInfo;
+    codecIDs: Int64LE[];
+}
+
+LocalParamInfo = {
+    intParams: IntParamInfo[];
+    copyParams: CopyParamInfo[];
+    refParams: RefParamInfo[];
+}
+
+IntParamInfo = {
+    paramId: Int64LE;
+    paramValue: Int64LE;
+}
+
+CopyParamInfo = {
+    paramId: Int64LE;
+    paramSize: Int64LE;
+    paramData: Bytes | null;
+}
+
+RefParamInfo = {
+    paramId: Int64LE;
+}
+```
+
+## Unversioned (v0.1.0)
+The same as version 1, but without the `libraryVersion`, `frameVersion`, or `traceVersion` fields.

--- a/tools/visualization_app/src/interfaces/SerializedStreamdump.ts
+++ b/tools/visualization_app/src/interfaces/SerializedStreamdump.ts
@@ -5,6 +5,9 @@ import type {SerializedCodec} from './SerializedCodec';
 import type {SerializedGraph} from './SerializedGraph';
 
 export interface SerializedStreamdump {
+  libraryVersion: number;
+  frameVersion: number;
+  traceVersion: number;
   streams: SerializedStream[];
   codecs: SerializedCodec[];
   graphs: SerializedGraph[];

--- a/tools/visualization_app/src/models/Streamdump.ts
+++ b/tools/visualization_app/src/models/Streamdump.ts
@@ -6,11 +6,17 @@ import {Stream} from './Stream';
 import {Graph} from './Graph';
 
 export class Streamdump {
+  readonly libraryVersion: number;
+  readonly frameVersion: number;
+  readonly traceVersion: number;
   readonly streams: Stream[];
   readonly codecs: Codec[];
   readonly graphs: Graph[];
 
-  constructor(streams: Stream[], codecs: Codec[], graphs: Graph[]) {
+  constructor(libraryVersion: number, frameVersion: number, traceVersion: number, streams: Stream[], codecs: Codec[], graphs: Graph[]) {
+    this.libraryVersion = libraryVersion;
+    this.frameVersion = frameVersion;
+    this.traceVersion = traceVersion;
     this.streams = streams;
     this.codecs = codecs;
     this.graphs = graphs;
@@ -18,6 +24,9 @@ export class Streamdump {
 
   static fromObject(obj: SerializedStreamdump): Streamdump {
     return new Streamdump(
+      obj.libraryVersion,
+      obj.frameVersion,
+      obj.traceVersion,
       obj.streams.map((stream, streamId) => Stream.fromObject(stream, streamId)),
       obj.codecs.map((codec, codecNum) => Codec.fromObject(codec, codecNum)),
       obj.graphs.map((graph, graphNum) => Graph.fromObject(graph, graphNum)),


### PR DESCRIPTION
Summary: Add library, frame, and trace-specific versioning to the CBOR and visualization

Reviewed By: kevinjzhang

Differential Revision: D87005943


