### PR TITLE
add trace version marshalling to CBOR decoding

### DIFF
--- a/tools/visualization_app/src/utils/decodeCbor.ts
+++ b/tools/visualization_app/src/utils/decodeCbor.ts
@@ -3,35 +3,112 @@
 import {decode} from 'cbor2';
 import type {SerializedStreamdump} from '../interfaces/SerializedStreamdump';
 import {Streamdump} from '../models/Streamdump';
+import type {StreamID, ZL_IDType} from '../models/idTypes';
 
-// Validate that the object loaded in is the contents of streamdump
-function isDecodedStreamdump(obj: unknown): obj is SerializedStreamdump {
-  return (
-    typeof obj === 'object' &&
-    obj !== null &&
-    'streams' in obj &&
-    Array.isArray(obj.streams) &&
-    'codecs' in obj &&
-    Array.isArray(obj.codecs) &&
-    'graphs' in obj &&
-    Array.isArray(obj.graphs)
-  );
+// format version 0, need to convert to format version 1
+function convertV0toV1(obj: SerializedStreamdump): SerializedStreamdump {
+  const retval: SerializedStreamdump = {
+    frameVersion: -1,
+    libraryVersion: 100,
+    traceVersion: 0,
+    streams: obj.streams,
+    codecs: obj.codecs,
+    graphs: obj.graphs,
+  };
+  // insert a root node before the first node
+  retval.codecs.unshift({
+    name: 'zl.#start',
+    cType: true,
+    cID: 0 as ZL_IDType,
+    cHeaderSize: 0,
+    cFailureString: '',
+    cLocalParams: {
+      copyParams: [],
+      intParams: [],
+      refParams: [],
+    },
+    inputStreams: [],
+    outputStreams: [0 as StreamID],
+  });
+
+  // rename all stream source/targets
+  retval.streams.forEach((stream) => {
+    stream.outputIdx += 1;
+  });
+  retval.graphs.forEach((graph) => {
+    for (let i = 0; i < graph.codecIDs.length; ++i) {
+      graph.codecIDs[i] += 1;
+    }
+  });
+
+  return retval;
+}
+
+function marshallV0(obj: object): SerializedStreamdump {
+  if (
+    !(
+      'streams' in obj &&
+      Array.isArray(obj.streams) &&
+      'codecs' in obj &&
+      Array.isArray(obj.codecs) &&
+      'graphs' in obj &&
+      Array.isArray(obj.graphs)
+    )
+  ) {
+    throw new Error(
+      'Decoded object does not have an explicit format version string but does not fit the structure of V0',
+    );
+  }
+  return convertV0toV1(obj as SerializedStreamdump);
+}
+
+function marshallV1(obj: object): SerializedStreamdump {
+  if (
+    !(
+      typeof obj === 'object' &&
+      obj !== null &&
+      'streams' in obj &&
+      Array.isArray(obj.streams) &&
+      'codecs' in obj &&
+      Array.isArray(obj.codecs) &&
+      'graphs' in obj &&
+      Array.isArray(obj.graphs) &&
+      'libraryVersion' in obj &&
+      typeof obj.libraryVersion === 'number' &&
+      'frameVersion' in obj &&
+      typeof obj.frameVersion === 'number'
+    )
+  ) {
+    throw new Error('Decoded object is declared to be V1 but is malformed.');
+  }
+
+  return obj as SerializedStreamdump;
+}
+
+/**
+ * Convert presented object into a valid SerializedStreamdump object with the latest format version.
+ * @throw error if no conversion is possible.
+ */
+function marshall(obj: unknown): SerializedStreamdump {
+  if (typeof obj !== 'object' || obj === null) {
+    throw new Error('Decoded data is not a valid object');
+  }
+  // determine format version
+  if (!('traceVersion' in obj && typeof obj.traceVersion === 'number')) {
+    return marshallV0(obj as object);
+  }
+  return marshallV1(obj as object);
 }
 
 export async function extractStreamdumpFromCborFile(file: File): Promise<Streamdump> {
-  let decodedCborData: SerializedStreamdump;
   // load the data
   try {
     const buffer = await file.arrayBuffer();
-    decodedCborData = decode(new Uint8Array(buffer));
+    const decodedCborData = decode(new Uint8Array(buffer));
+    // Validate wire format and massage old formats into the latest
+    return Streamdump.fromObject(marshall(decodedCborData));
   } catch (error) {
     console.error('Error decoding CBOR file', error);
     throw error;
   }
-  // Validate that this object is of proper structure
-  if (!isDecodedStreamdump(decodedCborData)) {
-    throw new Error("Decoded data does not match the expected structure of streamdump's contents.");
-  }
-
-  return Streamdump.fromObject(decodedCborData);
 }


### PR DESCRIPTION
Summary: The main difference between v0 and v1 of the trace format is that v1 has an extra 'start' codec. This difference messes everything up. Instead of adding conditionals everywhere in the code, this diff detects and massages the v0 format into the v1 format during validation.

Differential Revision: D87106953


