### PR TITLE
Add segmenter for Parquet

### DIFF
--- a/cli/commands/cmd_benchmark.cpp
+++ b/cli/commands/cmd_benchmark.cpp
@@ -22,7 +22,6 @@ using namespace openzl::tools::logger;
 
 namespace {
 constexpr size_t BYTES_TO_MB = 1000 * 1000;
-constexpr size_t BYTES_TO_GB = BYTES_TO_MB * 1000;
 
 /// Updates the printed line of benchmarks based on the new parameters provided.
 /// @return The BenchmarkResult structure containing ratio and speeds
@@ -123,11 +122,6 @@ BenchmarkResult runCompressionBenchmarks(const BenchmarkArgs& args)
         size_t uncompressed_size = 0;
         for (const auto& input : *inputs) {
             uncompressed_size += input.contentSize();
-        }
-        // TODO: Size limitations should be a library feature
-        if (uncompressed_size > BYTES_TO_GB / 2) {
-            throw std::runtime_error(
-                    "Chunking support is required for compressing inputs larger than 500 MB. ");
         }
         // get the compressed size
         const auto compressed = cctx.compress(inputVec);

--- a/cli/commands/cmd_compress.cpp
+++ b/cli/commands/cmd_compress.cpp
@@ -24,7 +24,6 @@ using namespace logger;
 
 namespace openzl::cli {
 constexpr size_t BYTES_TO_MB = 1000 * 1000;
-constexpr size_t BYTES_TO_GB = BYTES_TO_MB * 1000;
 
 namespace {
 
@@ -147,11 +146,6 @@ int performCompression(const CompressArgs& args)
 
     // ahead of time.
     const auto inputSize = input.size().value();
-    // TODO: Size limitations should be a library feature
-    if (inputSize > BYTES_TO_GB / 2) {
-        throw std::runtime_error(
-                "Chunking support is required for compressing inputs larger than 500 MB. ");
-    }
     Logger::log(VERBOSE1, "Input size: ", inputSize);
 
     std::string dstBuffer = std::string(ZL_compressBound(inputSize), '\0');

--- a/cli/commands/cmd_train.cpp
+++ b/cli/commands/cmd_train.cpp
@@ -17,7 +17,6 @@ using namespace tools::logger;
 
 const uint64_t kDefaultMaxSingleSampleSize = 150 * 1024 * 1024; /* 150MiB */
 const uint64_t kDefaultMaxTotalSize        = 300 * 1024 * 1024; /* 300MiB */
-constexpr size_t BYTES_TO_GB               = 1000 * 1000 * 1000;
 
 int cmdTrain(const TrainArgs& args)
 {
@@ -75,11 +74,6 @@ int cmdTrain(const TrainArgs& args)
     auto maxTotalSize = args.trainParams.maxTotalSizeMb.has_value()
             ? args.trainParams.maxTotalSizeMb.value() * 1024 * 1024
             : kDefaultMaxTotalSize;
-
-    if (maxFileSize > BYTES_TO_GB / 2) {
-        throw InvalidArgsException(
-                "Max file size must be less than 500MB. Chunking support is required for compressing inputs larger than 2 GB.");
-    }
 
     // Get samples for training
     auto limiter =

--- a/cli/utils/compress_profiles.cpp
+++ b/cli/utils/compress_profiles.cpp
@@ -203,7 +203,10 @@ compressProfiles()
                 "Parquet in the canonical format (no compression, plain encoding)",
                 [](ZL_Compressor* comp, void*, const ProfileArgs&) {
                     auto clustering = ZS2_createGraph_genericClustering(comp);
-                    return ZL_Parquet_registerGraph(comp, clustering);
+                    return ZL_Parquet_registerGraph_withChunkSize(
+                            comp,
+                            clustering,
+                            custom_parsers::kDefaultChunkSize);
                 });
 
         std::string kSDDLName = "sddl";

--- a/custom_parsers/dependency_registration.cpp
+++ b/custom_parsers/dependency_registration.cpp
@@ -6,40 +6,36 @@
 #include "custom_parsers/csv/csv_profile.h"
 #include "custom_parsers/dependency_registration.h"
 #include "custom_parsers/parquet/parquet_graph.h"
-#include "custom_parsers/shared_components/clustering.h"
 
 namespace openzl::custom_parsers {
 
 void processDependencies(Compressor& compressor, poly::string_view serialized)
 {
     const auto deps = compressor.getUnmetDependencies(serialized);
-    if (deps.graphNames.size() > 0) {
-        // Generic clustering graph
-        auto clustering = ZS2_createGraph_genericClustering(compressor.get());
-        if (clustering == ZL_GRAPH_ILLEGAL) {
-            throw std::runtime_error(
-                    "Failed to create generic clustering graph");
+
+    for (const auto& graphName : deps.graphNames) {
+        if (graphName == "Parquet Parser") {
+            // Parquet graph
+            auto parquetResult =
+                    ZL_Parquet_registerGraph(compressor.get(), ZL_GRAPH_STORE);
+            if (parquetResult == ZL_GRAPH_ILLEGAL) {
+                throw std::runtime_error("Failed to create parquet graph");
+            }
         }
 
-        // Parquet graph
-        auto parquetResult =
-                ZL_Parquet_registerGraph(compressor.get(), ZL_GRAPH_STORE);
-        if (parquetResult == ZL_GRAPH_ILLEGAL) {
-            throw std::runtime_error("Failed to create parquet graph");
+        if (graphName == "CSV Parser") {
+            // CSV graph
+            auto csvResult =
+                    ZL_createGraph_genericCSVCompressor(compressor.get());
+            if (csvResult == ZL_GRAPH_ILLEGAL) {
+                throw std::runtime_error("Failed to create CSV graph");
+            }
         }
-
-        // CSV graph
-        auto csvResult = ZL_createGraph_genericCSVCompressor(compressor.get());
-        if (csvResult == ZL_GRAPH_ILLEGAL) {
-            throw std::runtime_error("Failed to create CSV graph");
-        }
-
-        // TODO register any additional non-standard graphs that may appear in a
-        // compressor
     }
 
     if (deps.nodeNames.size() > 0) {
-        // TODO register any non-standard nodes that may appear in a compressor
+        // TODO register any non-standard nodes that may appear in a
+        // compressor
     }
 }
 std::unique_ptr<Compressor> createCompressorFromSerialized(

--- a/custom_parsers/parquet/parquet_graph.c
+++ b/custom_parsers/parquet/parquet_graph.c
@@ -7,8 +7,12 @@
 #include "openzl/zl_dyngraph.h"
 #include "openzl/zl_errors.h"
 #include "openzl/zl_graph_api.h"
+#include "openzl/zl_segmenter.h"
 
 #define ZL_TRY_SET_EL(_var, _expr) ZL_TRY_SET_T(ZL_EdgeList, _var, _expr)
+
+#define ZL_PARQUET_TOKENS_PID 1
+#define ZL_PARQUET_CHUNK_SIZE_PID 2
 
 // Run the conversion node for the given type and width.
 static ZL_Report
@@ -50,83 +54,64 @@ runConversion(ZL_Edge* in, ZL_Edge** out, ZL_Type type, size_t width)
     return ZL_returnSuccess();
 }
 
-static ZL_Report parquetGraphInner(
-        ZL_Graph* graph,
-        ZL_Edge* ins[],
-        size_t nbIns,
-        ZL_ParquetLexer* lexer)
+static ZL_Report parquetGraphFn(ZL_Graph* graph, ZL_Edge* ins[], size_t nbIns)
 {
     ZL_RESULT_DECLARE_SCOPE_REPORT(graph);
-    ZL_ERR_IF_NE(nbIns, 1, graph_invalidNumInputs);
-    ZL_Edge* edge               = ins[0];
-    ZL_Input const* const input = ZL_Edge_getData(edge);
-    const size_t size           = ZL_Input_numElts(input);
-    ZL_ErrorContext* errCtx     = ZL_GET_DEFAULT_ERROR_CONTEXT(graph);
 
-    // Will return an error if the input is not a valid Parquet file.
-    ZL_ERR_IF_ERR(
-            ZL_ParquetLexer_init(lexer, ZL_Input_ptr(input), size, errCtx));
+    // Get the tokens
+    ZL_RefParam const tokensParam =
+            ZL_Graph_getLocalRefParam(graph, ZL_PARQUET_TOKENS_PID);
+    const ZL_ParquetToken* tokens = tokensParam.paramRef;
+    ZL_ERR_IF_NE(tokensParam.paramSize % sizeof(ZL_ParquetToken), 0, GENERIC);
+    size_t const nbTokens = tokensParam.paramSize / sizeof(ZL_ParquetToken);
 
-    // Allocate space for segment sizes.
-    ZL_TRY_LET_R(maxNbSegments, ZL_ParquetLexer_maxNumTokens(lexer, errCtx));
-    ZL_ERR_IF_EQ(maxNbSegments, 0, corruption);
+    // Allocate space for the dispatch instructions
     size_t* const segmentSizes =
-            ZL_Graph_getScratchSpace(graph, maxNbSegments * sizeof(size_t));
+            ZL_Graph_getScratchSpace(graph, nbTokens * sizeof(size_t));
     uint32_t* const dispatchTags =
-            ZL_Graph_getScratchSpace(graph, maxNbSegments * sizeof(uint32_t));
+            ZL_Graph_getScratchSpace(graph, nbTokens * sizeof(uint32_t));
 
     // Allocate space for token metadata. Note: the tag here is different from
     // the "dispatch tag" above. This tag identifies the schema element that a
     // given data page belongs to.
     uint32_t* const tags =
-            ZL_Graph_getScratchSpace(graph, maxNbSegments * sizeof(uint32_t));
+            ZL_Graph_getScratchSpace(graph, nbTokens * sizeof(uint32_t));
     ZL_Type* const types =
-            ZL_Graph_getScratchSpace(graph, maxNbSegments * sizeof(ZL_Type));
+            ZL_Graph_getScratchSpace(graph, nbTokens * sizeof(ZL_Type));
     size_t* const widths =
-            ZL_Graph_getScratchSpace(graph, maxNbSegments * sizeof(size_t));
-
-    ZL_ERR_IF_NULL(segmentSizes, allocation);
+            ZL_Graph_getScratchSpace(graph, nbTokens * sizeof(size_t));
 
     // Header stream metadata
     tags[0]   = 0;
     types[0]  = ZL_Type_serial;
     widths[0] = 1;
 
-    // Iterate over all the tokens in the Parquet file, and fill out
-    // segmentSizes and tags. All non-data pages are dispatched to the 0th
-    // output edge. All data pages are dispatched to their own output edge.
-    size_t nbSegments = 0;
-    uint32_t nbTags   = 0;
-    while (!ZL_ParquetLexer_finished(lexer)) {
-        ZL_ParquetToken tokens[32] = { 0 };
-        size_t nbTokens            = 0;
-        ZL_TRY_SET_R(nbTokens, ZL_ParquetLexer_lex(lexer, tokens, 32, errCtx));
-        for (size_t i = 0; i < nbTokens; ++i) {
-            ZL_ERR_IF_GE(nbSegments, maxNbSegments, GENERIC);
-            const ZL_ParquetToken token = tokens[i];
-            bool isDataPage = token.type == ZL_ParquetTokenType_DataPage;
-            // Fill in dispatch instructions.
-            segmentSizes[nbSegments] = token.size;
-            dispatchTags[nbSegments] = isDataPage ? ++nbTags : 0;
+    uint32_t nbTags = 0;
+    for (size_t i = 0; i < nbTokens; ++i) {
+        const ZL_ParquetToken token = tokens[i];
+        bool isDataPage = token.type == ZL_ParquetTokenType_DataPage;
+        // Fill in dispatch instructions.
+        segmentSizes[i] = token.size;
+        dispatchTags[i] = isDataPage ? ++nbTags : 0;
 
-            // Fill in token metadata.
-            if (isDataPage) {
-                tags[nbTags]   = token.tag;
-                types[nbTags]  = token.dataType;
-                widths[nbTags] = token.dataWidth;
-            }
-            ++nbSegments;
+        // Fill in token metadata.
+        if (isDataPage) {
+            tags[nbTags]   = token.tag;
+            types[nbTags]  = token.dataType;
+            widths[nbTags] = token.dataWidth;
         }
     }
 
     ZL_DispatchInstructions di = {
         .segmentSizes = segmentSizes,
-        .nbSegments   = nbSegments,
+        .nbSegments   = nbTokens,
         .tags         = dispatchTags,
         .nbTags       = nbTags + 1,
     };
 
     // Split the input according to segmentSizes
+    ZL_ERR_IF_NE(nbIns, 1, graph_invalidNumInputs);
+    ZL_Edge* const edge = ins[0];
     ZL_TRY_LET_T(ZL_EdgeList, el, ZL_Edge_runDispatchNode(edge, &di));
     ZL_ERR_IF_NE(el.nbEdges, nbTags + 3, GENERIC);
 
@@ -162,41 +147,171 @@ static ZL_Report parquetGraphInner(
     return ZL_returnSuccess();
 }
 
-// Wrapper around the inner graph function that allocates a lexer
-static ZL_Report parquetGraphFn(ZL_Graph* graph, ZL_Edge* sctxs[], size_t nbIns)
+static ZL_Report commitChunk(
+        ZL_Segmenter* seg,
+        size_t* size,
+        const ZL_ParquetToken* tokens,
+        size_t tokensSize,
+        ZL_GraphID parquetGraph)
 {
-    ZL_RESULT_DECLARE_SCOPE_REPORT(graph);
+    ZL_RESULT_DECLARE_SCOPE_REPORT(seg);
+    ZL_RefParam const tokensRef = {
+        .paramId   = ZL_PARQUET_TOKENS_PID,
+        .paramRef  = tokens,
+        .paramSize = tokensSize * sizeof(ZL_ParquetToken),
+    };
+    ZL_LocalParams lParams              = { .refParams = { .nbRefParams = 1,
+                                                           .refParams   = &tokensRef } };
+    ZL_RuntimeGraphParameters const par = {
+        .localParams = &lParams,
+    };
+
+    ZL_ERR_IF_ERR(ZL_Segmenter_processChunk(seg, size, 1, parquetGraph, &par));
+
+    return ZL_returnSuccess();
+}
+
+static ZL_Report parquetSegmenterInner(
+        ZL_Segmenter* seg,
+        ZL_ParquetLexer* lexer)
+{
+    ZL_RESULT_DECLARE_SCOPE_REPORT(seg);
+    size_t const nbIns = ZL_Segmenter_numInputs(seg);
+    ZL_ERR_IF_NE(nbIns, 1, graph_invalidNumInputs);
+    ZL_Input const* const input = ZL_Segmenter_getInput(seg, 0);
+    const size_t size           = ZL_Input_numElts(input);
+    ZL_ErrorContext* errCtx     = ZL_GET_DEFAULT_ERROR_CONTEXT(seg);
+
+    // Will return an error if the input is not a valid Parquet file.
+    ZL_ERR_IF_ERR(
+            ZL_ParquetLexer_init(lexer, ZL_Input_ptr(input), size, errCtx));
+
+    // Get the custom graph
+    ZL_GraphIDList graphs = ZL_Segmenter_getCustomGraphs(seg);
+    ZL_ERR_IF_NE(graphs.nbGraphIDs, 1, GENERIC);
+    ZL_GraphID const parquetGraph = graphs.graphids[0];
+
+    // Get the max chunk size
+    size_t chunkSize = (size_t)ZL_Segmenter_getLocalIntParam(
+                               seg, ZL_PARQUET_CHUNK_SIZE_PID)
+                               .paramValue;
+
+    // Allocate space for token metadata.
+    ZL_TRY_LET_R(maxNbTokens, ZL_ParquetLexer_maxNumTokens(lexer, errCtx));
+    size_t nbTokens               = 0;
+    ZL_ParquetToken* const tokens = ZL_Segmenter_getScratchSpace(
+            seg, maxNbTokens * sizeof(ZL_ParquetToken));
+
+    ZL_ParquetToken* currTokensPtr = tokens;
+    size_t currTokensSize          = 0;
+    size_t currChunkSize           = 0;
+    while (!ZL_ParquetLexer_finished(lexer)) {
+        ZL_ERR_IF_GE(nbTokens, maxNbTokens, GENERIC);
+        ZL_ParquetToken* const token = currTokensPtr + currTokensSize;
+        ZL_ERR_IF_ERR(ZL_ParquetLexer_lex(lexer, token, 1, errCtx));
+
+        if (chunkSize != 0 && currChunkSize != 0
+            && currChunkSize + token->size > chunkSize) {
+            ZL_ERR_IF_ERR(commitChunk(
+                    seg,
+                    &currChunkSize,
+                    currTokensPtr,
+                    currTokensSize,
+                    parquetGraph));
+            currTokensPtr += currTokensSize;
+            currTokensSize = 0;
+            currChunkSize  = 0;
+        }
+
+        currChunkSize += token->size;
+        currTokensSize += 1;
+        ++nbTokens;
+    }
+
+    // Commit the last segment
+    ZL_ERR_IF_ERR(commitChunk(
+            seg, &currChunkSize, currTokensPtr, currTokensSize, parquetGraph));
+
+    return ZL_returnSuccess();
+}
+
+// Wrapper around the inner graph function that allocates a lexer
+static ZL_Report parquetSegmenterFn(ZL_Segmenter* seg)
+{
+    ZL_RESULT_DECLARE_SCOPE_REPORT(seg);
     ZL_ParquetLexer* lexer = ZL_ParquetLexer_create();
     ZL_ERR_IF_NULL(lexer, allocation);
-    ZL_Report ret = parquetGraphInner(graph, sctxs, nbIns, lexer);
+    ZL_Report ret = parquetSegmenterInner(seg, lexer);
     ZL_ParquetLexer_free(lexer);
     return ret;
+}
+
+ZL_GraphID ZL_Parquet_registerGraph_withChunkSize(
+        ZL_Compressor* compressor,
+        ZL_GraphID clusteringGraph,
+        int chunkSize)
+{
+    ZL_RESULT_DECLARE_SCOPE_REPORT(compressor);
+
+    // Register the dispatch graph
+    ZL_GraphID graph = ZL_Compressor_getGraph(compressor, "Parquet Graph");
+    if (graph.gid == ZL_GRAPH_ILLEGAL.gid) {
+        ZL_FunctionGraphDesc desc = {
+            .name           = "!Parquet Graph",
+            .graph_f        = parquetGraphFn,
+            .inputTypeMasks = (ZL_Type[]){ ZL_Type_serial },
+            .nbInputs       = 1,
+            .customGraphs   = &clusteringGraph,
+            .nbCustomGraphs = 1,
+        };
+
+        graph = ZL_Compressor_registerFunctionGraph(compressor, &desc);
+    }
+
+    // Register the parameterized graph
+    ZL_ParameterizedGraphDesc const graphDesc = {
+        .graph          = graph,
+        .customGraphs   = &clusteringGraph,
+        .nbCustomGraphs = 1,
+    };
+    ZL_GraphID parquetGraph =
+            ZL_Compressor_registerParameterizedGraph(compressor, &graphDesc);
+
+    // Register the parser/segmenter
+    ZL_GraphID parser = ZL_Compressor_getGraph(compressor, "Parquet Parser");
+    if (parser.gid == ZL_GRAPH_ILLEGAL.gid) {
+        // Register the anchor graph
+        ZL_SegmenterDesc desc = {
+            .name           = "!Parquet Parser",
+            .segmenterFn    = parquetSegmenterFn,
+            .inputTypeMasks = (ZL_Type[]){ ZL_Type_serial },
+            .numInputs      = 1,
+        };
+
+        parser = ZL_Compressor_registerSegmenter(compressor, &desc);
+    }
+
+    // Register the parameterized graph
+    ZL_IntParam intParams[] = { {
+            .paramId    = ZL_PARQUET_CHUNK_SIZE_PID,
+            .paramValue = chunkSize,
+    } };
+    ZL_LocalParams params   = (ZL_LocalParams){
+          .intParams = { .intParams = intParams, .nbIntParams = 1 },
+    };
+    ZL_ParameterizedGraphDesc const parserDesc = {
+        .graph          = parser,
+        .customGraphs   = &parquetGraph,
+        .nbCustomGraphs = 1,
+        .localParams    = &params,
+    };
+    return ZL_Compressor_registerParameterizedGraph(compressor, &parserDesc);
 }
 
 ZL_GraphID ZL_Parquet_registerGraph(
         ZL_Compressor* compressor,
         ZL_GraphID clusteringGraph)
 {
-    ZL_GraphID parser = ZL_Compressor_getGraph(compressor, "Parquet Parser");
-
-    if (parser.gid == ZL_GRAPH_ILLEGAL.gid) {
-        // Register the anchor graph
-        ZL_FunctionGraphDesc desc = {
-            .name           = "!Parquet Parser",
-            .graph_f        = parquetGraphFn,
-            .inputTypeMasks = (ZL_Type[]){ ZL_Type_serial },
-            .nbInputs       = 1,
-        };
-
-        parser = ZL_Compressor_registerFunctionGraph(compressor, &desc);
-    }
-
-    // Register the parameterized graph
-    ZL_ParameterizedGraphDesc const desc = {
-        .name           = "Parquet Parser",
-        .graph          = parser,
-        .customGraphs   = &clusteringGraph,
-        .nbCustomGraphs = 1,
-    };
-    return ZL_Compressor_registerParameterizedGraph(compressor, &desc);
+    return ZL_Parquet_registerGraph_withChunkSize(
+            compressor, clusteringGraph, 0);
 }

--- a/custom_parsers/parquet/parquet_graph.h
+++ b/custom_parsers/parquet/parquet_graph.h
@@ -22,6 +22,19 @@ ZL_GraphID ZL_Parquet_registerGraph(
         ZL_Compressor* compressor,
         ZL_GraphID clusteringGraph);
 
+/**
+ * Registration function for the Parquet graph.
+ *
+ * @param compressor The compressor to register the graph with.
+ * @param clusteringGraph The clustering graph to use as a successor.
+ * @param chunkSize The size of the chunks to split the input into. The
+ * default is no chunking (set to 0).
+ */
+ZL_GraphID ZL_Parquet_registerGraph_withChunkSize(
+        ZL_Compressor* compressor,
+        ZL_GraphID clusteringGraph,
+        int chunkSize);
+
 ZL_END_C_DECLS
 
 #endif


### PR DESCRIPTION
Summary: Adds chunking support for parquet. By default we will use a chunk size of 20MB in the zli.

Differential Revision: D87262568


