### PR TITLE
Only register missing dependencies

### DIFF
--- a/cli/commands/cmd_benchmark.cpp
+++ b/cli/commands/cmd_benchmark.cpp
@@ -22,7 +22,6 @@ using namespace openzl::tools::logger;
 
 namespace {
 constexpr size_t BYTES_TO_MB = 1000 * 1000;
-constexpr size_t BYTES_TO_GB = BYTES_TO_MB * 1000;
 
 /// Updates the printed line of benchmarks based on the new parameters provided.
 /// @return The BenchmarkResult structure containing ratio and speeds
@@ -123,11 +122,6 @@ BenchmarkResult runCompressionBenchmarks(const BenchmarkArgs& args)
         size_t uncompressed_size = 0;
         for (const auto& input : *inputs) {
             uncompressed_size += input.contentSize();
-        }
-        // TODO: Size limitations should be a library feature
-        if (uncompressed_size > BYTES_TO_GB / 2) {
-            throw std::runtime_error(
-                    "Chunking support is required for compressing inputs larger than 500 MB. ");
         }
         // get the compressed size
         const auto compressed = cctx.compress(inputVec);

--- a/cli/commands/cmd_compress.cpp
+++ b/cli/commands/cmd_compress.cpp
@@ -24,7 +24,6 @@ using namespace logger;
 
 namespace openzl::cli {
 constexpr size_t BYTES_TO_MB = 1000 * 1000;
-constexpr size_t BYTES_TO_GB = BYTES_TO_MB * 1000;
 
 namespace {
 
@@ -147,11 +146,6 @@ int performCompression(const CompressArgs& args)
 
     // ahead of time.
     const auto inputSize = input.size().value();
-    // TODO: Size limitations should be a library feature
-    if (inputSize > BYTES_TO_GB / 2) {
-        throw std::runtime_error(
-                "Chunking support is required for compressing inputs larger than 500 MB. ");
-    }
     Logger::log(VERBOSE1, "Input size: ", inputSize);
 
     std::string dstBuffer = std::string(ZL_compressBound(inputSize), '\0');

--- a/cli/commands/cmd_train.cpp
+++ b/cli/commands/cmd_train.cpp
@@ -17,7 +17,6 @@ using namespace tools::logger;
 
 const uint64_t kDefaultMaxSingleSampleSize = 150 * 1024 * 1024; /* 150MiB */
 const uint64_t kDefaultMaxTotalSize        = 300 * 1024 * 1024; /* 300MiB */
-constexpr size_t BYTES_TO_GB               = 1000 * 1000 * 1000;
 
 int cmdTrain(const TrainArgs& args)
 {
@@ -75,11 +74,6 @@ int cmdTrain(const TrainArgs& args)
     auto maxTotalSize = args.trainParams.maxTotalSizeMb.has_value()
             ? args.trainParams.maxTotalSizeMb.value() * 1024 * 1024
             : kDefaultMaxTotalSize;
-
-    if (maxFileSize > BYTES_TO_GB / 2) {
-        throw InvalidArgsException(
-                "Max file size must be less than 500MB. Chunking support is required for compressing inputs larger than 2 GB.");
-    }
 
     // Get samples for training
     auto limiter =

--- a/custom_parsers/dependency_registration.cpp
+++ b/custom_parsers/dependency_registration.cpp
@@ -6,40 +6,36 @@
 #include "custom_parsers/csv/csv_profile.h"
 #include "custom_parsers/dependency_registration.h"
 #include "custom_parsers/parquet/parquet_graph.h"
-#include "custom_parsers/shared_components/clustering.h"
 
 namespace openzl::custom_parsers {
 
 void processDependencies(Compressor& compressor, poly::string_view serialized)
 {
     const auto deps = compressor.getUnmetDependencies(serialized);
-    if (deps.graphNames.size() > 0) {
-        // Generic clustering graph
-        auto clustering = ZS2_createGraph_genericClustering(compressor.get());
-        if (clustering == ZL_GRAPH_ILLEGAL) {
-            throw std::runtime_error(
-                    "Failed to create generic clustering graph");
+
+    for (const auto& graphName : deps.graphNames) {
+        if (graphName == "Parquet Parser") {
+            // Parquet graph
+            auto parquetResult =
+                    ZL_Parquet_registerGraph(compressor.get(), ZL_GRAPH_STORE);
+            if (parquetResult == ZL_GRAPH_ILLEGAL) {
+                throw std::runtime_error("Failed to create parquet graph");
+            }
         }
 
-        // Parquet graph
-        auto parquetResult =
-                ZL_Parquet_registerGraph(compressor.get(), ZL_GRAPH_STORE);
-        if (parquetResult == ZL_GRAPH_ILLEGAL) {
-            throw std::runtime_error("Failed to create parquet graph");
+        if (graphName == "CSV Parser") {
+            // CSV graph
+            auto csvResult =
+                    ZL_createGraph_genericCSVCompressor(compressor.get());
+            if (csvResult == ZL_GRAPH_ILLEGAL) {
+                throw std::runtime_error("Failed to create CSV graph");
+            }
         }
-
-        // CSV graph
-        auto csvResult = ZL_createGraph_genericCSVCompressor(compressor.get());
-        if (csvResult == ZL_GRAPH_ILLEGAL) {
-            throw std::runtime_error("Failed to create CSV graph");
-        }
-
-        // TODO register any additional non-standard graphs that may appear in a
-        // compressor
     }
 
     if (deps.nodeNames.size() > 0) {
-        // TODO register any non-standard nodes that may appear in a compressor
+        // TODO register any non-standard nodes that may appear in a
+        // compressor
     }
 }
 std::unique_ptr<Compressor> createCompressorFromSerialized(


### PR DESCRIPTION
Summary:
This should really clean up the serialized graphs.

It was previously very confusing since we would have the "CSV Parser" registered in a serialized graph for parquet files.

Differential Revision: D87262327


