### PR TITLE
Remove file size limits

### DIFF
--- a/cli/commands/cmd_benchmark.cpp
+++ b/cli/commands/cmd_benchmark.cpp
@@ -22,7 +22,6 @@ using namespace openzl::tools::logger;
 
 namespace {
 constexpr size_t BYTES_TO_MB = 1000 * 1000;
-constexpr size_t BYTES_TO_GB = BYTES_TO_MB * 1000;
 
 /// Updates the printed line of benchmarks based on the new parameters provided.
 /// @return The BenchmarkResult structure containing ratio and speeds
@@ -123,11 +122,6 @@ BenchmarkResult runCompressionBenchmarks(const BenchmarkArgs& args)
         size_t uncompressed_size = 0;
         for (const auto& input : *inputs) {
             uncompressed_size += input.contentSize();
-        }
-        // TODO: Size limitations should be a library feature
-        if (uncompressed_size > BYTES_TO_GB / 2) {
-            throw std::runtime_error(
-                    "Chunking support is required for compressing inputs larger than 500 MB. ");
         }
         // get the compressed size
         const auto compressed = cctx.compress(inputVec);

--- a/cli/commands/cmd_compress.cpp
+++ b/cli/commands/cmd_compress.cpp
@@ -24,7 +24,6 @@ using namespace logger;
 
 namespace openzl::cli {
 constexpr size_t BYTES_TO_MB = 1000 * 1000;
-constexpr size_t BYTES_TO_GB = BYTES_TO_MB * 1000;
 
 namespace {
 
@@ -147,11 +146,6 @@ int performCompression(const CompressArgs& args)
 
     // ahead of time.
     const auto inputSize = input.size().value();
-    // TODO: Size limitations should be a library feature
-    if (inputSize > BYTES_TO_GB / 2) {
-        throw std::runtime_error(
-                "Chunking support is required for compressing inputs larger than 500 MB. ");
-    }
     Logger::log(VERBOSE1, "Input size: ", inputSize);
 
     std::string dstBuffer = std::string(ZL_compressBound(inputSize), '\0');

--- a/cli/commands/cmd_train.cpp
+++ b/cli/commands/cmd_train.cpp
@@ -17,7 +17,6 @@ using namespace tools::logger;
 
 const uint64_t kDefaultMaxSingleSampleSize = 150 * 1024 * 1024; /* 150MiB */
 const uint64_t kDefaultMaxTotalSize        = 300 * 1024 * 1024; /* 300MiB */
-constexpr size_t BYTES_TO_GB               = 1000 * 1000 * 1000;
 
 int cmdTrain(const TrainArgs& args)
 {
@@ -75,11 +74,6 @@ int cmdTrain(const TrainArgs& args)
     auto maxTotalSize = args.trainParams.maxTotalSizeMb.has_value()
             ? args.trainParams.maxTotalSizeMb.value() * 1024 * 1024
             : kDefaultMaxTotalSize;
-
-    if (maxFileSize > BYTES_TO_GB / 2) {
-        throw InvalidArgsException(
-                "Max file size must be less than 500MB. Chunking support is required for compressing inputs larger than 2 GB.");
-    }
 
     // Get samples for training
     auto limiter =


### PR DESCRIPTION
Summary: We should remove these limits in the zli now that we have chunking support for `csv` and `parquet`.

Differential Revision: D87262130


