### PR TITLE
fix: correct typo in benchmark CLI help text

### DIFF
--- a/cli/args/BenchmarkArgs.h
+++ b/cli/args/BenchmarkArgs.h
@@ -30,7 +30,7 @@ struct BenchmarkArgs : public GlobalArgs {
                 kOutputCsv,
                 0,
                 true,
-                "Output file path for CSV-formatted sumamry statistic.");
+                "Output file path for CSV-formatted summary statistic.");
         parser.addCommandFlag(
                 cmd(), kProfile, 'p', true, "Benchmark the given profile.");
         parser.addCommandFlag(


### PR DESCRIPTION
## Summary

  Fixes a typo in the benchmark command help output. Changed 'sumamry' to 'summary' in the `--output-csv` flag description.

  Fixes #196

  ## Type of Change

  - [x] Bug fix (non-breaking change which fixes an issue)

  ## Test Plan

  Verified the fix by running the CLI help command and confirming the output displays the correct spelling.

  **Manual test:**
  ```bash
  ./build/cli/zli -h | grep -A 2 "output-csv"

  Expected output:
    --output-csv
      Output file path for CSV-formatted summary statistic.