### PR TITLE
Graft "[openzl] Fix a bunch of warnings treated as errors by arvr builds"

### DIFF
--- a/src/openzl/codecs/bitpack/common_bitpack_kernel.c
+++ b/src/openzl/codecs/bitpack/common_bitpack_kernel.c
@@ -951,7 +951,7 @@ static size_t ZS_bitpackDecode8_generic(
 
 #if ZS_HAS_FAST_BITPACK
 
-static size_t ZS_bitpackDecode16_bmi2(
+static ZL_MAYBE_UNUSED_FUNCTION size_t ZS_bitpackDecode16_bmi2(
         uint16_t* op,
         size_t nbElts,
         uint8_t const* ip,

--- a/src/openzl/codecs/entropy/deprecated/decode_huf_avx2_decompress.c
+++ b/src/openzl/codecs/entropy/deprecated/decode_huf_avx2_decompress.c
@@ -591,7 +591,7 @@ static ZL_ALIGNED(32) uint32_t permute[256][8] = { // reverse binary bit order
 // clang-format on
 
 // Simulated gather.  This is sometimes faster as it can run on other ports.
-static inline __m256i
+static ZL_MAYBE_UNUSED_FUNCTION inline __m256i
 _mm256_i32gather_epi32x(void const* bv, __m256i idx, int size)
 {
     ZL_ALIGNED(32) int c[8];
@@ -648,7 +648,7 @@ _mm256_i32gather_epi32x(void const* bv, __m256i idx, int size)
 #        define LZ44_mm256_i32gather_epi32 _mm256_i32gather_epi32x
 #    endif
 
-static void dpr(char const* name, __m256i const vec32)
+static ZL_MAYBE_UNUSED_FUNCTION void dpr(char const* name, __m256i const vec32)
 {
     size_t n = 8;
     uint32_t data[8];

--- a/src/openzl/codecs/float_deconstruct/encode_float_deconstruct_kernel.c
+++ b/src/openzl/codecs/float_deconstruct/encode_float_deconstruct_kernel.c
@@ -2,6 +2,7 @@
 
 #include "openzl/codecs/float_deconstruct/encode_float_deconstruct_kernel.h"
 #include "openzl/shared/mem.h"
+#include "openzl/shared/utils.h"
 
 #if ZL_HAS_AVX2
 #    include <immintrin.h>
@@ -226,7 +227,7 @@ static void bfloat16_deconstruct_encode_AVX2(
 }
 #endif
 
-static void float16_deconstruct_encode_scalar(
+static ZL_MAYBE_UNUSED_FUNCTION void float16_deconstruct_encode_scalar(
         uint16_t const* __restrict const src16,
         uint8_t* __restrict const exponent,
         uint8_t* __restrict const signFrac,

--- a/src/openzl/codecs/lz/decode_field_lz.c
+++ b/src/openzl/codecs/lz/decode_field_lz.c
@@ -586,7 +586,7 @@ ZL_selectDecompressor(unsigned eltBits, uint16_t const* tokens, size_t nbTokens)
         return ZL_FIELD_LZ_DECOMPRESS_FN(0, 14, 14);
     }
 
-    if (0) {
+    if ((0)) {
         if (eltBits == 1) {
             shortLLCode = shortMLCode = 14;
         }

--- a/src/openzl/codecs/lz/encode_match_finder_fast_field_lz.c
+++ b/src/openzl/codecs/lz/encode_match_finder_fast_field_lz.c
@@ -353,7 +353,7 @@ bool findMatchDFast(
     // search the next position. If it is enabled, it may insert
     // into the hash table at the end of the match, which causes
     // offset=0 matches.
-    if (0) {
+    if ((0)) {
         uint8_t const* const ip1     = ip + kFieldSize;
         uint32_t const largeMatchPos = ZS_FastTable_getAndUpdateT(
                 largeTable, ip1, (uint32_t)(ip1 - base), kLargeMatch);
@@ -433,7 +433,7 @@ ZL_FORCE_INLINE void ZS_tokenLzMatchFinder_parseT(
         uint8_t const* match = NULL;
 
         if (1) {
-            if (0) {
+            if ((0)) {
                 for (int r = 0; r < kNumRep; ++r) {
                     bool isRepMatch =
                             ZS_checkMatch(ip, ip - rep[r], kSmallMatch);

--- a/src/openzl/codecs/rolz/decode_fast_dec.c
+++ b/src/openzl/codecs/rolz/decode_fast_dec.c
@@ -101,7 +101,7 @@ static ZL_Report decodeCodes16(uint16_t* codes, size_t numSequences, ZL_RC* src)
 
 #if ZL_HAS_AVX2
 
-static void dpr(char const* name, __m128i const vec32)
+static ZL_MAYBE_UNUSED_FUNCTION void dpr(char const* name, __m128i const vec32)
 {
     size_t n = 4;
     uint32_t data[4];
@@ -115,7 +115,9 @@ static void dpr(char const* name, __m128i const vec32)
     fprintf(stderr, "]\n");
 }
 
-static void dpr16(char const* name, __m128i const vec32)
+static ZL_MAYBE_UNUSED_FUNCTION void dpr16(
+        char const* name,
+        __m128i const vec32)
 {
     size_t n = 8;
     uint16_t data[8];
@@ -1066,7 +1068,7 @@ static ZL_UNUSED_ATTR ZL_Report decodeOffbits(
         size_t numOffsets,
         ZL_RC* in)
 {
-    if (0) {
+    if ((0)) {
         ZS_BitDStreamFF offbits;
         ZL_RET_R_IF_ERR(getBitstream(&offbits, in));
         uint32_t* const offsets1 = offsets;

--- a/src/openzl/codecs/rolz/encode_match_finder_lazy.c
+++ b/src/openzl/codecs/rolz/encode_match_finder_lazy.c
@@ -181,7 +181,7 @@ ZL_FORCE_INLINE ZS_RolzMatch ZS_rolz_findBestMatch2(
     size_t nbSearches = rolz->nbSearches;
     {
         ZL_VecMask matches;
-        if (1) {
+        if ((1)) {
             if (rolz->rowLog <= 4) {
                 ZL_Vec128 const hashes =
                         ZL_Vec128_read(rowStart + kRolzHashOffset);
@@ -1605,7 +1605,7 @@ ZL_FORCE_INLINE bool search(
     }
 
     //> Rolz match
-    if (rolzEnabled && (1 || ip - anchor < contextDepth)) {
+    if (rolzEnabled && ((1) || ip - anchor < contextDepth)) {
         ZS_RolzMatch const m = ZS_rolz_findBestMatch2(
                 rolz,
                 window,

--- a/src/openzl/codecs/transpose/decode_transpose_kernel.c
+++ b/src/openzl/codecs/transpose/decode_transpose_kernel.c
@@ -70,11 +70,12 @@ ZL_FORCE_INLINE void ZS_splitTransposeDecode_impl(
     }
 }
 
-#define ZS_GEN_SPLIT_TRANSPOSE_DECODE(kEltWidth)                               \
-    static ZL_TRANSPOSE_DEC_NOINLINE void ZS_splitTransposeDecode_##kEltWidth( \
-            uint8_t* dst, uint8_t const* restrict* src, size_t nbElts)         \
-    {                                                                          \
-        ZS_splitTransposeDecode_impl(dst, src, nbElts, kEltWidth);             \
+#define ZS_GEN_SPLIT_TRANSPOSE_DECODE(kEltWidth)                       \
+    static ZL_MAYBE_UNUSED_FUNCTION ZL_TRANSPOSE_DEC_NOINLINE void     \
+    ZS_splitTransposeDecode_##kEltWidth(                               \
+            uint8_t* dst, uint8_t const* restrict* src, size_t nbElts) \
+    {                                                                  \
+        ZS_splitTransposeDecode_impl(dst, src, nbElts, kEltWidth);     \
     }
 
 ZS_GEN_SPLIT_TRANSPOSE_DECODE(2)

--- a/src/openzl/common/errors.c
+++ b/src/openzl/common/errors.c
@@ -499,7 +499,7 @@ ZL_ErrorFrame ZL_EE_stackFrame(ZL_ErrorInfo ei, size_t idx)
     if (dy != NULL) {
         return ZL_DEE_stackFrame(dy, idx);
     }
-    return (ZL_ErrorFrame){};
+    return (ZL_ErrorFrame){ 0 };
 }
 
 static ZL_GraphContext ZL_DEE_graphContext(ZL_DynamicErrorInfo const* info)

--- a/src/openzl/compress/compressor_serialization.c
+++ b/src/openzl/compress/compressor_serialization.c
@@ -793,7 +793,7 @@ static ZL_Report CompressorSerializer_serializeNode_cb(
     ZL_CompressorSerializer* const state = (ZL_CompressorSerializer*)opaque;
     ZL_RESULT_DECLARE_SCOPE_REPORT(state);
 
-    CompressorSerializer_Node info = {};
+    CompressorSerializer_Node info = { 0 };
 
     const ZL_NodeID base_nid = ZL_Compressor_Node_getBaseNodeID(c, nid);
     {
@@ -1807,7 +1807,7 @@ static ZL_RESULT_OF(ZL_LocalParams)
         resolution = &_dummy;
     }
 
-    ZL_LocalParams result = (ZL_LocalParams){};
+    ZL_LocalParams result = (ZL_LocalParams){ 0 };
     if (base != NULL) {
         result = *base;
     }

--- a/src/openzl/compress/graphmgr.c
+++ b/src/openzl/compress/graphmgr.c
@@ -849,7 +849,7 @@ GM_GraphMetadata GM_getGraphMetadata(const GraphsMgr* gm, ZL_GraphID gid)
     if (meta.graphType == ZL_GraphType_standard) {
         ZL_ASSERT(
                 !memcmp(&meta.localParams,
-                        &(ZL_LocalParams){},
+                        &(ZL_LocalParams){ 0 },
                         sizeof(ZL_LocalParams)));
     }
     if (meta.graphType == ZL_GraphType_selector) {

--- a/src/openzl/shared/a1cbor.c
+++ b/src/openzl/shared/a1cbor.c
@@ -7,6 +7,8 @@
 #include <stdio.h>
 #include <string.h>
 
+#include "./utils.h"
+
 ////////////////////////////////////////
 // Constants
 ////////////////////////////////////////
@@ -154,7 +156,7 @@ const char A1C_kBase64Map[] = {
     '0', '1', '2', '3', '4', '5', '6', '7', '8', '9', '+', '/'
 };
 
-static size_t A1C_base64EncodedSize(size_t srcSize)
+static ZL_MAYBE_UNUSED_FUNCTION size_t A1C_base64EncodedSize(size_t srcSize)
 {
     size_t encodedSize = (srcSize / 3) * 4;
     if (srcSize % 3 != 0) {

--- a/src/openzl/shared/utils.h
+++ b/src/openzl/shared/utils.h
@@ -7,6 +7,18 @@
 
 ZL_BEGIN_C_DECLS
 
+#if defined(__GNUC__) || defined(__clang__)
+#    define ZL_MAYBE_UNUSED_FUNCTION __attribute__((__unused__))
+#elif defined(_MSC_VER)
+// MSVC does not have a direct equivalent for marking an entire function as
+// "unused" to suppress a warning if it is defined but not called.
+// Usually, this warning is handled by linker settings, or by ensuring
+// the function has internal linkage (static).
+#    define ZL_MAYBE_UNUSED_FUNCTION
+#else
+#    define ZL_MAYBE_UNUSED_FUNCTION
+#endif
+
 /**
  * This should only be for small helper functions that don't belong in any
  * grouping.


### PR DESCRIPTION
Summary:
Address several warnings, treated as errors, in openzl build.  This is mostly unused functions (some of which are used in debug builds), and unreachable code (hard-coded if(1) or if(0)).  Also use of GNU empty braces extension was replaced with zero initialization.

___

overriding_review_checks_triggers_an_audit_and_retroactive_review
Oncall Short Name: lars_oncall

Grafted ffdccbd6e2c7fa48e7b5133f543300135b69d650 (D86790857)
- Grafted fbcode/openzl/versions/release to fbcode/data_compression/experimental/zstrong

Reviewed By: Victor-C-Zhang

Differential Revision: D87448504


