### PR TITLE
Trainer bugfix

### DIFF
--- a/tools/training/clustering/clustering_config_builder.cpp
+++ b/tools/training/clustering/clustering_config_builder.cpp
@@ -7,26 +7,26 @@ namespace openzl::training {
 ClusteringConfigBuilder ClusteringConfigBuilder::buildConfigClusterSoloSplit(
         const ColumnMetadata& metadata,
         const CompressionUtils& cUtils,
-        int tag) const
+        ColumnInfo tag) const
 {
     ClusteringConfigBuilder soloSplitCandidate(*this);
-    ZL_Type type    = ZL_Type_any;
-    size_t eltWidth = 0;
     for (auto& cluster : soloSplitCandidate.clusters_) {
-        if (cluster.memberTags.find(tag) != cluster.memberTags.end()) {
-            cluster.memberTags.erase(tag);
-            type     = cluster.typeSuccessor.type;
-            eltWidth = cluster.typeSuccessor.eltWidth;
+        if (cluster.typeSuccessor.type != tag.type
+            || cluster.typeSuccessor.eltWidth != tag.width) {
+            continue;
+        }
+        if (cluster.memberTags.find(tag.tag) != cluster.memberTags.end()) {
+            cluster.memberTags.erase(tag.tag);
             break;
         }
     }
     Cluster newCluster;
-    newCluster.typeSuccessor.type     = type;
-    newCluster.typeSuccessor.eltWidth = eltWidth;
-    newCluster.memberTags.insert(tag);
+    newCluster.typeSuccessor.type     = tag.type;
+    newCluster.typeSuccessor.eltWidth = tag.width;
+    newCluster.memberTags.insert(tag.tag);
     // Pick a successor for the cluster
-    auto clusterInfo =
-            cUtils.getBestClusterInfo({ tag }, type, eltWidth, metadata);
+    auto clusterInfo = cUtils.getBestClusterInfo(
+            { tag.tag }, tag.type, tag.width, metadata);
     newCluster.typeSuccessor.successorIdx = clusterInfo.successorIdx;
     newCluster.typeSuccessor.clusteringCodecIdx =
             clusterInfo.clusteringCodecIdx;
@@ -37,24 +37,24 @@ ClusteringConfigBuilder ClusteringConfigBuilder::buildConfigClusterSoloSplit(
 ClusteringConfigBuilder ClusteringConfigBuilder::buildConfigClusterPairSplit(
         const ColumnMetadata& metadata,
         const CompressionUtils& cUtils,
-        int tag1,
-        int tag2) const
+        ColumnInfo tag1,
+        ColumnInfo tag2) const
 {
-    ZL_Type type1    = ZL_Type_any;
-    size_t eltWidth1 = 0;
-    ZL_Type type2    = ZL_Type_any;
-    size_t eltWidth2 = 0;
+    ZL_Type type1    = tag1.type;
+    size_t eltWidth1 = tag1.width;
+    ZL_Type type2    = tag2.type;
+    size_t eltWidth2 = tag2.width;
     ClusteringConfigBuilder pairSplitCandidate(*this);
     for (auto& cluster : pairSplitCandidate.clusters_) {
-        if (cluster.memberTags.find(tag1) != cluster.memberTags.end()) {
-            cluster.memberTags.erase(tag1);
-            type1     = cluster.typeSuccessor.type;
-            eltWidth1 = cluster.typeSuccessor.eltWidth;
+        if (cluster.typeSuccessor.type == tag1.type
+            && cluster.typeSuccessor.eltWidth == tag1.width
+            && cluster.memberTags.find(tag1.tag) != cluster.memberTags.end()) {
+            cluster.memberTags.erase(tag1.tag);
         }
-        if (cluster.memberTags.find(tag2) != cluster.memberTags.end()) {
-            cluster.memberTags.erase(tag2);
-            type2     = cluster.typeSuccessor.type;
-            eltWidth2 = cluster.typeSuccessor.eltWidth;
+        if (cluster.typeSuccessor.type == tag2.type
+            && cluster.typeSuccessor.eltWidth == tag2.width
+            && cluster.memberTags.find(tag2.tag) != cluster.memberTags.end()) {
+            cluster.memberTags.erase(tag2.tag);
         }
     }
     if (type1 != type2 || eltWidth1 != eltWidth2) {
@@ -64,10 +64,10 @@ ClusteringConfigBuilder ClusteringConfigBuilder::buildConfigClusterPairSplit(
     Cluster newCluster;
     newCluster.typeSuccessor.type     = type1;
     newCluster.typeSuccessor.eltWidth = eltWidth1;
-    newCluster.memberTags.insert(tag1);
-    newCluster.memberTags.insert(tag2);
+    newCluster.memberTags.insert(tag1.tag);
+    newCluster.memberTags.insert(tag2.tag);
     auto clusterInfo = cUtils.getBestClusterInfo(
-            { tag1, tag2 }, type1, eltWidth1, metadata);
+            { tag1.tag, tag2.tag }, type1, eltWidth1, metadata);
     newCluster.typeSuccessor.successorIdx = clusterInfo.successorIdx;
     newCluster.typeSuccessor.clusteringCodecIdx =
             clusterInfo.clusteringCodecIdx;
@@ -86,7 +86,7 @@ ClusteringConfigBuilder ClusteringConfigBuilder::buildConfigAddInputToCluster(
         if (cluster.memberTags.find(tag) != cluster.memberTags.end()) {
             if (type != cluster.typeSuccessor.type
                 || eltWidth != cluster.typeSuccessor.eltWidth) {
-                throw Exception("Incompatible types");
+                continue;
             }
             cluster.memberTags.erase(tag);
             break;

--- a/tools/training/clustering/clustering_config_builder.h
+++ b/tools/training/clustering/clustering_config_builder.h
@@ -20,12 +20,12 @@ class ClusteringConfigBuilder {
     ClusteringConfigBuilder buildConfigClusterSoloSplit(
             const ColumnMetadata& metadata,
             const CompressionUtils& cUtils,
-            int tag) const;
+            ColumnInfo tag) const;
     ClusteringConfigBuilder buildConfigClusterPairSplit(
             const ColumnMetadata& metadata,
             const CompressionUtils& cUtils,
-            int tag1,
-            int tag2) const;
+            ColumnInfo tag1,
+            ColumnInfo tag2) const;
     /* Builds a config where the input with @p tag is moved out of its existing
      * cluster and added to the cluster with index @p clusterIdx */
     ClusteringConfigBuilder buildConfigAddInputToCluster(

--- a/tools/training/clustering/trainers/greedy_trainer.cpp
+++ b/tools/training/clustering/trainers/greedy_trainer.cpp
@@ -67,14 +67,14 @@ ClusteringConfigBuilder GreedyTrainer::getTrainedClusteringConfig(
             // Solo splits
             std::vector<ClusteringConfigBuilder> candidates;
             auto soloSplitCandidate = bestConfig.buildConfigClusterSoloSplit(
-                    metadata, cUtils, column.tag);
+                    metadata, cUtils, column);
             // Add candidate to list of the candidates of the iteration
             candidates.emplace_back(soloSplitCandidate);
             // Pair splits
             for (auto similarTag : similarColumns_[column]) {
                 auto pairSplitCandidate =
                         bestConfig.buildConfigClusterPairSplit(
-                                metadata, cUtils, column.tag, similarTag.tag);
+                                metadata, cUtils, column, similarTag);
                 // Add candidate to list of the candidates of the iteration
                 candidates.emplace_back(pairSplitCandidate);
             }

--- a/tools/training/tests/test_clustering.cpp
+++ b/tools/training/tests/test_clustering.cpp
@@ -343,5 +343,49 @@ TEST_F(TestTraining, TestTrainingCustomParserRegistrationWorks)
     EXPECT_GT(serialized.size(), 0);
 }
 
+TEST_F(TestTraining, TestTrainingDifferentTypeSameTag)
+{
+    std::vector<training::MultiInput> samples;
+
+    auto sample1                  = training::MultiInput();
+    std::vector<uint64_t> numVec1 = { 0, 1, 2, 1, 1 };
+    sample1.add(createNumericData(numVec1, 0));
+
+    std::vector<uint64_t> numVec2 = { 1, 2, 3, 2, 2 };
+    sample1.add(createNumericData(numVec2, 1));
+
+    std::string strs1              = "aaabaababaaaaaaaaaaaaaa";
+    std::vector<uint32_t> strLens1 = { 2, 5, 6, 4, 6 };
+    sample1.add(createStringData(strs1, strLens1, 0));
+
+    std::string strs2              = "bbabaababaaaaaaaaaaaaaa";
+    std::vector<uint32_t> strLens2 = { 2, 4, 7, 4, 6 };
+    sample1.add(createStringData(strs1, strLens1, 1));
+
+    samples.emplace_back(std::move(sample1));
+
+    std::map<std::pair<ZL_Type, size_t>, size_t> typeToDefaultSuccessorIdxMap;
+    typeToDefaultSuccessorIdxMap[{ ZL_Type_serial, 1 }]  = 1;
+    typeToDefaultSuccessorIdxMap[{ ZL_Type_numeric, 8 }] = 2;
+    typeToDefaultSuccessorIdxMap[{ ZL_Type_string, 0 }]  = 3;
+
+    training::TrainParams trainParams = {
+        .clusteringTrainer = training::ClusteringTrainer::Greedy
+    };
+
+    auto trainedGraphId = openzl::training::train_cluster(
+            compressor_.get(),
+            *backingArena_,
+            samples,
+            successors_,
+            clusteringCodecs_,
+            typeToDefaultSuccessorIdxMap,
+            trainParams);
+    auto lparam = ZL_Compressor_Graph_getLocalParams(
+            compressor_.get(), trainedGraphId);
+    auto r = deserializeToClusteringConfig(lparam);
+    EXPECT_TRUE(!ZL_RES_isError(r));
+}
+
 } // namespace
 } // namespace openzl::tests

--- a/tools/training/tests/test_clustering_config_builder.cpp
+++ b/tools/training/tests/test_clustering_config_builder.cpp
@@ -312,15 +312,24 @@ TEST_F(TestClusteringConfigBuilder, TestBuildSoloSplit)
     EXPECT_EQ(config->nbTypeDefaults, 0);
     EXPECT_EQ(config->nbClusters, 4);
     configBuilder = configBuilder.buildConfigClusterSoloSplit(
-            columnMetadata_, *cUtils_, 0);
+            columnMetadata_,
+            *cUtils_,
+            (training::ColumnInfo){
+                    .tag = 0, .type = ZL_Type_numeric, .width = 1 });
     config = configBuilder.build();
     EXPECT_EQ(config->nbClusters, 5);
     configBuilder = configBuilder.buildConfigClusterSoloSplit(
-            columnMetadata_, *cUtils_, 1);
+            columnMetadata_,
+            *cUtils_,
+            (training::ColumnInfo){
+                    .tag = 1, .type = ZL_Type_numeric, .width = 1 });
     config = configBuilder.build();
     EXPECT_EQ(config->nbClusters, 6);
     configBuilder = configBuilder.buildConfigClusterSoloSplit(
-            columnMetadata_, *cUtils_, 2);
+            columnMetadata_,
+            *cUtils_,
+            (training::ColumnInfo){
+                    .tag = 2, .type = ZL_Type_numeric, .width = 1 });
     config = configBuilder.build();
     EXPECT_EQ(config->nbClusters, 7);
     // Expect tags 0-2 are separated into their own clusters
@@ -350,11 +359,21 @@ TEST_F(TestClusteringConfigBuilder, TestBuildPairSplit)
     EXPECT_EQ(config->nbTypeDefaults, 0);
     EXPECT_EQ(config->nbClusters, 4);
     configBuilder = configBuilder.buildConfigClusterPairSplit(
-            columnMetadata_, *cUtils_, 0, 1);
+            columnMetadata_,
+            *cUtils_,
+            (training::ColumnInfo){
+                    .tag = 0, .type = ZL_Type_numeric, .width = 1 },
+            (training::ColumnInfo){
+                    .tag = 1, .type = ZL_Type_numeric, .width = 1 });
     config = configBuilder.build();
     EXPECT_EQ(config->nbClusters, 5);
     configBuilder = configBuilder.buildConfigClusterPairSplit(
-            columnMetadata_, *cUtils_, 2, 3);
+            columnMetadata_,
+            *cUtils_,
+            (training::ColumnInfo){
+                    .tag = 2, .type = ZL_Type_numeric, .width = 1 },
+            (training::ColumnInfo){
+                    .tag = 3, .type = ZL_Type_numeric, .width = 1 });
     config = configBuilder.build();
     EXPECT_EQ(config->nbClusters, 6);
     // Expect tags {0,1} and {2,3} are separate tag sets in clusters


### PR DESCRIPTION
Summary: We did a refactor in D83007345 to allow the same tag to appear with different types, but it didn't completely move to using `ColumnInfo`. Fixes this issue.

Reviewed By: terrelln

Differential Revision: D87574908


