### PR TITLE
Add N-to-N graph for direct stream routing

### DIFF
--- a/src/openzl/compress/graph_registry.c
+++ b/src/openzl/compress/graph_registry.c
@@ -180,6 +180,8 @@ const InternalGraphDesc GR_standardGraphs[ZL_PrivateStandardGraphID_end] = {
     REGISTER_DYNAMIC_GRAPH(ZL_PrivateStandardGraphID_split_struct, "!zl.private.split_struct", ZL_Type_struct, ZL_splitFnGraph),
     REGISTER_DYNAMIC_GRAPH(ZL_PrivateStandardGraphID_split_numeric, "!zl.private.split_numeric", ZL_Type_numeric, ZL_splitFnGraph),
     REGISTER_DYNAMIC_GRAPH(ZL_PrivateStandardGraphID_split_string, "!zl.private.split_string", ZL_Type_string, ZL_splitFnGraph),
+
+    REGISTER_MIGRAPH(ZL_PrivateStandardGraphID_n_to_n, MIGRAPH_N_TO_N),
 };
 // clang-format on
 

--- a/src/openzl/compress/graphs/split_graph.c
+++ b/src/openzl/compress/graphs/split_graph.c
@@ -26,3 +26,20 @@ ZL_Report ZL_splitFnGraph(ZL_Graph* graph, ZL_Edge** inputs, size_t numInputs)
     }
     return ZL_returnSuccess();
 }
+
+ZL_Report ZL_nToNFnGraph(ZL_Graph* graph, ZL_Edge** inputs, size_t numInputs)
+{
+    ZL_RESULT_DECLARE_SCOPE_REPORT(graph);
+
+    ZL_ASSERT_NN(inputs);
+    ZL_ASSERT_NN(graph);
+
+    const ZL_GraphIDList graphs = ZL_Graph_getCustomGraphs(graph);
+    ZL_ERR_IF_NE(graphs.nbGraphIDs, numInputs, parameter_invalid);
+
+    for (size_t i = 0; i < numInputs; ++i) {
+        ZL_ERR_IF_ERR(
+                ZL_Edge_setDestination(inputs[i], graphs.graphids[i]));
+    }
+    return ZL_returnSuccess();
+}

--- a/src/openzl/compress/graphs/split_graph.h
+++ b/src/openzl/compress/graphs/split_graph.h
@@ -10,4 +10,17 @@
  */
 ZL_Report ZL_splitFnGraph(ZL_Graph* graph, ZL_Edge** inputs, size_t numInputs);
 
+/**
+ * Routes N input streams to N successor graphs.
+ * Input[i] is routed to successor graph[i].
+ */
+ZL_Report ZL_nToNFnGraph(ZL_Graph* graph, ZL_Edge** inputs, size_t numInputs);
+
+#define MIGRAPH_N_TO_N                                         \
+    { .name                = "!zl.n_to_n",                     \
+      .graph_f             = ZL_nToNFnGraph,                   \
+      .inputTypeMasks      = (const ZL_Type[]){ ZL_Type_any }, \
+      .nbInputs            = 1,                                \
+      .lastInputIsVariable = 1 }
+
 #endif

--- a/src/openzl/compress/private_nodes.h
+++ b/src/openzl/compress/private_nodes.h
@@ -192,6 +192,8 @@ typedef enum {
     ZL_PrivateStandardGraphID_split_numeric,
     ZL_PrivateStandardGraphID_split_string,
 
+    ZL_PrivateStandardGraphID_n_to_n,
+
     ZL_PrivateStandardGraphID_end // last id, used to detect out-of-bound enum
                                   // values
 } ZL_PrivateStandardGraphID;
@@ -266,6 +268,8 @@ typedef enum {
 #define ZL_GRAPH_SPLIT_STRUCT (ZL_GraphID){ZL_PrivateStandardGraphID_split_struct}
 #define ZL_GRAPH_SPLIT_NUMERIC (ZL_GraphID){ZL_PrivateStandardGraphID_split_numeric}
 #define ZL_GRAPH_SPLIT_STRING (ZL_GraphID){ZL_PrivateStandardGraphID_split_string}
+
+#define ZL_GRAPH_N_TO_N (ZL_GraphID){ZL_PrivateStandardGraphID_n_to_n}
 
 // clang-format on
 

--- a/tests/round_trip/test_n_to_n.cpp
+++ b/tests/round_trip/test_n_to_n.cpp
@@ -1,0 +1,224 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#include <gtest/gtest.h>
+
+#include <stdio.h>
+#include <string.h>
+
+#include "openzl/common/debug.h"
+#include "openzl/compress/private_nodes.h"
+#include "openzl/zl_compress.h"
+#include "openzl/zl_compressor.h"
+#include "openzl/zl_data.h"
+#include "openzl/zl_decompress.h"
+#include "openzl/zl_graph_api.h"
+#include "openzl/zl_graphs.h"
+
+#include "tests/utils.h"
+
+namespace {
+
+// N-to-N routing helper: routes input[i] to customGraph[i]
+// This replicates ZL_nToNFnGraph logic with noexcept for C++ testing
+static ZL_Report testNToNRouting(
+        ZL_Graph* graph,
+        ZL_Edge* inputs[],
+        size_t numInputs) noexcept
+{
+    ZL_GraphIDList const graphs = ZL_Graph_getCustomGraphs(graph);
+
+    if (graphs.nbGraphIDs != numInputs) {
+        return ZL_returnError(ZL_ErrorCode_parameter_invalid);
+    }
+
+    for (size_t i = 0; i < numInputs; ++i) {
+        ZL_Report result = ZL_Edge_setDestination(inputs[i], graphs.graphids[i]);
+        if (ZL_isError(result)) {
+            return result;
+        }
+    }
+
+    return ZL_returnSuccess();
+}
+
+static void fillTestData(int* data, size_t count, int startValue)
+{
+    for (size_t i = 0; i < count; i++) {
+        data[i] = startValue + (int)i;
+    }
+}
+
+TEST(NToNGraphTest, GraphIDRegistration)
+{
+    ZL_GraphID n_to_n_graph = ZL_GRAPH_N_TO_N;
+
+    EXPECT_EQ(n_to_n_graph.gid, ZL_PrivateStandardGraphID_n_to_n);
+    EXPECT_TRUE(ZL_GraphID_isValid(n_to_n_graph));
+}
+
+TEST(NToNGraphTest, FunctionalRoutingThreeStreams)
+{
+    ZL_Compressor* compressor = ZL_Compressor_create();
+    ASSERT_NE(compressor, nullptr);
+
+    static const ZL_GraphID successors[3] = {
+        ZL_GRAPH_STORE,
+        ZL_GRAPH_COMPRESS_GENERIC,
+        ZL_GRAPH_COMPRESS_GENERIC
+    };
+
+    static ZL_Type inputType = ZL_Type_any;
+    static ZL_FunctionGraphDesc const nToNDesc = {
+        .name                = "test-n-to-n-functional",
+        .graph_f             = testNToNRouting,
+        .inputTypeMasks      = &inputType,
+        .nbInputs            = 1,
+        .lastInputIsVariable = true,
+        .customGraphs        = successors,
+        .nbCustomGraphs      = 3
+    };
+
+    ZL_GraphID n_to_n_graph =
+            ZL_Compressor_registerFunctionGraph(compressor, &nToNDesc);
+    ASSERT_TRUE(ZL_GraphID_isValid(n_to_n_graph));
+
+    ZL_Report selectResult =
+            ZL_Compressor_selectStartingGraphID(compressor, n_to_n_graph);
+    ASSERT_FALSE(ZL_isError(selectResult));
+
+    int data1[50], data2[50], data3[50];
+    fillTestData(data1, 50, 0);
+    fillTestData(data2, 50, 1000);
+    fillTestData(data3, 50, 2000);
+
+    ZL_TypedRef* input1 = ZL_TypedRef_createNumeric(data1, sizeof(int), 50);
+    ZL_TypedRef* input2 = ZL_TypedRef_createNumeric(data2, sizeof(int), 50);
+    ZL_TypedRef* input3 = ZL_TypedRef_createNumeric(data3, sizeof(int), 50);
+    const ZL_TypedRef* inputs[3] = { input1, input2, input3 };
+
+    size_t const totalBytes = 150 * sizeof(int);
+    size_t const compressedBound = ZL_compressBound(totalBytes);
+    std::vector<uint8_t> compressedData(compressedBound);
+
+    ZL_CCtx* cctx = ZL_CCtx_create();
+    ASSERT_NE(cctx, nullptr);
+
+    ZL_Report versionResult =
+            ZL_CCtx_setParameter(cctx, ZL_CParam_formatVersion, ZL_MAX_FORMAT_VERSION);
+    ASSERT_FALSE(ZL_isError(versionResult));
+
+    ZL_Report refResult = ZL_CCtx_refCompressor(cctx, compressor);
+    ASSERT_FALSE(ZL_isError(refResult));
+
+    ZL_Report compressResult = ZL_CCtx_compressMultiTypedRef(
+            cctx, compressedData.data(), compressedData.size(), inputs, 3);
+    ASSERT_FALSE(ZL_isError(compressResult));
+
+    size_t const compressedSize = ZL_validResult(compressResult);
+    EXPECT_GT(compressedSize, 0);
+    EXPECT_LE(compressedSize, compressedBound);
+
+    ZL_TypedBuffer* outputs[3] = {
+        ZL_TypedBuffer_create(),
+        ZL_TypedBuffer_create(),
+        ZL_TypedBuffer_create()
+    };
+
+    ZL_DCtx* dctx = ZL_DCtx_create();
+    ASSERT_NE(dctx, nullptr);
+
+    ZL_Report decompressResult = ZL_DCtx_decompressMultiTBuffer(
+            dctx, outputs, 3, compressedData.data(), compressedSize);
+    ASSERT_FALSE(ZL_isError(decompressResult));
+
+    EXPECT_EQ(ZL_TypedBuffer_numElts(outputs[0]), 50);
+    EXPECT_EQ(ZL_TypedBuffer_numElts(outputs[1]), 50);
+    EXPECT_EQ(ZL_TypedBuffer_numElts(outputs[2]), 50);
+
+    const int* dec1 = (const int*)ZL_TypedBuffer_rPtr(outputs[0]);
+    const int* dec2 = (const int*)ZL_TypedBuffer_rPtr(outputs[1]);
+    const int* dec3 = (const int*)ZL_TypedBuffer_rPtr(outputs[2]);
+
+    EXPECT_EQ(memcmp(dec1, data1, 50 * sizeof(int)), 0);
+    EXPECT_EQ(memcmp(dec2, data2, 50 * sizeof(int)), 0);
+    EXPECT_EQ(memcmp(dec3, data3, 50 * sizeof(int)), 0);
+
+    ZL_TypedRef_free(input1);
+    ZL_TypedRef_free(input2);
+    ZL_TypedRef_free(input3);
+    for (int i = 0; i < 3; i++) {
+        ZL_TypedBuffer_free(outputs[i]);
+    }
+    ZL_DCtx_free(dctx);
+    ZL_CCtx_free(cctx);
+    ZL_Compressor_free(compressor);
+}
+
+// Test error handling: mismatched input/graph counts should fail
+TEST(NToNGraphTest, MismatchedCountsError)
+{
+    ZL_Compressor* compressor = ZL_Compressor_create();
+    ASSERT_NE(compressor, nullptr);
+
+    // Register with 2 successor graphs but will provide 3 inputs
+    static const ZL_GraphID successors[2] = {
+        ZL_GRAPH_STORE,
+        ZL_GRAPH_COMPRESS_GENERIC
+    };
+
+    static ZL_Type inputType = ZL_Type_any;
+    static ZL_FunctionGraphDesc const nToNDesc = {
+        .name                = "test-n-to-n-mismatch",
+        .graph_f             = testNToNRouting,
+        .inputTypeMasks      = &inputType,
+        .nbInputs            = 1,
+        .lastInputIsVariable = true,
+        .customGraphs        = successors,
+        .nbCustomGraphs      = 2  // Only 2 graphs
+    };
+
+    ZL_GraphID n_to_n_graph =
+            ZL_Compressor_registerFunctionGraph(compressor, &nToNDesc);
+    ASSERT_TRUE(ZL_GraphID_isValid(n_to_n_graph));
+
+    ZL_Report selectResult =
+            ZL_Compressor_selectStartingGraphID(compressor, n_to_n_graph);
+    ASSERT_FALSE(ZL_isError(selectResult));
+
+    int data1[10], data2[10], data3[10];
+    fillTestData(data1, 10, 0);
+    fillTestData(data2, 10, 10);
+    fillTestData(data3, 10, 20);
+
+    ZL_TypedRef* input1 = ZL_TypedRef_createNumeric(data1, sizeof(int), 10);
+    ZL_TypedRef* input2 = ZL_TypedRef_createNumeric(data2, sizeof(int), 10);
+    ZL_TypedRef* input3 = ZL_TypedRef_createNumeric(data3, sizeof(int), 10);
+    const ZL_TypedRef* inputs[3] = { input1, input2, input3 };  // 3 inputs!
+
+    size_t const compressedBound = ZL_compressBound(30 * sizeof(int));
+    std::vector<uint8_t> compressedData(compressedBound);
+
+    ZL_CCtx* cctx = ZL_CCtx_create();
+    ASSERT_NE(cctx, nullptr);
+
+    ZL_Report versionResult =
+            ZL_CCtx_setParameter(cctx, ZL_CParam_formatVersion, ZL_MAX_FORMAT_VERSION);
+    ASSERT_FALSE(ZL_isError(versionResult));
+
+    ZL_Report refResult = ZL_CCtx_refCompressor(cctx, compressor);
+    ASSERT_FALSE(ZL_isError(refResult));
+
+    // Compression should fail: 3 inputs but only 2 graphs
+    ZL_Report compressResult = ZL_CCtx_compressMultiTypedRef(
+            cctx, compressedData.data(), compressedData.size(), inputs, 3);
+    EXPECT_TRUE(ZL_isError(compressResult));
+    EXPECT_EQ(ZL_errorCode(compressResult), ZL_ErrorCode_parameter_invalid);
+
+    ZL_TypedRef_free(input1);
+    ZL_TypedRef_free(input2);
+    ZL_TypedRef_free(input3);
+    ZL_CCtx_free(cctx);
+    ZL_Compressor_free(compressor);
+}
+
+} // namespace


### PR DESCRIPTION
 ## Summary

  Implements a new graph type that routes N input streams directly to N successor graphs without intermediate node processing. Each input stream is routed to its corresponding successor graph (input[i] -> graph[i]).

  This addresses the need for parallel processing of multiple streams through different compression pipelines without data transformation between the router and successors.

  Feature Request #202

  ## Type of Change

  - [x] New feature (non-breaking change which adds functionality)

  ## Test Plan

  ### Verification Steps

  1. **Compilation Test**: Built the library successfully with the new graph implementation
     ```bash
     cmake -S . -B build
     cmake --build build

  2. API Validation Test: Created and ran test program test_n_to_n.cpp that verifies:
    - Graph ID is properly defined (ZL_GRAPH_N_TO_N)
    - Graph ID matches expected enum value (ZL_PrivateStandardGraphID_n_to_n)
    - Compressor creation succeeds
    - Graph ID validation passes (ZL_GraphID_isValid())

  Result: All tests passed ✓

  Test Configuration

  - Compiler: g++ (Apple clang version matching Xcode)
  - Build type: Default CMake build
  - Platform(s): macOS (Darwin 24.6.0, arm64)

  Implementation Details

  Files Modified:
  - src/openzl/compress/private_nodes.h - Added graph ID enum and convenience macro
  - src/openzl/compress/graphs/split_graph.h - Added function declaration and MIGRAPH_N_TO_N descriptor
  - src/openzl/compress/graphs/split_graph.c - Implemented ZL_nToNFnGraph() routing function
  - src/openzl/compress/graph_registry.c - Registered graph with REGISTER_MIGRAPH macro

  Core Function: ZL_nToNFnGraph() validates that the number of input streams matches the number of successor graphs, then routes each input[i] to its corresponding graph[i] using ZL_Edge_setDestination().

  ---