### PR TITLE
Graft "Fix MSVC Macro Expansion Issues in openzl"

### DIFF
--- a/BUCK
+++ b/BUCK
@@ -176,6 +176,7 @@ zs_library(
 )
 
 cpp_library(
+    # @autodeps-skip
     name = "openzl_fbcode",
     visibility = ["//openzl:openzl"],
     exported_deps = [
@@ -197,6 +198,7 @@ cpp_library(
 
 # This target exposes the standalone OpenZL core library that only has zstd as an external dependency.
 cpp_library(
+    # @autodeps-skip
     name = "openzl_core",
     visibility = ["//openzl:openzl_core"],
     exported_deps = [
@@ -206,6 +208,7 @@ cpp_library(
 
 # Not intended to be widely used. A supported Python binding is coming.
 python_library(
+    # @autodeps-skip
     name = "openzl_py_deprecated",
     visibility = ["//openzl:openzl_py_deprecated"],
     deps = [
@@ -218,6 +221,7 @@ python_library(
 
 # Do not use in production builds.
 cpp_library(
+    # @autodeps-skip
     name = "openzl_test_utils",
     visibility = ["//openzl:openzl_test_utils"],
     exported_deps = [

--- a/include/openzl/zl_macro_helpers.h
+++ b/include/openzl/zl_macro_helpers.h
@@ -16,42 +16,45 @@
 #define ZS_MACRO_QUOTE_INNER(a) #a
 #define ZS_MACRO_QUOTE(a) ZS_MACRO_QUOTE_INNER(a)
 
-#define ZS_MACRO_PAD_SELECT_33RD( \
-        _1,                       \
-        _2,                       \
-        _3,                       \
-        _4,                       \
-        _5,                       \
-        _6,                       \
-        _7,                       \
-        _8,                       \
-        _9,                       \
-        _10,                      \
-        _11,                      \
-        _12,                      \
-        _13,                      \
-        _14,                      \
-        _15,                      \
-        _16,                      \
-        _17,                      \
-        _18,                      \
-        _19,                      \
-        _20,                      \
-        _21,                      \
-        _22,                      \
-        _23,                      \
-        _24,                      \
-        _25,                      \
-        _26,                      \
-        _27,                      \
-        _28,                      \
-        _29,                      \
-        _30,                      \
-        _31,                      \
-        _32,                      \
-        _33,                      \
-        ...)                      \
+#define ZS_MACRO_EXPAND(...) __VA_ARGS__
+#define ZS_MACRO_PAD_SELECT_33RD_INNER( \
+        _1,                             \
+        _2,                             \
+        _3,                             \
+        _4,                             \
+        _5,                             \
+        _6,                             \
+        _7,                             \
+        _8,                             \
+        _9,                             \
+        _10,                            \
+        _11,                            \
+        _12,                            \
+        _13,                            \
+        _14,                            \
+        _15,                            \
+        _16,                            \
+        _17,                            \
+        _18,                            \
+        _19,                            \
+        _20,                            \
+        _21,                            \
+        _22,                            \
+        _23,                            \
+        _24,                            \
+        _25,                            \
+        _26,                            \
+        _27,                            \
+        _28,                            \
+        _29,                            \
+        _30,                            \
+        _31,                            \
+        _32,                            \
+        _33,                            \
+        ...)                            \
     _33
+#define ZS_MACRO_PAD_SELECT_33RD(...) \
+    ZS_MACRO_EXPAND(ZS_MACRO_PAD_SELECT_33RD_INNER(__VA_ARGS__))
 #define ZS_MACRO_PAD1_SUFFIX(...) \
     ZS_MACRO_PAD_SELECT_33RD(     \
             __VA_ARGS__,          \
@@ -266,11 +269,11 @@
 #define ZS_MACRO_PAD5_ARGS(...) \
     ZS_MACRO_CONCAT(ZS_MACRO_PAD, ZS_MACRO_PAD5_SUFFIX(__VA_ARGS__))
 
-#define ZS_MACRO_PAD1_INNER(macro, ...) macro(__VA_ARGS__)
-#define ZS_MACRO_PAD2_INNER(macro, ...) macro(__VA_ARGS__)
-#define ZS_MACRO_PAD3_INNER(macro, ...) macro(__VA_ARGS__)
-#define ZS_MACRO_PAD4_INNER(macro, ...) macro(__VA_ARGS__)
-#define ZS_MACRO_PAD5_INNER(macro, ...) macro(__VA_ARGS__)
+#define ZS_MACRO_PAD1_INNER(macro, ...) ZS_MACRO_EXPAND(macro(__VA_ARGS__))
+#define ZS_MACRO_PAD2_INNER(macro, ...) ZS_MACRO_EXPAND(macro(__VA_ARGS__))
+#define ZS_MACRO_PAD3_INNER(macro, ...) ZS_MACRO_EXPAND(macro(__VA_ARGS__))
+#define ZS_MACRO_PAD4_INNER(macro, ...) ZS_MACRO_EXPAND(macro(__VA_ARGS__))
+#define ZS_MACRO_PAD5_INNER(macro, ...) ZS_MACRO_EXPAND(macro(__VA_ARGS__))
 
 /**
  * These macros are designed to handle the case where, after N required


### PR DESCRIPTION
Summary:
NOTE: I cleaned up this diff a bit after grafting, because the `#if _MSC_VER` branch wasn't necessary.

---
## LLM-generated Summary:
I've implemented a fix for MSVC macro expansion issues in `fbcode/openzl/versions/release/include/openzl/zl_macro_helpers.h`. The fix addresses the `ZS_MACRO_PAD_NOT_ENOUGH_ARGS` errors. The changes include adding `ZS_MACRO_EXPAND(...) __VA_ARGS__` to force MSVC to properly expand variadic arguments, splitting `ZS_MACRO_PAD_SELECT_33RD` for MSVC, and keeping existing `ZS_MACRO_PAD*_INNER` fixes. These changes should resolve all the compilation errors with `ZL_ASSERT_LT`, `ZL_ASSERT_EQ`, and other assertion macros on MSVC. The fix works by forcing MSVC to fully expand all arguments before they reach the argument-counting logic, preventing the `NOT_ENOUGH_ARGS` sentinel from appearing in the final expansion.
---

## Initial Devmate Prompt:
I have macro expansions in openzl that work with gcc and clang, but not msvc.  Here are the errors:

```text
C:\re_cwd\buck-out\v2\gen\fbcode\openzl\versions\release\__common__\0599e042b911a84b\buck-headers\openzl/common/vector.h(342): error C2146: syntax error: missing ')' before identifier 'ZS_MACRO_PAD_NOT_ENOUGH_ARGS'

C:\re_cwd\buck-out\v2\gen\fbcode\openzl\versions\release\__common__\0599e042b911a84b\buck-headers\openzl/common/vector.h(342): error C2059: syntax error: ')'

C:\re_cwd\buck-out\v2\gen\fbcode\openzl\versions\release\__common__\0599e042b911a84b\buck-headers\openzl/common/vector.h(351): error C2146: syntax error: missing ')' before identifier 'ZS_MACRO_PAD_NOT_ENOUGH_ARGS'

C:\re_cwd\buck-out\v2\gen\fbcode\openzl\versions\release\__common__\0599e042b911a84b\buck-headers\openzl/common/vector.h(351): error C2059: syntax error: ')'

C:\re_cwd\buck-out\v2\gen\fbcode\openzl\versions\release\__common__\0599e042b911a84b\buck-headers\openzl/common/vector.h(385): error C2146: syntax error: missing ')' before identifier 'ZS_MACRO_PAD_NOT_ENOUGH_ARGS'

C:\re_cwd\buck-out\v2\gen\fbcode\openzl\versions\release\__common__\0599e042b911a84b\buck-headers\openzl/common/vector.h(385): error C2059: syntax error: ')'

C:\re_cwd\buck-out\v2\gen\fbcode\openzl\versions\release\__common__\0599e042b911a84b\buck-headers\openzl/common/vector.h(448): error C2146: syntax error: missing ')' before identifier 'ZS_MACRO_PAD_NOT_ENOUGH_ARGS'

C:\re_cwd\buck-out\v2\gen\fbcode\openzl\versions\release\__common__\0599e042b911a84b\buck-headers\openzl/common/vector.h(448): error C2059: syntax error: ')'

C:\re_cwd\buck-out\v2\gen\fbcode\openzl\versions\release\__common__\0599e042b911a84b\buck-headers\openzl/common/vector.h(449): error C2146: syntax error: missing ')' before identifier 'ZS_MACRO_PAD_NOT_ENOUGH_ARGS'

C:\re_cwd\buck-out\v2\gen\fbcode\openzl\versions\release\__common__\0599e042b911a84b\buck-headers\openzl/common/vector.h(449): error C2059: syntax error: ')'

C:\re_cwd\buck-out\v2\gen\fbcode\openzl\versions\release\__common__\0599e042b911a84b\buck-headers\openzl/common/vector.h(469): error C2146: syntax error: missing ')' before identifier 'ZS_MACRO_PAD_NOT_ENOUGH_ARGS'

C:\re_cwd\buck-out\v2\gen\fbcode\openzl\versions\release\__common__\0599e042b911a84b\buck-headers\openzl/common/vector.h(469): error C2059: syntax error: ')'

C:\re_cwd\buck-out\v2\gen\fbcode\openzl\versions\release\__common__\0599e042b911a84b\buck-headers\openzl/shared/utils.h(45): error C2146: syntax error: missing ')' before identifier 'ZS_MACRO_PAD_NOT_ENOUGH_ARGS'

C:\re_cwd\buck-out\v2\gen\fbcode\openzl\versions\release\__common__\0599e042b911a84b\buck-headers\openzl/shared/utils.h(45): error C2059: syntax error: ')'

C:\re_cwd\buck-out\v2\gen\fbcode\openzl\versions\release\__common__\0599e042b911a84b\buck-headers\openzl/shared/utils.h(46): error C2146: syntax error: missing ')' before identifier 'ZS_MACRO_PAD_NOT_ENOUGH_ARGS'

C:\re_cwd\buck-out\v2\gen\fbcode\openzl\versions\release\__common__\0599e042b911a84b\buck-headers\openzl/shared/utils.h(46): error C2059: syntax error: ')'

C:\re_cwd\buck-out\v2\gen\fbcode\openzl\versions\release\__common__\0599e042b911a84b\buck-headers\openzl/common/detail/table.h(368): error C2146: syntax error: missing ')' before identifier 'ZS_MACRO_PAD_NOT_ENOUGH_ARGS'

C:\re_cwd\buck-out\v2\gen\fbcode\openzl\versions\release\__common__\0599e042b911a84b\buck-headers\openzl/common/detail/table.h(368): error C2059: syntax error: ')'

C:\re_cwd\buck-out\v2\gen\fbcode\openzl\versions\release\__common__\0599e042b911a84b\buck-headers\openzl/common/detail/table.h(408): error C2146: syntax error: missing ')' before identifier 'ZS_MACRO_PAD_NOT_ENOUGH_ARGS'

C:\re_cwd\buck-out\v2\gen\fbcode\openzl\versions\release\__common__\0599e042b911a84b\buck-headers\openzl/common/detail/table.h(408): error C2059: syntax error: ')'

C:\re_cwd\buck-out\v2\gen\fbcode\openzl\versions\release\__common__\0599e042b911a84b\buck-headers\openzl/common/detail/table.h(419): error C2146: syntax error: missing ')' before identifier 'ZS_MACRO_PAD_NOT_ENOUGH_ARGS'

C:\re_cwd\buck-out\v2\gen\fbcode\openzl\versions\release\__common__\0599e042b911a84b\buck-headers\openzl/common/detail/table.h(419): error C2059: syntax error: ')'

C:\re_cwd\buck-out\v2\gen\fbcode\openzl\versions\release\__common__\0599e042b911a84b\buck-headers\openzl/common/detail/table.h(440): error C2146: syntax error: missing ')' before identifier 'ZS_MACRO_PAD_NOT_ENOUGH_ARGS'

C:\re_cwd\buck-out\v2\gen\fbcode\openzl\versions\release\__common__\0599e042b911a84b\buck-headers\openzl/common/detail/table.h(440): error C2059: syntax error: ')'

C:\re_cwd\buck-out\v2\gen\fbcode\openzl\versions\release\__common__\0599e042b911a84b\buck-headers\openzl/common/detail/table.h(474): error C2146: syntax error: missing ')' before identifier 'ZS_MACRO_PAD_NOT_ENOUGH_ARGS'

C:\re_cwd\buck-out\v2\gen\fbcode\openzl\versions\release\__common__\0599e042b911a84b\buck-headers\openzl/common/detail/table.h(474): error C2059: syntax error: ')'

C:\re_cwd\buck-out\v2\gen\fbcode\openzl\versions\release\__common__\0599e042b911a84b\buck-headers\openzl/common/detail/table.h(480): error C2146: syntax error: missing ')' before identifier 'ZS_MACRO_PAD_NOT_ENOUGH_ARGS'

C:\re_cwd\buck-out\v2\gen\fbcode\openzl\versions\release\__common__\0599e042b911a84b\buck-headers\openzl/common/detail/table.h(480): error C2059: syntax error: ')'

C:\re_cwd\buck-out\v2\gen\fbcode\openzl\versions\release\__common__\0599e042b911a84b\buck-headers\openzl/common/detail/table.h(508): error C2146: syntax error: missing ')' before identifier 'ZS_MACRO_PAD_NOT_ENOUGH_ARGS'

C:\re_cwd\buck-out\v2\gen\fbcode\openzl\versions\release\__common__\0599e042b911a84b\buck-headers\openzl/common/detail/table.h(508): error C2059: syntax error: ')'

C:\re_cwd\buck-out\v2\gen\fbcode\openzl\versions\release\__common__\0599e042b911a84b\buck-headers\openzl/common/detail/table.h(523): error C2146: syntax error: missing ')' before identifier 'ZS_MACRO_PAD_NOT_ENOUGH_ARGS'

C:\re_cwd\buck-out\v2\gen\fbcode\openzl\versions\release\__common__\0599e042b911a84b\buck-headers\openzl/common/detail/table.h(523): error C2059: syntax error: ')'

C:\re_cwd\buck-out\v2\gen\fbcode\openzl\versions\release\__common__\0599e042b911a84b\buck-headers\openzl/common/detail/table.h(549): error C2146: syntax error: missing ')' before identifier 'ZS_MACRO_PAD_NOT_ENOUGH_ARGS'

C:\re_cwd\buck-out\v2\gen\fbcode\openzl\versions\release\__common__\0599e042b911a84b\buck-headers\openzl/common/detail/table.h(549): error C2059: syntax error: ')'

C:\re_cwd\buck-out\v2\gen\fbcode\openzl\versions\release\__common__\0599e042b911a84b\buck-headers\openzl/common/detail/table.h(579): error C2146: syntax error: missing ')' before identifier 'ZS_MACRO_PAD_NOT_ENOUGH_ARGS'

C:\re_cwd\buck-out\v2\gen\fbcode\openzl\versions\release\__common__\0599e042b911a84b\buck-headers\openzl/common/detail/table.h(579): error C2059: syntax error: ')'

C:\re_cwd\buck-out\v2\gen\fbcode\openzl\versions\release\__common__\0599e042b911a84b\buck-headers\openzl/common/detail/table.h(591): error C2146: syntax error: missing ')' before identifier 'ZS_MACRO_PAD_NOT_ENOUGH_ARGS'

C:\re_cwd\buck-out\v2\gen\fbcode\openzl\versions\release\__common__\0599e042b911a84b\buck-headers\openzl/common/detail/table.h(591): error C2059: syntax error: ')'

C:\re_cwd\buck-out\v2\gen\fbcode\openzl\versions\release\__common__\0599e042b911a84b\buck-headers\openzl/common/detail/table.h(649): error C2146: syntax error: missing ')' before identifier 'ZS_MACRO_PAD_NOT_ENOUGH_ARGS'

C:\re_cwd\buck-out\v2\gen\fbcode\openzl\versions\release\__common__\0599e042b911a84b\buck-headers\openzl/common/detail/table.h(646): error C2059: syntax error: ')'

C:\re_cwd\buck-out\v2\gen\fbcode\openzl\versions\release\__common__\0599e042b911a84b\buck-headers\openzl/common/detail/table.h(661): error C2146: syntax error: missing ')' before identifier 'ZS_MACRO_PAD_NOT_ENOUGH_ARGS'

C:\re_cwd\buck-out\v2\gen\fbcode\openzl\versions\release\__common__\0599e042b911a84b\buck-headers\openzl/common/detail/table.h(661): error C2059: syntax error: ')'

C:\re_cwd\buck-out\v2\gen\fbcode\openzl\versions\release\__common__\0599e042b911a84b\buck-headers\openzl/common/detail/table.h(679): error C2146: syntax error: missing ')' before identifier 'ZS_MACRO_PAD_NOT_ENOUGH_ARGS'

C:\re_cwd\buck-out\v2\gen\fbcode\openzl\versions\release\__common__\0599e042b911a84b\buck-headers\openzl/common/detail/table.h(679): error C2059: syntax error: ')'

C:\re_cwd\buck-out\v2\gen\fbcode\openzl\versions\release\__common__\0599e042b911a84b\buck-headers\openzl/common/detail/table.h(682): error C2146: syntax error: missing ')' before identifier 'ZS_MACRO_PAD_NOT_ENOUGH_ARGS'

C:\re_cwd\buck-out\v2\gen\fbcode\openzl\versions\release\__common__\0599e042b911a84b\buck-headers\openzl/common/detail/table.h(682): error C2059: syntax error: ')'

C:\re_cwd\buck-out\v2\gen\fbcode\openzl\versions\release\__common__\0599e042b911a84b\buck-headers\openzl/common/detail/table.h(687): error C2146: syntax error: missing ')' before identifier 'ZS_MACRO_PAD_NOT_ENOUGH_ARGS'

C:\re_cwd\buck-out\v2\gen\fbcode\openzl\versions\release\__common__\0599e042b911a84b\buck-headers\openzl/common/detail/table.h(687): error C2059: syntax error: ')'

C:\re_cwd\buck-out\v2\gen\fbcode\openzl\versions\release\__common__\0599e042b911a84b\buck-headers\openzl/common/detail/table.h(705): error C2146: syntax error: missing ')' before identifier 'ZS_MACRO_PAD_NOT_ENOUGH_ARGS'

C:\re_cwd\buck-out\v2\gen\fbcode\openzl\versions\release\__common__\0599e042b911a84b\buck-headers\openzl/common/detail/table.h(705): error C2059: syntax error: ')'

C:\re_cwd\buck-out\v2\gen\fbcode\openzl\versions\release\__common__\0599e042b911a84b\buck-headers\openzl/common/detail/table.h(722): error C2146: syntax error: missing ')' before identifier 'ZS_MACRO_PAD_NOT_ENOUGH_ARGS'

C:\re_cwd\buck-out\v2\gen\fbcode\openzl\versions\release\__common__\0599e042b911a84b\buck-headers\openzl/common/detail/table.h(722): error C2059: syntax error: ')'

Suggest a fix and implement it in a diff
```

Session: DEV17336390

Grafted 211d158e77263afb15760bf90bdff9713ebdc154 (D87254904)
- Grafted fbcode/openzl/versions/release to fbcode/openzl/dev

Reviewed By: graphicsMan

Differential Revision: D87893482


