### PR TITLE
Graft "[openzl] Make openzl C++ via MSVC compatible"

### DIFF
--- a/BUCK
+++ b/BUCK
@@ -176,6 +176,7 @@ zs_library(
 )
 
 cpp_library(
+    # @autodeps-skip
     name = "openzl_fbcode",
     visibility = ["//openzl:openzl"],
     exported_deps = [
@@ -197,6 +198,7 @@ cpp_library(
 
 # This target exposes the standalone OpenZL core library that only has zstd as an external dependency.
 cpp_library(
+    # @autodeps-skip
     name = "openzl_core",
     visibility = ["//openzl:openzl_core"],
     exported_deps = [
@@ -206,6 +208,7 @@ cpp_library(
 
 # Not intended to be widely used. A supported Python binding is coming.
 python_library(
+    # @autodeps-skip
     name = "openzl_py_deprecated",
     visibility = ["//openzl:openzl_py_deprecated"],
     deps = [
@@ -218,6 +221,7 @@ python_library(
 
 # Do not use in production builds.
 cpp_library(
+    # @autodeps-skip
     name = "openzl_test_utils",
     visibility = ["//openzl:openzl_test_utils"],
     exported_deps = [

--- a/custom_transforms/thrift/directed_selector.h
+++ b/custom_transforms/thrift/directed_selector.h
@@ -2,11 +2,11 @@
 
 #pragma once
 
+#include "openzl/zl_selector.h"
+
 #ifdef __cplusplus
 extern "C" {
 #endif
-
-#include "openzl/zl_selector.h"
 
 /**
  * The int metadata id / key that should be set with the index of the successor

--- a/custom_transforms/thrift/empty_input_selector.h
+++ b/custom_transforms/thrift/empty_input_selector.h
@@ -2,11 +2,11 @@
 
 #pragma once
 
+#include "openzl/zl_selector.h"
+
 #ifdef __cplusplus
 extern "C" {
 #endif
-
-#include "openzl/zl_selector.h"
 
 /**
  * A selector that behaves as follows:

--- a/custom_transforms/thrift/kernels/decode_thrift_kernel.h
+++ b/custom_transforms/thrift/kernels/decode_thrift_kernel.h
@@ -3,14 +3,14 @@
 #ifndef ZSTRONG_CUSTOM_TRANSFORMS_THRIFT_KERNELS_DECODE_THRIFT_KERNEL_H
 #define ZSTRONG_CUSTOM_TRANSFORMS_THRIFT_KERNELS_DECODE_THRIFT_KERNEL_H
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
 #include <stddef.h>
 #include <stdint.h>
 
 #include "openzl/zl_errors.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 /**
  * All of these functions assume that you have an upper bound on the output

--- a/custom_transforms/thrift/kernels/encode_thrift_kernel.h
+++ b/custom_transforms/thrift/kernels/encode_thrift_kernel.h
@@ -3,14 +3,14 @@
 #ifndef ZSTRONG_CUSTOM_TRANSFORMS_THRIFT_KERNELS_ENCODE_THRIFT_KERNEL_H
 #define ZSTRONG_CUSTOM_TRANSFORMS_THRIFT_KERNELS_ENCODE_THRIFT_KERNEL_H
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
 #include <stddef.h>
 #include <stdint.h>
 
 #include "openzl/zl_errors.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 /**
  * All of these functions require knowing the containers size ahead of time.

--- a/custom_transforms/thrift/probabilistic_selector.h
+++ b/custom_transforms/thrift/probabilistic_selector.h
@@ -2,11 +2,11 @@
 
 #pragma once
 
+#include "openzl/zl_graph_api.h"
+
 #ifdef __cplusplus
 extern "C" {
 #endif
-
-#include "openzl/zl_graph_api.h"
 
 /**
  * A selector that chooses between a set of successors with a weighted

--- a/defs.bzl
+++ b/defs.bzl
@@ -4,7 +4,9 @@ load("@fbcode//fbpkg:fbpkg.bzl", "fbpkg")
 load("@fbcode_macros//build_defs:cpp_binary.bzl", "cpp_binary")
 load("@fbcode_macros//build_defs:cpp_library.bzl", "cpp_library")
 load("@fbcode_macros//build_defs:cpp_unittest.bzl", "cpp_unittest")
+load("@fbsource//tools/build_defs:selects.bzl", "selects")
 load("@fbsource//tools/build_defs:type_defs.bzl", "is_string")
+load("@fbsource//tools/build_defs/windows:windows_flag_map.bzl", "windows_convert_gcc_clang_flags")
 load("@fbsource//xplat/security/lionhead:defs.bzl", "ALL_EMPLOYEES", "Interaction", "Metadata", "Priv", "Reachability", "Severity")
 load("@fbsource//xplat/security/lionhead/build_defs:generic_harness.bzl", "generic_lionhead_harness")
 load("//security/lionhead/harnesses:defs.bzl", "cpp_lionhead_harness")
@@ -71,11 +73,13 @@ def relative_headers(headers):
 
     return header_map
 
-_ZS_COMPILER_FLAGS = [
+# Base compiler flags for all builds (GCC/Clang syntax)
+_ZS_COMPILER_FLAGS_CLANG = [
     "-fno-sanitize=pointer-overflow",
 ]
 
-_ZS_DEV_COMPILER_FLAGS = [
+# Dev compiler flags (GCC/Clang syntax)
+_ZS_DEV_COMPILER_FLAGS_CLANG = [
     "-Wall",
     "-Wcast-qual",
     "-Wcast-align",
@@ -97,13 +101,15 @@ _ZS_DEV_COMPILER_FLAGS = [
     # "-DZS_ERROR_ENABLE_LEAKY_ALLOCATIONS=1", # set this to always create verbose errors
 ]
 
-_ZS_DEV_C_COMPILER_FLAGS = [
+# Dev C-specific compiler flags (GCC/Clang syntax)
+_ZS_DEV_C_COMPILER_FLAGS_CLANG = [
     "-Wextra",
     "-Wconversion",
     "-Wno-missing-field-initializers",  # Allow missing fields in designated initializers
 ]
 
-_ZS_SRC_FILE_COMPILER_FLAGS = {
+# File-specific compiler flags (GCC/Clang syntax)
+_ZS_SRC_FILE_COMPILER_FLAGS_CLANG = {
     "src/openzl/common/errors.c": [
         "-Wno-format-nonliteral",
     ],
@@ -118,14 +124,48 @@ _ZS_SRC_FILE_COMPILER_FLAGS = {
     ],
 }
 
-_ZS_C_COMPILER_FLAGS = [
+# Convert flags for MSVC when needed
+_ZS_COMPILER_FLAGS = select({
+    "DEFAULT": _ZS_COMPILER_FLAGS_CLANG,
+    "ovr_config//compiler:msvc": windows_convert_gcc_clang_flags(_ZS_COMPILER_FLAGS_CLANG),
+})
+
+_ZS_DEV_COMPILER_FLAGS = select({
+    "DEFAULT": _ZS_DEV_COMPILER_FLAGS_CLANG,
+    "ovr_config//compiler:msvc": windows_convert_gcc_clang_flags(_ZS_DEV_COMPILER_FLAGS_CLANG),
+})
+
+_ZS_DEV_C_COMPILER_FLAGS = select({
+    "DEFAULT": _ZS_DEV_C_COMPILER_FLAGS_CLANG,
+    "ovr_config//compiler:msvc": windows_convert_gcc_clang_flags(_ZS_DEV_C_COMPILER_FLAGS_CLANG),
+})
+
+_ZS_SRC_FILE_COMPILER_FLAGS = {
+    src: select({
+        "DEFAULT": flags,
+        "ovr_config//compiler:msvc": windows_convert_gcc_clang_flags(flags),
+    })
+    for src, flags in _ZS_SRC_FILE_COMPILER_FLAGS_CLANG.items()
+}
+
+_ZS_C_COMPILER_FLAGS_CLANG = [
     "-std=c11",
 ]
 
-_ZS_CXX_COMPILER_FLAGS = [
+_ZS_C_COMPILER_FLAGS = select({
+    "DEFAULT": _ZS_C_COMPILER_FLAGS_CLANG,
+    "ovr_config//compiler:msvc": windows_convert_gcc_clang_flags(_ZS_C_COMPILER_FLAGS_CLANG),
+})
+
+_ZS_CXX_COMPILER_FLAGS_CLANG = [
     "-Wno-c99-extensions",  # permit use of C99 features from C++ (i.e., tests)
     "-Wno-language-extension-token",
 ]
+
+_ZS_CXX_COMPILER_FLAGS = select({
+    "DEFAULT": _ZS_CXX_COMPILER_FLAGS_CLANG,
+    "ovr_config//compiler:msvc": windows_convert_gcc_clang_flags(_ZS_CXX_COMPILER_FLAGS_CLANG),
+})
 
 ZS_HARNESS_MODES = [
     "fbcode//security/lionhead/mode/dbgo-asan-libfuzzer",
@@ -169,23 +209,24 @@ def _zs_src_file_compiler_flags(src):
     return (src, flags)
 
 def _add_zs_compiler_flags(kwargs, strict_conversions = True, float_equal = True):
-    # Add common compiler flags
-    compiler_flags = list(_ZS_COMPILER_FLAGS)
+    # Start with base compiler flags (already converted for MSVC via select)
+    compiler_flags = _ZS_COMPILER_FLAGS
 
-    # Add dev or release compiler flags
+    # Add dev or release compiler flags (already converted for MSVC via select)
     if not _is_release():
         compiler_flags += _ZS_DEV_COMPILER_FLAGS
 
-    # Add the original compiler flags
+    # Add the original compiler flags from kwargs
     compiler_flags += kwargs.get("compiler_flags", [])
 
-    # Remove strict conversions
+    # Handle strict_conversions and float_equal filtering
+    # Note: These filters work on GCC/Clang flags. For MSVC, the flags are already
+    # converted and these specific flags won't be present, so filtering is safe.
     if not strict_conversions:
-        compiler_flags = [x for x in compiler_flags if x != "-Wconversion"]
+        compiler_flags = selects.apply(compiler_flags, lambda flags: [x for x in flags if x != "-Wconversion"])
 
-    # Remove float equal
     if not float_equal:
-        compiler_flags = [x for x in compiler_flags if x != "-Wfloat-equal"]
+        compiler_flags = selects.apply(compiler_flags, lambda flags: [x for x in flags if x != "-Wfloat-equal"])
 
     kwargs["compiler_flags"] = compiler_flags
 

--- a/include/openzl/codecs/zl_bitpack.h
+++ b/include/openzl/codecs/zl_bitpack.h
@@ -11,11 +11,7 @@ extern "C" {
 
 // These Graphs essentially call their namesake Node and then STORE the result
 // into the frame
-#define ZL_GRAPH_BITPACK           \
-    (ZL_GraphID)                   \
-    {                              \
-        ZL_StandardGraphID_bitpack \
-    }
+#define ZL_GRAPH_BITPACK ZL_MAKE_GRAPH_ID(ZL_StandardGraphID_bitpack)
 
 #if defined(__cplusplus)
 }

--- a/include/openzl/codecs/zl_bitunpack.h
+++ b/include/openzl/codecs/zl_bitunpack.h
@@ -23,11 +23,7 @@ extern "C" {
 // zeroes. Both of these invariants are checked and compression would fail if
 // the checks fail.
 enum { ZL_Bitunpack_numBits = 1 };
-#define ZS2_NODE_BITUNPACK          \
-    (ZL_NodeID)                     \
-    {                               \
-        ZL_StandardNodeID_bitunpack \
-    }
+#define ZS2_NODE_BITUNPACK ZL_MAKE_NODE_ID(ZL_StandardNodeID_bitunpack)
 #define ZL_CREATENODE_BITUNPACK(graph, nbBits)                              \
     ZL_Compressor_cloneNode(                                                \
             graph,                                                          \

--- a/include/openzl/codecs/zl_concat.h
+++ b/include/openzl/codecs/zl_concat.h
@@ -14,39 +14,23 @@ extern "C" {
 // Output : 1 numeric stream, containing the size of each Input stream,
 //        + 1 serial stream, concatenation of all Input Streams, preserving
 //        order.
-#define ZL_NODE_CONCAT_SERIAL           \
-    (ZL_NodeID)                         \
-    {                                   \
-        ZL_StandardNodeID_concat_serial \
-    }
+#define ZL_NODE_CONCAT_SERIAL ZL_MAKE_NODE_ID(ZL_StandardNodeID_concat_serial)
 
 // Concat Numeric
 // Input : Multiple Numeric streams (this is a VI node)
 // Output : 1 numeric stream, containing the size of each Input stream,
 //        + 1 numeric stream, concatenation of all Input Streams, preserving
 //        order.
-#define ZL_NODE_CONCAT_NUMERIC       \
-    (ZL_NodeID)                      \
-    {                                \
-        ZL_StandardNodeID_concat_num \
-    }
+#define ZL_NODE_CONCAT_NUMERIC ZL_MAKE_NODE_ID(ZL_StandardNodeID_concat_num)
 
 // Concat Struct
 // Input : Multiple Struct streams (this is a VI node)
 // Output : 1 numeric stream, containing the size of each Input stream,
 //        + 1 struct stream, concatenation of all Input Streams, preserving
 //        order.
-#define ZL_NODE_CONCAT_STRUCT           \
-    (ZL_NodeID)                         \
-    {                                   \
-        ZL_StandardNodeID_concat_struct \
-    }
+#define ZL_NODE_CONCAT_STRUCT ZL_MAKE_NODE_ID(ZL_StandardNodeID_concat_struct)
 
-#define ZL_NODE_CONCAT_STRING           \
-    (ZL_NodeID)                         \
-    {                                   \
-        ZL_StandardNodeID_concat_string \
-    }
+#define ZL_NODE_CONCAT_STRING ZL_MAKE_NODE_ID(ZL_StandardNodeID_concat_string)
 
 #if defined(__cplusplus)
 }

--- a/include/openzl/codecs/zl_constant.h
+++ b/include/openzl/codecs/zl_constant.h
@@ -18,11 +18,7 @@ extern "C" {
 // Note : compression will fail if the stream is empty or isn't constant
 // Example 1 : 1 1 1 1 1 as 5 fields of size 1 => 1 as 1 field of size 1
 // Example 2 : 300 300 300 as 3 fields of size 3 => 300 as 1 field of size 3
-#define ZL_GRAPH_CONSTANT           \
-    (ZL_GraphID)                    \
-    {                               \
-        ZL_StandardGraphID_constant \
-    }
+#define ZL_GRAPH_CONSTANT ZL_MAKE_GRAPH_ID(ZL_StandardGraphID_constant)
 
 #if defined(__cplusplus)
 }

--- a/include/openzl/codecs/zl_conversion.h
+++ b/include/openzl/codecs/zl_conversion.h
@@ -319,11 +319,8 @@ ZL_Edge_runConvertSerialToStringNode(
 // The reverse operation, unbundling string, actually generates 2 output
 // streams: the first one (serialized) with the concatenation of all strings,
 // and the second one (numeric) for the array of string sizes.
-#define ZL_NODE_SEPARATE_STRING_COMPONENTS           \
-    (ZL_NodeID)                                      \
-    {                                                \
-        ZL_StandardNodeID_separate_string_components \
-    }
+#define ZL_NODE_SEPARATE_STRING_COMPONENTS \
+    ZL_MAKE_NODE_ID(ZL_StandardNodeID_separate_string_components)
 
 // Old names for nodes
 enum { ZL_trlip_tokenSize = 1 };

--- a/include/openzl/codecs/zl_dedup.h
+++ b/include/openzl/codecs/zl_dedup.h
@@ -13,11 +13,7 @@ extern "C" {
 // Input : Multiple Numeric streams (this is a VI node)
 // Condition: All input streams must be exactly identical
 // Output : 1 numeric stream, one copy of Input Streams
-#define ZL_NODE_DEDUP_NUMERIC       \
-    (ZL_NodeID)                     \
-    {                               \
-        ZL_StandardNodeID_dedup_num \
-    }
+#define ZL_NODE_DEDUP_NUMERIC ZL_MAKE_NODE_ID(ZL_StandardNodeID_dedup_num)
 
 #if defined(__cplusplus)
 }

--- a/include/openzl/codecs/zl_delta.h
+++ b/include/openzl/codecs/zl_delta.h
@@ -15,11 +15,7 @@ extern "C" {
 // Result : this transform stores the first value "raw",
 //          and then each value is a delta from previous value.
 //          Negative values are stored using 2-complement convention.
-#define ZL_NODE_DELTA_INT           \
-    (ZL_NodeID)                     \
-    {                               \
-        ZL_StandardNodeID_delta_int \
-    }
+#define ZL_NODE_DELTA_INT ZL_MAKE_NODE_ID(ZL_StandardNodeID_delta_int)
 
 #if defined(__cplusplus)
 }

--- a/include/openzl/codecs/zl_dispatch.h
+++ b/include/openzl/codecs/zl_dispatch.h
@@ -57,11 +57,7 @@ extern "C" {
 // ZL_DISPATCH_CHANNEL_ID, which can be used for coordination with
 // downstream node if needed.
 //
-#define ZL_NODE_DISPATCH                  \
-    (ZL_NodeID)                           \
-    {                                     \
-        ZL_StandardNodeID_dispatchN_byTag \
-    }
+#define ZL_NODE_DISPATCH ZL_MAKE_NODE_ID(ZL_StandardNodeID_dispatchN_byTag)
 
 typedef struct {
     const size_t* segmentSizes;
@@ -134,11 +130,8 @@ ZL_Edge_runDispatchNode(
 #define ZL_DISPATCH_STRING_NUM_OUTPUTS_PID 47
 #define ZL_DISPATCH_STRING_INDICES_PID 48
 
-#define ZL_NODE_DISPATCH_STRING           \
-    (ZL_NodeID)                           \
-    {                                     \
-        ZL_StandardNodeID_dispatch_string \
-    }
+#define ZL_NODE_DISPATCH_STRING \
+    ZL_MAKE_NODE_ID(ZL_StandardNodeID_dispatch_string)
 
 /**
  * Convenience function to get the maximum number of dispatches supported by the

--- a/include/openzl/codecs/zl_divide_by.h
+++ b/include/openzl/codecs/zl_divide_by.h
@@ -20,11 +20,7 @@ extern "C" {
 // by the divisor. If 0 is
 //           provided or the divisor is unavailable, instead calculates the GCD
 //           and uses that as the divisor.
-#define ZL_NODE_DIVIDE_BY           \
-    (ZL_NodeID)                     \
-    {                               \
-        ZL_StandardNodeID_divide_by \
-    }
+#define ZL_NODE_DIVIDE_BY ZL_MAKE_NODE_ID(ZL_StandardNodeID_divide_by)
 
 /// If set, 8-byte local param key containing the divisor
 /// If unset, the divisor is computed to be the GCD

--- a/include/openzl/codecs/zl_entropy.h
+++ b/include/openzl/codecs/zl_entropy.h
@@ -11,26 +11,14 @@ extern "C" {
 
 // Entropy backend that can use backends that are at least as fast as FSE
 // Supports serialized inputs
-#define ZL_GRAPH_FSE           \
-    (ZL_GraphID)               \
-    {                          \
-        ZL_StandardGraphID_fse \
-    }
+#define ZL_GRAPH_FSE ZL_MAKE_GRAPH_ID(ZL_StandardGraphID_fse)
 // Entropy backend that can use backends that are at least as fast as Huffman
 // Supports both serialized & 2-byte struct inputs
-#define ZL_GRAPH_HUFFMAN           \
-    (ZL_GraphID)                   \
-    {                              \
-        ZL_StandardGraphID_huffman \
-    }
+#define ZL_GRAPH_HUFFMAN ZL_MAKE_GRAPH_ID(ZL_StandardGraphID_huffman)
 // Entropy backend that can use any backend that satisfies the compression &
 // decompression speed requirements. Supports both serialized & 2-byte struct
 // inputs
-#define ZL_GRAPH_ENTROPY           \
-    (ZL_GraphID)                   \
-    {                              \
-        ZL_StandardGraphID_entropy \
-    }
+#define ZL_GRAPH_ENTROPY ZL_MAKE_GRAPH_ID(ZL_StandardGraphID_entropy)
 
 #if defined(__cplusplus)
 }

--- a/include/openzl/codecs/zl_field_lz.h
+++ b/include/openzl/codecs/zl_field_lz.h
@@ -23,11 +23,7 @@ extern "C" {
 // Output 3: Offsets: A numeric stream of non-zero u32 offsets.
 // Output 4: Extra Literal Lengths: A numeric stream of u32 lengths.
 // Output 5: Extra Match Lengths: A numeric stream of u32 lengths.
-#define ZL_NODE_FIELD_LZ           \
-    (ZL_NodeID)                    \
-    {                              \
-        ZL_StandardNodeID_field_lz \
-    }
+#define ZL_NODE_FIELD_LZ ZL_MAKE_NODE_ID(ZL_StandardNodeID_field_lz)
 
 /**
  * Create the field lz graph with the default backends.
@@ -36,11 +32,7 @@ extern "C" {
  *
  * Input: A fixed size stream of width 1, 2, 4, or 8.
  */
-#define ZL_GRAPH_FIELD_LZ           \
-    (ZL_GraphID)                    \
-    {                               \
-        ZL_StandardGraphID_field_lz \
-    }
+#define ZL_GRAPH_FIELD_LZ ZL_MAKE_GRAPH_ID(ZL_StandardGraphID_field_lz)
 
 /// DEPRECATED: Use ZL_GRAPH_FIELD_LZ instead.
 /// @returns ZL_GRAPH_FIELD_LZ

--- a/include/openzl/codecs/zl_flatpack.h
+++ b/include/openzl/codecs/zl_flatpack.h
@@ -9,11 +9,7 @@
 extern "C" {
 #endif
 
-#define ZL_GRAPH_FLATPACK           \
-    (ZL_GraphID)                    \
-    {                               \
-        ZL_StandardGraphID_flatpack \
-    }
+#define ZL_GRAPH_FLATPACK ZL_MAKE_GRAPH_ID(ZL_StandardGraphID_flatpack)
 
 #if defined(__cplusplus)
 }

--- a/include/openzl/codecs/zl_float_deconstruct.h
+++ b/include/openzl/codecs/zl_float_deconstruct.h
@@ -16,21 +16,12 @@ extern "C" {
 // Note : See zstrong/compress/transforms/float_deconstruct_encode.h for
 // detailed description
 //        of the bit layout for each transform.
-#define ZL_NODE_FLOAT32_DECONSTRUCT           \
-    (ZL_NodeID)                               \
-    {                                         \
-        ZL_StandardNodeID_float32_deconstruct \
-    }
-#define ZL_NODE_BFLOAT16_DECONSTRUCT           \
-    (ZL_NodeID)                                \
-    {                                          \
-        ZL_StandardNodeID_bfloat16_deconstruct \
-    }
-#define ZL_NODE_FLOAT16_DECONSTRUCT           \
-    (ZL_NodeID)                               \
-    {                                         \
-        ZL_StandardNodeID_float16_deconstruct \
-    }
+#define ZL_NODE_FLOAT32_DECONSTRUCT \
+    ZL_MAKE_NODE_ID(ZL_StandardNodeID_float32_deconstruct)
+#define ZL_NODE_BFLOAT16_DECONSTRUCT \
+    ZL_MAKE_NODE_ID(ZL_StandardNodeID_bfloat16_deconstruct)
+#define ZL_NODE_FLOAT16_DECONSTRUCT \
+    ZL_MAKE_NODE_ID(ZL_StandardNodeID_float16_deconstruct)
 
 #if defined(__cplusplus)
 }

--- a/include/openzl/codecs/zl_generic.h
+++ b/include/openzl/codecs/zl_generic.h
@@ -9,27 +9,20 @@
 extern "C" {
 #endif
 
-#define ZL_GRAPH_COMPRESS_GENERIC           \
-    (ZL_GraphID)                            \
-    {                                       \
-        ZL_StandardGraphID_compress_generic \
-    } // "default" compression for any stream type - supports multiple inputs
-#define ZL_GRAPH_GENERIC_LZ_BACKEND                  \
-    (ZL_GraphID)                                     \
-    {                                                \
-        ZL_StandardGraphID_select_generic_lz_backend \
-    } // Selects between LZ backends based on compression level - superseded by
-      // ZL_GRAPH_COMPRESS_GENERIC - could be retired now
+// "default" compression for any stream type - supports multiple inputs
+#define ZL_GRAPH_COMPRESS_GENERIC \
+    ZL_MAKE_GRAPH_ID(ZL_StandardGraphID_compress_generic)
+
+// Selects between LZ backends based on compression level - superseded by
+// ZL_GRAPH_COMPRESS_GENERIC - could be retired now
+#define ZL_GRAPH_GENERIC_LZ_BACKEND \
+    ZL_MAKE_GRAPH_ID(ZL_StandardGraphID_select_generic_lz_backend)
 
 // Numeric
 // Input : 1 stream of numeric data
 // Result : compresses a stream of numeric data using a GBT model to select the
 // best compression algorithm based on stream
-#define ZL_GRAPH_NUMERIC                  \
-    (ZL_GraphID)                          \
-    {                                     \
-        ZL_StandardGraphID_select_numeric \
-    }
+#define ZL_GRAPH_NUMERIC ZL_MAKE_GRAPH_ID(ZL_StandardGraphID_select_numeric)
 
 #define ZL_GRAPH_SEGMENT_NUMERIC           \
     (ZL_GraphID)                           \

--- a/include/openzl/codecs/zl_illegal.h
+++ b/include/openzl/codecs/zl_illegal.h
@@ -11,21 +11,13 @@ extern "C" {
 #endif
 
 // Error node, to specify an error in functions that return ZL_NodeID
-#define ZL_NODE_ILLEGAL           \
-    (ZL_NodeID)                   \
-    {                             \
-        ZL_StandardNodeID_illegal \
-    }
+#define ZL_NODE_ILLEGAL ZL_MAKE_NODE_ID(ZL_StandardNodeID_illegal)
 
 // Error graph, to specify an error in functions that return ZL_GraphID
-#define ZL_GRAPH_ILLEGAL           \
-    (ZL_GraphID)                   \
-    {                              \
-        ZL_StandardGraphID_illegal \
-    }
+#define ZL_GRAPH_ILLEGAL ZL_MAKE_GRAPH_ID(ZL_StandardGraphID_illegal)
 
 #if defined(__cplusplus)
-}
+} // extern "C"
 #endif
 
 #endif

--- a/include/openzl/codecs/zl_interleave.h
+++ b/include/openzl/codecs/zl_interleave.h
@@ -12,11 +12,8 @@ extern "C" {
 // Input: Variable number of stream with the same type and number of elements
 // Output: 1 stream with the same type consisting of the input streams
 // interleaved in round-robin order
-#define ZL_NODE_INTERLEAVE_STRING           \
-    (ZL_NodeID)                             \
-    {                                       \
-        ZL_StandardNodeID_interleave_string \
-    }
+#define ZL_NODE_INTERLEAVE_STRING \
+    ZL_MAKE_NODE_ID(ZL_StandardNodeID_interleave_string)
 
 #if defined(__cplusplus)
 }

--- a/include/openzl/codecs/zl_merge_sorted.h
+++ b/include/openzl/codecs/zl_merge_sorted.h
@@ -23,11 +23,7 @@ extern "C" {
 // Bitset with one bit per sorted run. The width is determined
 //           by the number of sorted runs.
 // Output 1: Numeric: The merged list of strictly increasing u32s
-#define ZL_NODE_MERGE_SORTED           \
-    (ZL_NodeID)                        \
-    {                                  \
-        ZL_StandardNodeID_merge_sorted \
-    }
+#define ZL_NODE_MERGE_SORTED ZL_MAKE_NODE_ID(ZL_StandardNodeID_merge_sorted)
 
 /**
  * Creates a graph for ZL_NODE_MERGE_SORTED that first detects whether

--- a/include/openzl/codecs/zl_parse_int.h
+++ b/include/openzl/codecs/zl_parse_int.h
@@ -14,11 +14,7 @@ extern "C" {
 // Input: 1 string stream, each string containing an ASCII representation of an
 // int64
 // Output: 1 numeric stream, integers converted from input strings
-#define ZL_NODE_PARSE_INT           \
-    (ZL_NodeID)                     \
-    {                               \
-        ZL_StandardNodeID_parse_int \
-    }
+#define ZL_NODE_PARSE_INT ZL_MAKE_NODE_ID(ZL_StandardNodeID_parse_int)
 
 /**
  * Try Parse Int

--- a/include/openzl/codecs/zl_prefix.h
+++ b/include/openzl/codecs/zl_prefix.h
@@ -29,11 +29,7 @@ extern "C" {
 // If the
 //       stream is not sorted or there is not much overlap between the strings,
 //       another transform may be more performant (see example 2)
-#define ZL_NODE_PREFIX           \
-    (ZL_NodeID)                  \
-    {                            \
-        ZL_StandardNodeID_prefix \
-    }
+#define ZL_NODE_PREFIX ZL_MAKE_NODE_ID(ZL_StandardNodeID_prefix)
 
 #if defined(__cplusplus)
 }

--- a/include/openzl/codecs/zl_range_pack.h
+++ b/include/openzl/codecs/zl_range_pack.h
@@ -13,11 +13,7 @@ extern "C" {
 // Substracts the minimal (unsigned) element from all other elements in the
 // stream and outputs the minimal sized numeric stream type that can contain the
 // 0-based range of values.
-#define ZL_NODE_RANGE_PACK           \
-    (ZL_NodeID)                      \
-    {                                \
-        ZL_StandardNodeID_range_pack \
-    }
+#define ZL_NODE_RANGE_PACK ZL_MAKE_NODE_ID(ZL_StandardNodeID_range_pack)
 
 #if defined(__cplusplus)
 }

--- a/include/openzl/codecs/zl_store.h
+++ b/include/openzl/codecs/zl_store.h
@@ -10,11 +10,7 @@ extern "C" {
 #endif
 
 // Storage operation. Final stage of any stored stream.
-#define ZL_GRAPH_STORE           \
-    (ZL_GraphID)                 \
-    {                            \
-        ZL_StandardGraphID_store \
-    }
+#define ZL_GRAPH_STORE ZL_MAKE_GRAPH_ID(ZL_StandardGraphID_store)
 
 #if defined(__cplusplus)
 }

--- a/include/openzl/codecs/zl_transpose.h
+++ b/include/openzl/codecs/zl_transpose.h
@@ -21,11 +21,8 @@ extern "C" {
 // Example : 1 2 3 4 5 6 7 8 as 2 fields of size 4
 //           => transposed into 4 streams as 2 fields of size 1
 //           => (1, 5), (2, 6), (3, 7), (4, 8)
-#define ZL_NODE_TRANSPOSE_SPLIT           \
-    (ZL_NodeID)                           \
-    {                                     \
-        ZL_StandardNodeID_transpose_split \
-    }
+#define ZL_NODE_TRANSPOSE_SPLIT \
+    ZL_MAKE_NODE_ID(ZL_StandardNodeID_transpose_split)
 
 /**
  * Helper function to create a graph for ZL_NODE_TRANSPOSE_SPLIT.

--- a/include/openzl/codecs/zl_zigzag.h
+++ b/include/openzl/codecs/zl_zigzag.h
@@ -20,11 +20,7 @@ extern "C" {
 //           with expected decreasing distribution starting from 0.
 // Note : It's unclear if this transform is really useful.
 //        If not, it will be removed from Standard Transforms.
-#define ZL_NODE_ZIGZAG           \
-    (ZL_NodeID)                  \
-    {                            \
-        ZL_StandardNodeID_zigzag \
-    }
+#define ZL_NODE_ZIGZAG ZL_MAKE_NODE_ID(ZL_StandardNodeID_zigzag)
 
 #if defined(__cplusplus)
 }

--- a/include/openzl/codecs/zl_zstd.h
+++ b/include/openzl/codecs/zl_zstd.h
@@ -10,11 +10,7 @@
 extern "C" {
 #endif
 
-#define ZL_GRAPH_ZSTD           \
-    (ZL_GraphID)                \
-    {                           \
-        ZL_StandardGraphID_zstd \
-    }
+#define ZL_GRAPH_ZSTD ZL_MAKE_GRAPH_ID(ZL_StandardGraphID_zstd)
 
 /// @return zstd graph with a compression level overridden
 ZL_GraphID ZL_Compressor_registerZstdGraph_withLevel(

--- a/include/openzl/detail/zl_errors_detail.h
+++ b/include/openzl/detail/zl_errors_detail.h
@@ -214,10 +214,16 @@ struct ZL_Error_s {
     ZL_ErrorInfo _info;
 };
 
-#define ZL_EE_EMPTY ((ZL_ErrorInfo){ ._st = NULL })
-
-#define ZL_E_EMPTY \
-    ((ZL_Error){ ._code = ZL_ErrorCode_no_error, ._info = ZL_EE_EMPTY })
+#if defined(__cplusplus)
+// C++ compatible versions using constructor syntax
+#    define ZL_EE_EMPTY (ZL_ErrorInfo{ nullptr })
+#    define ZL_E_EMPTY (ZL_Error{ ZL_ErrorCode_no_error, ZL_EE_EMPTY })
+#else
+// C99 compound literals
+#    define ZL_EE_EMPTY ((ZL_ErrorInfo){ ._st = NULL })
+#    define ZL_E_EMPTY \
+        ((ZL_Error){ ._code = ZL_ErrorCode_no_error, ._info = ZL_EE_EMPTY })
+#endif
 
 // Returns the ZL_Error descriptor from a ZL_RESULT_OF(<T>) object.
 #define ZL_RES_error(res) ((res)._error)
@@ -372,22 +378,67 @@ typedef struct {
 #define ZL_RESULT_MAKE_ERROR_CODE(type, ...) \
     ZS_MACRO_PAD4(ZL_RESULT_MAKE_ERROR_CODE_INNER, "", "", type, __VA_ARGS__)
 
-#define ZL_RESULT_MAKE_ERROR_CODE_INNER(               \
-        __PLACEHOLDER1__, __PLACEHOLDER2__, type, ...) \
-    ((ZL_RESULT_OF(type)){                             \
-            ._error = ZL_E_create(                     \
-                    NULL, NULL, __FILE__, __func__, __LINE__, __VA_ARGS__) })
+#if defined(__cplusplus)
+} // extern "C"
 
-#define ZL_RESULT_WRAP_ERROR(type, err) \
-    ((ZL_RESULT_OF(type)){ ._error = (err) })
+// Helper functions for C++ to avoid compound literals
+// These must be outside extern "C" block
+namespace openzl::detail {
+template <typename T>
+inline T make_result_with_error(ZL_Error err)
+{
+    T result;
+    result._error = err;
+    return result;
+}
 
-#define ZL_RESULT_WRAP_VALUE(type, value) \
-    ((ZL_RESULT_OF(type)){                  \
-            ._value = {                      \
-              ._code = ZL_ErrorCode_no_error, \
-              ._value = (value),           \
-          },                               \
-  })
+template <typename T, typename V>
+inline T make_result_with_value(V value)
+{
+    T result;
+    result._value._code  = ZL_ErrorCode_no_error;
+    result._value._value = value;
+    return result;
+}
+} // namespace openzl::detail
+
+// C++ compatible versions using helper functions
+#    define ZL_RESULT_MAKE_ERROR_CODE_INNER(               \
+            __PLACEHOLDER1__, __PLACEHOLDER2__, type, ...) \
+        (::openzl::detail::make_result_with_error<         \
+                ZL_RESULT_OF(type)>(ZL_E_create(           \
+                NULL, NULL, __FILE__, __func__, __LINE__, __VA_ARGS__)))
+
+#    define ZL_RESULT_WRAP_ERROR(type, err) \
+        (::openzl::detail::make_result_with_error<ZL_RESULT_OF(type)>(err))
+
+#    define ZL_RESULT_WRAP_VALUE(type, value) \
+        (::openzl::detail::make_result_with_value<ZL_RESULT_OF(type)>(value))
+
+extern "C" {
+#else
+// C99 compound literals
+#    define ZL_RESULT_MAKE_ERROR_CODE_INNER(               \
+            __PLACEHOLDER1__, __PLACEHOLDER2__, type, ...) \
+        ((ZL_RESULT_OF(type)){ ._error = ZL_E_create(      \
+                                       NULL,               \
+                                       NULL,               \
+                                       __FILE__,           \
+                                       __func__,           \
+                                       __LINE__,           \
+                                       __VA_ARGS__) })
+
+#    define ZL_RESULT_WRAP_ERROR(type, err) \
+        ((ZL_RESULT_OF(type)){ ._error = (err) })
+
+#    define ZL_RESULT_WRAP_VALUE(type, value) \
+        ((ZL_RESULT_OF(type)){                  \
+                ._value = {                     \
+                  ._code = ZL_ErrorCode_no_error, \
+                  ._value = (value),            \
+              },                                \
+      })
+#endif
 
 #define ZL_RET_IF_NOT_UNARY_IMPL(type, errcode, expr, ...) \
     ZL_RET_IF_UNARY_IMPL(type, errcode, !(expr), __VA_ARGS__)

--- a/include/openzl/zl_data.h
+++ b/include/openzl/zl_data.h
@@ -48,7 +48,13 @@ typedef enum {
             ZL_Type_serial | ZL_Type_struct | ZL_Type_numeric \
             | ZL_Type_string)
 
-#define ZL_DATA_ID_INPUTSTREAM (ZL_DataID){ .sid = (ZL_IDType) - 1 }
+#if defined(__cplusplus)
+// C++ compatible version using constructor syntax
+#    define ZL_DATA_ID_INPUTSTREAM (ZL_DataID{ (ZL_IDType) - 1 })
+#else
+// C99 compound literal
+#    define ZL_DATA_ID_INPUTSTREAM (ZL_DataID){ .sid = (ZL_IDType) - 1 }
+#endif
 
 /* ============================== */
 /* =====    Data object     ===== */

--- a/include/openzl/zl_errors.h
+++ b/include/openzl/zl_errors.h
@@ -382,16 +382,35 @@ ZL_Report ZL_reportError(
 #define ZL_ERR(...) ZS_MACRO_PAD1(ZL_ERR_RET_IMPL, __VA_ARGS__)
 
 /// Turn a @p value into a result.
-#define ZL_WRAP_VALUE(value) \
-    ((ZL__RetType){          \
-            ._value = { ._code = ZL_ErrorCode_no_error, ._value = (value) } })
+#if defined(__cplusplus)
+} // extern "C"
+
+// C++ compatible version using helper function
+#    define ZL_WRAP_VALUE(value) \
+        (::openzl::detail::make_result_with_value<ZL__RetType>(value))
+extern "C" {
+#else
+// C99 compound literal
+#    define ZL_WRAP_VALUE(value)                                     \
+        ((ZL__RetType){ ._value = { ._code  = ZL_ErrorCode_no_error, \
+                                    ._value = (value) } })
+#endif
 
 /// Turn a @p error into a result, and try to add a stack frame to the traceback
 /// in the error.
 #define ZL_WRAP_ERROR(error) ZL_WRAP_ERROR_ADD_FRAME(error)
 
 /// Turn a @p error into a result, without trying to record a stack frame.
-#define ZL_WRAP_ERROR_NO_FRAME(error) ((ZL__RetType){ ._error = (error) })
+#if defined(__cplusplus)
+} // extern "C"
+// C++ compatible version using helper function
+#    define ZL_WRAP_ERROR_NO_FRAME(error) \
+        (::openzl::detail::make_result_with_error<ZL__RetType>(error))
+extern "C" {
+#else
+// C99 compound literal
+#    define ZL_WRAP_ERROR_NO_FRAME(error) ((ZL__RetType){ ._error = (error) })
+#endif
 
 #define ZL_TRY_SET(_type, _var, _expr) ZL_TRY_SET_DT(_type, _var, _expr)
 

--- a/include/openzl/zl_macro_helpers.h
+++ b/include/openzl/zl_macro_helpers.h
@@ -16,42 +16,45 @@
 #define ZS_MACRO_QUOTE_INNER(a) #a
 #define ZS_MACRO_QUOTE(a) ZS_MACRO_QUOTE_INNER(a)
 
-#define ZS_MACRO_PAD_SELECT_33RD( \
-        _1,                       \
-        _2,                       \
-        _3,                       \
-        _4,                       \
-        _5,                       \
-        _6,                       \
-        _7,                       \
-        _8,                       \
-        _9,                       \
-        _10,                      \
-        _11,                      \
-        _12,                      \
-        _13,                      \
-        _14,                      \
-        _15,                      \
-        _16,                      \
-        _17,                      \
-        _18,                      \
-        _19,                      \
-        _20,                      \
-        _21,                      \
-        _22,                      \
-        _23,                      \
-        _24,                      \
-        _25,                      \
-        _26,                      \
-        _27,                      \
-        _28,                      \
-        _29,                      \
-        _30,                      \
-        _31,                      \
-        _32,                      \
-        _33,                      \
-        ...)                      \
+#define ZS_MACRO_EXPAND(...) __VA_ARGS__
+#define ZS_MACRO_PAD_SELECT_33RD_INNER( \
+        _1,                             \
+        _2,                             \
+        _3,                             \
+        _4,                             \
+        _5,                             \
+        _6,                             \
+        _7,                             \
+        _8,                             \
+        _9,                             \
+        _10,                            \
+        _11,                            \
+        _12,                            \
+        _13,                            \
+        _14,                            \
+        _15,                            \
+        _16,                            \
+        _17,                            \
+        _18,                            \
+        _19,                            \
+        _20,                            \
+        _21,                            \
+        _22,                            \
+        _23,                            \
+        _24,                            \
+        _25,                            \
+        _26,                            \
+        _27,                            \
+        _28,                            \
+        _29,                            \
+        _30,                            \
+        _31,                            \
+        _32,                            \
+        _33,                            \
+        ...)                            \
     _33
+#define ZS_MACRO_PAD_SELECT_33RD(...) \
+    ZS_MACRO_EXPAND(ZS_MACRO_PAD_SELECT_33RD_INNER(__VA_ARGS__))
 #define ZS_MACRO_PAD1_SUFFIX(...) \
     ZS_MACRO_PAD_SELECT_33RD(     \
             __VA_ARGS__,          \
@@ -266,11 +269,11 @@
 #define ZS_MACRO_PAD5_ARGS(...) \
     ZS_MACRO_CONCAT(ZS_MACRO_PAD, ZS_MACRO_PAD5_SUFFIX(__VA_ARGS__))
 
-#define ZS_MACRO_PAD1_INNER(macro, ...) macro(__VA_ARGS__)
-#define ZS_MACRO_PAD2_INNER(macro, ...) macro(__VA_ARGS__)
-#define ZS_MACRO_PAD3_INNER(macro, ...) macro(__VA_ARGS__)
-#define ZS_MACRO_PAD4_INNER(macro, ...) macro(__VA_ARGS__)
-#define ZS_MACRO_PAD5_INNER(macro, ...) macro(__VA_ARGS__)
+#define ZS_MACRO_PAD1_INNER(macro, ...) ZS_MACRO_EXPAND(macro(__VA_ARGS__))
+#define ZS_MACRO_PAD2_INNER(macro, ...) ZS_MACRO_EXPAND(macro(__VA_ARGS__))
+#define ZS_MACRO_PAD3_INNER(macro, ...) ZS_MACRO_EXPAND(macro(__VA_ARGS__))
+#define ZS_MACRO_PAD4_INNER(macro, ...) ZS_MACRO_EXPAND(macro(__VA_ARGS__))
+#define ZS_MACRO_PAD5_INNER(macro, ...) ZS_MACRO_EXPAND(macro(__VA_ARGS__))
 
 /**
  * These macros are designed to handle the case where, after N required

--- a/include/openzl/zl_opaque_types.h
+++ b/include/openzl/zl_opaque_types.h
@@ -33,6 +33,17 @@ typedef struct {
     ZL_IDType gid;
 } ZL_GraphID;
 
+// Helper macros for creating ZL_NodeID and ZL_GraphID in a C++ compatible way
+#if defined(__cplusplus)
+// C++ compatible versions using constructor syntax
+#    define ZL_MAKE_NODE_ID(id) (ZL_NodeID{ (id) })
+#    define ZL_MAKE_GRAPH_ID(id) (ZL_GraphID{ (id) })
+#else
+// C99 compound literals
+#    define ZL_MAKE_NODE_ID(id) ((ZL_NodeID){ .nid = (id) })
+#    define ZL_MAKE_GRAPH_ID(id) ((ZL_GraphID){ .gid = (id) })
+#endif
+
 // Incomplete types
 typedef struct Stream_s Stream;
 typedef Stream ZL_Data;


### PR DESCRIPTION
Summary:
MSVC can handle C11 in C mode, but doesn't have compatibility extensions for C++ for compound literals.  This makes C11 headers in openzl incompatible with C++ when compiling with MSVC.
This change creates C++ alternatives to many macros that use compound literals.

Grafted 4fc041c03acad388758cb389fbdc75d4829f5fa2 (D87466259)
- Grafted fbcode/openzl/versions/release to fbcode/openzl/dev

Reviewed By: graphicsMan

Differential Revision: D87893484
