### PR TITLE
Add Buck target and --diff flag for relative_buck.py

### DIFF
--- a/scripts/BUCK
+++ b/scripts/BUCK
@@ -3,6 +3,7 @@
 # @noautodeps
 
 load("@fbcode_macros//build_defs:cpp_binary.bzl", "cpp_binary")
+load("@fbcode_macros//build_defs:python_binary.bzl", "python_binary")
 
 oncall("data_compression")
 
@@ -22,4 +23,11 @@ cpp_binary(
     deps = [
         "..:zstronglib",
     ],
+)
+
+python_binary(
+    name = "relative_buck",
+    srcs = ["relative_buck.py"],
+    base_module = "",
+    main_module = "relative_buck",
 )

--- a/scripts/relative_buck.py
+++ b/scripts/relative_buck.py
@@ -1,11 +1,28 @@
 #!/usr/bin/env python3
 # Copyright (c) Meta Platforms, Inc. and affiliates.
 
+import argparse
+import difflib
 import os
 import re
+import subprocess
+import sys
 from pathlib import Path
 
-OPENZL_DIR = Path(__file__).parents[1]
+
+def get_openzl_dir() -> Path:
+    """Get the openzl/dev directory by calculating from hg root."""
+    result = subprocess.run(
+        ["hg", "root"],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    hg_root = Path(result.stdout.strip())
+    return hg_root / "fbcode" / "openzl" / "dev"
+
+
+OPENZL_DIR = get_openzl_dir()
 
 
 def fixup_match(relpath: Path, match: re.Match[str], is_load: bool = False) -> str:
@@ -46,23 +63,74 @@ def fixup_match(relpath: Path, match: re.Match[str], is_load: bool = False) -> s
     return path
 
 
-def fixup(file: Path) -> None:
+def fixup(file: Path, diff_mode: bool = False) -> bool:
+    """
+    Fix up Buck dependencies in a file.
+
+    Args:
+        file: Path to the file to fix
+        diff_mode: If True, print diff instead of writing changes
+
+    Returns:
+        True if changes were made (or would be made in diff mode), False otherwise
+    """
     with open(file, "r") as f:
-        content = f.read()
+        original_content = f.read()
 
     relpath = file.relative_to(OPENZL_DIR).parent
 
+    content = original_content
     regex = re.compile(r"load\(\"//openzl/dev(/[^:]*:|:)")
     content = regex.sub(lambda match: fixup_match(relpath, match, True), content)
 
     regex = re.compile(r"//openzl/dev((/[^:]*:|:))")
     content = regex.sub(lambda match: fixup_match(relpath, match), content)
 
-    with open(file, "w") as f:
-        f.write(content)
+    if content == original_content:
+        return False
+
+    if diff_mode:
+        # Generate and print unified diff
+        diff = difflib.unified_diff(
+            original_content.splitlines(keepends=True),
+            content.splitlines(keepends=True),
+            fromfile=str(file),
+            tofile=str(file),
+        )
+        sys.stdout.writelines(diff)
+    else:
+        # Write the changes
+        with open(file, "w") as f:
+            f.write(content)
+
+    return True
 
 
-for root, _, files in os.walk(OPENZL_DIR):
-    for file in files:
-        if file == "BUCK" or file.endswith(".bzl"):
-            fixup(Path(root) / file)
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Convert absolute Buck dependencies in openzl/dev to relative paths"
+    )
+    parser.add_argument(
+        "--diff",
+        action="store_true",
+        help="Print diffs instead of modifying files. Exit with code 1 if changes would be made.",
+    )
+    args = parser.parse_args()
+
+    changes_found = False
+
+    for root, _, files in os.walk(OPENZL_DIR):
+        for file in files:
+            if file == "BUCK" or file.endswith(".bzl"):
+                file_path = Path(root) / file
+                if fixup(file_path, diff_mode=args.diff):
+                    changes_found = True
+
+    if args.diff and changes_found:
+        return 1
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Summary:
Add Buck target for the relative_buck.py script to enable running it as a build target for CI validation. Enhance the script with a --diff flag that checks for absolute Buck dependencies without modifying files, returning exit code 1 if any are found.

This enables automated enforcement that all Buck dependencies under openzl/dev use relative paths instead of absolute //openzl/dev references, which is required for Directory Branching support.

Differential Revision: D88097936


