### PR TITLE
Add Skycastle workflow to enforce relative Buck dependencies

### DIFF
--- a/scripts/BUCK
+++ b/scripts/BUCK
@@ -3,6 +3,7 @@
 # @noautodeps
 
 load("@fbcode_macros//build_defs:cpp_binary.bzl", "cpp_binary")
+load("@fbcode_macros//build_defs:python_binary.bzl", "python_binary")
 
 oncall("data_compression")
 
@@ -22,4 +23,11 @@ cpp_binary(
     deps = [
         "..:zstronglib",
     ],
+)
+
+python_binary(
+    name = "relative_buck",
+    srcs = ["relative_buck.py"],
+    base_module = "",
+    main_module = "relative_buck",
 )

--- a/scripts/relative_buck.py
+++ b/scripts/relative_buck.py
@@ -1,11 +1,28 @@
 #!/usr/bin/env python3
 # Copyright (c) Meta Platforms, Inc. and affiliates.
 
+import argparse
+import difflib
 import os
 import re
+import subprocess
+import sys
 from pathlib import Path
 
-OPENZL_DIR = Path(__file__).parents[1]
+
+def get_openzl_dir() -> Path:
+    """Get the openzl/dev directory by calculating from hg root."""
+    result = subprocess.run(
+        ["hg", "root"],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    hg_root = Path(result.stdout.strip())
+    return hg_root / "fbcode" / "openzl" / "dev"
+
+
+OPENZL_DIR = get_openzl_dir()
 
 
 def fixup_match(relpath: Path, match: re.Match[str], is_load: bool = False) -> str:
@@ -46,23 +63,74 @@ def fixup_match(relpath: Path, match: re.Match[str], is_load: bool = False) -> s
     return path
 
 
-def fixup(file: Path) -> None:
+def fixup(file: Path, diff_mode: bool = False) -> bool:
+    """
+    Fix up Buck dependencies in a file.
+
+    Args:
+        file: Path to the file to fix
+        diff_mode: If True, print diff instead of writing changes
+
+    Returns:
+        True if changes were made (or would be made in diff mode), False otherwise
+    """
     with open(file, "r") as f:
-        content = f.read()
+        original_content = f.read()
 
     relpath = file.relative_to(OPENZL_DIR).parent
 
+    content = original_content
     regex = re.compile(r"load\(\"//openzl/dev(/[^:]*:|:)")
     content = regex.sub(lambda match: fixup_match(relpath, match, True), content)
 
     regex = re.compile(r"//openzl/dev((/[^:]*:|:))")
     content = regex.sub(lambda match: fixup_match(relpath, match), content)
 
-    with open(file, "w") as f:
-        f.write(content)
+    if content == original_content:
+        return False
+
+    if diff_mode:
+        # Generate and print unified diff
+        diff = difflib.unified_diff(
+            original_content.splitlines(keepends=True),
+            content.splitlines(keepends=True),
+            fromfile=str(file),
+            tofile=str(file),
+        )
+        sys.stdout.writelines(diff)
+    else:
+        # Write the changes
+        with open(file, "w") as f:
+            f.write(content)
+
+    return True
 
 
-for root, _, files in os.walk(OPENZL_DIR):
-    for file in files:
-        if file == "BUCK" or file.endswith(".bzl"):
-            fixup(Path(root) / file)
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Convert absolute Buck dependencies in openzl/dev to relative paths"
+    )
+    parser.add_argument(
+        "--diff",
+        action="store_true",
+        help="Print diffs instead of modifying files. Exit with code 1 if changes would be made.",
+    )
+    args = parser.parse_args()
+
+    changes_found = False
+
+    for root, _, files in os.walk(OPENZL_DIR):
+        for file in files:
+            if file == "BUCK" or file.endswith(".bzl"):
+                file_path = Path(root) / file
+                if fixup(file_path, diff_mode=args.diff):
+                    changes_found = True
+
+    if args.diff and changes_found:
+        return 1
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/skycastle/check_relative_deps.sky
+++ b/skycastle/check_relative_deps.sky
@@ -1,0 +1,80 @@
+load(
+    "//tools/skycastle/api2/action_results.sky",
+    "Classifier",
+    "InfraFailure",
+    "Success",
+    "UserFailure",
+)
+load("//tools/skycastle/api2/actions.sky", "RetryConfig")
+load(
+    "//tools/skycastle/api2/api.sky",
+    "config",
+    "entry_point",
+)
+load("//tools/skycastle/api2/predicates.sky", "ExitCode", "any", "eq", "gt")
+load("//tools/skycastle/api2/repositories.sky", "fbsource")
+load("//tools/skycastle/lib2/tools/buck_tool.sky", "buck_tool")
+load("//tools/skycastle/lib2/tools/hg.sky", hg_tool = "hg")
+load("//tools/skycastle/lib2/tools/interpreters.sky", "bash")
+
+# This workflow validates that all Buck dependencies under openzl/dev which refer
+# to targets within openzl/dev are relative. This is required for Directory Branching
+# to work correctly when OpenZL releases are cut.
+# https://www.internalfb.com/wiki/Source-Control-Users/Advanced/Directory_Branching/
+
+config(
+    oncall = "openzl",
+)
+
+relative_buck_tool = buck_tool(
+    name = "relative_buck",
+    target = "fbcode//openzl/dev/scripts:relative_buck",
+    modes = ["@mode/opt"],
+    buck_version = "buck2",
+    sandcastle_type = "fbcode",
+)
+
+check_relative_deps_action = bash(
+    script = """
+        # Run the relative_buck script with --diff flag
+        # Exit code 0: All dependencies are already relative
+        # Exit code 1: Some dependencies need to be made relative (user error)
+        # Other exit codes: Script failure (infra error)
+        relative_buck --diff
+    """,
+    cwd = fbsource.root(),
+    description = "Check that all Buck dependencies under openzl/dev are relative",
+    result_classifiers = [
+        Classifier(
+            predicate = ExitCode(eq(0)),
+            type = Success(),
+        ),
+        Classifier(
+            predicate = ExitCode(eq(1)),
+            type = UserFailure(
+                "Some Buck dependencies under openzl/dev are not relative. " +
+                "Run 'buck2 run fbcode//openzl/dev/scripts:relative_buck' to fix them.",
+                True,
+            ),
+        ),
+        Classifier(
+            predicate = any([ExitCode(gt(1))]),
+            type = InfraFailure("Script execution failed unexpectedly."),
+        ),
+    ],
+    cache = False,
+    retry = RetryConfig(
+        count = 3,
+        predicate = ExitCode(gt(1)),
+    ),
+    # Any tool used in the script must be included in the tools list
+    tools = [relative_buck_tool, hg_tool],
+)
+
+entry_point(
+    name = "main",
+    actions = [
+        check_relative_deps_action,
+    ],
+    alias = "check_relative_deps",
+)


### PR DESCRIPTION
Summary:
Add a Skycastle CI workflow to enforce that all Buck dependencies under openzl/dev which reference targets within openzl/dev use relative paths instead of absolute paths. This is required for Directory Branching to work correctly when OpenZL releases are cut.

The workflow runs the relative_buck.py script with the --diff flag to check for absolute dependencies without modifying files. It properly classifies exit codes: exit code 0 indicates success (all dependencies are relative), exit code 1 indicates user error (some dependencies need to be made relative), and exit codes greater than 1 indicate infrastructure failures.

Reviewed By: kevinjzhang

Differential Revision: D88099714


