### PR TITLE
[build] make: -O3 by default for `zli` and library

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,32 @@ include build/make/zldefs.make
 # Provides macros to generate targets
 include build/make/multiconf.make
 
+# =====================================
+# ADAPTIVE mode: Per-Target Smart Defaults
+# =====================================
+# In ADAPTIVE mode, targets add their own appropriate flags
+# In coercive modes (OPT, DEV, etc.), these complement are overridden by global settings
+ifeq ($(BUILD_TYPE),ADAPTIVE)
+    # Production binaries: optimize for performance
+    zli: CFLAGS += -g0 -O3
+    zli: CXXFLAGS += -g0 -O3
+    zli: CPPFLAGS += -DNDEBUG
+
+    libopenzl.a: CFLAGS += -g0 -O3
+    libopenzl.so: CFLAGS += -g0 -O3
+    libopenzl.a: CPPFLAGS += -DNDEBUG
+    libopenzl.so: CPPFLAGS += -DNDEBUG
+
+    # Benchmarks: optimize for representative performance
+    unitBench: CFLAGS += -g0 -O3
+    unitBench: CPPFLAGS += -DNDEBUG
+
+    # Test programs: enable asserts for correctness checking
+    gtests: CFLAGS += -g
+    gtests: CXXFLAGS += -g
+    gtests: CPPFLAGS += -DZL_ENABLE_ASSERT
+endif
+
 # dependencies
 ifneq (,$(filter Windows%,$(OS)))
 LIBZSTD_SO := deps/zstd/lib/dll/libzstd.dll
@@ -93,8 +119,6 @@ TRAINING_TEST_CXXOBJS := $(call cxx_objs,$(TRAINING_TEST_DIRS))
 SDDL_COMPILER_CXXOBJS := $(filter-out %main.o, $(call cxx_objs,$(SDDL_COMPILER_DIR)))
 SDDL2_COMPILER_CXXOBJS := $(filter-out %main.o, $(call cxx_objs,$(SDDL2_COMPILER_DIR)))
 
-zli: CFLAGS += -O3
-zli: CXXFLAGS += -O3
 $(eval $(call cxx_program,zli, \
 	cli/zli.o \
 	$(CLI_CXXOBJS) \
@@ -136,8 +160,6 @@ sddl2_test:
 
 # ********     Tools     ********
 
-unitBench: CFLAGS += -O3
-unitBench: CPPFLAGS += -DNDEBUG
 UNITBENCH_COBJS := $(foreach DIR,$(UNITBENCH_DIRS),$(call c_objs,$(DIR)))
 $(eval $(call c_program_shared_o,unitBench,tools/time/timefn.o tools/fileio/fileio.o $(UNITBENCH_COBJS) $(LIBOBJS),$(LIBZSTD_A)))
 
@@ -205,7 +227,6 @@ gtests: $(LIBGTEST_A) $(LIBZSTD_A)
 gtests: CPPFLAGS += -Ideps/googletest/googletest/include
 gtests: CXXFLAGS += -Wno-undef -Wno-sign-compare
 gtests: LDLIBS   += -lpthread
-gtests: CPPFLAGS += -g -DZL_ENABLE_ASSERT
 $(eval $(call cxx_program,gtests, \
 	$(ALL_GTESTS_OBJS), \
 	$(LIBGTEST_A) $(LIBZSTD_A)))

--- a/build/make/zldefs.make
+++ b/build/make/zldefs.make
@@ -39,7 +39,7 @@ ARFLAGS  += -c # do not print warning message when creating the archive (expecte
 
 # Default build mode
 # support both BUILD_TYPE and BUILD_MODE, priority to BUILD_TYPE
-BUILD_MODE ?= DEFAULT
+BUILD_MODE ?= OPT
 BUILD_TYPE ?= $(BUILD_MODE)
 
 # Sanitizer flags
@@ -100,7 +100,7 @@ else ifeq ($(BUILD_TYPE),DEFAULT)
 # no modification, just use baseline flags
     MCM_STRIP ?= 1
 else
-    $(error Invalid BUILD_TYPE: $(BUILD_TYPE). Valid options: DEFAULT, DEV, DEV_NOSAN, OPT, OPT_ASAN, DBGO, DBGO_ASAN, TRACES, TRACES_NOSAN)
+    $(error Invalid BUILD_TYPE: $(BUILD_TYPE). Valid options: OPT, OPT_ASAN, DBGO, DBGO_ASAN, DEV, DEV_NOSAN, TRACES, TRACES_NOSAN)
 endif
 
 # position user flags at the end, so that they have higher priority

--- a/build/make/zldefs.make
+++ b/build/make/zldefs.make
@@ -39,7 +39,8 @@ ARFLAGS  += -c # do not print warning message when creating the archive (expecte
 
 # Default build mode
 # support both BUILD_TYPE and BUILD_MODE, priority to BUILD_TYPE
-BUILD_MODE ?= OPT
+# ADAPTIVE mode provides smart per-target defaults (targets add their own flags)
+BUILD_MODE ?= ADAPTIVE
 BUILD_TYPE ?= $(BUILD_MODE)
 
 # Sanitizer flags
@@ -96,11 +97,12 @@ else ifeq ($(BUILD_TYPE),DBGO_ASAN)
     CFLAGS += $(SANITIZER_FLAGS)
     CXXFLAGS += $(SANITIZER_FLAGS)
     LDFLAGS += $(SANITIZER_FLAGS)
-else ifeq ($(BUILD_TYPE),DEFAULT)
+else ifeq ($(BUILD_TYPE),BASELINE)
 # no modification, just use baseline flags
-    MCM_STRIP ?= 1
+else ifeq ($(BUILD_TYPE),ADAPTIVE)
+# ADAPTIVE mode: baseline flags, targets add their own optimizations
 else
-    $(error Invalid BUILD_TYPE: $(BUILD_TYPE). Valid options: OPT, OPT_ASAN, DBGO, DBGO_ASAN, DEV, DEV_NOSAN, TRACES, TRACES_NOSAN)
+    $(error Invalid BUILD_TYPE: $(BUILD_TYPE). Valid options: ADAPTIVE, OPT, BASELINE, OPT_ASAN, DBGO, DBGO_ASAN, DEV, DEV_NOSAN, TRACES, TRACES_NOSAN)
 endif
 
 # position user flags at the end, so that they have higher priority
@@ -118,23 +120,28 @@ show-config:
 	@echo "CPPFLAGS: $(CPPFLAGS)"
 	@echo "LDFLAGS: $(LDFLAGS)"
 
-# Help target
 .PHONY: help
 help:
 	@echo "Available build types:"
-	@echo "  BUILD_TYPE=DEV        - Debug build with asserts and sanitizers"
-	@echo "  BUILD_TYPE=DEV_NOSAN  - Debug build with asserts (no sanitizers)"
-	@echo "  BUILD_TYPE=OPT        - Optimized build, no asserts (default)"
-	@echo "  BUILD_TYPE=OPT_ASAN   - Optimized build with sanitizers"
-	@echo "  BUILD_TYPE=DBGO       - Optimized build with asserts"
-	@echo "  BUILD_TYPE=DBGO_ASAN  - Optimized build with asserts and sanitizers"
-	@echo "  BUILD_TYPE=TRACES     - Debug build with asserts, sanitizers and traces"
+	@echo "  BUILD_TYPE=ADAPTIVE     - (default) Smart per-target defaults"
+	@echo "                            Production: -O3 -DNDEBUG"
+	@echo "                            Tests: -g -DZL_ENABLE_ASSERT"
+	@echo "                            Benchmarks: -O3 -DNDEBUG"
+	@echo "  BUILD_TYPE=OPT          - Optimized build, no asserts (coercive for all targets)"
+	@echo "  BUILD_TYPE=DEV          - Debug build with asserts and sanitizers (coercive)"
+	@echo "  BUILD_TYPE=DEV_NOSAN    - Debug build with asserts (no sanitizers)"
+	@echo "  BUILD_TYPE=OPT_ASAN     - Optimized build with sanitizers"
+	@echo "  BUILD_TYPE=DBGO         - Optimized build with asserts"
+	@echo "  BUILD_TYPE=DBGO_ASAN    - Optimized build with asserts and sanitizers"
+	@echo "  BUILD_TYPE=TRACES       - Debug build with asserts, sanitizers and traces"
 	@echo "  BUILD_TYPE=TRACES_NOSAN - Debug build with asserts and traces"
 	@echo ""
 	@echo "Usage examples:"
-	@echo "  make lib                        # Build library with DEFAULT type"
-	@echo "  make lib BUILD_TYPE=DBGO_ASAN   # Build library with DBGO_ASAN type"
-	@echo "  make zli BUILD_TYPE=DEV         # Build executable with DEV type"
+	@echo "  make                            # Build with ADAPTIVE mode (smart defaults)"
+	@echo "  make zli                        # Build zli with -O3 -DNDEBUG (ADAPTIVE)"
+	@echo "  make gtests                     # Build gtests with -g -DZL_ENABLE_ASSERT (ADAPTIVE)"
+	@echo "  make BUILD_TYPE=OPT             # Force OPT mode for all targets"
+	@echo "  make BUILD_TYPE=DEV             # Force DEV mode for all targets"
 	@echo "  make show-config BUILD_TYPE=DEV # Show configuration for DEV type"
 
 # Paths to source files

--- a/tests/compress/test_gbt.cpp
+++ b/tests/compress/test_gbt.cpp
@@ -229,11 +229,14 @@ class GBTBinaryForestTest : public Test {
     void SetUp() override
     {
         const size_t kTreeNb = 5;
-        nodes                = { { .featureIdx      = -1,
-                                   .value           = 0.2f,
-                                   .leftChildIdx    = 0,
-                                   .rightChildIdx   = 0,
-                                   .missingChildIdx = 0 } };
+        GBTPredictor_Node node;
+        node.featureIdx      = -1;
+        node.value           = 0.2f;
+        node.leftChildIdx    = 0;
+        node.rightChildIdx   = 0;
+        node.missingChildIdx = 0;
+        nodes.clear();
+        nodes.push_back(node);
         for (size_t i = 0; i < kTreeNb; i++) {
             trees.push_back(
                     { .numNodes = nodes.size(), .nodes = nodes.data() });

--- a/tests/unittest/transforms/test_tokenize_kernel.cpp
+++ b/tests/unittest/transforms/test_tokenize_kernel.cpp
@@ -15,10 +15,16 @@ namespace zstrong::tests {
 namespace {
 void roundtrip2to1(const std::vector<uint16_t>& input)
 {
-    std::vector<uint8_t> indexes(std::max(input.size(), size_t(1)));
+    std::vector<uint8_t> indexes(input.size());
+    if (input.size() == 0) {
+        indexes.reserve(1); // force a non-null pointer
+    }
     assert(indexes.data() != NULL);
     std::vector<uint16_t> alphabet(256);
-    std::vector<uint16_t> regenerated(std::max(input.size(), size_t(1)));
+    std::vector<uint16_t> regenerated(input.size());
+    if (input.size() == 0) {
+        regenerated.reserve(1); // force a non-null pointer
+    }
     assert(regenerated.data() != NULL);
 
     size_t const alphabetSize = ZS_tokenize2to1_encode(

--- a/tests/unittest/transforms/test_tokenize_kernel.cpp
+++ b/tests/unittest/transforms/test_tokenize_kernel.cpp
@@ -16,11 +16,9 @@ namespace {
 void roundtrip2to1(const std::vector<uint16_t>& input)
 {
     std::vector<uint8_t> indexes(input.size());
-    indexes.reserve(1); /* ensure buffer is not NULL */
     assert(indexes.data() != NULL);
     std::vector<uint16_t> alphabet(256);
     std::vector<uint16_t> regenerated(input.size());
-    regenerated.reserve(1); /* ensure buffer is not NULL */
     assert(regenerated.data() != NULL);
 
     size_t const alphabetSize = ZS_tokenize2to1_encode(

--- a/tests/unittest/transforms/test_tokenize_kernel.cpp
+++ b/tests/unittest/transforms/test_tokenize_kernel.cpp
@@ -15,10 +15,10 @@ namespace zstrong::tests {
 namespace {
 void roundtrip2to1(const std::vector<uint16_t>& input)
 {
-    std::vector<uint8_t> indexes(input.size());
+    std::vector<uint8_t> indexes(std::max(input.size(), size_t(1)));
     assert(indexes.data() != NULL);
     std::vector<uint16_t> alphabet(256);
-    std::vector<uint16_t> regenerated(input.size());
+    std::vector<uint16_t> regenerated(std::max(input.size(), size_t(1)));
     assert(regenerated.data() != NULL);
 
     size_t const alphabetSize = ZS_tokenize2to1_encode(


### PR DESCRIPTION
Compiling with `-O3` + `-Werror` is bound to emerge new errors due to compiler warnings becoming more sensitive with higher optimization level.

Since these new warnings are not observed locally, trigger these remaining cases in CI and fix them one by one.

Once done:
fix #129

`zli` compiled in `OPT` mode is about +20% faster, for both compression and decompression, on the `sao` scenario.