### PR TITLE
Fix fuzzer health signals

### DIFF
--- a/tests/version/VersionFuzzer.cpp
+++ b/tests/version/VersionFuzzer.cpp
@@ -7,6 +7,15 @@
 
 #include "tests/version/VersionTestInterface.h"
 
+extern "C" int LLVMFuzzerTestOneInput(uint8_t const* data, size_t size);
+
+extern "C" void FtestFuzzerSetup()
+{
+    // Run once during global setup so we are fully initialized before fuzzing
+    uint8_t c = 0;
+    LLVMFuzzerTestOneInput(&c, 1);
+}
+
 namespace zstrong {
 namespace tests {
 namespace {


### PR DESCRIPTION
Summary: Adds global setup before fuzzing in version tests to ensure things are fully set up before fuzzing. This adds to the version fuzzer only because these use a separate definition and these are the only fuzzer failures we see.

Reviewed By: terrelln

Differential Revision: D88085003


