### PR TITLE
Fix OOB memory access

### DIFF
--- a/tools/arg/arg_parser.cpp
+++ b/tools/arg/arg_parser.cpp
@@ -94,10 +94,16 @@ void ArgParser::addCommandImmediate(
 
 void ArgParser::addCommandPositional(
         int cmd,
+        NumArgs numArgs,
         const std::string& name,
         const std::string& help)
 {
-    cmdPositionals_[cmd].push_back({ name, help });
+    if (!cmdPositionals_[cmd].empty()
+        && cmdPositionals_[cmd].back().numArgs != NumArgs::One) {
+        throw ParseException(
+                "Cannot add a positional argument after a variadic positional argument!");
+    }
+    cmdPositionals_[cmd].push_back({ numArgs, name, help });
 }
 
 std::string ArgParser::help() const
@@ -163,7 +169,20 @@ std::string ArgParser::help(const Command& command) const
     ss << "Positionals:\n";
     if (cmdPositionals_.find(command.cmd) != cmdPositionals_.end()) {
         for (auto const& positional : cmdPositionals_.at(command.cmd)) {
-            ss << "  " << positional.name << "\n";
+            switch (positional.numArgs) {
+                case NumArgs::ZeroOrOne:
+                    ss << "  [" << positional.name << "]\n";
+                    break;
+                case NumArgs::One:
+                    ss << "  " << positional.name << "\n";
+                    break;
+                case NumArgs::OneOrMore:
+                    ss << "  " << positional.name << "...\n";
+                    break;
+                case NumArgs::ZeroOrMore:
+                    ss << "  [" << positional.name << "]...\n";
+                    break;
+            }
             ss << "    " << positional.help << "\n";
         }
     }
@@ -245,9 +264,9 @@ ParsedArgs ArgParser::parse(int argc, char** argv) const
                             "Option " + flag->name + " requires a value";
                     throw ParseException(err);
                 }
-                parsedArgs.cmdVals_[cmd][flag->name] = argv[i];
+                parsedArgs.cmdVals_[cmd][flag->name].push_back(argv[i]);
             } else {
-                parsedArgs.cmdVals_[cmd][flag->name] = "";
+                parsedArgs.cmdVals_[cmd][flag->name].push_back("");
             }
         };
         auto processShortFlag = [&](char shortName, int chosenCmd) {
@@ -298,8 +317,8 @@ ParsedArgs ArgParser::parse(int argc, char** argv) const
                     throw ParseException(err);
                 }
                 auto [flag, cmd] = flagOpt.value();
-                parsedArgs.cmdVals_[cmd][flag->name] =
-                        std::to_string(arg.size() + 2);
+                parsedArgs.cmdVals_[cmd][flag->name].push_back(
+                        std::to_string(arg.size() + 2));
             } else {
                 processShortFlag(argv[i][1], parsedArgs.chosenCmd_);
             }
@@ -341,36 +360,46 @@ ParsedArgs ArgParser::parse(int argc, char** argv) const
                 throw ParseException(
                         "Trying to pass a positional argument before specifying a subcommand!");
             }
-            const auto positionalIdx =
-                    cmdPositionalIndex[parsedArgs.chosenCmd_]++;
+            auto positionalIdx = cmdPositionalIndex[parsedArgs.chosenCmd_]++;
             const auto positionalSize =
                     cmdPositionals_.at(parsedArgs.chosenCmd_).size();
-            if (positionalSize <= positionalIdx) {
-                std::ostringstream msg;
-                msg << "Too many positional arguments for command '"
-                    << commandName(parsedArgs.chosenCmd_) << "'.\n";
+            if (positionalSize == 0) {
+                throw ParseException(
+                        "Trying to pass a positional argument when no positional arguments are expected!");
+            }
+            if (positionalIdx >= positionalSize) {
+                positionalIdx          = positionalSize - 1;
+                const auto& positional = cmdPositionals_.at(
+                        parsedArgs.chosenCmd_)[positionalIdx];
+                if (positional.numArgs == NumArgs::ZeroOrOne
+                    || positional.numArgs == NumArgs::One) {
+                    std::ostringstream msg;
+                    msg << "Too many positional arguments for command '"
+                        << commandName(parsedArgs.chosenCmd_) << "'.\n";
 
-                // Show expected positional arguments
-                msg << "Expected " << positionalSize << " positional argument"
-                    << (positionalSize == 1 ? "" : "s") << ":";
-                for (size_t j = 0; j < positionalSize; ++j) {
-                    msg << " <"
-                        << cmdPositionals_.at(parsedArgs.chosenCmd_)[j].name
-                        << ">";
+                    // Show expected positional arguments
+                    msg << "Expected " << positionalSize
+                        << " positional argument"
+                        << (positionalSize == 1 ? "" : "s") << ":";
+                    for (size_t j = 0; j < positionalSize; ++j) {
+                        msg << " <"
+                            << cmdPositionals_.at(parsedArgs.chosenCmd_)[j].name
+                            << ">";
+                    }
+                    msg << "\n";
+
+                    // Show the problematic argument
+                    msg << "Got unexpected positional argument '" << argv[i]
+                        << "' at position " << (positionalIdx + 1);
+
+                    throw ParseException({ msg.str() });
                 }
-                msg << "\n";
-
-                // Show the problematic argument
-                msg << "Got unexpected positional argument '" << argv[i]
-                    << "' at position " << (positionalIdx + 1);
-
-                throw ParseException({ msg.str() });
             }
             auto positionalName =
                     cmdPositionals_.at(parsedArgs.chosenCmd_)[positionalIdx]
                             .name;
-            parsedArgs.cmdVals_[parsedArgs.chosenCmd_][positionalName] =
-                    argv[i];
+            parsedArgs.cmdVals_[parsedArgs.chosenCmd_][positionalName]
+                    .push_back(argv[i]);
         }
     }
     return parsedArgs;
@@ -382,10 +411,24 @@ void ArgParser::validate(const ParsedArgs& parsedArgs) const
         throw ParseException("No subcommand specified!");
     }
     for (const auto& positional : cmdPositionals_.at(parsedArgs.chosenCmd_)) {
-        if (parsedArgs.cmdVals_.at(parsedArgs.chosenCmd_).find(positional.name)
-            == parsedArgs.cmdVals_.at(parsedArgs.chosenCmd_).end()) {
-            std::string err = "Missing positional argument: " + positional.name;
-            throw ParseException({ err });
+        const auto& positionals = parsedArgs.cmdVals_.at(parsedArgs.chosenCmd_);
+
+        // Validate required positional arguments are present
+        if (positionals.count(positional.name) == 0
+            || positionals.at(positional.name).size() == 0) {
+            if (positional.numArgs == NumArgs::One
+                || positional.numArgs == NumArgs::OneOrMore) {
+                throw ParseException(
+                        "Missing positional argument: " + positional.name);
+            } else {
+                continue;
+            }
+        }
+
+        auto numArgs = positionals.at(positional.name).size();
+        if (numArgs > 1 && positional.numArgs == NumArgs::One) {
+            throw ParseException(
+                    "Too many positional arguments for " + positional.name);
         }
     }
 }

--- a/tools/arg/arg_parser.cpp
+++ b/tools/arg/arg_parser.cpp
@@ -48,6 +48,11 @@ std::optional<const Flag*> findFlagByShort(
 
 } // namespace
 
+ArgParser::ArgParser()
+{
+    cmdFlags_[CMD_UNSPECIFIED] = {};
+}
+
 void ArgParser::addGlobalFlag(
         const std::string& name,
         char shortName,
@@ -336,8 +341,9 @@ ParsedArgs ArgParser::parse(int argc, char** argv) const
             bool isSubcommand = false;
             for (const auto& command : commands_) {
                 if (command.name == argv[i]
-                    || (argv[i][1] == 0 && command.shortName != 0
-                        && command.shortName == argv[i][0])) {
+                    || (command.shortName != 0
+                        && command.shortName == argv[i][0]
+                        && argv[i][1] == 0)) {
                     if (parsedArgs.chosenCmd_ != CMD_UNSPECIFIED) {
                         std::string err =
                                 "Trying to choose another subcommand '"

--- a/tools/arg/arg_parser.h
+++ b/tools/arg/arg_parser.h
@@ -17,6 +17,8 @@ class ArgParser {
    public:
     static constexpr int CMD_UNSPECIFIED = 0;
 
+    ArgParser();
+
     // see the documentation in struct Flag, Command, Positional for more info
     // on expected arguments
     void addGlobalFlag(

--- a/tools/arg/arg_parser.h
+++ b/tools/arg/arg_parser.h
@@ -43,11 +43,42 @@ class ArgParser {
             char shortName,
             bool hasVal,
             const std::string& help);
-    // order matters
+    /**
+     * @brief Add a positional argument to a command with a specified number of
+     * arguments.
+     *
+     * Positional arguments are added in order. Once a variadic positional
+     * argument (ZeroOrOne, ZeroOrMore, or OneOrMore) is added, no more
+     * positional arguments can be added to that command.
+     *
+     * @param cmd The command ID to which the positional argument should be
+     * added.
+     * @param numArgs Specifies how many values this positional accepts.
+     * @param name The name of the positional argument (used for lookup and
+     * help).
+     * @param help The help text describing this positional argument.
+     *
+     * @note Order matters - positional arguments must be specified in the order
+     * they appear on the command line.
+     */
+    void addCommandPositional(
+            int cmd,
+            NumArgs numArgs,
+            const std::string& name,
+            const std::string& help);
+
+    /**
+     * @brief Add a positional argument to a command (single value).
+     *
+     * Convenience overload that assumes exactly one value (NumArgs::One).
+     */
     void addCommandPositional(
             int cmd,
             const std::string& name,
-            const std::string& help);
+            const std::string& help)
+    {
+        return addCommandPositional(cmd, NumArgs::One, name, help);
+    }
 
     // Populated based on added flags, commands, and positionals
     std::string help() const;

--- a/tools/arg/parsed_args.cpp
+++ b/tools/arg/parsed_args.cpp
@@ -9,6 +9,15 @@
 #include "tools/arg/arg_parser.h"
 
 namespace openzl::arg {
+namespace {
+std::optional<std::string> vecToOptional(const std::vector<std::string>& vec)
+{
+    if (vec.size() == 1) {
+        return vec[0];
+    }
+    return std::nullopt;
+}
+} // namespace
 
 int ParsedArgs::chosenCmd() const
 {
@@ -68,7 +77,7 @@ std::optional<std::string> ParsedArgs::globalFlag(const std::string& name) const
     if (mp.find(name) == mp.end()) {
         return std::nullopt;
     }
-    return mp.at(name);
+    return vecToOptional(mp.at(name));
 }
 
 std::string ParsedArgs::globalRequiredFlag(const std::string& name) const
@@ -76,13 +85,25 @@ std::string ParsedArgs::globalRequiredFlag(const std::string& name) const
     return cmdRequiredFlag(ArgParser::CMD_UNSPECIFIED, name);
 }
 
-std::string ParsedArgs::cmdPositional(int cmd, const std::string& name) const
+std::vector<std::string> ParsedArgs::cmdPositionals(
+        int cmd,
+        const std::string& name) const
 {
     auto mp = cmdVals_.at(cmd);
     if (mp.find(name) == mp.end()) {
         throw ParseException("No positional arg with name " + name);
     }
-    return mp.at(name).value();
+    return mp.at(name);
+}
+
+std::string ParsedArgs::cmdPositional(int cmd, const std::string& name) const
+{
+    auto pos = vecToOptional(cmdPositionals(cmd, name));
+    if (!pos.has_value()) {
+        throw ParseException(
+                "Need exactly one positional arg with name " + name);
+    }
+    return pos.value();
 }
 
 bool ParsedArgs::cmdHasFlag(int cmd, const std::string& name) const
@@ -101,7 +122,7 @@ std::optional<std::string> ParsedArgs::cmdFlag(int cmd, const std::string& name)
     if (mp.find(name) == mp.end()) {
         return std::nullopt;
     }
-    return mp.at(name);
+    return vecToOptional(mp.at(name));
 }
 
 std::string ParsedArgs::cmdRequiredFlag(int cmd, const std::string& name) const

--- a/tools/arg/parsed_args.h
+++ b/tools/arg/parsed_args.h
@@ -25,13 +25,36 @@ class ParsedArgs {
     std::optional<std::string> globalFlag(const std::string& name) const;
     std::string globalRequiredFlag(const std::string& name) const;
 
+    /**
+     * @brief Retrieve all values for a variadic positional argument.
+     *
+     * Returns a vector containing all values that were passed for the specified
+     * positional argument. The number of elements in this vector depends on the
+     * number of arguments specified for the positional argument. The size of
+     * the vector is pre-validated to match the number of arguments specified.
+     *
+     * @param cmd The command ID for which to retrieve the positional argument
+     * values.
+     * @param name The name of the positional argument.
+     * @return A vector of strings containing all values for the positional
+     * argument.
+     */
+    std::vector<std::string> cmdPositionals(int cmd, const std::string& name)
+            const;
+
+    /**
+     * @brief Retrieve the value for a positional argument.
+     *
+     * Convenience overload that assumes exactly one value (NumArgs::One).
+     */
     std::string cmdPositional(int cmd, const std::string& name) const;
+
     bool cmdHasFlag(int cmd, const std::string& name) const;
     std::optional<std::string> cmdFlag(int cmd, const std::string& name) const;
     std::string cmdRequiredFlag(int cmd, const std::string& name) const;
 
    private:
-    std::map<int, std::map<std::string, std::optional<std::string>>> cmdVals_;
+    std::map<int, std::map<std::string, std::vector<std::string>>> cmdVals_;
     int chosenCmd_ = 0;
 
     // copied from ArgParser

--- a/tools/arg/positional.h
+++ b/tools/arg/positional.h
@@ -6,7 +6,15 @@
 
 namespace openzl::arg {
 
+enum class NumArgs {
+    ZeroOrOne,
+    One,
+    ZeroOrMore,
+    OneOrMore,
+};
+
 struct Positional {
+    NumArgs numArgs;
     std::string name;
     std::string help;
 };


### PR DESCRIPTION
Summary:
* `cmdFlags_[CMD_UNSPECIFIED]` needs to be pre-filled, otherwise the code accesses it and errors.
* We incorrectly access `argv[i][1]` before validating that `argv[i][0] != 0`.

Differential Revision: D88306747


