### PR TITLE
LZ Benchmark

### DIFF
--- a/contrib/lz-research/BUCK
+++ b/contrib/lz-research/BUCK
@@ -1,0 +1,57 @@
+load("@fbcode_macros//build_defs:cpp_binary.bzl", "cpp_binary")
+load("@fbcode_macros//build_defs:cpp_library.bzl", "cpp_library")
+
+oncall("data_compression")
+
+cpp_library(
+    name = "lz_compressors",
+    srcs = ["LzCompressors.cpp"],
+    headers = ["LzCompressors.hpp"],
+    exported_deps = [
+        "//openzl/dev/cpp:openzl_cpp",
+    ],
+)
+
+cpp_library(
+    name = "compressor",
+    srcs = ["Compressor.cpp"],
+    headers = ["Compressor.hpp"],
+    deps = [
+        ":lz_compressors",
+    ],
+    exported_deps = [
+        "fbsource//third-party/lz4:lz4",
+        "fbsource//third-party/zstd:zstd",
+        "//openzl/dev/cpp:openzl_cpp",
+        "//openzl/dev/tools:io",
+        "//openzl/dev/tools:json",
+        "//openzl/dev/tools/training:train",
+    ],
+)
+
+cpp_library(
+    name = "benchmark",
+    srcs = ["Benchmark.cpp"],
+    headers = ["Benchmark.hpp"],
+    exported_deps = [
+        ":compressor",
+        "//openzl/dev/tools:io",
+        "//openzl/dev/tools:json",
+        "//openzl/dev/tools:logger",
+    ],
+)
+
+cpp_binary(
+    name = "lz",
+    srcs = [
+        "Main.cpp",
+    ],
+    deps = [
+        "fbsource//third-party/zstd:zstd",
+        ":benchmark",
+        "//openzl/dev/cpp:openzl_cpp",
+        "//openzl/dev/tools:arg",
+        "//openzl/dev/tools:fileio",
+        "//openzl/dev/tools:logger",
+    ],
+)

--- a/contrib/lz-research/Benchmark.cpp
+++ b/contrib/lz-research/Benchmark.cpp
@@ -1,0 +1,176 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#include "Benchmark.hpp"
+
+#include "tools/logger/Logger.h"
+
+namespace openzl::bench {
+
+namespace {
+using tools::logger::Logger;
+using tools::logger::LogLevel;
+
+template <typename Fn>
+size_t benchmarkFn(
+        std::vector<std::chrono::nanoseconds>& durations,
+        size_t minIters,
+        std::chrono::nanoseconds minTime,
+        Fn&& fn)
+{
+    using Clock = std::chrono::steady_clock;
+
+    // Run one warmup iteration
+    auto firstResult = fn();
+
+    auto benchUntil = Clock::now() + minTime;
+    size_t iters    = 0;
+
+    for (; iters < minIters || Clock::now() < benchUntil; ++iters) {
+        auto start  = Clock::now();
+        auto result = fn();
+        auto stop   = Clock::now();
+        if (result != firstResult) {
+            throw std::runtime_error("Results differ!");
+        }
+        durations.push_back(stop - start);
+    }
+
+    return firstResult;
+}
+
+nlohmann::json toJson(const std::vector<std::chrono::nanoseconds>& durations)
+{
+    auto out = nlohmann::json::array();
+    for (const auto& d : durations) {
+        out.push_back(d.count());
+    }
+    return out;
+}
+
+std::string trunc(std::string str, size_t n, bool left)
+{
+    if (n < 3) {
+        throw std::runtime_error("bad n");
+    }
+    if (str.size() > n) {
+        size_t len = n - 3;
+        if (left) {
+            str = "..." + str.substr(str.size() - len);
+        } else {
+            str = str.substr(0, len) + "...";
+        }
+        return str;
+    } else {
+        return str;
+    }
+}
+} // namespace
+
+nlohmann::json BenchmarkResult::json() const
+{
+    nlohmann::json data;
+    data["file_name"]                  = fileName;
+    data["compressor_name"]            = compressorName;
+    data["compressor_config"]          = compressorConfig;
+    data["original_size"]              = originalSize;
+    data["compressed_size"]            = compressedSize;
+    data["compression_durations_ns"]   = toJson(compressionDurations);
+    data["decompression_durations_ns"] = toJson(decompressionDurations);
+    return data;
+}
+
+/* static */ std::string BenchmarkResult::header()
+{
+    char buffer[200];
+    int len = snprintf(
+            buffer,
+            sizeof(buffer),
+            "%20s, %40s, %10s, %20s, %20s",
+            "File",
+            "Compressor",
+            "Ratio",
+            "Compression Speed",
+            "Decompression Speed");
+    if (len < 0 || len >= sizeof(buffer)) {
+        throw std::runtime_error("bad format");
+    }
+    return buffer;
+}
+
+std::string BenchmarkResult::pretty() const
+{
+    char buffer[200];
+    int len = snprintf(
+            buffer,
+            sizeof(buffer),
+            "%20s, %40s, %10.2f, %15.1f MB/s, %15.1f MB/s",
+            trunc(fileName, 20, true).c_str(),
+            trunc(compressorName, 40, false).c_str(),
+            compressionRatio(),
+            bestCompressionSpeedMBps(),
+            bestDecompressionSpeedMBps());
+    if (len < 0 || len >= sizeof(buffer)) {
+        throw std::runtime_error("bad format");
+    }
+    return buffer;
+}
+
+std::vector<BenchmarkResult> benchmark(
+        const tools::io::InputSet& inputs,
+        const BenchmarkArgs& args)
+{
+    if (args.minIters == 0) {
+        throw std::runtime_error("min iters must be at least 1");
+    }
+    for (const auto& compressorConfig : args.compressorConfigs) {
+        // Ensure each compressor builds
+        makeCompressor(compressorConfig);
+    }
+
+    Logger::log_c(LogLevel::INFO, "%s", BenchmarkResult::header().c_str());
+    std::vector<BenchmarkResult> results;
+    for (const auto& input : inputs) {
+        for (const auto& compressorConfig : args.compressorConfigs) {
+            auto compressor = makeCompressor(compressorConfig);
+            auto data       = input->contents();
+
+            BenchmarkResult result;
+            result.fileName         = input->name();
+            result.compressorName   = compressor->name();
+            result.compressorConfig = compressorConfig;
+            result.originalSize     = data.size();
+
+            auto cCapacity = compressor->compressBound(data);
+            auto cBuf      = std::make_unique<char[]>(cCapacity);
+            auto dBuf      = std::make_unique<char[]>(data.size());
+
+            result.compressedSize = benchmarkFn(
+                    result.compressionDurations,
+                    args.minIters,
+                    args.minTime,
+                    [&] {
+                        return compressor->compress(
+                                { cBuf.get(), cCapacity }, data);
+                    });
+
+            auto dSize = benchmarkFn(
+                    result.decompressionDurations,
+                    args.minIters,
+                    args.minTime,
+                    [&] {
+                        return compressor->decompress(
+                                { dBuf.get(), data.size() },
+                                { cBuf.get(), result.compressedSize });
+                    });
+            Logger::log_c(LogLevel::INFO, "%s", result.pretty().c_str());
+
+            if (poly::string_view{ dBuf.get(), dSize } != data) {
+                throw std::runtime_error("Corruption!");
+            }
+            results.push_back(result);
+        }
+    }
+    return results;
+}
+
+} // namespace openzl::bench

--- a/contrib/lz-research/Benchmark.hpp
+++ b/contrib/lz-research/Benchmark.hpp
@@ -1,0 +1,59 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#pragma once
+
+#include <chrono>
+#include <memory>
+#include <vector>
+
+#include "tools/io/InputSet.h"
+#include "tools/json.hpp"
+
+#include "Compressor.hpp"
+
+namespace openzl::bench {
+
+struct BenchmarkArgs {
+    size_t minIters{ 1 };
+    std::chrono::nanoseconds minTime{ 1 };
+    std::vector<nlohmann::json> compressorConfigs;
+};
+
+struct BenchmarkResult {
+    std::string fileName;
+    std::string compressorName;
+    nlohmann::json compressorConfig;
+    size_t originalSize;
+    size_t compressedSize;
+    std::vector<std::chrono::nanoseconds> compressionDurations;
+    std::vector<std::chrono::nanoseconds> decompressionDurations;
+
+    double compressionRatio() const
+    {
+        return (double)originalSize / compressedSize;
+    }
+
+    double bestCompressionSpeedMBps() const
+    {
+        auto dur = *std::min_element(
+                compressionDurations.begin(), compressionDurations.end());
+        return (double)originalSize * 1000.0 / dur.count();
+    }
+
+    double bestDecompressionSpeedMBps() const
+    {
+        auto dur = *std::min_element(
+                decompressionDurations.begin(), decompressionDurations.end());
+        return (double)originalSize * 1000.0 / dur.count();
+    }
+
+    nlohmann::json json() const;
+    static std::string header();
+    std::string pretty() const;
+};
+
+std::vector<BenchmarkResult> benchmark(
+        const tools::io::InputSet& inputs,
+        const BenchmarkArgs& args);
+
+} // namespace openzl::bench

--- a/contrib/lz-research/Compressor.cpp
+++ b/contrib/lz-research/Compressor.cpp
@@ -1,0 +1,642 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#include <filesystem>
+
+#include "Compressor.hpp"
+
+#include "openzl/shared/varint.h"
+#include "tools/io/OutputFile.h"
+#include "tools/training/train.h"
+
+#include "LzCompressors.hpp"
+
+namespace openzl::bench {
+
+namespace {
+namespace fs = std::filesystem;
+
+const char kBase64EncodeTable[] = {
+    'A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', 'I', 'J', 'K', 'L', 'M',
+    'N', 'O', 'P', 'Q', 'R', 'S', 'T', 'U', 'V', 'W', 'X', 'Y', 'Z',
+    'a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j', 'k', 'l', 'm',
+    'n', 'o', 'p', 'q', 'r', 's', 't', 'u', 'v', 'w', 'x', 'y', 'z',
+    '0', '1', '2', '3', '4', '5', '6', '7', '8', '9', '+', '/'
+};
+
+static size_t base64EncodedSize(size_t srcSize)
+{
+    size_t encodedSize = (srcSize / 3) * 4;
+    if (srcSize % 3 != 0) {
+        encodedSize += 4;
+    }
+    return encodedSize;
+}
+
+static std::string base64Encode(std::string_view in)
+{
+    std::string out(base64EncodedSize(in.size()), '\0');
+
+    const uint8_t* src   = (const uint8_t*)in.data();
+    const size_t srcSize = in.size();
+    char* dst            = out.data();
+
+    const char* const dstBegin  = dst;
+    const uint8_t* const srcEnd = src + srcSize;
+    for (; (srcEnd - src) >= 3; src += 3, dst += 4) {
+        dst[0] = kBase64EncodeTable[src[0] >> 2];
+        dst[1] = kBase64EncodeTable[((src[0] & 0x03) << 4) + ((src[1] >> 4))];
+        dst[2] = kBase64EncodeTable[((src[1] & 0x0f) << 2) + ((src[2] >> 6))];
+        dst[3] = kBase64EncodeTable[src[2] & 0x3f];
+    }
+
+    if (src < srcEnd) {
+        assert(src + 1 == srcEnd || src + 2 == srcEnd);
+        dst[0] = kBase64EncodeTable[src[0] >> 2];
+        if (src + 1 == srcEnd) {
+            dst[1] = kBase64EncodeTable[(src[0] & 0x03) << 4];
+            dst[2] = '=';
+        } else {
+            dst[1] = kBase64EncodeTable[((src[0] & 0x03) << 4) + (src[1] >> 4)];
+            dst[2] = kBase64EncodeTable[(src[1] & 0x0f) << 2];
+        }
+        dst[3] = '=';
+        dst += 4;
+    }
+    const size_t dstSize = (size_t)(dst - dstBegin);
+    ZL_ASSERT_EQ(dstSize, base64EncodedSize(srcSize));
+    return out;
+}
+
+static const uint8_t kBase64DecodeTable[256] = {
+    0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
+    0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
+    0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
+    0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0x3e, 0xff, 0xff, 0xff, 0x3f,
+    0x34, 0x35, 0x36, 0x37, 0x38, 0x39, 0x3a, 0x3b, 0x3c, 0x3d, 0xff, 0xff,
+    0xff, 0xff, 0xff, 0xff, 0xff, 0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06,
+    0x07, 0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f, 0x10, 0x11, 0x12,
+    0x13, 0x14, 0x15, 0x16, 0x17, 0x18, 0x19, 0xff, 0xff, 0xff, 0xff, 0xff,
+    0xff, 0x1a, 0x1b, 0x1c, 0x1d, 0x1e, 0x1f, 0x20, 0x21, 0x22, 0x23, 0x24,
+    0x25, 0x26, 0x27, 0x28, 0x29, 0x2a, 0x2b, 0x2c, 0x2d, 0x2e, 0x2f, 0x30,
+    0x31, 0x32, 0x33, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
+    0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
+    0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
+    0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
+    0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
+    0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
+    0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
+    0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
+    0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
+    0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
+    0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
+    0xff, 0xff, 0xff, 0xff,
+};
+
+static std::string base64Decode(std::string_view in)
+{
+    while (!in.empty() && in.back() == '=') {
+        in = in.substr(0, in.size() - 1);
+    }
+
+    std::string out;
+    out.reserve(in.size() * 3 / 4);
+    const uint8_t* const src = (const uint8_t*)in.data();
+    for (size_t i = 0; i + 1 < in.size(); i += 4) {
+        out += (kBase64DecodeTable[src[i]] << 2)
+                | (kBase64DecodeTable[src[i + 1]] >> 4);
+        if (i + 2 < in.size()) {
+            out += ((kBase64DecodeTable[src[i + 1]] << 4) & 0xf0)
+                    | (kBase64DecodeTable[src[i + 2]] >> 2);
+            if (i + 3 < in.size()) {
+                out += ((kBase64DecodeTable[src[i + 2]] << 6) & 0xc0)
+                        | (kBase64DecodeTable[src[i + 3]]);
+            }
+        }
+    }
+    return out;
+}
+
+size_t zstdThrowIfError(size_t result)
+{
+    if (ZSTD_isError(result)) {
+        throw std::runtime_error(ZSTD_getErrorName(result));
+    }
+    return result;
+}
+size_t lz4ThrowIfError(int result)
+{
+    if (result <= 0) {
+        throw std::runtime_error("LZ4 error");
+    }
+    return result;
+}
+
+std::string shortParam(openzl::CParam key)
+{
+    switch (key) {
+        case openzl::CParam::CompressedChecksum:
+            return "ccheck";
+        case openzl::CParam::ContentChecksum:
+            return "dcheck";
+        case openzl::CParam::CompressionLevel:
+            return "clvl";
+        case openzl::CParam::DecompressionLevel:
+            return "dlvl";
+        case openzl::CParam::FormatVersion:
+            return "format";
+        case openzl::CParam::MinStreamSize:
+            return "minsize";
+        case openzl::CParam::PermissiveCompression:
+            return "permissive";
+        default:
+            return std::to_string(int(key));
+    }
+}
+
+std::string shortParam(ZSTD_cParameter key)
+{
+    switch (key) {
+        case ZSTD_c_windowLog:
+            return "wlog";
+        case ZSTD_c_hashLog:
+            return "hlog";
+        case ZSTD_c_chainLog:
+            return "clog";
+        case ZSTD_c_minMatch:
+            return "mlen";
+        case ZSTD_c_targetLength:
+            return "tlen";
+        case ZSTD_c_strategy:
+            return "strat";
+        case ZSTD_c_checksumFlag:
+            return "check";
+        default:
+            return std::to_string(key);
+    }
+}
+
+openzl::CParam parseOpenZLCParam(std::string_view key)
+{
+    if (key == "StickyParameters") {
+        throw std::runtime_error("cant set sticky");
+    }
+#define HANDLE(param)                 \
+    if (key == #param) {              \
+        return openzl::CParam::param; \
+    }
+
+    HANDLE(CompressionLevel);
+    HANDLE(DecompressionLevel);
+    HANDLE(FormatVersion);
+    HANDLE(PermissiveCompression);
+    HANDLE(CompressedChecksum);
+    HANDLE(ContentChecksum);
+    HANDLE(MinStreamSize);
+
+#undef HANDLE
+
+    throw std::runtime_error("Unknown parameter: " + std::string(key));
+}
+
+std::string param(openzl::CParam key)
+{
+#define HANDLE(param)           \
+    case openzl::CParam::param: \
+        return #param;
+
+    switch (key) {
+        HANDLE(CompressionLevel);
+        HANDLE(DecompressionLevel);
+        HANDLE(FormatVersion);
+        HANDLE(PermissiveCompression);
+        HANDLE(CompressedChecksum);
+        HANDLE(ContentChecksum);
+        HANDLE(MinStreamSize);
+        default:
+            throw std::runtime_error("Bad parameter: " + shortParam(key));
+    }
+#undef HANDLE
+} // namespace
+
+ZSTD_cParameter parseZstdCParam(std::string_view key)
+{
+    if (key == "compressionLevel") {
+        throw std::runtime_error("Set level via level");
+    }
+
+#define HANDLE(param)          \
+    if (key == #param) {       \
+        return ZSTD_c_##param; \
+    }
+
+    HANDLE(windowLog);
+    HANDLE(hashLog);
+    HANDLE(chainLog);
+    HANDLE(searchLog);
+    HANDLE(minMatch);
+    HANDLE(targetLength);
+    HANDLE(strategy);
+    HANDLE(targetCBlockSize);
+    HANDLE(enableLongDistanceMatching);
+    HANDLE(ldmHashLog);
+    HANDLE(ldmHashRateLog);
+    HANDLE(contentSizeFlag);
+    HANDLE(checksumFlag);
+    HANDLE(dictIDFlag);
+    HANDLE(nbWorkers);
+    HANDLE(jobSize);
+    HANDLE(overlapLog);
+
+#undef HANDLE
+
+    throw std::runtime_error("Unknown parameter: " + std::string(key));
+}
+} // namespace
+
+std::string ZstdCompressor::name() const
+{
+    std::string name = "zstd[";
+    if (level_.has_value()) {
+        name += "lvl=" + std::to_string(level_.value()) + ",";
+    }
+    if (!params_.empty()) {
+        for (const auto& [k, v] : params_) {
+            name += shortParam(k) + "=" + std::to_string(v) + ",";
+        }
+        name.pop_back();
+        name += ",";
+    }
+    name.pop_back();
+    if (level_.has_value() || !params_.empty()) {
+        name += "]";
+    }
+    return name;
+}
+
+ZstdCompressor::ZstdCompressor(nlohmann::json config)
+{
+    if (config.contains("level")) {
+        level_ = config["level"];
+    }
+    if (config.contains("params")) {
+        for (const auto& [key, value] : config["params"].items()) {
+            params_.emplace(parseZstdCParam(key), int(value));
+        }
+    }
+}
+
+size_t ZstdCompressor::compressBound(std::string_view data) const
+{
+    return ZSTD_compressBound(data.size());
+}
+
+size_t ZstdCompressor::decompressedSize(std::string_view compressed) const
+{
+    auto size = ZSTD_findDecompressedSize(compressed.data(), compressed.size());
+    if (size == ZSTD_CONTENTSIZE_ERROR || size == ZSTD_CONTENTSIZE_UNKNOWN) {
+        throw std::runtime_error("bad content size");
+    }
+    return size;
+}
+
+size_t ZstdCompressor::compress(
+        std::span<char> compressed,
+        std::string_view data)
+{
+    if (!cctx_) {
+        cctx_.reset(ZSTD_createCCtx());
+        if (!cctx_) {
+            throw std::bad_alloc{};
+        }
+
+        // Set default parameters
+        zstdThrowIfError(
+                ZSTD_CCtx_setParameter(cctx_.get(), ZSTD_c_checksumFlag, 0));
+
+        if (level_.has_value()) {
+            zstdThrowIfError(ZSTD_CCtx_setParameter(
+                    cctx_.get(), ZSTD_c_compressionLevel, level_.value_or(3)));
+        }
+        for (const auto& [k, v] : params_) {
+            zstdThrowIfError(ZSTD_CCtx_setParameter(cctx_.get(), k, v));
+        }
+    }
+    return zstdThrowIfError(ZSTD_compress2(
+            cctx_.get(),
+            compressed.data(),
+            compressed.size(),
+            data.data(),
+            data.size()));
+}
+
+size_t ZstdCompressor::decompress(
+        std::span<char> decompressed,
+        std::string_view compressed)
+{
+    if (!dctx_) {
+        dctx_.reset(ZSTD_createDCtx());
+        if (!dctx_) {
+            throw std::bad_alloc{};
+        }
+    }
+    return zstdThrowIfError(ZSTD_decompressDCtx(
+            dctx_.get(),
+            decompressed.data(),
+            decompressed.size(),
+            compressed.data(),
+            compressed.size()));
+}
+
+Lz4Compressor::Lz4Compressor(nlohmann::json config)
+{
+    if (config.contains("level")) {
+        level_ = config["level"];
+    }
+}
+
+std::string Lz4Compressor::name() const
+{
+    std::string name = "lz4";
+    if (level_.has_value()) {
+        name += "[lvl=" + std::to_string(level_.value()) + "]";
+    }
+    return name;
+}
+
+size_t Lz4Compressor::compressBound(std::string_view data) const
+{
+    if (data.size() == 0 || data.size() > LZ4_MAX_INPUT_SIZE) {
+        throw std::runtime_error("Invalid input size");
+    }
+    return ZL_VARINT_LENGTH_64 + LZ4_compressBound(data.size());
+}
+
+size_t Lz4Compressor::decompressedSize(std::string_view compressed) const
+{
+    return readHeader(compressed);
+}
+
+size_t Lz4Compressor::writeHeader(std::span<char>& compressed, size_t size)
+        const
+{
+    if (compressed.size() < ZL_VARINT_LENGTH_64) {
+        throw std::runtime_error("Not enough space for header");
+    }
+    auto hSize = ZL_varintEncode(size, (uint8_t*)compressed.data());
+    compressed = compressed.subspan(hSize);
+    return hSize;
+}
+
+size_t Lz4Compressor::readHeader(std::string_view& compressed) const
+{
+    const uint8_t* p = (const uint8_t*)compressed.data();
+    auto result      = ZL_varintDecode(&p, p + compressed.size());
+    if (ZL_RES_isError(result)) {
+        throw std::runtime_error("Invalid header");
+    }
+    compressed = compressed.substr(p - (const uint8_t*)compressed.data());
+    return size_t(ZL_RES_value(result));
+}
+
+size_t Lz4Compressor::compress(
+        std::span<char> compressed,
+        std::string_view data)
+{
+    auto hSize = writeHeader(compressed, data.size());
+    if (!level_.has_value() || level_.value() <= 1) {
+        if (!cctx_) {
+            cctx_ = std::make_unique<uint8_t[]>(LZ4_sizeofState());
+        }
+        auto accel = -level_.value_or(1);
+        return hSize
+                + lz4ThrowIfError(LZ4_compress_fast_extState(
+                        cctx_.get(),
+                        data.data(),
+                        compressed.data(),
+                        data.size(),
+                        compressed.size(),
+                        accel));
+    } else {
+        if (!cctx_) {
+            cctx_ = std::make_unique<uint8_t[]>(LZ4_sizeofStateHC());
+        }
+        return hSize
+                + lz4ThrowIfError(LZ4_compress_HC_extStateHC(
+                        cctx_.get(),
+                        data.data(),
+                        compressed.data(),
+                        data.size(),
+                        compressed.size(),
+                        level_.value()));
+    }
+}
+
+size_t Lz4Compressor::decompress(
+        std::span<char> decompressed,
+        std::string_view compressed)
+{
+    readHeader(compressed);
+    return lz4ThrowIfError(LZ4_decompress_safe(
+            compressed.data(),
+            decompressed.data(),
+            compressed.size(),
+            decompressed.size()));
+}
+
+OpenZLCompressor::OpenZLCompressor(nlohmann::json config)
+{
+    if (config.contains("params")) {
+        for (const auto& [key, val] : config["params"].items()) {
+            params_.emplace(parseOpenZLCParam(key), int(val));
+        }
+    }
+
+    if (config.contains("compressor")) {
+        auto compressor = config["compressor"];
+        auto data       = base64Decode(std::string(compressor));
+        serializedCompressor_.assign((const char*)data.data(), data.size());
+    }
+
+    if (config.contains("compressor_name")) {
+        compressorName_ = config["compressor_name"];
+        if (serializedCompressor_.empty()) {
+            serializedCompressor_ =
+                    lz::getSerializedCompressor(compressorName_);
+        }
+    }
+
+    if (config.contains("trace")) {
+        tracePath_ = config["trace"];
+    }
+    if (config.contains("trace_streams")) {
+        traceStreamsDir_ = config["trace_streams"];
+    }
+
+    configure(compressor_);
+}
+
+std::string OpenZLCompressor::name() const
+{
+    std::string name = "openzl[";
+    name += "c=" + compressorName_ + ",";
+    for (const auto& [key, val] : params_) {
+        name += shortParam(key) + "=" + std::to_string(val) + ",";
+    }
+    name.pop_back();
+    name += "]";
+    return name;
+}
+
+void OpenZLCompressor::configure(openzl::Compressor& compressor) const
+{
+    lz::registerGraphComponents(compressor);
+    compressor.deserialize(serializedCompressor_);
+}
+
+void OpenZLCompressor::configure(openzl::CCtx& cctx) const
+{
+    for (const auto& [key, value] : params_) {
+        cctx.setParameter(key, value);
+    }
+    if (tracePath_) {
+        cctx.writeTraces(true);
+    }
+}
+
+void OpenZLCompressor::configure(openzl::DCtx& dctx) const
+{
+    lz::registerCustomCodecs(dctx);
+}
+
+size_t OpenZLCompressor::compressBound(std::string_view data) const
+{
+    return ZL_compressBound(data.size());
+}
+
+size_t OpenZLCompressor::decompressedSize(std::string_view data) const
+{
+    auto size = ZL_getDecompressedSize(data.data(), data.size());
+    if (ZL_isError(size)) {
+        throw std::runtime_error("bad size");
+    }
+    return ZL_validResult(size);
+}
+
+size_t OpenZLCompressor::compress(
+        std::span<char> compressed,
+        std::string_view data)
+{
+    if (!cctx_) {
+        cctx_ = openzl::CCtx();
+
+        // Set default parameters
+        cctx_->setParameter(CParam::StickyParameters, 1);
+        cctx_->setParameter(CParam::FormatVersion, ZL_MAX_FORMAT_VERSION);
+        cctx_->setParameter(CParam::ContentChecksum, ZL_TernaryParam_disable);
+        cctx_->setParameter(
+                CParam::CompressedChecksum, ZL_TernaryParam_disable);
+
+        configure(*cctx_);
+    }
+    cctx_->refCompressor(compressor_);
+    auto cSize =
+            cctx_->compressSerial(compressed, { data.data(), data.size() });
+
+    if (tracePath_.has_value()) {
+        auto [trace, streams] = cctx_->getLatestTrace();
+        {
+            tools::io::OutputFile out(*tracePath_);
+            out.write(trace);
+        }
+        if (traceStreamsDir_.has_value()) {
+            fs::create_directories(*traceStreamsDir_);
+            for (const auto& [index, data] : streams) {
+                {
+                    tools::io::OutputFile out(
+                            fs::path(*traceStreamsDir_)
+                            / (std::to_string(index) + ".sdd"));
+                    out.write(data.first);
+                }
+                if (!data.second.empty()) {
+                    tools::io::OutputFile out(
+                            fs::path(*traceStreamsDir_)
+                            / (std::to_string(index) + ".sdlens"));
+                    out.write(data.first);
+                }
+            }
+        }
+    }
+
+    return cSize;
+}
+
+size_t OpenZLCompressor::decompress(
+        std::span<char> decompressed,
+        std::string_view compressed)
+{
+    if (!dctx_) {
+        dctx_ = openzl::DCtx();
+        configure(*dctx_);
+    }
+    return dctx_->decompressSerial(decompressed, compressed);
+}
+
+nlohmann::json OpenZLCompressor::makeConfig(
+        std::string_view suffix,
+        std::string_view serializedCompressor) const
+{
+    nlohmann::json config;
+    config["algorithm"] = "openzl";
+    for (const auto& [key, value] : params_) {
+        config[param(key)] = value;
+    }
+    config["compressor_name"] = compressorName_ + "/" + std::string(suffix);
+    config["compressor"]      = base64Encode(serializedCompressor);
+
+    return config;
+}
+
+nlohmann::json OpenZLCompressor::train(
+        poly::span<const std::string_view> samples) const
+{
+    std::vector<training::MultiInput> inputs;
+    for (const auto& sample : samples) {
+        training::MultiInput input;
+        input.add(Input::refSerial(sample));
+        inputs.push_back(std::move(input));
+    }
+    training::TrainParams params;
+    params.compressorGenFunc = [this](poly::string_view serialized) {
+        auto compressor = std::make_unique<openzl::Compressor>();
+        configure(*compressor);
+        compressor->deserialize(serialized);
+        return compressor;
+    };
+    params.paretoFrontier = true;
+    openzl::Compressor trainingCompressor;
+    configure(trainingCompressor);
+    auto compressors = training::train(inputs, trainingCompressor, params);
+
+    nlohmann::json out = nlohmann::json::array();
+    for (size_t idx = 0; idx < compressors.size(); ++idx) {
+        out.push_back(makeConfig(std::to_string(idx), *compressors[idx]));
+    }
+
+    return out;
+}
+
+std::unique_ptr<Compressor> makeCompressor(nlohmann::json config)
+{
+    std::string algo = config["algorithm"];
+    if (algo == "zstd") {
+        return std::make_unique<ZstdCompressor>(config);
+    } else if (algo == "lz4") {
+        return std::make_unique<Lz4Compressor>(config);
+    } else if (algo == "openzl") {
+        return std::make_unique<OpenZLCompressor>(config);
+    } else {
+        throw std::runtime_error("Unknown algorithm: " + algo);
+    }
+}
+
+} // namespace openzl::bench

--- a/contrib/lz-research/Compressor.hpp
+++ b/contrib/lz-research/Compressor.hpp
@@ -1,0 +1,174 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#pragma once
+
+#include <memory>
+#include <optional>
+#include <span>
+#include <string>
+#include <string_view>
+#include <unordered_map>
+
+#include <lz4.h>
+#include <lz4hc.h>
+#include <zstd.h>
+
+#include "openzl/openzl.hpp"
+#include "tools/json.hpp"
+
+namespace openzl::bench {
+class Compressor {
+   public:
+    virtual std::string name() const                                   = 0;
+    virtual size_t compressBound(std::string_view data) const          = 0;
+    virtual size_t decompressedSize(std::string_view compressed) const = 0;
+    virtual size_t compress(
+            std::span<char> compressed,
+            std::string_view data) = 0;
+    virtual size_t decompress(
+            std::span<char> decompressed,
+            std::string_view compressed) = 0;
+    virtual nlohmann::json train(
+            poly::span<const std::string_view> samples) const
+    {
+        throw std::runtime_error("Training not supported");
+    }
+
+    std::string compress(std::string_view data)
+    {
+        std::string compressed;
+        compressed.resize(compressBound(data));
+        auto size = compress(compressed, data);
+        compressed.resize(size);
+        return compressed;
+    }
+
+    std::string decompress(std::string_view compressed)
+    {
+        std::string decompressed;
+        decompressed.resize(decompressedSize(compressed));
+        auto size = decompress(decompressed, compressed);
+        decompressed.resize(size);
+        return decompressed;
+    }
+
+    virtual ~Compressor() = default;
+};
+
+class ZstdCompressor : public Compressor {
+   public:
+    explicit ZstdCompressor(int level) : level_(level) {}
+    explicit ZstdCompressor(std::unordered_map<ZSTD_cParameter, int> params)
+            : params_(std::move(params))
+    {
+    }
+    ZstdCompressor(
+            std::optional<int> level,
+            std::unordered_map<ZSTD_cParameter, int> params)
+            : level_(level), params_(std::move(params))
+    {
+    }
+    explicit ZstdCompressor(nlohmann::json config);
+
+    std::string name() const override;
+    size_t compressBound(std::string_view data) const override;
+    size_t decompressedSize(std::string_view compressed) const override;
+    size_t compress(std::span<char> compressed, std::string_view data) override;
+    size_t decompress(std::span<char> decompressed, std::string_view compressed)
+            override;
+
+    virtual ~ZstdCompressor() = default;
+
+   private:
+    struct CCtxDeleter {
+        void operator()(ZSTD_CCtx* ctx) const
+        {
+            ZSTD_freeCCtx(ctx);
+        }
+    };
+    using ZstdCCtx = std::unique_ptr<ZSTD_CCtx, CCtxDeleter>;
+    struct DCtxDeleter {
+        void operator()(ZSTD_DCtx* ctx) const
+        {
+            ZSTD_freeDCtx(ctx);
+        }
+    };
+    using ZstdDCtx = std::unique_ptr<ZSTD_DCtx, DCtxDeleter>;
+
+    std::optional<int> level_;
+    std::unordered_map<ZSTD_cParameter, int> params_;
+    ZstdCCtx cctx_;
+    ZstdDCtx dctx_;
+};
+
+class Lz4Compressor : public Compressor {
+   public:
+    explicit Lz4Compressor(std::optional<int> level) : level_(level) {}
+    explicit Lz4Compressor(nlohmann::json config);
+
+    std::string name() const override;
+    size_t compressBound(std::string_view data) const override;
+    size_t decompressedSize(std::string_view compressed) const override;
+    size_t compress(std::span<char> compressed, std::string_view data) override;
+    size_t decompress(std::span<char> decompressed, std::string_view compressed)
+            override;
+
+    virtual ~Lz4Compressor() = default;
+
+   private:
+    size_t writeHeader(std::span<char>& compressed, size_t size) const;
+    size_t readHeader(std::string_view& compressed) const;
+
+    std::optional<int> level_;
+    std::unique_ptr<uint8_t[]> cctx_;
+};
+
+class OpenZLCompressor : public Compressor {
+   public:
+    OpenZLCompressor(
+            std::string compressorName,
+            openzl::Compressor compressor,
+            std::unordered_map<openzl::CParam, int> params)
+            : compressorName_(std::move(compressorName)),
+              compressor_(std::move(compressor)),
+              params_(std::move(params))
+    {
+    }
+
+    explicit OpenZLCompressor(nlohmann::json config);
+
+    std::string name() const override;
+
+    size_t compressBound(std::string_view data) const override;
+    size_t decompressedSize(std::string_view compressed) const override;
+    size_t compress(std::span<char> compressed, std::string_view data) override;
+    size_t decompress(std::span<char> decompressed, std::string_view compressed)
+            override;
+
+    void configure(openzl::Compressor& compressor) const;
+    void configure(openzl::CCtx& cctx) const;
+    void configure(openzl::DCtx& dctx) const;
+
+    nlohmann::json train(
+            poly::span<const std::string_view> samples) const override;
+
+    virtual ~OpenZLCompressor() = default;
+
+   private:
+    nlohmann::json makeConfig(
+            std::string_view suffix,
+            std::string_view serializedCompressor) const;
+
+    std::string compressorName_;
+    std::string serializedCompressor_;
+    openzl::Compressor compressor_;
+    std::unordered_map<openzl::CParam, int> params_;
+    std::optional<openzl::CCtx> cctx_;
+    std::optional<openzl::DCtx> dctx_;
+    std::optional<std::string> tracePath_;
+    std::optional<std::string> traceStreamsDir_;
+};
+
+std::unique_ptr<Compressor> makeCompressor(nlohmann::json config);
+
+} // namespace openzl::bench

--- a/contrib/lz-research/LzCompressors.cpp
+++ b/contrib/lz-research/LzCompressors.cpp
@@ -1,0 +1,16 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#include "LzCompressors.hpp"
+
+namespace openzl::lz {
+
+std::string getSerializedCompressor(std::string_view name)
+{
+    throw std::runtime_error("TODO");
+}
+
+void registerGraphComponents(openzl::Compressor&) {}
+
+void registerCustomCodecs(openzl::DCtx&) {}
+
+} // namespace openzl::lz

--- a/contrib/lz-research/LzCompressors.hpp
+++ b/contrib/lz-research/LzCompressors.hpp
@@ -1,0 +1,17 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#pragma once
+
+#include <string>
+#include <string_view>
+
+#include <openzl/openzl.hpp>
+
+namespace openzl::lz {
+
+std::string getSerializedCompressor(std::string_view name);
+
+void registerGraphComponents(openzl::Compressor& compressor);
+void registerCustomCodecs(openzl::DCtx& dctx);
+
+} // namespace openzl::lz

--- a/contrib/lz-research/Main.cpp
+++ b/contrib/lz-research/Main.cpp
@@ -1,0 +1,415 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#include <filesystem>
+#include <fstream>
+#include <memory>
+#include <vector>
+
+#include "Benchmark.hpp"
+#include "tools/arg/arg_parser.h"
+#include "tools/arg/parsed_args.h"
+#include "tools/io/InputFile.h"
+#include "tools/io/InputSetBuilder.h"
+#include "tools/io/OutputFile.h"
+#include "tools/json.hpp"
+#include "tools/logger/Logger.h"
+
+namespace openzl {
+namespace {
+namespace fs = std::filesystem;
+
+nlohmann::json loadJsonFromFlag(const std::optional<std::string>& flag)
+{
+    if (!flag.has_value() || flag->empty()) {
+        throw std::runtime_error("Specify a value for --compressor");
+    }
+    nlohmann::json out;
+    try {
+        out = nlohmann::json::parse(*flag);
+    } catch (const std::exception&) {
+        tools::io::InputFile file(*flag);
+        out = nlohmann::json::parse(file.contents());
+    }
+    return out;
+}
+
+std::unique_ptr<tools::io::InputSet> buildInputSet(
+        const std::vector<std::string>& inputs,
+        bool staticSet = false)
+{
+    tools::io::InputSetBuilder builder(true);
+    for (const auto& path : inputs) {
+        builder.add_path(path);
+    }
+    return staticSet ? std::move(builder).build_static()
+                     : std::move(builder).build();
+}
+
+enum class Commands {
+    Benchmark  = 1,
+    Compress   = 2,
+    Decompress = 3,
+    Train      = 4,
+};
+
+class Command {
+   public:
+    virtual void addArguments(openzl::arg::ArgParser& parser) const    = 0;
+    virtual void parseArguments(const openzl::arg::ParsedArgs& parser) = 0;
+    virtual void run() const                                           = 0;
+    virtual ~Command() = default;
+};
+
+class BenchmarkCommand : public Command {
+   public:
+    void addArguments(openzl::arg::ArgParser& parser) const override
+    {
+        parser.addCommand(int(Commands::Benchmark), "benchmark", 'b');
+        parser.addCommandPositional(
+                int(Commands::Benchmark),
+                arg::NumArgs::OneOrMore,
+                "input",
+                "Input files or directories to benchmark on");
+        parser.addCommandFlag(
+                int(Commands::Benchmark),
+                "min-iters",
+                'i',
+                true,
+                "Minimum number of iterations to run - defaults to 1");
+        parser.addCommandFlag(
+                int(Commands::Benchmark),
+                "min-secs",
+                's',
+                true,
+                "Minimum number of seconds to run - defaults to 1");
+        parser.addCommandFlag(
+                int(Commands::Benchmark),
+                "compressors",
+                'c',
+                true,
+                "Either a JSON array of compressor configs, or a path to a file containing those configs");
+        parser.addCommandFlag(
+                int(Commands::Benchmark),
+                "output",
+                'o',
+                true,
+                "Path to output file");
+    }
+
+    void parseArguments(const openzl::arg::ParsedArgs& args) override
+    {
+        benchmark_ = args.chosenCmd() == int(Commands::Benchmark);
+        if (!benchmark_) {
+            return;
+        }
+        inputPaths_ = args.cmdPositionals(int(Commands::Benchmark), "input");
+
+        auto minItersFlag = args.cmdFlag(int(Commands::Benchmark), "min-iters");
+        if (minItersFlag.has_value()) {
+            args_.minIters = std::stoull(minItersFlag.value());
+        }
+
+        auto minSecsFlag = args.cmdFlag(int(Commands::Benchmark), "min-secs");
+        if (minSecsFlag.has_value()) {
+            args_.minTime =
+                    std::chrono::seconds(std::stoull(minSecsFlag.value()));
+        }
+
+        auto outputFlag = args.cmdFlag(int(Commands::Benchmark), "output");
+        if (!outputFlag.has_value()) {
+            throw std::runtime_error("Specify a value for --output");
+        }
+        output_ = outputFlag.value();
+
+        auto compressorsFlag =
+                args.cmdFlag(int(Commands::Benchmark), "compressors");
+        auto compressors = loadJsonFromFlag(compressorsFlag.value());
+        for (const auto& compressor : compressors) {
+            args_.compressorConfigs.push_back(compressor);
+        }
+    }
+
+    void run() const override
+    {
+        if (!benchmark_) {
+            return;
+        }
+        auto inputs  = buildInputSet(inputPaths_);
+        auto results = bench::benchmark(*inputs, args_);
+
+        nlohmann::json out = nlohmann::json::array();
+        for (const auto& result : results) {
+            out.push_back(result.json());
+        }
+        std::ofstream outStream(output_);
+        outStream << out.dump(2);
+    }
+
+    ~BenchmarkCommand() override = default;
+
+   private:
+    bool benchmark_ = false;
+    std::vector<std::string> inputPaths_;
+    bench::BenchmarkArgs args_;
+    std::string output_;
+};
+
+class CompressCommand : public Command {
+   public:
+    void addArguments(openzl::arg::ArgParser& parser) const
+    {
+        parser.addCommand(int(Commands::Compress), "compress", 'c');
+        parser.addCommandPositional(
+                int(Commands::Compress),
+                arg::NumArgs::OneOrMore,
+                "input",
+                "Input files or directories to compress");
+        parser.addCommandFlag(
+                int(Commands::Compress),
+                "compressor",
+                'c',
+                true,
+                "Either a JSON compressor config, or a path to a file containing a config");
+        parser.addCommandFlag(
+                int(Commands::Compress),
+                "output",
+                'o',
+                true,
+                "Path to output file");
+    }
+
+    void parseArguments(const openzl::arg::ParsedArgs& parser)
+    {
+        compress_ = parser.chosenCmd() == int(Commands::Compress);
+        if (!compress_) {
+            return;
+        }
+        inputPaths_ = parser.cmdPositionals(int(Commands::Compress), "input");
+
+        auto compressorFlag =
+                parser.cmdFlag(int(Commands::Compress), "compressor");
+        compressor_ = loadJsonFromFlag(compressorFlag.value());
+
+        outputPath_ = parser.cmdFlag(int(Commands::Compress), "output");
+
+        if (outputPath_.has_value()
+            && (inputPaths_.size() != 1 || fs::is_directory(inputPaths_[0]))) {
+            throw std::runtime_error(
+                    "--output can only be used with a single input");
+        }
+    }
+
+    void run() const
+    {
+        if (!compress_) {
+            return;
+        }
+
+        auto compressor = bench::makeCompressor(compressor_);
+        auto inputs     = buildInputSet(inputPaths_);
+        for (const auto& input : *inputs) {
+            auto compressed = compressor->compress(input->contents());
+            auto outputPath =
+                    outputPath_.value_or(std::string(input->name()) + ".zl");
+            tools::io::OutputFile out(outputPath);
+            out.write(compressed);
+        }
+    }
+
+    ~CompressCommand() override = default;
+
+   private:
+    bool compress_{ false };
+    std::vector<std::string> inputPaths_;
+    nlohmann::json compressor_;
+    std::optional<std::string> outputPath_;
+};
+
+class DecompressCommand : public Command {
+   public:
+    void addArguments(openzl::arg::ArgParser& parser) const
+    {
+        parser.addCommand(int(Commands::Decompress), "decompress", 'd');
+        parser.addCommandPositional(
+                int(Commands::Decompress),
+                arg::NumArgs::OneOrMore,
+                "input",
+                "Input files or directories to compress");
+        parser.addCommandFlag(
+                int(Commands::Decompress),
+                "compressor",
+                'c',
+                true,
+                "Either a JSON compressor config, or a path to a file containing a config");
+        parser.addCommandFlag(
+                int(Commands::Decompress),
+                "output",
+                'o',
+                true,
+                "Path to output file");
+    }
+
+    void parseArguments(const openzl::arg::ParsedArgs& parser)
+    {
+        decompress_ = parser.chosenCmd() == int(Commands::Decompress);
+        if (!decompress_) {
+            return;
+        }
+        inputPaths_ = parser.cmdPositionals(int(Commands::Decompress), "input");
+
+        auto compressorFlag =
+                parser.cmdFlag(int(Commands::Decompress), "compressor");
+        compressor_ = loadJsonFromFlag(compressorFlag.value());
+
+        outputPath_ = parser.cmdFlag(int(Commands::Decompress), "output");
+    }
+
+    void run() const
+    {
+        if (!decompress_) {
+            return;
+        }
+
+        auto compressor = bench::makeCompressor(compressor_);
+        auto inputs     = buildInputSet(inputPaths_);
+        for (const auto& input : *inputs) {
+            auto decompressed = compressor->decompress(input->contents());
+
+            auto outputPath = outputPath_;
+            if (!outputPath.has_value()) {
+                if (input->name().ends_with(".zl")) {
+                    outputPath =
+                            input->name().substr(0, input->name().size() - 3);
+                } else {
+                    throw std::runtime_error(
+                            "Cannot determine output for "
+                            + std::string(input->name()));
+                }
+            }
+            tools::io::OutputFile out(*outputPath);
+            out.write(decompressed);
+        }
+    }
+
+    ~DecompressCommand() override = default;
+
+   private:
+    bool decompress_{ false };
+    std::vector<std::string> inputPaths_;
+    nlohmann::json compressor_;
+    std::optional<std::string> outputPath_;
+};
+
+class TrainCommand : public Command {
+   public:
+    void addArguments(openzl::arg::ArgParser& parser) const
+    {
+        parser.addCommand(int(Commands::Train), "train", 't');
+        parser.addCommandPositional(
+                int(Commands::Train),
+                arg::NumArgs::OneOrMore,
+                "input",
+                "Input files or directories to compress");
+        parser.addCommandFlag(
+                int(Commands::Train),
+                "compressor",
+                'c',
+                true,
+                "Either a JSON compressor config, or a path to a file containing a config");
+        parser.addCommandFlag(
+                int(Commands::Train),
+                "output",
+                'o',
+                true,
+                "Path to output file");
+    }
+
+    void parseArguments(const openzl::arg::ParsedArgs& parser)
+    {
+        train_ = parser.chosenCmd() == int(Commands::Train);
+        if (!train_) {
+            return;
+        }
+        inputPaths_ = parser.cmdPositionals(int(Commands::Train), "input");
+
+        auto compressorFlag =
+                parser.cmdFlag(int(Commands::Train), "compressor");
+        compressor_ = loadJsonFromFlag(compressorFlag.value());
+
+        auto outputFlag = parser.cmdFlag(int(Commands::Train), "output");
+        if (!outputFlag.has_value()) {
+            throw std::runtime_error("--output must be provided");
+        }
+        outputPath_ = *outputFlag;
+    }
+
+    void run() const
+    {
+        if (!train_) {
+            return;
+        }
+
+        auto compressor = bench::makeCompressor(compressor_);
+        auto inputs     = buildInputSet(inputPaths_, /* static */ true);
+        std::vector<std::string_view> samples;
+        for (const auto& input : *inputs) {
+            samples.push_back(input->contents());
+        }
+        auto config = compressor->train(samples);
+
+        tools::io::OutputFile out(outputPath_);
+        out.write(config.dump(2));
+    }
+
+    ~TrainCommand() override = default;
+
+   private:
+    bool train_{ false };
+    std::vector<std::string> inputPaths_;
+    nlohmann::json compressor_;
+    std::string outputPath_;
+};
+
+} // namespace
+} // namespace openzl
+
+int main(int argc, char** argv)
+{
+    using openzl::tools::logger::Logger;
+    using openzl::tools::logger::LogLevel;
+
+    std::vector<std::unique_ptr<openzl::Command>> commands;
+    commands.emplace_back(std::make_unique<openzl::BenchmarkCommand>());
+    commands.emplace_back(std::make_unique<openzl::CompressCommand>());
+    commands.emplace_back(std::make_unique<openzl::DecompressCommand>());
+    commands.emplace_back(std::make_unique<openzl::TrainCommand>());
+
+    openzl::arg::ArgParser parser;
+    for (const auto& command : commands) {
+        command->addArguments(parser);
+    }
+
+    try {
+        auto parsedArgs = parser.parse(argc, argv);
+        for (auto& command : commands) {
+            command->parseArguments(parsedArgs);
+        }
+    } catch (const std::exception& e) {
+        Logger::log_c(LogLevel::INFO, "%s", parser.help().c_str());
+        Logger::log_c(
+                LogLevel::ERRORS, "Argument Parsing Error:\n\t %s", e.what());
+        return 1;
+    }
+
+    try {
+        for (auto& command : commands) {
+            command->run();
+        }
+    } catch (const std::exception& e) {
+        Logger::log_c(
+                LogLevel::ERRORS, "Unhandled Exception:\n\t %s", e.what());
+        return 1;
+    }
+
+    return 0;
+}

--- a/cpp/include/openzl/cpp/CustomDecoder.hpp
+++ b/cpp/include/openzl/cpp/CustomDecoder.hpp
@@ -20,6 +20,9 @@ class DecoderState {
             poly::span<const ZL_Input*> singletonInputs,
             poly::span<const ZL_Input*> variableInputs);
 
+    DecoderState(const DecoderState&)            = delete;
+    DecoderState& operator=(const DecoderState&) = delete;
+
     poly::span<const InputRef> singletonInputs() const
     {
         return singletonInputs_;

--- a/cpp/include/openzl/cpp/CustomEncoder.hpp
+++ b/cpp/include/openzl/cpp/CustomEncoder.hpp
@@ -19,6 +19,9 @@ class EncoderState {
    public:
     EncoderState(ZL_Encoder* encoder, poly::span<const ZL_Input*> inputs);
 
+    EncoderState(const EncoderState&)            = delete;
+    EncoderState& operator=(const EncoderState&) = delete;
+
     ZL_Encoder* get()
     {
         return encoder_;

--- a/cpp/include/openzl/cpp/LocalParams.hpp
+++ b/cpp/include/openzl/cpp/LocalParams.hpp
@@ -67,7 +67,7 @@ class LocalParams {
     }
 
     void addRefParam(ZL_RefParam param);
-    void addRefParam(int key, const void* ref);
+    void addRefParam(int key, const void* ref, size_t size = 0);
 
     poly::span<const ZL_IntParam> getIntParams() const
     {

--- a/cpp/src/openzl/cpp/LocalParams.cpp
+++ b/cpp/src/openzl/cpp/LocalParams.cpp
@@ -87,8 +87,8 @@ void LocalParams::addRefParam(ZL_RefParam param)
     params_.refParams.nbRefParams = refParams_.size();
 }
 
-void LocalParams::addRefParam(int key, const void* ref)
+void LocalParams::addRefParam(int key, const void* ref, size_t size)
 {
-    return addRefParam(ZL_RefParam{ key, ref });
+    return addRefParam(ZL_RefParam{ key, ref, size });
 }
 } // namespace openzl

--- a/cpp/tests/TestLocalParams.cpp
+++ b/cpp/tests/TestLocalParams.cpp
@@ -84,6 +84,26 @@ TEST(TestLocalParams, addRefParam)
     ASSERT_THROW(params.addCopyParam({ 0, &x, sizeof(x) }), Exception);
 }
 
+TEST(TestLocalParams, addRefParamWithSize)
+{
+    LocalParams params;
+    int x     = 42;
+    int64_t y = 350;
+    params.addRefParam(0, &x, sizeof(x));
+    params.addRefParam(1, &y, sizeof(y));
+
+    auto p = params.getRefParams();
+    ASSERT_EQ(p.size(), 2);
+
+    ASSERT_EQ(p[0].paramId, 0);
+    ASSERT_EQ(p[0].paramRef, &x);
+    ASSERT_EQ(p[0].paramSize, sizeof(x));
+
+    ASSERT_EQ(p[1].paramId, 1);
+    ASSERT_EQ(p[1].paramRef, &y);
+    ASSERT_EQ(p[1].paramSize, sizeof(y));
+}
+
 TEST(TestLocalParams, move)
 {
     auto params = std::make_unique<LocalParams>();

--- a/tools/arg/arg_parser.cpp
+++ b/tools/arg/arg_parser.cpp
@@ -94,10 +94,16 @@ void ArgParser::addCommandImmediate(
 
 void ArgParser::addCommandPositional(
         int cmd,
+        NumArgs numArgs,
         const std::string& name,
         const std::string& help)
 {
-    cmdPositionals_[cmd].push_back({ name, help });
+    if (!cmdPositionals_[cmd].empty()
+        && cmdPositionals_[cmd].back().numArgs != NumArgs::One) {
+        throw ParseException(
+                "Cannot add a positional argument after a variadic positional argument!");
+    }
+    cmdPositionals_[cmd].push_back({ numArgs, name, help });
 }
 
 std::string ArgParser::help() const
@@ -163,7 +169,20 @@ std::string ArgParser::help(const Command& command) const
     ss << "Positionals:\n";
     if (cmdPositionals_.find(command.cmd) != cmdPositionals_.end()) {
         for (auto const& positional : cmdPositionals_.at(command.cmd)) {
-            ss << "  " << positional.name << "\n";
+            switch (positional.numArgs) {
+                case NumArgs::ZeroOrOne:
+                    ss << "  [" << positional.name << "]\n";
+                    break;
+                case NumArgs::One:
+                    ss << "  " << positional.name << "\n";
+                    break;
+                case NumArgs::OneOrMore:
+                    ss << "  " << positional.name << "...\n";
+                    break;
+                case NumArgs::ZeroOrMore:
+                    ss << "  [" << positional.name << "]...\n";
+                    break;
+            }
             ss << "    " << positional.help << "\n";
         }
     }
@@ -245,9 +264,9 @@ ParsedArgs ArgParser::parse(int argc, char** argv) const
                             "Option " + flag->name + " requires a value";
                     throw ParseException(err);
                 }
-                parsedArgs.cmdVals_[cmd][flag->name] = argv[i];
+                parsedArgs.cmdVals_[cmd][flag->name].push_back(argv[i]);
             } else {
-                parsedArgs.cmdVals_[cmd][flag->name] = "";
+                parsedArgs.cmdVals_[cmd][flag->name].push_back("");
             }
         };
         auto processShortFlag = [&](char shortName, int chosenCmd) {
@@ -298,8 +317,8 @@ ParsedArgs ArgParser::parse(int argc, char** argv) const
                     throw ParseException(err);
                 }
                 auto [flag, cmd] = flagOpt.value();
-                parsedArgs.cmdVals_[cmd][flag->name] =
-                        std::to_string(arg.size() + 2);
+                parsedArgs.cmdVals_[cmd][flag->name].push_back(
+                        std::to_string(arg.size() + 2));
             } else {
                 processShortFlag(argv[i][1], parsedArgs.chosenCmd_);
             }
@@ -341,36 +360,46 @@ ParsedArgs ArgParser::parse(int argc, char** argv) const
                 throw ParseException(
                         "Trying to pass a positional argument before specifying a subcommand!");
             }
-            const auto positionalIdx =
-                    cmdPositionalIndex[parsedArgs.chosenCmd_]++;
+            auto positionalIdx = cmdPositionalIndex[parsedArgs.chosenCmd_]++;
             const auto positionalSize =
                     cmdPositionals_.at(parsedArgs.chosenCmd_).size();
-            if (positionalSize <= positionalIdx) {
-                std::ostringstream msg;
-                msg << "Too many positional arguments for command '"
-                    << commandName(parsedArgs.chosenCmd_) << "'.\n";
+            if (positionalSize == 0) {
+                throw ParseException(
+                        "Trying to pass a positional argument when no positional arguments are expected!");
+            }
+            if (positionalIdx >= positionalSize) {
+                positionalIdx          = positionalSize - 1;
+                const auto& positional = cmdPositionals_.at(
+                        parsedArgs.chosenCmd_)[positionalIdx];
+                if (positional.numArgs == NumArgs::ZeroOrOne
+                    || positional.numArgs == NumArgs::One) {
+                    std::ostringstream msg;
+                    msg << "Too many positional arguments for command '"
+                        << commandName(parsedArgs.chosenCmd_) << "'.\n";
 
-                // Show expected positional arguments
-                msg << "Expected " << positionalSize << " positional argument"
-                    << (positionalSize == 1 ? "" : "s") << ":";
-                for (size_t j = 0; j < positionalSize; ++j) {
-                    msg << " <"
-                        << cmdPositionals_.at(parsedArgs.chosenCmd_)[j].name
-                        << ">";
+                    // Show expected positional arguments
+                    msg << "Expected " << positionalSize
+                        << " positional argument"
+                        << (positionalSize == 1 ? "" : "s") << ":";
+                    for (size_t j = 0; j < positionalSize; ++j) {
+                        msg << " <"
+                            << cmdPositionals_.at(parsedArgs.chosenCmd_)[j].name
+                            << ">";
+                    }
+                    msg << "\n";
+
+                    // Show the problematic argument
+                    msg << "Got unexpected positional argument '" << argv[i]
+                        << "' at position " << (positionalIdx + 1);
+
+                    throw ParseException({ msg.str() });
                 }
-                msg << "\n";
-
-                // Show the problematic argument
-                msg << "Got unexpected positional argument '" << argv[i]
-                    << "' at position " << (positionalIdx + 1);
-
-                throw ParseException({ msg.str() });
             }
             auto positionalName =
                     cmdPositionals_.at(parsedArgs.chosenCmd_)[positionalIdx]
                             .name;
-            parsedArgs.cmdVals_[parsedArgs.chosenCmd_][positionalName] =
-                    argv[i];
+            parsedArgs.cmdVals_[parsedArgs.chosenCmd_][positionalName]
+                    .push_back(argv[i]);
         }
     }
     return parsedArgs;
@@ -382,10 +411,24 @@ void ArgParser::validate(const ParsedArgs& parsedArgs) const
         throw ParseException("No subcommand specified!");
     }
     for (const auto& positional : cmdPositionals_.at(parsedArgs.chosenCmd_)) {
-        if (parsedArgs.cmdVals_.at(parsedArgs.chosenCmd_).find(positional.name)
-            == parsedArgs.cmdVals_.at(parsedArgs.chosenCmd_).end()) {
-            std::string err = "Missing positional argument: " + positional.name;
-            throw ParseException({ err });
+        const auto& positionals = parsedArgs.cmdVals_.at(parsedArgs.chosenCmd_);
+
+        // Validate required positional arguments are present
+        if (positionals.count(positional.name) == 0
+            || positionals.at(positional.name).size() == 0) {
+            if (positional.numArgs == NumArgs::One
+                || positional.numArgs == NumArgs::OneOrMore) {
+                throw ParseException(
+                        "Missing positional argument: " + positional.name);
+            } else {
+                continue;
+            }
+        }
+
+        auto numArgs = positionals.at(positional.name).size();
+        if (numArgs > 1 && positional.numArgs == NumArgs::One) {
+            throw ParseException(
+                    "Too many positional arguments for " + positional.name);
         }
     }
 }

--- a/tools/arg/arg_parser.cpp
+++ b/tools/arg/arg_parser.cpp
@@ -48,6 +48,11 @@ std::optional<const Flag*> findFlagByShort(
 
 } // namespace
 
+ArgParser::ArgParser()
+{
+    cmdFlags_[CMD_UNSPECIFIED] = {};
+}
+
 void ArgParser::addGlobalFlag(
         const std::string& name,
         char shortName,
@@ -336,8 +341,9 @@ ParsedArgs ArgParser::parse(int argc, char** argv) const
             bool isSubcommand = false;
             for (const auto& command : commands_) {
                 if (command.name == argv[i]
-                    || (argv[i][1] == 0 && command.shortName != 0
-                        && command.shortName == argv[i][0])) {
+                    || (command.shortName != 0
+                        && command.shortName == argv[i][0]
+                        && argv[i][1] == 0)) {
                     if (parsedArgs.chosenCmd_ != CMD_UNSPECIFIED) {
                         std::string err =
                                 "Trying to choose another subcommand '"

--- a/tools/arg/arg_parser.h
+++ b/tools/arg/arg_parser.h
@@ -17,6 +17,8 @@ class ArgParser {
    public:
     static constexpr int CMD_UNSPECIFIED = 0;
 
+    ArgParser();
+
     // see the documentation in struct Flag, Command, Positional for more info
     // on expected arguments
     void addGlobalFlag(

--- a/tools/arg/arg_parser.h
+++ b/tools/arg/arg_parser.h
@@ -43,11 +43,42 @@ class ArgParser {
             char shortName,
             bool hasVal,
             const std::string& help);
-    // order matters
+    /**
+     * @brief Add a positional argument to a command with a specified number of
+     * arguments.
+     *
+     * Positional arguments are added in order. Once a variadic positional
+     * argument (ZeroOrOne, ZeroOrMore, or OneOrMore) is added, no more
+     * positional arguments can be added to that command.
+     *
+     * @param cmd The command ID to which the positional argument should be
+     * added.
+     * @param numArgs Specifies how many values this positional accepts.
+     * @param name The name of the positional argument (used for lookup and
+     * help).
+     * @param help The help text describing this positional argument.
+     *
+     * @note Order matters - positional arguments must be specified in the order
+     * they appear on the command line.
+     */
+    void addCommandPositional(
+            int cmd,
+            NumArgs numArgs,
+            const std::string& name,
+            const std::string& help);
+
+    /**
+     * @brief Add a positional argument to a command (single value).
+     *
+     * Convenience overload that assumes exactly one value (NumArgs::One).
+     */
     void addCommandPositional(
             int cmd,
             const std::string& name,
-            const std::string& help);
+            const std::string& help)
+    {
+        return addCommandPositional(cmd, NumArgs::One, name, help);
+    }
 
     // Populated based on added flags, commands, and positionals
     std::string help() const;

--- a/tools/arg/parsed_args.cpp
+++ b/tools/arg/parsed_args.cpp
@@ -9,6 +9,15 @@
 #include "tools/arg/arg_parser.h"
 
 namespace openzl::arg {
+namespace {
+std::optional<std::string> vecToOptional(const std::vector<std::string>& vec)
+{
+    if (vec.size() == 1) {
+        return vec[0];
+    }
+    return std::nullopt;
+}
+} // namespace
 
 int ParsedArgs::chosenCmd() const
 {
@@ -68,7 +77,7 @@ std::optional<std::string> ParsedArgs::globalFlag(const std::string& name) const
     if (mp.find(name) == mp.end()) {
         return std::nullopt;
     }
-    return mp.at(name);
+    return vecToOptional(mp.at(name));
 }
 
 std::string ParsedArgs::globalRequiredFlag(const std::string& name) const
@@ -76,13 +85,25 @@ std::string ParsedArgs::globalRequiredFlag(const std::string& name) const
     return cmdRequiredFlag(ArgParser::CMD_UNSPECIFIED, name);
 }
 
-std::string ParsedArgs::cmdPositional(int cmd, const std::string& name) const
+std::vector<std::string> ParsedArgs::cmdPositionals(
+        int cmd,
+        const std::string& name) const
 {
     auto mp = cmdVals_.at(cmd);
     if (mp.find(name) == mp.end()) {
         throw ParseException("No positional arg with name " + name);
     }
-    return mp.at(name).value();
+    return mp.at(name);
+}
+
+std::string ParsedArgs::cmdPositional(int cmd, const std::string& name) const
+{
+    auto pos = vecToOptional(cmdPositionals(cmd, name));
+    if (!pos.has_value()) {
+        throw ParseException(
+                "Need exactly one positional arg with name " + name);
+    }
+    return pos.value();
 }
 
 bool ParsedArgs::cmdHasFlag(int cmd, const std::string& name) const
@@ -101,7 +122,7 @@ std::optional<std::string> ParsedArgs::cmdFlag(int cmd, const std::string& name)
     if (mp.find(name) == mp.end()) {
         return std::nullopt;
     }
-    return mp.at(name);
+    return vecToOptional(mp.at(name));
 }
 
 std::string ParsedArgs::cmdRequiredFlag(int cmd, const std::string& name) const

--- a/tools/arg/parsed_args.h
+++ b/tools/arg/parsed_args.h
@@ -25,13 +25,36 @@ class ParsedArgs {
     std::optional<std::string> globalFlag(const std::string& name) const;
     std::string globalRequiredFlag(const std::string& name) const;
 
+    /**
+     * @brief Retrieve all values for a variadic positional argument.
+     *
+     * Returns a vector containing all values that were passed for the specified
+     * positional argument. The number of elements in this vector depends on the
+     * number of arguments specified for the positional argument. The size of
+     * the vector is pre-validated to match the number of arguments specified.
+     *
+     * @param cmd The command ID for which to retrieve the positional argument
+     * values.
+     * @param name The name of the positional argument.
+     * @return A vector of strings containing all values for the positional
+     * argument.
+     */
+    std::vector<std::string> cmdPositionals(int cmd, const std::string& name)
+            const;
+
+    /**
+     * @brief Retrieve the value for a positional argument.
+     *
+     * Convenience overload that assumes exactly one value (NumArgs::One).
+     */
     std::string cmdPositional(int cmd, const std::string& name) const;
+
     bool cmdHasFlag(int cmd, const std::string& name) const;
     std::optional<std::string> cmdFlag(int cmd, const std::string& name) const;
     std::string cmdRequiredFlag(int cmd, const std::string& name) const;
 
    private:
-    std::map<int, std::map<std::string, std::optional<std::string>>> cmdVals_;
+    std::map<int, std::map<std::string, std::vector<std::string>>> cmdVals_;
     int chosenCmd_ = 0;
 
     // copied from ArgParser

--- a/tools/arg/positional.h
+++ b/tools/arg/positional.h
@@ -6,7 +6,15 @@
 
 namespace openzl::arg {
 
+enum class NumArgs {
+    ZeroOrOne,
+    One,
+    ZeroOrMore,
+    OneOrMore,
+};
+
 struct Positional {
+    NumArgs numArgs;
     std::string name;
     std::string help;
 };


### PR DESCRIPTION
Summary:
Add a CLI that runs LZ benchmarks. It supports OpenZL, LZ4, and Zstd, and supports setting custom parameters per compressor.

A stacked diff adds serialized OpenZL LZ compressors to benchmark.

Differential Revision: D88313195


