### PR TITLE
Void unused parameters in CompressionIntrospectionHooks.hpp

### DIFF
--- a/cpp/include/openzl/cpp/CompressIntrospectionHooks.hpp
+++ b/cpp/include/openzl/cpp/CompressIntrospectionHooks.hpp
@@ -16,8 +16,15 @@ class CompressIntrospectionHooks {
         return &rawHooks_;
     }
 
-    virtual void on_segmenterEncode_start(ZL_Segmenter* segCtx) {}
-    virtual void on_segmenterEncode_end(ZL_Segmenter* segCtx, ZL_Report r) {}
+    virtual void on_segmenterEncode_start(ZL_Segmenter* segCtx)
+    {
+        (void)segCtx;
+    }
+    virtual void on_segmenterEncode_end(ZL_Segmenter* segCtx, ZL_Report r)
+    {
+        (void)segCtx;
+        (void)r;
+    }
     virtual void on_ZL_Segmenter_processChunk_start(
             ZL_Segmenter* segCtx,
             const size_t numElts[],
@@ -25,19 +32,33 @@ class CompressIntrospectionHooks {
             ZL_GraphID startingGraphID,
             const ZL_RuntimeGraphParameters* rGraphParams)
     {
+        (void)segCtx;
+        (void)numElts;
+        (void)numInputs;
+        (void)startingGraphID;
+        (void)rGraphParams;
     }
     virtual void on_ZL_Segmenter_processChunk_end(
             ZL_Segmenter* segCtx,
             ZL_Report r)
     {
+        (void)segCtx;
+        (void)r;
     }
 
-    virtual void on_ZL_Encoder_getScratchSpace(ZL_Encoder* ei, size_t size) {}
+    virtual void on_ZL_Encoder_getScratchSpace(ZL_Encoder* ei, size_t size)
+    {
+        (void)ei;
+        (void)size;
+    }
     virtual void on_ZL_Encoder_sendCodecHeader(
             ZL_Encoder* eictx,
             const void* trh,
             size_t trhSize)
     {
+        (void)eictx;
+        (void)trh;
+        (void)trhSize;
     }
     virtual void on_ZL_Encoder_createTypedStream(
             ZL_Encoder* eic,
@@ -46,9 +67,18 @@ class CompressIntrospectionHooks {
             size_t eltWidth,
             ZL_Output* createdStream)
     {
+        (void)eic;
+        (void)outStreamIndex;
+        (void)eltsCapacity;
+        (void)eltWidth;
+        (void)createdStream;
     }
 
-    virtual void on_ZL_Graph_getScratchSpace(ZL_Graph* gctx, size_t size) {}
+    virtual void on_ZL_Graph_getScratchSpace(ZL_Graph* gctx, size_t size)
+    {
+        (void)gctx;
+        (void)size;
+    }
     virtual void on_ZL_Edge_setMultiInputDestination_wParams(
             ZL_Graph* gctx,
             ZL_Edge* inputs[],
@@ -56,6 +86,11 @@ class CompressIntrospectionHooks {
             ZL_GraphID gid,
             const ZL_LocalParams* lparams)
     {
+        (void)gctx;
+        (void)inputs;
+        (void)nbInputs;
+        (void)gid;
+        (void)lparams;
     }
 
     virtual void on_migraphEncode_start(
@@ -65,6 +100,11 @@ class CompressIntrospectionHooks {
             ZL_Edge* inputs[],
             size_t nbInputs)
     {
+        (void)gctx;
+        (void)compressor;
+        (void)gid;
+        (void)inputs;
+        (void)nbInputs;
     }
     virtual void on_migraphEncode_end(
             ZL_Graph*,
@@ -72,6 +112,9 @@ class CompressIntrospectionHooks {
             size_t nbSuccessors,
             ZL_Report graphExecResult)
     {
+        (void)successorGraphs;
+        (void)nbSuccessors;
+        (void)graphExecResult;
     }
     virtual void on_codecEncode_start(
             ZL_Encoder* eictx,
@@ -80,6 +123,11 @@ class CompressIntrospectionHooks {
             const ZL_Input* inStreams[],
             size_t nbInStreams)
     {
+        (void)eictx;
+        (void)compressor;
+        (void)nid;
+        (void)inStreams;
+        (void)nbInStreams;
     }
     virtual void on_codecEncode_end(
             ZL_Encoder*,
@@ -87,6 +135,9 @@ class CompressIntrospectionHooks {
             size_t nbOutputs,
             ZL_Report codecExecResult)
     {
+        (void)outStreams;
+        (void)nbOutputs;
+        (void)codecExecResult;
     }
     virtual void on_cctx_convertOneInput(
             const ZL_CCtx* const cctx,
@@ -95,6 +146,10 @@ class CompressIntrospectionHooks {
             const ZL_Type portTypeMask,
             const ZL_Report conversionResult)
     {
+        (void)cctx;
+        (void)inType;
+        (void)portTypeMask;
+        (void)conversionResult;
     }
 
     virtual void on_ZL_CCtx_compressMultiTypedRef_start(
@@ -104,11 +159,18 @@ class CompressIntrospectionHooks {
             ZL_TypedRef const* const inputs[],
             size_t const nbInputs)
     {
+        (void)cctx;
+        (void)dst;
+        (void)dstCapacity;
+        (void)inputs;
+        (void)nbInputs;
     }
     virtual void on_ZL_CCtx_compressMultiTypedRef_end(
             ZL_CCtx const* const cctx,
             ZL_Report const result)
     {
+        (void)cctx;
+        (void)result;
     }
 
    private:


### PR DESCRIPTION
Summary: I was getting build failures when using `CCtx.hpp` in Managed Compression.

Differential Revision: D88398424


