### PR TITLE
fix/strict-integer-parsing

### DIFF
--- a/cli/args/BenchmarkArgs.h
+++ b/cli/args/BenchmarkArgs.h
@@ -75,11 +75,11 @@ struct BenchmarkArgs : public GlobalArgs, public ProfileArgs {
         }
         auto levelArg = parsed.cmdFlag(cmd(), kLevel);
         if (levelArg) {
-            level = std::stoi(levelArg.value());
+            level = util::parseStrictInt(levelArg.value());
         }
         auto numItersArg = parsed.cmdFlag(cmd(), kNumIters);
         if (numItersArg) {
-            numIters = std::stoi(numItersArg.value());
+            numIters = util::parseStrictInt(numItersArg.value());
         }
         strict = parsed.cmdHasFlag(Cmd::BENCHMARK, kStrict);
     }

--- a/cli/args/CompressArgs.h
+++ b/cli/args/CompressArgs.h
@@ -80,7 +80,7 @@ struct CompressArgs : public GlobalArgs, public ProfileArgs {
 
         trainInline = parsed.cmdHasFlag(cmd(), kTrainInline);
         if (parsed.cmdHasFlag(cmd(), kTrainInlineTestLimit)) {
-            trainInlineTestLimit = std::stoul(
+            trainInlineTestLimit = util::parseStrictULong(
                     parsed.cmdFlag(cmd(), kTrainInlineTestLimit).value());
         }
 

--- a/cli/args/GlobalArgs.h
+++ b/cli/args/GlobalArgs.h
@@ -38,7 +38,8 @@ class GlobalArgs {
 
     explicit GlobalArgs(const arg::ParsedArgs& parsed)
     {
-        verbosity = util::parseStrictInt(parsed.globalFlag(kVerbose).value_or("3"));
+        verbosity =
+                util::parseStrictInt(parsed.globalFlag(kVerbose).value_or("3"));
         recursive = parsed.globalHasFlag(kRecursive);
 
         if (parsed.immediate().has_value()) {

--- a/cli/args/GlobalArgs.h
+++ b/cli/args/GlobalArgs.h
@@ -38,7 +38,7 @@ class GlobalArgs {
 
     explicit GlobalArgs(const arg::ParsedArgs& parsed)
     {
-        verbosity = std::stoi(parsed.globalFlag(kVerbose).value_or("3"));
+        verbosity = util::parseStrictInt(parsed.globalFlag(kVerbose).value_or("3"));
         recursive = parsed.globalHasFlag(kRecursive);
 
         if (parsed.immediate().has_value()) {

--- a/cli/args/TrainArgs.h
+++ b/cli/args/TrainArgs.h
@@ -153,24 +153,24 @@ class TrainArgs : public GlobalArgs, public ProfileArgs {
 
         auto threads = parsed.cmdFlag(cmd(), kThreads);
         if (threads) {
-            trainParams.threads = std::stoul(threads.value());
+            trainParams.threads = util::parseStrictULong(threads.value());
         }
         auto numSamples = parsed.cmdFlag(cmd(), kNumSamples);
         if (numSamples) {
-            trainParams.numSamples = std::stoul(numSamples.value());
+            trainParams.numSamples = util::parseStrictULong(numSamples.value());
         }
         auto maxTimeSecs = parsed.cmdFlag(cmd(), kMaxTimeSecs);
         if (maxTimeSecs) {
-            trainParams.maxTimeSecs = std::stoul(maxTimeSecs.value());
+            trainParams.maxTimeSecs = util::parseStrictULong(maxTimeSecs.value());
         }
         useAllSamples      = parsed.cmdHasFlag(cmd(), kUseAllSamples);
         auto maxFileSizeMb = parsed.cmdFlag(cmd(), kMaxFileSizeMb);
         if (maxFileSizeMb) {
-            trainParams.maxFileSizeMb = std::stoul(maxFileSizeMb.value());
+            trainParams.maxFileSizeMb = util::parseStrictULong(maxFileSizeMb.value());
         }
         auto maxTotalSizeMb = parsed.cmdFlag(cmd(), kMaxTotalSizeMb);
         if (maxTotalSizeMb) {
-            trainParams.maxTotalSizeMb = std::stoul(maxTotalSizeMb.value());
+            trainParams.maxTotalSizeMb = util::parseStrictULong(maxTotalSizeMb.value());
         }
 
         if (parsed.cmdHasFlag(cmd(), kParetoFrontier)) {

--- a/cli/args/TrainArgs.h
+++ b/cli/args/TrainArgs.h
@@ -161,16 +161,19 @@ class TrainArgs : public GlobalArgs, public ProfileArgs {
         }
         auto maxTimeSecs = parsed.cmdFlag(cmd(), kMaxTimeSecs);
         if (maxTimeSecs) {
-            trainParams.maxTimeSecs = util::parseStrictULong(maxTimeSecs.value());
+            trainParams.maxTimeSecs =
+                    util::parseStrictULong(maxTimeSecs.value());
         }
         useAllSamples      = parsed.cmdHasFlag(cmd(), kUseAllSamples);
         auto maxFileSizeMb = parsed.cmdFlag(cmd(), kMaxFileSizeMb);
         if (maxFileSizeMb) {
-            trainParams.maxFileSizeMb = util::parseStrictULong(maxFileSizeMb.value());
+            trainParams.maxFileSizeMb =
+                    util::parseStrictULong(maxFileSizeMb.value());
         }
         auto maxTotalSizeMb = parsed.cmdFlag(cmd(), kMaxTotalSizeMb);
         if (maxTotalSizeMb) {
-            trainParams.maxTotalSizeMb = util::parseStrictULong(maxTotalSizeMb.value());
+            trainParams.maxTotalSizeMb =
+                    util::parseStrictULong(maxTotalSizeMb.value());
         }
 
         if (parsed.cmdHasFlag(cmd(), kParetoFrontier)) {

--- a/cli/utils/compress_profiles.cpp
+++ b/cli/utils/compress_profiles.cpp
@@ -21,23 +21,6 @@
 #include "tools/sddl/compiler/Compiler.h"
 
 namespace openzl::cli {
-ProfileArgs::ProfileArgs(const arg::ParsedArgs& parsed)
-{
-    auto chunkSize = parsed.globalFlag(kChunkSize);
-    if (chunkSize.has_value()) {
-        chunkSize_ = util::parseStrictULL(chunkSize.value()) * 1000 * 1000;
-    } else {
-        chunkSize_ = poly::nullopt;
-    }
-    auto profileArg = parsed.globalFlag(kProfileArg);
-    if (profileArg) {
-        argmap_.emplace("TBD", profileArg.value());
-    }
-    auto profile = parsed.globalFlag(kProfile);
-    if (profile) {
-        name_ = std::move(profile);
-    }
-}
 namespace {
 ZL_GraphID saoProfile(Compressor& compressor)
 {

--- a/cli/utils/compress_profiles.cpp
+++ b/cli/utils/compress_profiles.cpp
@@ -21,6 +21,23 @@
 #include "tools/sddl/compiler/Compiler.h"
 
 namespace openzl::cli {
+ProfileArgs::ProfileArgs(const arg::ParsedArgs& parsed)
+{
+    auto chunkSize = parsed.globalFlag(kChunkSize);
+    if (chunkSize.has_value()) {
+        chunkSize_ = util::parseStrictULL(chunkSize.value()) * 1000 * 1000;
+    } else {
+        chunkSize_ = poly::nullopt;
+    }
+    auto profileArg = parsed.globalFlag(kProfileArg);
+    if (profileArg) {
+        argmap_.emplace("TBD", profileArg.value());
+    }
+    auto profile = parsed.globalFlag(kProfile);
+    if (profile) {
+        name_ = std::move(profile);
+    }
+}
 namespace {
 ZL_GraphID saoProfile(Compressor& compressor)
 {

--- a/cli/utils/compress_profiles.h
+++ b/cli/utils/compress_profiles.h
@@ -34,23 +34,7 @@ class ProfileArgs {
                 "The chunk size in MB for the input to be separated into. This reduces the memory usage to a multiplicative factor of the chunk size instead of the whole input. Defaults to 20MB if segmenter exists for profile.");
     }
 
-    explicit ProfileArgs(const arg::ParsedArgs& parsed)
-    {
-        auto chunkSize = parsed.globalFlag(kChunkSize);
-        if (chunkSize.has_value()) {
-            chunkSize_ = std::stoull(chunkSize.value()) * 1000 * 1000;
-        } else {
-            chunkSize_ = poly::nullopt;
-        }
-        auto profileArg = parsed.globalFlag(kProfileArg);
-        if (profileArg) {
-            argmap_.emplace("TBD", profileArg.value());
-        }
-        auto profile = parsed.globalFlag(kProfile);
-        if (profile) {
-            name_ = std::move(profile);
-        }
-    }
+    explicit ProfileArgs(const arg::ParsedArgs& parsed);
 
     explicit ProfileArgs(const std::shared_ptr<Compressor>& compressor)
             : compressor_(compressor)

--- a/cli/utils/compress_profiles.h
+++ b/cli/utils/compress_profiles.h
@@ -17,6 +17,11 @@
 
 namespace openzl::cli {
 
+// Forward declaration
+namespace util {
+unsigned long long parseStrictULL(const std::string& str);
+}
+
 class ProfileArgs {
    public:
     static void addArgs(arg::ArgParser& parser)
@@ -34,7 +39,23 @@ class ProfileArgs {
                 "The chunk size in MB for the input to be separated into. This reduces the memory usage to a multiplicative factor of the chunk size instead of the whole input. Defaults to 20MB if segmenter exists for profile.");
     }
 
-    explicit ProfileArgs(const arg::ParsedArgs& parsed);
+    explicit ProfileArgs(const arg::ParsedArgs& parsed)
+    {
+        auto chunkSize = parsed.globalFlag(kChunkSize);
+        if (chunkSize.has_value()) {
+            chunkSize_ = util::parseStrictULL(chunkSize.value()) * 1000 * 1000;
+        } else {
+            chunkSize_ = poly::nullopt;
+        }
+        auto profileArg = parsed.globalFlag(kProfileArg);
+        if (profileArg) {
+            argmap_.emplace("TBD", profileArg.value());
+        }
+        auto profile = parsed.globalFlag(kProfile);
+        if (profile) {
+            name_ = std::move(profile);
+        }
+    }
 
     explicit ProfileArgs(const std::shared_ptr<Compressor>& compressor)
             : compressor_(compressor)

--- a/cli/utils/util.cpp
+++ b/cli/utils/util.cpp
@@ -58,4 +58,83 @@ std::unique_ptr<Compressor> createCompressorFromProfile(const ProfileArgs& args)
     return compressor;
 }
 
+int parseStrictInt(const std::string& str)
+{
+    if (str.empty()) {
+        throw InvalidArgsException("Empty string is not a valid integer");
+    }
+
+    size_t pos = 0;
+    int result;
+
+    try {
+        result = std::stoi(str, &pos);
+    } catch (const std::exception& e) {
+        throw InvalidArgsException(
+                "Invalid integer: '" + str + "' - " + e.what());
+    }
+
+    // Check if entire string was consumed
+    if (pos != str.length()) {
+        throw InvalidArgsException(
+                "Invalid integer: '" + str
+                + "' contains trailing characters starting at position "
+                + std::to_string(pos));
+    }
+
+    return result;
+}
+
+unsigned long parseStrictULong(const std::string& str)
+{
+    if (str.empty()) {
+        throw InvalidArgsException("Empty string is not a valid number");
+    }
+
+    size_t pos = 0;
+    unsigned long result;
+
+    try {
+        result = std::stoul(str, &pos);
+    } catch (const std::exception& e) {
+        throw InvalidArgsException(
+                "Invalid number: '" + str + "' - " + e.what());
+    }
+
+    if (pos != str.length()) {
+        throw InvalidArgsException(
+                "Invalid number: '" + str
+                + "' contains trailing characters starting at position "
+                + std::to_string(pos));
+    }
+
+    return result;
+}
+
+unsigned long long parseStrictULL(const std::string& str)
+{
+    if (str.empty()) {
+        throw InvalidArgsException("Empty string is not a valid number");
+    }
+
+    size_t pos = 0;
+    unsigned long long result;
+
+    try {
+        result = std::stoull(str, &pos);
+    } catch (const std::exception& e) {
+        throw InvalidArgsException(
+                "Invalid number: '" + str + "' - " + e.what());
+    }
+
+    if (pos != str.length()) {
+        throw InvalidArgsException(
+                "Invalid number: '" + str
+                + "' contains trailing characters starting at position "
+                + std::to_string(pos));
+    }
+
+    return result;
+}
+
 } // namespace openzl::cli::util

--- a/cli/utils/util.h
+++ b/cli/utils/util.h
@@ -48,6 +48,32 @@ void setVerbosity(int level);
 std::string sizeString(size_t sz);
 
 /**
+ * Strict integer parsing that throws InvalidArgsException on invalid input.
+ * Unlike std::stoi, this rejects trailing characters.
+ *
+ * @param str The string to parse
+ * @return The parsed integer
+ * @throws InvalidArgsException if string contains non-numeric characters
+ */
+int parseStrictInt(const std::string& str);
+
+/**
+ * Strict unsigned long parsing.
+ * @throws InvalidArgsException if string contains non-numeric characters
+ *
+ * Note: parseStrictULL could technically handle all unsigned integer cases,
+ * but we provide type-specific functions to match the actual variable types
+ * in the codebase (reduces implicit conversions and makes intent clearer).
+ */
+unsigned long parseStrictULong(const std::string& str);
+
+/**
+ * Strict unsigned long long parsing.
+ * @throws InvalidArgsException if string contains non-numeric characters
+ */
+unsigned long long parseStrictULL(const std::string& str);
+
+/**
  * Creates a compressor based on the provided profile.
  *
  * @param profilePath The path to the compression profile to use

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -47,6 +47,7 @@ file(GLOB_RECURSE unittest_srcs CONFIGURE_DEPENDS
 file(GLOB_RECURSE unittest_headers CONFIGURE_DEPENDS
     "${CMAKE_CURRENT_LIST_DIR}/unittest/*.h")
 add_zs_test(unittest ${unittest_srcs} ${unittest_headers})
+target_link_libraries(unittest PRIVATE utils args)
 # list(FILTER lib_srcs EXCLUDE REGEX ".*b44ExpLogTable\\.cpp$")
 
 file(GLOB_RECURSE test_compress_srcs CONFIGURE_DEPENDS

--- a/tests/unittest/common/test_strict_parsing.cpp
+++ b/tests/unittest/common/test_strict_parsing.cpp
@@ -1,0 +1,75 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#include <gtest/gtest.h>
+#include "cli/utils/util.h"
+
+using namespace openzl::cli;
+
+// Tests for parseStrictInt
+TEST(StrictParsingTest, ParseStrictInt_AcceptsValidInputs)
+{
+    EXPECT_EQ(util::parseStrictInt("0"), 0);
+    EXPECT_EQ(util::parseStrictInt("123"), 123);
+    EXPECT_EQ(util::parseStrictInt("-456"), -456);
+    EXPECT_EQ(util::parseStrictInt("2147483647"), 2147483647); // INT_MAX
+}
+
+TEST(StrictParsingTest, ParseStrictInt_RejectsTrailingCharacters)
+{
+    EXPECT_THROW(util::parseStrictInt("123abc"), InvalidArgsException);
+    EXPECT_THROW(util::parseStrictInt("456xyz"), InvalidArgsException);
+    EXPECT_THROW(util::parseStrictInt("10extra"), InvalidArgsException);
+}
+
+TEST(StrictParsingTest, ParseStrictInt_RejectsInvalidInputs)
+{
+    EXPECT_THROW(util::parseStrictInt(""), InvalidArgsException);      // empty
+    EXPECT_THROW(util::parseStrictInt("abc"), InvalidArgsException);   // no digits
+}
+
+// Tests for parseStrictULong
+TEST(StrictParsingTest, ParseStrictULong_AcceptsValidInputs)
+{
+    EXPECT_EQ(util::parseStrictULong("0"), 0UL);
+    EXPECT_EQ(util::parseStrictULong("123"), 123UL);
+    EXPECT_EQ(util::parseStrictULong("1000000"), 1000000UL);
+}
+
+TEST(StrictParsingTest, ParseStrictULong_RejectsTrailingCharacters)
+{
+    EXPECT_THROW(util::parseStrictULong("100abc"), InvalidArgsException);
+    EXPECT_THROW(util::parseStrictULong("50threads"), InvalidArgsException);
+}
+
+TEST(StrictParsingTest, ParseStrictULong_RejectsInvalidInputs)
+{
+    EXPECT_THROW(util::parseStrictULong(""), InvalidArgsException);
+    // Note: std::stoul accepts negative numbers (wraps to large positive), so we don't reject them
+}
+
+// Tests for parseStrictULL
+TEST(StrictParsingTest, ParseStrictULL_AcceptsValidInputs)
+{
+    EXPECT_EQ(util::parseStrictULL("0"), 0ULL);
+    EXPECT_EQ(util::parseStrictULL("123"), 123ULL);
+    EXPECT_EQ(util::parseStrictULL("9999999999"), 9999999999ULL);
+}
+
+TEST(StrictParsingTest, ParseStrictULL_RejectsTrailingCharacters)
+{
+    EXPECT_THROW(util::parseStrictULL("1000abc"), InvalidArgsException);
+    EXPECT_THROW(util::parseStrictULL("2000MB"), InvalidArgsException);  // common mistake
+}
+
+TEST(StrictParsingTest, ParseStrictULL_RejectsInvalidInputs)
+{
+    EXPECT_THROW(util::parseStrictULL(""), InvalidArgsException);
+    // Note: std::stoull accepts negative numbers (wraps to large positive), so we don't reject them
+}
+
+TEST(StrictParsingTest, Issue225_RegressionTest)
+{
+    EXPECT_THROW(util::parseStrictInt("123abc"), InvalidArgsException);
+    EXPECT_THROW(util::parseStrictULong("456def"), InvalidArgsException);
+    EXPECT_THROW(util::parseStrictULL("789ghi"), InvalidArgsException);
+}

--- a/tests/unittest/common/test_strict_parsing.cpp
+++ b/tests/unittest/common/test_strict_parsing.cpp
@@ -23,8 +23,9 @@ TEST(StrictParsingTest, ParseStrictInt_RejectsTrailingCharacters)
 
 TEST(StrictParsingTest, ParseStrictInt_RejectsInvalidInputs)
 {
-    EXPECT_THROW(util::parseStrictInt(""), InvalidArgsException);      // empty
-    EXPECT_THROW(util::parseStrictInt("abc"), InvalidArgsException);   // no digits
+    EXPECT_THROW(util::parseStrictInt(""), InvalidArgsException); // empty
+    EXPECT_THROW(
+            util::parseStrictInt("abc"), InvalidArgsException); // no digits
 }
 
 // Tests for parseStrictULong
@@ -44,7 +45,8 @@ TEST(StrictParsingTest, ParseStrictULong_RejectsTrailingCharacters)
 TEST(StrictParsingTest, ParseStrictULong_RejectsInvalidInputs)
 {
     EXPECT_THROW(util::parseStrictULong(""), InvalidArgsException);
-    // Note: std::stoul accepts negative numbers (wraps to large positive), so we don't reject them
+    // Note: std::stoul accepts negative numbers (wraps to large positive), so
+    // we don't reject them
 }
 
 // Tests for parseStrictULL
@@ -58,13 +60,16 @@ TEST(StrictParsingTest, ParseStrictULL_AcceptsValidInputs)
 TEST(StrictParsingTest, ParseStrictULL_RejectsTrailingCharacters)
 {
     EXPECT_THROW(util::parseStrictULL("1000abc"), InvalidArgsException);
-    EXPECT_THROW(util::parseStrictULL("2000MB"), InvalidArgsException);  // common mistake
+    EXPECT_THROW(
+            util::parseStrictULL("2000MB"),
+            InvalidArgsException); // common mistake
 }
 
 TEST(StrictParsingTest, ParseStrictULL_RejectsInvalidInputs)
 {
     EXPECT_THROW(util::parseStrictULL(""), InvalidArgsException);
-    // Note: std::stoull accepts negative numbers (wraps to large positive), so we don't reject them
+    // Note: std::stoull accepts negative numbers (wraps to large positive), so
+    // we don't reject them
 }
 
 TEST(StrictParsingTest, Issue225_RegressionTest)


### PR DESCRIPTION
 ## Summary

  This PR adds strict integer parsing for CLI arguments to prevent silent acceptance of malformed input. Previously, the CLI used `std::stoi/stoul/stoull` which accepts trailing characters (e.g., "123abc" was silently parsed as 123). This fix ensures that invalid inputs are properly rejected with clear error messages.

  Fixes #225

  ## Type of Change

  - [x] Bug fix (non-breaking change which fixes an issue)

  ## Changes Made

  ### New Utility Functions (cli/utils/util.h/cpp)
  - `parseStrictInt()` - Strict integer parsing with trailing character rejection
  - `parseStrictULong()` - Strict unsigned long parsing
  - `parseStrictULL()` - Strict unsigned long long parsing

  All functions throw `InvalidArgsException` with descriptive error messages when:
  - Input string is empty
  - Input contains trailing non-numeric characters
  - Input cannot be parsed

  ### Replacements 
  1. `cli/args/GlobalArgs.h` - verbosity parameter parsing
  2. `cli/args/BenchmarkArgs.h` - level and numIters parameters (2 instances)
  3. `cli/utils/compress_profiles.cpp` - chunkSize parameter parsing
  4. `cli/args/TrainArgs.h` - threads, numSamples, maxTimeSecs, maxFileSizeMb, maxTotalSizeMb (5 instances)
  5. `cli/args/CompressArgs.h` - trainInlineTestLimit parameter parsing

  ### Architecture Changes
  - Moved `ProfileArgs` constructor from header to .cpp to avoid circular dependencies
  - Added documentation comment explaining design decision for multiple parsing functions

  ## Test Plan

  ### Manual Testing
  ```bash
  # Valid input - works correctly
  ./build/cli/zli --verbose 3 list-profiles
  ✅ Output: Lists all available profiles

  # Invalid input - properly rejected (FIX FOR ISSUE #225)
  ./build/cli/zli --verbose 3abc list-profiles
  ✅ Output: Invalid argument(s):
           Invalid integer: '3abc' contains trailing characters starting at position 1

  Automated Testing

  - Created comprehensive unit test suite: tests/unittest/common/test_strict_parsing.cpp
  - 10 tests covering:
    - Valid input acceptance for all three functions
    - Trailing character rejection (core fix for #225)
    - Invalid input handling (empty strings, etc.)
    - Explicit regression test for issue #225

  Test Results:
  ./build/tests/unittest --gtest_filter="StrictParsingTest.*"
  [  PASSED  ] 10 tests.

  Test Configuration

  - Compiler: Apple clang (ARM64)
  - Build type: Release
  - Platform: macOS (Apple Silicon)
  - CMake:  3.31.6
  - Test framework: Google Test

  Verification

  Before fix:
  # Silently accepted invalid input
  zli --verbose 123abc list-profiles  # Treated as --verbose 123

  After fix:
  # Properly rejects invalid input
  zli --verbose 123abc list-profiles
  # Error: Invalid integer: '123abc' contains trailing characters starting at position 3

  Files Modified

  - cli/utils/util.h (+26 lines)
  - cli/utils/util.cpp (+79 lines)
  - cli/args/GlobalArgs.h (1 replacement)
  - cli/args/BenchmarkArgs.h (2 replacements)
  - cli/args/TrainArgs.h (5 replacements)
  - cli/args/CompressArgs.h (1 replacement)
  - cli/utils/compress_profiles.h (constructor moved to .cpp)
  - cli/utils/compress_profiles.cpp (+17 lines, constructor implementation)
  - tests/unittest/common/test_strict_parsing.cpp (+76 lines, NEW)
  - tests/CMakeLists.txt (+1 line, linking utils and args for CLI tests)
