### PR TITLE
Fix CMake `DOWNLOAD_EXTRACT_TIMESTAMP` compatibility for versions below 3.24

### DIFF
--- a/build-scripts/cmake/openzl-deps.cmake
+++ b/build-scripts/cmake/openzl-deps.cmake
@@ -66,11 +66,18 @@ if(NOT ZSTD_AVAILABLE)
     file(REMOVE_RECURSE "${CMAKE_CURRENT_SOURCE_DIR}/deps/zstd")
     file(REMOVE_RECURSE "${CMAKE_CURRENT_SOURCE_DIR}/deps/${ZSTD_DIRNAME}")
 
+    # DOWNLOAD_EXTRACT_TIMESTAMP was added in CMake 3.24
+    if(CMAKE_VERSION VERSION_GREATER_EQUAL "3.24")
+        set(ZSTD_FETCH_TIMESTAMP_OPT DOWNLOAD_EXTRACT_TIMESTAMP TRUE)
+    else()
+        set(ZSTD_FETCH_TIMESTAMP_OPT)
+    endif()
+
     message(STATUS "Using hash verification for tarball download")
     FetchContent_Declare(zstd_tarball
         URL https://github.com/facebook/zstd/releases/download/v${ZSTD_VERSION}/${ZSTD_DIRNAME}.tar.gz
         URL_HASH SHA256=${ZSTD_TARBALL_SHA256}
-        DOWNLOAD_EXTRACT_TIMESTAMP ON
+        ${ZSTD_FETCH_TIMESTAMP_OPT}
         SOURCE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/deps/zstd"
     )
 


### PR DESCRIPTION
## Summary

Fix CMake build failure on versions below 3.24
(e.g., Ubuntu 22.04 with CMake 3.22).

The `DOWNLOAD_EXTRACT_TIMESTAMP` option in
`FetchContent_Declare` was added in CMake 3.24.

On older versions, this unrecognized keyword is
misinterpreted as part of the `URL_HASH` value,
causing the build to fail with:

```
CMake Error: URL_HASH is set to
  SHA256=...;DOWNLOAD_EXTRACT_TIMESTAMP;ON
but must be ALGO=value
```

## Type of Change

Bug fix (non-breaking change which fixes an issue)

## Test Plan

Use Docker to verify the fix on Ubuntu 22.04
(CMake 3.22):

```dockerfile
FROM ubuntu:22.04

ENV DEBIAN_FRONTEND=noninteractive

RUN apt-get update && apt-get install -y \
    build-essential \
    cmake \
    git \
    python3 \
    python3-dev \
    && rm -rf /var/lib/apt/lists/*

RUN cmake --version

WORKDIR /workspace

COPY . .

# Remove zstd and .git to force FetchContent (Tier 2) to run
RUN rm -rf deps/zstd .git

CMD cmake \
    -S. \
    -B../openzl.build \
    -DCMAKE_INSTALL_PREFIX=/tmp/local \
    -DCMAKE_BUILD_TYPE=Release
```

### Commands:

```bash
docker build -t openzl-debug .
docker run --rm openzl-debug
```

### Expected result

- On `dev` branch: Build fails with `URL_HASH is set to SHA256=...;DOWNLOAD_EXTRACT_TIMESTAMP;ON`
- On this branch: Build succeeds with `zstd dependency resolved successfully`

### Test Configuration

- Compiler: GCC 11.4.0
- Build type: Release
- Platform(s): Ubuntu 22.04 (Docker), CMake 3.22