### PR TITLE
Switch LZ Research to relative deps

### DIFF
--- a/contrib/lz-research/BUCK
+++ b/contrib/lz-research/BUCK
@@ -4,15 +4,17 @@ load("@fbcode_macros//build_defs:cpp_library.bzl", "cpp_library")
 oncall("data_compression")
 
 cpp_library(
+    # @autodeps-skip
     name = "lz_compressors",
     srcs = ["LzCompressors.cpp"],
     headers = ["LzCompressors.hpp"],
     exported_deps = [
-        "//openzl/dev/cpp:openzl_cpp",
+        "../../cpp:openzl_cpp",
     ],
 )
 
 cpp_library(
+    # @autodeps-skip
     name = "compressor",
     srcs = ["Compressor.cpp"],
     headers = ["Compressor.hpp"],
@@ -20,38 +22,40 @@ cpp_library(
         ":lz_compressors",
     ],
     exported_deps = [
+        "../../cpp:openzl_cpp",
+        "../../tools:io",
+        "../../tools:json",
+        "../../tools/training:train",
         "fbsource//third-party/lz4:lz4",
         "fbsource//third-party/zstd:zstd",
-        "//openzl/dev/cpp:openzl_cpp",
-        "//openzl/dev/tools:io",
-        "//openzl/dev/tools:json",
-        "//openzl/dev/tools/training:train",
     ],
 )
 
 cpp_library(
+    # @autodeps-skip
     name = "benchmark",
     srcs = ["Benchmark.cpp"],
     headers = ["Benchmark.hpp"],
     exported_deps = [
+        "../../tools:io",
+        "../../tools:json",
+        "../../tools:logger",
         ":compressor",
-        "//openzl/dev/tools:io",
-        "//openzl/dev/tools:json",
-        "//openzl/dev/tools:logger",
     ],
 )
 
 cpp_binary(
+    # @autodeps-skip
     name = "lz",
     srcs = [
         "Main.cpp",
     ],
     deps = [
+        "../../cpp:openzl_cpp",
+        "../../tools:arg",
+        "../../tools:fileio",
+        "../../tools:logger",
         "fbsource//third-party/zstd:zstd",
         ":benchmark",
-        "//openzl/dev/cpp:openzl_cpp",
-        "//openzl/dev/tools:arg",
-        "//openzl/dev/tools:fileio",
-        "//openzl/dev/tools:logger",
     ],
 )

--- a/tools/streamdump/BUCK
+++ b/tools/streamdump/BUCK
@@ -9,9 +9,6 @@ zs_library(
     headers = [
         "stream_dump2.h",
     ],
-    exported_deps = [
-        "../..:zstronglib",
-    ],
 )
 
 zs_binary(
@@ -35,10 +32,10 @@ zs_release_binary(
         "stream_dump2.c",
     ],
     deps = [
-        "..:fileio",
         ":stream_dump2_headers",
         "//common/managed_compression/zstrong:stream_dump_shim",
         "//openzl:openzl",
+        "//openzl:openzl_test_utils",
     ],
 )
 
@@ -48,8 +45,9 @@ zs_release_binary(
         "stream_dump2.c",
     ],
     deps = [
-        "..:fileio",
         ":stream_dump2_headers",
         "//data_compression/experimental/zstrong_compressors/xldb/bin:xldb_compressor_stream_dump_shim",
+        "//openzl:openzl",
+        "//openzl:openzl_test_utils",
     ],
 )

--- a/tools/streamdump/stream_dump2.h
+++ b/tools/streamdump/stream_dump2.h
@@ -3,11 +3,11 @@
 #ifndef ZSTRONG_STREAM_DUMP2_H
 #define ZSTRONG_STREAM_DUMP2_H
 
-#include "openzl/zl_decompress.h"
-
 #if defined(__cplusplus)
 extern "C" {
 #endif
+
+typedef struct ZL_DCtx_s ZL_DCtx;
 
 // You must provide an implementation of this function to register any custom
 // decoders needed to understand the frame. A no-op implementation is provided


### PR DESCRIPTION
Summary: The absolute deps were leftover after rebasing. Delete them.

Differential Revision: D88646141


