### PR TITLE
Fix Thrift kernel encoding

### DIFF
--- a/contrib/lz-research/BUCK
+++ b/contrib/lz-research/BUCK
@@ -4,15 +4,17 @@ load("@fbcode_macros//build_defs:cpp_library.bzl", "cpp_library")
 oncall("data_compression")
 
 cpp_library(
+    # @autodeps-skip
     name = "lz_compressors",
     srcs = ["LzCompressors.cpp"],
     headers = ["LzCompressors.hpp"],
     exported_deps = [
-        "//openzl/dev/cpp:openzl_cpp",
+        "../../cpp:openzl_cpp",
     ],
 )
 
 cpp_library(
+    # @autodeps-skip
     name = "compressor",
     srcs = ["Compressor.cpp"],
     headers = ["Compressor.hpp"],
@@ -20,38 +22,40 @@ cpp_library(
         ":lz_compressors",
     ],
     exported_deps = [
+        "../../cpp:openzl_cpp",
+        "../../tools:io",
+        "../../tools:json",
+        "../../tools/training:train",
         "fbsource//third-party/lz4:lz4",
         "fbsource//third-party/zstd:zstd",
-        "//openzl/dev/cpp:openzl_cpp",
-        "//openzl/dev/tools:io",
-        "//openzl/dev/tools:json",
-        "//openzl/dev/tools/training:train",
     ],
 )
 
 cpp_library(
+    # @autodeps-skip
     name = "benchmark",
     srcs = ["Benchmark.cpp"],
     headers = ["Benchmark.hpp"],
     exported_deps = [
+        "../../tools:io",
+        "../../tools:json",
+        "../../tools:logger",
         ":compressor",
-        "//openzl/dev/tools:io",
-        "//openzl/dev/tools:json",
-        "//openzl/dev/tools:logger",
     ],
 )
 
 cpp_binary(
+    # @autodeps-skip
     name = "lz",
     srcs = [
         "Main.cpp",
     ],
     deps = [
+        "../../cpp:openzl_cpp",
+        "../../tools:arg",
+        "../../tools:fileio",
+        "../../tools:logger",
         "fbsource//third-party/zstd:zstd",
         ":benchmark",
-        "//openzl/dev/cpp:openzl_cpp",
-        "//openzl/dev/tools:arg",
-        "//openzl/dev/tools:fileio",
-        "//openzl/dev/tools:logger",
     ],
 )

--- a/custom_transforms/thrift/kernels/decode_thrift_kernel.c
+++ b/custom_transforms/thrift/kernels/decode_thrift_kernel.c
@@ -356,7 +356,7 @@ ZL_Report ZS2_ThriftKernel_serializeArrayFloat(
     ZL_RET_R_IF_ERR(
             ZS2_ThriftKernel_serializeArrayHeader(&op, oend, 0xD, arraySize));
 
-    ZL_RET_R_IF_GT(internalBuffer_tooSmall, arraySize * 4, (size_t)(oend - op));
+    ZL_RET_R_IF_GT(internalBuffer_tooSmall, arraySize, (size_t)(oend - op) / 4);
     for (size_t i = 0; i < arraySize; ++i) {
         ZL_writeBE32(op + 4 * i, values[i]);
     }

--- a/custom_transforms/thrift/kernels/encode_thrift_kernel.c
+++ b/custom_transforms/thrift/kernels/encode_thrift_kernel.c
@@ -197,7 +197,7 @@ ZL_Report ZS2_ThriftKernel_deserializeMapI32ArrayFloat(
                 node_invalid_input, ZL_uintFits(ZL_RES_value(arraySize), 4));
         lengths[i] = (uint32_t)ZL_RES_value(arraySize);
 
-        ZL_RET_R_IF_GT(srcSize_tooSmall, 4 * lengths[i], (size_t)(iend - ip));
+        ZL_RET_R_IF_GT(srcSize_tooSmall, lengths[i], (size_t)(iend - ip) / 4);
 
         for (uint32_t pos = 0, end = lengths[i]; pos < end;) {
             if (values.ptr == values.end) {
@@ -456,7 +456,7 @@ ZL_Report ZS2_ThriftKernel_deserializeArrayFloat(
             ZS2_ThriftKernel_validateArrayHeader(&ip, iend, 0xD, arraySize));
 
     // Copy the floats
-    ZL_RET_R_IF_GT(srcSize_tooSmall, arraySize * 4, (size_t)(iend - ip));
+    ZL_RET_R_IF_GT(srcSize_tooSmall, arraySize, (size_t)(iend - ip) / 4);
     for (size_t i = 0; i < arraySize; ++i) {
         ZL_write32(values + i, ZL_readBE32(ip + 4 * i));
     }

--- a/tools/streamdump/BUCK
+++ b/tools/streamdump/BUCK
@@ -9,9 +9,6 @@ zs_library(
     headers = [
         "stream_dump2.h",
     ],
-    exported_deps = [
-        "../..:zstronglib",
-    ],
 )
 
 zs_binary(
@@ -35,10 +32,10 @@ zs_release_binary(
         "stream_dump2.c",
     ],
     deps = [
-        "..:fileio",
         ":stream_dump2_headers",
         "//common/managed_compression/zstrong:stream_dump_shim",
         "//openzl:openzl",
+        "//openzl:openzl_test_utils",
     ],
 )
 
@@ -48,8 +45,9 @@ zs_release_binary(
         "stream_dump2.c",
     ],
     deps = [
-        "..:fileio",
         ":stream_dump2_headers",
         "//data_compression/experimental/zstrong_compressors/xldb/bin:xldb_compressor_stream_dump_shim",
+        "//openzl:openzl",
+        "//openzl:openzl_test_utils",
     ],
 )

--- a/tools/streamdump/stream_dump2.h
+++ b/tools/streamdump/stream_dump2.h
@@ -3,11 +3,11 @@
 #ifndef ZSTRONG_STREAM_DUMP2_H
 #define ZSTRONG_STREAM_DUMP2_H
 
-#include "openzl/zl_decompress.h"
-
 #if defined(__cplusplus)
 extern "C" {
 #endif
+
+typedef struct ZL_DCtx_s ZL_DCtx;
 
 // You must provide an implementation of this function to register any custom
 // decoders needed to understand the frame. A no-op implementation is provided


### PR DESCRIPTION
Summary: Multiplying a size by 4 can cause overflow. Fix the one in `ZS2_ThriftKernel_deserializeMapI32ArrayFloat()` triggering the fuzzer crash, and look for other instances of the same pattern.

Reviewed By: kevinjzhang

Differential Revision: D88650887


