### PR TITLE
move CPP test files under dev/tests from namespace zstrong to openzl

### DIFF
--- a/benchmark/benchmark_data.h
+++ b/benchmark/benchmark_data.h
@@ -530,7 +530,7 @@ class CustomDistributionData : public BenchmarkData {
 class FixedWidthDataProducerData : public BenchmarkData {
    public:
     explicit FixedWidthDataProducerData(
-            zstrong::tests::datagen::FixedWidthDataProducer& producer)
+            openzl::tests::datagen::FixedWidthDataProducer& producer)
             : data_(producer("FixedWidthDataProducerData"))
     {
         std::ostringstream oss;
@@ -552,7 +552,7 @@ class FixedWidthDataProducerData : public BenchmarkData {
     }
 
    private:
-    zstrong::tests::datagen::FixedWidthData data_;
+    openzl::tests::datagen::FixedWidthData data_;
     std::string name_;
 };
 

--- a/benchmark/e2e/e2e_fieldlz.h
+++ b/benchmark/e2e/e2e_fieldlz.h
@@ -91,11 +91,11 @@ inline void registerFieldLzBenchmarks()
     // Create instances of the benchmark corpora.
     // We want to benchmark multiple different distributions with
     // different integer sizes.
-    zstrong::tests::datagen::VectorOfTokensParameters params{};
+    openzl::tests::datagen::VectorOfTokensParameters params{};
     params.numTokens = 100000;
-    auto rand        = std::make_shared<tests::datagen::PRNGWrapper>(
+    auto rand        = std::make_shared<openzl::tests::datagen::PRNGWrapper>(
             std::make_shared<std::mt19937>(0xdeadbeef));
-    zstrong::tests::datagen::VectorOfTokensProducer producer(rand, params);
+    openzl::tests::datagen::VectorOfTokensProducer producer(rand, params);
     std::vector<std::shared_ptr<BenchmarkData>> corpora = {
         // 10K 16bit values with cardinality of 100
         std::make_shared<UniformDistributionData<uint16_t>>(10240, 100),

--- a/benchmark/e2e/e2e_json_extract.cpp
+++ b/benchmark/e2e/e2e_json_extract.cpp
@@ -45,7 +45,7 @@ class JsonExtractCompressor : public ZstrongCompressor {
 void registerBenchmark(size_t size)
 {
     auto corpus = std::make_shared<ArbitrarySerializedData>(
-            tests::genJsonLikeData(size));
+            openzl::tests::genJsonLikeData(size));
     auto compressor = std::make_shared<JsonExtractCompressor>();
     E2EBenchmarkTestcase(compressor, corpus).registerBenchmarks();
 }

--- a/benchmark/e2e/e2e_parse.cpp
+++ b/benchmark/e2e/e2e_parse.cpp
@@ -23,7 +23,7 @@
 namespace zstrong::bench::e2e::parse {
 
 namespace {
-using tests::parse::Type;
+using openzl::tests::parse::Type;
 
 class ParseCompressor : public ZstrongStringCompressor {
    public:
@@ -60,8 +60,8 @@ class ParseCompressor : public ZstrongStringCompressor {
 
 void registerBenchmark(size_t size, Type type)
 {
-    auto data                  = tests::parse::genData(size, type);
-    auto [content, fieldSizes] = tests::parse::flatten(data);
+    auto data                  = openzl::tests::parse::genData(size, type);
+    auto [content, fieldSizes] = openzl::tests::parse::flatten(data);
     auto corpus                = std::make_shared<ArbitraryStringData>(
             std::move(content), std::move(fieldSizes));
     auto compressor =

--- a/benchmark/e2e/e2e_thrift.cpp
+++ b/benchmark/e2e/e2e_thrift.cpp
@@ -153,7 +153,7 @@ std::vector<T> buildRandomList(size_t size)
     std::vector<T> result;
     std::mt19937 gen(0xdeadbeef);
     for (size_t i = 0; i < size; ++i) {
-        result.push_back(::zstrong::thrift::tests::generate<T>(gen));
+        result.push_back(::openzl::thrift::tests::generate<T>(gen));
     }
     return result;
 }
@@ -320,10 +320,10 @@ std::vector<ThriftTestCase> buildTestCases()
         size_t binaryBytes  = 0;
         while (true) {
             std::string const str_compact =
-                    ::zstrong::thrift::tests::generateRandomThrift<
+                    ::openzl::thrift::tests::generateRandomThrift<
                             apache::thrift::CompactSerializer>(genCompact);
             std::string const str_binary =
-                    ::zstrong::thrift::tests::generateRandomThrift<
+                    ::openzl::thrift::tests::generateRandomThrift<
                             apache::thrift::BinarySerializer>(genBinary);
 
             ss_compact << str_compact;

--- a/custom_parsers/csv/tests/CsvLexerFuzzer.cpp
+++ b/custom_parsers/csv/tests/CsvLexerFuzzer.cpp
@@ -10,7 +10,7 @@
 
 using namespace ::testing;
 using namespace facebook::security::lionhead::fdp;
-using zstrong::tests::datagen::LionheadFDPWrapper;
+using openzl::tests::datagen::LionheadFDPWrapper;
 
 namespace openzl::custom_parsers {
 

--- a/custom_parsers/csv/tests/CsvSegmenterFuzzer.cpp
+++ b/custom_parsers/csv/tests/CsvSegmenterFuzzer.cpp
@@ -10,7 +10,7 @@
 
 using namespace ::testing;
 using namespace facebook::security::lionhead::fdp;
-using zstrong::tests::datagen::LionheadFDPWrapper;
+using openzl::tests::datagen::LionheadFDPWrapper;
 
 namespace openzl::custom_parsers {
 

--- a/custom_parsers/parquet/tests/fuzz_utils.h
+++ b/custom_parsers/parquet/tests/fuzz_utils.h
@@ -24,7 +24,7 @@ std::shared_ptr<arrow::Field> gen_arrow_field(
 {
     bool isLeaf = maxDepth == depth ? true : f.coin("is_leaf");
     // Hack to enforce unique names for the same struct
-    auto name = tests::gen_str(f, "field_name", Range<size_t>(1, 10));
+    auto name = openzl::tests::gen_str(f, "field_name", Range<size_t>(1, 10));
     name += std::to_string(name.size()) + std::to_string(idx);
 
     std::shared_ptr<arrow::DataType> type;
@@ -97,7 +97,7 @@ std::vector<std::optional<std::string>> gen_str_vec(
         if (!f.has_more_data() || f.coin("null")) {
             vec[i] = std::nullopt;
         } else {
-            vec[i] = tests::gen_str(f, name, lenDist);
+            vec[i] = openzl::tests::gen_str(f, name, lenDist);
         }
     }
     return vec;

--- a/custom_parsers/tests/DebugIntrospectionHooks.h
+++ b/custom_parsers/tests/DebugIntrospectionHooks.h
@@ -7,7 +7,7 @@
 #include "openzl/cpp/CompressIntrospectionHooks.hpp"
 #include "openzl/zl_reflection.h"
 
-namespace zstrong {
+namespace openzl {
 
 // until errors are propagated fully all the time, this is an alternative way to
 // bubble the transform trace to the user
@@ -46,4 +46,4 @@ class DebugIntrospectionHooks : public openzl::CompressIntrospectionHooks {
     }
 };
 
-} // namespace zstrong
+} // namespace openzl

--- a/custom_parsers/tests/csv_main.cpp
+++ b/custom_parsers/tests/csv_main.cpp
@@ -18,7 +18,7 @@
 #include "openzl/zl_compress.h"
 #include "openzl/zl_reflection.h"
 
-namespace zstrong::tests {
+namespace openzl::tests {
 namespace {
 
 enum CsvSuccessorIdx : size_t {
@@ -876,7 +876,7 @@ ZL_Report TestCsv::run(const std::string& csvFile)
 }
 
 } // namespace
-} // namespace zstrong::tests
+} // namespace openzl::tests
 
 int main(int argc, char** argv)
 {
@@ -885,7 +885,7 @@ int main(int argc, char** argv)
         return 1;
     }
     std::string csvFile = argv[1];
-    auto report         = zstrong::tests::TestCsv().run(csvFile);
+    auto report         = openzl::tests::TestCsv().run(csvFile);
     if (ZL_isError(report)) {
         std::cerr << ZL_ErrorCode_toString(ZL_errorCode(report));
     }

--- a/custom_parsers/tests/test_clustering.cpp
+++ b/custom_parsers/tests/test_clustering.cpp
@@ -14,7 +14,7 @@
 
 #include "tests/utils.h"
 
-namespace zstrong::tests {
+namespace openzl::tests {
 namespace {
 
 class TestClusteringGraph : public testing::Test {
@@ -38,7 +38,7 @@ class TestClusteringGraph : public testing::Test {
         cctx_   = ZL_CCtx_create();
         ZL_REQUIRE_SUCCESS(ZL_CCtx_setParameter(
                 cctx_, ZL_CParam_formatVersion, ZL_MAX_FORMAT_VERSION));
-        hooks_ = std::make_unique<DebugIntrospectionHooks>();
+        hooks_ = std::make_unique<openzl::DebugIntrospectionHooks>();
         if (0) {
             ZL_REQUIRE_SUCCESS(ZL_CCtx_attachIntrospectionHooks(
                     cctx_, hooks_->getRawHooks()));
@@ -137,7 +137,7 @@ class TestClusteringGraph : public testing::Test {
     ZL_Compressor* cgraph_{};
     ZL_DCtx* dctx_{};
     ZL_CCtx* cctx_{};
-    std::unique_ptr<DebugIntrospectionHooks> hooks_;
+    std::unique_ptr<openzl::DebugIntrospectionHooks> hooks_;
     std::vector<ZL_GraphID> successors_; /* Assume successors are registered in
                                              the same cgraph */
     std::vector<ZL_Type> defaultSuccessorTypes_{ ZL_Type_serial,
@@ -576,4 +576,4 @@ TEST_F(TestClusteringGraph, TestClusteringValidCodecIndices)
 }
 
 } // namespace
-} // namespace zstrong::tests
+} // namespace openzl::tests

--- a/custom_transforms/json_extract/tests/fuzz_json_extract.cpp
+++ b/custom_transforms/json_extract/tests/fuzz_json_extract.cpp
@@ -13,20 +13,22 @@
 
 using namespace ::testing;
 
-namespace zstrong::tests {
+namespace openzl::tests {
+using namespace zstrong;
+
 namespace {
 std::string compressJson(std::string_view data)
 {
-    CGraph cgraph;
+    zstrong::CGraph cgraph;
     auto node = ZS2_Compressor_registerJsonExtract(cgraph.get(), 0);
     std::vector<ZL_GraphID> store(4, ZL_GRAPH_STORE);
     ZL_GraphID graph = ZL_Compressor_registerStaticGraph_fromNode(
             cgraph.get(), node, store.data(), store.size());
     cgraph.unwrap(ZL_Compressor_selectStartingGraphID(cgraph.get(), graph));
-    CCtx cctx;
+    zstrong::CCtx cctx;
     std::string compressed;
     compressed.resize(data.size() * 6 + 1024);
-    compress(cctx, &compressed, data, cgraph);
+    zstrong::compress(cctx, &compressed, data, cgraph);
     return compressed;
 }
 
@@ -34,9 +36,9 @@ std::string decompressJson(
         std::string_view compressed,
         std::optional<size_t> maxDstSize = std::nullopt)
 {
-    DCtx dctx;
+    zstrong::DCtx dctx;
     dctx.unwrap(ZS2_DCtx_registerJsonExtract(dctx.get(), 0));
-    return decompress(dctx, compressed, maxDstSize);
+    return zstrong::decompress(dctx, compressed, maxDstSize);
 }
 
 std::vector<std::string> const& compressExamples()
@@ -87,4 +89,4 @@ FUZZ(JsonExtractTest, FuzzDecompress)
     }
 }
 
-} // namespace zstrong::tests
+} // namespace openzl::tests

--- a/custom_transforms/json_extract/tests/json_extract_test_data.h
+++ b/custom_transforms/json_extract/tests/json_extract_test_data.h
@@ -7,7 +7,7 @@
 #include <folly/dynamic.h>
 #include <folly/json.h>
 
-namespace zstrong::tests {
+namespace openzl::tests {
 
 template <typename Gen>
 int64_t genInt(Gen& gen)
@@ -104,4 +104,4 @@ inline std::string genJsonLikeData(size_t bytes)
     return genJsonLikeData(gen, bytes);
 }
 
-} // namespace zstrong::tests
+} // namespace openzl::tests

--- a/custom_transforms/json_extract/tests/test_json_extract.cpp
+++ b/custom_transforms/json_extract/tests/test_json_extract.cpp
@@ -14,26 +14,26 @@
 
 using namespace ::testing;
 
-namespace zstrong::tests {
+namespace openzl::tests {
 
 namespace {
 std::string compressJson(std::string_view data)
 {
-    CGraph cgraph;
+    zstrong::CGraph cgraph;
     auto node = ZS2_Compressor_registerJsonExtract(cgraph.get(), 0);
     std::vector<ZL_GraphID> store(4, ZL_GRAPH_STORE);
     ZL_GraphID graph = ZL_Compressor_registerStaticGraph_fromNode(
             cgraph.get(), node, store.data(), store.size());
     cgraph.unwrap(ZL_Compressor_selectStartingGraphID(cgraph.get(), graph));
-    CCtx cctx;
-    return compress(cctx, data, cgraph);
+    zstrong::CCtx cctx;
+    return zstrong::compress(cctx, data, cgraph);
 }
 
 std::string decompressJson(std::string_view compressed)
 {
-    DCtx dctx;
+    zstrong::DCtx dctx;
     dctx.unwrap(ZS2_DCtx_registerJsonExtract(dctx.get(), 0));
-    return decompress(dctx, compressed);
+    return zstrong::decompress(dctx, compressed);
 }
 
 void testRoundTripJson(std::string_view data)
@@ -114,4 +114,4 @@ TEST(TestJsonExtract, JsonLikeData)
 }
 
 } // namespace
-} // namespace zstrong::tests
+} // namespace openzl::tests

--- a/custom_transforms/parse/tests/fuzz_parse.cpp
+++ b/custom_transforms/parse/tests/fuzz_parse.cpp
@@ -11,7 +11,7 @@
 
 using namespace ::testing;
 
-namespace zstrong::tests::parse {
+namespace openzl::tests::parse {
 namespace {
 template <Type kType>
 std::vector<std::string> const& fieldExamples()
@@ -102,4 +102,4 @@ FUZZ(ParseTest, FuzzFloat64Decompress)
     }
 }
 
-} // namespace zstrong::tests::parse
+} // namespace openzl::tests::parse

--- a/custom_transforms/parse/tests/parse_test_data.h
+++ b/custom_transforms/parse/tests/parse_test_data.h
@@ -17,7 +17,7 @@
 #include "openzl/zl_public_nodes.h"
 #include "tools/zstrong_cpp.h"
 
-namespace zstrong::tests::parse {
+namespace openzl::tests::parse {
 inline ZL_SetStringLensInstructions setFieldSizes(
         ZL_SetStringLensState* state,
         ZL_Input const*)
@@ -54,7 +54,7 @@ inline std::pair<std::string, std::vector<uint32_t>> flatten(
 
 inline std::string compress(std::vector<std::string> const& data, Type type)
 {
-    CGraph cgraph;
+    zstrong::CGraph cgraph;
     auto node = type == Type::Int64
             ? ZS2_Compressor_registerParseInt64(cgraph.get(), 0)
             : ZS2_Compressor_registerParseFloat64(cgraph.get(), 1);
@@ -70,7 +70,7 @@ inline std::string compress(std::vector<std::string> const& data, Type type)
     auto const content       = flatten(data).first;
     auto const compressBound = data.size() * 5 + content.size() * 2 + 1000;
 
-    CCtx cctx;
+    zstrong::CCtx cctx;
     cctx.unwrap(ZL_CCtx_setParameter(
             cctx.get(), ZL_CParam_formatVersion, ZL_MAX_FORMAT_VERSION));
     cctx.unwrap(ZL_CCtx_refCompressor(cctx.get(), cgraph.get()));
@@ -91,13 +91,13 @@ inline std::string decompress(
         Type type,
         std::optional<size_t> maxDstSize = std::nullopt)
 {
-    DCtx dctx;
+    zstrong::DCtx dctx;
     if (type == Type::Int64) {
         dctx.unwrap(ZS2_DCtx_registerParseInt64(dctx.get(), 0));
     } else {
         dctx.unwrap(ZS2_DCtx_registerParseFloat64(dctx.get(), 1));
     }
-    return decompress(dctx, compressed, maxDstSize);
+    return zstrong::decompress(dctx, compressed, maxDstSize);
 }
 
 template <typename Gen>
@@ -143,4 +143,4 @@ inline std::vector<std::string> genData(size_t bytes, Type type)
     return genData(gen, bytes, type);
 }
 
-} // namespace zstrong::tests::parse
+} // namespace openzl::tests::parse

--- a/custom_transforms/parse/tests/test_parse.cpp
+++ b/custom_transforms/parse/tests/test_parse.cpp
@@ -12,7 +12,7 @@
 
 using namespace ::testing;
 
-namespace zstrong::tests::parse {
+namespace openzl::tests::parse {
 
 namespace {
 void testRoundTrip(std::vector<std::string> const& data)
@@ -165,4 +165,4 @@ TEST(TestParse, Random)
 }
 
 } // namespace
-} // namespace zstrong::tests::parse
+} // namespace openzl::tests::parse

--- a/custom_transforms/thrift/kernels/tests/fuzz_thrift_kernel.cpp
+++ b/custom_transforms/thrift/kernels/tests/fuzz_thrift_kernel.cpp
@@ -16,8 +16,9 @@
 #include "tests/fuzz_utils.h"
 #include "tests/zstrong/test_zstrong_fixture.h"
 
-namespace zstrong::thrift::tests {
-using namespace zstrong::tests;
+namespace openzl::thrift::tests {
+using namespace openzl::tests;
+using ThriftKernelData = zstrong::thrift::tests::ThriftKernelData;
 
 enum class TransformIDs {
     MapI32Float,
@@ -212,4 +213,4 @@ FUZZ_F(ThriftKernelTest, FuzzDecompress)
     testDecompress(input);
 }
 
-} // namespace zstrong::thrift::tests
+} // namespace openzl::thrift::tests

--- a/custom_transforms/thrift/kernels/tests/thrift_kernel_test_utils.h
+++ b/custom_transforms/thrift/kernels/tests/thrift_kernel_test_utils.h
@@ -29,7 +29,7 @@
 #    include "openzl/dev/custom_transforms/thrift/kernels/tests/gen-cpp2/fuzz_data_visitation.h"
 #endif
 
-namespace zstrong::thrift::tests {
+namespace openzl::thrift::tests {
 template <typename T>
 std::string serialize(const T& value)
 {
@@ -205,17 +205,17 @@ T generate(RNG&& gen)
 }
 
 template <typename T>
-class ThriftProducer : public zstrong::tests::datagen::FixedWidthDataProducer {
+class ThriftProducer : public openzl::tests::datagen::FixedWidthDataProducer {
    public:
     explicit ThriftProducer(
-            std::shared_ptr<zstrong::tests::datagen::RandWrapper> rw,
+            std::shared_ptr<openzl::tests::datagen::RandWrapper> rw,
             size_t maxSamples = 10)
             : FixedWidthDataProducer(rw, 1), dist_(std::move(rw), 5, maxSamples)
     {
     }
 
-    ::zstrong::tests::datagen::FixedWidthData operator()(
-            zstrong::tests::datagen::RandWrapper::NameType name) override
+    ::openzl::tests::datagen::FixedWidthData operator()(
+            openzl::tests::datagen::RandWrapper::NameType name) override
     {
         std::string datum;
         const size_t n = dist_(name);
@@ -223,8 +223,8 @@ class ThriftProducer : public zstrong::tests::datagen::FixedWidthDataProducer {
             // todo: Thrift is important enough we should migrate generate<>()
             // to get structured randomness from randwrapper instead of just
             // using it as an rng. For e.g. fuzzing
-            T value = zstrong::thrift::tests::generate<T>(
-                    zstrong::tests::datagen::RNGEngine<uint64_t>(
+            T value = openzl::thrift::tests::generate<T>(
+                    openzl::tests::datagen::RNGEngine<uint64_t>(
                             rw_.get(),
                             "ThriftProducer::RNGEngine::operator()"));
             apache::thrift::CompactSerializer::serialize(value, &datum);
@@ -238,7 +238,7 @@ class ThriftProducer : public zstrong::tests::datagen::FixedWidthDataProducer {
     }
 
    private:
-    zstrong::tests::datagen::VecLengthDistribution dist_;
+    openzl::tests::datagen::VecLengthDistribution dist_;
 };
 
-} // namespace zstrong::thrift::tests
+} // namespace openzl::thrift::tests

--- a/custom_transforms/thrift/tests/fuzz.cpp
+++ b/custom_transforms/thrift/tests/fuzz.cpp
@@ -16,8 +16,11 @@ using apache::thrift::BinarySerializer;
 using apache::thrift::CompactSerializer;
 using namespace ::testing;
 
-namespace zstrong::thrift::tests {
-using namespace ::zstrong::tests;
+namespace openzl::thrift::tests {
+
+using namespace zstrong::thrift;
+namespace cpp2 = zstrong::thrift::tests::cpp2;
+using namespace ::openzl::tests;
 namespace lionhead = ::facebook::security::lionhead;
 
 namespace {
@@ -117,17 +120,15 @@ std::pair<int, int> genFormatVersions(
             lionhead::fdp::Coin(0.9).gen(
                     "should_format_versions_be_compatible", f)
             || mode == GenFormatVersionsMode::kForceCompatible;
-    int const encoderFormatVersion = helper(
-            ::zstrong::thrift::kMinFormatVersionEncode, ZL_MAX_FORMAT_VERSION);
+    int const encoderFormatVersion =
+            helper(kMinFormatVersionEncode, ZL_MAX_FORMAT_VERSION);
     if (useCompatibleVersions) {
         int const configFormatVersion =
-                helper(::zstrong::thrift::kMinFormatVersionEncode,
-                       encoderFormatVersion);
+                helper(kMinFormatVersionEncode, encoderFormatVersion);
         return { configFormatVersion, encoderFormatVersion };
     } else {
         int const configFormatVersion =
-                helper(::zstrong::thrift::kMinFormatVersionEncode,
-                       ZL_MAX_FORMAT_VERSION);
+                helper(kMinFormatVersionEncode, ZL_MAX_FORMAT_VERSION);
         return { configFormatVersion, encoderFormatVersion };
     }
 }
@@ -268,4 +269,4 @@ FUZZ_F(ProbSelectorTest, FuzzRoundTrip)
             convertedInput);
 }
 
-} // namespace zstrong::thrift::tests
+} // namespace openzl::thrift::tests

--- a/custom_transforms/thrift/tests/test_prob_selector.cpp
+++ b/custom_transforms/thrift/tests/test_prob_selector.cpp
@@ -4,7 +4,7 @@
 #include "custom_transforms/thrift/tests/test_prob_selector_fixture.h"
 #include "openzl/zl_public_nodes.h"
 
-namespace zstrong::thrift::tests {
+namespace openzl::thrift::tests {
 
 // A test that tests a few random inputs and checks the graph ID obtained is
 // correct.
@@ -113,4 +113,4 @@ TEST_F(ProbSelectorTest, ProbSelectorRoundTrip)
                 sample);
     }
 }
-} // namespace zstrong::thrift::tests
+} // namespace openzl::thrift::tests

--- a/custom_transforms/thrift/tests/test_prob_selector_fixture.cpp
+++ b/custom_transforms/thrift/tests/test_prob_selector_fixture.cpp
@@ -1,12 +1,14 @@
 // Copyright (c) Meta Platforms, Inc. and affiliates.
 
 #include "custom_transforms/thrift/tests/test_prob_selector_fixture.h"
+
+#include "custom_transforms/thrift/constants.h" // @manual
 #include "custom_transforms/thrift/probabilistic_selector.h"
 
 #include "openzl/zl_compressor.h"
 #include "openzl/zl_decompress.h"
 
-namespace zstrong::thrift::tests {
+namespace openzl::thrift::tests {
 
 ZL_Report ProbSelectorTest::compress(
         ZL_Compressor* const cgraph,
@@ -134,4 +136,4 @@ size_t ProbSelectorTest::compressWithGid(
     free(dstBuff);
     return ZL_validResult(result);
 }
-} // namespace zstrong::thrift::tests
+} // namespace openzl::thrift::tests

--- a/custom_transforms/thrift/tests/test_prob_selector_fixture.h
+++ b/custom_transforms/thrift/tests/test_prob_selector_fixture.h
@@ -9,11 +9,11 @@
 
 #pragma once
 
-namespace zstrong::thrift::tests {
+namespace openzl::thrift::tests {
 
 class ProbSelectorTest : public ::testing::Test {
    public:
-    ::zstrong::tests::datagen::DataGen dataGen_;
+    ::openzl::tests::datagen::DataGen dataGen_;
 
     void testRoundTrip(
             ZL_GraphID* selGraphs,
@@ -45,4 +45,4 @@ class ProbSelectorTest : public ::testing::Test {
             const void* compressed,
             size_t cSize);
 };
-} // namespace zstrong::thrift::tests
+} // namespace openzl::thrift::tests

--- a/custom_transforms/thrift/tests/test_round_trip.cpp
+++ b/custom_transforms/thrift/tests/test_round_trip.cpp
@@ -12,7 +12,11 @@
 using apache::thrift::BinarySerializer;
 using apache::thrift::CompactSerializer;
 
-namespace zstrong::thrift::tests {
+namespace openzl::thrift::tests {
+
+using namespace zstrong::thrift;
+namespace cpp2 = zstrong::thrift::tests::cpp2;
+
 namespace {
 // Test round-trip where the root type is not T_STRUCT
 template <typename Serializer>
@@ -134,7 +138,7 @@ TEST(RoundTripTest, TestTulipV2)
 
     std::mt19937 gen(0xdeadbeef);
     for (size_t n = 1; n < 10; ++n) {
-        auto data = zstrong::tulip_v2::tests::generateTulipV2(n, gen);
+        auto data = openzl::tulip_v2::tests::generateTulipV2(n, gen);
         EXPECT_NO_THROW(runThriftSplitterRoundTrip(
                 thriftCompactConfigurableSplitter,
                 data,
@@ -296,4 +300,4 @@ TEST(RoundTripTest, OldStyleVSF)
                 ZL_MAX_FORMAT_VERSION));
     }
 }
-} // namespace zstrong::thrift::tests
+} // namespace openzl::thrift::tests

--- a/custom_transforms/thrift/tests/test_serialization.cpp
+++ b/custom_transforms/thrift/tests/test_serialization.cpp
@@ -10,7 +10,9 @@
 #    include "openzl/dev/custom_transforms/thrift/gen-cpp2/parse_config_types.h" // @manual
 #endif
 
-namespace zstrong::thrift::tests {
+namespace openzl::thrift::tests {
+
+using namespace zstrong::thrift;
 
 TEST(ConfigSerializationTest, RoundTrip)
 {
@@ -369,4 +371,4 @@ TEST(ConfigSerializationTest, RejectIllegalListLengthsSplit)
     EXPECT_NO_THROW(builder.finalize());
 }
 
-} // namespace zstrong::thrift::tests
+} // namespace openzl::thrift::tests

--- a/custom_transforms/thrift/tests/test_split.cpp
+++ b/custom_transforms/thrift/tests/test_split.cpp
@@ -13,7 +13,11 @@
 using apache::thrift::BinarySerializer;
 using apache::thrift::CompactSerializer;
 
-namespace zstrong::thrift::tests {
+namespace openzl::thrift::tests {
+
+using namespace zstrong::thrift;
+namespace cpp2 = zstrong::thrift::tests::cpp2;
+
 namespace {
 
 template <typename Parser, typename Serializer>
@@ -325,4 +329,4 @@ TEST(SplitTest, CompactAgainstBinary)
     }
 }
 
-} // namespace zstrong::thrift::tests
+} // namespace openzl::thrift::tests

--- a/custom_transforms/thrift/tests/util.cpp
+++ b/custom_transforms/thrift/tests/util.cpp
@@ -13,7 +13,11 @@
 #include "openzl/zl_data.h"
 #include "tools/zstrong_cpp.h" // @manual
 
-namespace zstrong::thrift::tests {
+namespace openzl::thrift::tests {
+
+using namespace zstrong::thrift;
+namespace cpp2 = zstrong::thrift::tests::cpp2;
+
 namespace {
 // TODO(T190725275) Hard-coding the list of paths is brittle: for example, if we
 // add a new special ThriftNodeId, we'd need to update the list manually. The
@@ -24,39 +28,72 @@ namespace {
 // For the short term, as long as we check this list against the TestStruct
 // schema in code review, our coverage should be fine. The schema can be found
 // at https://fburl.com/code/chgygv3s.
-std::vector<std::pair<ThriftPath, TType>> getAllPaths()
+std::vector<std::pair<zstrong::thrift::ThriftPath, zstrong::thrift::TType>>
+getAllPaths()
 {
-    std::vector<std::pair<ThriftPath, TType>> suffixes = {
-        { { ThriftNodeId(-1) }, TType::T_BYTE },
-        { { ThriftNodeId(-2) }, TType::T_BOOL },
-        { { ThriftNodeId(1) }, TType::T_I16 },
-        { { ThriftNodeId(42) }, TType::T_I32 },
-        { { ThriftNodeId(2) }, TType::T_I64 },
-        { { ThriftNodeId(3) }, TType::T_FLOAT },
-        { { ThriftNodeId(4) }, TType::T_DOUBLE },
-        { { ThriftNodeId(5) }, TType::T_STRING },
-        { { ThriftNodeId(5), ThriftNodeId::kLength }, TType::T_U32 },
-        { { ThriftNodeId(6), ThriftNodeId::kListElem }, TType::T_BOOL },
-        { { ThriftNodeId(6), ThriftNodeId::kLength }, TType::T_U32 },
-        { { ThriftNodeId(7), ThriftNodeId::kMapKey }, TType::T_STRING },
-        { { ThriftNodeId(7), ThriftNodeId::kMapValue }, TType::T_BOOL },
-        { { ThriftNodeId(7), ThriftNodeId::kLength }, TType::T_U32 },
-        { { ThriftNodeId(7), ThriftNodeId::kMapKey, ThriftNodeId::kLength },
-          TType::T_U32 },
-        { { ThriftNodeId(8), ThriftNodeId::kListElem }, TType::T_I32 },
-        { { ThriftNodeId(8), ThriftNodeId::kLength }, TType::T_U32 },
-        { { ThriftNodeId(-123) }, TType::T_FLOAT }, // include a fake path
+    std::vector<std::pair<zstrong::thrift::ThriftPath, zstrong::thrift::TType>>
+            suffixes = {
+                { { zstrong::thrift::ThriftNodeId(-1) },
+                  zstrong::thrift::TType::T_BYTE },
+                { { zstrong::thrift::ThriftNodeId(-2) },
+                  zstrong::thrift::TType::T_BOOL },
+                { { zstrong::thrift::ThriftNodeId(1) },
+                  zstrong::thrift::TType::T_I16 },
+                { { zstrong::thrift::ThriftNodeId(42) },
+                  zstrong::thrift::TType::T_I32 },
+                { { zstrong::thrift::ThriftNodeId(2) },
+                  zstrong::thrift::TType::T_I64 },
+                { { zstrong::thrift::ThriftNodeId(3) },
+                  zstrong::thrift::TType::T_FLOAT },
+                { { zstrong::thrift::ThriftNodeId(4) },
+                  zstrong::thrift::TType::T_DOUBLE },
+                { { zstrong::thrift::ThriftNodeId(5) },
+                  zstrong::thrift::TType::T_STRING },
+                { { zstrong::thrift::ThriftNodeId(5),
+                    zstrong::thrift::ThriftNodeId::kLength },
+                  zstrong::thrift::TType::T_U32 },
+                { { zstrong::thrift::ThriftNodeId(6),
+                    zstrong::thrift::ThriftNodeId::kListElem },
+                  zstrong::thrift::TType::T_BOOL },
+                { { zstrong::thrift::ThriftNodeId(6),
+                    zstrong::thrift::ThriftNodeId::kLength },
+                  zstrong::thrift::TType::T_U32 },
+                { { zstrong::thrift::ThriftNodeId(7),
+                    zstrong::thrift::ThriftNodeId::kMapKey },
+                  zstrong::thrift::TType::T_STRING },
+                { { zstrong::thrift::ThriftNodeId(7),
+                    zstrong::thrift::ThriftNodeId::kMapValue },
+                  zstrong::thrift::TType::T_BOOL },
+                { { zstrong::thrift::ThriftNodeId(7),
+                    zstrong::thrift::ThriftNodeId::kLength },
+                  zstrong::thrift::TType::T_U32 },
+                { { zstrong::thrift::ThriftNodeId(7),
+                    zstrong::thrift::ThriftNodeId::kMapKey,
+                    zstrong::thrift::ThriftNodeId::kLength },
+                  zstrong::thrift::TType::T_U32 },
+                { { zstrong::thrift::ThriftNodeId(8),
+                    zstrong::thrift::ThriftNodeId::kListElem },
+                  zstrong::thrift::TType::T_I32 },
+                { { zstrong::thrift::ThriftNodeId(8),
+                    zstrong::thrift::ThriftNodeId::kLength },
+                  zstrong::thrift::TType::T_U32 },
+                { { zstrong::thrift::ThriftNodeId(-123) },
+                  zstrong::thrift::TType::T_FLOAT }, // include a fake path
+            };
+
+    std::vector<zstrong::thrift::ThriftPath> prefixes = {
+        { zstrong::thrift::ThriftNodeId(4) },
+        { zstrong::thrift::ThriftNodeId(3) },
+        { zstrong::thrift::ThriftNodeId(2),
+          zstrong::thrift::ThriftNodeId::kListElem },
+        { zstrong::thrift::ThriftNodeId(1),
+          zstrong::thrift::ThriftNodeId::kMapKey },
+        { zstrong::thrift::ThriftNodeId(1),
+          zstrong::thrift::ThriftNodeId::kMapValue },
     };
 
-    std::vector<ThriftPath> prefixes = {
-        { ThriftNodeId(4) },
-        { ThriftNodeId(3) },
-        { ThriftNodeId(2), ThriftNodeId::kListElem },
-        { ThriftNodeId(1), ThriftNodeId::kMapKey },
-        { ThriftNodeId(1), ThriftNodeId::kMapValue },
-    };
-
-    std::vector<std::pair<ThriftPath, TType>> result;
+    std::vector<std::pair<zstrong::thrift::ThriftPath, zstrong::thrift::TType>>
+            result;
     result.reserve(prefixes.size() * suffixes.size());
     for (const auto& prefix : prefixes) {
         for (const auto& [innerPath, innerType] : suffixes) {
@@ -70,13 +107,17 @@ std::vector<std::pair<ThriftPath, TType>> getAllPaths()
 }
 
 // Work around the annoying kLength bug
-std::vector<std::pair<ThriftPath, TType>> purgeLengthOnlySplits(
-        const std::vector<std::pair<ThriftPath, TType>>& paths)
+std::vector<std::pair<zstrong::thrift::ThriftPath, zstrong::thrift::TType>>
+purgeLengthOnlySplits(
+        const std::vector<
+                std::pair<zstrong::thrift::ThriftPath, zstrong::thrift::TType>>&
+                paths)
 {
-    std::set<ThriftPath> dataPrefixes;
+    std::set<zstrong::thrift::ThriftPath> dataPrefixes;
     for (auto& [path, _] : paths) {
-        if (!path.empty() && path.back() != ThriftNodeId::kLength) {
-            ThriftPath prefix(path.begin(), path.end() - 1);
+        if (!path.empty()
+            && path.back() != zstrong::thrift::ThriftNodeId::kLength) {
+            zstrong::thrift::ThriftPath prefix(path.begin(), path.end() - 1);
             dataPrefixes.insert(std::move(prefix));
             dataPrefixes.insert(path);
         }
@@ -88,8 +129,9 @@ std::vector<std::pair<ThriftPath, TType>> purgeLengthOnlySplits(
         if (path.empty()) {
             continue;
         }
-        if (path.back() == ThriftNodeId::kLength) {
-            const ThriftPath prefix(path.begin(), path.end() - 1);
+        if (path.back() == zstrong::thrift::ThriftNodeId::kLength) {
+            const zstrong::thrift::ThriftPath prefix(
+                    path.begin(), path.end() - 1);
             if (!dataPrefixes.contains(prefix)) {
                 // It's illegal to split lengths without data
                 continue;
@@ -101,12 +143,15 @@ std::vector<std::pair<ThriftPath, TType>> purgeLengthOnlySplits(
 }
 
 // Support for string length paths is removed in format version 14
-std::vector<std::pair<ThriftPath, TType>> purgeStringLengthPaths(
-        const std::vector<std::pair<ThriftPath, TType>>& paths)
+std::vector<std::pair<zstrong::thrift::ThriftPath, zstrong::thrift::TType>>
+purgeStringLengthPaths(
+        const std::vector<
+                std::pair<zstrong::thrift::ThriftPath, zstrong::thrift::TType>>&
+                paths)
 {
-    std::set<ThriftPath> stringVsfPaths;
+    std::set<zstrong::thrift::ThriftPath> stringVsfPaths;
     for (auto& [path, type] : paths) {
-        if (type == TType::T_STRING) {
+        if (type == zstrong::thrift::TType::T_STRING) {
             stringVsfPaths.insert(path);
         }
     }
@@ -117,8 +162,9 @@ std::vector<std::pair<ThriftPath, TType>> purgeStringLengthPaths(
         if (path.empty()) {
             continue;
         }
-        if (path.back() == ThriftNodeId::kLength) {
-            const ThriftPath prefix(path.begin(), path.end() - 1);
+        if (path.back() == zstrong::thrift::ThriftNodeId::kLength) {
+            const zstrong::thrift::ThriftPath prefix(
+                    path.begin(), path.end() - 1);
             if (stringVsfPaths.contains(prefix)) {
                 // Lengths are already covered by the corresponding VSF path
                 continue;
@@ -270,7 +316,7 @@ std::string buildValidEncoderConfig(
         int maxFormatVersion)
 {
     std::mt19937 gen(seed);
-    EncoderConfigBuilder builder;
+    zstrong::thrift::EncoderConfigBuilder builder;
 
     // Add a random subset of possible paths to the config
     {
@@ -281,7 +327,7 @@ std::string buildValidEncoderConfig(
                 : std::uniform_real_distribution<double>(0.0, 1.0)(gen);
         paths.resize(size_t(fractionOfPathsToUse * paths.size()));
         paths = purgeLengthOnlySplits(paths);
-        if (maxFormatVersion >= kMinFormatVersionStringVSF) {
+        if (maxFormatVersion >= zstrong::thrift::kMinFormatVersionStringVSF) {
             paths = purgeStringLengthPaths(paths);
         }
         for (const auto& [path, type] : paths) {
@@ -290,10 +336,10 @@ std::string buildValidEncoderConfig(
     }
 
     // Cluster a random subset of paths
-    std::set<ThriftPath> clusteredPaths{};
-    if (minFormatVersion >= kMinFormatVersionEncodeClusters) {
-        folly::F14FastMap<TType, size_t> clusterIndices;
-        clusterIndices.reserve(size_t(TType::T_FLOAT));
+    std::set<zstrong::thrift::ThriftPath> clusteredPaths{};
+    if (minFormatVersion >= zstrong::thrift::kMinFormatVersionEncodeClusters) {
+        folly::F14FastMap<zstrong::thrift::TType, size_t> clusterIndices;
+        clusterIndices.reserve(size_t(zstrong::thrift::TType::T_FLOAT));
         for (const auto& [_, pathInfo] : builder.pathMap()) {
             if (!clusterIndices.contains(pathInfo.type)) {
                 clusterIndices.emplace(
@@ -334,11 +380,12 @@ std::string buildValidEncoderConfig(
     if (seed == kDefaultConfigSeed && mode == ConfigGenMode::kMoreCoverage) {
         assert(builder.pathMap().size() >= 20);
 
-        if (minFormatVersion >= kMinFormatVersionEncodeClusters) {
+        if (minFormatVersion
+            >= zstrong::thrift::kMinFormatVersionEncodeClusters) {
             assert(!builder.clusters().empty());
             assert(builder.clusters().front().idList.size() >= 2);
 
-            folly::F14FastSet<TType> clusteredTypes;
+            folly::F14FastSet<zstrong::thrift::TType> clusteredTypes;
             for (int i = 0; i < builder.clusters().size(); ++i) {
                 clusteredTypes.insert(builder.getClusterType(i));
             }
@@ -349,4 +396,4 @@ std::string buildValidEncoderConfig(
     return result;
 }; // namespace
 
-} // namespace zstrong::thrift::tests
+} // namespace openzl::thrift::tests

--- a/custom_transforms/thrift/tests/util.h
+++ b/custom_transforms/thrift/tests/util.h
@@ -32,7 +32,9 @@
 
 #pragma once
 
-namespace zstrong::thrift::tests {
+namespace openzl::thrift::tests {
+
+using namespace zstrong::thrift;
 
 // Works for any ZL_VOEncoderDesc which takes Thrift splitter localParams.
 // In other words, this function works equally well for TCompact and TBinary.
@@ -108,7 +110,8 @@ std::string buildValidEncoderConfig(
 template <typename Serializer, typename RNG>
 std::string generateRandomThrift(RNG&& gen)
 {
-    const auto testStruct = generate<cpp2::TestStruct>(std::forward<RNG>(gen));
+    const auto testStruct = generate<zstrong::thrift::tests::cpp2::TestStruct>(
+            std::forward<RNG>(gen));
     return Serializer::template serialize<std::string>(testStruct);
 }
 
@@ -119,20 +122,20 @@ inline size_t thriftSplitCompressBound(size_t srcSize, size_t configSize)
 
 template <typename Serializer>
 class ConfigurableThriftProducer
-        : public zstrong::tests::datagen::FixedWidthDataProducer {
+        : public openzl::tests::datagen::FixedWidthDataProducer {
    public:
     explicit ConfigurableThriftProducer(
-            std::shared_ptr<zstrong::tests::datagen::RandWrapper> rw)
+            std::shared_ptr<openzl::tests::datagen::RandWrapper> rw)
             : FixedWidthDataProducer(std::move(rw), 1)
     {
     }
 
-    ::zstrong::tests::datagen::FixedWidthData operator()(
-            zstrong::tests::datagen::RandWrapper::NameType) override
+    ::openzl::tests::datagen::FixedWidthData operator()(
+            openzl::tests::datagen::RandWrapper::NameType) override
     {
         return {
             generateRandomThrift<Serializer>(
-                    zstrong::tests::datagen::RNGEngine<uint32_t>(
+                    openzl::tests::datagen::RNGEngine<uint32_t>(
                             this->rw_.get(),
                             "ConfigurableThriftProducer::RNG::operator()")),
             1
@@ -145,4 +148,4 @@ class ConfigurableThriftProducer
     }
 };
 
-} // namespace zstrong::thrift::tests
+} // namespace openzl::thrift::tests

--- a/custom_transforms/tulip_v2/tests/fuzz_tulip_v2.cpp
+++ b/custom_transforms/tulip_v2/tests/fuzz_tulip_v2.cpp
@@ -11,8 +11,9 @@
 
 using namespace ::testing;
 
-namespace zstrong::tulip_v2::tests {
-using namespace zstrong::tests;
+namespace openzl::tulip_v2::tests {
+using namespace openzl::tests;
+using zstrong::tulip_v2::TulipV2Successors;
 
 namespace {
 template <typename FDP>
@@ -97,4 +98,4 @@ FUZZ(TulipV2Test, FuzzDecompress)
     }
 }
 
-} // namespace zstrong::tulip_v2::tests
+} // namespace openzl::tulip_v2::tests

--- a/custom_transforms/tulip_v2/tests/fuzz_tulip_v2_generator.cpp
+++ b/custom_transforms/tulip_v2/tests/fuzz_tulip_v2_generator.cpp
@@ -14,7 +14,7 @@
 #include "custom_transforms/tulip_v2/tests/tulip_v2_data_utils.h"
 
 namespace {
-using namespace zstrong::tulip_v2::tests;
+using namespace openzl::tulip_v2::tests;
 namespace fs = std::filesystem;
 
 std::vector<std::string> generateFuzzCompressCorpus()

--- a/custom_transforms/tulip_v2/tests/test_tulip_v2.cpp
+++ b/custom_transforms/tulip_v2/tests/test_tulip_v2.cpp
@@ -7,7 +7,7 @@
 #include "custom_transforms/tulip_v2/encode_tulip_v2.h"
 #include "custom_transforms/tulip_v2/tests/tulip_v2_data_utils.h"
 
-namespace zstrong::tulip_v2::tests {
+namespace openzl::tulip_v2::tests {
 using namespace ::testing;
 
 TEST(TulipV2Test, RoundTripDefaultSuccessors)
@@ -20,4 +20,4 @@ TEST(TulipV2Test, RoundTripDefaultSuccessors)
         ASSERT_TRUE(data == decompressed);
     }
 }
-} // namespace zstrong::tulip_v2::tests
+} // namespace openzl::tulip_v2::tests

--- a/custom_transforms/tulip_v2/tests/tulip_v2_data_utils.cpp
+++ b/custom_transforms/tulip_v2/tests/tulip_v2_data_utils.cpp
@@ -7,8 +7,8 @@
 
 #include "tools/cxx/Resources.h"
 
-namespace zstrong::tulip_v2::tests {
+namespace openzl::tulip_v2::tests {
 
 namespace {
 
-} // namespace zstrong::tulip_v2::tests
+} // namespace openzl::tulip_v2::tests

--- a/custom_transforms/tulip_v2/tests/tulip_v2_data_utils.h
+++ b/custom_transforms/tulip_v2/tests/tulip_v2_data_utils.h
@@ -31,8 +31,9 @@
 #    include "openzl/dev/custom_transforms/tulip_v2/tests/gen-cpp2/tulip_v2_data_visitation.h"
 #endif
 
-namespace zstrong::tulip_v2::tests {
-using zstrong::thrift::tests::generate;
+namespace openzl::tulip_v2::tests {
+using openzl::thrift::tests::generate;
+using zstrong::tulip_v2::tests::TulipV2Data;
 
 inline std::string encodeTulipV2(TulipV2Data const& data)
 {
@@ -60,21 +61,21 @@ std::string generateTulipV2(size_t n, RNG&& gen)
     return out;
 }
 
-class TulipV2Producer : public zstrong::tests::datagen::FixedWidthDataProducer {
+class TulipV2Producer : public openzl::tests::datagen::FixedWidthDataProducer {
    public:
     explicit TulipV2Producer(
-            std::shared_ptr<zstrong::tests::datagen::RandWrapper> rw,
+            std::shared_ptr<openzl::tests::datagen::RandWrapper> rw,
             size_t maxSamples = 10)
             : FixedWidthDataProducer(rw, 1), dist_(rw, 5, maxSamples)
     {
     }
 
-    ::zstrong::tests::datagen::FixedWidthData operator()(
-            ::zstrong::tests::datagen::RandWrapper::NameType name) override
+    ::openzl::tests::datagen::FixedWidthData operator()(
+            ::openzl::tests::datagen::RandWrapper::NameType name) override
     {
         return { generateTulipV2(
                          dist_(name),
-                         zstrong::tests::datagen::RNGEngine<uint32_t>(
+                         openzl::tests::datagen::RNGEngine<uint32_t>(
                                  this->rw_.get(),
                                  "TulipV2Producer::RNGEngine::operator()")),
                  1 };
@@ -86,22 +87,23 @@ class TulipV2Producer : public zstrong::tests::datagen::FixedWidthDataProducer {
     }
 
    private:
-    ::zstrong::tests::datagen::VecLengthDistribution dist_;
+    ::openzl::tests::datagen::VecLengthDistribution dist_;
 };
 
 inline std::string compressTulipV2(
         std::string_view data,
-        TulipV2Successors const& successors,
+        zstrong::tulip_v2::TulipV2Successors const& successors,
         std::optional<size_t> minDstCapacity = std::nullopt)
 {
-    CGraph cgraph;
-    auto graph = createTulipV2Graph(cgraph.get(), successors, 0, 100);
+    zstrong::CGraph cgraph;
+    auto graph = zstrong::tulip_v2::createTulipV2Graph(
+            cgraph.get(), successors, 0, 100);
     cgraph.unwrap(ZL_Compressor_selectStartingGraphID(cgraph.get(), graph));
     size_t const compressBound = ZL_compressBound(data.size());
     std::string compressed;
     compressed.resize(
             std::max(compressBound, minDstCapacity.value_or(compressBound)));
-    CCtx cctx;
+    zstrong::CCtx cctx;
     cctx.unwrap(ZL_CCtx_refCompressor(cctx.get(), cgraph.get()));
     cctx.unwrap(ZL_CCtx_setParameter(
             cctx.get(), ZL_CParam_formatVersion, ZL_MAX_FORMAT_VERSION));
@@ -119,9 +121,10 @@ inline std::string decompressTulipV2(
         std::string_view data,
         std::optional<size_t> maxDstSize = std::nullopt)
 {
-    DCtx dctx;
-    dctx.unwrap(registerCustomTransforms(dctx.get(), 0, 100));
-    return decompress(dctx, data, maxDstSize);
+    zstrong::DCtx dctx;
+    dctx.unwrap(
+            zstrong::tulip_v2::registerCustomTransforms(dctx.get(), 0, 100));
+    return zstrong::decompress(dctx, data, maxDstSize);
 }
 
-} // namespace zstrong::tulip_v2::tests
+} // namespace openzl::tulip_v2::tests

--- a/py/pyproject.toml
+++ b/py/pyproject.toml
@@ -1,7 +1,7 @@
 # Copyright (c) Meta Platforms, Inc. and affiliates.
 
 [build-system]
-requires = ["scikit-build-core >=0.11.5", "nanobind >=2.7.0"]
+requires = ["scikit-build-core >=0.11.5", "nanobind >=2.7.0, <2.10.0"]
 build-backend = "scikit_build_core.build"
 
 # TODO: Figure out how to get the version from zl_version.h

--- a/tests/codecs/test_sddl.cpp
+++ b/tests/codecs/test_sddl.cpp
@@ -241,7 +241,7 @@ TEST_F(SimpleDataDescriptionLanguageTest, TrivialRoundtrip)
     const auto prog   = R"(
         : Byte[_rem]
     )";
-    const auto& input = zstrong::tests::kLoremTestInput;
+    const auto& input = openzl::tests::kLoremTestInput;
     roundtrip(prog, input);
 }
 

--- a/tests/codecs/test_sddl2.cpp
+++ b/tests/codecs/test_sddl2.cpp
@@ -239,7 +239,7 @@ TEST_F(SimpleDataDescriptionLanguageV2Test, TrivialRoundtrip)
     const auto prog   = R"(
         : Byte[_rem]
     )";
-    const auto& input = zstrong::tests::kLoremTestInput;
+    const auto& input = openzl::tests::kLoremTestInput;
     roundtrip(prog, input);
 }
 

--- a/tests/compress/test_cgraph.cpp
+++ b/tests/compress/test_cgraph.cpp
@@ -17,8 +17,8 @@
 #include "tests/utils.h"
 
 using namespace ::testing;
-using namespace ::zstrong::tests;
-using namespace ::zstrong::tests::datagen;
+using namespace ::openzl::tests;
+using namespace ::openzl::tests::datagen;
 
 namespace {
 

--- a/tests/compress/test_compressor_serialization.cpp
+++ b/tests/compress/test_compressor_serialization.cpp
@@ -14,7 +14,7 @@
 
 using namespace ::testing;
 
-namespace zstrong {
+namespace openzl {
 namespace tests {
 
 namespace {
@@ -340,4 +340,4 @@ TEST_F(CompressorSerializationTest, GetDepsWithCompressor)
 }
 
 } // namespace tests
-} // namespace zstrong
+} // namespace openzl

--- a/tests/compress/test_features.cpp
+++ b/tests/compress/test_features.cpp
@@ -47,7 +47,7 @@ void generateStreamAndVerifyIntegerFeatures(
         const std::map<std::string, double>& featureMap)
 {
     ASSERT_TRUE(std::is_arithmetic<T>::value);
-    zstrong::tests::WrappedStream<T> stream(streamData, ZL_Type_numeric);
+    openzl::tests::WrappedStream<T> stream(streamData, ZL_Type_numeric);
 
     verifyIntegerFeatures(stream.getStream(), featureMap);
 }

--- a/tests/compress/test_gbt.cpp
+++ b/tests/compress/test_gbt.cpp
@@ -359,7 +359,7 @@ class GBTBinaryModelTest : public Test {
 
     GBTModel model;
 
-    std::unique_ptr<zstrong::tests::WrappedStream<int>> stream;
+    std::unique_ptr<openzl::tests::WrappedStream<int>> stream;
 
     void SetUp() override
     {
@@ -406,7 +406,7 @@ class GBTBinaryModelTest : public Test {
                   .nbFeatures       = featureLabels.size(),
                   .featureLabels    = featureLabels.data() };
 
-        stream = std::make_unique<zstrong::tests::WrappedStream<int>>(
+        stream = std::make_unique<openzl::tests::WrappedStream<int>>(
                 streamData, ZL_Type_numeric);
     }
 
@@ -479,7 +479,7 @@ class GBTMultiClassModelTest : public GBTMultiClassForestTest {
     std::unique_ptr<GBTPredictor> multiClassPredictor;
     GBTModel model;
 
-    std::unique_ptr<zstrong::tests::WrappedStream<int>> stream;
+    std::unique_ptr<openzl::tests::WrappedStream<int>> stream;
 
     void SetUp() override
     {
@@ -529,7 +529,7 @@ class GBTMultiClassModelTest : public GBTMultiClassForestTest {
                   .nbFeatures       = featureLabels.size(),
                   .featureLabels    = featureLabels.data() };
 
-        stream = std::make_unique<zstrong::tests::WrappedStream<int>>(
+        stream = std::make_unique<openzl::tests::WrappedStream<int>>(
                 streamData, ZL_Type_numeric);
     }
 

--- a/tests/compress/test_generic_clustering.cpp
+++ b/tests/compress/test_generic_clustering.cpp
@@ -91,7 +91,7 @@ static std::ostream& operator<<(
     return os;
 }
 
-namespace zstrong::tests {
+namespace openzl::tests {
 namespace {
 
 class GenericClusteringTest : public testing::Test {
@@ -409,4 +409,4 @@ TEST_F(GenericClusteringTest, TestEmptyConfig)
 }
 
 } // namespace
-} // namespace zstrong::tests
+} // namespace openzl::tests

--- a/tests/compress/test_zstrong_ml_core_models_generator.cpp
+++ b/tests/compress/test_zstrong_ml_core_models_generator.cpp
@@ -18,7 +18,7 @@ void createStreamAndVerifyPrediction(
      * Creates a ZL_Data and populates it with the data from streamData. Uses
      * GBTModel to make a prediction and verifies the prediction.
      */
-    zstrong::tests::WrappedStream<int> stream(streamData, ZL_Type_numeric);
+    openzl::tests::WrappedStream<int> stream(streamData, ZL_Type_numeric);
 
     ZL_RESULT_OF(Label)
     predicted = GBTModel_predict(&gbtModel, stream.getStream());

--- a/tests/constants.h
+++ b/tests/constants.h
@@ -1,7 +1,7 @@
 // Copyright (c) Meta Platforms, Inc. and affiliates.
 #pragma once
 
-namespace zstrong {
+namespace openzl {
 namespace tests {
 
 // Maximum number of nodes to include in a graph when creating a random graph
@@ -15,4 +15,4 @@ static size_t constexpr kMaxNodesInGraph = 20;
 static size_t constexpr kMaxGraphDepth = 4;
 
 } // namespace tests
-} // namespace zstrong
+} // namespace openzl

--- a/tests/datagen/DataGen.h
+++ b/tests/datagen/DataGen.h
@@ -10,7 +10,7 @@
 #include "tests/datagen/structures/StringProducer.h"
 #include "tests/datagen/structures/VectorProducer.h"
 
-namespace zstrong::tests::datagen {
+namespace openzl::tests::datagen {
 
 class DataGen {
    public:
@@ -195,4 +195,4 @@ class DataGen {
     std::shared_ptr<RandWrapper> rw_;
 };
 
-} // namespace zstrong::tests::datagen
+} // namespace openzl::tests::datagen

--- a/tests/datagen/DataProducer.h
+++ b/tests/datagen/DataProducer.h
@@ -6,7 +6,7 @@
 
 #include "tests/datagen/random_producer/RandWrapper.h"
 
-namespace zstrong::tests::datagen {
+namespace openzl::tests::datagen {
 
 /**
  * Base class for all data-generating objects.
@@ -30,4 +30,4 @@ std::ostream& operator<<(std::ostream& os, const DataProducer<RetType>& dist)
     return os;
 }
 
-} // namespace zstrong::tests::datagen
+} // namespace openzl::tests::datagen

--- a/tests/datagen/InputExpander.cpp
+++ b/tests/datagen/InputExpander.cpp
@@ -5,7 +5,7 @@
 #include <cstring>
 #include <stdexcept>
 
-namespace zstrong::tests::datagen {
+namespace openzl::tests::datagen {
 
 namespace {
 
@@ -117,4 +117,4 @@ InputExpander::expandStringWithMutation(
     return std::make_pair(result, newSizes);
 }
 
-} // namespace zstrong::tests::datagen
+} // namespace openzl::tests::datagen

--- a/tests/datagen/InputExpander.h
+++ b/tests/datagen/InputExpander.h
@@ -6,7 +6,7 @@
 #include <random>
 #include <string>
 
-namespace zstrong::tests::datagen {
+namespace openzl::tests::datagen {
 
 class InputExpander {
    public:
@@ -27,4 +27,4 @@ class InputExpander {
     InputExpander() = default;
 };
 
-} // namespace zstrong::tests::datagen
+} // namespace openzl::tests::datagen

--- a/tests/datagen/distributions/ConstantDistribution.h
+++ b/tests/datagen/distributions/ConstantDistribution.h
@@ -4,7 +4,7 @@
 
 #include "tests/datagen/distributions/Distribution.h"
 
-namespace zstrong::tests::datagen {
+namespace openzl::tests::datagen {
 
 template <typename RetType>
 class ConstantDistribution : public Distribution<RetType> {
@@ -25,4 +25,4 @@ class ConstantDistribution : public Distribution<RetType> {
     const RetType value_;
 };
 
-} // namespace zstrong::tests::datagen
+} // namespace openzl::tests::datagen

--- a/tests/datagen/distributions/Distribution.h
+++ b/tests/datagen/distributions/Distribution.h
@@ -7,7 +7,7 @@
 #include "tests/datagen/DataProducer.h"
 #include "tests/datagen/random_producer/RandWrapper.h"
 
-namespace zstrong::tests::datagen {
+namespace openzl::tests::datagen {
 
 /**
  * @brief The base class for all random distributions that uses a random source
@@ -22,4 +22,4 @@ class Distribution : public DataProducer<RetType> {
     std::shared_ptr<RandWrapper> rw_;
 };
 
-} // namespace zstrong::tests::datagen
+} // namespace openzl::tests::datagen

--- a/tests/datagen/distributions/StringLengthDistribution.h
+++ b/tests/datagen/distributions/StringLengthDistribution.h
@@ -4,7 +4,7 @@
 
 #include "tests/datagen/distributions/VecLengthDistribution.h"
 
-namespace zstrong::tests::datagen {
+namespace openzl::tests::datagen {
 
 constexpr size_t kDefaultMaxStringLength = 4096;
 
@@ -34,4 +34,4 @@ class StringLengthDistribution : public VecLengthDistribution {
     }
 };
 
-} // namespace zstrong::tests::datagen
+} // namespace openzl::tests::datagen

--- a/tests/datagen/distributions/UniformDistribution.h
+++ b/tests/datagen/distributions/UniformDistribution.h
@@ -4,7 +4,7 @@
 
 #include "tests/datagen/distributions/Distribution.h"
 
-namespace zstrong::tests::datagen {
+namespace openzl::tests::datagen {
 
 template <typename RetType>
 class UniformDistribution : public Distribution<RetType> {
@@ -62,4 +62,4 @@ class UniformDistribution : public Distribution<RetType> {
     RetType max_;
 };
 
-} // namespace zstrong::tests::datagen
+} // namespace openzl::tests::datagen

--- a/tests/datagen/distributions/VecLengthDistribution.h
+++ b/tests/datagen/distributions/VecLengthDistribution.h
@@ -4,7 +4,7 @@
 
 #include "tests/datagen/distributions/Distribution.h"
 
-namespace zstrong::tests::datagen {
+namespace openzl::tests::datagen {
 
 /**
  * @brief Distribution for generating vector lengths, skewed towards shorter
@@ -66,4 +66,4 @@ class VecLengthDistribution : public Distribution<size_t> {
     const size_t max_;
 };
 
-} // namespace zstrong::tests::datagen
+} // namespace openzl::tests::datagen

--- a/tests/datagen/random_producer/LionheadFDPWrapper.h
+++ b/tests/datagen/random_producer/LionheadFDPWrapper.h
@@ -9,7 +9,7 @@
 #include "tests/datagen/random_producer/RNGEngine.h"
 #include "tests/datagen/random_producer/RandWrapper.h"
 
-namespace zstrong::tests::datagen {
+namespace openzl::tests::datagen {
 
 // A non-templated wrapper around StructuredFDP that provides a consistent
 // interface for downstream distributions to use.
@@ -123,4 +123,4 @@ class LionheadFDPWrapper : public RandWrapper {
     FDP* fdp_;
 };
 
-} // namespace zstrong::tests::datagen
+} // namespace openzl::tests::datagen

--- a/tests/datagen/random_producer/PRNGWrapper.h
+++ b/tests/datagen/random_producer/PRNGWrapper.h
@@ -7,7 +7,7 @@
 
 #include "tests/datagen/random_producer/RandWrapper.h"
 
-namespace zstrong::tests::datagen {
+namespace openzl::tests::datagen {
 
 class PRNGWrapper : public RandWrapper {
    public:
@@ -120,4 +120,4 @@ class PRNGWrapper : public RandWrapper {
     std::uniform_real_distribution<double> f64dist_;
 };
 
-} // namespace zstrong::tests::datagen
+} // namespace openzl::tests::datagen

--- a/tests/datagen/random_producer/RNGEngine.h
+++ b/tests/datagen/random_producer/RNGEngine.h
@@ -5,7 +5,7 @@
 #include <memory>
 #include "tests/datagen/random_producer/RandWrapper.h"
 
-namespace zstrong::tests::datagen {
+namespace openzl::tests::datagen {
 
 /**
  * A simple RNG interface around RandWrapper that implements the same methods as
@@ -46,8 +46,8 @@ class RNGEngine {
     }
 
    private:
-    zstrong::tests::datagen::RandWrapper* rw_;
+    RandWrapper* rw_;
     RandWrapper::NameType name_;
 };
 
-} // namespace zstrong::tests::datagen
+} // namespace openzl::tests::datagen

--- a/tests/datagen/random_producer/RandWrapper.h
+++ b/tests/datagen/random_producer/RandWrapper.h
@@ -7,7 +7,7 @@
 #include <type_traits>
 #include <vector>
 
-namespace zstrong::tests::datagen {
+namespace openzl::tests::datagen {
 
 class RandWrapper {
    public:
@@ -180,4 +180,4 @@ class RandWrapper {
     explicit RandWrapper(RandType type_) : type(type_) {}
 };
 
-} // namespace zstrong::tests::datagen
+} // namespace openzl::tests::datagen

--- a/tests/datagen/random_producer/uniform_distribution.h
+++ b/tests/datagen/random_producer/uniform_distribution.h
@@ -8,7 +8,7 @@
 
 #include "openzl/shared/bits.h"
 
-namespace zstrong::tests::datagen {
+namespace openzl::tests::datagen {
 
 //===----------------------------------------------------------------------===//
 //
@@ -539,4 +539,4 @@ inline std::basic_istream<_CharT, _Traits>& operator>>(
 
 // end LLVM project
 
-} // namespace zstrong::tests::datagen
+} // namespace openzl::tests::datagen

--- a/tests/datagen/registry_records/RegistryRecord.h
+++ b/tests/datagen/registry_records/RegistryRecord.h
@@ -6,7 +6,7 @@
 
 #include "tests/datagen/DataProducer.h"
 
-namespace zstrong::tests::datagen {
+namespace openzl::tests::datagen {
 
 /**
  * Base class for hardcoded pre-prepared inputs.
@@ -18,4 +18,4 @@ class RegistryRecord : public DataProducer<std::string> {
     virtual size_t size() const = 0;
 };
 
-} // namespace zstrong::tests::datagen
+} // namespace openzl::tests::datagen

--- a/tests/datagen/registry_records/ZigzagRegistryRecord.h
+++ b/tests/datagen/registry_records/ZigzagRegistryRecord.h
@@ -6,7 +6,7 @@
 
 #include "tests/datagen/registry_records/RegistryRecord.h"
 
-namespace zstrong::tests::datagen {
+namespace openzl::tests::datagen {
 
 class ZigzagRegistryRecord : public RegistryRecord {
    public:
@@ -36,4 +36,4 @@ class ZigzagRegistryRecord : public RegistryRecord {
     };
 };
 
-} // namespace zstrong::tests::datagen
+} // namespace openzl::tests::datagen

--- a/tests/datagen/structures/CompressorProducer.cpp
+++ b/tests/datagen/structures/CompressorProducer.cpp
@@ -11,7 +11,7 @@
 
 #include "tests/utils.h"
 
-namespace zstrong {
+namespace openzl {
 namespace tests {
 namespace datagen {
 
@@ -1054,4 +1054,4 @@ RandomCompressorMultiBuilder::Compressor RandomCompressorMultiBuilder::make() &&
 
 } // namespace datagen
 } // namespace tests
-} // namespace zstrong
+} // namespace openzl

--- a/tests/datagen/structures/CompressorProducer.h
+++ b/tests/datagen/structures/CompressorProducer.h
@@ -13,7 +13,7 @@
 #include "tests/datagen/random_producer/RandWrapper.h"
 #include "tests/datagen/structures/LocalParamsProducer.h"
 
-namespace zstrong::tests::datagen {
+namespace openzl::tests::datagen {
 
 /**
  * This is a work in progress class. The motivation was originally to provide
@@ -316,4 +316,4 @@ class RandomCompressorMultiBuilder {
     ZL_IDType next_ctid_{ 1 };
 };
 
-} // namespace zstrong::tests::datagen
+} // namespace openzl::tests::datagen

--- a/tests/datagen/structures/FSENCountProducer.h
+++ b/tests/datagen/structures/FSENCountProducer.h
@@ -8,7 +8,7 @@
 #include "tests/datagen/distributions/UniformDistribution.h"
 #include "tests/datagen/structures/FixedWidthDataProducer.h"
 
-namespace zstrong::tests::datagen {
+namespace openzl::tests::datagen {
 
 class FSENCountProducer : public FixedWidthDataProducer {
    public:
@@ -42,4 +42,4 @@ class FSENCountProducer : public FixedWidthDataProducer {
     UniformDistribution<unsigned> tableLog_;
 };
 
-} // namespace zstrong::tests::datagen
+} // namespace openzl::tests::datagen

--- a/tests/datagen/structures/FixedWidthDataProducer.h
+++ b/tests/datagen/structures/FixedWidthDataProducer.h
@@ -10,7 +10,7 @@
 #include "tests/datagen/DataProducer.h"
 #include "tests/datagen/random_producer/RandWrapper.h"
 
-namespace zstrong::tests::datagen {
+namespace openzl::tests::datagen {
 
 struct FixedWidthData {
     template <typename T>
@@ -45,4 +45,4 @@ class FixedWidthDataProducer : public DataProducer<FixedWidthData> {
     std::shared_ptr<RandWrapper> rw_;
 };
 
-} // namespace zstrong::tests::datagen
+} // namespace openzl::tests::datagen

--- a/tests/datagen/structures/IntegerStringProducer.h
+++ b/tests/datagen/structures/IntegerStringProducer.h
@@ -10,7 +10,7 @@
 #include "tests/datagen/distributions/UniformDistribution.h"
 #include "tests/datagen/distributions/VecLengthDistribution.h"
 
-namespace zstrong::tests::datagen {
+namespace openzl::tests::datagen {
 
 class IntegerStringProducer : public DataProducer<std::vector<std::string>> {
    public:
@@ -79,4 +79,4 @@ class IntegerStringProducer : public DataProducer<std::vector<std::string>> {
     std::shared_ptr<RandWrapper> rw_;
 };
 
-} // namespace zstrong::tests::datagen
+} // namespace openzl::tests::datagen

--- a/tests/datagen/structures/LocalParamsProducer.cpp
+++ b/tests/datagen/structures/LocalParamsProducer.cpp
@@ -9,7 +9,7 @@
 
 #include "tests/utils.h"
 
-namespace zstrong {
+namespace openzl {
 namespace tests {
 namespace datagen {
 
@@ -267,4 +267,4 @@ LocalParams LocalParamsProducer::mutateParamsPerturbingEquality(
 
 } // namespace datagen
 } // namespace tests
-} // namespace zstrong
+} // namespace openzl

--- a/tests/datagen/structures/LocalParamsProducer.h
+++ b/tests/datagen/structures/LocalParamsProducer.h
@@ -9,7 +9,7 @@
 #include "tests/datagen/random_producer/RandWrapper.h"
 #include "tests/local_params_utils.h"
 
-namespace zstrong::tests::datagen {
+namespace openzl::tests::datagen {
 
 class LocalParamsProducer : public DataProducer<LocalParams> {
    public:
@@ -66,4 +66,4 @@ class LocalParamsProducer : public DataProducer<LocalParams> {
     std::shared_ptr<RandWrapper> rw_;
 };
 
-} // namespace zstrong::tests::datagen
+} // namespace openzl::tests::datagen

--- a/tests/datagen/structures/StringProducer.h
+++ b/tests/datagen/structures/StringProducer.h
@@ -5,7 +5,7 @@
 #include "tests/datagen/DataProducer.h"
 #include "tests/datagen/distributions/StringLengthDistribution.h"
 
-namespace zstrong::tests::datagen {
+namespace openzl::tests::datagen {
 
 class StringProducer : public DataProducer<std::string> {
    public:
@@ -46,4 +46,4 @@ class StringProducer : public DataProducer<std::string> {
     StringLengthDistribution lengthDist_;
 };
 
-} // namespace zstrong::tests::datagen
+} // namespace openzl::tests::datagen

--- a/tests/datagen/structures/VectorOfTokensProducer.h
+++ b/tests/datagen/structures/VectorOfTokensProducer.h
@@ -10,7 +10,7 @@
 #include "tests/datagen/distributions/UniformDistribution.h"
 #include "tests/datagen/structures/FixedWidthDataProducer.h"
 
-namespace zstrong::tests::datagen {
+namespace openzl::tests::datagen {
 
 struct VectorOfTokensParameters {
     /// At every level of the tree, there will be branchingFactor children
@@ -110,4 +110,4 @@ class VectorOfTokensProducer : public FixedWidthDataProducer {
     uint32_t nextToken_ = 0;
 };
 
-} // namespace zstrong::tests::datagen
+} // namespace openzl::tests::datagen

--- a/tests/datagen/structures/VectorProducer.h
+++ b/tests/datagen/structures/VectorProducer.h
@@ -8,7 +8,7 @@
 #include "tests/datagen/distributions/UniformDistribution.h"
 #include "tests/datagen/distributions/VecLengthDistribution.h"
 
-namespace zstrong::tests::datagen {
+namespace openzl::tests::datagen {
 
 template <typename RetType>
 class VectorProducer : public DataProducer<std::vector<RetType>> {
@@ -54,4 +54,4 @@ class VectorProducer : public DataProducer<std::vector<RetType>> {
     std::unique_ptr<DataProducer<size_t>> lengthDist_;
 };
 
-} // namespace zstrong::tests::datagen
+} // namespace openzl::tests::datagen

--- a/tests/datagen/structures/openzl/StringInputProducer.cpp
+++ b/tests/datagen/structures/openzl/StringInputProducer.cpp
@@ -2,7 +2,7 @@
 
 #include "tests/datagen/structures/openzl/StringInputProducer.h"
 
-namespace zstrong::tests::datagen::openzl {
+namespace openzl::tests::datagen::openzl {
 
 std::ostream& operator<<(
         std::ostream& os,
@@ -96,4 +96,4 @@ std::vector<uint32_t> StringInputProducer::genSplitRoughlyEvenSizes(
     return fieldSizes;
 }
 
-} // namespace zstrong::tests::datagen::openzl
+} // namespace openzl::tests::datagen::openzl

--- a/tests/datagen/structures/openzl/StringInputProducer.h
+++ b/tests/datagen/structures/openzl/StringInputProducer.h
@@ -8,7 +8,7 @@
 #include "tests/datagen/DataProducer.h"
 #include "tests/datagen/structures/StringProducer.h"
 
-namespace zstrong::tests::datagen::openzl {
+namespace openzl::tests::datagen::openzl {
 
 // Generator for string openzl::Input. Since Input is non-owning, we return a
 // pair that can then be ref-ed by Input.
@@ -67,4 +67,4 @@ class StringInputProducer : public DataProducer<PreStringInput> {
     Strategy strategy_;
 };
 
-} // namespace zstrong::tests::datagen::openzl
+} // namespace openzl::tests::datagen::openzl

--- a/tests/datagen/test/DataGenTest.cpp
+++ b/tests/datagen/test/DataGenTest.cpp
@@ -6,7 +6,7 @@
 
 using namespace ::testing;
 
-namespace zstrong::tests::datagen {
+namespace openzl::tests::datagen {
 
 TEST(DataGenTest, RandVal)
 {
@@ -78,4 +78,4 @@ TEST(DataGenTest, RandString)
     EXPECT_LT(data.size(), 4096);
 }
 
-} // namespace zstrong::tests::datagen
+} // namespace openzl::tests::datagen

--- a/tests/datagen/test/InputExpanderTest.cpp
+++ b/tests/datagen/test/InputExpanderTest.cpp
@@ -6,7 +6,7 @@
 
 using namespace ::testing;
 
-namespace zstrong::tests::datagen {
+namespace openzl::tests::datagen {
 
 TEST(InputExpanderTest, expandSerialWithMutation)
 {
@@ -21,4 +21,4 @@ TEST(InputExpanderTest, expandSerialWithMutation)
     }
 }
 
-} // namespace zstrong::tests::datagen
+} // namespace openzl::tests::datagen

--- a/tests/datagen/test/RegistryTest.cpp
+++ b/tests/datagen/test/RegistryTest.cpp
@@ -6,7 +6,7 @@
 
 using namespace ::testing;
 
-namespace zstrong::tests::datagen {
+namespace openzl::tests::datagen {
 
 TEST(RegistryTest, Test)
 {
@@ -18,4 +18,4 @@ TEST(RegistryTest, Test)
     EXPECT_EQ(record.size(), 2);
 }
 
-} // namespace zstrong::tests::datagen
+} // namespace openzl::tests::datagen

--- a/tests/datagen/test/UniformDistributionTest.cpp
+++ b/tests/datagen/test/UniformDistributionTest.cpp
@@ -10,7 +10,7 @@
 
 using namespace ::testing;
 
-namespace zstrong::tests::datagen {
+namespace openzl::tests::datagen {
 
 namespace {
 
@@ -120,4 +120,4 @@ TEST(UniformDistributionTest, IntegralChiSquare)
     EXPECT_LT(csStat<uint32_t>(data, 0, 100), csCriticalValue);
 }
 
-} // namespace zstrong::tests::datagen
+} // namespace openzl::tests::datagen

--- a/tests/datagen/test_registry/CustomNodes.cpp
+++ b/tests/datagen/test_registry/CustomNodes.cpp
@@ -22,7 +22,7 @@
 using apache::thrift::BinarySerializer;
 using apache::thrift::CompactSerializer;
 
-namespace zstrong::tests::datagen::test_registry {
+namespace openzl::tests::datagen::test_registry {
 namespace {
 
 ZL_NodeID createSplitByStructNode(ZL_Compressor* cgraph)
@@ -214,32 +214,34 @@ void registerAdditionalThriftNodes(
             customNodes,
             tidCompact,
             [=](ZL_Compressor* cgraph) {
-                ZL_NodeID node = thrift::registerCompactTransform(
+                ZL_NodeID node = ::zstrong::thrift::registerCompactTransform(
                         cgraph, commonIdCompact);
-                return thrift::cloneThriftNodeWithLocalParams(
+                return ::zstrong::thrift::cloneThriftNodeWithLocalParams(
                         cgraph,
                         node,
-                        thrift::tests::buildValidEncoderConfig(
+                        ::openzl::thrift::tests::buildValidEncoderConfig(
                                 minFormatVersion));
             },
 
-            std::make_unique<thrift::tests::ConfigurableThriftProducer<
-                    CompactSerializer>>(rw));
+            std::make_unique<
+                    ::openzl::thrift::tests::ConfigurableThriftProducer<
+                            CompactSerializer>>(rw));
 
     registerCustomParser(
             customNodes,
             tidBinary,
             [=](ZL_Compressor* cgraph) {
-                ZL_NodeID node =
-                        thrift::registerBinaryTransform(cgraph, commonIdBinary);
-                return thrift::cloneThriftNodeWithLocalParams(
+                ZL_NodeID node = ::zstrong::thrift::registerBinaryTransform(
+                        cgraph, commonIdBinary);
+                return ::zstrong::thrift::cloneThriftNodeWithLocalParams(
                         cgraph,
                         node,
-                        thrift::tests::buildValidEncoderConfig(
+                        ::openzl::thrift::tests::buildValidEncoderConfig(
                                 minFormatVersion));
             },
-            std::make_unique<thrift::tests::ConfigurableThriftProducer<
-                    BinarySerializer>>(rw));
+            std::make_unique<
+                    ::openzl::thrift::tests::ConfigurableThriftProducer<
+                            BinarySerializer>>(rw));
 }
 
 std::unordered_map<TransformID, CustomNode> makeCustomNodes()
@@ -254,13 +256,14 @@ std::unordered_map<TransformID, CustomNode> makeCustomNodes()
     std::unordered_map<TransformID, CustomNode> customNodes;
     auto rw = std::make_shared<PRNGWrapper>(std::make_shared<std::mt19937>());
 
-#define ZS2_REGISTER_THRIFT_KERNEL(kernel)               \
-    registerCustomTransform(                             \
-            customNodes,                                 \
-            TransformID::ThriftKernel##kernel,           \
-            ZS2_ThriftKernel_registerCTransform##kernel, \
-            ZS2_ThriftKernel_registerDTransform##kernel, \
-            std::make_unique<thrift::tests::ThriftProducer<kernel>>(rw))
+#define ZS2_REGISTER_THRIFT_KERNEL(kernel)                                     \
+    registerCustomTransform(                                                   \
+            customNodes,                                                       \
+            TransformID::ThriftKernel##kernel,                                 \
+            ZS2_ThriftKernel_registerCTransform##kernel,                       \
+            ZS2_ThriftKernel_registerDTransform##kernel,                       \
+            std::make_unique<::openzl::thrift::tests::ThriftProducer<kernel>>( \
+                    rw))
 
     using MapI32Float      = std::map<int32_t, float>;
     using MapI32ArrayFloat = std::map<int32_t, std::vector<float>>;
@@ -286,8 +289,8 @@ std::unordered_map<TransformID, CustomNode> makeCustomNodes()
     registerCustomParser(
             customNodes,
             TransformID::TulipV2,
-            tulip_v2::createTulipV2Node,
-            std::make_unique<tulip_v2::tests::TulipV2Producer>(rw));
+            ::zstrong::tulip_v2::createTulipV2Node,
+            std::make_unique<::openzl::tulip_v2::tests::TulipV2Producer>(rw));
 
     registerCustomParser(
             customNodes, TransformID::SplitByStruct, createSplitByStructNode);
@@ -320,31 +323,35 @@ std::unordered_map<TransformID, CustomNode> makeCustomNodes()
             customNodes,
             TransformID::ThriftCompact,
             [](ZL_Compressor* cgraph, ZL_IDType id) {
-                ZL_NodeID node = thrift::registerCompactTransform(cgraph, id);
-                return thrift::cloneThriftNodeWithLocalParams(
+                ZL_NodeID node =
+                        ::zstrong::thrift::registerCompactTransform(cgraph, id);
+                return ::zstrong::thrift::cloneThriftNodeWithLocalParams(
                         cgraph,
                         node,
-                        thrift::tests::buildValidEncoderConfig(
+                        ::openzl::thrift::tests::buildValidEncoderConfig(
                                 ::zstrong::thrift::kMinFormatVersionEncode));
             },
-            thrift::registerCompactTransform,
-            std::make_unique<thrift::tests::ConfigurableThriftProducer<
-                    CompactSerializer>>(rw));
+            ::zstrong::thrift::registerCompactTransform,
+            std::make_unique<
+                    ::openzl::thrift::tests::ConfigurableThriftProducer<
+                            CompactSerializer>>(rw));
 
     registerCustomTransform(
             customNodes,
             TransformID::ThriftBinary,
             [](ZL_Compressor* cgraph, ZL_IDType id) {
-                ZL_NodeID node = thrift::registerBinaryTransform(cgraph, id);
-                return thrift::cloneThriftNodeWithLocalParams(
+                ZL_NodeID node =
+                        ::zstrong::thrift::registerBinaryTransform(cgraph, id);
+                return ::zstrong::thrift::cloneThriftNodeWithLocalParams(
                         cgraph,
                         node,
-                        thrift::tests::buildValidEncoderConfig(
+                        ::openzl::thrift::tests::buildValidEncoderConfig(
                                 ::zstrong::thrift::kMinFormatVersionEncode));
             },
-            thrift::registerBinaryTransform,
-            std::make_unique<thrift::tests::ConfigurableThriftProducer<
-                    BinarySerializer>>(rw));
+            ::zstrong::thrift::registerBinaryTransform,
+            std::make_unique<
+                    ::openzl::thrift::tests::ConfigurableThriftProducer<
+                            BinarySerializer>>(rw));
 
     // We want to test the Thrift custom node with the highest format version
     // shared between dev and release. A higher format version means more
@@ -433,4 +440,4 @@ std::unordered_map<TransformID, CustomGraph> const& getCustomGraphs()
     return *customGraphsPtr;
 }
 
-} // namespace zstrong::tests::datagen::test_registry
+} // namespace openzl::tests::datagen::test_registry

--- a/tests/datagen/test_registry/CustomNodes.h
+++ b/tests/datagen/test_registry/CustomNodes.h
@@ -12,7 +12,7 @@
 
 #include "tests/datagen/structures/FixedWidthDataProducer.h"
 
-namespace zstrong::tests::datagen::test_registry {
+namespace openzl::tests::datagen::test_registry {
 
 // NOTE: The IDs must remain stable!
 enum class TransformID : int {
@@ -59,4 +59,4 @@ struct CustomGraph {
 std::unordered_map<TransformID, CustomNode> const& getCustomNodes();
 
 std::unordered_map<TransformID, CustomGraph> const& getCustomGraphs();
-} // namespace zstrong::tests::datagen::test_registry
+} // namespace openzl::tests::datagen::test_registry

--- a/tests/fuzz_utils.h
+++ b/tests/fuzz_utils.h
@@ -10,7 +10,7 @@
 #include "tests/datagen/DataGen.h"
 #include "tests/datagen/random_producer/LionheadFDPWrapper.h"
 
-namespace zstrong::tests {
+namespace openzl::tests {
 using namespace facebook::security::lionhead::fdp;
 
 template <class HarnessMode>
@@ -218,4 +218,4 @@ std::vector<size_t> getSplitNSegments(
     return segmentSizes;
 }
 
-} // namespace zstrong::tests
+} // namespace openzl::tests

--- a/tests/integrationtest/CompressIntrospectionTest.cpp
+++ b/tests/integrationtest/CompressIntrospectionTest.cpp
@@ -19,7 +19,7 @@
 
 using namespace ::testing;
 
-namespace zstrong::tests {
+namespace openzl::tests {
 
 namespace {
 
@@ -336,4 +336,4 @@ TEST(CompressIntrospectionTest, EncoderSpecific)
     ZL_CCtx_free(mcctx);
 }
 
-} // namespace zstrong::tests
+} // namespace openzl::tests

--- a/tests/integrationtest/NoIntrospectionTest.cpp
+++ b/tests/integrationtest/NoIntrospectionTest.cpp
@@ -18,7 +18,7 @@
 
 using namespace ::testing;
 
-namespace zstrong::tests {
+namespace openzl::tests {
 
 namespace {
 
@@ -74,4 +74,4 @@ TEST(NoIntrospectionTest, IFnoHooksTHENnoop)
     ZL_CCtx_free(cctx);
 }
 
-} // namespace zstrong::tests
+} // namespace openzl::tests

--- a/tests/local_params_utils.cpp
+++ b/tests/local_params_utils.cpp
@@ -8,7 +8,7 @@
 
 #include "openzl/compress/localparams.h"
 
-namespace zstrong {
+namespace openzl {
 namespace tests {
 
 ZL_INLINE bool matches(const ZL_IntParam& lhs, const ZL_IntParam& rhs)
@@ -134,4 +134,4 @@ std::ostream& operator<<(std::ostream& os, const LocalParams& lp)
 }
 
 } // namespace tests
-} // namespace zstrong
+} // namespace openzl

--- a/tests/local_params_utils.h
+++ b/tests/local_params_utils.h
@@ -8,7 +8,7 @@
 
 #include "openzl/zl_localParams.h"
 
-namespace zstrong {
+namespace openzl {
 namespace tests {
 
 /**
@@ -184,4 +184,4 @@ void LocalParams_check_eq(const LocalParams& lhs, const LocalParams& rhs);
 void LocalParams_check_ne(const LocalParams& lhs, const LocalParams& rhs);
 
 } // namespace tests
-} // namespace zstrong
+} // namespace openzl

--- a/tests/round_trip/InterleaveTest.cpp
+++ b/tests/round_trip/InterleaveTest.cpp
@@ -10,12 +10,12 @@ using namespace ::testing;
 
 namespace openzl::tests {
 
-using zstrong::tests::datagen::openzl::PreStringInput;
-using zstrong::tests::datagen::openzl::StringInputProducer;
+using openzl::tests::datagen::openzl::PreStringInput;
+using openzl::tests::datagen::openzl::StringInputProducer;
 
 TEST_F(InterleaveTest, MultipleInputs)
 {
-    auto dg         = zstrong::tests::datagen::DataGen();
+    auto dg         = openzl::tests::datagen::DataGen();
     size_t nbInputs = dg.randVal("nbInputs", 5, 100);
     uint32_t nbStrs = dg.u32_range("nbStrs", 100, 200);
 
@@ -43,7 +43,7 @@ TEST_F(InterleaveTest, MultipleInputs)
 
 TEST_F(InterleaveTest, SingleInput)
 {
-    auto dg         = zstrong::tests::datagen::DataGen();
+    auto dg         = openzl::tests::datagen::DataGen();
     size_t nbInputs = 1;
     uint32_t nbStrs = dg.u32_range("nbStrs", 100, 200);
 
@@ -65,7 +65,7 @@ TEST_F(InterleaveTest, SingleInput)
 
 TEST_F(InterleaveTest, MultipleDegenerateInputs)
 {
-    auto dg         = zstrong::tests::datagen::DataGen();
+    auto dg         = openzl::tests::datagen::DataGen();
     size_t nbInputs = dg.randVal("nbInputs", 5, 100);
     uint32_t nbStrs = dg.u32_range("nbStrs", 100, 200);
 

--- a/tests/round_trip/test_bruteForceSelector.cpp
+++ b/tests/round_trip/test_bruteForceSelector.cpp
@@ -13,7 +13,7 @@
 #include "openzl/zl_compress.h"
 
 using namespace testing;
-namespace zstrong::tests {
+namespace openzl::tests {
 
 #define EXPECT_SUCCESS(r)                                          \
     EXPECT_FALSE(ZL_isError(r)) << "Zstrong failed with message: " \
@@ -159,4 +159,4 @@ TEST_F(BruteForceSelectorTest, testString)
     ZL_TypedRef_free(data);
 }
 
-} // namespace zstrong::tests
+} // namespace openzl::tests

--- a/tests/round_trip/test_custom_transform.cpp
+++ b/tests/round_trip/test_custom_transform.cpp
@@ -14,7 +14,7 @@
 
 using namespace ::testing;
 
-namespace zstrong::tests {
+namespace openzl::tests {
 namespace {
 template <typename T, void (*FreeFn)(T*)>
 struct StaticFunctionDeleter {
@@ -424,4 +424,4 @@ TEST_F(TestCustomTransform, ZeroOutputTransform)
 }
 
 } // namespace
-} // namespace zstrong::tests
+} // namespace openzl::tests

--- a/tests/round_trip/test_mlselector.cpp
+++ b/tests/round_trip/test_mlselector.cpp
@@ -190,7 +190,7 @@ class MLSelectorTest : public ::testing::Test {
         // EXPECT_TRUE(ZL_GraphID_isValid(tokenizeGid_));
 
         deltaData = generateDeltaData();
-        auto dg   = zstrong::tests::datagen::DataGen();
+        auto dg   = openzl::tests::datagen::DataGen();
         // Generate data with repeated values
         tokenizeData = dg.template randLongVector<uint64_t>(
                 "randLongVec", 0, 500, 10000, 10000);

--- a/tests/round_trip/test_parseInt.cpp
+++ b/tests/round_trip/test_parseInt.cpp
@@ -89,7 +89,7 @@ static void testRoundTrip(
         ZL_GraphFn const graphFn)
 {
     auto const [input, fieldSizes] =
-            zstrong::tests::datagen::IntegerStringProducer::flatten(data);
+            openzl::tests::datagen::IntegerStringProducer::flatten(data);
     size_t uncompressedSize =
             input.size() + fieldSizes.size() * sizeof(uint32_t);
     size_t const compressedBound = ZL_compressBound(uncompressedSize);
@@ -127,7 +127,7 @@ static void testCompressFail(
         ZL_GraphFn const graphFn)
 {
     auto const [input, fieldSizes] =
-            zstrong::tests::datagen::IntegerStringProducer::flatten(data);
+            openzl::tests::datagen::IntegerStringProducer::flatten(data);
     size_t uncompressedSize =
             input.size() + fieldSizes.size() * sizeof(uint32_t);
     size_t const compressedBound = ZL_compressBound(uncompressedSize);
@@ -237,9 +237,9 @@ TEST(ParseIntTest, Basic)
 
 TEST(ParseIntTest, GeneratedRandom)
 {
-    auto rw = std::make_shared<zstrong::tests::datagen::PRNGWrapper>(
+    auto rw = std::make_shared<openzl::tests::datagen::PRNGWrapper>(
             std::make_shared<std::mt19937>());
-    auto gen = zstrong::tests::datagen::IntegerStringProducer(rw);
+    auto gen = openzl::tests::datagen::IntegerStringProducer(rw);
     for (size_t trials = 0; trials < 1000; ++trials) {
         auto data = gen("data");
         testRoundTrip(data, registerParseIntGraph);

--- a/tests/unittest/common/test_bitstream.cpp
+++ b/tests/unittest/common/test_bitstream.cpp
@@ -13,7 +13,7 @@
 #include "openzl/zl_errors.h"
 #include "tests/utils.h"
 
-namespace zstrong {
+namespace openzl {
 namespace tests {
 namespace {
 
@@ -583,7 +583,7 @@ void benchmark(int argc, char** argv)
 
 } // namespace
 } // namespace tests
-} // namespace zstrong
+} // namespace openzl
 
 #ifdef BENCHMARK_BITSTREAM
 int main(int argc, char** argv)
@@ -593,6 +593,6 @@ int main(int argc, char** argv)
     if (ret != 0) {
         return ret;
     }
-    zstrong::tests::benchmark(argc, argv);
+    openzl::tests::benchmark(argc, argv);
 }
 #endif

--- a/tests/unittest/common/test_buffer.cpp
+++ b/tests/unittest/common/test_buffer.cpp
@@ -5,7 +5,7 @@
 #include "openzl/common/buffer.h"
 #include "tests/utils.h"
 
-namespace zstrong {
+namespace openzl {
 namespace tests {
 namespace {
 
@@ -122,4 +122,4 @@ TEST(BufferTest, testMove)
 
 } // namespace
 } // namespace tests
-} // namespace zstrong
+} // namespace openzl

--- a/tests/unittest/common/test_data_stats.cpp
+++ b/tests/unittest/common/test_data_stats.cpp
@@ -14,7 +14,7 @@
 #define HUF_STATIC_LINKING_ONLY
 #include "openzl/fse/huf.h"
 
-namespace zstrong {
+namespace openzl {
 namespace tests {
 namespace {
 
@@ -621,4 +621,4 @@ INSTANTIATE_TEST_SUITE_P(
 
 } // namespace
 } // namespace tests
-} // namespace zstrong
+} // namespace openzl

--- a/tests/unittest/common/test_endianness.cpp
+++ b/tests/unittest/common/test_endianness.cpp
@@ -6,7 +6,7 @@
 #include "openzl/shared/bits.h"
 #include "tests/utils.h"
 
-using namespace zstrong::tests;
+using namespace openzl::tests;
 
 namespace {
 

--- a/tests/unittest/common/test_local_params.cpp
+++ b/tests/unittest/common/test_local_params.cpp
@@ -9,7 +9,7 @@
 
 using namespace ::testing;
 
-namespace zstrong {
+namespace openzl {
 namespace tests {
 
 namespace {
@@ -75,4 +75,4 @@ TEST_F(LocalParamsTest, ComparisonOfRandomParams)
 }
 
 } // namespace tests
-} // namespace zstrong
+} // namespace openzl

--- a/tests/unittest/common/test_varint.cpp
+++ b/tests/unittest/common/test_varint.cpp
@@ -7,7 +7,7 @@
 
 #include "openzl/shared/varint.h"
 
-namespace zstrong {
+namespace openzl {
 namespace tests {
 namespace {
 
@@ -174,4 +174,4 @@ TEST(VarintTest, VarintStrictDecodeEncode)
 
 } // namespace
 } // namespace tests
-} // namespace zstrong
+} // namespace openzl

--- a/tests/unittest/compress/RTGraphsTest.cpp
+++ b/tests/unittest/compress/RTGraphsTest.cpp
@@ -8,7 +8,7 @@
 
 using namespace ::testing;
 
-namespace zstrong::tests {
+namespace openzl::tests {
 
 TEST(RTGraphsTest, WHENcreateAndDeleteStreamsTHENallStreamsHaveUniqueID)
 {
@@ -55,4 +55,4 @@ TEST(RTGraphsTest, WHENcreateAndDeleteStreamsTHENallStreamsHaveUniqueID)
     free(rtgm);
 }
 
-} // namespace zstrong::tests
+} // namespace openzl::tests

--- a/tests/unittest/transforms/test_fse.cpp
+++ b/tests/unittest/transforms/test_fse.cpp
@@ -9,7 +9,7 @@
 #include "openzl/codecs/entropy/deprecated/encode_fse_kernel.h"
 #include "tests/utils.h"
 
-namespace zstrong {
+namespace openzl {
 namespace tests {
 namespace {
 
@@ -232,4 +232,4 @@ TEST(FSEContextTest, testUniformCompressibleRoundTrip)
 
 } // namespace
 } // namespace tests
-} // namespace zstrong
+} // namespace openzl

--- a/tests/unittest/transforms/test_parse_int_kernel.cpp
+++ b/tests/unittest/transforms/test_parse_int_kernel.cpp
@@ -53,9 +53,9 @@ TEST(ParseIntKernelTest, UnsafeVsFallbackFailure)
 
 TEST(ParseIntKernelTest, GeneratedRandom)
 {
-    auto rw = std::make_shared<zstrong::tests::datagen::PRNGWrapper>(
+    auto rw = std::make_shared<openzl::tests::datagen::PRNGWrapper>(
             std::make_shared<std::mt19937>());
-    auto gen = zstrong::tests::datagen::IntegerStringProducer(rw);
+    auto gen = openzl::tests::datagen::IntegerStringProducer(rw);
     for (size_t i = 0; i < 1000; i++) {
         for (auto& intStr : gen("intstring_vec")) {
             int64_t value;

--- a/tests/unittest/transforms/test_tokenize_kernel.cpp
+++ b/tests/unittest/transforms/test_tokenize_kernel.cpp
@@ -10,7 +10,7 @@
 #include "openzl/codecs/tokenize/encode_tokenize4to2_kernel.h"
 #include "openzl/codecs/tokenize/encode_tokenizeVarto4_kernel.h"
 
-namespace zstrong::tests {
+namespace openzl::tests {
 
 namespace {
 void roundtrip2to1(const std::vector<uint16_t>& input)
@@ -206,4 +206,4 @@ TEST(TokenizeKernelTest, RoundTripVarTo4)
             maxLength /* because content is all the same char */);
 }
 
-} // namespace zstrong::tests
+} // namespace openzl::tests

--- a/tests/utils.cpp
+++ b/tests/utils.cpp
@@ -6,7 +6,7 @@
 #include "openzl/zl_data.h"
 #include "openzl/zl_reflection.h"
 
-namespace zstrong {
+namespace openzl {
 namespace tests {
 
 const std::string kEmptyTestInput = "";
@@ -1209,4 +1209,4 @@ ZL_GraphID buildTrivialGraph(ZL_Compressor* cgraph, ZL_NodeID node)
 }
 
 } // namespace tests
-} // namespace zstrong
+} // namespace openzl

--- a/tests/utils.h
+++ b/tests/utils.h
@@ -35,7 +35,7 @@
 #    define ZS_CHECK_REQUIRE_FIRES(expr) expr
 #endif
 
-namespace zstrong {
+namespace openzl {
 namespace tests {
 
 extern const std::string kEmptyTestInput;
@@ -104,4 +104,4 @@ ZL_GraphID addConversionToGraph(
 ZL_GraphID buildTrivialGraph(ZL_Compressor* cgraph, ZL_NodeID node);
 
 } // namespace tests
-} // namespace zstrong
+} // namespace openzl

--- a/tests/version/VersionFuzzer.cpp
+++ b/tests/version/VersionFuzzer.cpp
@@ -16,7 +16,7 @@ extern "C" void FtestFuzzerSetup()
     LLVMFuzzerTestOneInput(&c, 1);
 }
 
-namespace zstrong {
+namespace openzl {
 namespace tests {
 namespace {
 
@@ -226,4 +226,4 @@ FUZZ(VersionTest, FuzzRandomGraphBackwardCompatible)
 
 } // namespace
 } // namespace tests
-} // namespace zstrong
+} // namespace openzl

--- a/tests/version/VersionTest.cpp
+++ b/tests/version/VersionTest.cpp
@@ -14,7 +14,7 @@
 
 #include "custom_transforms/thrift/kernels/tests/thrift_kernel_test_utils.h"
 
-namespace zstrong {
+namespace openzl {
 namespace {
 uint32_t hash4(uint32_t x)
 {
@@ -556,4 +556,4 @@ TEST_P(ReleaseGraphTest, BackwardCompatibility)
 }
 
 } // namespace
-} // namespace zstrong
+} // namespace openzl

--- a/tests/version/VersionTestInterface.cpp
+++ b/tests/version/VersionTestInterface.cpp
@@ -12,7 +12,7 @@
 
 #include <gflags/gflags.h>
 
-namespace zstrong {
+namespace openzl {
 
 VersionTestInterface::VersionTestInterface(
         char const* libVersionTestInterfaceSO)
@@ -376,4 +376,4 @@ std::string VersionTestInterface::decompress(std::string_view source) const
     out.resize(ret);
     return out;
 }
-} // namespace zstrong
+} // namespace openzl

--- a/tests/version/VersionTestInterface.h
+++ b/tests/version/VersionTestInterface.h
@@ -8,7 +8,7 @@
 #include <memory>
 #include <vector>
 
-namespace zstrong {
+namespace openzl {
 enum class UseCustomData : bool { Enable = true, Disable = false };
 
 struct CustomData {
@@ -269,4 +269,4 @@ class VersionTestInterface {
     std::map<GraphID, std::vector<CustomData>> graphCustomDataCache_;
 };
 
-} // namespace zstrong
+} // namespace openzl

--- a/tests/version/VersionTestInterfaceABI.cpp
+++ b/tests/version/VersionTestInterfaceABI.cpp
@@ -23,7 +23,7 @@
 #include "tests/datagen/test_registry/CustomNodes.h"
 
 namespace {
-using namespace zstrong::tests::datagen::test_registry;
+using namespace openzl::tests::datagen::test_registry;
 
 struct CGraphDeleter {
     void operator()(ZL_Compressor* cgraph) const
@@ -64,7 +64,7 @@ ZL_NodeID vtiNodeIDToZStrongNodeID(ZL_Compressor* cgraph, int nodeID)
     }
 }
 
-std::vector<zstrong::tests::datagen::FixedWidthData> genCustomTestDataForNode(
+std::vector<openzl::tests::datagen::FixedWidthData> genCustomTestDataForNode(
         int nodeID)
 {
     if (nodeID >= 0) {
@@ -74,7 +74,7 @@ std::vector<zstrong::tests::datagen::FixedWidthData> genCustomTestDataForNode(
         if (it != getCustomNodes().end()) {
             if (it->second.dataProducer != nullptr) {
                 // generate 10 samples
-                std::vector<zstrong::tests::datagen::FixedWidthData> samples;
+                std::vector<openzl::tests::datagen::FixedWidthData> samples;
                 for (size_t i = 0; i < 10; ++i) {
                     samples.emplace_back((*it->second.dataProducer)(
                             "VTI:Node:FixedWidthData"));
@@ -116,7 +116,7 @@ ZL_GraphID vtiGraphIDToZStrongGraphID(ZL_Compressor* cgraph, int graphID)
     }
 }
 
-std::vector<zstrong::tests::datagen::FixedWidthData> genCustomTestDataForGraph(
+std::vector<openzl::tests::datagen::FixedWidthData> genCustomTestDataForGraph(
         int graphID)
 {
     if (graphID >= 0) {
@@ -126,7 +126,7 @@ std::vector<zstrong::tests::datagen::FixedWidthData> genCustomTestDataForGraph(
         if (it != getCustomGraphs().end()) {
             if (it->second.dataProducer != nullptr) {
                 // generate 10 samples
-                std::vector<zstrong::tests::datagen::FixedWidthData> samples;
+                std::vector<openzl::tests::datagen::FixedWidthData> samples;
                 for (size_t i = 0; i < 10; ++i) {
                     samples.emplace_back((*it->second.dataProducer)(
                             "VTI:Graph:FixedWidthData"));
@@ -144,7 +144,7 @@ std::vector<zstrong::tests::datagen::FixedWidthData> genCustomTestDataForGraph(
 
 extern "C" unsigned VersionTestInterface_getZStrongVersion(int versionType)
 {
-    using VT = zstrong::detail::VersionType;
+    using VT = openzl::detail::VersionType;
     switch (static_cast<VT>(versionType)) {
         case VT::MAJOR:
             return ZL_LIBRARY_VERSION_MAJOR;
@@ -433,7 +433,7 @@ static ZL_GraphID buildGraph(
         unsigned maxVersion = ZL_MAX_FORMAT_VERSION)
 {
     ++nodesInGraph;
-    if (nodesInGraph > zstrong::tests::kMaxNodesInGraph || entropy.size() < 2) {
+    if (nodesInGraph > openzl::tests::kMaxNodesInGraph || entropy.size() < 2) {
         return store(cgraph, inType);
     }
     unsigned const stopByte    = (unsigned)entropy[0];
@@ -612,7 +612,7 @@ static size_t fillCustomTestData(
         char** bufferPtr,
         size_t** eltWidthsPtr,
         size_t** sizesPtr,
-        const std::vector<zstrong::tests::datagen::FixedWidthData>& testData)
+        const std::vector<openzl::tests::datagen::FixedWidthData>& testData)
 {
     if (testData.empty()) {
         *bufferPtr    = nullptr;

--- a/tests/version/VersionTestInterfaceABI.h
+++ b/tests/version/VersionTestInterfaceABI.h
@@ -7,7 +7,7 @@
 #include <memory>
 #include <vector>
 
-namespace zstrong::detail {
+namespace openzl::detail {
 enum class VersionType {
     MAJOR = 0,
     MINOR = 1,
@@ -16,7 +16,7 @@ enum class VersionType {
     MIN_FORMAT = 4,
     MAX_FORMAT = 5,
 };
-} // namespace zstrong::detail
+} // namespace openzl::detail
 
 extern "C" unsigned VersionTestInterface_getZStrongVersion(int versionType);
 

--- a/tests/zstrong/InterleaveFuzzer.cpp
+++ b/tests/zstrong/InterleaveFuzzer.cpp
@@ -8,12 +8,12 @@
 
 namespace openzl::tests {
 
-using zstrong::tests::datagen::openzl::PreStringInput;
-using zstrong::tests::datagen::openzl::StringInputProducer;
+using openzl::tests::datagen::openzl::PreStringInput;
+using openzl::tests::datagen::openzl::StringInputProducer;
 
 FUZZ_F(InterleaveTest, FuzzInterleaveRoundTrip)
 {
-    zstrong::tests::datagen::DataGen dg = zstrong::tests::fromFDP(f);
+    openzl::tests::datagen::DataGen dg = openzl::tests::fromFDP(f);
     // At least one is required, library version 20 can only support 2048 inputs
     uint16_t nbInputs = dg.u16_range("nbInputs", 0, 2048);
     // Flip a coin to decide if we should test with equal-sized inputs or not.

--- a/tests/zstrong/fuzz_alloc_failure.cpp
+++ b/tests/zstrong/fuzz_alloc_failure.cpp
@@ -18,7 +18,7 @@
 
 #include <algorithm>
 
-namespace zstrong {
+namespace openzl {
 namespace tests {
 namespace {
 
@@ -311,4 +311,4 @@ FUZZ(AllocFailureTest, FuzzAllocFailure)
 }
 } // namespace
 } // namespace tests
-} // namespace zstrong
+} // namespace openzl

--- a/tests/zstrong/fuzz_compress_reuse.cpp
+++ b/tests/zstrong/fuzz_compress_reuse.cpp
@@ -106,9 +106,9 @@ ZL_GraphID setCopyGraph(ZL_Compressor* cgraph)
 
 FUZZ(CompressTest, ReuseCCtx)
 {
-    zstrong::tests::datagen::DataGen dg = zstrong::tests::fromFDP(f);
-    ZL_g_logLevel                       = ZL_LOG_LVL_ALWAYS;
-    ZL_CCtx* const cctx                 = ZL_CCtx_create();
+    openzl::tests::datagen::DataGen dg = openzl::tests::fromFDP(f);
+    ZL_g_logLevel                      = ZL_LOG_LVL_ALWAYS;
+    ZL_CCtx* const cctx                = ZL_CCtx_create();
     ZL_REQUIRE_NN(cctx);
     ZL_Compressor* const cgraph1 = ZL_Compressor_create();
     ZL_REQUIRE_NN(cgraph1);

--- a/tests/zstrong/fuzz_decompress_reuse.cpp
+++ b/tests/zstrong/fuzz_decompress_reuse.cpp
@@ -35,9 +35,9 @@ constexpr ZL_TypedDecoderDesc kTransform = {
 
 FUZZ(DecompressTest, ReuseDCtx)
 {
-    zstrong::tests::datagen::DataGen dg = zstrong::tests::fromFDP(f);
-    ZL_g_logLevel                       = ZL_LOG_LVL_ALWAYS;
-    ZL_DCtx* const dctx                 = ZL_DCtx_create();
+    openzl::tests::datagen::DataGen dg = openzl::tests::fromFDP(f);
+    ZL_g_logLevel                      = ZL_LOG_LVL_ALWAYS;
+    ZL_DCtx* const dctx                = ZL_DCtx_create();
     ZL_REQUIRE_NN(dctx);
     while (dg.has_more_data()) {
         std::string input      = dg.randString("input_data");

--- a/tests/zstrong/fuzz_fixed.cpp
+++ b/tests/zstrong/fuzz_fixed.cpp
@@ -7,7 +7,7 @@
 #include "tests/fuzz_utils.h"
 #include "tests/zstrong/test_fixed_fixture.h"
 
-namespace zstrong {
+namespace openzl {
 namespace tests {
 
 FUZZ_F(FixedTest, FuzzInterpretTokenAsLEIntRoundTrip)
@@ -252,4 +252,4 @@ FUZZ_F(FixedTest, FuzzSplitNRoundTrip)
 }
 
 } // namespace tests
-} // namespace zstrong
+} // namespace openzl

--- a/tests/zstrong/fuzz_graph.cpp
+++ b/tests/zstrong/fuzz_graph.cpp
@@ -17,7 +17,7 @@
 
 #include <algorithm>
 
-namespace zstrong {
+namespace openzl {
 namespace tests {
 namespace {
 
@@ -212,4 +212,4 @@ FUZZ(GraphTest, FuzzGraphRoundTrip)
 }
 } // namespace
 } // namespace tests
-} // namespace zstrong
+} // namespace openzl

--- a/tests/zstrong/fuzz_integer.cpp
+++ b/tests/zstrong/fuzz_integer.cpp
@@ -8,7 +8,7 @@
 
 #include "openzl/zl_compressor.h" // ZS2_Compressor_*, ZL_Compressor_registerStaticGraph_fromNode1o
 
-namespace zstrong {
+namespace openzl {
 namespace tests {
 namespace {
 
@@ -206,4 +206,4 @@ FUZZ_F(IntegerTest, FuzzIntegerDivideBy)
 }
 } // namespace
 } // namespace tests
-} // namespace zstrong
+} // namespace openzl

--- a/tests/zstrong/fuzz_large.cpp
+++ b/tests/zstrong/fuzz_large.cpp
@@ -7,7 +7,7 @@
 #include "tests/fuzz_utils.h"
 #include "tests/zstrong/test_fixed_fixture.h"
 
-namespace zstrong {
+namespace openzl {
 namespace tests {
 
 class LargeInputTest : public ZStrongTest {};
@@ -82,4 +82,4 @@ FUZZ_F(LargeInputTest, FuzzSerialGraph)
 }
 
 } // namespace tests
-} // namespace zstrong
+} // namespace openzl

--- a/tests/zstrong/fuzz_multi_input.cpp
+++ b/tests/zstrong/fuzz_multi_input.cpp
@@ -8,7 +8,7 @@
 #include "tests/zstrong/test_multi_input_fixture.h"
 #include "tools/ml_selector/ml_selector_graph.h"
 
-namespace zstrong {
+namespace openzl {
 namespace tests {
 namespace {
 
@@ -397,4 +397,4 @@ FUZZ_F(MLSelectorMultiInputTest, FuzzMLSelectorRoundTrip)
 
 } // namespace
 } // namespace tests
-} // namespace zstrong
+} // namespace openzl

--- a/tests/zstrong/fuzz_serialized.cpp
+++ b/tests/zstrong/fuzz_serialized.cpp
@@ -6,7 +6,7 @@
 #include "tests/fuzz_utils.h"
 #include "tests/zstrong/test_serialized_fixture.h"
 
-namespace zstrong {
+namespace openzl {
 namespace tests {
 namespace {
 ZL_NodeID selectNode(
@@ -311,4 +311,4 @@ FUZZ_F(SerializedTest, FuzzConstantRoundTrip)
 
 } // namespace
 } // namespace tests
-} // namespace zstrong
+} // namespace openzl

--- a/tests/zstrong/fuzz_sort.cpp
+++ b/tests/zstrong/fuzz_sort.cpp
@@ -7,7 +7,7 @@
 
 #include "openzl/shared/pdqsort.h"
 
-namespace zstrong {
+namespace openzl {
 namespace tests {
 namespace {
 
@@ -48,4 +48,4 @@ FUZZ(SortTest, FuzzPDQsort)
 
 } // namespace
 } // namespace tests
-} // namespace zstrong
+} // namespace openzl

--- a/tests/zstrong/fuzz_variable.cpp
+++ b/tests/zstrong/fuzz_variable.cpp
@@ -12,7 +12,7 @@
 #include "tests/fuzz_utils.h"
 #include "tests/zstrong/test_variable_fixture.h"
 
-namespace zstrong {
+namespace openzl {
 namespace tests {
 namespace {
 
@@ -223,7 +223,7 @@ FUZZ_F(VariableTest, FuzzParseIntRoundTrip)
 
     reset();
     auto const [input, fieldSizes] =
-            zstrong::tests::datagen::IntegerStringProducer::flatten(data);
+            openzl::tests::datagen::IntegerStringProducer::flatten(data);
 
     std::vector<std::unique_ptr<ZL_TypedRef, ZS2_TypedRef_Deleter>> inputs;
     std::vector<TypedInputDesc> inputDescs;
@@ -272,4 +272,4 @@ FUZZ_F(VariableTest, FuzzParseIntSafeRoundTrip)
 
 } // namespace
 } // namespace tests
-} // namespace zstrong
+} // namespace openzl

--- a/tests/zstrong/test_fixed.cpp
+++ b/tests/zstrong/test_fixed.cpp
@@ -14,7 +14,7 @@
 #include "openzl/zl_opaque_types.h"
 #include "tests/zstrong/test_fixed_fixture.h"
 
-namespace zstrong {
+namespace openzl {
 namespace tests {
 TEST_F(FixedTest, InterpretTokenAsLEInt1)
 {
@@ -543,4 +543,4 @@ TEST_F(FixedTest, SplitN)
 }
 
 } // namespace tests
-} // namespace zstrong
+} // namespace openzl

--- a/tests/zstrong/test_fixed_fixture.cpp
+++ b/tests/zstrong/test_fixed_fixture.cpp
@@ -9,7 +9,7 @@
 #include "tests/utils.h"
 #include "tests/zstrong/test_fixed_fixture.h"
 
-namespace zstrong {
+namespace openzl {
 namespace tests {
 void FixedTest::setAlphabetMask(const std::string& mask)
 {
@@ -130,4 +130,4 @@ void FixedTest::testGraphOnInput(
     testRoundTrip(input);
 }
 } // namespace tests
-} // namespace zstrong
+} // namespace openzl

--- a/tests/zstrong/test_fixed_fixture.h
+++ b/tests/zstrong/test_fixed_fixture.h
@@ -8,7 +8,7 @@
 #include "openzl/zl_decompress.h"
 #include "tests/zstrong/test_zstrong_fixture.h"
 
-namespace zstrong {
+namespace openzl {
 namespace tests {
 
 class FixedTest : public ZStrongTest {
@@ -42,4 +42,4 @@ class FixedTest : public ZStrongTest {
 };
 
 } // namespace tests
-} // namespace zstrong
+} // namespace openzl

--- a/tests/zstrong/test_format_version.cpp
+++ b/tests/zstrong/test_format_version.cpp
@@ -16,7 +16,7 @@
 #include "tests/utils.h"
 #include "tests/zstrong/test_zstrong_fixture.h"
 
-namespace zstrong::tests {
+namespace openzl::tests {
 namespace {
 class FormatVersionTest : public ZStrongTest {
    public:
@@ -150,4 +150,4 @@ TEST_F(FormatVersionTest, MaxFormatVersionWorksFailsCompression)
 }
 
 } // namespace
-} // namespace zstrong::tests
+} // namespace openzl::tests

--- a/tests/zstrong/test_graph_validation.cpp
+++ b/tests/zstrong/test_graph_validation.cpp
@@ -10,7 +10,7 @@
 #include "openzl/zl_errors.h"
 #include "tests/zstrong/test_zstrong_fixture.h"
 
-namespace zstrong::tests {
+namespace openzl::tests {
 
 class GraphValidationTest : public ZStrongTest {
    public:
@@ -147,4 +147,4 @@ TEST_F(GraphValidationTest, ErrorContextIsProvided)
             << std::string(errorContext);
 }
 
-} // namespace zstrong::tests
+} // namespace openzl::tests

--- a/tests/zstrong/test_graphs.cpp
+++ b/tests/zstrong/test_graphs.cpp
@@ -8,7 +8,7 @@
 
 using namespace ::testing;
 
-namespace zstrong::tests {
+namespace openzl::tests {
 namespace {
 class GraphsTest : public ZStrongTest {
    public:
@@ -116,4 +116,4 @@ TEST_F(GraphsTest, UndersizedDstBuffer)
 }
 
 } // namespace
-} // namespace zstrong::tests
+} // namespace openzl::tests

--- a/tests/zstrong/test_helpful_error_messages.cpp
+++ b/tests/zstrong/test_helpful_error_messages.cpp
@@ -10,7 +10,7 @@
 
 using namespace ::testing;
 
-namespace zstrong::tests {
+namespace openzl::tests {
 namespace {
 /**
  * These test cases test common scenarios that the user may run into where we
@@ -150,4 +150,4 @@ TEST_F(HelpfulErrorMessagesTest, TestGetErrorContextOnWrongObject)
 }
 
 } // namespace
-} // namespace zstrong::tests
+} // namespace openzl::tests

--- a/tests/zstrong/test_integer.cpp
+++ b/tests/zstrong/test_integer.cpp
@@ -10,7 +10,7 @@
 #include "openzl/zl_opaque_types.h"
 #include "tests/zstrong/test_integer_fixture.h"
 
-namespace zstrong {
+namespace openzl {
 namespace tests {
 TEST_F(IntegerTest, ConvertIntToToken1)
 {
@@ -283,4 +283,4 @@ TEST_F(IntegerTest, FSENCount)
 }
 
 } // namespace tests
-} // namespace zstrong
+} // namespace openzl

--- a/tests/zstrong/test_integer_fixture.cpp
+++ b/tests/zstrong/test_integer_fixture.cpp
@@ -10,7 +10,7 @@
 #include "tests/utils.h"
 #include "tests/zstrong/test_integer_fixture.h"
 
-namespace zstrong {
+namespace openzl {
 namespace tests {
 std::string IntegerTest::generatedData(size_t nbElts, uint64_t cardinality)
 {
@@ -95,4 +95,4 @@ void IntegerTest::testGraph(ZL_GraphID graph, size_t eltWidth)
 }
 
 } // namespace tests
-} // namespace zstrong
+} // namespace openzl

--- a/tests/zstrong/test_integer_fixture.h
+++ b/tests/zstrong/test_integer_fixture.h
@@ -8,7 +8,7 @@
 #include "openzl/zl_decompress.h"
 #include "tests/zstrong/test_zstrong_fixture.h"
 
-namespace zstrong {
+namespace openzl {
 namespace tests {
 
 class IntegerTest : public ZStrongTest {
@@ -38,4 +38,4 @@ class IntegerTest : public ZStrongTest {
 };
 
 } // namespace tests
-} // namespace zstrong
+} // namespace openzl

--- a/tests/zstrong/test_multi_input_fixture.cpp
+++ b/tests/zstrong/test_multi_input_fixture.cpp
@@ -2,7 +2,7 @@
 
 #include "tests/zstrong/test_multi_input_fixture.h"
 
-namespace zstrong {
+namespace openzl {
 namespace tests {
 std::unique_ptr<ZL_TypedRef, ZS2_TypedRef_Deleter>
 MultiInputTest::getTypedInput(TypedInputDesc const& inputDesc)
@@ -38,4 +38,4 @@ MultiInputTest::getTypedInput(TypedInputDesc const& inputDesc)
     return std::unique_ptr<ZL_TypedRef, ZS2_TypedRef_Deleter>(tref);
 }
 } // namespace tests
-} // namespace zstrong
+} // namespace openzl

--- a/tests/zstrong/test_multi_input_fixture.h
+++ b/tests/zstrong/test_multi_input_fixture.h
@@ -5,7 +5,7 @@
 
 #include "tests/zstrong/test_zstrong_fixture.h"
 
-namespace zstrong {
+namespace openzl {
 namespace tests {
 class MultiInputTest : public ZStrongTest {
    public:
@@ -13,4 +13,4 @@ class MultiInputTest : public ZStrongTest {
             TypedInputDesc const& inputDesc);
 };
 } // namespace tests
-} // namespace zstrong
+} // namespace openzl

--- a/tests/zstrong/test_serialized.cpp
+++ b/tests/zstrong/test_serialized.cpp
@@ -13,7 +13,7 @@
 #include "tests/utils.h"
 #include "tests/zstrong/test_serialized_fixture.h"
 
-namespace zstrong {
+namespace openzl {
 namespace tests {
 TEST_F(SerializedTest, InterpretAsLEU64)
 {
@@ -531,4 +531,4 @@ TEST_F(SerializedTest, SplitOptimizationInMultiInputGraph)
 }
 
 } // namespace tests
-} // namespace zstrong
+} // namespace openzl

--- a/tests/zstrong/test_serialized.h
+++ b/tests/zstrong/test_serialized.h
@@ -8,7 +8,7 @@
 #include "openzl/zl_decompress.h"
 #include "tests/zstrong/test_zstrong_fixture.h"
 
-namespace zstrong {
+namespace openzl {
 namespace tests {
 
 class SerializedTest : public ZStrongTest {
@@ -24,4 +24,4 @@ class SerializedTest : public ZStrongTest {
 };
 
 } // namespace tests
-} // namespace zstrong
+} // namespace openzl

--- a/tests/zstrong/test_serialized_fixture.cpp
+++ b/tests/zstrong/test_serialized_fixture.cpp
@@ -10,7 +10,7 @@
 #include "tests/utils.h"
 #include "tests/zstrong/test_serialized_fixture.h"
 
-namespace zstrong {
+namespace openzl {
 namespace tests {
 
 std::string SerializedTest::generatedData(size_t nbElts, size_t cardinality)
@@ -115,4 +115,4 @@ void SerializedTest::testParameterizedNodeOnInput(
 }
 
 } // namespace tests
-} // namespace zstrong
+} // namespace openzl

--- a/tests/zstrong/test_serialized_fixture.h
+++ b/tests/zstrong/test_serialized_fixture.h
@@ -8,7 +8,7 @@
 #include "openzl/zl_decompress.h"
 #include "tests/zstrong/test_zstrong_fixture.h"
 
-namespace zstrong {
+namespace openzl {
 namespace tests {
 
 class SerializedTest : public ZStrongTest {
@@ -39,4 +39,4 @@ class SerializedTest : public ZStrongTest {
 };
 
 } // namespace tests
-} // namespace zstrong
+} // namespace openzl

--- a/tests/zstrong/test_string_view.cpp
+++ b/tests/zstrong/test_string_view.cpp
@@ -4,7 +4,7 @@
 #include "openzl/shared/string_view.h"
 #include "tests/datagen/DataGen.h"
 
-namespace zstrong {
+namespace openzl {
 namespace tests {
 class StringViewTest : public ::testing::Test {
    protected:
@@ -83,4 +83,4 @@ TEST_F(StringViewTest, SubstringView)
     EXPECT_TRUE(StringView_eq(&sv3Sub1, &sv3Sub2));
 }
 } // namespace tests
-} // namespace zstrong
+} // namespace openzl

--- a/tests/zstrong/test_surpassing_limits.cpp
+++ b/tests/zstrong/test_surpassing_limits.cpp
@@ -11,7 +11,7 @@
  * We want to make sure that exceeding these limits doesn't crash.
  */
 
-namespace zstrong::tests {
+namespace openzl::tests {
 
 class SurpassingLimitsTest : public ZStrongTest {
    public:
@@ -143,4 +143,4 @@ TEST_F(SurpassingLimitsTest, TestRuntimeStreamLimit)
         }
     }
 }
-} // namespace zstrong::tests
+} // namespace openzl::tests

--- a/tests/zstrong/test_variable.cpp
+++ b/tests/zstrong/test_variable.cpp
@@ -6,7 +6,7 @@
 #include "openzl/compress/private_nodes.h"
 #include "tests/zstrong/test_variable_fixture.h"
 
-namespace zstrong {
+namespace openzl {
 namespace tests {
 
 TEST_F(VariableTest, Prefix)
@@ -37,4 +37,4 @@ TEST_F(VariableTest, TokenizeSorted)
 }
 
 } // namespace tests
-} // namespace zstrong
+} // namespace openzl

--- a/tests/zstrong/test_variable_fixture.cpp
+++ b/tests/zstrong/test_variable_fixture.cpp
@@ -6,7 +6,7 @@
 #include "tests/utils.h"
 #include "tests/zstrong/test_variable_fixture.h"
 
-namespace zstrong {
+namespace openzl {
 namespace tests {
 
 // TODO: replace with the datagen StringInputProducer
@@ -101,4 +101,4 @@ void VariableTest::testGraphOnInput(
 }
 
 } // namespace tests
-} // namespace zstrong
+} // namespace openzl

--- a/tests/zstrong/test_variable_fixture.h
+++ b/tests/zstrong/test_variable_fixture.h
@@ -7,7 +7,7 @@
 #include "openzl/zl_compressor.h"
 #include "tests/zstrong/test_zstrong_fixture.h"
 
-namespace zstrong {
+namespace openzl {
 namespace tests {
 
 class VariableTest : public ZStrongTest {
@@ -33,4 +33,4 @@ class VariableTest : public ZStrongTest {
 };
 
 } // namespace tests
-} // namespace zstrong
+} // namespace openzl

--- a/tests/zstrong/test_zstrong_fixture.cpp
+++ b/tests/zstrong/test_zstrong_fixture.cpp
@@ -15,7 +15,7 @@
 #include "openzl/zl_reflection.h"
 #include "openzl/zl_selector.h"
 
-namespace zstrong {
+namespace openzl {
 namespace tests {
 
 ZStrongTest::~ZStrongTest()
@@ -496,4 +496,4 @@ void ZStrongTest::testRoundTripMIImpl(
 }
 
 } // namespace tests
-} // namespace zstrong
+} // namespace openzl

--- a/tests/zstrong/test_zstrong_fixture.h
+++ b/tests/zstrong/test_zstrong_fixture.h
@@ -16,7 +16,7 @@
 #include "openzl/common/stream.h"
 #include "openzl/zl_data.h"
 
-namespace zstrong {
+namespace openzl {
 namespace tests {
 
 struct ZS2_TypedRef_Deleter {
@@ -220,4 +220,4 @@ class ZStrongTest : public testing::Test {
 };
 
 } // namespace tests
-} // namespace zstrong
+} // namespace openzl

--- a/tests/zstrong/test_zstrong_selector.cpp
+++ b/tests/zstrong/test_zstrong_selector.cpp
@@ -15,7 +15,7 @@
 #include "tests/utils.h"
 #include "tests/zstrong/test_zstrong_fixture.h"
 
-namespace zstrong {
+namespace openzl {
 namespace tests {
 
 template <size_t seed>
@@ -403,4 +403,4 @@ TEST_F(SelectorTest, StreamTypeSerializedSuccess)
 }
 
 } // namespace tests
-} // namespace zstrong
+} // namespace openzl

--- a/tools/ml_selector/test_mlSelectorGraph.cpp
+++ b/tools/ml_selector/test_mlSelectorGraph.cpp
@@ -20,7 +20,7 @@ class TestMLSelectorGraph : public testing::Test {
     void SetUp() override
     {
         deltaData_ = generateDeltaData();
-        auto dg    = zstrong::tests::datagen::DataGen();
+        auto dg    = openzl::tests::datagen::DataGen();
         randomData_ =
                 dg.template randVector<uint64_t>("randVec", 0, 10000, 10000);
 

--- a/tools/tests/fuzz_zstrong_ml.cpp
+++ b/tools/tests/fuzz_zstrong_ml.cpp
@@ -20,7 +20,7 @@ namespace {
 
 using namespace gbt_predictor;
 using namespace zstrong::ml::features;
-using namespace zstrong::tests;
+using namespace openzl::tests;
 
 std::vector<std::string> getConfigExamples()
 {

--- a/tools/training/tests/test_clustering.cpp
+++ b/tools/training/tests/test_clustering.cpp
@@ -139,7 +139,7 @@ class TestTraining : public testing::Test {
     std::vector<ZL_NodeID> clusteringCodecs_;
     A1C_Arena a1cArena_{};
     Arena* backingArena_{};
-    zstrong::tests::datagen::DataGen dataGen_;
+    openzl::tests::datagen::DataGen dataGen_;
 };
 
 TEST_F(TestTraining, TestTrainingBasic)


### PR DESCRIPTION
Summary: At a high level, this changes files under `openzl/dev/tests` from `namespace zstrong` to `namespace openzl`. This is done to mirror the use of the `openzl` namespace in the C++ bindings and move us closer to an all-openzl world. Misc. changes to other files to ensure everything compiles.

Differential Revision: D88439572
