### PR TITLE
C++: Extend FrameInfo to Expose Format Version and Comment

### DIFF
--- a/cpp/include/openzl/cpp/FrameInfo.hpp
+++ b/cpp/include/openzl/cpp/FrameInfo.hpp
@@ -26,18 +26,21 @@ class FrameInfo {
         return info_.get();
     }
 
+    size_t formatVersion() const;
     size_t numOutputs() const;
     Type outputType(size_t index) const;
     size_t outputContentSize(size_t index) const;
+    poly::string_view comment() const;
 
-    size_t unwrap(
-            ZL_Report report,
+    template <typename ResultType>
+    typename ResultType::ValueType unwrap(
+            ResultType result,
             poly::string_view msg = {},
             poly::source_location location =
                     poly::source_location::current()) const
     {
         return openzl::unwrap(
-                report, std::move(msg), nullptr, std::move(location));
+                result, std::move(msg), nullptr, std::move(location));
     }
 
    private:

--- a/cpp/src/openzl/cpp/FrameInfo.cpp
+++ b/cpp/src/openzl/cpp/FrameInfo.cpp
@@ -21,6 +21,11 @@ FrameInfo::FrameInfo(poly::string_view compressed)
 {
 }
 
+size_t FrameInfo::formatVersion() const
+{
+    return unwrap(ZL_FrameInfo_getFormatVersion(get()));
+}
+
 size_t FrameInfo::numOutputs() const
 {
     return unwrap(ZL_FrameInfo_getNumOutputs(get()));
@@ -34,6 +39,13 @@ Type FrameInfo::outputType(size_t index) const
 size_t FrameInfo::outputContentSize(size_t index) const
 {
     return unwrap(ZL_FrameInfo_getDecompressedSize(get(), (int)index));
+}
+
+poly::string_view FrameInfo::comment() const
+{
+    const auto raw_comment = unwrap(ZL_FrameInfo_getComment(get()));
+    return poly::string_view{ static_cast<const char*>(raw_comment.data),
+                              raw_comment.size };
 }
 
 } // namespace openzl

--- a/cpp/tests/TestFrameInfo.cpp
+++ b/cpp/tests/TestFrameInfo.cpp
@@ -30,11 +30,13 @@ TEST(TestFrameInfo, basic)
     auto compressed = cctx.compress(inputs);
 
     FrameInfo info(compressed);
+    ASSERT_EQ(info.formatVersion(), ZL_MAX_FORMAT_VERSION);
     ASSERT_EQ(info.numOutputs(), inputs.size());
     for (size_t i = 0; i < inputs.size(); ++i) {
         ASSERT_EQ(info.outputType(i), inputs[i].type());
         ASSERT_EQ(info.outputContentSize(i), inputs[i].contentSize());
     }
+    ASSERT_EQ(info.comment(), "");
 }
 
 TEST(TestFrameInfo, HelpfulExceptionOnCorruption)
@@ -45,5 +47,24 @@ TEST(TestFrameInfo, HelpfulExceptionOnCorruption)
         ASSERT_EQ(e.code(), ZL_ErrorCode_corruption);
         ASSERT_NE(e.msg().find("Corrupt"), poly::string_view::npos);
     }
+}
+
+TEST(TestFrameInfo, comment)
+{
+    Compressor compressor;
+    compressor.setParameter(CParam::FormatVersion, ZL_MAX_FORMAT_VERSION);
+    compressor.unwrap(ZL_Compressor_selectStartingGraphID(
+            compressor.get(), ZL_GRAPH_COMPRESS_GENERIC));
+    std::vector<Input> inputs;
+    CCtx cctx;
+    cctx.refCompressor(compressor);
+    const std::string_view comment{ "fo\0o", 4 };
+    cctx.unwrap(ZL_CCtx_addHeaderComment(
+            cctx.get(), comment.data(), comment.size()));
+    auto compressed = cctx.compressSerial(
+            "hello world this is some test input hello hello hello world hello test input");
+
+    FrameInfo info(compressed);
+    ASSERT_EQ(info.comment(), comment);
 }
 } // namespace openzl::tests


### PR DESCRIPTION
Summary:
As title. Also requires templatizing `unwrap` on this class to handle the
return type for `ZL_FrameInfo_getComment()`, which is
`ZL_RESULT_OF(ZL_Comment)`.

Differential Revision: D88860369


