### PR TITLE
Fix `-Wtypedef-redefinition` errors in public headers for C99 compatibility

### DIFF
--- a/include/openzl/zl_graph_api.h
+++ b/include/openzl/zl_graph_api.h
@@ -45,8 +45,6 @@ extern "C" {
  * Note: Function Graph is (currently) the only way to deal with multiple
  * Inputs.
  */
-typedef struct ZL_Graph_s ZL_Graph;
-typedef struct ZL_Edge_s ZL_Edge;
 typedef struct ZL_FunctionGraphDesc ZL_FunctionGraphDesc;
 /**
  * The function signature for function graphs.
@@ -157,8 +155,6 @@ const ZL_Input* ZL_Edge_getData(const ZL_Edge* sctx);
 
 /* Actions */
 /* ------- */
-
-typedef struct ZL_GraphParameters_s ZL_RuntimeGraphParameters;
 
 /* Scratch space allocation:
  * When the function graph function needs some temporary space for some


### PR DESCRIPTION
## Summary

Remove duplicate typedef definitions in `zl_graph_api.h` that cause compilation errors when external projects include OpenZL headers with C99 mode and `-Werror -Wtypedef-redefinition`.

Before this fix, compiling with C99 produced:
```console
zl_graph_api.h:48:27: error: redefinition of typedef 'ZL_Graph' is a C11 feature [-Werror,-Wtypedef-redefinition]
   48 | typedef struct ZL_Graph_s ZL_Graph;
      |                           ^
zl_opaque_types.h:61:27: note: previous definition is here
   61 | typedef struct ZL_Graph_s ZL_Graph;
      |                           ^
zl_graph_api.h:49:26: error: redefinition of typedef 'ZL_Edge' is a C11 feature [-Werror,-Wtypedef-redefinition]
   49 | typedef struct ZL_Edge_s ZL_Edge;
      |                          ^
zl_opaque_types.h:62:26: note: previous definition is here
   62 | typedef struct ZL_Edge_s ZL_Edge;
      |                          ^
zl_graph_api.h:161:37: error: redefinition of typedef 'ZL_RuntimeGraphParameters' is a C11 feature [-Werror,-Wtypedef-redefinition]
  161 | typedef struct ZL_GraphParameters_s ZL_RuntimeGraphParameters;
      |                                     ^
zl_introspection.h:12:37: note: previous definition is here
   12 | typedef struct ZL_GraphParameters_s ZL_RuntimeGraphParameters;
      |                                     ^
3 errors generated.
```

## Type of Change

Bug fix (non-breaking change which fixes an issue)

## Test Plan

### Prepare: Build OpenZL and install

```bash
cmake \
  -S . \
  -B ../openzl.build \
  -DCMAKE_C_COMPILER=clang \
  -DCMAKE_CXX_COMPILER=clang++ \
  -DOPENZL_BUILD_TESTS=ON \
  -DCMAKE_INSTALL_PREFIX=/tmp/local && \
cmake --build ../openzl.build &&\
cmake --install ../openzl.build
```

### Verify C99 compilation works with installed headers

Confirm that including OpenZL headers compiles without errors in C99 mode with `-Werror -Wtypedef-redefinition`.

```bash
echo '#include "openzl/zl_graph_api.h"
int main() { return 0; }' > /tmp/test.c
```
```bash
clang -std=c99 -Werror -Wtypedef-redefinition \
      -I/tmp/local/include \
      -c /tmp/test.c -o /tmp/test.o
```

### Run all tests

Verify no regressions: `ctest` (1202 tests passed)

### Test Configuration

- Compiler: Clang 18.1.8
- Build type: none
- Platform(s): Linux (Ubuntu noble)