### PR TITLE
Address use of GNU empty initializer extension -Werror

### DIFF
--- a/src/openzl/compress/graphs/sddl2/sddl2.c
+++ b/src/openzl/compress/graphs/sddl2/sddl2.c
@@ -120,12 +120,12 @@ ZL_GraphID ZL_Compressor_registerSDDL2Graph(
     };
 
     const ZL_LocalParams lp = {
-        .intParams  = {},
+        .intParams  = {0},
         .copyParams = {
             .copyParams   = &cp,
             .nbCopyParams = 1,
         },
-        .refParams = {},
+        .refParams = {0},
     };
 
     // Create parameterized graph descriptor with bytecode and destination


### PR DESCRIPTION
Summary: arvr modes use the -Wgnu-empty-initializer flag to encourage portability, and this combines with -Werror to fail to build code using the GNU empty initializer extension.  Fix an instance of this.

Differential Revision: D88979924


