### PR TITLE
Run core library tests on arvr modes

### DIFF
--- a/cpp/tests/BUCK
+++ b/cpp/tests/BUCK
@@ -2,7 +2,7 @@
 
 # @noautodeps
 load("@fbcode_macros//build_defs:cpp_unittest.bzl", "cpp_unittest")
-load("../../defs.bzl", "relative_headers")
+load("../../defs.bzl", "cross_platform_labels", "relative_headers")
 
 oncall("data_compression")
 
@@ -15,6 +15,7 @@ cpp_unittest(
         "**/*.hpp",
     ])),
     header_namespace = "",
+    labels = cross_platform_labels(),
     deps = [
         "..:openzl_cpp",
     ],

--- a/cpp/tests/experimental/trace/CompressIntrospectionHooksTest.cpp
+++ b/cpp/tests/experimental/trace/CompressIntrospectionHooksTest.cpp
@@ -36,7 +36,7 @@ TEST(CompressIntrospectionHooksTest, writeTestFile)
     cctx.writeTraces(true);
     auto str         = cctx.compressOne(input);
     const auto trace = cctx.getLatestTrace();
-    if (0) {
+    if ((0)) {
         std::ofstream out("/tmp/streamdump.cbor", std::ios::binary);
         ASSERT_TRUE(out);
         out << trace.first;

--- a/defs.bzl
+++ b/defs.bzl
@@ -7,9 +7,19 @@ load("@fbcode_macros//build_defs:cpp_unittest.bzl", "cpp_unittest")
 load("@fbsource//tools/build_defs:selects.bzl", "selects")
 load("@fbsource//tools/build_defs:type_defs.bzl", "is_string")
 load("@fbsource//tools/build_defs/windows:windows_flag_map.bzl", "windows_convert_gcc_clang_flags")
+load("@fbsource//tools/target_determinator/macros:ci.bzl", "ci")
 load("@fbsource//xplat/security/lionhead:defs.bzl", "ALL_EMPLOYEES", "Interaction", "Metadata", "Priv", "Reachability", "Severity")
 load("@fbsource//xplat/security/lionhead/build_defs:generic_harness.bzl", "generic_lionhead_harness")
 load("//security/lionhead/harnesses:defs.bzl", "cpp_lionhead_harness")
+
+# Labels that should be added to tests that pass cross-platform
+def cross_platform_labels():
+    return ci.labels(
+        ci.mac(ci.mode("fbsource//arvr/mode/mac-arm/opt")),
+        ci.mac(ci.mode("fbsource//arvr/mode/mac-arm/dev")),
+        ci.linux(ci.mode("fbsource//arvr/mode/fb-linux-nh/opt")),
+        ci.linux(ci.mode("fbsource//arvr/mode/fb-linux-nh/dev-asan")),
+    )
 
 _ZL_PROD_PREFIXES = [
     "openzl/prod",

--- a/tests/BUCK
+++ b/tests/BUCK
@@ -1,6 +1,6 @@
 # Copyright (c) Meta Platforms, Inc. and affiliates.
 
-load("../defs.bzl", "zs_cxxbinary", "zs_cxxlibrary", "zs_fuzzers", "zs_library", "zs_raw_fuzzer", "zs_unittest")
+load("../defs.bzl", "cross_platform_labels", "zs_cxxbinary", "zs_cxxlibrary", "zs_fuzzers", "zs_library", "zs_raw_fuzzer", "zs_unittest")
 
 oncall("data_compression")
 
@@ -12,6 +12,7 @@ zs_unittest(
         "unittest/**/*.c",
     ]),
     headers = glob(["unittest/**/*.h"]),
+    labels = cross_platform_labels(),
     supports_static_listing = False,
     deps = [
         "..:common",
@@ -32,6 +33,7 @@ zs_unittest(
         ],
     ),
     headers = glob(["compress/**/*.h"]),
+    labels = cross_platform_labels(),
     deps = [
         "..:compress",
         "../tools/sddl2/assembler:lib",
@@ -46,6 +48,7 @@ zs_unittest(
     name = "test_decompress",
     srcs = glob(["decompress/**/*.cpp"]),
     headers = glob(["decompress/**/*.h"]),
+    labels = cross_platform_labels(),
     deps = [
         "..:decompress",
         ":utils",
@@ -59,6 +62,7 @@ zs_unittest(
         exclude = ["integrationtest/NoIntrospectionTest.cpp"],
     ),
     headers = glob(["integrationtest/**/*.h"]),
+    labels = cross_platform_labels(),
     supports_static_listing = False,
     deps = [
         "..:compress",
@@ -76,6 +80,7 @@ zs_unittest(
         exclude = ["round_trip/test_mlselector.cpp"],
     ),
     headers = glob(["round_trip/**/*.h"]),
+    labels = cross_platform_labels(),
     deps = [
         "..:compress",
         "..:decompress",
@@ -90,6 +95,7 @@ zs_unittest(
 zs_unittest(
     name = "test_ml_selector",
     srcs = ["round_trip/test_mlselector.cpp"],
+    labels = cross_platform_labels(),
     deps = [
         "..:compress",
         "..:decompress",
@@ -106,6 +112,7 @@ zs_unittest(
     name = "test_zstrong",
     srcs = glob(["zstrong/**/test_*.cpp"]),
     headers = glob(["zstrong/**/test_*.h"]),
+    labels = cross_platform_labels(),
     deps = [
         "..:zstronglib",
         "datagen:datagen",
@@ -130,6 +137,7 @@ zs_unittest(
     name = "test_codecs",
     srcs = glob(["codecs/**/test_*.cpp"]),
     headers = glob(["codecs/**/test_*.h"]),
+    labels = cross_platform_labels(),
     deps = [
         "..:zstronglib",
         "../tools/sddl/compiler:lib",

--- a/tests/registry/OpenZLInput.h
+++ b/tests/registry/OpenZLInput.h
@@ -49,6 +49,8 @@ class SerialOpenZLInput : public OpenZLInput {
         return result;
     }
 
+    ~SerialOpenZLInput() override = default;
+
    private:
     std::string str_;
 };
@@ -92,7 +94,7 @@ class NumericOpenZLInput : public OpenZLInput {
         return result;
     }
 
-    ~NumericOpenZLInput() = default;
+    ~NumericOpenZLInput() override = default;
 
    private:
     std::vector<T> vec_;
@@ -144,7 +146,7 @@ class StructOpenZLInput : public OpenZLInput {
         return std::make_unique<StructOpenZLInput>(std::forward<Args>(args)...);
     }
 
-    std::vector<Input> inputs() const
+    std::vector<Input> inputs() const override
     {
         std::vector<Input> result;
         result.push_back(
@@ -152,7 +154,7 @@ class StructOpenZLInput : public OpenZLInput {
         return result;
     }
 
-    ~StructOpenZLInput() = default;
+    ~StructOpenZLInput() override = default;
 
    private:
     std::string data_;
@@ -184,14 +186,14 @@ class StringOpenZLInput : public OpenZLInput {
         return std::make_unique<StringOpenZLInput>(std::forward<Args>(args)...);
     }
 
-    std::vector<Input> inputs() const
+    std::vector<Input> inputs() const override
     {
         std::vector<Input> result;
         result.push_back(Input::refString(data_, lens_));
         return result;
     }
 
-    ~StringOpenZLInput() = default;
+    ~StringOpenZLInput() override = default;
 
    private:
     std::string data_;
@@ -225,6 +227,8 @@ class MultiOpenZLInput : public OpenZLInput {
         }
         return ins;
     }
+
+    ~MultiOpenZLInput() override = default;
 
    private:
     std::vector<std::unique_ptr<OpenZLInput>> inputs_;

--- a/tests/utils.cpp
+++ b/tests/utils.cpp
@@ -1273,7 +1273,7 @@ class DeserializeEncoder : public CustomEncoder {
         }
     }
 
-    ~DeserializeEncoder() = default;
+    ~DeserializeEncoder() override = default;
 };
 
 class DeserializeDecoder : public CustomDecoder {


### PR DESCRIPTION
Summary:
As title

This is so we don't break ARVR build modes.

Reviewed By: graphicsMan

Differential Revision: D88985778
