### PR TITLE
Refactor GBTModel featureCtxt

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,19 +40,25 @@ endif
 ifneq (,$(filter Windows%,$(OS)))
 LIBZSTD_SO := deps/zstd/lib/dll/libzstd.dll
 LIBLZ4_SO := deps/lz4/lib/dll/liblz4.dll
+LIBXGBOOST_SO := deps/xgboost/lib/libxgboost.dll
 else ifeq ($(shell uname), Darwin)
 LIBZSTD_SO := deps/zstd/lib/libzstd.dylib
 LIBLZ4_SO := deps/lz4/lib/liblz4.dylib
+LIBXGBOOST_SO := deps/xgboost/lib/libxgboost.dylib
 else
 LIBZSTD_SO := deps/zstd/lib/libzstd.so
 LIBLZ4_SO := deps/lz4/lib/liblz4.so
+LIBXGBOOST_SO := deps/xgboost/lib/libxgboost.so
 endif
 
 LIBZSTD_A := deps/zstd/lib/libzstd.a
 LIBLZ4_A := deps/lz4/lib/liblz4.a
 LIBGTEST_A := deps/googletest/lib/libgtest.a
+LIBXGBOOST_A := deps/xgboost/lib/libxgboost.a
+LIBDMLC_A := deps/xgboost/lib/libdmlc.a
 
 GTEST_HEADERS := deps/googletest/googletest/include/gtest/gtest.h
+XGBOOST_HEADER := deps/xgboost/include/xgboost/c_api.h
 
 ifndef SKIP_BUILDDEPS_CHECK
   # Check if any gtest-dependent targets are being built
@@ -65,6 +71,24 @@ ifndef SKIP_BUILDDEPS_CHECK
       GTEST_BUILD_RESULT := $(shell $(MAKE) SKIP_BUILDDEPS_CHECK=1 $(GTEST_HEADERS))
       _ := $(shell sync)
       $(if $(shell test -f $(GTEST_HEADERS) && echo EXISTS),,$(error FATAL: $(GTEST_HEADERS) still missing after download attempt))
+    endif
+  endif
+
+  # Check if xgboost headers are being built
+  XGBOOST_TARGETS := zli gtests test all
+  BUILDING_XGBOOST_TARGETS := $(filter $(XGBOOST_TARGETS),$(MAKECMDGOALS))
+  ifeq ($(MAKECMDGOALS),)
+    # If no targets are specified, assume we're building everything
+    BUILDING_XGBOOST_TARGETS := zli
+  endif
+
+  ifneq ($(BUILDING_XGBOOST_TARGETS),)
+    # Download XGBoost library
+    ifeq ($(wildcard $(XGBOOST_HEADER)),)
+      $(info Downloading xgboost dependency for targets: $(BUILDING_XGBOOST_TARGETS))
+      XGBOOST_BUILD_RESULT := $(shell $(MAKE) SKIP_BUILDDEPS_CHECK=1 $(XGBOOST_HEADER))
+      _ := $(shell sync)
+      $(if $(shell test -f $(XGBOOST_HEADER) && echo EXISTS),,$(error FATAL: $(XGBOOST_HEADER) still missing after download attempt))
     endif
   endif
 endif
@@ -82,10 +106,10 @@ LIBASMSRCS := $(wildcard $(addsuffix /*.S, $(LIBDIRS)))
 LIBOBJS := $(patsubst %.c,%.o,$(LIBCSRCS)) $(patsubst %.S,%.o,$(LIBASMSRCS))
 
 libopenzl.a:
-$(eval $(call static_library,libopenzl.a,$(LIBOBJS),$(LIBZSTD_A) $(LIBLZ4_A)))
+$(eval $(call static_library,libopenzl.a,$(LIBOBJS),$(LIBZSTD_A) $(LIBLZ4_A) $(LIBXGBOOST_A) $(LIBDMLC_A)))
 
 libopenzl.so: CFLAGS += -fPIC
-$(eval $(call c_dynamic_library,libopenzl.so,$(LIBOBJS),$(LIBZSTD_SO) $(LIBLZ4_SO)))
+$(eval $(call c_dynamic_library,libopenzl.so,$(LIBOBJS),$(LIBZSTD_SO) $(LIBLZ4_SO) $(LIBXGBOOST_SO)))
 
 .PHONY:lib
 lib: libopenzl.a libopenzl.so
@@ -125,6 +149,16 @@ SDDL2_COMPILER_CXXOBJS := $(filter-out %main.o, $(call cxx_objs,$(SDDL2_COMPILER
 ML_SELECTOR_COBJS := $(call c_objs,$(ML_SELECTOR_DIR))
 ML_SELECTOR_CXXOBJS := $(call cxx_objs,$(ML_SELECTOR_DIR))
 
+# ML selector files depend on xgboost headers
+$(ML_SELECTOR_COBJS) $(ML_SELECTOR_CXXOBJS): | $(XGBOOST_HEADER)
+
+# Add flags for cross platform compatibility for Windows
+zli: LDFLAGS += $(XGBOOST_LDFLAGS)
+zli: LDLIBS += $(XGBOOST_LDLIBS)
+
+gtests: LDFLAGS += $(XGBOOST_LDFLAGS)
+gtests: LDLIBS += $(XGBOOST_LDLIBS)
+
 $(eval $(call cxx_program,zli, \
 	cli/zli.o \
 	$(CLI_CXXOBJS) \
@@ -147,7 +181,7 @@ $(eval $(call cxx_program,zli, \
 	$(ML_SELECTOR_CXXOBJS) \
 	$(ZLCPP_OBJS) \
 	$(LIBOBJS), \
-	$(LIBZSTD_A) $(LIBLZ4_A)))
+	$(LIBZSTD_A) $(LIBLZ4_A) $(LIBXGBOOST_A) $(LIBDMLC_A)))
 
 .PHONY: examples
 examples: zs2_pipeline zs2_trygraph zs2_selector zs2_struct zs2_round_trip
@@ -169,18 +203,18 @@ sddl2_test:
 # ********     Tools     ********
 
 UNITBENCH_COBJS := $(foreach DIR,$(UNITBENCH_DIRS),$(call c_objs,$(DIR)))
-$(eval $(call c_program_shared_o,unitBench,tools/time/timefn.o tools/fileio/fileio.o $(UNITBENCH_COBJS) $(LIBOBJS),$(LIBZSTD_A) $(LIBLZ4_A)))
+$(eval $(call c_program_shared_o,unitBench,tools/time/timefn.o tools/fileio/fileio.o $(UNITBENCH_COBJS) $(LIBOBJS),$(LIBZSTD_A) $(LIBLZ4_A) $(LIBXGBOOST_A) $(LIBDMLC_A)))
 
 stream_dump2:
 $(eval $(call c_program_shared_o,stream_dump2, \
-    $(STREAMDUMP_COBJS) tools/fileio/fileio.o $(LIBOBJS),$(LIBZSTD_A) $(LIBLZ4_A)))
+    $(STREAMDUMP_COBJS) tools/fileio/fileio.o $(LIBOBJS),$(LIBZSTD_A) $(LIBLZ4_A) $(LIBXGBOOST_A) $(LIBDMLC_A)))
 
 $(eval $(call cxx_program,sddl_compiler, \
 	$(SDDL_COMPILER_DIR)/main.o \
 	$(SDDL_COMPILER_CXXOBJS) \
 	$(ZLCPP_OBJS), \
 	libopenzl.a \
-	$(LIBZSTD_A) $(LIBLZ4_A)))
+	$(LIBZSTD_A) $(LIBLZ4_A) $(LIBXGBOOST_A) $(LIBDMLC_A)))
 
 # Selection of gtest units (by file name convention)
 CXX_FILE_OBJS := $(notdir $(CXX_OBJS))
@@ -233,31 +267,30 @@ ALL_GTESTS_OBJS := \
 	$(ZLCPP_OBJS) \
 	$(LIBOBJS)
 
-gtests: $(LIBGTEST_A) $(LIBZSTD_A) $(LIBLZ4_A)
+gtests: $(LIBGTEST_A) $(LIBZSTD_A) $(LIBLZ4_A) $(LIBXGBOOST_A)
 gtests: CPPFLAGS += -Ideps/googletest/googletest/include
 gtests: CXXFLAGS += -Wno-undef -Wno-sign-compare
 gtests: LDLIBS   += -lpthread
 $(eval $(call cxx_program,gtests, \
 	$(ALL_GTESTS_OBJS), \
-	$(LIBGTEST_A) $(LIBZSTD_A) $(LIBLZ4_A)))
+	$(LIBGTEST_A) $(LIBZSTD_A) $(LIBLZ4_A) $(LIBXGBOOST_A) $(LIBDMLC_A)))
 
 # ********     Examples     ********
 
 zs2_pipeline:
-$(eval $(call c_program_shared_o,zs2_pipeline,examples/zs2_pipeline.o tools/fileio/fileio.o $(LIBOBJS),$(LIBZSTD_A) $(LIBLZ4_A)))
+$(eval $(call c_program_shared_o,zs2_pipeline,examples/zs2_pipeline.o tools/fileio/fileio.o $(LIBOBJS),$(LIBZSTD_A) $(LIBLZ4_A) $(LIBXGBOOST_A) $(LIBDMLC_A)))
 
 zs2_struct:
-$(eval $(call c_program_shared_o,zs2_struct,examples/zs2_struct.o tools/fileio/fileio.o $(LIBOBJS),$(LIBZSTD_A) $(LIBLZ4_A)))
+$(eval $(call c_program_shared_o,zs2_struct,examples/zs2_struct.o tools/fileio/fileio.o $(LIBOBJS),$(LIBZSTD_A) $(LIBLZ4_A) $(LIBXGBOOST_A) $(LIBDMLC_A)))
 
 zs2_trygraph:
-$(eval $(call c_program_shared_o,zs2_trygraph,examples/zs2_trygraph.o $(LIBOBJS),$(LIBZSTD_A) $(LIBLZ4_A)))
+$(eval $(call c_program_shared_o,zs2_trygraph,examples/zs2_trygraph.o $(LIBOBJS),$(LIBZSTD_A) $(LIBLZ4_A) $(LIBXGBOOST_A) $(LIBDMLC_A)))
 
 zs2_selector:
-$(eval $(call c_program_shared_o,zs2_selector,examples/zs2_selector.o tools/fileio/fileio.o $(LIBOBJS),$(LIBZSTD_A) $(LIBLZ4_A)))
+$(eval $(call c_program_shared_o,zs2_selector,examples/zs2_selector.o tools/fileio/fileio.o $(LIBOBJS),$(LIBZSTD_A) $(LIBLZ4_A) $(LIBXGBOOST_A) $(LIBDMLC_A)))
 
 zs2_round_trip:
-$(eval $(call cxx_program_shared_o,zs2_round_trip,tests/round_trip.o tools/fileio/fileio.o $(SHARED_COMPONENTS_CXXOBJS) $(LIBOBJS),$(LIBZSTD_A) $(LIBLZ4_A)))
-
+$(eval $(call cxx_program_shared_o,zs2_round_trip,tests/round_trip.o tools/fileio/fileio.o $(SHARED_COMPONENTS_CXXOBJS) $(LIBOBJS),$(LIBZSTD_A) $(LIBLZ4_A) $(LIBXGBOOST_A) $(LIBDMLC_A)))
 
 # ********     Cleaning     ********
 
@@ -266,7 +299,6 @@ clean:
 	# note: a lot is done within multiconf.make
 	$(MAKE) -C $(SDDL2_DIR) clean
 	@echo Cleaning completed
-
 
 #special cases : these targets require additional flags to compile without warnings
 $(CACHE_ROOT)/%/src/openzl/common/errors.o : CFLAGS += -Wno-format-nonliteral
@@ -283,7 +315,7 @@ TAR ?= tar
 # Use this target as a work-around if dependencies are not correctly built
 # automatically.
 .PHONY : builddeps
-builddeps : $(LIBGTEST_A) $(LIBZSTD_A) $(LIBZSTD_SO) $(LIBLZ4_A) $(LIBLZ4_SO)
+builddeps : $(LIBGTEST_A) $(LIBZSTD_A) $(LIBZSTD_SO) $(LIBLZ4_A) $(LIBLZ4_SO) $(LIBXGBOOST_A) $(LIBXGBOOST_SO)
 
 .PHONY: cleandeps
 cleandeps:
@@ -292,6 +324,7 @@ cleandeps:
 	$(RM) -r deps/zstd deps/$(ZSTD_DIRNAME) $(ZSTD_TARBALL)
 	-$(GIT) submodule deinit -f deps/lz4 2> /dev/null
 	$(RM) -r deps/lz4 deps/$(LZ4_DIRNAME) $(LZ4_TARBALL)
+	$(RM) -r deps/xgboost deps/xgboost.tar.gz
 
 # Variables are by default not exported, but when they're passed on the CLI,
 # they are exported. We do not want to pass super restrictive flags to our
@@ -393,3 +426,68 @@ $(LIBGTEST_A) : MAKEOVERRIDES=
 $(LIBGTEST_A) : $(GTEST_HEADERS)
 	cd deps/googletest && cmake .
 	$(MAKE) -C deps/googletest
+
+# XGBoost
+XGBOOST_LIBDIR := deps/xgboost/lib
+
+XGBOOST_VERSION ?= 3.1.0
+XGBOOST_DIRNAME := xgboost-src-$(XGBOOST_VERSION)
+XGBOOST_TARBALL := deps/$(XGBOOST_DIRNAME).tar.gz
+
+# Common CMake flags for xgboost shared library build
+XGBOOST_CMAKE_COMMON := -DBUILD_STATIC_LIB=OFF -DUSE_OPENMP=OFF \
+	-DCMAKE_LIBRARY_OUTPUT_DIRECTORY=$(abspath $(XGBOOST_LIBDIR))
+
+# Platform-specific CMake flags for xgboost
+XGBOOST_CMAKE_PLATFORM :=
+XGBOOST_LDFLAGS :=
+XGBOOST_LDLIBS :=
+ifneq (,$(filter $(SMALL_CMD_LINE),$(UNAME)))
+    # MinGW/MSYS: Link ws2_32 for Windows socket functions
+    XGBOOST_CMAKE_PLATFORM := -DCMAKE_CXX_STANDARD_LIBRARIES="-lws2_32" \
+        -DCMAKE_SHARED_LINKER_FLAGS="-lws2_32"
+    XGBOOST_LDFLAGS += -L$(abspath $(XGBOOST_LIBDIR))
+    XGBOOST_LDLIBS += -lws2_32
+else ifeq ($(shell uname),Darwin)
+    # macOS: Set install_name to absolute path so dyld can find the library
+    XGBOOST_CMAKE_PLATFORM := -DCMAKE_INSTALL_NAME_DIR=$(abspath $(XGBOOST_LIBDIR)) \
+        -DCMAKE_BUILD_WITH_INSTALL_RPATH=ON -DCMAKE_MACOSX_RPATH=ON
+endif
+
+$(XGBOOST_TARBALL):
+	$(MKDIR) -p deps
+	$(CURL) -L https://github.com/dmlc/xgboost/releases/download/v$(XGBOOST_VERSION)/$(XGBOOST_DIRNAME).tar.gz -o $@
+
+.PHONY: xgboost-fallback
+xgboost-fallback: $(XGBOOST_TARBALL)
+	$(RM) -r deps/xgboost
+	$(TAR) -xzf $(XGBOOST_TARBALL) -C deps
+	@if [ -d deps/$(XGBOOST_DIRNAME) ] && [ ! -d deps/xgboost ]; then \
+		mv deps/$(XGBOOST_DIRNAME) deps/xgboost; \
+	fi
+
+$(XGBOOST_HEADER):
+	-$(GIT) submodule update --init --recursive --single-branch --depth 1 deps/xgboost
+	if [ ! -f $@ ]; then \
+		echo "Falling back to tarball download and extraction for xgboost"; \
+		$(MAKE) xgboost-fallback; \
+	fi
+
+# Build shared library only after static library is done (to avoid parallel cmake conflicts)
+$(LIBXGBOOST_SO) : MAKEOVERRIDES=
+$(LIBXGBOOST_SO) : $(LIBXGBOOST_A)
+	$(MKDIR) -p $(XGBOOST_LIBDIR)
+	cd deps/xgboost && mkdir -p build-shared && cd build-shared && \
+		cmake .. $(XGBOOST_CMAKE_COMMON) $(XGBOOST_CMAKE_PLATFORM) && $(MAKE)
+ifeq ($(shell uname),Darwin)
+	install_name_tool -id "$(abspath $(XGBOOST_LIBDIR))/libxgboost.dylib" \
+		"$(abspath $(XGBOOST_LIBDIR))/libxgboost.dylib" || true
+endif
+
+$(LIBXGBOOST_A) : MAKEOVERRIDES=
+$(LIBXGBOOST_A) : $(XGBOOST_HEADER)
+	$(MKDIR) -p $(XGBOOST_LIBDIR)
+	cd deps/xgboost && mkdir -p build && cd build && cmake .. -DBUILD_STATIC_LIB=ON -DUSE_OPENMP=OFF -DCMAKE_ARCHIVE_OUTPUT_DIRECTORY=$(abspath $(XGBOOST_LIBDIR)) && $(MAKE)
+
+# libdmlc.a is built as part of xgboost static build
+$(LIBDMLC_A): $(LIBXGBOOST_A)

--- a/benchmark/micro/micro_feature_gen.h
+++ b/benchmark/micro/micro_feature_gen.h
@@ -84,7 +84,7 @@ void inline registerFeatureGenIntegerBench(size_t size)
         VECTOR(LabeledFeature) features = empty_vector();
 
         while (state.KeepRunning()) {
-            ZL_Report report = FeatureGen_integer(stream, &features, nullptr);
+            ZL_Report report = FeatureGen_integer(stream, &features);
             VECTOR_CLEAR(features);
             benchmark::DoNotOptimize(report);
             benchmark::ClobberMemory();

--- a/build-scripts/make/zldefs.make
+++ b/build-scripts/make/zldefs.make
@@ -36,6 +36,7 @@ LDFLAGS  += $(MOREFLAGS)
 LDLIBS   += -lm # note: to be removed from library once dependency fixed
 CPPFLAGS += -Ideps/zstd/lib/ # "zstd.h"
 CPPFLAGS += -Ideps/lz4/lib/  # "lz4.h"
+CPPFLAGS += -Ideps/xgboost/include -Ideps/xgboost/dmlc-core/include # xgboost headers
 ARFLAGS  += -c # do not print warning message when creating the archive (expected)
 
 # Default build mode

--- a/cli/CMakeLists.txt
+++ b/cli/CMakeLists.txt
@@ -37,6 +37,7 @@ add_dependencies(zli
     commands
     utils
     logger
+    xgboost_external
 )
 
 apply_openzl_compile_options_to_target(zli)

--- a/custom_parsers/CMakeLists.txt
+++ b/custom_parsers/CMakeLists.txt
@@ -48,7 +48,7 @@ target_link_libraries(custom_parsers
     parquet_graph
     shared_components
 )
-add_dependencies(custom_parsers openzl openzl_cpp)
+add_dependencies(custom_parsers openzl openzl_cpp xgboost_external)
 apply_openzl_compile_options_to_target(custom_parsers
     csv_parser
     parquet_graph

--- a/src/openzl/compress/selectors/ml/features.c
+++ b/src/openzl/compress/selectors/ml/features.c
@@ -228,11 +228,8 @@ static bool calcIntegerFeatures(
 
 ZL_Report FeatureGen_integer(
         const ZL_Input* inputStream,
-        VECTOR(LabeledFeature) * features,
-        const void* featureContext)
+        VECTOR(LabeledFeature) * features)
 {
-    (void)featureContext;
-
     ZL_ASSERT(ZL_Input_type(inputStream) == ZL_Type_numeric);
     const void* data      = ZL_Input_ptr(inputStream);
     const size_t nbElts   = ZL_Input_numElts(inputStream);

--- a/src/openzl/compress/selectors/ml/features.h
+++ b/src/openzl/compress/selectors/ml/features.h
@@ -33,8 +33,7 @@ typedef enum {
  */
 ZL_Report FeatureGen_integer(
         const ZL_Input* inputStream,
-        VECTOR(LabeledFeature) * features,
-        const void* featureContext);
+        VECTOR(LabeledFeature) * features);
 
 /**
  * Defines type Feature Generator, which takes a stream and generates various
@@ -44,8 +43,7 @@ ZL_Report FeatureGen_integer(
  */
 typedef ZL_Report (*FeatureGenerator)(
         const ZL_Input* inputStream,
-        VECTOR(LabeledFeature) * features,
-        const void* featureContext);
+        VECTOR(LabeledFeature) * features);
 
 ZL_RESULT_DECLARE_TYPE(FeatureGenerator);
 

--- a/src/openzl/compress/selectors/ml/gbt.c
+++ b/src/openzl/compress/selectors/ml/gbt.c
@@ -101,8 +101,7 @@ GBTModel_predictInd(const GBTModel* model, const ZL_Input* in, ZL_Graph* graph)
     ZL_RESULT_DECLARE_SCOPE_REPORT(graph);
 
     VECTOR(LabeledFeature) featuresMap = VECTOR_EMPTY(kMaxFeaturesCapacity);
-    const ZL_Report report =
-            model->featureGenerator(in, &featuresMap, model->featureContext);
+    const ZL_Report report = model->featureGenerator(in, &featuresMap);
 
     if (ZL_isError(report)) {
         VECTOR_DESTROY(featuresMap);

--- a/src/openzl/compress/selectors/ml/gbt.h
+++ b/src/openzl/compress/selectors/ml/gbt.h
@@ -110,16 +110,14 @@ ZL_RESULT_DECLARE_TYPE(Label);
 /**
  * Defines type GBTModel, which is composed of 3 parts. First, the predictor,
  * which can take a vector of features as input and return a class id. Second,
- * the feature generator, which takes a stream and returns the features. The
- * feature generator can use the optional featureContext opaque ptr. Lastly, the
- * labels for the classes and features, which allows us to easily translate
+ * the feature generator, which takes a stream and returns the features. Lastly,
+ * the labels for the classes and features, which allows us to easily translate
  * class ids to class names and also ensure portability between training and
  * inference time.
  */
 typedef struct {
     const GBTPredictor* predictor;
     FeatureGenerator featureGenerator;
-    const void* featureContext;
     size_t nbLabels;
     const Label* classLabels;
     size_t nbFeatures;

--- a/tests/compress/test_features.cpp
+++ b/tests/compress/test_features.cpp
@@ -23,7 +23,7 @@ void verifyIntegerFeatures(
         const std::map<std::string, double>& featureMap)
 {
     VECTOR(LabeledFeature) features = VECTOR_EMPTY(kDefaultVectorCapacity);
-    const ZL_Report report = FeatureGen_integer(stream, &features, nullptr);
+    const ZL_Report report          = FeatureGen_integer(stream, &features);
     ASSERT_FALSE(ZL_errorCode(report));
 
     for (size_t i = 0; i < VECTOR_SIZE(features); ++i) {

--- a/tests/compress/test_gbt.cpp
+++ b/tests/compress/test_gbt.cpp
@@ -364,12 +364,9 @@ class GBTBinaryModelTest : public Test {
     void SetUp() override
     {
         // Lambda for generating hardcoded features
-        auto featureGen_binaryModelTest =
-                [](const ZL_Input* inputStream,
-                   VECTOR(LabeledFeature) * features,
-                   const void* featureContext) -> ZL_Report {
-            (void)featureContext;
-
+        auto featureGen_binaryModelTest = [](const ZL_Input* inputStream,
+                                             VECTOR(LabeledFeature)
+                                                     * features) -> ZL_Report {
             ZL_ASSERT(ZL_Input_type(inputStream) == ZL_Type_numeric);
 
             LabeledFeature meanFeature             = { "mean", 2.0f };
@@ -400,7 +397,6 @@ class GBTBinaryModelTest : public Test {
 
         model = { .predictor        = &binaryClassPredictor,
                   .featureGenerator = featureGen_binaryModelTest,
-                  .featureContext   = nullptr,
                   .nbLabels         = classLabels.size(),
                   .classLabels      = classLabels.data(),
                   .nbFeatures       = featureLabels.size(),
@@ -490,10 +486,7 @@ class GBTMultiClassModelTest : public GBTMultiClassForestTest {
 
         auto featureGen_multiClassModelTest =
                 [](const ZL_Input* inputStream,
-                   VECTOR(LabeledFeature) * features,
-                   const void* featureContext) -> ZL_Report {
-            (void)featureContext;
-
+                   VECTOR(LabeledFeature) * features) -> ZL_Report {
             ZL_ASSERT(ZL_Input_type(inputStream) == ZL_Type_numeric);
 
             LabeledFeature meanFeature             = { "mean", 5.0f };
@@ -523,7 +516,6 @@ class GBTMultiClassModelTest : public GBTMultiClassForestTest {
         };
         model = { .predictor        = multiClassPredictor.get(),
                   .featureGenerator = featureGen_multiClassModelTest,
-                  .featureContext   = nullptr,
                   .nbLabels         = classLabels.size(),
                   .classLabels      = classLabels.data(),
                   .nbFeatures       = featureLabels.size(),

--- a/tests/compress/test_zstrong_ml_core_models_generator.cpp
+++ b/tests/compress/test_zstrong_ml_core_models_generator.cpp
@@ -58,10 +58,8 @@ class ZstrongCoreBinaryMLTest : public Test {
 
     static ZL_Report featureGenerator(
             const ZL_Input* inputStream,
-            VECTOR(LabeledFeature) * features,
-            const void* featureContext)
+            VECTOR(LabeledFeature) * features)
     {
-        (void)featureContext;
         ZL_ASSERT_EQ((int)ZL_Input_type(inputStream), (int)ZL_Type_numeric);
 
         ZL_ASSERT_EQ(ZL_Input_eltWidth(inputStream), 4);
@@ -93,10 +91,8 @@ class ZstrongCoreMultiMLTest : public Test {
     // features
     static ZL_Report featureGenerator(
             const ZL_Input* inputStream,
-            VECTOR(LabeledFeature) * features,
-            const void* featureContext)
+            VECTOR(LabeledFeature) * features)
     {
-        (void)featureContext;
         ZL_ASSERT_EQ((int)ZL_Input_type(inputStream), (int)ZL_Type_numeric);
 
         ZL_ASSERT_EQ(ZL_Input_eltWidth(inputStream), 4);

--- a/tests/ml_selector_utils.cpp
+++ b/tests/ml_selector_utils.cpp
@@ -58,7 +58,6 @@ SampleBinaryGBTModel::SampleBinaryGBTModel()
     gbtModel_ = {
         .predictor        = &predictor_,
         .featureGenerator = FeatureGen_integer,
-        .featureContext   = NULL, // Ignoring for now
         .nbLabels         = classLabels_.size(),
         .classLabels      = classLabels_.data(),
         .nbFeatures       = featureLabels_.size(),
@@ -88,7 +87,6 @@ SampleCyclicGBTModel::SampleCyclicGBTModel()
     gbtModel_ = {
         .predictor        = &predictor_,
         .featureGenerator = FeatureGen_integer,
-        .featureContext   = NULL, // Ignoring for now
         .nbLabels         = classLabels_.size(),
         .classLabels      = classLabels_.data(),
         .nbFeatures       = featureLabels_.size(),

--- a/tests/round_trip/test_mlselector.cpp
+++ b/tests/round_trip/test_mlselector.cpp
@@ -19,14 +19,12 @@
 namespace {
 auto deltaFeatureGenerator(
         const ZL_Input* inputStream,
-        VECTOR(LabeledFeature) * features,
-        const void* featureContext)
+        VECTOR(LabeledFeature) * features)
 {
     // Calculates nbElts, eltWidth and hasConstDelta features. hasConstDelta
     // represents whether or not the stream is an arithmetic sequence, which
     // will always have a constant delta since the difference between each ith
     // and (i+1)th element is the same.
-    (void)featureContext;
 
     const void* data      = ZL_Input_ptr(inputStream);
     const size_t nbElts   = ZL_Input_numElts(inputStream);

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -8,10 +8,10 @@ add_subdirectory(logger)
 add_subdirectory(time)
 
 # Tools
+add_subdirectory(ml_selector)
 add_subdirectory(parquet)
 add_subdirectory(sddl)
 add_subdirectory(sddl2)
 add_subdirectory(streamdump)
 add_subdirectory(training)
 add_subdirectory(protobuf)
-add_subdirectory(ml_selector)

--- a/tools/ml_selector/BUCK
+++ b/tools/ml_selector/BUCK
@@ -17,15 +17,23 @@ zs_cxxlibrary(
     name = "ml_selector_trainer",
     srcs = ["ml_selector_trainer.cpp"],
     headers = ["ml_selector_trainer.h"],
+    compiler_flags = [
+        "-Wno-unused-exception-parameter",  # For XGBoost warnings
+    ],
     deps = [
         "../..:zstronglib",
         "../../cpp:openzl_cpp",
+        "../../tests/datagen:datagen",  # @manual
         "../training:train_common",
         "../training/graph_mutation:graph_mutation",
         "../training/sample_collection:sample_collection",
         "../training/utils:training_utils",
         ":ml_features",
         ":ml_selector_graph",
+    ],
+    exported_external_deps = [
+        ("xgboost", None, "xgboost-cpp"),
+        ("xgboost", None, "dmlc"),
     ],
 )
 

--- a/tools/ml_selector/CMakeLists.txt
+++ b/tools/ml_selector/CMakeLists.txt
@@ -1,5 +1,67 @@
 # Copyright (c) Meta Platforms, Inc. and affiliates.
 
+include(ExternalProject)
+include(GNUInstallDirs)
+
+# Build xgboost as an external project
+set(XGBOOST_INSTALL_DIR "${CMAKE_CURRENT_BINARY_DIR}/xgboost-install")
+set(XGBOOST_LIB_DIR "${XGBOOST_INSTALL_DIR}/lib")
+
+# Create install directories at configure time
+file(MAKE_DIRECTORY ${XGBOOST_INSTALL_DIR}/include)
+file(MAKE_DIRECTORY ${XGBOOST_LIB_DIR})
+
+# Add XGBoost as external project due to vs build issues
+# Turn logs on to prevent polluting stdout when building xgboost
+# Disable DMLC stack trace to avoid dependency on execinfo.h
+ExternalProject_Add(xgboost_external
+    GIT_REPOSITORY https://github.com/dmlc/xgboost.git
+    GIT_TAG        ccb511768e13d1670c10be07dea89d0edca138f3 # v3.1.0
+    GIT_SUBMODULES "dmlc-core"
+    GIT_SHALLOW    TRUE
+    CMAKE_ARGS
+        -DCMAKE_INSTALL_PREFIX=${XGBOOST_INSTALL_DIR}
+        -DCMAKE_INSTALL_LIBDIR=lib
+        -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}
+        -DUSE_OPENMP=OFF
+        -DBUILD_TESTING=OFF
+        -DUSE_CUDA=OFF
+        -DUSE_NCCL=OFF
+        -DCMAKE_POSITION_INDEPENDENT_CODE=ON
+        -DBUILD_STATIC_LIB=ON
+        "-DCMAKE_C_FLAGS=-DDMLC_LOG_STACK_TRACE=0"
+        "-DCMAKE_CXX_FLAGS=-DDMLC_LOG_STACK_TRACE=0"
+        ${XGBOOST_EXTRA_CMAKE_ARGS}
+    BUILD_BYPRODUCTS
+        ${XGBOOST_LIB_DIR}/libxgboost${CMAKE_STATIC_LIBRARY_SUFFIX}
+        ${XGBOOST_LIB_DIR}/libdmlc${CMAKE_STATIC_LIBRARY_SUFFIX}
+    LOG_DOWNLOAD ON
+    LOG_CONFIGURE ON
+    LOG_BUILD ON
+    LOG_INSTALL ON
+)
+
+# Create imported targets
+add_library(xgboost STATIC IMPORTED GLOBAL)
+set_target_properties(xgboost PROPERTIES
+    IMPORTED_LOCATION
+        ${XGBOOST_LIB_DIR}/libxgboost${CMAKE_STATIC_LIBRARY_SUFFIX}
+    INTERFACE_INCLUDE_DIRECTORIES ${XGBOOST_INSTALL_DIR}/include
+)
+add_dependencies(xgboost xgboost_external)
+
+if(WIN32 OR MINGW)
+    set_target_properties(xgboost PROPERTIES
+        INTERFACE_LINK_LIBRARIES "ws2_32")
+endif()
+
+add_library(dmlc STATIC IMPORTED GLOBAL)
+set_target_properties(dmlc PROPERTIES
+    IMPORTED_LOCATION ${XGBOOST_LIB_DIR}/libdmlc${CMAKE_STATIC_LIBRARY_SUFFIX}
+    INTERFACE_INCLUDE_DIRECTORIES ${XGBOOST_INSTALL_DIR}/include
+)
+add_dependencies(dmlc xgboost_external)
+
 add_library(ml_selector_graph
     ml_selector_graph.c
     ml_selector_graph.h
@@ -8,16 +70,33 @@ add_library(ml_selector_graph
     ml_features.cpp
     ml_features.h
 )
-target_include_directories(ml_selector_graph PUBLIC ${PROJECT_SOURCE_DIR})
-target_link_libraries(ml_selector_graph
+
+target_include_directories(ml_selector_graph
     PUBLIC
+        ${PROJECT_SOURCE_DIR}
+        ${XGBOOST_INSTALL_DIR}/include
+)
+
+# Disable DMLC stack trace to avoid dependency on execinfo.h
+target_compile_definitions(ml_selector_graph
+    PUBLIC
+        DMLC_LOG_STACK_TRACE=0
+)
+
+target_link_libraries(ml_selector_graph
+        PUBLIC
         openzl
         openzl_cpp
+        xgboost
+        dmlc
     )
+
+add_dependencies(ml_selector_graph xgboost_external)
 
 if (OPENZL_BUILD_TESTS)
     add_executable(test_ml_selector_graph tests/test_mlSelectorGraph.cpp)
-    add_executable(test_ml_selector_trainer tests/test_mlSelectorTrainer.cpp)
+    add_dependencies(test_ml_selector_graph xgboost_external)
+
     target_link_libraries(test_ml_selector_graph
         PRIVATE
             ml_selector_graph
@@ -27,17 +106,25 @@ if (OPENZL_BUILD_TESTS)
             tools_training
             GTest::gtest_main
     )
-    target_link_libraries(test_ml_selector_trainer
-        PRIVATE
-            ml_selector_graph
-            openzl
-            openzl_cpp
-            openzl_test_support
-            tools_training
-            GTest::gtest_main
-    )
     apply_openzl_compile_options_to_target(test_ml_selector_graph)
-    apply_openzl_compile_options_to_target(test_ml_selector_trainer)
+
     gtest_discover_tests(test_ml_selector_graph)
-    gtest_discover_tests(test_ml_selector_trainer)
+
+    if (OPENZL_ALLOW_INTROSPECTION)
+        add_executable(test_ml_selector_trainer
+            tests/test_mlSelectorTrainer.cpp)
+        add_dependencies(test_ml_selector_trainer xgboost_external)
+
+        target_link_libraries(test_ml_selector_trainer
+            PRIVATE
+                ml_selector_graph
+                openzl
+                openzl_cpp
+                openzl_test_support
+                tools_training
+                GTest::gtest_main
+        )
+        apply_openzl_compile_options_to_target(test_ml_selector_trainer)
+        gtest_discover_tests(test_ml_selector_trainer)
+    endif()
 endif()

--- a/tools/ml_selector/ml_features.cpp
+++ b/tools/ml_selector/ml_features.cpp
@@ -135,9 +135,8 @@ ProcessedMLTrainingSamples extractMLFeatures(
             compressor.selectStartingGraph(startingGraphId);
             targetData.push_back(targets);
 
-            FeatureMap features = VECTOR_EMPTY(kMaxVectorSize);
-            const ZL_Report report =
-                    featureGen(input.get(), &features, nullptr);
+            FeatureMap features    = VECTOR_EMPTY(kMaxVectorSize);
+            const ZL_Report report = featureGen(input.get(), &features);
             if (ZL_isError(report)) {
                 throw std::runtime_error(
                         std::string("Error generating integer features: ")

--- a/tools/ml_selector/ml_selector_graph.c
+++ b/tools/ml_selector/ml_selector_graph.c
@@ -795,7 +795,6 @@ MLSelector_registerGraphWithEmptyGBTModel(
     GBTModel emptyModel = {
         .predictor        = &emptyPredictor,
         .featureGenerator = FeatureGen_integer,
-        .featureContext   = NULL,
         .nbLabels         = nbSuccessors,
         .classLabels      = classLabels,
         .nbFeatures       = 1,

--- a/tools/ml_selector/ml_selector_graph.c
+++ b/tools/ml_selector/ml_selector_graph.c
@@ -484,9 +484,6 @@ static ZL_RESULT_OF(GBTModel) GBTModel_deserialize(
     ZL_ERR_IF_ERR(featureGenerator);
     model.featureGenerator = ZL_RES_value(featureGenerator);
 
-    // Ignoring feature context for now since it is not used
-    model.featureContext = NULL;
-
     // Deserialize nbLabels
     A1C_TRY_EXTRACT_INT64(nbLabels, A1C_Map_get_cstr(&rootMap, "nbLabels"));
     model.nbLabels = (size_t)nbLabels;
@@ -637,9 +634,8 @@ MLSelector_deserializeMLSelectorConfig(
                     ZL_MLSelectorConfig, ZL_RES_error(gbtModelResult));
         }
 
-        *gbtModelCopy                = ZL_RES_value(gbtModelResult);
-        gbtModelCopy->featureContext = NULL;
-        runtimeConfig                = gbtModelCopy;
+        *gbtModelCopy = ZL_RES_value(gbtModelResult);
+        runtimeConfig = gbtModelCopy;
     }
     dst.runtimeConfig = runtimeConfig;
 

--- a/tools/ml_selector/ml_selector_trainer.cpp
+++ b/tools/ml_selector/ml_selector_trainer.cpp
@@ -1,14 +1,520 @@
 // Copyright (c) Meta Platforms, Inc. and affiliates.
 #include "tools/ml_selector/ml_selector_trainer.h"
+#include <cstdio>
+#include <numeric>
+#include <random>
 #include <string>
 #include <vector>
+#include "ml_features.h"
 #include "openzl/zl_reflection.h"
-#include "tools/ml_selector/ml_features.h"
+#include "src/openzl/compress/selectors/ml/features.h"
+#include "tools/logger/Logger.h"
+#include "tools/ml_selector/ml_selector_graph.h"
 #include "tools/training/graph_mutation/graph_mutation_utils.h"
 #include "tools/training/sample_collection/training_sample_collector.h"
 
+// Suppress warnings for XGBoost headers
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wcast-qual"
+#pragma GCC diagnostic ignored "-Wfloat-equal"
+#pragma GCC diagnostic ignored "-Wcast-align"
+#include <xgboost/c_api.h>
+#include <xgboost/json.h>
+#pragma GCC diagnostic pop
+using namespace openzl::tools::logger;
+
 namespace openzl::training {
+
 const std::string ML_SELECTOR_GRAPH_NAME = "mlSelector";
+
+namespace {
+/**
+ * Macro provided by xgboost cpp to guard all calls
+ */
+#define safe_xgboost(call)                                                 \
+    {                                                                      \
+        int err = (call);                                                  \
+        if (err != 0) {                                                    \
+            throw std::runtime_error(                                      \
+                    std::string(__FILE__) + ":" + std::to_string(__LINE__) \
+                    + ": error in " + #call + ":" + XGBGetLastError());    \
+        }                                                                  \
+    }
+
+/**
+ * Contains both the 2D feature matrices and their flattened versions. The 2D
+ * format is for train test split, while the flattened format is required by
+ * XGBoost's DMatrix API.
+ *
+ * Naming follows scikit-learn conventions:
+ * - X: Feature matrix
+ * - y: Label vector
+ */
+struct FeatureData {
+    std::vector<std::vector<float>> X;
+    std::vector<float> y;
+    std::vector<float> XFlat;
+
+    FeatureData(
+            const std::vector<std::vector<float>>& X_,
+            const std::vector<float>& y_)
+    {
+        this->X = X_;
+        this->y = y_;
+
+        for (const auto& x : X) {
+            XFlat.insert(XFlat.end(), x.begin(), x.end());
+        }
+    }
+};
+
+/**
+ * Holds the train/test split data for XGBoost model training.
+ *
+ */
+struct TestTrainData {
+    FeatureData train;
+    FeatureData test;
+};
+
+/**
+ * Owns the memory for a GBTPredictor.
+ */
+struct GBTPredictorWrapper {
+    /// Node arrays for each tree (indexed by tree)
+    std::vector<std::unique_ptr<std::vector<GBTPredictor_Node>>> core_nodes_;
+    /// Tree arrays for each forest (indexed by forest)
+    std::vector<std::unique_ptr<std::vector<GBTPredictor_Tree>>> core_trees_;
+    /// All forests in the model
+    std::unique_ptr<std::vector<GBTPredictor_Forest>> core_forests_;
+    std::unique_ptr<GBTPredictor> core_predictor_;
+};
+
+} // namespace
+
+/**
+ * Extracts a numeric value from an XGBoost JSON node.
+ *
+ * Handles both JsonNumber (float) and JsonInteger, converting
+ * the value to a float. Returns -1.0f if the JSON node is not
+ * a number and not an integer type.
+ *
+ * @param json The XGBoost JSON node to extract the value from
+ * @return The numeric value as a float, or -1.0f if not a numeric type
+ */
+static float extractNumericVal(const xgboost::Json& json)
+{
+    if (xgboost::IsA<xgboost::JsonNumber>(json)) {
+        return xgboost::get<xgboost::JsonNumber const>(json);
+    } else if (xgboost::IsA<xgboost::JsonInteger>(json)) {
+        return static_cast<float>(
+                xgboost::get<xgboost::JsonInteger const>(json));
+    }
+    return -1.0f;
+}
+
+/**
+ * Recursively computes the maximum node ID in an XGBoost decision tree.
+ *
+ * Traverses the JSON format for XGBoost model. Used to
+ * pre-allocate a contiguous vector for storing parsed tree nodes.
+ *
+ * @param json The root JSON node of the XGBoost tree
+ * @return The maximum node ID found in the tree
+ */
+static int findMaxNodeId(const xgboost::Json& json)
+{
+    auto& objMap = xgboost::get<xgboost::JsonObject const>(json);
+    int maxId    = extractNumericVal(json["nodeid"]);
+
+    if (objMap.find("children") != objMap.end()) {
+        auto& children =
+                xgboost::get<xgboost::JsonArray const>(json["children"]);
+        for (const auto& child : children) {
+            maxId = std::max(maxId, findMaxNodeId(child));
+        }
+    }
+    return maxId;
+}
+
+/**
+ * Deleter functor to manage XGBoost BoosterHandle resource. Automatically calls
+ * XGBoosterFree when unique_pointer goes out of scope
+ */
+struct BoosterHandleDeleter {
+    using pointer = BoosterHandle;
+    void operator()(BoosterHandle handle) const
+    {
+        if (handle != nullptr) {
+            XGBoosterFree(handle);
+        }
+    }
+};
+
+using BoosterUniquePtr = std::unique_ptr<void, BoosterHandleDeleter>;
+
+/**
+ * Deleter functor to manage XGBoost DMatrixHandle resource. Automatically calls
+ * XGDMatrixFree when unique_pointer goes out of scope
+ */
+struct DMatrixHandleDeleter {
+    using pointer = DMatrixHandle;
+    void operator()(DMatrixHandle handle) const
+    {
+        if (handle != nullptr) {
+            XGDMatrixFree(handle);
+        }
+    }
+};
+
+using DMatrixUniquePtr = std::unique_ptr<void, DMatrixHandleDeleter>;
+
+/**
+ * Recursively parses an XGBoost decision tree node from JSON into a
+ * GBTPredictor_Node structure.
+ *
+ * The parsed node is stored directly into the pre-allocated nodes vector
+ * at the position corresponding to its nodeid.
+ *
+ * @param nodeJson    The JSON representation of the tree node
+ * @param labelMap    Mapping from feature names to feature indices
+ * @param nodes       Output vector where parsed nodes are stored by their ID
+ *
+ * @throws Exception if nodeid exceeds the bounds of the nodes vector
+ */
+static void parseXGBoostNode(
+        const xgboost::Json& nodeJson,
+        std::unordered_map<std::string, int>& labelMap,
+        std::vector<GBTPredictor_Node>& nodes)
+{
+    GBTPredictor_Node node{};
+
+    auto& objMap = xgboost::get<xgboost::JsonObject const>(nodeJson);
+
+    size_t nodeid = extractNumericVal(nodeJson["nodeid"]);
+    if (objMap.find("leaf") != objMap.end()) {
+        // Leaf node
+        float leafValue = extractNumericVal(nodeJson["leaf"]);
+        node.value      = leafValue;
+        node.featureIdx = -1;
+
+        Logger::log_c(VERBOSE1, "Leaf node: %f\n", leafValue);
+    } else {
+        // Internal node
+        std::string splitFeature =
+                xgboost::get<xgboost::JsonString const>(nodeJson["split"]);
+        float threshold  = extractNumericVal(nodeJson["split_condition"]);
+        int yesChild     = extractNumericVal(nodeJson["yes"]);
+        int noChild      = extractNumericVal(nodeJson["no"]);
+        int missingChild = extractNumericVal(nodeJson["missing"]);
+
+        node.featureIdx      = labelMap[splitFeature];
+        node.leftChildIdx    = yesChild;
+        node.rightChildIdx   = noChild;
+        node.missingChildIdx = missingChild;
+        node.value           = threshold;
+
+        Logger::log_c(VERBOSE1, "Internal Node %d: ,", nodeid);
+
+        Logger::log_c(
+                VERBOSE1, "split[%s < %f] \n", splitFeature.c_str(), threshold);
+
+        Logger::log_c(
+                VERBOSE1,
+                ", Yes node %d, no node %d, missing node %d\n",
+                yesChild,
+                noChild,
+                missingChild);
+
+        // Recursively process children
+        if (objMap.find("children") != objMap.end()) {
+            auto& children = xgboost::get<xgboost::JsonArray const>(
+                    nodeJson["children"]);
+            for (const auto& child : children) {
+                parseXGBoostNode(child, labelMap, nodes);
+            }
+        }
+    }
+
+    if (nodeid >= nodes.size()) {
+        throw Exception("Node id is out of range");
+    }
+    nodes[nodeid] = node;
+}
+
+/**
+ * Splits feature and label data into training and test sets. Used for
+ * evaluating model performance during XGBoost boosting rounds.
+ *
+ * @param features     Feature vectors to split
+ * @param labels       Corresponding labels to split
+ * @param testSize     Fraction of data to reserve for testing
+ * @param shuffle      Whether to shuffle (in place) data before splitting
+ * @param randomState  Seed for shuffling
+ *
+ * @return TrainTestData containing XTrain, XTest, yTrain, and yTest splits
+ *
+ * @throws Exception if features and labels have different sizes
+ */
+static TestTrainData trainTestSplit(
+        std::vector<std::vector<float>>& features,
+        std::vector<float>& labels,
+        float testSize           = 0.2,
+        bool shuffle             = true,
+        unsigned int randomState = 40)
+{
+    if (features.size() != labels.size()) {
+        throw Exception("Features and labels must have same size");
+    }
+
+    std::vector<size_t> indices(features.size());
+    std::iota(indices.begin(), indices.end(), 0);
+
+    if (shuffle) {
+        std::mt19937 rng(randomState);
+        std::shuffle(indices.begin(), indices.end(), rng);
+
+        std::vector<std::vector<float>> shuffledFeatures;
+        std::vector<float> shuffledLabels;
+        shuffledFeatures.reserve(features.size());
+        shuffledLabels.reserve(labels.size());
+
+        for (size_t idx : indices) {
+            shuffledFeatures.push_back(features[idx]);
+            shuffledLabels.push_back(labels[idx]);
+        }
+        features = shuffledFeatures;
+        labels   = shuffledLabels;
+    }
+
+    size_t trainSize = static_cast<size_t>(features.size() * (1.0f - testSize));
+
+    std::vector<std::vector<float>> XTrain(
+            features.begin(), features.begin() + trainSize);
+    std::vector<std::vector<float>> XTest(
+            features.begin() + trainSize, features.end());
+    std::vector<float> yTrain(labels.begin(), labels.begin() + trainSize);
+    std::vector<float> yTest(labels.begin() + trainSize, labels.end());
+
+    return { .train = FeatureData(XTrain, yTrain),
+             .test  = FeatureData(XTest, yTest) };
+}
+
+/**
+ * Transforms a trained XGBoost model into GBTPredictor.
+ *
+ * @param xgBoostDump      JSON strings for each tree
+ * @param featureLabelMap  Mapping from feature names to indices
+ * @param numClasses       Number of classification classes (2 for binary)
+ *
+ * @return GBTPredictorWrapper containing the converted model with ownership
+ *         of all internal structures
+ * @throws Exception if the XGBoost dump is unexpected size
+ */
+static GBTPredictorWrapper createGBTModelFromXGBoost(
+        std::vector<std::string>& xgBoostDump,
+        std::unordered_map<std::string, int>& featureLabelMap,
+        size_t numClasses)
+{
+    GBTPredictorWrapper pred;
+    // For binary classification, XGBoost creates 1 forest
+    // For multiclass, it creates one forest per class
+    if (numClasses == 1) {
+        throw Exception("Only 1 class found in XGBoost dump, expected 2");
+    }
+    size_t numForests = numClasses == 2 ? 1 : numClasses;
+    size_t numRounds  = xgBoostDump.size() / numForests;
+
+    /**
+     * For each boosting round, XGBoost creates a tree per class (unless its
+     * binary classification then it's just one tree). So we have something like
+     * this:
+     *
+     * r0: tree_label_0, tree_label_1, .... tree_label_n
+     * r1: tree_label_0, tree_label_1, .... tree_label_n
+     * ...
+     *
+     * So for forest i, we use (jth_round * numForests) + i to get all trees in
+     * that forest
+     */
+    for (size_t forestIdx = 0; forestIdx < numForests; forestIdx++) {
+        std::vector<GBTPredictor_Tree> trees;
+        for (size_t round = 0; round < numRounds; round++) {
+            size_t treeIdx = round * numForests + forestIdx;
+            if (treeIdx >= xgBoostDump.size()) {
+                throw Exception("XGBoost Dump unexpected size");
+            }
+            const std::string& treeStr = xgBoostDump[treeIdx];
+            xgboost::Json treeJson     = xgboost::Json::Load(
+                    xgboost::StringView(treeStr.data(), treeStr.size()));
+
+            std::vector<GBTPredictor_Node> nodes;
+            int maxNodeId = findMaxNodeId(treeJson);
+            nodes.resize(maxNodeId + 1);
+
+            parseXGBoostNode(treeJson, featureLabelMap, nodes);
+
+            pred.core_nodes_.push_back(
+                    std::make_unique<std::vector<GBTPredictor_Node>>(
+                            std::move(nodes)));
+
+            trees.push_back(
+                    { .numNodes = pred.core_nodes_.back()->size(),
+                      .nodes    = pred.core_nodes_.back()->data() });
+        }
+
+        pred.core_trees_.push_back(
+                std::make_unique<std::vector<GBTPredictor_Tree>>(
+                        std::move(trees)));
+
+        if (!pred.core_forests_) {
+            pred.core_forests_ =
+                    std::make_unique<std::vector<GBTPredictor_Forest>>();
+        }
+
+        pred.core_forests_->push_back(
+                { .numTrees = pred.core_trees_.back()->size(),
+                  .trees    = pred.core_trees_.back()->data() });
+    }
+
+    pred.core_predictor_ = std::make_unique<GBTPredictor>(
+            GBTPredictor{ .numForests = pred.core_forests_->size(),
+                          .forests    = pred.core_forests_->data() });
+
+    return pred;
+}
+
+/**
+ * Trains an XGBoost gradient boosted tree model and converts it to the
+ * GBTPredictor format for inference.
+ *
+ * @param data          Train/test split data
+ * @param featureNames  Feature names
+ * @param featureTypes  Feature types (e.g., "q" for quantitative)
+ * @param featuresMap   Mapping from feature names to indices
+ * @param num_classes   Number of classification classes
+ *
+ * @return GBTPredictorWrapper containing the trained model
+ *
+ */
+static GBTPredictorWrapper trainXGBoostModel(
+        TestTrainData& data,
+        std::vector<const char*>& featureNames,
+        std::vector<const char*>& featureTypes,
+        std::unordered_map<std::string, int>& featuresMap,
+        size_t num_classes)
+{
+    if (data.train.X.empty() || data.train.y.empty()) {
+        throw Exception("Training data cannot be empty");
+    }
+
+    if (data.test.X.empty() || data.test.y.empty()) {
+        throw Exception("Test data cannot be empty");
+    }
+
+    std::vector<std::string> xgBoostDump;
+
+    // equivalent to n_estimators in python XGBoost
+    constexpr size_t DEFAULT_XGBOOST_ROUNDS = 30;
+
+    // Create raw handles first, then wrap in unique_ptr
+    DMatrixHandle trainHandleRaw   = nullptr;
+    DMatrixHandle testHandleRaw    = nullptr;
+    BoosterHandle boosterHandleRaw = nullptr;
+
+    // Convert training and test data to DMatrixHandle needed by XGBoost
+    safe_xgboost(XGDMatrixCreateFromMat(
+            data.train.XFlat.data(),
+            data.train.X.size(),
+            data.train.X.front().size(),
+            -1,
+            &trainHandleRaw));
+    DMatrixUniquePtr train(trainHandleRaw);
+
+    safe_xgboost(XGDMatrixSetFloatInfo(
+            train.get(), "label", data.train.y.data(), data.train.y.size()));
+
+    safe_xgboost(XGDMatrixCreateFromMat(
+            data.test.XFlat.data(),
+            data.test.X.size(),
+            data.test.X.front().size(),
+            -1,
+            &testHandleRaw));
+    DMatrixUniquePtr test(testHandleRaw);
+
+    // Set model parameters
+    safe_xgboost(XGDMatrixSetFloatInfo(
+            test.get(), "label", data.test.y.data(), data.test.y.size()));
+
+    DMatrixHandle trainHandle = train.get();
+    safe_xgboost(XGBoosterCreate(&trainHandle, 1, &boosterHandleRaw));
+    BoosterUniquePtr booster(boosterHandleRaw);
+
+    BoosterHandle boosterHandle = booster.get();
+    safe_xgboost(XGBoosterSetParam(boosterHandle, "booster", "gbtree"));
+    safe_xgboost(XGBoosterSetParam(boosterHandle, "learning_rate", "0.1"));
+    // equivalent to n_jobs in python XGBoost
+    safe_xgboost(XGBoosterSetParam(boosterHandle, "nthread", "1"));
+    safe_xgboost(XGBoosterSetParam(boosterHandle, "min_child_weight", "0.0"));
+    safe_xgboost(XGBoosterSetParam(boosterHandle, "subsample", "0.7"));
+    safe_xgboost(XGBoosterSetParam(boosterHandle, "colsample_bynode", "0.8"));
+
+    // Set the objective function based on whether multiclass or binary
+    if (num_classes > 2) {
+        safe_xgboost(XGBoosterSetParam(
+                boosterHandle, "objective", "multi:softprob"));
+        safe_xgboost(XGBoosterSetParam(
+                boosterHandle,
+                "num_class",
+                std::to_string(num_classes).c_str()));
+    } else {
+        safe_xgboost(XGBoosterSetParam(
+                boosterHandle, "objective", "binary:logistic"));
+    }
+
+    const int eval_dmats_size                 = 2;
+    DMatrixHandle eval_dmats[eval_dmats_size] = { trainHandle, test.get() };
+    Logger::log_c(
+            VERBOSE1,
+            "Training XGBoost model with %d boosting rounds\n",
+            DEFAULT_XGBOOST_ROUNDS);
+    // Start training the model
+    for (size_t i = 0; i < DEFAULT_XGBOOST_ROUNDS; ++i) {
+        // Update the model performance for each iteration
+        safe_xgboost(
+                XGBoosterUpdateOneIter(boosterHandle, (int)i, trainHandle));
+
+        const char* eval_names[eval_dmats_size] = { "train", "test" };
+        const char* eval_result                 = NULL;
+        safe_xgboost(XGBoosterEvalOneIter(
+                boosterHandle,
+                (int)i,
+                eval_dmats,
+                eval_names,
+                eval_dmats_size,
+                &eval_result));
+        Logger::log_c(VERBOSE1, "%s\n", eval_result);
+    }
+
+    bst_ulong len = 0;
+
+    const char** dump = nullptr;
+
+    safe_xgboost(XGBoosterDumpModelExWithFeatures(
+            boosterHandle,
+            (int)featureNames.size(),
+            featureNames.data(),
+            featureTypes.data(),
+            0, // No stats
+            "json",
+            &len,
+            &dump));
+
+    xgBoostDump = std::vector<std::string>(dump, dump + len);
+
+    // unique_ptr will automatically free the handles when they go out of scope
+    return createGBTModelFromXGBoost(xgBoostDump, featuresMap, num_classes);
+}
 
 std::shared_ptr<const std::string_view> trainMLSelectorGraph(
         const std::vector<MultiInput>& inputs,
@@ -47,6 +553,10 @@ std::shared_ptr<const std::string_view> trainMLSelectorGraph(
     auto mlSelectorInputs =
             collectInputStreamsForGraph(inputs, mlSelectorGraphName, cctx);
 
+    if (mlSelectorInputs.empty()) {
+        throw std::runtime_error("Unable to get inputs to mlSelector");
+    }
+
     ProcessedMLTrainingSamples trainingSample = extractMLFeatures(
             mlSelectorInputs,
             compressor,
@@ -54,6 +564,68 @@ std::shared_ptr<const std::string_view> trainMLSelectorGraph(
             successorGraphs,
             successorLabels);
 
-    return graph_mutation::createSharedStringView(compressor.serialize());
+    TestTrainData splitData = trainTestSplit(
+            trainingSample.features, trainingSample.numericLabels);
+
+    // all integer features are quantitative and not categorical
+    std::vector<std::string> featureTypes(
+            trainingSample.featureNames.size(), "q");
+
+    std::vector<const char*> featureNamePtrs;
+    std::vector<const char*> featureTypePtrs;
+    std::unordered_map<std::string, int> featuresMap;
+    featureNamePtrs.reserve(trainingSample.featureNames.size());
+    featureTypePtrs.reserve(featureTypes.size());
+
+    int ind = 0;
+    for (const auto& name : trainingSample.featureNames) {
+        featuresMap[name] = ind++;
+        featureNamePtrs.push_back(name.c_str());
+    }
+
+    for (const auto& type : featureTypes) {
+        featureTypePtrs.push_back(type.c_str());
+    }
+
+    std::vector<Label> classLabelPtrs;
+    classLabelPtrs.reserve(successorLabels.size());
+
+    for (const auto& label : successorLabels) {
+        classLabelPtrs.push_back(label.c_str());
+    }
+
+    GBTPredictorWrapper gbtPred = trainXGBoostModel(
+            splitData,
+            featureNamePtrs,
+            featureTypePtrs,
+            featuresMap,
+            trainingSample.labelMap.size());
+
+    GBTModel coreModel = {
+        .predictor        = gbtPred.core_predictor_.get(),
+        .featureGenerator = FeatureGen_integer,
+        .nbLabels         = classLabelPtrs.size(),
+        .classLabels      = classLabelPtrs.data(),
+        .nbFeatures       = featureNamePtrs.size(),
+        .featureLabels    = featureNamePtrs.data(),
+    };
+
+    ZL_MLSelectorConfig config = { .model         = ZL_GBT,
+                                   .runtimeConfig = &coreModel };
+
+    auto mlSelectorGraphId = unwrap(ZL_MLSelector_registerGraph(
+            compressor.get(),
+            &config,
+            successorGraphs.data(),
+            successorGraphs.size()));
+
+    auto newMlSelectorGraphName =
+            ZL_Compressor_Graph_getName(compressor.get(), mlSelectorGraphId);
+
+    return graph_mutation::createSharedStringView(
+            graph_mutation::renameGraphInCompressor(
+                    compressor.serialize(),
+                    mlSelectorGraphName,
+                    newMlSelectorGraphName));
 }
 } // namespace openzl::training

--- a/tools/ml_selector/tests/test_mlSelectorGraph.cpp
+++ b/tools/ml_selector/tests/test_mlSelectorGraph.cpp
@@ -288,11 +288,10 @@ TEST_F(TestMLSelectorGraph, TestInvalidGBTModel)
 TEST_F(TestMLSelectorGraph, TestInvalidFeatureGenerator)
 {
     gbtModel_.featureGenerator = [](const ZL_Input* inputStream,
-                                    VECTOR(LabeledFeature) * features,
-                                    const void* featureContext) -> ZL_Report {
+                                    VECTOR(LabeledFeature)
+                                            * features) -> ZL_Report {
         (void)inputStream;
         (void)features;
-        (void)featureContext;
         return ZL_returnSuccess();
     };
 

--- a/tools/ml_selector/tests/test_mlSelectorTrainer.cpp
+++ b/tools/ml_selector/tests/test_mlSelectorTrainer.cpp
@@ -1,12 +1,14 @@
 // Copyright (c) Meta Platforms, Inc. and affiliates.
 
 #include <gtest/gtest.h>
+#include "openzl/cpp/CCtx.hpp"
 #include "openzl/cpp/Compressor.hpp"
 #include "openzl/cpp/DCtx.hpp"
 #include "tests/datagen/DataGen.h"
 #include "tests/ml_selector_utils.h"
 #include "tools/ml_selector/ml_features.h"
 #include "tools/ml_selector/ml_selector_graph.h"
+#include "tools/ml_selector/ml_selector_trainer.h"
 #include "tools/training/train.h"
 #include "tools/training/train_params.h"
 #include "tools/training/utils/utils.h"
@@ -14,10 +16,17 @@
 namespace openzl::tests {
 namespace {
 
-class TestMLSelectorGraph : public testing::Test {
+class TestMLSelectorTrainer : public testing::Test {
    public:
     void SetUp() override
     {
+        trainedCompressor_.setParameter(
+                CParam::FormatVersion, ZL_MAX_FORMAT_VERSION);
+        compressor_.setParameter(CParam::FormatVersion, ZL_MAX_FORMAT_VERSION);
+
+        generateTrainData();
+        testData_ = generateTestData();
+
         trainParams_ = {
             .compressorGenFunc =
                     [](std::string_view serialized) {
@@ -27,70 +36,127 @@ class TestMLSelectorGraph : public testing::Test {
                         return compressor;
                     },
         };
-        deltaData_    = generateDeltaData();
-        auto dg       = openzl::tests::datagen::DataGen();
-        tokenizeData_ = dg.template randLongVector<uint64_t>(
-                "randLongVec", 0, 500, 10000, 10000);
-        compressor_.setParameter(CParam::FormatVersion, ZL_MAX_FORMAT_VERSION);
-
-        numericInputs_.emplace_back();
-        numericInputs_.back().add(
-                Input::refNumeric(deltaData_.data(), deltaData_.size()));
-
-        numericInputs_.emplace_back();
-        numericInputs_.back().add(
-                Input::refNumeric(tokenizeData_.data(), tokenizeData_.size()));
-
-        serialInputs_.emplace_back();
-        serialInputs_.back().add(
-                Input::refNumeric(deltaData_.data(), deltaData_.size()));
-
-        serialInputs_.emplace_back();
-        serialInputs_.back().add(
-                Input::refNumeric(tokenizeData_.data(), tokenizeData_.size()));
-
-        SetUpCompressorWithStaticSuccessors();
     }
 
-    void SetUpCompressorWithStaticSuccessors()
+    std::vector<GraphID> registerSuccessors(
+            Compressor& compressor,
+            bool multi = false)
     {
-        auto deltaGid_ = ZL_Compressor_registerStaticGraph_fromNode1o(
-                compressor_.get(), ZL_NODE_DELTA_INT, ZL_GRAPH_ZSTD);
+        auto deltaGid = ZL_Compressor_registerStaticGraph_fromNode1o(
+                compressor.get(), ZL_NODE_DELTA_INT, ZL_GRAPH_ZSTD);
 
-        auto tokenizeGid_ = ZL_Compressor_registerTokenizeGraph(
-                compressor_.get(),
+        auto tokenizeGid = ZL_Compressor_registerTokenizeGraph(
+                compressor.get(),
                 ZL_Type_numeric,
                 true,
-                deltaGid_,
+                deltaGid,
                 ZL_GRAPH_ZSTD);
 
-        successors_ = { deltaGid_, tokenizeGid_ };
+        std::vector<ZL_GraphID> successorGraphs = { deltaGid, tokenizeGid };
 
-        ZL_RESULT_OF(ZL_GraphID)
-        mlSelectorResult = MLSelector_registerGraphWithEmptyGBTModel(
-                compressor_.get(), successors_.data(), successors_.size());
-        ASSERT_FALSE(ZL_RES_isError(mlSelectorResult));
-
-        ZL_GraphID mlSelectorGraphId = ZL_RES_value(mlSelectorResult);
-
-        ZL_GraphID _ = ZL_Compressor_registerStaticGraph_fromNode1o(
-                compressor_.get(),
-                ZL_NODE_CONVERT_SERIAL_TO_NUM_LE64,
-                mlSelectorGraphId);
+        if (multi) {
+            successorGraphs.push_back(ZL_GRAPH_ZSTD);
+        }
+        return successorGraphs;
     }
 
-    Compressor deserializeCompressor(
-            std::shared_ptr<const std::string_view>& serializedCompressor)
+    std::vector<GraphID> setUpCompressor(
+            Compressor& compressor,
+            bool multi = false)
     {
-        Compressor mlCompressor;
-        auto graphid = ZL_MLSelector_registerBaseGraph(mlCompressor.get());
-        EXPECT_TRUE(!ZL_RES_isError(graphid));
-        mlCompressor.setParameter(CParam::FormatVersion, ZL_MAX_FORMAT_VERSION);
-        mlCompressor.deserialize(*serializedCompressor.get());
+        std::vector<ZL_GraphID> successorGraphs =
+                registerSuccessors(compressor, multi);
 
-        return mlCompressor;
+        auto mlSelectorGraphId = MLSelector_registerGraphWithEmptyGBTModel(
+                compressor.get(),
+                successorGraphs.data(),
+                successorGraphs.size());
+
+        EXPECT_TRUE(!ZL_RES_isError(mlSelectorGraphId));
+
+        // Wrap with serial-to-numeric conversion so the graph accepts serial
+        // input
+        ZL_GraphID staticGraph = ZL_Compressor_registerStaticGraph_fromNode1o(
+                compressor.get(),
+                ZL_NODE_CONVERT_SERIAL_TO_NUM_LE64,
+                ZL_RES_value(mlSelectorGraphId));
+
+        // Parameterize so ml selector graph can be updated during training
+        ZL_GraphParameters const wrapperDesc = {};
+
+        auto sgid = ZL_Compressor_parameterizeGraph(
+                compressor.get(), staticGraph, &wrapperDesc);
+        EXPECT_TRUE(!ZL_RES_isError(sgid));
+        compressor.selectStartingGraph(ZL_RES_value(sgid));
+
+        return successorGraphs;
     }
 
+    std::vector<std::vector<uint64_t>> generateTestData()
+    {
+        std::vector<std::vector<uint64_t>> data;
+        auto dg = openzl::tests::datagen::DataGen();
+
+        data.push_back(generateDeltaData());
+        data.push_back(dg.template randLongVector<uint64_t>(
+                "randLongVec", 0, 100, 10000, 10000));
+
+        data.push_back(dg.template randLongVector<uint64_t>(
+                "randLongVec", 0, UINT64_MAX, 10000, 10000));
+        return data;
+    }
+
+    void generateTrainData(int size = 500)
+    {
+        for (auto i = 0; i < size; ++i) {
+            auto dg = openzl::tests::datagen::DataGen();
+
+            deltaData_.push_back(generateDeltaData());
+
+            tokenizeData_.push_back(dg.template randLongVector<uint64_t>(
+                    "randLongVec", 0, 100, 10000, 10000));
+
+            zstd_.push_back(dg.template randLongVector<uint64_t>(
+                    "randLongVec", 0, UINT64_MAX, 10000, 10000));
+
+            // For binary classification, only add delta and tokenize data
+            training::MultiInput binaryInput1;
+            binaryInput1.add(
+                    Input::refSerial(
+                            deltaData_.back().data(),
+                            deltaData_.back().size() * sizeof(uint64_t)));
+            binaryInputs_.push_back(std::move(binaryInput1));
+
+            training::MultiInput binaryInput2;
+            binaryInput2.add(
+                    Input::refSerial(
+                            tokenizeData_.back().data(),
+                            tokenizeData_.back().size() * sizeof(uint64_t)));
+            binaryInputs_.push_back(std::move(binaryInput2));
+
+            // For multiclass classification, add delta, tokenize, and zstd data
+            training::MultiInput multiInput1;
+            multiInput1.add(
+                    Input::refSerial(
+                            deltaData_.back().data(),
+                            deltaData_.back().size() * sizeof(uint64_t)));
+            multiInputs_.push_back(std::move(multiInput1));
+
+            training::MultiInput multiInput2;
+            multiInput2.add(
+                    Input::refSerial(
+                            tokenizeData_.back().data(),
+                            tokenizeData_.back().size() * sizeof(uint64_t)));
+            multiInputs_.push_back(std::move(multiInput2));
+
+            training::MultiInput multiInput3;
+            multiInput3.add(
+                    Input::refSerial(
+                            zstd_.back().data(),
+                            zstd_.back().size() * sizeof(uint64_t)));
+            multiInputs_.push_back(std::move(multiInput3));
+        }
+    }
     size_t compress(
             Compressor& compressor,
             std::string& dst,
@@ -99,6 +165,7 @@ class TestMLSelectorGraph : public testing::Test {
         compressor.setParameter(CParam::FormatVersion, ZL_MAX_FORMAT_VERSION);
 
         cctx_.refCompressor(compressor);
+        // Use refSerial since ./zli assumes all data is serial
         auto s_input =
                 Input::refSerial(input.data(), input.size() * sizeof(uint64_t));
         return cctx_.compressOne(dst, s_input);
@@ -115,6 +182,7 @@ class TestMLSelectorGraph : public testing::Test {
         cBuffer.resize(compressedSize);
 
         // Decompress and verify that the result is the same as the input
+        // Since we compress with refSerial, we use decompressSerial
         const auto decompressedOutput = dctx_.decompressSerial(cBuffer);
 
         const uint64_t* output =
@@ -125,57 +193,180 @@ class TestMLSelectorGraph : public testing::Test {
         EXPECT_EQ(outputVec, input);
     }
 
+    void testSelection(
+            const std::vector<uint64_t>& input,
+            Compressor& compressor,
+            Compressor& mlCompressor)
+    {
+        auto compressBound = ZL_compressBound(input.size() * sizeof(uint64_t));
+
+        // Compress using selected successor
+        std::string cBuffer = std::string(compressBound, '\0');
+        auto compressedSize = compress(compressor, cBuffer, input);
+        cBuffer.resize(compressedSize);
+
+        // Compress using ml selector graph
+        std::string scBuffer  = std::string(compressBound, '\0');
+        auto mlCompressedSize = compress(mlCompressor, scBuffer, input);
+        scBuffer.resize(mlCompressedSize);
+
+        // Check that the ml selector graph selects the correct successor
+        EXPECT_EQ(cBuffer, scBuffer);
+    }
+
+    Compressor deserializeCompressor(
+            std::shared_ptr<const std::string_view>& serializedCompressor)
+    {
+        Compressor mlCompressor;
+        auto graphid = ZL_MLSelector_registerBaseGraph(mlCompressor.get());
+        EXPECT_TRUE(!ZL_RES_isError(graphid));
+        mlCompressor.setParameter(CParam::FormatVersion, ZL_MAX_FORMAT_VERSION);
+        mlCompressor.deserialize(*serializedCompressor.get());
+
+        return mlCompressor;
+    }
+
    protected:
     Compressor compressor_;
-    CCtx cctx_;
-    DCtx dctx_;
+    Compressor trainedCompressor_;
 
-    std::vector<uint64_t> deltaData_;
-    std::vector<uint64_t> tokenizeData_;
-    std::vector<uint64_t> serialData_;
-    std::vector<training::MultiInput> numericInputs_;
-    std::vector<training::MultiInput> serialInputs_;
+    std::vector<std::vector<uint64_t>> deltaData_;
+    std::vector<std::vector<uint64_t>> tokenizeData_;
+    std::vector<std::vector<uint64_t>> zstd_;
+
+    std::vector<std::vector<uint64_t>> testData_;
+
+    std::vector<training::MultiInput> binaryInputs_;
+    std::vector<training::MultiInput> multiInputs_;
+
+    std::vector<ZL_GraphID> multiSuccessors_;
+    std::vector<std::string> multiSuccessorLabels_ = { "delta",
+                                                       "tokenize",
+                                                       "zstd" };
+
+    std::vector<ZL_GraphID> binarySuccessors_;
+    std::vector<std::string> binarySuccessorsLabels_ = { "delta", "tokenize" };
+
     openzl::training::TrainParams trainParams_;
 
-    std::vector<ZL_GraphID> successors_;
-    std::vector<std::string> successorLabels_ = { "delta", "tokenize" };
+    CCtx cctx_;
+    DCtx dctx_;
 };
 
-TEST_F(TestMLSelectorGraph, TestNumericRoundTrip)
+TEST_F(TestMLSelectorTrainer, MultiClassSelection)
 {
-    auto serializedTrainedCompressors =
-            openzl::training::train(numericInputs_, compressor_, trainParams_);
+    multiSuccessors_ = registerSuccessors(compressor_);
+    setUpCompressor(trainedCompressor_, true);
+    auto serializedCompressor = openzl::training::trainMLSelectorGraph(
+            multiInputs_, trainedCompressor_, trainParams_);
 
-    ASSERT_FALSE(serializedTrainedCompressors.empty());
-    ASSERT_NE(serializedTrainedCompressors[0], nullptr);
+    // Deserialize the trained compressor
+    Compressor mlCompressor = deserializeCompressor(serializedCompressor);
 
-    Compressor comp = deserializeCompressor(serializedTrainedCompressors[0]);
-    testRoundTrip(deltaData_, comp);
+    // Check that the ml selector graph selects the correct successor
+    for (size_t i = 0; i < multiSuccessors_.size(); i++) {
+        auto gid = compressor_.buildStaticGraph(
+                ZL_NODE_CONVERT_SERIAL_TO_NUM_LE64, { multiSuccessors_[i] });
+        compressor_.selectStartingGraph(gid);
+        testSelection(testData_[i], compressor_, mlCompressor);
+    }
 }
 
-TEST_F(TestMLSelectorGraph, TestSerialRoundTrip)
+TEST_F(TestMLSelectorTrainer, BinaryClassSelection)
 {
-    auto serializedTrainedCompressors =
-            openzl::training::train(serialInputs_, compressor_, trainParams_);
+    binarySuccessors_ = registerSuccessors(compressor_);
+    setUpCompressor(trainedCompressor_);
 
-    ASSERT_FALSE(serializedTrainedCompressors.empty());
-    ASSERT_NE(serializedTrainedCompressors[0], nullptr);
+    auto serializedCompressor = openzl::training::trainMLSelectorGraph(
+            binaryInputs_, trainedCompressor_, trainParams_);
 
-    Compressor comp = deserializeCompressor(serializedTrainedCompressors[0]);
-    testRoundTrip(deltaData_, comp);
+    // Deserialize the trained compressor
+    Compressor mlCompressor = deserializeCompressor(serializedCompressor);
+
+    // Check that the ml selector graph selects the correct successor
+    for (size_t i = 0; i < binarySuccessors_.size(); i++) {
+        auto gid = compressor_.buildStaticGraph(
+                ZL_NODE_CONVERT_SERIAL_TO_NUM_LE64, { binarySuccessors_[i] });
+        compressor_.selectStartingGraph(gid);
+        testSelection(testData_[i], compressor_, mlCompressor);
+    }
 }
 
-TEST_F(TestMLSelectorGraph, TestFeatureExtraction)
+TEST_F(TestMLSelectorTrainer, BinaryClassRoundTrip)
 {
+    binarySuccessors_ = setUpCompressor(trainedCompressor_, true);
+
+    auto serializedBinaryClassCompressors =
+            openzl::training::trainMLSelectorGraph(
+                    binaryInputs_, trainedCompressor_, trainParams_);
+
+    Compressor mlCompressor =
+            deserializeCompressor(serializedBinaryClassCompressors);
+
+    // Make sure deserialized data is same as original data
+    for (size_t i = 0; i < testData_.size(); i++) {
+        testRoundTrip(testData_[i], mlCompressor);
+    }
+}
+
+TEST_F(TestMLSelectorTrainer, MultiClassRoundTrip)
+{
+    multiSuccessors_ = setUpCompressor(trainedCompressor_, true);
+
+    auto serializedMultiClassCompressors =
+            openzl::training::trainMLSelectorGraph(
+                    multiInputs_, trainedCompressor_, trainParams_);
+
+    Compressor mlCompressor =
+            deserializeCompressor(serializedMultiClassCompressors);
+
+    // Make sure deserialized data is same as original data
+    for (size_t i = 0; i < testData_.size(); i++) {
+        testRoundTrip(testData_[i], mlCompressor);
+    }
+}
+
+TEST_F(TestMLSelectorTrainer, TrainRoundTrip)
+{
+    multiSuccessors_ = setUpCompressor(trainedCompressor_, true);
+
+    auto serializedCompressor = openzl::training::train(
+            multiInputs_, trainedCompressor_, trainParams_);
+
+    Compressor mlCompressor =
+            deserializeCompressor(serializedCompressor.front());
+
+    testRoundTrip(testData_.front(), mlCompressor);
+}
+
+TEST_F(TestMLSelectorTrainer, TestFeatureExtraction)
+{
+    // Use refNumeric here since extactMLFeatures expects numeric data
+    training::MultiInput multiInput1;
+    multiInput1.add(
+            Input::refNumeric(
+                    deltaData_.front().data(), deltaData_.front().size()));
+
+    training::MultiInput multiInput2;
+    multiInput2.add(
+            Input::refNumeric(
+                    tokenizeData_.front().data(),
+                    tokenizeData_.front().size()));
+
+    std::vector<training::MultiInput> featureInputs = { multiInput1,
+                                                        multiInput2 };
+
+    binarySuccessors_ = setUpCompressor(trainedCompressor_);
     training::ProcessedMLTrainingSamples trainingSample = extractMLFeatures(
-            numericInputs_, compressor_, cctx_, successors_, successorLabels_);
+            featureInputs,
+            trainedCompressor_,
+            cctx_,
+            binarySuccessors_,
+            binarySuccessorsLabels_);
 
-    std::vector<std::string> expectedLabels = { "delta", "tokenize" };
+    EXPECT_EQ(trainingSample.labels[0], "delta");
+    EXPECT_EQ(trainingSample.labels[1], "tokenize");
 
-    EXPECT_EQ(trainingSample.labels.size(), 2);
-    EXPECT_EQ(trainingSample.labels, expectedLabels);
-
-    EXPECT_EQ(trainingSample.features.size(), 2);
     // featureGen_int should generate 11 features
     EXPECT_EQ(trainingSample.features[0].size(), 11);
 
@@ -192,14 +383,19 @@ TEST_F(TestMLSelectorGraph, TestFeatureExtraction)
                                                       "kurtosis" };
 
     EXPECT_EQ(trainingSample.featureNames, expectedFeatureNames);
-    std::swap(numericInputs_[0], numericInputs_[1]);
-    std::swap(expectedLabels[0], expectedLabels[1]);
+
+    // Swap to verify that we are getting correct labels
+    std::swap(featureInputs[0], featureInputs[1]);
 
     training::ProcessedMLTrainingSamples trainingSample2 = extractMLFeatures(
-            numericInputs_, compressor_, cctx_, successors_, successorLabels_);
+            featureInputs,
+            trainedCompressor_,
+            cctx_,
+            binarySuccessors_,
+            binarySuccessorsLabels_);
 
-    EXPECT_EQ(trainingSample2.labels.size(), 2);
-    EXPECT_EQ(trainingSample2.labels, expectedLabels);
+    EXPECT_EQ(trainingSample2.labels[0], "tokenize");
+    EXPECT_EQ(trainingSample2.labels[1], "delta");
 }
 
 } // namespace

--- a/tools/training/CMakeLists.txt
+++ b/tools/training/CMakeLists.txt
@@ -46,7 +46,8 @@ if (OPENZL_BUILD_TRAINING_TOOLS)
         openzl_cpp
         tools_io
         logger
-        ml_selector_graph)
+        ml_selector_graph
+        xgboost_external)
 
   if (OPENZL_BUILD_TESTS AND OPENZL_ALLOW_INTROSPECTION)
     file(
@@ -60,6 +61,7 @@ if (OPENZL_BUILD_TRAINING_TOOLS)
         CONFIGURE_DEPENDS
         "${CMAKE_CURRENT_LIST_DIR}/tests/*.h")
     add_executable(test_training ${test_training_srcs} ${test_training_headers})
+    add_dependencies(test_training xgboost_external)
     target_link_libraries(
         test_training
         PRIVATE

--- a/tools/zstrong_ml.cpp
+++ b/tools/zstrong_ml.cpp
@@ -71,20 +71,6 @@ gbt_predictor::GBTPredictor getPredictorFromJson(folly::dynamic const& model)
     return gbt_predictor::GBTPredictor(model["predictor"]);
 }
 
-::GBTModel getModel(
-        const gbt_predictor::GBTPredictor& predictor,
-        const std::vector<Label>& labels,
-        const std::vector<Label>& features)
-{
-    ::GBTModel model{
-        .predictor     = predictor.getCorePredictor().get(),
-        .nbLabels      = labels.size(),
-        .classLabels   = labels.data(),
-        .nbFeatures    = features.size(),
-        .featureLabels = features.data(),
-    };
-    return model;
-}
 } // namespace
 
 GBTModel::GBTModel(folly::dynamic const& model)
@@ -92,8 +78,7 @@ GBTModel::GBTModel(folly::dynamic const& model)
           labels_(getLabelsFromStrings(labels_str_)),
           features_str_(getFeaturesFromJson(model)),
           features_(getLabelsFromStrings(features_str_)),
-          predictor_(getPredictorFromJson(model)),
-          gbtModel_(getModel(predictor_, labels_, features_))
+          predictor_(getPredictorFromJson(model))
 {
     if (predictor_.getNumClasses() != labels_str_.size()) {
         throw std::runtime_error(
@@ -105,20 +90,16 @@ GBTModel::GBTModel(std::string_view model) : GBTModel(folly::parseJson(model))
 {
 }
 
-Label GBTModel::predict(
-        const ZL_Input* input,
-        ::FeatureGenerator fgen,
-        const void* featureCxt) const
+Label GBTModel::predict(const ZL_Input* input, const FeatureGenerator* fgen)
+        const
 {
-    auto gbtModel              = gbtModel_;
-    gbtModel.featureGenerator  = fgen;
-    gbtModel.featureContext    = featureCxt;
-    ZL_RESULT_OF(Label) result = GBTModel_predict(&gbtModel, input);
-    if (ZL_RES_isError(result)) {
+    FeatureMap featuresMap;
+    fgen->getFeatures(featuresMap, input);
+    size_t classIdx = predict(featuresMap);
+    if (classIdx >= labels_.size()) {
         return "";
     }
-    const char* decodedLabel = ZL_RES_value(result);
-    return decodedLabel;
+    return labels_[classIdx];
 }
 
 size_t GBTModel::predict(const FeatureMap& featuresMap) const
@@ -145,7 +126,7 @@ void calcIntegerFeatures(
 {
     ZL_Input* stream = ZL_TypedRef_createNumeric(data, eltWidth, nbElts);
     VECTOR(LabeledFeature) features = VECTOR_EMPTY(kMaxVectorSize);
-    const ZL_Report report = FeatureGen_integer(stream, &features, nullptr);
+    const ZL_Report report          = FeatureGen_integer(stream, &features);
     for (size_t i = 0; i < VECTOR_SIZE(features); i++) {
         auto const& feature        = VECTOR_AT(features, i);
         featuresMap[feature.label] = feature.value;
@@ -329,11 +310,9 @@ ZL_GraphID MLSelector::select(
         ZL_Input const* input,
         std::span<ZL_GraphID const> successors) const
 {
-    (void)eictx;
-
     if (labelsIdx_.size()) {
-        std::string predictedLabel = model_.get()->predict(
-                input, featureGen_MLSelector, featureGenerator_.get());
+        std::string predictedLabel =
+                model_.get()->predict(input, featureGenerator_.get());
         size_t predictedIdx = labelsIdx_.at(predictedLabel);
         return successors[predictedIdx];
     } else {

--- a/tools/zstrong_ml.h
+++ b/tools/zstrong_ml.h
@@ -37,14 +37,15 @@ using FeatureMap = std::unordered_map<std::string, double>;
 using TargetsMap =
         std::unordered_map<std::string, std::unordered_map<std::string, float>>;
 
+// Forward declaration
+class FeatureGenerator;
+
 /// A base class that defines the interface of any ML based
 /// model used by Zstrong's selectors.
 class MLModel {
    public:
-    virtual Label predict(
-            const ZL_Input* input,
-            FeatureGenerator fgen,
-            const void* featureCxt) const = 0;
+    virtual Label predict(const ZL_Input* input, const FeatureGenerator* fgen)
+            const = 0;
 
     virtual size_t predict(const FeatureMap& features) const = 0;
     std::string predictLabel(const FeatureMap& features) const
@@ -60,10 +61,8 @@ class GBTModel : public MLModel {
    public:
     explicit GBTModel(folly::dynamic const& model);
     explicit GBTModel(std::string_view model);
-    Label predict(
-            const ZL_Input* input,
-            FeatureGenerator fgen,
-            const void* featureCxt) const override;
+    Label predict(const ZL_Input* input, const FeatureGenerator* fgen)
+            const override;
     size_t predict(const FeatureMap& features) const override;
     std::span<const std::string> getLabels() const override
     {
@@ -77,7 +76,6 @@ class GBTModel : public MLModel {
     const std::vector<Label> features_;
 
     const gbt_predictor::GBTPredictor predictor_;
-    const ::GBTModel gbtModel_;
 };
 
 /// FeatureGenerators are used to create a FeatureMaps from a Zstrong Streams
@@ -109,26 +107,6 @@ class FeatureGenerator {
                 ZL_Input_type(data),
                 ZL_Input_eltWidth(data),
                 ZL_Input_numElts(data));
-    }
-
-    void getCFeatures(VECTOR(LabeledFeature) * features, ZL_Input const* data)
-            const
-    {
-        FeatureMap featuresMap;
-        getFeatures(
-                featuresMap,
-                ZL_Input_ptr(data),
-                ZL_Input_type(data),
-                ZL_Input_eltWidth(data),
-                ZL_Input_numElts(data));
-        bool badAlloc = false;
-        for (auto it : featuresMap) {
-            LabeledFeature lf = { getLabel(it.first), (float)it.second };
-            badAlloc |= !VECTOR_PUSHBACK(*features, lf);
-        }
-        if (badAlloc) {
-            throw std::runtime_error("Failed to add features to vector");
-        }
     }
 
     virtual ~FeatureGenerator() = default;
@@ -232,28 +210,6 @@ class MLSelector : public CustomSelector {
                             + label);
                 }
             }
-        }
-    }
-
-    static ZL_Report featureGen_MLSelector(
-            const ZL_Input* inputStream,
-            VECTOR(LabeledFeature) * features,
-            const void* featureContext)
-    {
-        try {
-            // TODO: Not efficient to use cpp implementation to get features,
-            // since the cpp implementation uses the c implementation, this
-            // means that we are turning VECTOR into FeatureMap then back to
-            // VECTOR.
-
-            const FeatureGenerator* cppFeatureGen =
-                    (const FeatureGenerator*)featureContext;
-
-            cppFeatureGen->getCFeatures(features, inputStream);
-
-            return ZL_returnSuccess();
-        } catch (const std::exception& e) {
-            ZL_RET_R_ERR(GENERIC, "ML selector error %s", e.what());
         }
     }
 


### PR DESCRIPTION
Summary: Remove `featureContext` from GBTModel struct, since it cannot be serialized and is not being used right now.

Differential Revision: D88529141


