### PR TITLE
[fix][Windows][clang-cl build] add missing STL includes

### DIFF
--- a/src/openzl/shared/portability.h
+++ b/src/openzl/shared/portability.h
@@ -226,8 +226,7 @@ typedef __m128i __m128i_u;
 #if (defined(__STDC_IEC_559__) && __STDC_IEC_559__) \
         || (defined(__STDC_IEC_60559_BFP__)         \
             && __STDC_IEC_60559_BFP__ >= 202311L)   \
-        || defined(__APPLE__) || defined(__MINGW32__) \
-        || defined(_MSC_VER)
+        || defined(__APPLE__) || defined(__MINGW32__) || defined(_MSC_VER)
 #    define ZL_HAS_IEEE_754 1
 #else
 #    define ZL_HAS_IEEE_754 0

--- a/src/openzl/shared/portability.h
+++ b/src/openzl/shared/portability.h
@@ -222,10 +222,12 @@ typedef __m128i __m128i_u;
 // Detect IEEE 754 floating point support.
 // Apple doesn't define __STDC_IEC_559__, but supports IEEE 754.
 // MinGW doesn't define __STDC_IEC_559__, but supports IEEE 754.
+// MSVC on x86/x64 supports IEEE 754.
 #if (defined(__STDC_IEC_559__) && __STDC_IEC_559__) \
         || (defined(__STDC_IEC_60559_BFP__)         \
             && __STDC_IEC_60559_BFP__ >= 202311L)   \
-        || defined(__APPLE__) || defined(__MINGW32__)
+        || defined(__APPLE__) || defined(__MINGW32__) \
+        || defined(_MSC_VER)
 #    define ZL_HAS_IEEE_754 1
 #else
 #    define ZL_HAS_IEEE_754 0

--- a/tests/decompress/test_decode_frameheader.cpp
+++ b/tests/decompress/test_decode_frameheader.cpp
@@ -1,6 +1,7 @@
 // Copyright (c) Meta Platforms, Inc. and affiliates.
 
 #include <gtest/gtest.h>
+#include <numeric>
 #include <random>
 
 #include "openzl/common/assertion.h"

--- a/tests/round_trip/test_functionGraphs.cpp
+++ b/tests/round_trip/test_functionGraphs.cpp
@@ -3,8 +3,8 @@
 #include <gtest/gtest.h>
 
 // standard C
-#include <array>
 #include <stdio.h> // printf
+#include <array>
 
 // Zstrong
 #include <zstd.h> // ZSTD_c_* parameters

--- a/tests/round_trip/test_functionGraphs.cpp
+++ b/tests/round_trip/test_functionGraphs.cpp
@@ -3,6 +3,7 @@
 #include <gtest/gtest.h>
 
 // standard C
+#include <array>
 #include <stdio.h> // printf
 
 // Zstrong

--- a/tools/io/InputSet.cpp
+++ b/tools/io/InputSet.cpp
@@ -2,6 +2,8 @@
 
 #include "tools/io/InputSet.h"
 
+#include <stdexcept>
+
 namespace openzl::tools::io {
 
 InputSet::Iterator InputSet::begin() const

--- a/tools/io/InputSetBuilder.h
+++ b/tools/io/InputSetBuilder.h
@@ -3,6 +3,8 @@
 #pragma once
 
 #include <memory>
+#include <optional>
+#include <string>
 #include <vector>
 
 #include "tools/io/InputSet.h"

--- a/tools/io/InputSetDir.cpp
+++ b/tools/io/InputSetDir.cpp
@@ -3,6 +3,7 @@
 #include "tools/io/InputSetDir.h"
 
 #include <filesystem>
+#include <stdexcept>
 
 #include "tools/io/InputFile.h"
 

--- a/tools/io/InputSetMulti.cpp
+++ b/tools/io/InputSetMulti.cpp
@@ -2,6 +2,8 @@
 
 #include "tools/io/InputSetMulti.h"
 
+#include <stdexcept>
+
 namespace openzl::tools::io {
 
 class InputSetMulti::IteratorStateMulti : public InputSet::IteratorState {

--- a/tools/io/InputSetStatic.cpp
+++ b/tools/io/InputSetStatic.cpp
@@ -2,6 +2,8 @@
 
 #include "tools/io/InputSetStatic.h"
 
+#include <stdexcept>
+
 namespace openzl::tools::io {
 
 class InputSetStatic::IteratorStateStatic : public InputSet::IteratorState {

--- a/tools/logger/Logger.h
+++ b/tools/logger/Logger.h
@@ -6,6 +6,7 @@
 #include <iostream>
 #include <ostream>
 #include <stdexcept>
+#include <string>
 #include <vector>
 
 namespace openzl::tools::logger {

--- a/tools/training/clustering/trainers/bottom_up_trainer.cpp
+++ b/tools/training/clustering/trainers/bottom_up_trainer.cpp
@@ -1,6 +1,9 @@
 // Copyright (c) Meta Platforms, Inc. and affiliates.
 
 #include "tools/training/clustering/trainers/bottom_up_trainer.h"
+
+#include <chrono>
+
 #include "tools/logger/Logger.h"
 #include "tools/training/clustering/clustering_config_builder.h"
 

--- a/tools/training/clustering/trainers/greedy_trainer.cpp
+++ b/tools/training/clustering/trainers/greedy_trainer.cpp
@@ -3,6 +3,8 @@
 #include "tools/training/clustering/trainers/greedy_trainer.h"
 
 #include <algorithm>
+#include <chrono>
+
 #include "tools/logger/Logger.h"
 
 #include "tools/training/clustering/clustering_config_builder.h"

--- a/tools/training/utils/genetic_algorithm.cpp
+++ b/tools/training/utils/genetic_algorithm.cpp
@@ -2,6 +2,8 @@
 
 #include "tools/training/utils/genetic_algorithm.h"
 
+#include <numeric>
+
 namespace openzl {
 namespace training {
 


### PR DESCRIPTION
## Summary

Adds missing STL headers required for Windows/clang-cl builds:

- `<string>` for `std::to_string` in `Logger.h`
- `<numeric>` for `std::accumulate`, `std::iota` in test and training files
- `<stdexcept>` for `std::runtime_error` in `InputSet*.cpp`
- `<array>` for `std::array` in `test_functionGraphs.cpp`
- `<optional>` for `std::optional` in `InputSetBuilder.h`
- `<chrono>` for `std::chrono::high_resolution_clock` in trainer files
- Added MSVC detection (`_MSC_VER`) for IEEE 754 floating-point support in `portability.h`

These headers are implicitly included via transitive dependencies on GCC/Clang but MSVC requires explicit includes. **No runtime or performance impact** - purely compile-time fixes.

Fixes #95

**Note:** I have also validated that #97 (std::future move-only fix) works correctly on my Windows setup.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Test Plan

Built the project

cmake -S . -B build -G "Visual Studio 14 2015" -T ClangCL
cmake --build build --config Release

build is now successful 
The only error is for libzstd_shared.vcxproj (the shared/DLL version of zstd):
```fatal error RC1012: mismatched parenthesis : missing '```
This is a resource compiler issue with Clang headers when building the shared library. But this is non-blocking

After build successful, subsequent fix is about passing test, correcting ```std::future``` using PR from #97 and std::uniform distribution #301 

### Test Configuration

- **Compiler:** clang-cl (ClangCL toolset)
- **Generator:** Visual Studio 14 2015 with ClangCL toolset (`-T ClangCL`)
- **Build type:** Release
- **Platform:** Windows 11 x64