### PR TITLE
[fix][Windows] MSVC compatibility for std::uniform_int_distribution with small types

### DIFF
--- a/tests/BUCK
+++ b/tests/BUCK
@@ -116,6 +116,7 @@ zs_cxxlibrary(
     headers = glob(["zstrong/**/*ixture.h"]),
     deps = [
         "..:zstronglib",
+        "datagen:datagen",
         "fbsource//third-party/googletest:gtest",
         ":utils",
     ],

--- a/tests/codecs/test_tokenize.cpp
+++ b/tests/codecs/test_tokenize.cpp
@@ -9,6 +9,7 @@
 
 #include "openzl/openzl.hpp"
 #include "tests/codecs/test_codec.h"
+#include "tests/datagen/random_producer/compat_uniform_distribution.h"
 
 namespace openzl {
 namespace tests {
@@ -234,7 +235,7 @@ TEST_F(TokenizeTest, TokenizeStringSorted)
             { "hello", "me", "world", "zstd" },
             std::vector<uint8_t>{ 3, 0, 2, 0, 1, 3 });
 
-    std::uniform_int_distribution<uint8_t> chrDist('a', 'z');
+    datagen::compat_uniform_int_distribution<uint8_t> chrDist('a', 'z');
     std::uniform_int_distribution<size_t> lenDist(0, 5);
     std::mt19937 gen(0xdeadbeef);
 

--- a/tests/compress/test_estimate.cpp
+++ b/tests/compress/test_estimate.cpp
@@ -12,11 +12,14 @@
 #include <gtest/gtest.h>
 
 #include "openzl/shared/estimate.h"
+#include "tests/datagen/random_producer/compat_uniform_distribution.h"
 
 namespace {
 template <typename Int>
 std::vector<Int> generateFixedData(size_t cardinality)
 {
+    using compat_dist =
+            openzl::tests::datagen::compat_uniform_int_distribution<Int>;
     std::mt19937 gen(42);
     std::unordered_set<Int> tokens;
     if (cardinality > (size_t)std::numeric_limits<Int>::max()) {
@@ -24,7 +27,7 @@ std::vector<Int> generateFixedData(size_t cardinality)
             tokens.insert(Int(i));
         }
     } else {
-        std::uniform_int_distribution<Int> dis;
+        compat_dist dis;
         while (tokens.size() < cardinality) {
             tokens.insert(dis(gen));
         }
@@ -48,7 +51,7 @@ VariableData generateVariableData(size_t cardinality, size_t size)
     std::mt19937 gen(42);
     std::unordered_set<std::string> tokens;
     std::uniform_int_distribution<size_t> len(0, 100);
-    std::uniform_int_distribution<int8_t> chr;
+    openzl::tests::datagen::compat_uniform_int_distribution<int8_t> chr;
 
     while (tokens.size() < cardinality) {
         std::string x;
@@ -131,15 +134,17 @@ void testEstimateVariable()
 template <typename Int>
 void testComputeUnsignedRange()
 {
+    using compat_dist =
+            openzl::tests::datagen::compat_uniform_int_distribution<Int>;
     std::mt19937 gen(42);
-    std::uniform_int_distribution<Int> bounds(
+    compat_dist bounds(
             std::numeric_limits<Int>::min(), std::numeric_limits<Int>::max());
     for (size_t i = 0; i < 1000; ++i) {
         auto const bound1 = bounds(gen);
         auto const bound2 = bounds(gen);
         auto const min    = std::min(bound1, bound2);
         auto const max    = std::max(bound1, bound2);
-        std::uniform_int_distribution<Int> value(min, max);
+        compat_dist value(min, max);
         std::vector<Int> values;
         values.reserve(100);
         for (size_t j = 0; j < 100; ++j) {
@@ -157,8 +162,10 @@ void testComputeUnsignedRange()
 template <typename Int>
 std::vector<Int> genStridedData(int stride)
 {
+    using compat_dist =
+            openzl::tests::datagen::compat_uniform_int_distribution<Int>;
     std::mt19937 gen(42);
-    std::uniform_int_distribution<Int> dist;
+    compat_dist dist;
     std::bernoulli_distribution match(0.5);
     std::bernoulli_distribution copyStride(0.9);
     std::poisson_distribution<int> offset(1.5);
@@ -305,7 +312,7 @@ TEST(Estimate, GuessFloatWidth)
     ASSERT_EQ(ZL_guessFloatWidth(data8.data(), data8.size()), 1u);
     ASSERT_EQ(ZL_guessFloatWidth(data16.data(), data16.size() * 2), 1u);
 
-    std::uniform_int_distribution<uint8_t> dist8;
+    openzl::tests::datagen::compat_uniform_int_distribution<uint8_t> dist8;
     for (size_t i = 0; i < 8192; ++i) {
         data8[i] = dist8(gen);
     }

--- a/tests/compress/test_gbt.cpp
+++ b/tests/compress/test_gbt.cpp
@@ -2,11 +2,13 @@
 
 #include <gtest/gtest.h>
 #include <cmath>
+#include <numeric>
 #include <random>
 #include <vector>
 
 #include "openzl/common/stream.h" // For stream usage in hardcoded feature generators
 #include "openzl/compress/selectors/ml/gbt.h"
+#include "tests/datagen/random_producer/compat_uniform_distribution.h"
 #include "tests/zstrong/test_zstrong_fixture.h"
 
 using namespace ::testing;
@@ -33,7 +35,8 @@ GBTPredictor_Tree generateTree(
         bool forceRight         = false)
 {
     std::mt19937_64 mt(kRandomSeed);
-    std::uniform_int_distribution<uint8_t> dist(0, 100);
+    openzl::tests::datagen::compat_uniform_int_distribution<uint8_t> dist(
+            0, 100);
 
     for (size_t i = 0; i < sz; ++i) {
         // Update necessary variables if node is leaf node

--- a/tests/datagen/random_producer/PRNGWrapper.h
+++ b/tests/datagen/random_producer/PRNGWrapper.h
@@ -6,6 +6,7 @@
 #include <random>
 
 #include "tests/datagen/random_producer/RandWrapper.h"
+#include "tests/datagen/random_producer/compat_uniform_distribution.h"
 
 namespace openzl::tests::datagen {
 
@@ -52,42 +53,42 @@ class PRNGWrapper : public RandWrapper {
 
     uint8_t u8_range(NameType, uint8_t min, uint8_t max) override
     {
-        return std::uniform_int_distribution<uint8_t>(min, max)(*generator_);
+        return compat_uniform_int_distribution<uint8_t>(min, max)(*generator_);
     }
 
     uint16_t u16_range(NameType, uint16_t min, uint16_t max) override
     {
-        return std::uniform_int_distribution<uint16_t>(min, max)(*generator_);
+        return compat_uniform_int_distribution<uint16_t>(min, max)(*generator_);
     }
 
     uint32_t u32_range(NameType, uint32_t min, uint32_t max) override
     {
-        return std::uniform_int_distribution<uint32_t>(min, max)(*generator_);
+        return compat_uniform_int_distribution<uint32_t>(min, max)(*generator_);
     }
 
     uint64_t u64_range(NameType, uint64_t min, uint64_t max) override
     {
-        return std::uniform_int_distribution<uint64_t>(min, max)(*generator_);
+        return compat_uniform_int_distribution<uint64_t>(min, max)(*generator_);
     }
 
     int8_t i8_range(NameType, int8_t min, int8_t max) override
     {
-        return std::uniform_int_distribution<int8_t>(min, max)(*generator_);
+        return compat_uniform_int_distribution<int8_t>(min, max)(*generator_);
     }
 
     int16_t i16_range(NameType, int16_t min, int16_t max) override
     {
-        return std::uniform_int_distribution<int16_t>(min, max)(*generator_);
+        return compat_uniform_int_distribution<int16_t>(min, max)(*generator_);
     }
 
     int32_t i32_range(NameType, int32_t min, int32_t max) override
     {
-        return std::uniform_int_distribution<int32_t>(min, max)(*generator_);
+        return compat_uniform_int_distribution<int32_t>(min, max)(*generator_);
     }
 
     int64_t i64_range(NameType, int64_t min, int64_t max) override
     {
-        return std::uniform_int_distribution<int64_t>(min, max)(*generator_);
+        return compat_uniform_int_distribution<int64_t>(min, max)(*generator_);
     }
 
     float f32_range(NameType, float min, float max) override
@@ -113,9 +114,9 @@ class PRNGWrapper : public RandWrapper {
 
    private:
     std::shared_ptr<std::mt19937> generator_;
-    std::uniform_int_distribution<uint8_t> u8dist_;
-    std::uniform_int_distribution<uint32_t> u32dist_;
-    std::uniform_int_distribution<uint64_t> u64dist_;
+    compat_uniform_int_distribution<uint8_t> u8dist_;
+    compat_uniform_int_distribution<uint32_t> u32dist_;
+    compat_uniform_int_distribution<uint64_t> u64dist_;
     std::uniform_real_distribution<float> f32dist_;
     std::uniform_real_distribution<double> f64dist_;
 };

--- a/tests/datagen/random_producer/compat_uniform_distribution.h
+++ b/tests/datagen/random_producer/compat_uniform_distribution.h
@@ -1,0 +1,120 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#pragma once
+
+#include <random>
+#include <type_traits>
+
+// MSVC's std::uniform_int_distribution, binomial_distribution,
+// geometric_distribution don't support uint8_t, int8_t, etc. per the C++
+// standard N4950 [rand.req.genl]/1.5. GCC/Clang are more permissive and allow
+// these types.
+//
+// Solution: On MSVC, promote small types to short/unsigned short, use std::,
+// then cast back. This is simple and avoids potential bugs in custom
+// implementations.
+
+namespace openzl::tests::datagen {
+
+// Helper: map small types to larger ones that MSVC supports
+template <typename T>
+struct promoted_int_type {
+    using type = std::conditional_t<
+            sizeof(T) < sizeof(short),
+            std::conditional_t<std::is_signed_v<T>, short, unsigned short>,
+            T>;
+};
+template <typename T>
+using promoted_int_type_t = typename promoted_int_type<T>::type;
+
+#if defined(_MSC_VER)
+
+// Wrapper for uniform_int_distribution that handles small types on MSVC
+template <typename IntType>
+class compat_uniform_int_distribution {
+    using LargerType = promoted_int_type_t<IntType>;
+    std::uniform_int_distribution<LargerType> dist_;
+
+   public:
+    using result_type = IntType;
+
+    compat_uniform_int_distribution() : dist_() {}
+    explicit compat_uniform_int_distribution(
+            IntType a,
+            IntType b = std::numeric_limits<IntType>::max())
+            : dist_(static_cast<LargerType>(a), static_cast<LargerType>(b))
+    {
+    }
+
+    template <typename Gen>
+    IntType operator()(Gen& g)
+    {
+        return static_cast<IntType>(dist_(g));
+    }
+
+    IntType min() const
+    {
+        return static_cast<IntType>(dist_.min());
+    }
+    IntType max() const
+    {
+        return static_cast<IntType>(dist_.max());
+    }
+};
+
+// Wrapper for binomial_distribution that handles small types on MSVC
+template <typename IntType>
+class compat_binomial_distribution {
+    using LargerType = promoted_int_type_t<IntType>;
+    std::binomial_distribution<LargerType> dist_;
+
+   public:
+    using result_type = IntType;
+
+    compat_binomial_distribution() = default;
+    explicit compat_binomial_distribution(IntType t, double p = 0.5)
+            : dist_(static_cast<LargerType>(t), p)
+    {
+    }
+
+    template <typename Gen>
+    IntType operator()(Gen& g)
+    {
+        return static_cast<IntType>(dist_(g));
+    }
+};
+
+// Wrapper for geometric_distribution that handles small types on MSVC
+template <typename IntType>
+class compat_geometric_distribution {
+    using LargerType = promoted_int_type_t<IntType>;
+    std::geometric_distribution<LargerType> dist_;
+
+   public:
+    using result_type = IntType;
+
+    compat_geometric_distribution() = default;
+    explicit compat_geometric_distribution(double p) : dist_(p) {}
+
+    template <typename Gen>
+    IntType operator()(Gen& g)
+    {
+        return static_cast<IntType>(dist_(g));
+    }
+};
+
+#else
+// On GCC/Clang, use std:: which already supports these types
+
+template <typename IntType>
+using compat_uniform_int_distribution = std::uniform_int_distribution<IntType>;
+
+template <typename IntType>
+using compat_binomial_distribution = std::binomial_distribution<IntType>;
+
+template <typename IntType>
+using compat_geometric_distribution = std::geometric_distribution<IntType>;
+
+#endif
+
+} // namespace openzl::tests::datagen

--- a/tests/round_trip/test_entropy.cpp
+++ b/tests/round_trip/test_entropy.cpp
@@ -10,6 +10,7 @@
 #include "openzl/common/cursor.h"
 #include "openzl/common/speed.h"
 #include "openzl/zl_errors.h"
+#include "tests/datagen/random_producer/compat_uniform_distribution.h"
 #include "tests/utils.h"
 
 namespace {
@@ -139,7 +140,8 @@ void testRoundTripHuf(bool allowNonHuf, bool allowAvx2Huffman)
 {
     size_t const maxSymbol =
             std::min<size_t>(std::numeric_limits<Int>::max(), (1u << 12) - 1);
-    std::binomial_distribution<Int> dist(maxSymbol, 0.5);
+    openzl::tests::datagen::compat_binomial_distribution<Int> dist(
+            (Int)maxSymbol, 0.5);
     std::mt19937 gen(42);
     std::vector<Int> data;
     size_t const minSize = allowNonHuf ? 0 : 1000;
@@ -171,7 +173,7 @@ void testRoundTripHuf(bool allowNonHuf, bool allowAvx2Huffman)
 template <typename Int>
 void testRoundTripFse(bool allowNonFse, uint8_t nbstates)
 {
-    std::geometric_distribution<Int> dist;
+    openzl::tests::datagen::compat_geometric_distribution<Int> dist;
     std::mt19937 gen(42);
     std::vector<Int> data;
     size_t const minSize = allowNonFse ? 0 : 1000;
@@ -207,7 +209,8 @@ void testRoundTripBit(bool allowNonBit)
     std::mt19937 gen(42);
     size_t const size = 100000;
     for (size_t numBits = 1; numBits < sizeof(Int) * 8; ++numBits) {
-        std::uniform_int_distribution<Int> dist(0, (Int)((1 << numBits) - 1));
+        openzl::tests::datagen::compat_uniform_int_distribution<Int> dist(
+                0, (Int)((1 << numBits) - 1));
         std::vector<Int> data;
         data.reserve(size);
         while (data.size() < size) {
@@ -274,7 +277,7 @@ TEST(EntropyTest, HufOnlyRoundTrip)
 
 TEST(EntropyTest, HufAvx2RoundTrip)
 {
-    std::binomial_distribution<uint8_t> dist;
+    openzl::tests::datagen::compat_binomial_distribution<uint8_t> dist;
     std::mt19937 gen(42);
     std::vector<uint8_t> data;
     size_t const size = ZS_HUF_MAX_BLOCK_SIZE;

--- a/tests/unittest/common/test_data_stats.cpp
+++ b/tests/unittest/common/test_data_stats.cpp
@@ -10,6 +10,7 @@
 #include "openzl/codecs/flatpack/common_flatpack.h"
 #include "openzl/codecs/flatpack/encode_flatpack_kernel.h"
 #include "openzl/shared/data_stats.h"
+#include "tests/datagen/random_producer/compat_uniform_distribution.h"
 
 #define HUF_STATIC_LINKING_ONLY
 #include "openzl/fse/huf.h"
@@ -55,7 +56,8 @@ std::vector<uint8_t> generateUniformVec(
         const uint8_t max = 255)
 {
     std::mt19937_64 mt(kRandomSeed);
-    std::uniform_int_distribution<uint8_t> dist(min, max);
+    openzl::tests::datagen::compat_uniform_int_distribution<uint8_t> dist(
+            min, max);
 
     std::vector<uint8_t> vec(n);
     for (size_t i = 0; i < n; i++) {

--- a/tests/unittest/common/test_histogram.cpp
+++ b/tests/unittest/common/test_histogram.cpp
@@ -7,6 +7,7 @@
 #include <gtest/gtest.h>
 
 #include "openzl/shared/histogram.h"
+#include "tests/datagen/random_producer/compat_uniform_distribution.h"
 
 using namespace ::testing;
 
@@ -131,13 +132,15 @@ TYPED_TEST(HistogramTest, TwoValues)
 
 TYPED_TEST(HistogramTest, RandomHistogram)
 {
+    using compat_dist =
+            openzl::tests::datagen::compat_uniform_int_distribution<TypeParam>;
     std::mt19937 gen(0xdeadbeef);
     for (size_t i = 0; i < 100; ++i) {
         std::vector<TypeParam> vals;
-        auto max = std::uniform_int_distribution<TypeParam>{}(gen);
+        auto max = compat_dist{}(gen);
         auto const numVals =
                 std::uniform_int_distribution<size_t>{ 0, 1000 }(gen);
-        std::uniform_int_distribution<TypeParam> dist{ 0, max };
+        compat_dist dist{ 0, max };
         for (size_t j = 0; j < numVals; ++j) {
             vals.push_back(dist(gen));
         }

--- a/tests/unittest/transforms/test_fse.cpp
+++ b/tests/unittest/transforms/test_fse.cpp
@@ -7,6 +7,7 @@
 #include "openzl/codecs/entropy/deprecated/common_entropy.h"
 #include "openzl/codecs/entropy/deprecated/decode_fse_kernel.h"
 #include "openzl/codecs/entropy/deprecated/encode_fse_kernel.h"
+#include "tests/datagen/random_producer/compat_uniform_distribution.h"
 #include "tests/utils.h"
 
 namespace openzl {
@@ -211,7 +212,7 @@ TEST(FSEContextTest, testUncompressibleRoundTrip)
     std::string input;
     input.resize(10000);
     std::mt19937 gen(42);
-    std::uniform_int_distribution<int8_t> dist;
+    datagen::compat_uniform_int_distribution<int8_t> dist;
     for (size_t i = 0; i < input.size(); i++) {
         input[i] = dist(gen);
     }
@@ -223,7 +224,7 @@ TEST(FSEContextTest, testUniformCompressibleRoundTrip)
     std::string input;
     input.resize(10000);
     std::mt19937 gen(42);
-    std::uniform_int_distribution<int8_t> dist(0, 15);
+    datagen::compat_uniform_int_distribution<int8_t> dist(0, 15);
     for (size_t i = 0; i < input.size(); i++) {
         input[i] = dist(gen);
     }

--- a/tests/zstrong/test_fixed_fixture.cpp
+++ b/tests/zstrong/test_fixed_fixture.cpp
@@ -6,6 +6,7 @@
 #include <gtest/gtest.h>
 
 #include "openzl/zl_opaque_types.h"
+#include "tests/datagen/random_producer/compat_uniform_distribution.h"
 #include "tests/utils.h"
 #include "tests/zstrong/test_fixed_fixture.h"
 
@@ -25,7 +26,7 @@ std::string FixedTest::generatedData(size_t nbElts, size_t cardinality)
     std::mt19937 gen(42);
     std::string alphabet(cardinality * eltWidth_, 0);
     {
-        std::uniform_int_distribution<int8_t> dist;
+        datagen::compat_uniform_int_distribution<int8_t> dist;
         for (size_t i = 0; i < alphabet.size(); ++i) {
             alphabet[i] = dist(gen);
             if (i < alphabetMask_.size()) {

--- a/tests/zstrong/test_zstrong_selector.cpp
+++ b/tests/zstrong/test_zstrong_selector.cpp
@@ -12,6 +12,7 @@
 #include "openzl/zl_errors.h"
 #include "openzl/zl_selector.h"
 #include "openzl/zl_version.h"
+#include "tests/datagen/random_producer/compat_uniform_distribution.h"
 #include "tests/utils.h"
 #include "tests/zstrong/test_zstrong_fixture.h"
 
@@ -27,7 +28,8 @@ static size_t xorRandTransform(
 {
     EXPECT_GE(dstCapacity, srcSize);
     std::mt19937_64 generator(seed);
-    std::uniform_int_distribution<unsigned char> distribution(0, 255);
+    datagen::compat_uniform_int_distribution<unsigned char> distribution(
+            0, 255);
     const unsigned char* const src8 = (const unsigned char*)src;
     unsigned char* const dst8       = (unsigned char*)dst;
     for (unsigned int i = 0; i < srcSize; i++) {


### PR DESCRIPTION
## Summary

MSVC's `std::uniform_int_distribution<T>` requires `T` to be `short` or larger per C++ standard N4950 [rand.req.genl]/1.5. GCC/Clang are more permissive and allow `uint8_t`/`int8_t`.

This adds `compat_uniform_distribution.h` with cross-platform wrappers:
- `compat_uniform_int_distribution<T>`
- `compat_binomial_distribution<T>`
- `compat_geometric_distribution<T>`

On MSVC, small types (`uint8_t`, `int8_t`) are promoted to `short`/`unsigned short` internally, then cast back. On GCC/Clang, the wrappers are simple type aliases to `std::` types.

**No performance impact** - the promotion is a single cast at generation time, identical to what `std::uniform_int_distribution<short>` would produce.

Fixes #300

**Note:** Together with #299 (missing STL includes), this brings Windows test pass rate to **1208/1209 (99.9%)**. The remaining failure (`ErrorsTest.BinaryTestArgTypesDeducedInC`) is a platform-specific error message formatting difference and will be addressed in a future diff.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Test Plan

Built and ran full test suite on Windows:
ershell
cmake -S . -B build -G "Visual Studio 14 2015" -T ClangCL
cmake --build build --config Release
cd build && ctest -C Release --output-on-failure --timeout 60**Result:** 1208/1209 tests passing (99.9%)
- 1 platform-specific error message formatting test (known MSVC difference, future fix)
<img width="839" height="201" alt="image" src="https://github.com/user-attachments/assets/7aa15bc9-dac7-4f63-95a8-a9ec69b2dae8" />

### Test Configuration

- **Compiler:** clang-cl (ClangCL toolset)
- **Generator:** Visual Studio 14 2015 with ClangCL toolset (`-T ClangCL`)
- **Build type:** Release
- **Platform:** Windows 11 x64