### PR TITLE
[fix][Windows] Enable error message type printing on clang-cl and fix cross-platform enum test

### DIFF
--- a/include/openzl/detail/zl_errors_detail.h
+++ b/include/openzl/detail/zl_errors_detail.h
@@ -567,7 +567,7 @@ extern "C" {
 // implementation (if enabled) or the fallback standards-compliant version (if
 // disabled).
 #ifndef ZL_ENABLE_RET_IF_ARG_PRINTING
-#    if defined(__GNUC__) && !defined(__cplusplus)
+#    if (defined(__GNUC__) || defined(__clang__)) && !defined(__cplusplus)
 #        define ZL_ENABLE_RET_IF_ARG_PRINTING 1
 #    elif defined(__cplusplus) && (defined(__GNUC__) || defined(__clang__))
 #        define ZL_ENABLE_RET_IF_ARG_PRINTING 1

--- a/tests/unittest/common/test_errors_in_c.c
+++ b/tests/unittest/common/test_errors_in_c.c
@@ -220,9 +220,30 @@ ZL_Report ZS2_test_errors_binary_arg_types_deduced_in_c_inner(
 
     EXPECT_ERROR_MESSAGE_CONTAINS(pi_1, pi_2, "(pointer)");
 
-    EXPECT_ERROR_MESSAGE_CONTAINS(
-            e_1, e_2, "(int"); // matches both "(int)" and "(unsigned int)"
-                               // across platforms
+    // Enum underlying type differs across platforms:
+    // - Linux/GCC: "(unsigned int)"
+    // - Windows/MSVC: "(int)"
+    // - ARM64 may use either depending on ABI
+    // Check for both possibilities explicitly
+    {
+        ZL_Report _report =
+                generate_error_message_e_1(ZL__scopeContext, e_1, e_2);
+        ZL_RET_R_IF_NOT(
+                GENERIC,
+                ZL_RES_isError(_report),
+                "ZL_RET_R_IF_LT(e_1, e_2) failed to fail.");
+        ZL_E_ADDFRAME(&ZL_RES_error(_report), ZL_EE_EMPTY, "");
+        const char* _str = ZL_E_str(ZL_RES_error(_report));
+        ZL_RET_R_IF_NULL(GENERIC, _str, "Error message is NULL!");
+        const char* _found_int  = strstr(_str, "(int)");
+        const char* _found_uint = strstr(_str, "(unsigned int)");
+        if (!_found_int && !_found_uint) {
+            ZL_RET_R_ERR(
+                    GENERIC,
+                    "Message '(int)' or '(unsigned int)' not found in error message '%s'",
+                    _str);
+        }
+    }
 
     return ZL_returnSuccess();
 }

--- a/tests/unittest/common/test_errors_in_c.c
+++ b/tests/unittest/common/test_errors_in_c.c
@@ -220,7 +220,9 @@ ZL_Report ZS2_test_errors_binary_arg_types_deduced_in_c_inner(
 
     EXPECT_ERROR_MESSAGE_CONTAINS(pi_1, pi_2, "(pointer)");
 
-    EXPECT_ERROR_MESSAGE_CONTAINS(e_1, e_2, "(unsigned int)");
+    EXPECT_ERROR_MESSAGE_CONTAINS(
+            e_1, e_2, "(int"); // matches both "(int)" and "(unsigned int)"
+                               // across platforms
 
     return ZL_returnSuccess();
 }


### PR DESCRIPTION
## Summary

Enables the error message type printing feature (ZL_ENABLE_RET_IF_ARG_PRINTING) on clang-cl and fixes a cross-platform test incompatibility.

### Issue 1: Type printing disabled on clang-cl

**File:** include/openzl/detail/zl_errors_detail.h (line 570)

The preprocessor check for enabling verbose error messages only checked for \__GNUC_\_. However, clang-cl defines \__clang__ instead, causing the feature to remain disabled on Windows/Clang builds.

**Before:**

` if defined(\__GNUC_\_) && !defined(\__cplusplus)  `

**After:**

` if (defined(\__GNUC_\_) || defined(\__clang_\_)) && !defined(\__cplusplus)  `

### Issue 2: Enum type differs between platforms

**File:** tests/unittest/common/test_errors_in_c.c (line 223)

C enums have different underlying types depending on the platform ABI:

- **Linux/GCC:** unsigned int
- **Windows/MSVC ABI:** int
- **ARM64**: May use either depending on ABI
The test previously expected a strict string match that failed on Windows.

**Before:**

`EXPECT_ERROR_MESSAGE_CONTAINS(e_1, e_2, "(unsigned int)");  `

**After:**

```
// Explicitly check for both possibilities using exact string matching
const char* _found_int  = strstr(_str, "(int)");
const char* _found_uint = strstr(_str, "(unsigned int)");
if (!_found_int && !_found_uint) {
    ZL_RET_R_ERR(GENERIC, "Message '(int)' or '(unsigned int)' not found...");
}  
```

## Type of Change

- \[x\] Bug fix (non-breaking change which fixes an issue)

## Test Plan

**Test affected:** ErrorsTest.BinaryTestArgTypesDeducedInC (Test #306)

Built and ran the full test suite on Windows.
```
cmake --build build --config Release  
cd build && ctest -C Release --timeout 60  
```

**Result:**

**1209/1209 tests passing (100%)** ✅

<img width="891" height="359" alt="image" src="https://github.com/user-attachments/assets/e13fc529-c1fa-4676-879d-26d71786b182" />

After windows compatibility fix #97, #299, #301 

Specifically verified the affected test:

ctest -C Release -R "ErrorsTest.BinaryTestArgTypesDeducedInC" --output-on-failure  

**Output:**

\# Result: 1/1 Test #306: ErrorsTest.BinaryTestArgTypesDeducedInC ... Passed  

### Test Configuration

| **Component** | **Detail** |
| **Compiler** | clang-cl (ClangCL toolset) |
| **Generator** | Visual Studio with ClangCL toolset (-T ClangCL) |
| **Build type** | Release |
| **Platform** | Windows 11 x64 |