### PR TITLE
Fix openzl-config.cmake

### DIFF
--- a/build-scripts/cmake/openzl-config.cmake.in
+++ b/build-scripts/cmake/openzl-config.cmake.in
@@ -14,8 +14,8 @@
 
 include(CMakeFindDependencyMacro)
 
-set_and_check(OPENZL_INCLUDE_DIR "@PACKAGE_INCLUDE_INSTALL_DIR@")
-set_and_check(OPENZL_CMAKE_DIR "@PACKAGE_CMAKE_INSTALL_DIR@")
+set_and_check(OPENZL_INCLUDE_DIR "@PACKAGE_OPENZL_INSTALL_INCLUDEDIR@")
+set_and_check(OPENZL_CMAKE_DIR "@PACKAGE_OPENZL_INSTALL_CMAKEDIR@")
 
 # find_dependency() ends up changing PACKAGE_PREFIX_DIR, so save
 # openzl's prefix directory in the OPENZL_PREFIX_DIR variable

--- a/build-scripts/cmake/tests/CMakeLists.txt
+++ b/build-scripts/cmake/tests/CMakeLists.txt
@@ -1,0 +1,9 @@
+project(test)
+cmake_minimum_required(VERSION 3.20.2 FATAL_ERROR)
+
+find_package(zstd REQUIRED)
+find_package(lz4 REQUIRED)
+find_package(OpenZL CONFIG REQUIRED)
+
+add_executable(build_test main.cpp)
+target_link_libraries(build_test OpenZL::openzl_cpp)

--- a/build-scripts/cmake/tests/test-install.py
+++ b/build-scripts/cmake/tests/test-install.py
@@ -49,5 +49,15 @@ lib_paths = [str(INSTALL_DIR / "lib"), str(INSTALL_DIR / "lib64")]
 env["LD_LIBRARY_PATH"] = ":".join(lib_paths)
 run(["./main"], cwd=BUILD_DIR, check=True, env=env)
 
+# Make sure the installed package can be imported in cmake
+BUILD_DIR_FOR_TEST = tempfile.mkdtemp(dir=TEST_DIR, prefix="build-")
+run(
+    ["cmake", f"-DCMAKE_PREFIX_PATH={INSTALL_DIR}", ".."],
+    cwd=BUILD_DIR_FOR_TEST,
+    check=True,
+)
+run(["make"], cwd=BUILD_DIR_FOR_TEST, check=True)
+run(["./build_test"], cwd=BUILD_DIR_FOR_TEST, check=True)
+
 # Clean up build dir on success. On failure, keep it around so we can debug.
 shutil.rmtree(BUILD_DIR, ignore_errors=True)


### PR DESCRIPTION
## Summary
* Fixes #303
* Fixed parameter names and updated tests 

## Type of Change
Build/CI changes

## Test Plan
Updated `build-scripts/cmake/tests/test-install.py` to build the test program using cmake.
