### PR TITLE
pin js-yaml to version 4.1.1

### DIFF
--- a/tools/visualization_app/package.json
+++ b/tools/visualization_app/package.json
@@ -16,7 +16,6 @@
     "@floating-ui/react": "0.27.13",
     "@xyflow/react": "12.6.4",
     "cbor2": "2.0.1",
-    "js-yaml": "4.1.1",
     "react": "19.1.1",
     "react-dom": "19.1.1",
     "react-hook-form": "7.66.0",
@@ -44,6 +43,7 @@
   },
   "resolutions": {
     "@eslint/plugin-kit": "0.3.5",
-    "brace-expansion": "2.0.2"
+    "brace-expansion": "2.0.2",
+    "js-yaml": "4.1.1"
   }
 }

--- a/tools/visualization_app/yarn.lock
+++ b/tools/visualization_app/yarn.lock
@@ -3115,17 +3115,10 @@ iterator.prototype@^1.1.4:
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-4.0.0.tgz#19203fb59991df98e3a287050d4647cdeaf32499"
   integrity sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==
 
-js-yaml@4.1.1:
+js-yaml@4.1.1, js-yaml@^4.1.0:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-4.1.1.tgz#854c292467705b699476e1a2decc0c8a3458806b"
   integrity sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==
-  dependencies:
-    argparse "^2.0.1"
-
-js-yaml@^4.1.0:
-  version "4.1.0"
-  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-4.1.0.tgz#c1fb65f8f5017901cdd2c951864ba18458a10602"
-  integrity sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==
   dependencies:
     argparse "^2.0.1"
 


### PR DESCRIPTION
Summary: There's a transitive dependency on js-yaml via eslint, via eslintrc. Luckily, eslintrc requires a version via `^` (major version compat) so we can just require a resolution to 4.1.1.

Reviewed By: Cyan4973

Differential Revision: D89205896


