### PR TITLE
add python formating test (using `black`) into github CI

### DIFF
--- a/.github/workflows/dev-ci.yml
+++ b/.github/workflows/dev-ci.yml
@@ -233,6 +233,21 @@ jobs:
           clang-format-version: '21'
           check-path: '.'
 
+  # Python formatting check
+  test-python-format:
+    name: Python Code Formating (black)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      - name: Install black
+        run: pip install black
+      - name: Check Python formatting with black
+        run: make check-python-format
+
   # Static analysis
   test-static-analysis:
     name: Static Analysis (scan-build)

--- a/.github/workflows/dev-ci.yml
+++ b/.github/workflows/dev-ci.yml
@@ -244,7 +244,8 @@ jobs:
         with:
           python-version: '3.12'
       - name: Install black
-        run: pip install black
+        # pin to internal phabricator version (not: may change in the future)
+        run: pip install black==25.11.0
       - name: Check Python formatting with black
         run: make check-python-format
 

--- a/Makefile
+++ b/Makefile
@@ -156,6 +156,10 @@ examples: zs2_pipeline zs2_trygraph zs2_selector zs2_struct zs2_round_trip
 test : gtests zs2_test sddl2_test
 	$(EXEC_PREFIX) ./gtests
 
+.PHONY: check-python-format
+check-python-format:
+	@./scripts/check_python_format.sh .
+
 .PHONY: zs2_test
 zs2_test : examples
 	$(EXEC_PREFIX) ./zs2_pipeline

--- a/Makefile
+++ b/Makefile
@@ -158,7 +158,11 @@ test : gtests zs2_test sddl2_test
 
 .PHONY: check-python-format
 check-python-format:
-	@./scripts/check_python_format.sh .
+	@./scripts/check_python_format.sh
+
+.PHONY: fix-python-format
+fix-python-format:
+	@./scripts/check_python_format.sh --fix
 
 .PHONY: zs2_test
 zs2_test : examples

--- a/doc/mkdocs/mkdocstrings-zstd/src/mkdocstrings_handlers/zstd/doxygen.py
+++ b/doc/mkdocs/mkdocstrings-zstd/src/mkdocstrings_handlers/zstd/doxygen.py
@@ -754,7 +754,9 @@ class Doxygen:
                 " ".join([f'"{str(s)}"' for s in sources]),
                 self._doxyxml_dir,
                 " ".join([f'"{p}"' for p in predefined]),
-            ).encode("utf-8")
+            ).encode(
+                "utf-8"
+            )
         )
         with open(self._doxyxml_dir / "stdout.txt", "wb") as f:
             f.write(out)

--- a/scripts/check_python_format.sh
+++ b/scripts/check_python_format.sh
@@ -19,40 +19,39 @@ if ! command -v black &> /dev/null; then
     exit 1
 fi
 
-# Explicitly list source directories containing Python files.
-# This avoids scanning large build/deps directories.
-PYTHON_DIRS=(
-    benchmark
-    cli
-    custom_parsers
-    examples
-    py
-    scripts
-    src
-    tests
-    tools
-)
+# Directories to exclude (build artifacts, dependencies, caches)
+EXCLUDE_DIRS=(deps build cachedObjs cmakebuild .git __pycache__ .eggs build-py node_modules .cache .claude .vscode)
 
-# Filter to only existing directories
-EXISTING_DIRS=()
-for dir in "${PYTHON_DIRS[@]}"; do
-    if [[ -d "$dir" ]]; then
-        EXISTING_DIRS+=("$dir")
+# Build the find prune expression
+PRUNE_EXPR=""
+for dir in "${EXCLUDE_DIRS[@]}"; do
+    if [[ -n "$PRUNE_EXPR" ]]; then
+        PRUNE_EXPR="$PRUNE_EXPR -o"
     fi
+    PRUNE_EXPR="$PRUNE_EXPR -name $dir"
 done
 
-if [[ ${#EXISTING_DIRS[@]} -eq 0 ]]; then
-    echo "No Python source directories found."
+# Find all Python files directly (skip excluded directories with -prune)
+# Pass files to black instead of directories - avoids black's slow directory traversal
+PYTHON_FILES=()
+while IFS= read -r file; do
+    [[ -n "$file" ]] && PYTHON_FILES+=("$file")
+done < <(
+    find . \( $PRUNE_EXPR \) -prune -o -name "*.py" -type f -print
+)
+
+if [[ ${#PYTHON_FILES[@]} -eq 0 ]]; then
+    echo "No Python files found."
     exit 0
 fi
 
 echo "Checking Python file formatting with black..."
-echo "Directories: ${EXISTING_DIRS[*]}"
+echo "Found ${#PYTHON_FILES[@]} Python files"
 echo ""
 
 # Run black in check mode with diff output
 set +e
-BLACK_OUTPUT=$(black --check --diff --color "${EXISTING_DIRS[@]}" 2>&1)
+BLACK_OUTPUT=$(black --check --diff --color "${PYTHON_FILES[@]}" 2>&1)
 BLACK_EXIT_CODE=$?
 set -e
 
@@ -91,7 +90,7 @@ while IFS= read -r line; do
         echo ""
         echo "❌ $line"
         echo "   Explanation: Some Python files need reformatting."
-        echo "   To fix all issues: Run 'black ${EXISTING_DIRS[*]}' from the repository root."
+        echo "   To fix all issues: Run 'make check-python-format' after fixing, or 'black <file>' for individual files."
     elif [[ -n "$line" ]]; then
         echo "$line"
     fi
@@ -100,6 +99,6 @@ done <<< "$BLACK_OUTPUT"
 echo ""
 echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
 echo "Python formatting check failed!"
-echo "Run 'black ${EXISTING_DIRS[*]}' locally to auto-format all Python files."
+echo "Run 'black <file>' to auto-format individual files."
 echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
 exit 1

--- a/scripts/check_python_format.sh
+++ b/scripts/check_python_format.sh
@@ -1,16 +1,23 @@
 #!/bin/bash
 # Copyright (c) Meta Platforms, Inc. and affiliates.
 #
-# Check Python file formatting using black.
+# Check or fix Python file formatting using black.
 # Reports file and line numbers when formatting issues are detected.
 #
-# Usage: ./scripts/check_python_format.sh
+# Usage: ./scripts/check_python_format.sh [--fix]
+#   --fix: Apply formatting fixes instead of just checking
 #
 # Exit codes:
-#   0 - All files are correctly formatted
-#   1 - Formatting issues detected
+#   0 - All files are correctly formatted (or fixed successfully)
+#   1 - Formatting issues detected (check mode only)
 
 set -euo pipefail
+
+# Parse arguments
+FIX_MODE=false
+if [[ "${1:-}" == "--fix" ]]; then
+    FIX_MODE=true
+fi
 
 # Check if black is installed
 if ! command -v black &> /dev/null; then
@@ -45,6 +52,17 @@ if [[ ${#PYTHON_FILES[@]} -eq 0 ]]; then
     exit 0
 fi
 
+if [[ "$FIX_MODE" == true ]]; then
+    echo "Fixing Python file formatting with black..."
+    echo "Found ${#PYTHON_FILES[@]} Python files"
+    echo ""
+    black "${PYTHON_FILES[@]}"
+    echo ""
+    echo "✓ Python formatting complete."
+    exit 0
+fi
+
+# Check mode
 echo "Checking Python file formatting with black..."
 echo "Found ${#PYTHON_FILES[@]} Python files"
 echo ""
@@ -90,7 +108,7 @@ while IFS= read -r line; do
         echo ""
         echo "❌ $line"
         echo "   Explanation: Some Python files need reformatting."
-        echo "   To fix all issues: Run 'make check-python-format' after fixing, or 'black <file>' for individual files."
+        echo "   To fix all issues: Run 'make fix-python-format'"
     elif [[ -n "$line" ]]; then
         echo "$line"
     fi
@@ -99,6 +117,6 @@ done <<< "$BLACK_OUTPUT"
 echo ""
 echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
 echo "Python formatting check failed!"
-echo "Run 'black <file>' to auto-format individual files."
+echo "Run 'make fix-python-format' to auto-format all Python files."
 echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
 exit 1

--- a/scripts/check_python_format.sh
+++ b/scripts/check_python_format.sh
@@ -1,0 +1,105 @@
+#!/bin/bash
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# Check Python file formatting using black.
+# Reports file and line numbers when formatting issues are detected.
+#
+# Usage: ./scripts/check_python_format.sh
+#
+# Exit codes:
+#   0 - All files are correctly formatted
+#   1 - Formatting issues detected
+
+set -euo pipefail
+
+# Check if black is installed
+if ! command -v black &> /dev/null; then
+    echo "Error: 'black' is not installed."
+    echo "Install it with: pip install black"
+    exit 1
+fi
+
+# Explicitly list source directories containing Python files.
+# This avoids scanning large build/deps directories.
+PYTHON_DIRS=(
+    benchmark
+    cli
+    custom_parsers
+    examples
+    py
+    scripts
+    src
+    tests
+    tools
+)
+
+# Filter to only existing directories
+EXISTING_DIRS=()
+for dir in "${PYTHON_DIRS[@]}"; do
+    if [[ -d "$dir" ]]; then
+        EXISTING_DIRS+=("$dir")
+    fi
+done
+
+if [[ ${#EXISTING_DIRS[@]} -eq 0 ]]; then
+    echo "No Python source directories found."
+    exit 0
+fi
+
+echo "Checking Python file formatting with black..."
+echo "Directories: ${EXISTING_DIRS[*]}"
+echo ""
+
+# Run black in check mode with diff output
+set +e
+BLACK_OUTPUT=$(black --check --diff --color "${EXISTING_DIRS[@]}" 2>&1)
+BLACK_EXIT_CODE=$?
+set -e
+
+if [[ $BLACK_EXIT_CODE -eq 0 ]]; then
+    echo "✓ All Python files are correctly formatted."
+    exit 0
+fi
+
+# Parse and display the diff output with enhanced information
+CURRENT_FILE=""
+while IFS= read -r line; do
+    # Detect file being processed from diff header
+    if [[ "$line" =~ ^"--- " ]]; then
+        CURRENT_FILE=$(echo "$line" | sed 's/^--- //' | sed 's/[[:space:]]*$//')
+        echo "$line"
+    elif [[ "$line" =~ ^"+++ " ]]; then
+        echo "$line"
+    elif [[ "$line" =~ ^"@@" ]]; then
+        # Extract line numbers from diff hunk header: @@ -start,count +start,count @@
+        echo "$line"
+        if [[ "$line" =~ @@\ -([0-9]+) ]]; then
+            LINE_NUM="${BASH_REMATCH[1]}"
+            echo "  → Line $LINE_NUM: Formatting issue detected"
+        fi
+    elif [[ "$line" =~ ^[-+] ]] && [[ ! "$line" =~ ^"---" ]] && [[ ! "$line" =~ ^"+++" ]]; then
+        # Show actual diff lines (additions/removals)
+        echo "$line"
+    elif [[ "$line" =~ "would reformat" ]]; then
+        echo ""
+        echo "❌ $line"
+        echo "   Explanation: This file does not match black's formatting standards."
+        echo "   To fix: Run 'black <file>' locally to auto-format."
+    elif [[ "$line" =~ "file would be left unchanged" ]] || [[ "$line" =~ "files would be left unchanged" ]]; then
+        echo "✓ $line"
+    elif [[ "$line" =~ "Oh no!" ]]; then
+        echo ""
+        echo "❌ $line"
+        echo "   Explanation: Some Python files need reformatting."
+        echo "   To fix all issues: Run 'black ${EXISTING_DIRS[*]}' from the repository root."
+    elif [[ -n "$line" ]]; then
+        echo "$line"
+    fi
+done <<< "$BLACK_OUTPUT"
+
+echo ""
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+echo "Python formatting check failed!"
+echo "Run 'black ${EXISTING_DIRS[*]}' locally to auto-format all Python files."
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+exit 1


### PR DESCRIPTION
Can also be invoked manually with `make check-python-format`.

The new test is pretty quick in CI (~10 seconds):
https://github.com/facebook/openzl/actions/runs/20315664447/job/58358458611?pr=310#step:5:16