### PR TITLE
new APIs to materialize params in the ZL_Compressor

### DIFF
--- a/include/openzl/zl_common_types.h
+++ b/include/openzl/zl_common_types.h
@@ -65,6 +65,15 @@ typedef struct {
     size_t size;
 } ZL_Comment;
 
+/**
+ * @brief Typedef for void pointer to satisfy ZL_RESULT_OF requirements.
+ *
+ * ZL_RESULT_OF requires a bare type name, so we need a typedef for void*. You
+ * should use ZL_RESULT_OF(VoidPtr) instead of ZL_RESULT_OF(void*) and similarly
+ * with ZL_RESULT_DECLARE_SCOPE
+ */
+typedef void* ZL_VoidPtr;
+
 #if defined(__cplusplus)
 } // extern "C"
 #endif

--- a/include/openzl/zl_ctransform.h
+++ b/include/openzl/zl_ctransform.h
@@ -75,6 +75,80 @@ _Static_assert(
         "Condition required to ensure H(ZL_CodecStateManager) doesn't depend on padding bytes");
 #endif
 
+/**
+ * @brief Descriptor for materializing and dematerializing local params
+ *
+ * This structure defines functions to materialize an in-memory object from
+ * local parameters and to dematerialize (free) that object.
+ *
+ * Materialized objects are available as a @ref ZL_RefParam via the typical
+ * local params access methods. Specify the retrieval key with the paramId
+ * field.
+ */
+typedef struct ZL_MaterializerDesc_s {
+    /**
+     * @brief A custom function that materializes an in-memory object from a
+     * provided @p params object.
+     *
+     * This function may arbitrarily use none, any, or all of the provided
+     * local params to generate the materialized object, but the generation
+     * MUST be deterministic and hermetic. In particular, materialization shall
+     * not depend on variables other than the provided @ref ZL_LocalParams
+     * object.
+     *
+     * Materialized object lifetimes will be managed by the @ref ZL_Compressor
+     * on which the node is registered/parameterized. Objects will be
+     * materialized around the time of node registration/parameterization and
+     * will remain allocated for the lifetime of the associated @ref
+     * ZL_Compressor.
+     *
+     * Do NOT rely on the materialization function being called at any specific
+     * time to do side-effect work. Doing so will result in undefined behavior.
+     *
+     * The @ref ZL_Compressor may arbitrarily share the same materialized object
+     * between multiple nodes with the same @p params and the @ref ZL_CCtx may
+     * provide concurrent access to materialized objects. DO NOT attempt to
+     * modify the materialized object after creation, either directly or via API
+     * getters.
+     *
+     * @param params  A pointer to the local params object to materialize. The
+     * provided params have no lifetime guarantees past the invocation of this
+     * function. You may not hold references into the params object in the
+     * materialized object.
+     *
+     * @returns A ZL_RESULT containing a pointer to the materialized object on
+     * success, or an error. Returning NULL as a valid result (when there's
+     * nothing to materialize) should be wrapped in ZL_WRAP_VALUE(NULL). Ensure
+     * the function declares a result scope with ZL_RESULT_DECLARE_SCOPE or you
+     * will get a compiler error.
+     */
+    ZL_RESULT_OF(ZL_VoidPtr) (*materializeFn)(
+            const void* opaque,
+            const ZL_LocalParams* params)ZL_NOEXCEPT_FUNC_PTR;
+
+    /**
+     * @brief A custom function that destructs a materialized object.
+     * NB: if this fn fails to deallocate memory allocated by @ref
+     * materializeFn, you will leak memory!
+     */
+    void (*dematerializeFn)(const void* opaque, void* materialized)
+            ZL_NOEXCEPT_FUNC_PTR;
+
+    /**
+     * The paramId to use for the materialized param. If there is an existing
+     * param that uses this paramId, the registration will fail.
+     */
+    int paramId;
+
+    /**
+     * Optionally an opaque pointer that can be queried with
+     * ZL_Materializer_getOpaquePtr(). OpenZL does not take ownership of this
+     * pointer. If lifetime extension is needed, it should be managed by the
+     * `ZL_OpaquePtr` in the outer `ZL_MIEncoderDesc`.
+     */
+    const void* opaque;
+} ZL_MaterializerDesc;
+
 /* ------------------------------------
  * Typed Transforms
  * ------------------------------------
@@ -336,6 +410,12 @@ typedef struct {
      * registration fails, and it lives for the lifetime of the compressor.
      */
     ZL_OpaquePtr opaque;
+    /**
+     * Optional materializer descriptor for materialized local params.
+     * If both materializeFn and dematerializeFn are non-null, the materializer
+     * will be used to create materialized objects from local params.
+     */
+    ZL_MaterializerDesc materializer;
 } ZL_MIEncoderDesc;
 
 /**

--- a/include/openzl/zl_errors.h
+++ b/include/openzl/zl_errors.h
@@ -13,6 +13,7 @@
 #include <assert.h>
 #include <stddef.h> // size_t
 
+#include "openzl/zl_common_types.h"  // ZL_VoidPtr
 #include "openzl/zl_errors_types.h"  // ZL_ErrorCode
 #include "openzl/zl_macro_helpers.h" // ZS_MACRO_PAD1 and friends
 #include "openzl/zl_portability.h"   // ZL_INLINE
@@ -191,6 +192,7 @@ extern "C" {
 
 ZL_RESULT_DECLARE_TYPE(ZL_GraphID);
 ZL_RESULT_DECLARE_TYPE(ZL_NodeID);
+ZL_RESULT_DECLARE_TYPE(ZL_VoidPtr);
 
 /*-*********************************************
  *  ZL_Report type

--- a/src/openzl/compress/cgraph.c
+++ b/src/openzl/compress/cgraph.c
@@ -39,8 +39,10 @@ struct ZL_Compressor_s {
 ZL_Compressor* ZL_Compressor_create(void)
 {
     ZL_Compressor* const cgraph = ZL_calloc(sizeof(ZL_Compressor));
-    if (cgraph == NULL)
+    if (cgraph == NULL) {
         return NULL;
+    }
+    ZL_OC_init(&cgraph->opCtx);
     if (ZL_isError(NM_init(&cgraph->nmgr, &cgraph->opCtx))) {
         ZL_Compressor_free(cgraph);
         return NULL;
@@ -56,8 +58,6 @@ ZL_Compressor* ZL_Compressor_create(void)
     // In debug mode, runtime check on the configuration of the Standard Graphs
     GR_validate();
 #endif
-
-    ZL_OC_init(&cgraph->opCtx);
     ZL_OC_startOperation(&cgraph->opCtx, ZL_Operation_createCGraph);
     return cgraph;
 }

--- a/src/openzl/compress/cnodes.c
+++ b/src/openzl/compress/cnodes.c
@@ -12,15 +12,63 @@
 #include "openzl/shared/xxhash.h"
 #include "openzl/zl_errors.h"
 
-ZL_Report CTM_init(CNodes_manager* ctm)
+size_t MaterializedParamMap_hash(const MaterializedParamKey* key)
 {
+    XXH3_state_t hs;
+    XXH3_INITSTATE(&hs);
+    XXH3_64bits_reset(&hs);
+
+    size_t lpHash = ZL_LocalParams_hash(&key->localParams);
+    XXH3_64bits_update(&hs, &lpHash, sizeof(lpHash));
+
+    XXH3_64bits_update(
+            &hs,
+            &key->materializer.materializeFn,
+            sizeof(key->materializer.materializeFn));
+    XXH3_64bits_update(
+            &hs,
+            &key->materializer.dematerializeFn,
+            sizeof(key->materializer.dematerializeFn));
+    XXH3_64bits_update(
+            &hs, &key->materializer.opaque, sizeof(key->materializer.opaque));
+
+    return XXH3_64bits_digest(&hs);
+}
+
+bool MaterializedParamMap_eq(
+        const MaterializedParamKey* lhs,
+        const MaterializedParamKey* rhs)
+{
+    if (!ZL_LocalParams_eq(&lhs->localParams, &rhs->localParams)) {
+        return false;
+    }
+
+    if (lhs->materializer.materializeFn != rhs->materializer.materializeFn
+        || lhs->materializer.dematerializeFn
+                != rhs->materializer.dematerializeFn) {
+        return false;
+    }
+
+    if (lhs->materializer.opaque != rhs->materializer.opaque) {
+        return false;
+    }
+
+    return true;
+}
+
+ZL_Report CTM_init(CNodes_manager* ctm, ZL_OperationContext* opCtx)
+{
+    ZL_RESULT_DECLARE_SCOPE_REPORT(opCtx);
     VECTOR_INIT(ctm->cnodes, ZL_ENCODER_CUSTOM_NODE_LIMIT);
+    ctm->materializedParams =
+            MaterializedParamMap_create(ZL_ENCODER_CUSTOM_NODE_LIMIT);
     ZL_OpaquePtrRegistry_init(&ctm->opaquePtrs);
+    ctm->opCtx = opCtx;
     // Note: this Arena could also be borrowed from the cgraph,
     // but it doesn't have one (yet).
     // Note 2: this is why this init function can fail
     ctm->allocator = ALLOC_HeapArena_create();
-    ZL_RET_R_IF_NULL(allocation, ctm->allocator);
+    ZL_ERR_IF_NULL(ctm->allocator, allocation);
     return ZL_returnSuccess();
 }
 
@@ -29,6 +77,19 @@ void CTM_destroy(CNodes_manager* ctm)
     ZL_DLOG(OBJ, "CTM_destroy");
     ZL_ASSERT_NN(ctm);
     ZL_OpaquePtrRegistry_destroy(&ctm->opaquePtrs);
+    // Dematerialize all materialized params before freeing any corresponding
+    // CNodes
+    MaterializedParamMap_Iter iter =
+            MaterializedParamMap_iter(&ctm->materializedParams);
+    MaterializedParamMap_Entry const* entry;
+    while ((entry = MaterializedParamMap_Iter_next(&iter)) != NULL) {
+        if (entry->val.materializedParam != NULL
+            && entry->key.materializer.dematerializeFn != NULL) {
+            entry->key.materializer.dematerializeFn(
+                    NULL, entry->val.materializedParam);
+        }
+    }
+    MaterializedParamMap_destroy(&ctm->materializedParams);
     VECTOR_DESTROY(ctm->cnodes);
     ALLOC_Arena_freeArena(ctm->allocator);
     ZL_zeroes(ctm, sizeof(*ctm));
@@ -39,6 +100,19 @@ void CTM_reset(CNodes_manager* ctm)
     ZL_DLOG(FRAME, "CTM_reset");
     ZL_ASSERT_NN(ctm);
     ZL_OpaquePtrRegistry_reset(&ctm->opaquePtrs);
+    // Dematerialize all materialized params before freeing any corresponding
+    // CNodes
+    MaterializedParamMap_Iter iter =
+            MaterializedParamMap_iter(&ctm->materializedParams);
+    MaterializedParamMap_Entry const* entry;
+    while ((entry = MaterializedParamMap_Iter_next(&iter)) != NULL) {
+        if (entry->val.materializedParam != NULL
+            && entry->key.materializer.dematerializeFn != NULL) {
+            entry->key.materializer.dematerializeFn(
+                    NULL, entry->val.materializedParam);
+        }
+    }
+    MaterializedParamMap_clear(&ctm->materializedParams);
     VECTOR_RESET(ctm->cnodes);
     ALLOC_Arena_freeAll(ctm->allocator);
 }
@@ -66,6 +140,73 @@ static ZL_Report CTM_transferLocalParams(
     return LP_transferLocalParams(cnm->allocator, lp);
 }
 
+// Validate that paramId is not invalid and not already in use by existing local
+// params
+static ZL_Report validateMaterializedParamId(ZL_LocalParams* lp, int paramId)
+{
+    ZL_RET_R_IF_EQ(
+            node_invalid,
+            paramId,
+            ZL_LP_INVALID_PARAMID,
+            "Materialized paramId cannot be ZL_LP_INVALID_PARAMID");
+
+    ZL_RefParam rp = LP_getLocalRefParam(lp, paramId);
+    ZL_RET_R_IF_NE(
+            node_invalid,
+            rp.paramId,
+            ZL_LP_INVALID_PARAMID,
+            "Materialized paramId %d is already registered",
+            paramId);
+
+    ZL_IntParam ip = LP_getLocalIntParam(lp, paramId);
+    ZL_RET_R_IF_NE(
+            node_invalid,
+            ip.paramId,
+            ZL_LP_INVALID_PARAMID,
+            "Materialized paramId %d is already registered as an intParam",
+            paramId);
+    return ZL_returnSuccess();
+}
+
+/* CTM_addMaterializedRefParam():
+ * Add a materialized param to the refParams of the local params.
+ * @return : success, or error if paramId is already in use
+ */
+static ZL_Report CTM_addMaterializedRefParam(
+        CNodes_manager* cnm,
+        ZL_LocalParams* lp,
+        int paramId,
+        const void* materializedObj)
+{
+    ZL_ASSERT_NN(cnm);
+    ZL_ASSERT_NN(lp);
+    ZL_RESULT_DECLARE_SCOPE_REPORT(cnm->opCtx);
+
+    // Allocate new refParams array with one more entry
+    size_t const newNbRefParams = lp->refParams.nbRefParams + 1;
+    ZL_RefParam* newRefParams   = ALLOC_Arena_malloc(
+            cnm->allocator, newNbRefParams * sizeof(ZL_RefParam));
+    ZL_ERR_IF_NULL(newRefParams, allocation);
+
+    // Copy existing refParams
+    for (size_t i = 0; i < lp->refParams.nbRefParams; i++) {
+        newRefParams[i] = lp->refParams.refParams[i];
+    }
+
+    // Add the materialized param
+    newRefParams[lp->refParams.nbRefParams] = (ZL_RefParam){
+        .paramId   = paramId,
+        .paramRef  = materializedObj,
+        .paramSize = 0, // Size unknown for materialized objects
+    };
+
+    // Update the localParams
+    lp->refParams.refParams   = newRefParams;
+    lp->refParams.nbRefParams = newNbRefParams;
+
+    return ZL_returnSuccess();
+}
+
 /* CTM_transferStreamTypes():
  * Transfer streamType information from user-controlled memory
  * towards internal memory,
@@ -90,6 +231,67 @@ static ZL_Report CTM_transferPrivateParam(
     ZL_ASSERT_NN(itd);
     ZL_DLOG(BLOCK, "CTM_transferPrivateParam: ppSize=%zu", itd->ppSize);
     return CTM_transferBuffer(cnm, &itd->privateParam, itd->ppSize);
+}
+
+/**
+ * Find or create a materialized param in the registry. This function will
+ * handle cleaning up the materialized object if an error occurs.
+ */
+static ZL_Report CTM_addOrReuseMaterializedParam(
+        CNodes_manager* ctm,
+        ZL_LocalParams* lp,
+        const ZL_MaterializerDesc* materializer)
+{
+    ZL_RESULT_DECLARE_SCOPE_REPORT(ctm->opCtx);
+    if (materializer == NULL || materializer->materializeFn == NULL) {
+        return ZL_returnSuccess();
+    }
+    if (materializer->dematerializeFn == NULL) {
+        ZL_ERR(GENERIC,
+               "Materializer must provide a valid dematerialize function pointer");
+    }
+
+    // Create key for lookup
+    MaterializedParamKey key = {
+        .localParams  = *lp,
+        .materializer = *materializer,
+    };
+
+    // Search for existing materialized param with same key
+    MaterializedParamMap_Entry const* existingEntry =
+            MaterializedParamMap_find(&ctm->materializedParams, &key);
+    if (existingEntry != NULL) {
+        return CTM_addMaterializedRefParam(
+                ctm,
+                lp,
+                materializer->paramId,
+                existingEntry->val.materializedParam);
+    }
+
+    // Not found, create new materialized param
+    ZL_RESULT_OF(ZL_VoidPtr) matResult = materializer->materializeFn(NULL, lp);
+    ZL_ERR_IF_ERR(matResult);
+
+    void* materialized = ZL_RES_value(matResult);
+
+    MaterializedParamEntry newEntry = {
+        .materializedParam = materialized,
+    };
+
+    MaterializedParamMap_Entry entryToInsert = {
+        .key = key,
+        .val = newEntry,
+    };
+
+    MaterializedParamMap_Insert insertResult = MaterializedParamMap_insert(
+            &ctm->materializedParams, &entryToInsert);
+    if (insertResult.badAlloc) {
+        materializer->dematerializeFn(NULL, materialized);
+        ZL_ERR(allocation, "Failed to insert materialized param into map");
+    }
+
+    return CTM_addMaterializedRefParam(
+            ctm, lp, materializer->paramId, materialized);
 }
 
 /*
@@ -148,6 +350,24 @@ static ZL_RESULT_OF(CNodeID) CTM_registerCNode(
             ZL_RET_T_IF_ERR(
                     CNodeID,
                     CTM_transferLocalParams(ctm, &trDesc->localParams));
+            // Materialize params if materializer is provided (with
+            // deduplication)
+            if (trDesc->materializer.materializeFn != NULL) {
+                // Validate provided params don't contain the paramId reserved
+                // for the materializer
+                ZL_RET_T_IF_ERR(
+                        CNodeID,
+                        validateMaterializedParamId(
+                                &trDesc->localParams,
+                                trDesc->materializer.paramId));
+                // Add the materialized object to refParams
+                ZL_RET_T_IF_ERR(
+                        CNodeID,
+                        CTM_addOrReuseMaterializedParam(
+                                ctm,
+                                &trDesc->localParams,
+                                &trDesc->materializer));
+            }
             // A valid transform must have at least one input
             ZL_RET_T_IF_LT(
                     CNodeID,
@@ -273,6 +493,9 @@ CTM_parameterizeNode(
 
 void CTM_rollback(CNodes_manager* ctm, CNodeID id)
 {
+    // Note that local params and materialized params are not rolled back. Local
+    // params will stay allocated in the arena and materialized params will stay
+    // allocated in the vector.
     ZL_ASSERT_EQ(id.cnid + 1, VECTOR_SIZE(ctm->cnodes));
     VECTOR_POPBACK(ctm->cnodes);
 }

--- a/src/openzl/compress/cnodes.h
+++ b/src/openzl/compress/cnodes.h
@@ -4,6 +4,7 @@
 #define ZSTRONG_COMPRESS_CNODES_H
 
 #include "openzl/common/allocation.h" // Arena
+#include "openzl/common/map.h"
 #include "openzl/common/opaque.h"
 #include "openzl/common/vector.h"
 #include "openzl/compress/cnode.h"          // CNode
@@ -20,15 +21,35 @@ ZL_RESULT_DECLARE_TYPE(CNodeID);
 
 DECLARE_VECTOR_TYPE(CNode)
 
+// Definitions for MaterializedParamMap
+typedef ZL_MIEncoderDesc MaterializedParamKey;
+typedef struct {
+    void* materializedParam; // The materialized object
+} MaterializedParamEntry;
+
+// Custom hash and equality functions for MaterializedParamKey. Uses the
+// LocalParams object and ZL_MaterializerDesc for the comparison.
+size_t MaterializedParamMap_hash(const MaterializedParamKey* key);
+bool MaterializedParamMap_eq(
+        const MaterializedParamKey* lhs,
+        const MaterializedParamKey* rhs);
+
+ZL_DECLARE_CUSTOM_MAP_TYPE(
+        MaterializedParamMap,
+        MaterializedParamKey,
+        MaterializedParamEntry);
+
 typedef struct {
     VECTOR(CNode) cnodes;
     ZL_OpaquePtrRegistry opaquePtrs;
     Arena* allocator;
+    MaterializedParamMap materializedParams;
+    ZL_OperationContext* opCtx; // Non-owning pointer to error context
 } CNodes_manager;
 
 // Lifetime Management
 
-ZL_Report CTM_init(CNodes_manager* ctm);
+ZL_Report CTM_init(CNodes_manager* ctm, ZL_OperationContext* opCtx);
 
 void CTM_destroy(CNodes_manager* ctm);
 
@@ -72,8 +93,11 @@ CTM_registerStandardTransform(
         unsigned minFormatVersion,
         unsigned maxFormatVersion);
 
-/// Rolls back the registration of @p id
-/// @warning This only works when @p id was the last node registered
+/**
+ * Rolls back the registration of @p id
+ * @warning This only works when @p id was the last node registered. If local
+ * params are transferred or a materialized param created, it will not be freed.
+ */
 void CTM_rollback(CNodes_manager* ctm, CNodeID id);
 
 ZL_END_C_DECLS

--- a/src/openzl/compress/nodemgr.c
+++ b/src/openzl/compress/nodemgr.c
@@ -27,7 +27,7 @@ static ZL_Report NM_fillStandardNodes(Nodes_manager* nmgr)
 
 ZL_Report NM_init(Nodes_manager* nmgr, ZL_OperationContext* opCtx)
 {
-    ZL_RET_R_IF_ERR(CTM_init(&nmgr->ctm));
+    ZL_RET_R_IF_ERR(CTM_init(&nmgr->ctm, opCtx));
     nmgr->nameMap = NodeMap_create(ZL_ENCODER_GRAPH_LIMIT);
     nmgr->opCtx   = opCtx;
     return NM_fillStandardNodes(nmgr);


### PR DESCRIPTION
Summary:
Create a new API to materialize params from localparams. This relies on a new functionality associated with the ZL_Compressor to manage allocated objects.

A materialized param is a new type of local parameter object that is fundamentally an object in memory. This object's constructor and destructor functions shall be specified in the new `ZL_MaterializerDesc` struct passed to a node registration.

At the time of registration and subsequent node parameterizations^, the constructor function is called to create this new object in memory. This new object will live as long as the ZL_Compressor. When a CCtx uses this Compressor to compress, the associated node will be able to access the materialized object using the `ZL_Encoder_getMaterializedParam()` function.

^ not all parameterizations will necessarily result in a construction. See next diff in stack.

Differential Revision: D89093023


