### PR TITLE
[CI] less Wheels

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -4,13 +4,31 @@ name: Wheels
 
 on:
   workflow_dispatch:
+
   pull_request:
+    paths:
+      - 'py/**'
+      - 'src/**'
+      - 'include/**'
+      - 'deps/**'
+      - 'CMakeLists.txt'
+      - '.github/workflows/wheels.yml'
+
   push:
     branches:
-     - dev
+      - dev
+    paths:
+      - 'py/**'
+      - 'src/**'
+      - 'include/**'
+      - 'deps/**'
+      - 'CMakeLists.txt'
+      - '.github/workflows/wheels.yml'
+
   release:
     types:
       - published
+
 
 jobs:
   build_sdist:

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -6,24 +6,21 @@ on:
   workflow_dispatch:
 
   pull_request:
-    paths:
+    paths: &wheel_paths
       - 'py/**'
+      - 'cpp/**'
       - 'src/**'
       - 'include/**'
-      - 'deps/**'
+      - 'tools/sddl/**'
+      - 'tools/sddl2/**'
       - 'CMakeLists.txt'
+      - 'build-scripts/**'
       - '.github/workflows/wheels.yml'
 
   push:
     branches:
       - dev
-    paths:
-      - 'py/**'
-      - 'src/**'
-      - 'include/**'
-      - 'deps/**'
-      - 'CMakeLists.txt'
-      - '.github/workflows/wheels.yml'
+    paths: *wheel_paths
 
   release:
     types:

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -42,7 +42,7 @@ jobs:
         # Once MSVC is supported we can build Windows packages as well by adding windows-latest
         # Once we're public we can build on ubuntu-24.04-arm & windows-11-arm.
         # They are not supported for private repos.
-        os: [ubuntu-latest, macos-13, macos-latest]
+        os: [ubuntu-latest, macos-latest]
 
     steps:
     - uses: actions/checkout@v4


### PR DESCRIPTION
Wheels tests are among the longest ones on Github Actions.

Furthermore, they may not even be necessary, since many repository changes to not impact Wheels.

Update the test condition to only trigger when relevant directories are impacted.