### PR TITLE
Fix gbtModel binary classification boundary

### DIFF
--- a/src/openzl/compress/selectors/ml/gbt.c
+++ b/src/openzl/compress/selectors/ml/gbt.c
@@ -76,7 +76,7 @@ size_t GBTPredictor_predict(
     }
 
     if (predictor->numForests == 1) {
-        if (maxValue < 0.5) {
+        if (maxValue < 0) {
             return 0;
         }
         return 1;

--- a/src/openzl/compress/selectors/ml/gbt.h
+++ b/src/openzl/compress/selectors/ml/gbt.h
@@ -53,7 +53,7 @@ typedef struct {
  * trees and getting a sum of the values per forest. The forest with the highest
  * value is chosen as the predicted class. Binary-classification is a special
  * case in which only one forest is needed and if its combined value is compared
- * to 0.5 to decide on the class.
+ * to 0 to decide on the class.
  */
 typedef struct {
     size_t numForests;

--- a/tests/compress/test_gbt.cpp
+++ b/tests/compress/test_gbt.cpp
@@ -249,7 +249,7 @@ class GBTBinaryForestTest : public Test {
 TEST_F(GBTBinaryForestTest, binaryClassification)
 {
     /* Result should be 1, since each tree in the 5 forests have value of 0.2.
-     * The resulting sum is greater than 0.5, so the predicted label is 1.
+     * The resulting sum is greater than 0, so the predicted label is 1.
      */
     const GBTPredictor predictor = { .numForests = binaryForest.size(),
                                      .forests    = binaryForest.data() };
@@ -422,7 +422,7 @@ TEST_F(GBTBinaryModelTest, labeledBinaryClass)
              /            \                  //            \
      (card = 5, 4) (card_u = 5, 5)    (card_l = 5, 6) (range = 4, 7)
 
-     The final result depends on the 5th node of this tree, since 6 > 0.5 the
+     The final result depends on the 5th node of this tree, since 6 > 0 the
      resulting binary classification is 1.
    */
     ZL_RESULT_OF(Label) result = GBTModel_predict(&model, stream->getStream());
@@ -435,10 +435,10 @@ TEST_F(GBTBinaryModelTest, swappedLabeledBinaryClass)
 {
     /* From the above test, we know that the result depends on the 5th node of
      * the tree, we want to make sure that if we change the value of this node
-     * that the resulting classification changes too. Set the value to 0.45, and
-     * verify that the classification is now 0 since 0.45f < 0.5.
+     * that the resulting classification changes too. Set the value to -0.45,
+     * and verify that the classification is now 0 since -0.45f < 0.
      */
-    nodes[5].value             = 0.45f;
+    nodes[5].value             = -0.45f;
     ZL_RESULT_OF(Label) result = GBTModel_predict(&model, stream->getStream());
     ASSERT_FALSE(ZL_RES_isError(result));
     const std::string decodedLabel = ZL_RES_value(result);

--- a/tests/ml_selector_utils.cpp
+++ b/tests/ml_selector_utils.cpp
@@ -16,13 +16,13 @@ SampleBinaryGBTModel::SampleBinaryGBTModel()
                  .rightChildIdx   = 2,
                  .missingChildIdx = 2 },
                { .featureIdx      = -1,
-                 .value           = 0.1f,
+                 .value           = -0.1f,
                  .leftChildIdx    = 0,
                  .rightChildIdx   = 0,
                  .missingChildIdx = 0 },
                /* If skewness > 0.001 select class 1
                otherwise select class 2
-               Binary classification threshold is 0.5
+               Binary classification threshold is 0
                */
                { .featureIdx      = 1,
                  .value           = 0.001f,
@@ -35,7 +35,7 @@ SampleBinaryGBTModel::SampleBinaryGBTModel()
                  .rightChildIdx   = 0,
                  .missingChildIdx = 0 },
                { .featureIdx      = -1,
-                 .value           = 0.25f,
+                 .value           = -0.25f,
                  .leftChildIdx    = 0,
                  .rightChildIdx   = 0,
                  .missingChildIdx = 0 }

--- a/tests/round_trip/test_mlselector.cpp
+++ b/tests/round_trip/test_mlselector.cpp
@@ -68,7 +68,7 @@ auto deltaFeatureGenerator(
 // contains one forest with a single tree possessing three nodes. The root
 // node examines whether the stream has a const delta throughout
 // (hasConstDelta < 0.5), and if so, it returns the value of the left child
-// node (which is less than 0.5), effectively assigning the label class1.
+// node (which is less than 0), effectively assigning the label class1.
 
 const std::vector<GBTPredictor_Node> nodes = { { .featureIdx      = 0,
                                                  .value           = 0.5f,
@@ -76,7 +76,7 @@ const std::vector<GBTPredictor_Node> nodes = { { .featureIdx      = 0,
                                                  .rightChildIdx   = 2,
                                                  .missingChildIdx = 1 },
                                                { .featureIdx      = -1,
-                                                 .value           = 0.1f,
+                                                 .value           = -0.1f,
                                                  .leftChildIdx    = 0,
                                                  .rightChildIdx   = 0,
                                                  .missingChildIdx = 0 },

--- a/tools/gbt_predictor/zstrong_gbt_predictor.h
+++ b/tools/gbt_predictor/zstrong_gbt_predictor.h
@@ -19,7 +19,7 @@ namespace zstrong::ml::gbt_predictor {
 // values per forest. The forest with the highest value is chosen as the
 // predicted class.
 // Binary-classificaiton is a special case in which only one forest is needed
-// and if its combined value is compared to 0.5 to decide on the class.
+// and if its combined value is compared to 0 to decide on the class.
 //
 // The predictor is initialized from a JSON string / a folly:dynamic object. The
 // schema for the JSON is an array of arrays of trees. Each tree is encoded

--- a/tools/ml_selector/ml_selector_graph.c
+++ b/tools/ml_selector/ml_selector_graph.c
@@ -751,7 +751,7 @@ MLSelector_registerGraphWithEmptyGBTModel(
 {
     const GBTPredictor_Node emptyNode = {
         .featureIdx      = -1, // leaf node
-        .value           = 0.0f,
+        .value           = -1.0f,
         .leftChildIdx    = 0,
         .rightChildIdx   = 0,
         .missingChildIdx = 0,

--- a/tools/ml_selector/ml_selector_trainer.cpp
+++ b/tools/ml_selector/ml_selector_trainer.cpp
@@ -468,6 +468,11 @@ static GBTPredictorWrapper trainXGBoostModel(
     } else {
         safe_xgboost(XGBoosterSetParam(
                 boosterHandle, "objective", "binary:logistic"));
+        // Explicitly set base_score to 0.5 (this just means that data has 50/50
+        // chance to be in class 1 or class 2 as a start point). This is to
+        // avoid auto-computation error, which happens if training data is
+        // heavily imbalanced and only labeled to one class.
+        safe_xgboost(XGBoosterSetParam(boosterHandle, "base_score", "0.5"));
     }
 
     const int eval_dmats_size                 = 2;

--- a/tools/ml_selector/tests/test_mlSelectorTrainer.cpp
+++ b/tools/ml_selector/tests/test_mlSelectorTrainer.cpp
@@ -167,6 +167,68 @@ class TestMLSelectorTrainer : public testing::Test {
         }
     }
 
+    std::vector<training::MultiInput> generateAmbiguousData(
+            std::vector<std::vector<uint64_t>>& delta,
+            std::vector<std::vector<uint64_t>>& token)
+    {
+        std::vector<training::MultiInput> trainData;
+        auto dg = openzl::tests::datagen::DataGen();
+
+        /* The training data will have following features:
+         * - Delta optimized data: 500-800 elements, values starting in range
+         * [100000, 300000]
+         * - Tokenize optimized data: 700-1000 elements, values starting in
+         * range [200000, 400000]
+         *
+         * XGBoost learns to distinguish these patterns:
+         * - Choose Delta when nbElts < 700 and mean < 200000
+         * - Choose Token when nbElts > 800 and mean > 300000
+         *
+         * If we make the test data have the following features:
+         * - Size: 700-800 elements
+         * - Mean: 200000-300000
+         *
+         * The resulting prediction will be very close to 0 because this input
+         * is ambiguous and straddling the threshold of choosing between Delta
+         * and Tokenize.
+         */
+        for (auto i = 0; i < 100; ++i) {
+            uint64_t dSize = dg.u64_range("deltaSize", 500, 800);
+            uint64_t tSize = dg.u64_range("tokenSize", 700, 1000);
+
+            std::vector<uint64_t> data(dSize);
+            uint64_t deltaStart = dg.u64_range("deltaStart", 100000, 300000);
+            for (size_t j = 0; j < dSize; ++j) {
+                data[j] = deltaStart;
+                deltaStart += dg.i64_range("deltaDiff", -2, 4);
+            }
+            delta.push_back(data);
+
+            uint64_t tokenStart = dg.u64_range("tokenStart", 200000, 400000);
+            token.push_back(dg.template randLongVector<uint64_t>(
+                    "randLongVec",
+                    tokenStart,
+                    tokenStart + dg.u64_range("tokenDiff", 500, 1000),
+                    tSize,
+                    tSize));
+
+            training::MultiInput binaryInput1;
+            binaryInput1.add(
+                    Input::refSerial(
+                            delta.back().data(),
+                            delta.back().size() * sizeof(uint64_t)));
+            trainData.push_back(std::move(binaryInput1));
+
+            training::MultiInput binaryInput2;
+            binaryInput2.add(
+                    Input::refSerial(
+                            token.back().data(),
+                            token.back().size() * sizeof(uint64_t)));
+            trainData.push_back(std::move(binaryInput2));
+        }
+        return trainData;
+    }
+
     size_t compress(
             Compressor& compressor,
             std::string& dst,
@@ -406,6 +468,53 @@ TEST_F(TestMLSelectorTrainer, TestFeatureExtraction)
 
     EXPECT_EQ(trainingSample2.labels[0], "tokenize");
     EXPECT_EQ(trainingSample2.labels[1], "delta");
+}
+
+TEST_F(TestMLSelectorTrainer, TestAmbiguousData)
+{
+    std::vector<std::vector<uint64_t>> delta;
+    std::vector<std::vector<uint64_t>> token;
+    std::vector<training::MultiInput> trainData =
+            generateAmbiguousData(delta, token);
+
+    auto successors = registerSuccessors(compressor_);
+    setUpCompressor(trainedCompressor_);
+
+    auto dg = openzl::tests::datagen::DataGen();
+
+    // Test data has nbElts < 700 and mean ~200000 which leans towards delta,
+    // but other features (like high variance) should correctly push prediction
+    // to tokenize, making the final prediction close to 0 (this specific
+    // test data has prediction around 0.48).
+    auto testData = (dg.template randLongVector<uint64_t>(
+            "randLongVec", 195000, 205400, 695, 695));
+
+    auto serializedCompressor = openzl::training::trainMLSelectorGraph(
+            trainData, trainedCompressor_, trainParams_);
+
+    // Deserialize the trained compressor
+    Compressor mlCompressor = deserializeCompressor(serializedCompressor);
+
+    // Check that the ml selector graph selects the correct successor
+    std::vector<size_t> sizes          = {};
+    std::vector<GraphID> staticGraphId = {};
+    for (size_t i = 0; i < successors.size(); i++) {
+        auto gid = compressor_.buildStaticGraph(
+                ZL_NODE_CONVERT_SERIAL_TO_NUM_LE64, { successors[i] });
+        compressor_.selectStartingGraph(gid);
+        staticGraphId.push_back(gid);
+
+        // Compress
+        auto compressBound =
+                ZL_compressBound(testData.size() * sizeof(uint64_t));
+        std::string cBuffer = std::string(compressBound, '\0');
+        sizes.push_back(compress(compressor_, cBuffer, testData));
+    }
+
+    // Expect tokenize to compress better and ml selector should choose tokenize
+    EXPECT_LE(sizes[1], sizes[0]);
+    compressor_.selectStartingGraph(staticGraphId[1]);
+    testSelection(testData, compressor_, mlCompressor);
 }
 
 } // namespace


### PR DESCRIPTION
Summary: Update gbtModel binary classification boundary to be 0 instead of 0.5 since XGBoost model dump contains raw logits and not probabilities.

Differential Revision: D89422330
