### PR TITLE
[cli] zli default to permissive mode

### DIFF
--- a/.github/workflows/dev-ci.yml
+++ b/.github/workflows/dev-ci.yml
@@ -188,6 +188,19 @@ jobs:
       - name: Run tests
         run: make test
 
+  # CLI integration testing
+  test-cli:
+    name: CLI Integration Tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      - name: Run CLI integration tests
+        run: make cli_test
+
   # Sanitizer testing
   test-sanitizers:
     name: ${{ matrix.name }}

--- a/Makefile
+++ b/Makefile
@@ -190,6 +190,10 @@ examples: zs2_pipeline zs2_trygraph zs2_selector zs2_struct zs2_round_trip
 test : gtests zs2_test sddl2_test
 	$(EXEC_PREFIX) ./gtests
 
+.PHONY: cli_test
+cli_test: zli
+	cd cli/tests && python3 cli_integration_tests.py ../../zli
+
 .PHONY: check-python-format
 check-python-format:
 	@./scripts/check_python_format.sh

--- a/cli/args/CompressArgs.h
+++ b/cli/args/CompressArgs.h
@@ -61,6 +61,12 @@ struct CompressArgs : public GlobalArgs, public ProfileArgs {
                 0,
                 true,
                 "Directory to write trace streamdump to.");
+        parser.addCommandFlag(
+                cmd(),
+                kStrict,
+                0,
+                false,
+                "Enforce strict mode compression. Fail on errors instead of falling back to generic compression.");
     }
 
     explicit CompressArgs(const arg::ParsedArgs& parsed)
@@ -90,6 +96,7 @@ struct CompressArgs : public GlobalArgs, public ProfileArgs {
         }
 
         traceStreamsDir = parsed.cmdFlag(cmd(), kTraceStreamsDir);
+        strict          = parsed.cmdHasFlag(cmd(), kStrict);
     }
 
     static Cmd cmd()
@@ -105,6 +112,7 @@ struct CompressArgs : public GlobalArgs, public ProfileArgs {
 
     std::shared_ptr<tools::io::Output> traceOutput;
     std::optional<std::string> traceStreamsDir;
+    bool strict = false;
 
    private:
     inline static const std::string kInput      = "input";
@@ -119,6 +127,7 @@ struct CompressArgs : public GlobalArgs, public ProfileArgs {
             "train-inline-test-limit";
     inline static const std::string kTrace           = "trace";
     inline static const std::string kTraceStreamsDir = "trace-streams-dir";
+    inline static const std::string kStrict          = "strict";
 };
 
 } // namespace openzl::cli

--- a/cli/commands/cmd_compress.cpp
+++ b/cli/commands/cmd_compress.cpp
@@ -131,6 +131,9 @@ int performCompression(const CompressArgs& args)
     // create compressor and context
     CCtx cctx;
     cctx.setParameter(CParam::FormatVersion, ZL_MAX_FORMAT_VERSION);
+    if (!args.strict) {
+        cctx.setParameter(CParam::PermissiveCompression, 1);
+    }
     cctx.refCompressor(*args.compressor());
     if (args.traceOutput) {
         args.traceOutput->open();

--- a/cli/tests/BUCK
+++ b/cli/tests/BUCK
@@ -161,6 +161,34 @@ custom_unittest(
 )
 
 custom_unittest(
+    name = "strict_mode_permissive_test",
+    command = [
+        "$(location :integration_test_bin)",
+        "$(location ..:zli)",
+        "StrictModeTest.test_permissive_mode_succeeds",
+    ],
+    type = "simple",
+    deps = [
+        "..:zli",
+        ":integration_test_bin",
+    ],
+)
+
+custom_unittest(
+    name = "strict_mode_fails_test",
+    command = [
+        "$(location :integration_test_bin)",
+        "$(location ..:zli)",
+        "StrictModeTest.test_strict_mode_fails",
+    ],
+    type = "simple",
+    deps = [
+        "..:zli",
+        ":integration_test_bin",
+    ],
+)
+
+custom_unittest(
     name = "all_integration_tests",
     command = [
         "$(location :integration_test_bin)",

--- a/cli/tests/cli_integration_tests.py
+++ b/cli/tests/cli_integration_tests.py
@@ -413,7 +413,9 @@ class StrictModeTest(_CompressDecompressBaseTest):
             "Expected at least one compression to fail in strict mode",
         )
 
-        print(f"Verified that strict mode fails: {failed_count} file(s) failed as expected")
+        print(
+            f"Verified that strict mode fails: {failed_count} file(s) failed as expected"
+        )
 
 
 def main():

--- a/cli/tests/cli_integration_tests.py
+++ b/cli/tests/cli_integration_tests.py
@@ -346,6 +346,76 @@ class BenchmarkCsvCompressionTest(_BenchmarkBaseTest):
         self.benchmark()
 
 
+class StrictModeTest(_CompressDecompressBaseTest):
+    """
+    Test case for strict mode behavior.
+
+    This test verifies that:
+    1. By default (permissive mode), compression succeeds even when using a
+       mismatched profile (e.g., le-u64 profile on data not divisible by 8)
+    2. With --strict flag, compression fails on mismatched data
+
+    The test uses the le-u64 profile (64-bit little-endian unsigned integers)
+    to compress data whose size is NOT a multiple of 8 bytes. This should:
+    - Succeed in permissive mode (default) by falling back to generic compression
+    - Fail in strict mode because the input size doesn't match 64-bit alignment
+    """
+
+    @property
+    def input_dir_name(self) -> str:
+        return "serial"
+
+    @property
+    def compressor_profile_name(self) -> str:
+        # Use le-u64 profile which expects input size to be multiple of 8 bytes
+        return "le-u64"
+
+    def test_permissive_mode_succeeds(self):
+        """
+        Test that compression succeeds in permissive mode (default).
+
+        This verifies that when using a mismatched profile (le-u64 on non-aligned data),
+        the compression falls back to generic compression and succeeds.
+        """
+        self.compress_and_decompress_samples()
+
+    def test_strict_mode_fails(self):
+        """
+        Test that compression fails in strict mode with mismatched data.
+
+        This verifies that when using --strict flag with a mismatched profile,
+        the compression fails instead of falling back to generic compression.
+
+        Note: Only files whose size is NOT a multiple of 8 AND larger than
+        a minimum threshold will trigger the failure. Very small files may
+        be handled differently by the compression pipeline.
+        """
+        from command_utils import execute_command
+
+        failed_count = 0
+        for sample in self.input_samples:
+            # Attempt compression with --strict flag
+            cflag = self.compressor_info.compressor_type.value
+            cstr = self.compressor_info.compressor_str
+
+            compress_args = f"compress {sample.orig_file_path} --{cflag} {cstr} -o {sample.compressed_file_path} --strict"
+
+            result = execute_command(compress_args)
+
+            if result != 0:
+                failed_count += 1
+                print(f"Strict mode correctly failed for {sample.orig_file_path}")
+
+        # At least one file should fail in strict mode
+        self.assertGreater(
+            failed_count,
+            0,
+            "Expected at least one compression to fail in strict mode",
+        )
+
+        print(f"Verified that strict mode fails: {failed_count} file(s) failed as expected")
+
+
 def main():
     """
     Run the test suite with proper command line arguments.

--- a/doc/mkdocs/doc/getting-started/cli.md
+++ b/doc/mkdocs/doc/getting-started/cli.md
@@ -15,6 +15,15 @@ The `--profile` option allows you to select a predefined **compression profile**
 
 > **More about profiles:** Under the hood, a `profile` is simply a pre-configured OpenZL **graph**. Since we did not do any [ACE](./using-openzl.md#ace-training) training, the graph contains a single Zstd node. Other profiles contain more complex graphs, as we will see later.
 
+### Strict Mode
+By default, `zli compress` operates in **permissive mode**: if a compression graph encounters an error (e.g., data doesn't match some expected properties), it falls back to generic compression instead of failing. This ensures compression always succeeds.
+
+Use `--strict` to disable this fallback behavior:
+```sh
+./zli compress --profile le-i32 --strict data.bin -o data.zl
+```
+In strict mode, compression fails if the data doesn't match the profile's expectations. This is useful for validating that your data conforms to expectations.
+
 ### Numeric data in OpenZL
 Now let's try to compress a file of numbers. We have preconfigured profile called `le-i32` that takes advantage of fixed-width structure of integer data to compress better than byte-wise LZ. In this example, we will compress a small sample of integers from the [ERA5](https://cds.climate.copernicus.eu/datasets/reanalysis-era5-single-levels?tab=overview) dataset.
 


### PR DESCRIPTION
The benchmark functionality is already defaulting to permissive mode, and only uses strict mode when explicitly requested using the `--strict` command.

For consistency, this PR unify the behavior, so that normal compression also uses permissive mode by default, and can be turned to strict mode using the `--strict` command.

This is notably helpful when the trainer generates graphs which require specific properties of the input and just fail when the conditions are not met. Permissive mode will catch these issues and replace the dangling branches using safe generic solutions like `zstd` for example.

Test Plan:
`make test` now includes the CLI command tests, which are now also run automatically on Github CI.