### PR TITLE
[ZLI][UX]: Support = in parameters, and better error messages (#24)

### DIFF
--- a/cli/zli.cpp
+++ b/cli/zli.cpp
@@ -54,6 +54,8 @@ int impl(int argc, char** argv)
         return "Demo CLI for OpenZL. NO VERSION STABILITY IS IMPLIED!!\n"
                 "\n"
                 "Usage: " + std::string(argv[0]) + " <command> [options] <args>\n"
+                "\n"
+                "Options can be specified with or without = sign. For example: --profile=u32 or --profile u32\n"
                 "\n" +
                 std::move(help) + "<<<< NO VERSION STABILITY IS IMPLIED!! >>>>";
     };

--- a/tools/arg/CMakeLists.txt
+++ b/tools/arg/CMakeLists.txt
@@ -10,9 +10,23 @@ if (OPENZL_BUILD_ARG_TOOLS)
         CONFIGURE_DEPENDS
         "${CMAKE_CURRENT_SOURCE_DIR}/*.h")
 
+    list(FILTER arg_sources EXCLUDE REGEX ".*/tests/.*")
+
     add_library(arg
       ${arg_sources}
     )
     target_include_directories(arg PUBLIC ${PROJECT_SOURCE_DIR})
     apply_openzl_compile_options_to_target(arg)
+
+    if (OPENZL_BUILD_TESTS)
+        add_executable(test_arg_parser
+            ${CMAKE_CURRENT_LIST_DIR}/tests/arg_parser_test.cpp)
+        target_link_libraries(test_arg_parser
+            PRIVATE
+                arg
+                GTest::gtest_main
+        )
+        apply_openzl_compile_options_to_target(test_arg_parser)
+        gtest_discover_tests(test_arg_parser)
+    endif()
 endif()

--- a/tools/arg/arg_parser.cpp
+++ b/tools/arg/arg_parser.cpp
@@ -250,24 +250,30 @@ ParsedArgs ArgParser::parse(int argc, char** argv) const
                                    { ptr.value(), chosenCmd })
                          : std::nullopt;
         };
-        auto populateOption = [&](const Flag* flag, int cmd) {
+        auto formatFlagName = [](const Flag* flag) {
+            auto flagName = "--" + std::string(flag->name);
+            if (flag->shortName != 0) {
+                flagName += ", -" + std::string(1, flag->shortName);
+            }
+            return flagName;
+        };
+        auto checkDuplicateFlag = [&](const Flag* flag, int cmd) {
             if (parsedArgs.cmdVals_[cmd].find(flag->name)
                 != parsedArgs.cmdVals_[cmd].end()) {
-                auto flagName = "--" + std::string(flag->name);
-                if (flag->shortName != 0) {
-                    flagName += ", -" + std::string(1, flag->shortName);
-                }
-                std::string err =
-                        "Option " + flagName + " specified more than once";
-                throw ParseException(err);
+                throw ParseException(
+                        "Option " + formatFlagName(flag)
+                        + " specified more than once");
             }
+        };
+        auto populateOption = [&](const Flag* flag, int cmd) {
+            checkDuplicateFlag(flag, cmd);
 
             if (flag->hasVal) {
                 ++i;
                 if (i >= argc || isShortOpt(argv[i]) || isLongOpt(argv[i])) {
-                    std::string err =
-                            "Option " + flag->name + " requires a value";
-                    throw ParseException(err);
+                    throw ParseException(
+                            "Option " + formatFlagName(flag)
+                            + " requires a value");
                 }
                 parsedArgs.cmdVals_[cmd][flag->name].push_back(argv[i]);
             } else {
@@ -285,14 +291,41 @@ ParsedArgs ArgParser::parse(int argc, char** argv) const
             populateOption(flag, cmd);
         };
         auto processLongFlag = [&](char* name, int chosenCmd) {
-            auto str     = std::string{ name };
-            auto flagOpt = findFlag(false, str, chosenCmd);
+            std::string str{ name };
+            auto equalPos = str.find('=');
+
+            auto flagName = (equalPos != std::string::npos)
+                    ? str.substr(0, equalPos)
+                    : str;
+
+            auto flagOpt = findFlag(false, flagName, chosenCmd);
             if (!flagOpt.has_value()) {
-                std::string err = "Unknown option: " + std::string(argv[i]);
-                throw ParseException(err);
+                throw ParseException("Unknown option: --" + flagName);
             }
             auto [flag, cmd] = flagOpt.value();
-            populateOption(flag, cmd);
+
+            // No = syntax, use populateOption for space-separated or boolean
+            if (equalPos == std::string::npos) {
+                populateOption(flag, cmd);
+                return;
+            }
+
+            auto flagValue = str.substr(equalPos + 1);
+
+            if (!flag->hasVal) {
+                throw ParseException(
+                        "Option " + formatFlagName(flag)
+                        + " does not accept a value, but got '=" + flagValue
+                        + "'");
+            }
+            if (flagValue.empty()) {
+                throw ParseException(
+                        "Option " + formatFlagName(flag)
+                        + " requires a value, but got '--" + flag->name + "='");
+            }
+
+            checkDuplicateFlag(flag, cmd);
+            parsedArgs.cmdVals_[cmd][flag->name].push_back(flagValue);
         };
 
         if (seenEndOfOptions) {

--- a/tools/arg/tests/BUCK
+++ b/tools/arg/tests/BUCK
@@ -1,0 +1,13 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+
+load("../../../defs.bzl", "zs_unittest")
+
+oncall("data_compression")
+
+zs_unittest(
+    name = "arg_parser_test",
+    srcs = ["arg_parser_test.cpp"],
+    deps = [
+        "../..:arg",
+    ],
+)

--- a/tools/arg/tests/arg_parser_test.cpp
+++ b/tools/arg/tests/arg_parser_test.cpp
@@ -1,0 +1,193 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#include <gtest/gtest.h>
+
+#include "tools/arg/ParseException.h"
+#include "tools/arg/arg_parser.h"
+
+using namespace openzl::arg;
+
+namespace {
+
+// Test that --flag=value syntax works correctly
+TEST(ArgParserTest, LongFlagWithEqualsSign)
+{
+    ArgParser parser;
+    parser.addCommand(1, "test", 't');
+    parser.addCommandFlag(1, "profile", 'p', true, "Profile name");
+
+    const char* argv[] = { "prog", "test", "--profile=u32" };
+    auto parsed        = parser.parse(3, const_cast<char**>(argv));
+
+    EXPECT_EQ(parsed.cmdFlag(1, "profile").value(), "u32");
+}
+
+// Test that flag value with no = works correctly
+TEST(ArgParserTest, LongFlagWithSpaceSeparatedValue)
+{
+    ArgParser parser;
+    parser.addCommand(1, "test", 't');
+    parser.addCommandFlag(1, "profile", 'p', true, "Profile name");
+
+    const char* argv[] = { "prog", "test", "--profile", "u32" };
+    auto parsed        = parser.parse(4, const_cast<char**>(argv));
+
+    EXPECT_EQ(parsed.cmdFlag(1, "profile").value(), "u32");
+}
+
+// Test that both syntaxes produce the same result
+TEST(ArgParserTest, BothSyntaxesProduceSameResult)
+{
+    ArgParser parser1;
+    parser1.addCommand(1, "test", 't');
+    parser1.addCommandFlag(1, "profile", 'p', true, "Profile name");
+
+    const char* argv1[] = { "prog", "test", "--profile=u32" };
+    auto parsed1        = parser1.parse(3, const_cast<char**>(argv1));
+
+    ArgParser parser2;
+    parser2.addCommand(1, "test", 't');
+    parser2.addCommandFlag(1, "profile", 'p', true, "Profile name");
+
+    const char* argv2[] = { "prog", "test", "--profile", "u32" };
+    auto parsed2        = parser2.parse(4, const_cast<char**>(argv2));
+
+    EXPECT_EQ(
+            parsed1.cmdFlag(1, "profile").value(),
+            parsed2.cmdFlag(1, "profile").value());
+}
+
+// Test Equal Syntax with multiple values
+TEST(ArgParserTest, EqualSyntaxWithMultipleValues)
+{
+    ArgParser parser;
+    parser.addCommand(1, "test", 't');
+    parser.addCommandFlag(1, "profile", 'p', true, "Profile name");
+    parser.addCommandFlag(1, "output", 'o', true, "Output path");
+
+    const char* argv[] = {
+        "prog", "test", "--profile=u32", "--output=file.zl"
+    };
+    auto parsed = parser.parse(4, const_cast<char**>(argv));
+
+    EXPECT_EQ(parsed.cmdFlag(1, "profile").value(), "u32");
+    EXPECT_EQ(parsed.cmdFlag(1, "output").value(), "file.zl");
+}
+
+// Test mixed syntax (Some with =, some without)
+TEST(ArgParserTest, MixedSyntax)
+{
+    ArgParser parser;
+    parser.addCommand(1, "test", 't');
+    parser.addCommandFlag(1, "profile", 'p', true, "Profile name");
+    parser.addCommandFlag(1, "output", 'o', true, "Output path");
+
+    const char* argv[] = {
+        "prog", "test", "--profile=u32", "--output", "file.zl"
+    };
+
+    auto parsed = parser.parse(5, const_cast<char**>(argv));
+
+    EXPECT_EQ(parsed.cmdFlag(1, "profile").value(), "u32");
+    EXPECT_EQ(parsed.cmdFlag(1, "output").value(), "file.zl");
+}
+
+// Test that boolean flag (no value) works correctly
+TEST(ArgParserTest, BooleanFlagWithoutValue)
+{
+    ArgParser parser;
+    parser.addCommand(1, "test", 't');
+    parser.addCommandFlag(1, "force", 'f', false, "Force overwrite");
+
+    const char* argv[] = { "prog", "test", "--force" };
+    auto parsed        = parser.parse(3, const_cast<char**>(argv));
+
+    EXPECT_TRUE(parsed.cmdFlag(1, "force"));
+}
+
+// Test that value containing special characters (like paths) works with =
+// syntax
+TEST(ArgParserTest, ValueContainingSpecialCharacters)
+{
+    ArgParser parser;
+    parser.addCommand(1, "test", 't');
+    parser.addCommandFlag(1, "path", 'p', true, "Path Value"); // hasVal=true
+
+    const char* argv[] = { "prog", "test", "--path=/tmp/test-file.txt" };
+    auto parsed        = parser.parse(3, const_cast<char**>(argv));
+
+    EXPECT_EQ(parsed.cmdFlag(1, "path").value(), "/tmp/test-file.txt");
+}
+
+// Test that boolean flag with = value gives proper error
+TEST(ArgParserTest, BooleanFlagWithEqualsValueThrows)
+{
+    ArgParser parser;
+    parser.addCommand(1, "test", 't');
+    parser.addCommandFlag(1, "force", 'f', false, "Force overwrite");
+
+    const char* argv[] = { "prog", "test", "--force=true" };
+
+    EXPECT_THROW(
+            {
+                try {
+                    parser.parse(3, const_cast<char**>(argv));
+                } catch (const ParseException& e) {
+                    std::string errorMsg = e.what();
+                    EXPECT_NE(
+                            errorMsg.find("does not accept a value"),
+                            std::string::npos);
+                    throw;
+                }
+            },
+            ParseException);
+}
+
+// Test that unknown flag with equals sign gives proper error
+TEST(ArgParserTest, UnknownFlagWithEquals)
+{
+    ArgParser parser;
+    parser.addCommand(1, "test", 't');
+    parser.addCommandFlag(1, "profile", 'p', true, "Profile name");
+
+    const char* argv[] = { "prog", "test", "--unknown=value" };
+
+    EXPECT_THROW(
+            {
+                try {
+                    parser.parse(3, const_cast<char**>(argv));
+                } catch (const ParseException& e) {
+                    std::string errorMsg = e.what();
+                    EXPECT_NE(
+                            errorMsg.find("Unknown option: --unknown"),
+                            std::string::npos);
+                    throw;
+                }
+            },
+            ParseException);
+}
+
+TEST(ArgParserTest, EqualsWithEmptyValueThrows)
+{
+    ArgParser parser;
+    parser.addCommand(1, "test", 't');
+    parser.addCommandFlag(1, "profile", 'p', true, "Profile name");
+
+    const char* argv[] = { "prog", "test", "--profile=" };
+
+    EXPECT_THROW(
+            {
+                try {
+                    parser.parse(3, const_cast<char**>(argv));
+                } catch (const ParseException& e) {
+                    std::string errorMsg = e.what();
+                    EXPECT_NE(
+                            errorMsg.find("requires a value"),
+                            std::string::npos);
+                    throw;
+                }
+            },
+            ParseException);
+}
+
+} // namespace


### PR DESCRIPTION
This PR addresses issue #24 by adding support for the --flag=value syntax in the ZLI command-line interface.

### Changes:

- `tools/arg/arg_parser.cpp`: Updated processLongFlag to parse = syntax, extracting flag name and value separately. Added validation to reject =value for boolean flags that don't accept values.
- `tools/arg/tests/arg_parser_test.cpp` : Added 9  unit tests covering various scenarios.
- `tools/arg/tests/BUCK` : Added Buck build configuration for the new tests.
- `tools/arg/CMakeLists.txt` : Added CMake test configuration using gtest.
- `cli/zli.cpp` : Updated usage message to document the = syntax.

Before:
```
zli compress --profile=u32 tmp# Error: Unknown option: --profile=u32
```
After:
```
zli compress --profile=u32 tmp# ✅ Works correctly!
```

Both syntaxes are now supported:
```
--profile=u32 (new)
--profile u32 (existing)
```


### Test Plan:
Run unit tests with CMake:
```
# Configure with tests enabled
cmake -B build -DOPENZL_BUILD_TESTS=ON -DOPENZL_BUILD_CLI=ON# Build the arg parser testscmake --build build --target test_arg --config Release# Run the tests./build/tools/arg/Release/test_arg.exe   # Windows
```

Expected output:
```
$ cd C:\Users\Zhining\source\repos\openzl\openzl; .\build\tools\arg\Release\test_arg.exe
Running main() from C:\Users\Zhining\source\repos\openzl\openzl\build\_deps\googletest-src\googletest\src\gtest_main.cc
[==========] Running 9 tests from 1 test suite.
[----------] Global test environment set-up.
[----------] 9 tests from ArgParserTest
[ RUN      ] ArgParserTest.LongFlagWithEqualsSign
[       OK ] ArgParserTest.LongFlagWithEqualsSign (0 ms)
[ RUN      ] ArgParserTest.LongFlagWithSpaceSeparatedValue
[       OK ] ArgParserTest.LongFlagWithSpaceSeparatedValue (0 ms)
[ RUN      ] ArgParserTest.BothSyntaxesProduceSameResult
[       OK ] ArgParserTest.BothSyntaxesProduceSameResult (0 ms)
[ RUN      ] ArgParserTest.EqualSyntaxWithMultipleValues
[       OK ] ArgParserTest.EqualSyntaxWithMultipleValues (0 ms)
[ RUN      ] ArgParserTest.MixedSyntax
[       OK ] ArgParserTest.MixedSyntax (0 ms)
[ RUN      ] ArgParserTest.BooleanFlagWithoutValue
[       OK ] ArgParserTest.BooleanFlagWithoutValue (0 ms)
[ RUN      ] ArgParserTest.ValueContainingSpecialCharacters
[       OK ] ArgParserTest.ValueContainingSpecialCharacters (0 ms)
[ RUN      ] ArgParserTest.BooleanFlagWithEqualsValueThrows
[       OK ] ArgParserTest.BooleanFlagWithEqualsValueThrows (0 ms)
[ RUN      ] ArgParserTest.UnknownFlagWithEquals
[       OK ] ArgParserTest.UnknownFlagWithEquals (0 ms)
[----------] 9 tests from ArgParserTest (0 ms total)

[----------] Global test environment tear-down
[==========] 9 tests from 1 test suite ran. (0 ms total)
[  PASSED  ] 9 tests.
$ 
```
<img width="920" height="504" alt="image" src="https://github.com/user-attachments/assets/ec44fb7d-637c-414d-b114-1808611ad7fb" />
