### PR TITLE
Add small optimization for constant zero

### DIFF
--- a/src/openzl/compress/selectors/selector_constant.c
+++ b/src/openzl/compress/selectors/selector_constant.c
@@ -44,7 +44,7 @@ ZL_GraphID SI_selector_constant(
     ZL_ASSERT(inType == ZL_Type_serial || inType == ZL_Type_struct);
 
     /* If all bytes are identical, Serial path is more efficient */
-    if (isSingleBytePattern(inputStream)) {
+    if (ZL_Input_eltWidth(inputStream)> 1 && isSingleBytePattern(inputStream)) {
         return ZL_GRAPH_CONSTANT_SERIAL;
     }
 

--- a/src/openzl/compress/selectors/selector_constant.c
+++ b/src/openzl/compress/selectors/selector_constant.c
@@ -4,10 +4,30 @@
 #include "openzl/common/assertion.h"
 #include "openzl/compress/private_nodes.h"
 
+/* Returns non-zero if all bytes of the first element are identical.
+ * This covers 0x00..00, 0xFF..FF, 0x55..55, etc.
+ * For such patterns, Serial path is more efficient. */
+static int isSingleBytePattern(const ZL_Input* inputStream)
+{
+    const uint8_t* ptr      = ZL_Input_ptr(inputStream);
+    size_t const eltWidth   = ZL_Input_eltWidth(inputStream);
+    ZL_ASSERT_NN(ZL_Input_numElts(inputStream));
+    uint8_t const firstByte = ptr[0];
+    for (size_t i = 1; i < eltWidth; ++i) {
+        if (ptr[i] != firstByte)
+            return 0;
+    }
+    return 1;
+}
+
 /* SI_selector_constant():
  *
  * The goal of this selector is to select between serialized and
- * fixed-size constant encoding given an input that can be either type
+ * fixed-size constant encoding given an input that can be any of
+ * these types.
+ *
+ * Single-byte patterns (0x00, 0xFF, 0x55, etc.) are routed
+ * to CONSTANT_SERIAL (more efficient).
  */
 
 ZL_GraphID SI_selector_constant(
@@ -20,12 +40,23 @@ ZL_GraphID SI_selector_constant(
     (void)customGraphs;
     (void)nbCustomGraphs;
 
-    ZL_ASSERT(
-            ZL_Input_type(inputStream) == ZL_Type_serial
-            || ZL_Input_type(inputStream) == ZL_Type_struct);
-    ZL_ASSERT_GE(ZL_Input_eltWidth(inputStream), 1);
+    ZL_Type const inType = ZL_Input_type(inputStream);
+    ZL_ASSERT(inType == ZL_Type_serial || inType == ZL_Type_struct);
 
-    return ZL_Input_type(inputStream) == ZL_Type_serial
-            ? ZL_GRAPH_CONSTANT_SERIAL
-            : ZL_GRAPH_CONSTANT_FIXED;
+    /* If all bytes are identical, Serial path is more efficient */
+    if (isSingleBytePattern(inputStream)) {
+        return ZL_GRAPH_CONSTANT_SERIAL;
+    }
+
+    switch (inType) {
+        case ZL_Type_serial:
+            return ZL_GRAPH_CONSTANT_SERIAL;
+        case ZL_Type_struct:
+            return ZL_GRAPH_CONSTANT_FIXED;
+        /* fallthrough - not supported */
+        case ZL_Type_numeric:
+        case ZL_Type_string:
+        default:
+            ZL_REQUIRE(0, "Unsupported input type for constant selector");
+    }
 }

--- a/src/openzl/compress/selectors/selector_constant.c
+++ b/src/openzl/compress/selectors/selector_constant.c
@@ -9,8 +9,8 @@
  * For such patterns, Serial path is more efficient. */
 static int isSingleBytePattern(const ZL_Input* inputStream)
 {
-    const uint8_t* ptr      = ZL_Input_ptr(inputStream);
-    size_t const eltWidth   = ZL_Input_eltWidth(inputStream);
+    const uint8_t* ptr    = ZL_Input_ptr(inputStream);
+    size_t const eltWidth = ZL_Input_eltWidth(inputStream);
     ZL_ASSERT_NN(ZL_Input_numElts(inputStream));
     uint8_t const firstByte = ptr[0];
     for (size_t i = 1; i < eltWidth; ++i) {
@@ -44,7 +44,8 @@ ZL_GraphID SI_selector_constant(
     ZL_ASSERT(inType == ZL_Type_serial || inType == ZL_Type_struct);
 
     /* If all bytes are identical, Serial path is more efficient */
-    if (ZL_Input_eltWidth(inputStream)> 1 && isSingleBytePattern(inputStream)) {
+    if (ZL_Input_eltWidth(inputStream) > 1
+        && isSingleBytePattern(inputStream)) {
         return ZL_GRAPH_CONSTANT_SERIAL;
     }
 

--- a/src/openzl/compress/selectors/selector_constant.c
+++ b/src/openzl/compress/selectors/selector_constant.c
@@ -11,7 +11,7 @@ static int isSingleBytePattern(const ZL_Input* inputStream)
 {
     const uint8_t* ptr    = ZL_Input_ptr(inputStream);
     size_t const eltWidth = ZL_Input_eltWidth(inputStream);
-    ZL_ASSERT_NN(ZL_Input_numElts(inputStream));
+    ZL_ASSERT_NE(ZL_Input_numElts(inputStream), 0);
     uint8_t const firstByte = ptr[0];
     for (size_t i = 1; i < eltWidth; ++i) {
         if (ptr[i] != firstByte)

--- a/tests/zstrong/test_fixed.cpp
+++ b/tests/zstrong/test_fixed.cpp
@@ -472,7 +472,7 @@ TEST_F(FixedTest, Constant)
 
 TEST_F(FixedTest, ConstantZeroRanges)
 {
-    const std::vector<size_t> sizes = { 1, 10, 100, 1000, 10000, 50000 };
+    const std::vector<size_t> sizes     = { 1, 10, 100, 1000, 10000, 50000 };
     const std::vector<size_t> eltWidths = { 1, 2, 4, 8, 16, 32, 64 };
     for (size_t eltWidth : eltWidths) {
         for (size_t size : sizes) {
@@ -486,9 +486,9 @@ TEST_F(FixedTest, ConstantZeroRanges)
 
 TEST_F(FixedTest, ConstantSingleBytePatterns)
 {
-    const std::vector<size_t> sizes = { 1, 10, 100, 1000, 10000 };
+    const std::vector<size_t> sizes     = { 1, 10, 100, 1000, 10000 };
     const std::vector<size_t> eltWidths = { 2, 4, 8, 16 };
-    const std::vector<char> patterns = { '\x00', '\xFF', '\x55', '\xAA' };
+    const std::vector<char> patterns    = { '\x00', '\xFF', '\x55', '\xAA' };
     for (char pattern : patterns) {
         for (size_t eltWidth : eltWidths) {
             for (size_t size : sizes) {

--- a/tests/zstrong/test_fixed.cpp
+++ b/tests/zstrong/test_fixed.cpp
@@ -470,6 +470,37 @@ TEST_F(FixedTest, Constant)
     }
 }
 
+TEST_F(FixedTest, ConstantZeroRanges)
+{
+    const std::vector<size_t> sizes = { 1, 10, 100, 1000, 10000, 50000 };
+    const std::vector<size_t> eltWidths = { 1, 2, 4, 8, 16, 32, 64 };
+    for (size_t eltWidth : eltWidths) {
+        for (size_t size : sizes) {
+            std::string inputStr(size * eltWidth, '\0');
+            reset();
+            setStreamInType(ZL_Type_struct);
+            testGraphOnInput(ZL_GRAPH_CONSTANT, eltWidth, inputStr);
+        }
+    }
+}
+
+TEST_F(FixedTest, ConstantSingleBytePatterns)
+{
+    const std::vector<size_t> sizes = { 1, 10, 100, 1000, 10000 };
+    const std::vector<size_t> eltWidths = { 2, 4, 8, 16 };
+    const std::vector<char> patterns = { '\x00', '\xFF', '\x55', '\xAA' };
+    for (char pattern : patterns) {
+        for (size_t eltWidth : eltWidths) {
+            for (size_t size : sizes) {
+                std::string inputStr(size * eltWidth, pattern);
+                reset();
+                setStreamInType(ZL_Type_struct);
+                testGraphOnInput(ZL_GRAPH_CONSTANT, eltWidth, inputStr);
+            }
+        }
+    }
+}
+
 TEST_F(FixedTest, SplitN)
 {
     reset();

--- a/tests/zstrong/test_serialized.cpp
+++ b/tests/zstrong/test_serialized.cpp
@@ -210,7 +210,7 @@ TEST_F(SerializedTest, ConstantZeroRanges)
 
 TEST_F(SerializedTest, ConstantSingleBytePatterns)
 {
-    const std::vector<size_t> sizes = { 1, 10, 100, 1000, 10000 };
+    const std::vector<size_t> sizes  = { 1, 10, 100, 1000, 10000 };
     const std::vector<char> patterns = { '\x00', '\xFF', '\x55', '\xAA' };
     for (char pattern : patterns) {
         for (size_t size : sizes) {

--- a/tests/zstrong/test_serialized.cpp
+++ b/tests/zstrong/test_serialized.cpp
@@ -198,6 +198,28 @@ TEST_F(SerializedTest, Constant)
     }
 }
 
+TEST_F(SerializedTest, ConstantZeroRanges)
+{
+    const std::vector<size_t> sizes = { 1, 10, 100, 1000, 10000, 50000 };
+    for (size_t size : sizes) {
+        std::string zeroData(size, '\0');
+        testGraphOnInput(ZL_GRAPH_CONSTANT, zeroData);
+        testNodeOnInput(ZL_NODE_CONSTANT_SERIAL, zeroData);
+    }
+}
+
+TEST_F(SerializedTest, ConstantSingleBytePatterns)
+{
+    const std::vector<size_t> sizes = { 1, 10, 100, 1000, 10000 };
+    const std::vector<char> patterns = { '\x00', '\xFF', '\x55', '\xAA' };
+    for (char pattern : patterns) {
+        for (size_t size : sizes) {
+            std::string patternData(size, pattern);
+            testGraphOnInput(ZL_GRAPH_CONSTANT, patternData);
+        }
+    }
+}
+
 TEST_F(SerializedTest, SplitN)
 {
     reset();


### PR DESCRIPTION
When encoding a `constant` stream,
the most commonly expected case is `0`.
So it makes sense to have an optimization just for this case.

The proposed optimization works for any byte-repeated sequence, therefore including `0`.
It's implemented at graph level, and therefore doesn't impact Transforms, decoders nor format version.

It saves the cost of including the multi-byte constant.
This is mostly important for 64-bit numeric streams.

```

Element Width | Zero Pattern | Mixed Pattern | Savings
-- | -- | -- | --
2 bytes | 35 bytes | 36 bytes | 1 byte (2%)
4 bytes | 35 bytes | 38 bytes | 3 bytes (7%)
8 bytes | 35 bytes | 42 bytes | 7 bytes (16%)

```

It also works for any multi-byte pattern (even odd 7-bytes ones for example),
though, in practice, `numeric` streams of zeroes are the most expected ones.