### PR TITLE
Remove semi support

### DIFF
--- a/tests/codecs/test_sddl2.cpp
+++ b/tests/codecs/test_sddl2.cpp
@@ -217,8 +217,8 @@ class SimpleDataDescriptionLanguageV2Test : public Test {
 TEST_F(SimpleDataDescriptionLanguageV2Test, DieIf2Plus2DoesntEqual4)
 {
     const auto prog  = R"(
-        two = 2;
-        expect 2 + two == 4;
+        two = 2
+        expect 2 + two == 4
     )";
     const auto input = std::string_view{ "" };
     exec(prog, input, Expected::SUCCEED);
@@ -227,8 +227,8 @@ TEST_F(SimpleDataDescriptionLanguageV2Test, DieIf2Plus2DoesntEqual4)
 TEST_F(SimpleDataDescriptionLanguageV2Test, DieIf2Plus2Equals4)
 {
     const auto prog  = R"(
-        two = 2;
-        expect 2 + two != 4;
+        two = 2
+        expect 2 + two != 4
     )";
     const auto input = std::string_view{ "" };
     exec(prog, input, Expected::FAIL_TO_EXECUTE);
@@ -246,22 +246,22 @@ TEST_F(SimpleDataDescriptionLanguageV2Test, TrivialRoundtrip)
 TEST_F(SimpleDataDescriptionLanguageV2Test, AlternateFields)
 {
     const auto prog  = R"(
-        field_width = 4;
-        Field1 = Byte[field_width];
-        Field2 = Byte[field_width];
+        field_width = 4
+        Field1 = Byte[field_width]
+        Field2 = Byte[field_width]
         Row = {
             Field1,
             Field2
-        };
-        row_width = sizeof Row;
-        input_size = _rem;
-        row_count = input_size / row_width;
+        }
+        row_width = sizeof Row
+        input_size = _rem
+        row_count = input_size / row_width
 
         # check row size evenly divides input
-        expect input_size % row_width == 0;
+        expect input_size % row_width == 0
 
-        RowArray = Row[row_count];
-        : RowArray;
+        RowArray = Row[row_count]
+        : RowArray
     )";
     const auto input = std::string_view{
         "1234567812345678123456781234567812345678123456781234567812345678"
@@ -811,8 +811,8 @@ TEST_F(SimpleDataDescriptionLanguageV2Test, indeterminateArrayLength)
     }
 
     // Zero-sized objects can't be expanded.
-    exec(": {}[]; :Byte[3]", iota(3), Expected::FAIL_TO_EXECUTE);
-    exec(": Byte[0][]; :Byte[3]", iota(3), Expected::FAIL_TO_EXECUTE);
+    exec(": {}[] :Byte[3]", iota(3), Expected::FAIL_TO_EXECUTE);
+    exec(": Byte[0][] :Byte[3]", iota(3), Expected::FAIL_TO_EXECUTE);
 }
 
 TEST_F(SimpleDataDescriptionLanguageV2Test, unusedFields)

--- a/tools/sddl2/compiler/Grouper.cpp
+++ b/tools/sddl2/compiler/Grouper.cpp
@@ -195,12 +195,6 @@ class GrouperImpl {
                     }
                     continue;
                 }
-                if (*token == Symbol::SEMI) {
-                    nodes_in_cur_stmt.push_back(*it);
-                    stmts.push_back(group_expr(std::move(nodes_in_cur_stmt)));
-                    nodes_in_cur_stmt.clear();
-                    continue;
-                }
 
                 auto maybe_list = maybe_group_list(it, end);
                 if (maybe_list) {

--- a/tools/sddl2/compiler/Syntax.cpp
+++ b/tools/sddl2/compiler/Syntax.cpp
@@ -52,7 +52,6 @@ const std::map<Symbol, ListSymSet> list_sym_sets{ []() {
 
 static const std::map<Symbol, SymbolType> sym_types{
     { Symbol::NL, SymbolType::GROUPING },
-    { Symbol::SEMI, SymbolType::GROUPING },
     { Symbol::COMMA, SymbolType::GROUPING },
     { Symbol::PAREN_OPEN, SymbolType::GROUPING },
     { Symbol::PAREN_CLOSE, SymbolType::GROUPING },
@@ -148,7 +147,6 @@ SymbolType sym_type(Symbol sym)
 
 static const std::map<Symbol, poly::string_view> syms_to_debug_strs{
     { Symbol::NL, "NL" },
-    { Symbol::SEMI, "SEMI" },
     { Symbol::COMMA, "COMMA" },
     { Symbol::PAREN_OPEN, "PAREN_OPEN" },
     { Symbol::PAREN_CLOSE, "PAREN_CLOSE" },
@@ -245,7 +243,6 @@ poly::string_view sym_to_debug_str(Symbol sym)
 
 /* non-static: this is exposed */
 const std::vector<std::pair<poly::string_view, Symbol>> strs_to_syms{
-    { ";", Symbol::SEMI },
     { ",", Symbol::COMMA },
     { "(", Symbol::PAREN_OPEN },
     { ")", Symbol::PAREN_CLOSE },

--- a/tools/sddl2/compiler/Syntax.h
+++ b/tools/sddl2/compiler/Syntax.h
@@ -13,7 +13,6 @@ namespace openzl::sddl2 {
 enum class Symbol {
     // Grouping Tokens
     NL,           // \n
-    SEMI,         // ;
     COMMA,        // ,
     PAREN_OPEN,   // (
     PAREN_CLOSE,  // )

--- a/tools/sddl2/compiler/Syntax.md
+++ b/tools/sddl2/compiler/Syntax.md
@@ -5,7 +5,7 @@ This section serves as an in-depth reference for the features of SDDL. For an in
 !!! warning
     The SDDL Language is under active development. Its capabilities are expected to grow significantly. As part of that development, the syntax and semantics of existing features may change or break without warning.
 
-An SDDL Description is a series of **Statements**. A statement is a newline or semicolon-terminated **Expression**. There are multiple kinds of **Expressions**:
+An SDDL Description is a series of **Statements**. A statement is a newline-terminated **Expression**. There are multiple kinds of **Expressions**:
 
 ### Fields
 

--- a/tools/sddl2/compiler/tests/CompilerTest.cpp
+++ b/tools/sddl2/compiler/tests/CompilerTest.cpp
@@ -48,13 +48,13 @@ class CompilerTest : public Test {
 
 TEST_F(CompilerTest, ErrorMsgOpsMissingArgs)
 {
-    expect_error("foo = ;", "right-hand argument");
-    expect_error("= foo;", "left-hand argument");
+    expect_error("foo = \n", "right-hand argument");
+    expect_error("= foo\n", "left-hand argument");
 }
 
 TEST_F(CompilerTest, ErrorMsgEmptyExpr)
 {
-    expect_error(";", "Empty expression");
+    expect_error("()", "Empty expression");
 }
 
 TEST_F(CompilerTest, ErrorMsgNoOperatorBetweenSubExpressions)


### PR DESCRIPTION
Summary: Remove support for semi-colons in the sddl2 compiler.

Differential Revision: D90400953


