### PR TITLE
Expose python bindings publicly

### DIFF
--- a/BUCK
+++ b/BUCK
@@ -243,3 +243,12 @@ cpp_library(
         "tools/streamdump:stream_dump2_headers",  # @manual
     ],
 )
+
+python_library(
+    # @autodeps-skip
+    name = "openzl_py",
+    visibility = ["//openzl:openzl_py"],
+    deps = [
+        "py:openzl",
+    ],
+)


### PR DESCRIPTION
Summary: So they can be used outside of OpenZL

Differential Revision: D90709147


