### PR TITLE
Allow ML Selector to take in folder of compressors

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -190,8 +190,14 @@ examples: zs2_pipeline zs2_trygraph zs2_selector zs2_struct zs2_round_trip
 test : gtests zs2_test sddl2_test
 	$(EXEC_PREFIX) ./gtests
 
+# Python bindings for openzl.ext module (required for ML tests)
+.PHONY: python-bindings
+python-bindings:
+	@echo "Building and installing openzl Python bindings..."
+	pip install --quiet py/
+
 .PHONY: cli_test
-cli_test: zli
+cli_test: zli python-bindings
 	cd cli/tests && python3 cli_integration_tests.py ../../zli
 
 .PHONY: check-python-format

--- a/cli/tests/BUCK
+++ b/cli/tests/BUCK
@@ -6,6 +6,8 @@ load("@fbcode_macros//build_defs:python_library.bzl", "python_library")
 
 oncall("data_compression")
 
+# @autodeps-skip
+
 custom_unittest(
     name = "serial_test",
     command = [
@@ -209,6 +211,7 @@ python_binary(
     deps = [
         ":abstract_compression_test",
         ":command_utils",
+        ":file_utils",
     ],
 )
 
@@ -220,6 +223,7 @@ python_library(
     deps = [
         ":command_utils",
         ":file_utils",
+        "//openzl:openzl_py",
     ],
 )
 
@@ -250,6 +254,34 @@ custom_unittest(
         "$(location :integration_test_bin)",
         "$(location ..:zli)",
         "MLSelectorTest.test_train_compress_decompress",
+    ],
+    type = "simple",
+    deps = [
+        "..:zli",
+        ":integration_test_bin",
+    ],
+)
+
+custom_unittest(
+    name = "ml_dynamic_successor_test",
+    command = [
+        "$(location :integration_test_bin)",
+        "$(location ..:zli)",
+        "MLDynamicSuccessorTest.test_dynamic_ml_successors",
+    ],
+    type = "simple",
+    deps = [
+        "..:zli",
+        ":integration_test_bin",
+    ],
+)
+
+custom_unittest(
+    name = "ml_dynamic_successor_compression_ratio_test",
+    command = [
+        "$(location :integration_test_bin)",
+        "$(location ..:zli)",
+        "MLDynamicSuccessorTest.test_compression_ratios",
     ],
     type = "simple",
     deps = [

--- a/cli/tests/abstract_compression_test.py
+++ b/cli/tests/abstract_compression_test.py
@@ -234,6 +234,118 @@ class _TrainBaseTest(_CompressDecompressBaseTest):
         self.compress_and_decompress_samples()
 
 
+class _MLBaseTest(_TrainBaseTest):
+    """
+    Abstract base class for ML compression tests with training.
+    """
+
+    def setUp(self) -> None:
+        super().setUp()
+        # Create the serialized compressors folder once per test
+        self.serialized_compressors_folder = self.get_serialized_compressors()
+
+    def get_serialized_compressors(self) -> str:
+        """
+        Generate serialized compressors using static successors from numeric-ml-selector-64 profile.
+
+        Returns:
+            str: Path to the temporary folder containing the serialized .cbor files
+        """
+        import openzl.ext as zl
+
+        def field_lz() -> bytes:
+            compressor = zl.Compressor()
+            graph = zl.graphs.FieldLz()(compressor)
+            compressor.select_starting_graph(graph)
+            return compressor.serialize()
+
+        def delta_field_lz() -> bytes:
+            compressor = zl.Compressor()
+            graph = zl.graphs.FieldLz()(compressor)
+            graph = zl.nodes.DeltaInt()(compressor, graph)
+            compressor.select_starting_graph(graph)
+            return compressor.serialize()
+
+        def range_pack() -> bytes:
+            compressor = zl.Compressor()
+            graph = zl.nodes.RangePack()(compressor, successor=zl.graphs.FieldLz())
+            compressor.select_starting_graph(graph)
+            return compressor.serialize()
+
+        def range_pack_zstd() -> bytes:
+            compressor = zl.Compressor()
+            graph = zl.nodes.RangePack()(compressor, successor=zl.graphs.Zstd())
+            compressor.select_starting_graph(graph)
+            return compressor.serialize()
+
+        def tokenize_delta_fieldlz() -> bytes:
+            compressor = zl.Compressor()
+            delta_fieldlz = zl.nodes.DeltaInt()(compressor, zl.graphs.FieldLz())
+            tokenize = zl.nodes.Tokenize(type=zl.Type.Numeric, sort=True)
+            graph = tokenize(
+                compressor,
+                alphabet=delta_fieldlz,
+                indices=zl.graphs.FieldLz(),
+            )
+            compressor.select_starting_graph(graph)
+            return compressor.serialize()
+
+        def zstd() -> bytes:
+            compressor = zl.Compressor()
+            graph = zl.graphs.Zstd()(compressor)
+            compressor.select_starting_graph(graph)
+            return compressor.serialize()
+
+        compressors = {
+            "00_field_lz": field_lz(),
+            "01_range_pack": range_pack(),
+            "02_range_pack_zstd": range_pack_zstd(),
+            "03_delta_field_lz": delta_field_lz(),
+            "04_tokenize_delta_fieldlz": tokenize_delta_fieldlz(),
+            "05_zstd": zstd(),
+        }
+
+        # Create a temporary directory for the serialized compressors
+        compressor_dir = tempfile.mkdtemp()
+        self.addCleanup(lambda: shutil.rmtree(compressor_dir, True))
+
+        for name, data in compressors.items():
+            with open(os.path.join(compressor_dir, f"{name}.cbor"), "wb") as f:
+                f.write(data)
+
+        return compressor_dir
+
+    @property
+    def input_dir_name(self) -> str:
+        """
+        Return the directory name for input sample files.
+
+        This property determines where sample files are located:
+        cli/tests/sample_files/ml_selector/
+
+        Note: sample files are generated using the following command from
+        tutorial in examples/ml_selector and taking the first file:
+
+        ```
+        buck2 run @//mode/opt examples/ml_selector:generate_data -- /tmp/ml_test_samples
+        ```
+
+        Returns:
+            "ml_selector" as the input directory name
+        """
+        return "ml_selector"
+
+    @property
+    def compressor_profile_name(self) -> str:
+        """
+        Return the profile name to use for compression/training.
+
+        Returns:
+            "numeric-ml-selector-64" as the profile name
+        """
+        return "numeric-ml-selector-64"
+
+
 class _CsvBaseTest(_TrainBaseTest):
     """
     Abstract base class for CSV compression tests with training.

--- a/cli/tests/cli_integration_tests.py
+++ b/cli/tests/cli_integration_tests.py
@@ -1,5 +1,6 @@
 # Copyright (c) Meta Platforms, Inc. and affiliates.
 
+import os
 import sys
 import unittest
 
@@ -8,9 +9,17 @@ from abstract_compression_test import (
     _BenchmarkBaseTest,
     _CompressDecompressBaseTest,
     _CsvBaseTest,
+    _MLBaseTest,
     _TrainBaseTest,
     _TrainInlineBaseTest,
 )
+from command_utils import (
+    CompressorInfo,
+    CompressorType,
+    execute_compress,
+    execute_train,
+)
+from file_utils import input_dir_path
 
 
 class SerialTest(_CompressDecompressBaseTest):
@@ -191,40 +200,121 @@ class CsvChunkedTest(_CsvBaseTest):
         self.train_compress_decompress()
 
 
-class MLSelectorTest(_TrainBaseTest):
+class MLDynamicSuccessorTest(_MLBaseTest):
+    """
+    Test case for ml selector with dynamic successors created from folder of serialized compressors.
+    Sample files are located in cli/tests/sample_files/ml_selector/
+    Serialized compressors are created dynamically
+    """
+
+    @property
+    def extra_args(self) -> str | None:
+        """Pass the serialized compressor folder via --profile-arg."""
+        return f"--profile-arg {self.serialized_compressors_folder}"
+
+    def test_dynamic_ml_successors(self):
+        """
+        Test train_compress_decompress works when there is ml selector successor in compressor.
+        """
+        default_compressor_info = CompressorInfo(
+            compressor_str=self.compressor_profile_name,
+            compressor_type=CompressorType.PROFILE,
+        )
+
+        # Train ml selector and save trained compressor
+        execute_train(
+            compressor_info=default_compressor_info,
+            uncompressed_dir=input_dir_path(self.input_dir_name),
+            trained_compressor_path=os.path.join(
+                self.serialized_compressors_folder, "trained.cbor"
+            ),
+        )
+
+        # Train ml selector that has a ml selector as a successor
+        execute_train(
+            compressor_info=default_compressor_info,
+            uncompressed_dir=input_dir_path(self.input_dir_name),
+            trained_compressor_path=self.compressor_info.compressor_str,
+            trainer_name=self.trainer_name,
+            extra_args=self.extra_args,
+        )
+
+        self.compress_and_decompress_samples()
+
+    def test_compression_ratios(self):
+        """
+        Create trained compressor using dynamic successors that match static successors in numeric-ml-selector-64 profile.
+        Resulting compressed files should have the same compression ratio as directly using the numeric-ml-selector-64 profile.
+        """
+        from file_utils import file_contents_match
+
+        default_compressor_info = CompressorInfo(
+            compressor_str=self.compressor_profile_name,
+            compressor_type=CompressorType.PROFILE,
+        )
+
+        # Train with static successors (no extra_args)
+        static_trained_path = os.path.join(self.output_dir_path, "static_trained.zlc")
+        execute_train(
+            compressor_info=default_compressor_info,
+            uncompressed_dir=input_dir_path(self.input_dir_name),
+            trained_compressor_path=static_trained_path,
+            trainer_name=self.trainer_name,
+            extra_args=None,
+        )
+
+        # Train with dynamic successors (with extra_args)
+        dynamic_trained_path = os.path.join(self.output_dir_path, "dynamic_trained.zlc")
+        execute_train(
+            compressor_info=default_compressor_info,
+            uncompressed_dir=input_dir_path(self.input_dir_name),
+            trained_compressor_path=dynamic_trained_path,
+            trainer_name=self.trainer_name,
+            extra_args=self.extra_args,
+        )
+
+        # Compress samples with both trained compressors and compare outputs
+        static_compressor_info = CompressorInfo(
+            compressor_str=static_trained_path,
+            compressor_type=CompressorType.FILE,
+        )
+        dynamic_compressor_info = CompressorInfo(
+            compressor_str=dynamic_trained_path,
+            compressor_type=CompressorType.FILE,
+        )
+
+        for sample in self.input_samples:
+            static_compressed_path = sample.compressed_file_path + "_static"
+            execute_compress(
+                file_to_compress_path=sample.orig_file_path,
+                compressor_info=static_compressor_info,
+                compressed_file_path=static_compressed_path,
+                extra_args=None,
+            )
+
+            dynamic_compressed_path = sample.compressed_file_path + "_dynamic"
+            execute_compress(
+                file_to_compress_path=sample.orig_file_path,
+                compressor_info=dynamic_compressor_info,
+                compressed_file_path=dynamic_compressed_path,
+                extra_args=None,
+            )
+
+            self.assertTrue(
+                file_contents_match(static_compressed_path, dynamic_compressed_path),
+                f"Compressed files differ for {sample.orig_file_path}: "
+                f"static={os.path.getsize(static_compressed_path)} bytes, "
+                f"dynamic={os.path.getsize(dynamic_compressed_path)} bytes",
+            )
+
+        print("Compressed files are identical between static and dynamic successors.")
+
+
+class MLSelectorTest(_MLBaseTest):
     """
     Test case for ml selector and compression using the trainer.
+    Sample files are located in cli/tests/sample_files/ml_selector/
     """
-
-    @property
-    def input_dir_name(self) -> str:
-        """
-        Return the directory name for input sample files.
-
-        This property determines where sample files are located:
-        cli/tests/sample_files/ml_selector/
-
-        Note: sample files are generated using the following command from
-        tutorial in examples/ml_selector and taking the first file:
-
-        ```
-        buck2 run @//mode/opt examples/ml_selector:generate_data -- /tmp/ml_test_samples
-        ```
-
-        Returns:
-            "ml_selector" as the input directory name
-        """
-        return "ml_selector"
-
-    @property
-    def compressor_profile_name(self) -> str:
-        """
-        Return the profile name to use for compression/training.
-
-        Returns:
-            "numeric-ml-selector-64" as the profile name
-        """
-        return "numeric-ml-selector-64"
 
     def test_train_compress_decompress(self):
         """

--- a/cli/tests/command_utils.py
+++ b/cli/tests/command_utils.py
@@ -181,6 +181,7 @@ def execute_train(
     uncompressed_dir: str,
     trained_compressor_path: str,
     trainer_name: str | None = None,
+    extra_args: str | None = None,
 ):
     """
     Execute the train command to train a compressor on sample files.
@@ -202,6 +203,8 @@ def execute_train(
             - "greedy": Makes locally optimal choices at each step
             - "full-split": Analyzes the entire dataset before making decisions
             If None, the default trainer for the profile will be used.
+        extra_args: Additional arguments to pass to the train command (optional).
+            For example: "--profile-arg /path/to/folder"
 
     Raises:
         ValueError: If the training fails or the trained compressor is not created
@@ -212,6 +215,8 @@ def execute_train(
     train_args = f"train --max-time-secs 1 --{cflag} {cstr} {str(uncompressed_dir)} -o {str(trained_compressor_path)}"
     if trainer_name:
         train_args += f" -t {trainer_name}"
+    if extra_args:
+        train_args += f" {extra_args}"
 
     if execute_command(train_args) != 0:
         raise ValueError("Executing train command failed")

--- a/cli/utils/compress_profiles.cpp
+++ b/cli/utils/compress_profiles.cpp
@@ -9,8 +9,10 @@
 #include "openzl/cpp/Exception.hpp"
 #include "openzl/openzl.hpp"
 #include "openzl/zl_compressor.h"
+#include "openzl/zl_reflection.h"
 
 #include "custom_parsers/csv/csv_profile.h"
+#include "custom_parsers/dependency_registration.h"
 #include "custom_parsers/parquet/parquet_graph.h"
 #include "custom_parsers/pytorch_model_parser.h"
 #include "custom_parsers/sddl/sddl2_profile.h"
@@ -18,6 +20,7 @@
 #include "custom_parsers/shared_components/clustering.h"
 
 #include "tools/io/InputFile.h"
+#include "tools/io/InputSetFileOrDir.h"
 #include "tools/ml_selector/ml_selector_graph.h"
 #include "tools/sddl/compiler/Compiler.h"
 
@@ -143,6 +146,51 @@ static void addLEintProfile(
             std::move(nodeid));
 }
 } // namespace
+
+static ZL_RESULT_OF(ZL_GraphID) extractFolderOfCompressors(
+        Compressor& compressor,
+        const std::string& folder)
+{
+    ZL_RESULT_DECLARE_SCOPE(ZL_GraphID, compressor.get());
+
+    auto inputSet = tools::io::InputSetFileOrDir(folder, true);
+
+    std::vector<ZL_GraphID> successors;
+    for (const auto& input : inputSet) {
+        auto contents = input->contents();
+
+        custom_parsers::processDependencies(compressor, contents);
+
+        compressor.deserialize(contents);
+
+        ZL_GraphID startingGraphId;
+        ZL_Compressor_getStartingGraphID(compressor.get(), &startingGraphId);
+        successors.push_back(startingGraphId);
+    }
+
+    // ML selectors require at least 2 successors to choose between
+    if (successors.size() < 2) {
+        throw Exception(
+                "ML selector requires at least 2 successor compressors, but "
+                "only "
+                + std::to_string(successors.size()) + " were provided in '"
+                + folder + "'");
+    }
+
+    ZL_TRY_LET(
+            ZL_GraphID,
+            mlSelectorGraphId,
+            MLSelector_registerGraphWithEmptyGBTModel(
+                    compressor.get(), successors.data(), successors.size()));
+
+    // Wrap with serial-to-numeric conversion so the graph accepts serial input
+    auto graph = ZL_Compressor_registerStaticGraph_fromNode1o(
+            compressor.get(),
+            ZL_NODE_CONVERT_SERIAL_TO_NUM_LE64,
+            mlSelectorGraphId);
+
+    return ZL_RESULT_WRAP_VALUE(ZL_GraphID, graph);
+}
 
 /**
  * @brief Registers static successor graphs for the ML selector.
@@ -314,10 +362,16 @@ compressProfiles()
                 "64 bit numeric data using ml selectors (Placeholder)",
                 [](ZL_Compressor* comp, void*, const ProfileArgs& args) {
                     (void)args;
-                    return unwrap(
-                            numeric64BitMLSelectorProfile(comp),
-                            "Failed to set up numeric profile",
-                            comp);
+                    if (args.map().find("TBD") != args.map().end()) {
+                        CompressorRef compressor(comp);
+                        return unwrap(extractFolderOfCompressors(
+                                compressor, args.map().at("TBD")));
+                    } else {
+                        return unwrap(
+                                numeric64BitMLSelectorProfile(comp),
+                                "Failed to set up numeric profile",
+                                comp);
+                    }
                 });
 
         return mp;

--- a/tools/ml_selector/ml_selector_trainer.cpp
+++ b/tools/ml_selector/ml_selector_trainer.cpp
@@ -6,7 +6,9 @@
 #include <string>
 #include <vector>
 #include "ml_features.h"
+#include "openzl/common/a1cbor_helpers.h"
 #include "openzl/zl_reflection.h"
+#include "src/openzl/compress/cgraph.h"
 #include "src/openzl/compress/selectors/ml/features.h"
 #include "tools/logger/Logger.h"
 #include "tools/ml_selector/ml_selector_graph.h"
@@ -509,79 +511,143 @@ static GBTPredictorWrapper trainXGBoostModel(
     return createGBTModelFromXGBoost(xgBoostDump, num_classes);
 }
 
+static void updateCompressor(
+        Compressor& compressor,
+        ZL_MLSelectorConfig& config,
+        std::string& mlSelectorGraphName)
+{
+    Arena* arena       = ALLOC_HeapArena_create();
+    A1C_Arena a1cArena = A1C_Arena_wrap(arena);
+
+    ZL_SerializedMLConfig serializedConfig = unwrap(
+            MLSelector_serializeMLSelectorConfig(nullptr, &config, &a1cArena));
+
+    ZL_CopyParam configParam = {
+        .paramId   = ZL_GENERIC_ML_SELECTOR_CONFIG_ID,
+        .paramPtr  = serializedConfig.data,
+        .paramSize = serializedConfig.size,
+    };
+
+    ZL_LocalParams localParams = { .copyParams = { .genParams    = &configParam,
+                                                   .nbCopyParams = 1 } };
+
+    ZL_GraphParameters newParams = {
+        .localParams = &localParams,
+    };
+
+    ZL_GraphID existingMlSelectorGraphId =
+            compressor.getGraph(mlSelectorGraphName).value();
+
+    // Replace old config with new trained config
+    auto result = ZL_Compressor_overrideGraphParams(
+            compressor.get(), existingMlSelectorGraphId, &newParams);
+
+    ALLOC_Arena_freeArena(arena);
+
+    if (ZL_isError(result)) {
+        throw std::runtime_error("Error overriding graph params");
+    }
+}
+
 std::shared_ptr<const std::string_view> trainMLSelectorGraph(
         const std::vector<MultiInput>& inputs,
         Compressor& compressor,
         const TrainParams& trainParams)
 {
     (void)trainParams;
-    std::vector<ZL_GraphID> successorGraphs;
 
     // Find the ML selector graph by prefix
     auto mlSelectorGraphNames = graph_mutation::findAllGraphsWithPrefix(
             compressor.serialize(), ML_SELECTOR_GRAPH_NAME);
 
-    if (mlSelectorGraphNames.empty() || mlSelectorGraphNames.size() > 1) {
+    if (mlSelectorGraphNames.empty()) {
         throw std::runtime_error(
                 "Error finding ML selector graph with prefix '"
                 + ML_SELECTOR_GRAPH_NAME + "'");
     }
 
-    // Use the first mlSelector graph found
-    const ZL_GraphID mlSelectorGraph =
-            compressor.getGraph(mlSelectorGraphNames[0]).value();
-    const auto& mlSelectorGraphName = mlSelectorGraphNames[0];
+    std::set<std::string> trainedMlSelectors;
+    bool trainedAnyThisPass = true;
+    /**
+     * Process ML selectors iteratively until no more can be trained.
+     *
+     * ML selectors may be chained (output of one feeds into another), but
+     * mlSelectorGraphNames has no guaranteed order. On each pass, we train
+     * any selector that currently has available inputs. Once trained, its
+     * outputs become inputs for downstream selectors, which can then be
+     * trained in subsequent passes.
+     */
+    while (trainedMlSelectors.size() < mlSelectorGraphNames.size()
+           && trainedAnyThisPass) {
+        trainedAnyThisPass = false;
 
-    const auto successors = ZL_Compressor_Graph_getCustomGraphs(
-            compressor.get(), mlSelectorGraph);
+        for (auto& mlSelectorGraphName : mlSelectorGraphNames) {
+            if (trainedMlSelectors.count(mlSelectorGraphName) > 0) {
+                continue;
+            }
 
-    successorGraphs.reserve(successors.nbGraphIDs);
-    for (size_t i = 0; i < successors.nbGraphIDs; ++i) {
-        successorGraphs.push_back(successors.graphids[i]);
+            auto cctx = refCCtxForTraining(compressor);
+
+            // Collect inputs for mlSelector graph
+            auto mlSelectorInputs = collectInputStreamsForGraph(
+                    inputs, mlSelectorGraphName, cctx);
+
+            if (mlSelectorInputs.empty()) {
+                continue;
+            }
+
+            const ZL_GraphID mlSelectorGraph =
+                    compressor.getGraph(mlSelectorGraphName).value();
+
+            const auto successors = ZL_Compressor_Graph_getCustomGraphs(
+                    compressor.get(), mlSelectorGraph);
+
+            std::vector<ZL_GraphID> successorGraphs;
+            successorGraphs.reserve(successors.nbGraphIDs);
+            for (size_t i = 0; i < successors.nbGraphIDs; ++i) {
+                successorGraphs.push_back(successors.graphids[i]);
+            }
+
+            ProcessedMLTrainingSamples trainingSample = extractMLFeatures(
+                    mlSelectorInputs, compressor, cctx, successorGraphs);
+
+            TestTrainData splitData = trainTestSplit(
+                    trainingSample.features, trainingSample.numericLabels);
+
+            GBTPredictorWrapper gbtPred =
+                    trainXGBoostModel(splitData, successors.nbGraphIDs);
+
+            GBTModel coreModel = {
+                .predictor        = gbtPred.core_predictor_.get(),
+                .featureGenerator = FeatureGen_integer,
+                .nbSuccessors     = successors.nbGraphIDs,
+                .nbFeatures       = trainingSample.featurePtrNames.size(),
+                .featureLabels    = trainingSample.featurePtrNames.data(),
+            };
+
+            ZL_MLSelectorConfig config = { .model         = ZL_GBT,
+                                           .runtimeConfig = &coreModel };
+
+            // Update compressor with new trained config
+            updateCompressor(compressor, config, mlSelectorGraphName);
+            trainedAnyThisPass = true;
+            trainedMlSelectors.insert(mlSelectorGraphName);
+        }
     }
 
-    auto cctx = refCCtxForTraining(compressor);
-    // Collect inputs for first mlSelector graph
-    auto mlSelectorInputs =
-            collectInputStreamsForGraph(inputs, mlSelectorGraphName, cctx);
-
-    if (mlSelectorInputs.empty()) {
-        throw std::runtime_error("Unable to get inputs to mlSelector");
+    if (trainedMlSelectors.size() == 0) {
+        throw std::runtime_error("No inputs captured for any mlSelector graph");
     }
 
-    ProcessedMLTrainingSamples trainingSample = extractMLFeatures(
-            mlSelectorInputs, compressor, cctx, successorGraphs);
+    // Warn if some mlSelectors were left untrained
+    if (trainedMlSelectors.size() < mlSelectorGraphNames.size()) {
+        Logger::log(
+                WARNINGS,
+                "Warning: ",
+                mlSelectorGraphNames.size() - trainedMlSelectors.size(),
+                " mlSelector(s) could not be trained - no inputs captured.");
+    }
 
-    TestTrainData splitData = trainTestSplit(
-            trainingSample.features, trainingSample.numericLabels);
-
-    GBTPredictorWrapper gbtPred =
-            trainXGBoostModel(splitData, successors.nbGraphIDs);
-
-    GBTModel coreModel = {
-        .predictor        = gbtPred.core_predictor_.get(),
-        .featureGenerator = FeatureGen_integer,
-        .nbSuccessors     = successors.nbGraphIDs,
-        .nbFeatures       = trainingSample.featurePtrNames.size(),
-        .featureLabels    = trainingSample.featurePtrNames.data(),
-    };
-
-    ZL_MLSelectorConfig config = { .model         = ZL_GBT,
-                                   .runtimeConfig = &coreModel };
-
-    auto mlSelectorGraphId = unwrap(ZL_MLSelector_registerGraph(
-            compressor.get(),
-            &config,
-            successorGraphs.data(),
-            successorGraphs.size()));
-
-    auto newMlSelectorGraphName =
-            ZL_Compressor_Graph_getName(compressor.get(), mlSelectorGraphId);
-
-    return graph_mutation::createSharedStringView(
-            graph_mutation::renameGraphInCompressor(
-                    compressor.serialize(),
-                    mlSelectorGraphName,
-                    newMlSelectorGraphName));
+    return graph_mutation::createSharedStringView(compressor.serialize());
 }
 } // namespace openzl::training


### PR DESCRIPTION
Summary:
Add utility function to pass in folder of serialized compressors that can be used as successors for ml selectors.
- Throw error if csv/parquet parsers are passed in
- Do not train ml selectors that are passed in as successors

Differential Revision: D90815985
