### PR TITLE
Graft "[llvm21-migration][openzm/prod:compress] Fix -Wdefault-const-init-field-unsafe"

### DIFF
--- a/include/openzl/detail/zl_errors_detail.h
+++ b/include/openzl/detail/zl_errors_detail.h
@@ -23,6 +23,17 @@
 extern "C" {
 #endif
 
+// Zero-initialization syntax differs between C and C++.
+// C++ uses {} to avoid -Wmissing-braces with nested structs.
+// C uses { 0 } which is the standard zero-initialization idiom.
+#if defined(__cplusplus)
+#    define ZL_ZERO_INIT \
+        {                \
+        }
+#else
+#    define ZL_ZERO_INIT { 0 }
+#endif
+
 #ifndef ZL_ERROR_ENABLE_STATIC_ERROR_INFO
 #    define ZL_ERROR_ENABLE_STATIC_ERROR_INFO 1
 #endif
@@ -358,8 +369,8 @@ typedef struct {
     {                                                                    \
         /* Avoids using the inactive members of the union. */            \
         if (ZL_RES_isError(result)) {                                    \
-            *error = result._error;                                      \
-            _value_type dummy_value;                                     \
+            *error                  = result._error;                     \
+            _value_type dummy_value = ZL_ZERO_INIT;                      \
             memset(&dummy_value, 0, sizeof(dummy_value));                \
             return dummy_value;                                          \
         } else {                                                         \

--- a/src/openzl/compress/cctx.c
+++ b/src/openzl/compress/cctx.c
@@ -752,7 +752,7 @@ static ZL_Report CCTX_runGraph_internal(
         } else {
             size_t nbSuccs = VECTOR_SIZE(gctx->dstGraphDescs);
             DECLARE_VECTOR_TYPE(ZL_GraphID);
-            VECTOR(ZL_GraphID) succGids;
+            VECTOR(ZL_GraphID) succGids = { 0 };
             VECTOR_INIT(succGids, nbSuccs);
             for (size_t i = 0; i < nbSuccs; i++) {
                 bool pushbackSuccess = VECTOR_PUSHBACK(


### PR DESCRIPTION
Summary:
Grafted 94ebcf084887f18e2ff6205f65772aebc2817251 (D90781593)
- Grafted fbcode/openzl/prod to fbcode/openzl/dev

Reviewed By: r-barnes

Differential Revision: D90889352


