### PR TITLE
quiet noisy dispatch_string logs

### DIFF
--- a/src/openzl/codecs/dispatch_string/encode_dispatch_string_binding.c
+++ b/src/openzl/codecs/dispatch_string/encode_dispatch_string_binding.c
@@ -71,7 +71,7 @@ EI_dispatch_string(ZL_Encoder* eictx, const ZL_Input* ins[], size_t nbIns)
         outputSizes[indices[i]] += srcStrLens[i];
     }
 
-    ZL_DLOG(DEBUG,
+    ZL_DLOG(TRANSFORM,
             "EI_dispatch_string: splitting %u strings into %i outputs",
             nbElts,
             nbOutputs);


### PR DESCRIPTION
Summary: Dispatch_string was logging to `DEBUG`, which can flood the terminal e.g. during training. Move this down to `TRANSFORM` to match other codecs.

Differential Revision: D91846297


