### PR TITLE
move materialized params to a central location

### DIFF
--- a/include/openzl/zl_ctransform.h
+++ b/include/openzl/zl_ctransform.h
@@ -16,6 +16,7 @@
 #include "openzl/zl_ctransform_legacy.h" // Pipe and Split transforms
 #include "openzl/zl_errors.h"            // ZL_Report
 #include "openzl/zl_input.h"
+#include "openzl/zl_materializer.h" // ZL_MaterializerDesc
 #include "openzl/zl_opaque_types.h"
 #include "openzl/zl_output.h"
 #include "openzl/zl_portability.h" // ZL_NOEXCEPT_FUNC_PTR
@@ -74,108 +75,6 @@ _Static_assert(
         sizeof(void*) == sizeof(size_t),
         "Condition required to ensure H(ZL_CodecStateManager) doesn't depend on padding bytes");
 #endif
-
-/**
- * @brief Descriptor for materializing and dematerializing local params
- *
- * This structure defines functions to materialize an in-memory object from
- * local parameters and to dematerialize (free) that object.
- *
- * Materialized objects are available as a @ref ZL_RefParam via the typical
- * local params access methods. Specify the retrieval key with the paramId
- * field.
- */
-typedef struct ZL_MaterializerDesc_s {
-    /**
-     * @brief A custom function that materializes an in-memory object from a
-     * provided @p params object.
-     *
-     * This function may arbitrarily use none, any, or all of the provided
-     * local params to generate the materialized object, but the generation
-     * MUST be deterministic and hermetic. In particular, materialization shall
-     * not depend on variables other than the provided @ref ZL_LocalParams
-     * object.
-     *
-     * Materialized object lifetimes will be managed by the @ref ZL_Compressor
-     * on which the node is registered/parameterized. Objects will be
-     * materialized around the time of node registration/parameterization and
-     * will remain allocated for the lifetime of the associated @ref
-     * ZL_Compressor.
-     *
-     * Do NOT rely on the materialization function being called at any specific
-     * time to do side-effect work. Doing so will result in undefined behavior.
-     *
-     * The @ref ZL_Compressor may arbitrarily share the same materialized object
-     * between multiple nodes with the same @p params and the @ref ZL_CCtx may
-     * provide concurrent access to materialized objects. DO NOT attempt to
-     * modify the materialized object after creation, either directly or via API
-     * getters.
-     *
-     * @param matCtx A pointer to a materializer context object associated with
-     * the @ref ZL_Compressor. The materialization function may use this to
-     * request managed memory from the ZL_Compressor as an alternative to
-     * managing allocations itself and via the dematerializeFn.
-     * @param params  A pointer to the local params object to materialize. The
-     * provided params have no lifetime guarantees past the invocation of this
-     * function. You may not hold references into the params object in the
-     * materialized object.
-     *
-     * @returns A ZL_RESULT containing a pointer to the materialized object on
-     * success, or an error. Returning NULL as a valid result (when there's
-     * nothing to materialize) should be wrapped in ZL_WRAP_VALUE(NULL). Ensure
-     * the function declares a result scope with ZL_RESULT_DECLARE_SCOPE or you
-     * will get a compiler error.
-     */
-    ZL_RESULT_OF(ZL_VoidPtr) (*materializeFn)(
-            ZL_Materializer* matCtx,
-            const ZL_LocalParams* params)ZL_NOEXCEPT_FUNC_PTR;
-
-    /**
-     * @brief A custom function that destructs a materialized object.
-     *
-     * You should use this to deallocate all non-arena memory and free any held
-     * resources. As a convenience, if there are no resources or memory to free,
-     * you may use ZL_NOOP_DEMATERIALIZE as a placeholder.
-     */
-    void (*dematerializeFn)(ZL_Materializer* matCtx, void* materialized)
-            ZL_NOEXCEPT_FUNC_PTR;
-
-    /**
-     * The paramId to use for the materialized param. If there is an existing
-     * param that uses this paramId, the registration will fail.
-     */
-    int paramId;
-
-    /**
-     * Optionally an opaque pointer that can be queried with
-     * ZL_Materializer_getOpaquePtr(). OpenZL does not take ownership of this
-     * pointer. If lifetime extension is needed, it should be managed by the
-     * `ZL_OpaquePtr` in the outer `ZL_MIEncoderDesc`.
-     */
-    const void* opaque;
-} ZL_MaterializerDesc;
-
-void ZL_NOOP_DEMATERIALIZE(ZL_Materializer* matCtx, void* materialized)
-        ZL_NOEXCEPT_FUNC_PTR;
-
-/**
- * Managed space allocation:
- * Materialization may request arena space to hold materialized objects. It is
- * allowed to request multiple buffers of any size. Returned buffers are not
- * initialized, and cannot be freed individually. All buffers are
- * automatically released at end of the owning @ref ZL_Compressor 's lifetime.
- */
-void* ZL_Materializer_allocate(ZL_Materializer* matCtx, size_t size);
-
-/**
- * Scratch space allocation:
- * When the materializer needs some buffer space for some local operation,
- * it can request such space from the engine. It is allowed to
- * request multiple buffers of any size. Returned buffers are not
- * initialized, and cannot be freed individually. All scratch buffers are
- * automatically released at the end of the materializer's execution.
- */
-void* ZL_Materializer_getScratchSpace(ZL_Materializer* matCtx, size_t size);
 
 /* ------------------------------------
  * Typed Transforms

--- a/include/openzl/zl_materializer.h
+++ b/include/openzl/zl_materializer.h
@@ -1,0 +1,127 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#ifndef OPENZL_ZL_MATERIALIZER_H
+#define OPENZL_ZL_MATERIALIZER_H
+
+#include <stddef.h> // size_t
+#include "openzl/zl_common_types.h"
+#include "openzl/zl_errors.h"       // ZL_RESULT_OF, ZL_VoidPtr
+#include "openzl/zl_localParams.h"  // ZL_LocalParams
+#include "openzl/zl_opaque_types.h" // ZL_Materializer
+#include "openzl/zl_portability.h"  // ZL_NOEXCEPT_FUNC_PTR
+
+#if defined(__cplusplus)
+extern "C" {
+#endif
+
+/**
+ * @brief Descriptor for materializing and dematerializing local params
+ *
+ * This structure defines functions to materialize an in-memory object from
+ * local parameters and to dematerialize (free) that object.
+ *
+ * Materialized objects are available as a @ref ZL_RefParam via the typical
+ * local params access methods. Specify the retrieval key with the paramId
+ * field.
+ */
+typedef struct ZL_MaterializerDesc_s {
+    /**
+     * @brief A custom function that materializes an in-memory object from a
+     * provided @p params object.
+     *
+     * This function may arbitrarily use none, any, or all of the provided
+     * local params to generate the materialized object, but the generation
+     * MUST be deterministic and hermetic. In particular, materialization shall
+     * not depend on variables other than the provided @ref ZL_LocalParams
+     * object.
+     *
+     * Materialized object lifetimes will be managed by the @ref ZL_Compressor
+     * on which the node is registered/parameterized. Objects will be
+     * materialized around the time of node registration/parameterization and
+     * will remain allocated for the lifetime of the associated @ref
+     * ZL_Compressor.
+     *
+     * Do NOT rely on the materialization function being called at any specific
+     * time to do side-effect work. Doing so will result in undefined behavior.
+     *
+     * The @ref ZL_Compressor may arbitrarily share the same materialized object
+     * between multiple nodes with the same @p params and the @ref ZL_CCtx may
+     * provide concurrent access to materialized objects. DO NOT attempt to
+     * modify the materialized object after creation, either directly or via API
+     * getters.
+     *
+     * @param matCtx A pointer to a materializer context object associated with
+     * the @ref ZL_Compressor. The materialization function may use this to
+     * request managed memory from the ZL_Compressor as an alternative to
+     * managing allocations itself and via the dematerializeFn.
+     * @param params  A pointer to the local params object to materialize. The
+     * provided params have no lifetime guarantees past the invocation of this
+     * function. You may not hold references into the params object in the
+     * materialized object.
+     *
+     * @returns A ZL_RESULT containing a pointer to the materialized object on
+     * success, or an error. Returning NULL as a valid result (when there's
+     * nothing to materialize) should be wrapped in ZL_WRAP_VALUE(NULL). Ensure
+     * the function declares a result scope with ZL_RESULT_DECLARE_SCOPE or you
+     * will get a compiler error.
+     */
+    ZL_RESULT_OF(ZL_VoidPtr) (*materializeFn)(
+            ZL_Materializer* matCtx,
+            const ZL_LocalParams* params)ZL_NOEXCEPT_FUNC_PTR;
+
+    /**
+     * @brief A custom function that destructs a materialized object.
+     *
+     * You should use this to deallocate all non-arena memory and free any held
+     * resources. As a convenience, if there are no resources or memory to free,
+     * you may use ZL_NOOP_DEMATERIALIZE as a placeholder.
+     */
+    void (*dematerializeFn)(ZL_Materializer* matCtx, void* materialized)
+            ZL_NOEXCEPT_FUNC_PTR;
+
+    /**
+     * The paramId to use for the materialized param. If there is an existing
+     * param that uses this paramId, the registration will fail.
+     */
+    int paramId;
+
+    /**
+     * Optionally an opaque pointer that can be queried with
+     * ZL_Materializer_getOpaquePtr(). OpenZL does not take ownership of this
+     * pointer. If lifetime extension is needed, it should be managed by the
+     * `ZL_OpaquePtr` in the outer `ZL_MIEncoderDesc`.
+     */
+    const void* opaque;
+} ZL_MaterializerDesc;
+
+/**
+ * No-op dematerialization function.
+ * Use this as a placeholder when there are no resources or memory to free.
+ */
+void ZL_NOOP_DEMATERIALIZE(ZL_Materializer* matCtx, void* materialized)
+        ZL_NOEXCEPT_FUNC_PTR;
+
+/**
+ * Managed space allocation:
+ * Materialization may request arena space to hold materialized objects. It is
+ * allowed to request multiple buffers of any size. Returned buffers are not
+ * initialized, and cannot be freed individually. All buffers are
+ * automatically released at end of the owning @ref ZL_Compressor 's lifetime.
+ */
+void* ZL_Materializer_allocate(ZL_Materializer* matCtx, size_t size);
+
+/**
+ * Scratch space allocation:
+ * When the materializer needs some buffer space for some local operation,
+ * it can request such space from the engine. It is allowed to
+ * request multiple buffers of any size. Returned buffers are not
+ * initialized, and cannot be freed individually. All scratch buffers are
+ * automatically released at the end of the materializer's execution.
+ */
+void* ZL_Materializer_getScratchSpace(ZL_Materializer* matCtx, size_t size);
+
+#if defined(__cplusplus)
+} // extern "C"
+#endif
+
+#endif // OPENZL_ZL_MATERIALIZER_H

--- a/src/openzl/compress/cnodes.c
+++ b/src/openzl/compress/cnodes.c
@@ -8,70 +8,10 @@
 #include "openzl/common/wire_format.h" // trt_standard
 #include "openzl/compress/cnode.h"
 #include "openzl/compress/localparams.h"
-#include "openzl/shared/mem.h" // ZL_memcpy
+#include "openzl/compress/materializer.h" // ZL_Materializer functions
+#include "openzl/shared/mem.h"            // ZL_memcpy
 #include "openzl/shared/xxhash.h"
 #include "openzl/zl_errors.h"
-
-// ******************************************************************
-// ZL_Materializer
-// ******************************************************************
-
-struct ZL_Materializer_s {
-    CNodes_manager* ctm;
-    Arena* matArena;
-    const void* opaquePtr;
-} /* typedef'ed to ZL_Materializer in zl_opaque_types.h */;
-
-static ZL_Materializer* ZL_Materializer_create(
-        CNodes_manager* ctm,
-        ZL_MaterializerDesc matDesc)
-{
-    ZL_Materializer* mat = ALLOC_Arena_malloc(ctm->allocator, sizeof(*mat));
-    if (mat == NULL) {
-        return NULL;
-    }
-    mat->ctm      = ctm;
-    mat->matArena = ALLOC_StackArena_create();
-    if (mat->matArena == NULL) {
-        ALLOC_Arena_free(ctm->allocator, mat);
-        return NULL;
-    }
-    mat->opaquePtr = matDesc.opaque;
-    return mat;
-}
-
-static void ZL_Materializer_free(ZL_Materializer* mat)
-{
-    if (mat == NULL) {
-        return;
-    }
-    ALLOC_Arena_freeArena(mat->matArena);
-    ALLOC_Arena_free(mat->ctm->allocator, mat);
-}
-
-void* ZL_Materializer_allocate(ZL_Materializer* mat, size_t size)
-{
-    if (mat == NULL || mat->ctm == NULL) {
-        return NULL;
-    }
-    return ALLOC_Arena_malloc(mat->ctm->allocator, size);
-}
-
-void* ZL_Materializer_getScratchSpace(ZL_Materializer* mat, size_t size)
-{
-    if (mat == NULL || mat->matArena == NULL) {
-        return NULL;
-    }
-    return ALLOC_Arena_malloc(mat->matArena, size);
-}
-
-void ZL_NOOP_DEMATERIALIZE(ZL_Materializer* matCtx, void* materialized)
-        ZL_NOEXCEPT_FUNC_PTR
-{
-    (void)matCtx;
-    (void)materialized;
-    return;
-}
 
 // ******************************************************************
 // CTM (CNodes manager)
@@ -142,22 +82,7 @@ void CTM_destroy(CNodes_manager* ctm)
     ZL_ASSERT_NN(ctm);
     // Dematerialize all materialized params before freeing any corresponding
     // CNodes
-    MaterializedParamMap_Iter iter =
-            MaterializedParamMap_iter(&ctm->materializedParams);
-    MaterializedParamMap_Entry const* entry;
-    while ((entry = MaterializedParamMap_Iter_next(&iter)) != NULL) {
-        if (entry->val.materializedParam != NULL) {
-            ZL_ASSERT_NN(entry->key.matDesc.dematerializeFn);
-            ZL_Materializer* mat =
-                    ZL_Materializer_create(ctm, entry->key.matDesc);
-            if (mat == NULL) {
-                continue;
-            }
-            entry->key.matDesc.dematerializeFn(
-                    mat, entry->val.materializedParam);
-            ZL_Materializer_free(mat);
-        }
-    }
+    MPM_dematerializeAllParams(&ctm->materializedParams, ctm->allocator);
     MaterializedParamMap_destroy(&ctm->materializedParams);
     ZL_OpaquePtrRegistry_destroy(&ctm->opaquePtrs);
     VECTOR_DESTROY(ctm->cnodes);
@@ -178,7 +103,7 @@ void CTM_reset(CNodes_manager* ctm)
         if (entry->val.materializedParam != NULL
             && entry->key.matDesc.dematerializeFn != NULL) {
             ZL_Materializer* mat =
-                    ZL_Materializer_create(ctm, entry->key.matDesc);
+                    ZL_Materializer_create(ctm->allocator, entry->key.matDesc);
             if (mat == NULL) {
                 continue;
             }
@@ -216,73 +141,6 @@ static ZL_Report CTM_transferLocalParams(
     return LP_transferLocalParams(cnm->allocator, lp);
 }
 
-// Validate that paramId is not invalid and not already in use by existing local
-// params
-static ZL_Report validateMaterializedParamId(ZL_LocalParams* lp, int paramId)
-{
-    ZL_RET_R_IF_EQ(
-            node_invalid,
-            paramId,
-            ZL_LP_INVALID_PARAMID,
-            "Materialized paramId cannot be ZL_LP_INVALID_PARAMID");
-
-    ZL_RefParam rp = LP_getLocalRefParam(lp, paramId);
-    ZL_RET_R_IF_NE(
-            node_invalid,
-            rp.paramId,
-            ZL_LP_INVALID_PARAMID,
-            "Materialized paramId %d is already registered",
-            paramId);
-
-    ZL_IntParam ip = LP_getLocalIntParam(lp, paramId);
-    ZL_RET_R_IF_NE(
-            node_invalid,
-            ip.paramId,
-            ZL_LP_INVALID_PARAMID,
-            "Materialized paramId %d is already registered as an intParam",
-            paramId);
-    return ZL_returnSuccess();
-}
-
-/* CTM_addMaterializedRefParam():
- * Add a materialized param to the refParams of the local params.
- * @return : success, or error if paramId is already in use
- */
-static ZL_Report CTM_addMaterializedRefParam(
-        CNodes_manager* cnm,
-        ZL_LocalParams* lp,
-        int paramId,
-        const void* materializedObj)
-{
-    ZL_ASSERT_NN(cnm);
-    ZL_ASSERT_NN(lp);
-    ZL_RESULT_DECLARE_SCOPE_REPORT(cnm->opCtx);
-
-    // Allocate new refParams array with one more entry
-    size_t const newNbRefParams = lp->refParams.nbRefParams + 1;
-    ZL_RefParam* newRefParams   = ALLOC_Arena_malloc(
-            cnm->allocator, newNbRefParams * sizeof(ZL_RefParam));
-    ZL_ERR_IF_NULL(newRefParams, allocation);
-
-    // Copy existing refParams
-    for (size_t i = 0; i < lp->refParams.nbRefParams; i++) {
-        newRefParams[i] = lp->refParams.refParams[i];
-    }
-
-    // Add the materialized param
-    newRefParams[lp->refParams.nbRefParams] = (ZL_RefParam){
-        .paramId   = paramId,
-        .paramRef  = materializedObj,
-        .paramSize = 0, // Size unknown for materialized objects
-    };
-
-    // Update the localParams
-    lp->refParams.refParams   = newRefParams;
-    lp->refParams.nbRefParams = newNbRefParams;
-
-    return ZL_returnSuccess();
-}
-
 /* CTM_transferStreamTypes():
  * Transfer streamType information from user-controlled memory
  * towards internal memory,
@@ -307,72 +165,6 @@ static ZL_Report CTM_transferPrivateParam(
     ZL_ASSERT_NN(itd);
     ZL_DLOG(BLOCK, "CTM_transferPrivateParam: ppSize=%zu", itd->ppSize);
     return CTM_transferBuffer(cnm, &itd->privateParam, itd->ppSize);
-}
-
-/**
- * Find or create a materialized param in the registry. This function will
- * handle cleaning up the materialized object if an error occurs.
- */
-static ZL_Report CTM_addOrReuseMaterializedParam(
-        CNodes_manager* ctm,
-        ZL_LocalParams* lp,
-        const ZL_MaterializerDesc* matDesc)
-{
-    ZL_RESULT_DECLARE_SCOPE_REPORT(ctm->opCtx);
-    if (matDesc == NULL || matDesc->materializeFn == NULL) {
-        return ZL_returnSuccess();
-    }
-    if (matDesc->dematerializeFn == NULL) {
-        ZL_ERR(GENERIC,
-               "Materializer must provide a valid dematerialize function pointer");
-    }
-
-    // Create key for lookup
-    MaterializedParamKey key = {
-        .localParams = *lp,
-        .matDesc     = *matDesc,
-    };
-
-    // Search for existing materialized param with same key
-    MaterializedParamMap_Entry const* existingEntry =
-            MaterializedParamMap_find(&ctm->materializedParams, &key);
-    if (existingEntry != NULL) {
-        return CTM_addMaterializedRefParam(
-                ctm,
-                lp,
-                matDesc->paramId,
-                existingEntry->val.materializedParam);
-    }
-
-    // Not found, create new materialized param
-    ZL_Materializer* mat = ZL_Materializer_create(ctm, *matDesc);
-    ZL_ERR_IF_NULL(mat, allocation);
-    ZL_RESULT_OF(ZL_VoidPtr) matResult = matDesc->materializeFn(mat, lp);
-    ZL_Materializer_free(mat);
-    ZL_ERR_IF_ERR(matResult);
-
-    void* materialized = ZL_RES_value(matResult);
-
-    MaterializedParamEntry newEntry = {
-        .materializedParam = materialized,
-    };
-
-    MaterializedParamMap_Entry entryToInsert = {
-        .key = key,
-        .val = newEntry,
-    };
-
-    MaterializedParamMap_Insert insertResult = MaterializedParamMap_insert(
-            &ctm->materializedParams, &entryToInsert);
-    if (insertResult.badAlloc) {
-        ZL_Materializer* mat2 = ZL_Materializer_create(ctm, *matDesc);
-        ZL_ERR_IF_NULL(mat2, allocation);
-        matDesc->dematerializeFn(mat2, materialized);
-        ZL_Materializer_free(mat2);
-        ZL_ERR(allocation, "Failed to insert materialized param into map");
-    }
-
-    return CTM_addMaterializedRefParam(ctm, lp, matDesc->paramId, materialized);
 }
 
 /*
@@ -438,14 +230,16 @@ static ZL_RESULT_OF(CNodeID) CTM_registerCNode(
                 // for the materializer
                 ZL_RET_T_IF_ERR(
                         CNodeID,
-                        validateMaterializedParamId(
+                        MPM_validateMaterializedParamId(
                                 &trDesc->localParams,
                                 trDesc->materializer.paramId));
                 // Add the materialized object to refParams
                 ZL_RET_T_IF_ERR(
                         CNodeID,
-                        CTM_addOrReuseMaterializedParam(
-                                ctm,
+                        MPM_addOrReuseMaterializedParam(
+                                ctm->allocator,
+                                &ctm->materializedParams,
+                                ctm->opCtx,
                                 &trDesc->localParams,
                                 &trDesc->materializer));
             }

--- a/src/openzl/compress/cnodes.h
+++ b/src/openzl/compress/cnodes.h
@@ -4,13 +4,12 @@
 #define ZSTRONG_COMPRESS_CNODES_H
 
 #include "openzl/common/allocation.h" // Arena
-#include "openzl/common/map.h"
 #include "openzl/common/opaque.h"
 #include "openzl/common/vector.h"
 #include "openzl/compress/cnode.h"          // CNode
 #include "openzl/compress/compress_types.h" // InternalTransform_Desc
+#include "openzl/compress/materializer.h"   // MaterializedParamMap
 #include "openzl/shared/portability.h"
-#include "openzl/zl_errors.h" // ZL_RESULT_DECLARE_TYPE_IMPL, ZL_RESULT_OF
 
 ZL_BEGIN_C_DECLS
 
@@ -21,29 +20,7 @@ ZL_RESULT_DECLARE_TYPE(CNodeID);
 
 DECLARE_VECTOR_TYPE(CNode)
 
-// Definitions for MaterializedParamMap
-typedef struct {
-    ZL_LocalParams localParams;
-    ZL_MaterializerDesc matDesc; // The description provided at registration
-} MaterializedParamKey;
-
-typedef struct {
-    void* materializedParam; // The materialized object
-} MaterializedParamEntry;
-
-// Custom hash and equality functions for MaterializedParamKey. Uses the
-// LocalParams object and ZL_MaterializerDesc for the comparison.
-size_t MaterializedParamMap_hash(const MaterializedParamKey* key);
-bool MaterializedParamMap_eq(
-        const MaterializedParamKey* lhs,
-        const MaterializedParamKey* rhs);
-
-ZL_DECLARE_CUSTOM_MAP_TYPE(
-        MaterializedParamMap,
-        MaterializedParamKey,
-        MaterializedParamEntry);
-
-typedef struct {
+typedef struct CNodes_manager_s {
     VECTOR(CNode) cnodes;
     ZL_OpaquePtrRegistry opaquePtrs;
     Arena* allocator;

--- a/src/openzl/compress/materializer.c
+++ b/src/openzl/compress/materializer.c
@@ -1,0 +1,217 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#include "openzl/compress/materializer.h"
+#include "openzl/common/allocation.h" // ALLOC_*
+#include "openzl/compress/localparams.h" // LP_getLocalRefParam, LP_getLocalIntParam
+
+// ******************************************************************
+// ZL_Materializer
+// ******************************************************************
+
+ZL_Materializer* ZL_Materializer_create(
+        Arena* allocator,
+        ZL_MaterializerDesc matDesc)
+{
+    ZL_Materializer* mat = ALLOC_Arena_malloc(allocator, sizeof(*mat));
+    if (mat == NULL) {
+        return NULL;
+    }
+    mat->allocator = allocator;
+    mat->matArena  = ALLOC_StackArena_create();
+    if (mat->matArena == NULL) {
+        ALLOC_Arena_free(allocator, mat);
+        return NULL;
+    }
+    mat->opaquePtr = matDesc.opaque;
+    return mat;
+}
+
+void ZL_Materializer_free(ZL_Materializer* mat)
+{
+    if (mat == NULL) {
+        return;
+    }
+    ALLOC_Arena_freeArena(mat->matArena);
+    ALLOC_Arena_free(mat->allocator, mat);
+}
+
+void* ZL_Materializer_allocate(ZL_Materializer* mat, size_t size)
+{
+    if (mat == NULL || mat->allocator == NULL) {
+        return NULL;
+    }
+    return ALLOC_Arena_malloc(mat->allocator, size);
+}
+
+void* ZL_Materializer_getScratchSpace(ZL_Materializer* mat, size_t size)
+{
+    if (mat == NULL || mat->matArena == NULL) {
+        return NULL;
+    }
+    return ALLOC_Arena_malloc(mat->matArena, size);
+}
+
+void ZL_NOOP_DEMATERIALIZE(ZL_Materializer* matCtx, void* materialized)
+        ZL_NOEXCEPT_FUNC_PTR
+{
+    (void)matCtx;
+    (void)materialized;
+    return;
+}
+
+// ******************************************************************
+// MaterializedParamMap
+// ******************************************************************
+
+// Validate that paramId is not invalid and not already in use by existing local
+// params
+ZL_Report MPM_validateMaterializedParamId(ZL_LocalParams* lp, int paramId)
+{
+    ZL_RET_R_IF_EQ(
+            GENERIC,
+            paramId,
+            ZL_LP_INVALID_PARAMID,
+            "Materialized paramId cannot be ZL_LP_INVALID_PARAMID");
+
+    ZL_RefParam rp = LP_getLocalRefParam(lp, paramId);
+    ZL_RET_R_IF_NE(
+            GENERIC,
+            rp.paramId,
+            ZL_LP_INVALID_PARAMID,
+            "Materialized paramId %d is already registered",
+            paramId);
+
+    ZL_IntParam ip = LP_getLocalIntParam(lp, paramId);
+    ZL_RET_R_IF_NE(
+            GENERIC,
+            ip.paramId,
+            ZL_LP_INVALID_PARAMID,
+            "Materialized paramId %d is already registered as an intParam",
+            paramId);
+    return ZL_returnSuccess();
+}
+
+ZL_Report MPM_addMaterializedRefParam(
+        Arena* allocator,
+        ZL_OperationContext* opCtx,
+        ZL_LocalParams* lp,
+        int paramId,
+        const void* materializedObj)
+{
+    ZL_ASSERT_NN(allocator);
+    ZL_ASSERT_NN(opCtx);
+    ZL_ASSERT_NN(lp);
+    ZL_RESULT_DECLARE_SCOPE_REPORT(opCtx);
+
+    // Allocate new refParams array with one more entry
+    size_t const newNbRefParams = lp->refParams.nbRefParams + 1;
+    ZL_RefParam* newRefParams =
+            ALLOC_Arena_malloc(allocator, newNbRefParams * sizeof(ZL_RefParam));
+    ZL_ERR_IF_NULL(newRefParams, allocation);
+
+    // Copy existing refParams
+    for (size_t i = 0; i < lp->refParams.nbRefParams; i++) {
+        newRefParams[i] = lp->refParams.refParams[i];
+    }
+
+    // Add the materialized param
+    newRefParams[lp->refParams.nbRefParams] = (ZL_RefParam){
+        .paramId   = paramId,
+        .paramRef  = materializedObj,
+        .paramSize = 0, // Size unknown for materialized objects
+    };
+
+    // Update the localParams
+    lp->refParams.refParams   = newRefParams;
+    lp->refParams.nbRefParams = newNbRefParams;
+
+    return ZL_returnSuccess();
+}
+
+ZL_Report MPM_addOrReuseMaterializedParam(
+        Arena* allocator,
+        MaterializedParamMap* materializedParams,
+        ZL_OperationContext* opCtx,
+        ZL_LocalParams* lp,
+        const ZL_MaterializerDesc* matDesc)
+{
+    ZL_RESULT_DECLARE_SCOPE_REPORT(opCtx);
+    if (matDesc == NULL || matDesc->materializeFn == NULL) {
+        return ZL_returnSuccess();
+    }
+    if (matDesc->dematerializeFn == NULL) {
+        ZL_ERR(GENERIC,
+               "Materializer must provide a valid dematerialize function pointer");
+    }
+
+    // Create key for lookup
+    MaterializedParamKey key = {
+        .localParams = *lp,
+        .matDesc     = *matDesc,
+    };
+
+    // Search for existing materialized param with same key
+    MaterializedParamMap_Entry const* existingEntry =
+            MaterializedParamMap_find(materializedParams, &key);
+    if (existingEntry != NULL) {
+        return MPM_addMaterializedRefParam(
+                allocator,
+                opCtx,
+                lp,
+                matDesc->paramId,
+                existingEntry->val.materializedParam);
+    }
+
+    // Not found, create new materialized param
+    ZL_Materializer* mat = ZL_Materializer_create(allocator, *matDesc);
+    ZL_ERR_IF_NULL(mat, allocation);
+    ZL_RESULT_OF(ZL_VoidPtr) matResult = matDesc->materializeFn(mat, lp);
+    ZL_Materializer_free(mat);
+    ZL_ERR_IF_ERR(matResult);
+
+    void* materialized = ZL_RES_value(matResult);
+
+    MaterializedParamEntry newEntry = {
+        .materializedParam = materialized,
+    };
+
+    MaterializedParamMap_Entry entryToInsert = {
+        .key = key,
+        .val = newEntry,
+    };
+
+    MaterializedParamMap_Insert insertResult =
+            MaterializedParamMap_insert(materializedParams, &entryToInsert);
+    if (insertResult.badAlloc) {
+        ZL_Materializer* mat2 = ZL_Materializer_create(allocator, *matDesc);
+        ZL_ERR_IF_NULL(mat2, allocation);
+        matDesc->dematerializeFn(mat2, materialized);
+        ZL_Materializer_free(mat2);
+        ZL_ERR(allocation, "Failed to insert materialized param into map");
+    }
+
+    return MPM_addMaterializedRefParam(
+            allocator, opCtx, lp, matDesc->paramId, materialized);
+}
+
+void MPM_dematerializeAllParams(
+        MaterializedParamMap* materializedParams,
+        Arena* allocator)
+{
+    MaterializedParamMap_Iter iter =
+            MaterializedParamMap_iter(materializedParams);
+    MaterializedParamMap_Entry const* entry;
+    while ((entry = MaterializedParamMap_Iter_next(&iter)) != NULL) {
+        if (entry->val.materializedParam != NULL) {
+            ZL_ASSERT_NN(entry->key.matDesc.dematerializeFn);
+            ZL_Materializer* mat =
+                    ZL_Materializer_create(allocator, entry->key.matDesc);
+            if (mat == NULL) {
+                continue;
+            }
+            entry->key.matDesc.dematerializeFn(
+                    mat, entry->val.materializedParam);
+            ZL_Materializer_free(mat);
+        }
+    }
+}

--- a/src/openzl/compress/materializer.h
+++ b/src/openzl/compress/materializer.h
@@ -1,0 +1,94 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#ifndef ZSTRONG_COMPRESS_MATERIALIZER_H
+#define ZSTRONG_COMPRESS_MATERIALIZER_H
+
+#include "openzl/common/allocation.h" // Arena
+#include "openzl/common/map.h"
+#include "openzl/shared/portability.h"
+#include "openzl/zl_errors.h" // ZL_RESULT_DECLARE_TYPE_IMPL, ZL_RESULT_OF
+
+ZL_BEGIN_C_DECLS
+
+// ******************************************************************
+// ZL_Materializer
+// ******************************************************************
+
+struct ZL_Materializer_s {
+    Arena* allocator;
+    Arena* matArena;
+    const void* opaquePtr;
+} /* typedef'ed to ZL_Materializer in zl_opaque_types.h */;
+
+ZL_Materializer* ZL_Materializer_create(
+        Arena* allocator,
+        ZL_MaterializerDesc matDesc);
+
+void ZL_Materializer_free(ZL_Materializer* mat);
+
+// ******************************************************************
+// MaterializedParamMap
+// ******************************************************************
+
+typedef struct {
+    ZL_LocalParams localParams;
+    ZL_MaterializerDesc matDesc; // The description provided at registration
+} MaterializedParamKey;
+
+typedef struct {
+    void* materializedParam; // The materialized object
+} MaterializedParamEntry;
+
+// Custom hash and equality functions for MaterializedParamKey. Uses the
+// LocalParams object and ZL_MaterializerDesc for the comparison.
+size_t MaterializedParamMap_hash(const MaterializedParamKey* key);
+bool MaterializedParamMap_eq(
+        const MaterializedParamKey* lhs,
+        const MaterializedParamKey* rhs);
+
+ZL_DECLARE_CUSTOM_MAP_TYPE(
+        MaterializedParamMap,
+        MaterializedParamKey,
+        MaterializedParamEntry);
+
+/* MPM_validateMaterializedParamId():
+ * Validate that paramId is not invalid and not already in use by existing
+ * local params.
+ * @return : success, or error if paramId is invalid or already in use
+ */
+ZL_Report MPM_validateMaterializedParamId(ZL_LocalParams* lp, int paramId);
+
+/* MPM_addMaterializedRefParam():
+ * Add a materialized param to the refParams of the local params.
+ * @return : success, or error if paramId is already in use
+ */
+ZL_Report MPM_addMaterializedRefParam(
+        Arena* allocator,
+        ZL_OperationContext* opCtx,
+        ZL_LocalParams* lp,
+        int paramId,
+        const void* materializedObj);
+
+/* MPM_addOrReuseMaterializedParam():
+ * Find or create a materialized param in the registry. This function will
+ * handle cleaning up the materialized object if an error occurs.
+ * @return : success, or error
+ */
+ZL_Report MPM_addOrReuseMaterializedParam(
+        Arena* allocator,
+        MaterializedParamMap* materializedParams,
+        ZL_OperationContext* opCtx,
+        ZL_LocalParams* lp,
+        const ZL_MaterializerDesc* matDesc);
+
+/* MPM_dematerializeAllParams():
+ * Function called before MaterializedParamMap_destroy() to free all non-arena
+ * memory allocated by materializers.
+ */
+void MPM_dematerializeAllParams(
+        MaterializedParamMap* materializedParams,
+        Arena* allocator);
+
+ZL_END_C_DECLS
+
+#endif

--- a/tests/unittest/compress/CNodesTest.cpp
+++ b/tests/unittest/compress/CNodesTest.cpp
@@ -4,6 +4,7 @@
 
 #include <random>
 
+#include "openzl/common/operation_context.h"
 #include "openzl/compress/cnodes.h"
 #include "openzl/compress/compress_types.h"
 #include "openzl/zl_ctransform.h"
@@ -70,7 +71,8 @@ class CNodesTest : public Test {
     void SetUp() override
     {
         gCounter.reset();
-        ZL_Report r = CTM_init(&ctm_, NULL);
+        ZL_OC_init(&opCtx_);
+        ZL_Report r = CTM_init(&ctm_, &opCtx_);
         ASSERT_FALSE(ZL_isError(r)) << "CTM_init should succeed";
         nextCtid_ = 1000;
     }
@@ -78,6 +80,7 @@ class CNodesTest : public Test {
     void TearDown() override
     {
         CTM_destroy(&ctm_);
+        ZL_OC_destroy(&opCtx_);
         EXPECT_TRUE(gCounter.balanced())
                 << "materializeCount=" << gCounter.materializeCount
                 << " dematerializeCount=" << gCounter.dematerializeCount;
@@ -154,6 +157,7 @@ class CNodesTest : public Test {
         };
     }
 
+    ZL_OperationContext opCtx_{};
     CNodes_manager ctm_{};
     ZL_IDType nextCtid_;
     ZL_MaterializerDesc trackingMaterializer_{


### PR DESCRIPTION
Summary: In preparation to add similar materialization functionality to graphs as nodes, it makes sense to centralize to avoid duplicating code. In addition to the internal `materializer.h` shared API functions, this also motivates a new `zl_materializer.h` public header. It no longer makes logical sense for materialization to be tied to `zl_ctransform.h` since it will be available for codecs, graphs, selectors, and segmenters.

Reviewed By: kevinjzhang

Differential Revision: D91830637


