### PR TITLE
Add a --block-size / -B flag

### DIFF
--- a/contrib/lz-research/BUCK
+++ b/contrib/lz-research/BUCK
@@ -4,12 +4,39 @@ load("@fbcode_macros//build_defs:cpp_library.bzl", "cpp_library")
 oncall("data_compression")
 
 cpp_library(
+    name = "codecs",
+    srcs = [
+        "codecs/Bucket.cpp",
+        "codecs/Bucket16.cpp",
+        "codecs/IsoByte.cpp",
+        "codecs/Lz.cpp",
+        "codecs/SmallInt.cpp",
+        "codecs/VarByte.cpp",
+    ],
+    headers = [
+        "codecs/Bucket.hpp",
+        "codecs/Bucket16.hpp",
+        "codecs/CodecIDs.hpp",
+        "codecs/IsoByte.hpp",
+        "codecs/Lz.hpp",
+        "codecs/SmallInt.hpp",
+        "codecs/VarByte.hpp",
+        "codecs/utils/Partition.hpp",
+    ],
+    exported_deps = [
+        "../../cpp:openzl_cpp",
+    ],
+)
+
+cpp_library(
     # @autodeps-skip
     name = "lz_compressors",
     srcs = ["LzCompressors.cpp"],
     headers = ["LzCompressors.hpp"],
+    deps = [":codecs"],
     exported_deps = [
         "../../cpp:openzl_cpp",
+        ":codecs",
     ],
 )
 

--- a/contrib/lz-research/Benchmark.cpp
+++ b/contrib/lz-research/Benchmark.cpp
@@ -66,16 +66,37 @@ std::string trunc(std::string str, size_t n, bool left)
 }
 } // namespace
 
+nlohmann::json BlockResult::json() const
+{
+    nlohmann::json data;
+    data["original_size"]                = originalSize;
+    data["compressed_size"]              = compressedSize;
+    data["best_compression_duration_ns"] = bestCompressionDuration().count();
+    data["best_decompression_duration_ns"] =
+            bestDecompressionDuration().count();
+    data["compression_durations_ns"]   = toJson(compressionDurations);
+    data["decompression_durations_ns"] = toJson(decompressionDurations);
+    return data;
+}
+
 nlohmann::json BenchmarkResult::json() const
 {
     nlohmann::json data;
-    data["file_name"]                  = fileName;
-    data["compressor_name"]            = compressorName;
-    data["compressor_config"]          = compressorConfig;
-    data["original_size"]              = originalSize;
-    data["compressed_size"]            = compressedSize;
-    data["compression_durations_ns"]   = toJson(compressionDurations);
-    data["decompression_durations_ns"] = toJson(decompressionDurations);
+    data["file_name"]                    = fileName;
+    data["compressor_name"]              = compressorName;
+    data["compressor_config"]            = compressorConfig;
+    data["original_size"]                = originalSize();
+    data["compressed_size"]              = compressedSize();
+    data["compression_ratio"]            = compressionRatio();
+    data["best_compression_duration_ns"] = bestCompressionDuration().count();
+    data["best_decompression_duration_ns"] =
+            bestDecompressionDuration().count();
+    data["best_compression_speed_mbps"]   = bestCompressionSpeedMBps();
+    data["best_decompression_speed_mbps"] = bestDecompressionSpeedMBps();
+    data["blocks"]                        = nlohmann::json::array();
+    for (const auto& block : blockResults) {
+        data["blocks"].push_back(block.json());
+    }
     return data;
 }
 
@@ -138,40 +159,52 @@ std::vector<BenchmarkResult> benchmark(
             result.fileName         = input->name();
             result.compressorName   = compressor->name();
             result.compressorConfig = compressorConfig;
-            result.originalSize     = data.size();
 
-            auto cCapacity = compressor->compressBound(data);
-            auto cBuf      = std::make_unique<char[]>(cCapacity);
-            auto dBuf      = std::make_unique<char[]>(data.size());
+            const auto blockSize   = args.blockSize.value_or(data.size());
+            const size_t numBlocks = (data.size() + blockSize - 1) / blockSize;
+            const auto minTimePerBlock = args.minTime / numBlocks;
 
-            result.compressedSize = benchmarkFn(
-                    result.compressionDurations,
-                    args.mode == BenchmarkMode::Decompression ? 0
-                                                              : args.minIters,
-                    args.mode == BenchmarkMode::Decompression
-                            ? std::chrono::seconds(0)
-                            : args.minTime,
-                    [&] {
-                        return compressor->compress(
-                                { cBuf.get(), cCapacity }, data);
-                    });
+            do {
+                auto block = data.substr(0, blockSize);
+                BlockResult blockResult;
+                blockResult.originalSize = block.size();
+                auto cCapacity           = compressor->compressBound(block);
+                auto cBuf                = std::make_unique<char[]>(cCapacity);
+                auto dBuf = std::make_unique<char[]>(block.size());
 
-            auto dSize = benchmarkFn(
-                    result.decompressionDurations,
-                    args.mode == BenchmarkMode::Compression ? 0 : args.minIters,
-                    args.mode == BenchmarkMode::Compression
-                            ? std::chrono::seconds(0)
-                            : args.minTime,
-                    [&] {
-                        return compressor->decompress(
-                                { dBuf.get(), data.size() },
-                                { cBuf.get(), result.compressedSize });
-                    });
+                blockResult.compressedSize = benchmarkFn(
+                        blockResult.compressionDurations,
+                        args.mode == BenchmarkMode::Decompression
+                                ? 0
+                                : args.minIters,
+                        args.mode == BenchmarkMode::Decompression
+                                ? std::chrono::seconds(0)
+                                : minTimePerBlock,
+                        [&] {
+                            return compressor->compress(
+                                    { cBuf.get(), cCapacity }, block);
+                        });
+
+                auto dSize = benchmarkFn(
+                        blockResult.decompressionDurations,
+                        args.mode == BenchmarkMode::Compression ? 0
+                                                                : args.minIters,
+                        args.mode == BenchmarkMode::Compression
+                                ? std::chrono::seconds(0)
+                                : minTimePerBlock,
+                        [&] {
+                            return compressor->decompress(
+                                    { dBuf.get(), block.size() },
+                                    { cBuf.get(), blockResult.compressedSize });
+                        });
+
+                if (poly::string_view{ dBuf.get(), dSize } != block) {
+                    throw std::runtime_error("Corruption!");
+                }
+                result.blockResults.push_back(blockResult);
+                data = data.substr(block.size());
+            } while (!data.empty());
             Logger::log_c(LogLevel::INFO, "%s", result.pretty().c_str());
-
-            if (poly::string_view{ dBuf.get(), dSize } != data) {
-                throw std::runtime_error("Corruption!");
-            }
             results.push_back(result);
         }
     }

--- a/contrib/lz-research/Benchmark.cpp
+++ b/contrib/lz-research/Benchmark.cpp
@@ -146,8 +146,11 @@ std::vector<BenchmarkResult> benchmark(
 
             result.compressedSize = benchmarkFn(
                     result.compressionDurations,
-                    args.minIters,
-                    args.minTime,
+                    args.mode == BenchmarkMode::Decompression ? 0
+                                                              : args.minIters,
+                    args.mode == BenchmarkMode::Decompression
+                            ? std::chrono::seconds(0)
+                            : args.minTime,
                     [&] {
                         return compressor->compress(
                                 { cBuf.get(), cCapacity }, data);
@@ -155,8 +158,10 @@ std::vector<BenchmarkResult> benchmark(
 
             auto dSize = benchmarkFn(
                     result.decompressionDurations,
-                    args.minIters,
-                    args.minTime,
+                    args.mode == BenchmarkMode::Compression ? 0 : args.minIters,
+                    args.mode == BenchmarkMode::Compression
+                            ? std::chrono::seconds(0)
+                            : args.minTime,
                     [&] {
                         return compressor->decompress(
                                 { dBuf.get(), data.size() },

--- a/contrib/lz-research/Benchmark.hpp
+++ b/contrib/lz-research/Benchmark.hpp
@@ -13,9 +13,16 @@
 
 namespace openzl::bench {
 
+enum class BenchmarkMode {
+    Both,
+    Compression,
+    Decompression,
+};
+
 struct BenchmarkArgs {
     size_t minIters{ 1 };
     std::chrono::nanoseconds minTime{ 1 };
+    BenchmarkMode mode{ BenchmarkMode::Both };
     std::vector<nlohmann::json> compressorConfigs;
 };
 
@@ -35,6 +42,9 @@ struct BenchmarkResult {
 
     double bestCompressionSpeedMBps() const
     {
+        if (compressionDurations.empty()) {
+            return std::numeric_limits<double>::quiet_NaN();
+        }
         auto dur = *std::min_element(
                 compressionDurations.begin(), compressionDurations.end());
         return (double)originalSize * 1000.0 / dur.count();
@@ -42,6 +52,9 @@ struct BenchmarkResult {
 
     double bestDecompressionSpeedMBps() const
     {
+        if (decompressionDurations.empty()) {
+            return std::numeric_limits<double>::quiet_NaN();
+        }
         auto dur = *std::min_element(
                 decompressionDurations.begin(), decompressionDurations.end());
         return (double)originalSize * 1000.0 / dur.count();

--- a/contrib/lz-research/Benchmark.hpp
+++ b/contrib/lz-research/Benchmark.hpp
@@ -24,40 +24,99 @@ struct BenchmarkArgs {
     std::chrono::nanoseconds minTime{ 1 };
     BenchmarkMode mode{ BenchmarkMode::Both };
     std::vector<nlohmann::json> compressorConfigs;
+    std::optional<size_t> blockSize;
+};
+
+struct BlockResult {
+    size_t originalSize;
+    size_t compressedSize;
+    std::vector<std::chrono::nanoseconds> compressionDurations;
+    std::vector<std::chrono::nanoseconds> decompressionDurations;
+
+    std::chrono::nanoseconds bestCompressionDuration() const
+    {
+        if (compressionDurations.empty()) {
+            return std::chrono::nanoseconds(0);
+        }
+        return *std::min_element(
+                compressionDurations.begin(), compressionDurations.end());
+    }
+
+    std::chrono::nanoseconds bestDecompressionDuration() const
+    {
+        if (decompressionDurations.empty()) {
+            return std::chrono::nanoseconds(0);
+        }
+        return *std::min_element(
+                decompressionDurations.begin(), decompressionDurations.end());
+    }
+
+    nlohmann::json json() const;
 };
 
 struct BenchmarkResult {
     std::string fileName;
     std::string compressorName;
     nlohmann::json compressorConfig;
-    size_t originalSize;
-    size_t compressedSize;
-    std::vector<std::chrono::nanoseconds> compressionDurations;
-    std::vector<std::chrono::nanoseconds> decompressionDurations;
+    std::vector<BlockResult> blockResults;
+
+    size_t originalSize() const
+    {
+        size_t total = 0;
+        for (const auto& block : blockResults) {
+            total += block.originalSize;
+        }
+        return total;
+    }
+
+    size_t compressedSize() const
+    {
+        size_t total = 0;
+        for (const auto& block : blockResults) {
+            total += block.compressedSize;
+        }
+        return total;
+    }
 
     double compressionRatio() const
     {
-        return (double)originalSize / compressedSize;
+        return (double)originalSize() / compressedSize();
+    }
+
+    std::chrono::nanoseconds bestCompressionDuration() const
+    {
+        std::chrono::nanoseconds total{ 0 };
+        for (const auto& block : blockResults) {
+            total += block.bestCompressionDuration();
+        }
+        return total;
+    }
+
+    std::chrono::nanoseconds bestDecompressionDuration() const
+    {
+        std::chrono::nanoseconds total{ 0 };
+        for (const auto& block : blockResults) {
+            total += block.bestDecompressionDuration();
+        }
+        return total;
     }
 
     double bestCompressionSpeedMBps() const
     {
-        if (compressionDurations.empty()) {
+        auto dur = bestCompressionDuration();
+        if (dur.count() == 0) {
             return std::numeric_limits<double>::quiet_NaN();
         }
-        auto dur = *std::min_element(
-                compressionDurations.begin(), compressionDurations.end());
-        return (double)originalSize * 1000.0 / dur.count();
+        return (double)originalSize() * 1000.0 / dur.count();
     }
 
     double bestDecompressionSpeedMBps() const
     {
-        if (decompressionDurations.empty()) {
+        auto dur = bestDecompressionDuration();
+        if (dur.count() == 0) {
             return std::numeric_limits<double>::quiet_NaN();
         }
-        auto dur = *std::min_element(
-                decompressionDurations.begin(), decompressionDurations.end());
-        return (double)originalSize * 1000.0 / dur.count();
+        return (double)originalSize() * 1000.0 / dur.count();
     }
 
     nlohmann::json json() const;

--- a/contrib/lz-research/LzCompressors.cpp
+++ b/contrib/lz-research/LzCompressors.cpp
@@ -2,15 +2,235 @@
 
 #include "LzCompressors.hpp"
 
+#include "codecs/Bucket.hpp"
+#include "codecs/Bucket16.hpp"
+#include "codecs/IsoByte.hpp"
+#include "codecs/Lz.hpp"
+#include "codecs/SmallInt.hpp"
+#include "codecs/VarByte.hpp"
+
 namespace openzl::lz {
+namespace {
+GraphID
+smallIntGraph(Compressor& compressor, GraphID smallGraph, GraphID largeGraph)
+{
+    auto node = compressor.getNode("lz_research.small_int");
+    if (!node.has_value()) {
+        throw std::runtime_error("small_int node not found");
+    }
+    return compressor.buildStaticGraph(*node, { smallGraph, largeGraph });
+}
+
+GraphID
+varByteGraph(Compressor& compressor, GraphID controlGraph, GraphID packedGraph)
+{
+    auto node = compressor.getNode("lz_research.var_byte");
+    if (!node.has_value()) {
+        throw std::runtime_error("var_byte node not found");
+    }
+    return compressor.buildStaticGraph(*node, { controlGraph, packedGraph });
+}
+
+GraphID isoByteGraph(
+        Compressor& compressor,
+        GraphID bitmapGraph   = ZL_GRAPH_HUFFMAN,
+        GraphID highByteGraph = ZL_GRAPH_HUFFMAN)
+{
+    auto node = compressor.getNode("lz_research.iso_byte");
+    if (!node.has_value()) {
+        throw std::runtime_error("iso_byte node not found");
+    }
+    return compressor.buildStaticGraph(
+            *node, { bitmapGraph, ZL_GRAPH_STORE, highByteGraph });
+}
+
+GraphID bucketGraph(Compressor& compressor, bool entropyCompressFixed = false)
+{
+    return BucketGraph::create(compressor, entropyCompressFixed);
+}
+
+GraphID bucket16Graph(Compressor& compressor)
+{
+    return Bucket16Graph::create(compressor);
+}
+
+std::string lzStoreCompressor(int llBits)
+{
+    openzl::Compressor compressor;
+    registerGraphComponents(compressor);
+    auto lzNode = registerLz(compressor, { .llBits = llBits });
+    auto store  = graphs::Store{}();
+    auto graph  = compressor.buildStaticGraph(
+            lzNode,
+            { graphs::ACE{ store }(compressor),
+               graphs::ACE{ store }(compressor),
+               graphs::ACE{ store }(compressor),
+               graphs::ACE{ store }(compressor) });
+    compressor.selectStartingGraph(graph);
+    return compressor.serialize();
+}
+
+std::string lzLz4Compressor(int llBits, bool huf)
+{
+    openzl::Compressor compressor;
+    registerGraphComponents(compressor);
+    auto lzNode = registerLz(compressor, { .llBits = llBits });
+    auto store  = graphs::Store{}();
+    auto lits   = huf ? graphs::Huffman{}() : store;
+    auto graph  = compressor.buildStaticGraph(
+            lzNode,
+            { lits,
+               store,
+               store,
+               smallIntGraph(
+                      compressor,
+                      store,
+                      nodes::RangePack{}(compressor, store)) });
+    compressor.selectStartingGraph(graph);
+    return compressor.serialize();
+}
+
+std::string
+lzZstdCompressor(int llBits, bool slow, bool iso = false, bool bucket = false)
+{
+    openzl::Compressor compressor;
+    registerGraphComponents(compressor);
+    auto lzNode = registerLz(compressor, { .llBits = llBits });
+    auto store  = graphs::Store{}();
+    auto quantize =
+            nodes::QuantizeLengths{}(compressor, graphs::Fse{}(), store);
+    auto huf     = graphs::Huffman{}();
+    auto lits    = huf;
+    auto tokens  = huf;
+    auto offsets = slow
+            ? (iso ? isoByteGraph(compressor, huf, bucketGraph(compressor))
+                   : varByteGraph(compressor, huf, store))
+            : store;
+    if (bucket) {
+        offsets = bucket16Graph(compressor);
+    }
+    auto extraLens = smallIntGraph(compressor, slow ? huf : store, quantize);
+    auto graph     = compressor.buildStaticGraph(
+            lzNode, { lits, tokens, offsets, extraLens });
+    compressor.selectStartingGraph(graph);
+    return compressor.serialize();
+}
+
+std::string varByteCompressor(int width)
+{
+    openzl::Compressor compressor;
+    registerGraphComponents(compressor);
+    auto store = graphs::Store{}();
+    auto huf   = graphs::Huffman{}();
+    auto graph = varByteGraph(compressor, huf, store);
+    graph      = nodes::ConvertSerialToNumLE{ width }(compressor, graph);
+    compressor.selectStartingGraph(graph);
+    return compressor.serialize();
+}
+
+std::string isoByteCompressor(bool useBucket, bool entropy = false)
+{
+    openzl::Compressor compressor;
+    registerGraphComponents(compressor);
+    auto huf   = graphs::Huffman{}();
+    auto graph = isoByteGraph(
+            compressor,
+            huf,
+            useBucket ? bucketGraph(compressor, entropy) : huf);
+    graph = nodes::ConvertSerialToNumLE{ 2 }(compressor, graph);
+    compressor.selectStartingGraph(graph);
+    return compressor.serialize();
+}
+
+std::string smallIntCompressor(bool slow)
+{
+    openzl::Compressor compressor;
+    registerGraphComponents(compressor);
+    auto store = graphs::Store{}();
+    auto huf   = graphs::Huffman{}();
+    auto quantize =
+            nodes::QuantizeLengths{}(compressor, graphs::Fse{}(), store);
+    auto graph = smallIntGraph(compressor, slow ? huf : store, quantize);
+    graph      = nodes::ConvertSerialToNumLE{ 4 }(compressor, graph);
+    compressor.selectStartingGraph(graph);
+    return compressor.serialize();
+}
+
+std::string bucket16Compressor()
+{
+    openzl::Compressor compressor;
+    registerGraphComponents(compressor);
+    auto graph = bucket16Graph(compressor);
+    graph      = nodes::ConvertSerialToNumLE{ 2 }(compressor, graph);
+    compressor.selectStartingGraph(graph);
+    return compressor.serialize();
+}
+
+} // namespace
 
 std::string getSerializedCompressor(std::string_view name)
 {
-    throw std::runtime_error("TODO");
+    for (int llBits = 0; llBits <= 7; ++llBits) {
+        auto suffix = "[llbits=" + std::to_string(llBits) + "]";
+        if (llBits == 0) {
+            suffix = "";
+        }
+        if (name == "lz-store" + suffix) {
+            return lzStoreCompressor(llBits);
+        } else if (name == "lz-lz4" + suffix) {
+            return lzLz4Compressor(llBits, false);
+        } else if (name == "lz-lz4-huf" + suffix) {
+            return lzLz4Compressor(llBits, true);
+        } else if (name == "lz-zstd-fast" + suffix) {
+            return lzZstdCompressor(llBits, false);
+        } else if (name == "lz-zstd-slow" + suffix) {
+            return lzZstdCompressor(llBits, true);
+        } else if (name == "lz-zstd-iso" + suffix) {
+            return lzZstdCompressor(llBits, true, true);
+        } else if (name == "lz-zstd-buc" + suffix) {
+            return lzZstdCompressor(llBits, false, false, true);
+        }
+    }
+    if (name == "varbyte16") {
+        return varByteCompressor(2);
+    } else if (name == "isobyte16") {
+        return isoByteCompressor(false);
+    } else if (name == "isobyte16-bucket") {
+        return isoByteCompressor(true);
+    } else if (name == "isobyte16-bucket-huf") {
+        return isoByteCompressor(true, true);
+    } else if (name == "varbyte32") {
+        return varByteCompressor(4);
+    } else if (name == "smallint-store") {
+        return smallIntCompressor(false);
+    } else if (name == "smallint-huf") {
+        return smallIntCompressor(true);
+    } else if (name == "bucket16") {
+        return bucket16Compressor();
+    }
+    throw std::runtime_error("Unknown compressor: " + std::string(name));
 }
 
-void registerGraphComponents(openzl::Compressor&) {}
+void registerGraphComponents(openzl::Compressor& compressor)
+{
+    compressor.registerFunctionGraph(std::make_shared<BucketGraph>());
+    compressor.registerFunctionGraph(std::make_shared<Bucket16Graph>());
+    registerLz(compressor, {});
+    compressor.registerCustomEncoder(std::make_shared<SmallIntEncoder>());
+    compressor.registerCustomEncoder(std::make_shared<VarByteEncoder>());
+    compressor.registerCustomEncoder(std::make_shared<IsoByteEncoder>());
+    compressor.registerCustomEncoder(std::make_shared<BucketEncoder>());
+    compressor.registerCustomEncoder(std::make_shared<Bucket16Encoder>());
+}
 
-void registerCustomCodecs(openzl::DCtx&) {}
+void registerCustomCodecs(openzl::DCtx& dctx)
+{
+    registerLz(dctx);
+    dctx.registerCustomDecoder(std::make_shared<SmallIntDecoder>());
+    dctx.registerCustomDecoder(std::make_shared<VarByteDecoder>());
+    dctx.registerCustomDecoder(std::make_shared<IsoByteDecoder>());
+    dctx.registerCustomDecoder(std::make_shared<BucketDecoder>());
+    dctx.registerCustomDecoder(std::make_shared<Bucket16Decoder>());
+}
 
 } // namespace openzl::lz

--- a/contrib/lz-research/Main.cpp
+++ b/contrib/lz-research/Main.cpp
@@ -3,6 +3,7 @@
 #include <filesystem>
 #include <fstream>
 #include <memory>
+#include <optional>
 #include <vector>
 
 #include "Benchmark.hpp"
@@ -106,6 +107,12 @@ class BenchmarkCommand : public Command {
                 'D',
                 false,
                 "Only benchmark decompression, not compression");
+        parser.addCommandFlag(
+                int(Commands::Benchmark),
+                "block-size",
+                'B',
+                true,
+                "Break input into blocks of this size, and benchmark on each block");
     }
 
     void parseArguments(const openzl::arg::ParsedArgs& args) override
@@ -125,6 +132,12 @@ class BenchmarkCommand : public Command {
         if (minSecsFlag.has_value()) {
             args_.minTime =
                     std::chrono::seconds(std::stoull(minSecsFlag.value()));
+        }
+
+        auto blockSizeFlag =
+                args.cmdFlag(int(Commands::Benchmark), "block-size");
+        if (blockSizeFlag.has_value()) {
+            args_.blockSize = std::stoull(blockSizeFlag.value());
         }
 
         auto outputFlag = args.cmdFlag(int(Commands::Benchmark), "output");

--- a/contrib/lz-research/Main.cpp
+++ b/contrib/lz-research/Main.cpp
@@ -94,6 +94,18 @@ class BenchmarkCommand : public Command {
                 'o',
                 true,
                 "Path to output file");
+        parser.addCommandFlag(
+                int(Commands::Benchmark),
+                "compress-only",
+                'C',
+                false,
+                "Only benchmark compression, not decompression");
+        parser.addCommandFlag(
+                int(Commands::Benchmark),
+                "decompress-only",
+                'D',
+                false,
+                "Only benchmark decompression, not compression");
     }
 
     void parseArguments(const openzl::arg::ParsedArgs& args) override
@@ -120,6 +132,24 @@ class BenchmarkCommand : public Command {
             throw std::runtime_error("Specify a value for --output");
         }
         output_ = outputFlag.value();
+
+        const bool compressOnly =
+                args.cmdFlag(int(Commands::Benchmark), "compress-only")
+                        .has_value();
+        const bool decompressOnly =
+                args.cmdFlag(int(Commands::Benchmark), "decompress-only")
+                        .has_value();
+        if (compressOnly && decompressOnly) {
+            throw std::runtime_error(
+                    "Cannot specify both --compress-only and --decompress-only");
+        }
+        if (compressOnly) {
+            args_.mode = bench::BenchmarkMode::Compression;
+        } else if (decompressOnly) {
+            args_.mode = bench::BenchmarkMode::Decompression;
+        } else {
+            args_.mode = bench::BenchmarkMode::Both;
+        }
 
         auto compressorsFlag =
                 args.cmdFlag(int(Commands::Benchmark), "compressors");

--- a/contrib/lz-research/codecs/Bucket.cpp
+++ b/contrib/lz-research/codecs/Bucket.cpp
@@ -1,0 +1,782 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#include "Bucket.hpp"
+
+#include <algorithm>
+#include <array>
+#include <limits>
+#include <numeric>
+
+#include "CodecIDs.hpp"
+
+#include "openzl/codecs/common/bitstream/ff_bitstream.h"
+#include "openzl/common/assertion.h"
+#include "openzl/shared/bits.h"
+#include "openzl/shared/data_stats.h"
+#include "openzl/shared/histogram.h"
+#include "openzl/shared/mem.h"
+#include "openzl/shared/portability.h"
+#include "openzl/shared/utils.h"
+#include "utils/Partition.hpp"
+
+namespace openzl::lz {
+namespace {
+SimpleCodecDescription bucketCodecDescription()
+{
+    return SimpleCodecDescription{
+        .id          = unsigned(CustomCodecIDs::Bucket),
+        .name        = "!lz_research.bucket",
+        .inputType   = Type::Serial,
+        .outputTypes = { Type::Serial, Type::Serial },
+    };
+}
+
+class BucketEncoderState {
+   public:
+    BucketEncoderState(poly::span<const uint8_t> bases) : bases_(bases)
+    {
+        if (bases.empty()) {
+            throw std::runtime_error("bases is empty");
+        }
+        for (size_t i = 1; i < bases.size(); ++i) {
+            if (bases[i - 1] >= bases[i]) {
+                throw std::runtime_error("bases not strictly increasing");
+            }
+        }
+
+        fixedBits_ = ZL_nextPow2(bases_.size());
+
+        size_t nextBaseIdx = 0;
+        size_t bits        = 0;
+        maxVarBits_        = 0;
+        for (size_t byte = 0; byte < 256; ++byte) {
+            const auto end =
+                    nextBaseIdx == bases_.size() ? 256 : bases_[nextBaseIdx];
+            if (byte >= end) {
+                bits        = ZL_nextPow2(getBucketSize(nextBaseIdx));
+                maxVarBits_ = std::max(maxVarBits_, bits);
+                ++nextBaseIdx;
+            }
+            byteToVarBits_[byte] = bits;
+            byteToBucket_[byte]  = nextBaseIdx - 1;
+            byteToBase_[byte]    = bases_[nextBaseIdx - 1];
+        }
+    }
+
+    size_t fixedBits() const
+    {
+        return fixedBits_;
+    }
+
+    size_t maxVarBits() const
+    {
+        return maxVarBits_;
+    }
+
+    poly::span<const uint8_t> bases() const
+    {
+        return bases_;
+    }
+
+    size_t fixedStreamSize(size_t numElts) const
+    {
+        return (fixedBits() * numElts + 7) / 8;
+    }
+
+    size_t varStreamBound(size_t numElts) const
+    {
+        return (maxVarBits() * numElts + 7) / 8;
+    }
+
+    size_t encode(poly::span<const uint8_t> input, uint8_t* fixed, uint8_t* var)
+            const
+    {
+        ZS_BitCStreamFF fixedBitstream =
+                ZS_BitCStreamFF_init(fixed, fixedStreamSize(input.size()));
+        ZS_BitCStreamFF varBitstream =
+                ZS_BitCStreamFF_init(var, varStreamBound(input.size()));
+
+        for (const auto x : input) {
+            const auto varBits = byteToVarBits_[x];
+            if (x - byteToBase_[x] >= (1u << varBits)) {
+                throw std::runtime_error("Invalid bases for input");
+            }
+            assert(x >= byteToBase_[x]);
+            assert(x - byteToBase_[x] < (1u << varBits));
+            ZS_BitCStreamFF_write(
+                    &fixedBitstream, byteToBucket_[x], fixedBits_);
+            ZS_BitCStreamFF_flush(&fixedBitstream);
+            ZS_BitCStreamFF_write(&varBitstream, x - byteToBase_[x], varBits);
+            ZS_BitCStreamFF_flush(&varBitstream);
+        }
+
+        unwrap(ZS_BitCStreamFF_finish(&fixedBitstream));
+        return unwrap(ZS_BitCStreamFF_finish(&varBitstream));
+    }
+
+   private:
+    size_t getBucketSize(size_t baseIdx) const
+    {
+        if (baseIdx >= bases_.size()) {
+            return 1;
+        }
+        size_t base = bases_[baseIdx];
+        assert(base < 256);
+        auto end = baseIdx + 1 == bases_.size() ? size_t(256)
+                                                : size_t(bases_[baseIdx + 1]);
+        assert(end > base);
+        return end - base;
+    }
+
+    poly::span<const uint8_t> bases_;
+    size_t fixedBits_;
+    std::array<uint8_t, 256> byteToBucket_;
+    std::array<uint8_t, 256> byteToBase_;
+    std::array<uint8_t, 256> byteToVarBits_;
+    size_t maxVarBits_;
+};
+
+class BucketDecoderState {
+   public:
+    BucketDecoderState(poly::span<const uint8_t> header)
+    {
+        if (header.empty()) {
+            throw std::runtime_error("header is empty");
+        }
+        unusedFixedBits_ = header[0] % 8;
+        const auto bases = header.subspan(1);
+        if (bases.empty()) {
+            throw std::runtime_error("bases is empty");
+        }
+        if (bases.size() > bases_.size()) {
+            throw std::runtime_error("bases is > 256");
+        }
+        for (size_t i = 1; i < bases.size(); ++i) {
+            if (bases[i - 1] >= bases[i]) {
+                throw std::runtime_error("bases not strictly increasing");
+            }
+        }
+        memcpy(bases_.data(), bases.data(), bases.size());
+        numBases_ = bases.size();
+
+        maxVarBits_ = 0;
+        for (size_t i = 0; i < bases.size(); ++i) {
+            varBits_[i] = ZL_nextPow2(getBucketSize(i));
+            maxVarBits_ = std::max<size_t>(maxVarBits_, varBits_[i]);
+            assert(varBits_[i] <= 8);
+        }
+
+        fixedBits_ = ZL_nextPow2(bases.size());
+        assert(fixedBits_ <= 8);
+    }
+
+    size_t fixedBits() const
+    {
+        return fixedBits_;
+    }
+
+    poly::span<const uint8_t> bases() const
+    {
+        return { bases_.data(), numBases_ };
+    }
+
+    size_t numElts(size_t fixedSize) const
+    {
+        const auto totalFixedBits = fixedSize * 8;
+        if (totalFixedBits < unusedFixedBits_) {
+            throw std::runtime_error("bad number of bits");
+        }
+        if ((totalFixedBits - unusedFixedBits_) % fixedBits_ != 0) {
+            throw std::runtime_error("leftover bits");
+        }
+        return (totalFixedBits - unusedFixedBits_) / fixedBits_;
+    }
+
+    static std::array<uint16_t, 256> expandLUT(poly::span<const uint8_t> lut)
+    {
+        std::array<uint16_t, 256> expanded;
+        for (size_t byte = 0; byte < 256; ++byte) {
+            const size_t lo = byte & 0xF;
+            const size_t hi = byte >> 4;
+            expanded[byte]  = uint16_t(lut[lo]) | (uint16_t(lut[hi]) << 8);
+        }
+        return expanded;
+    }
+
+    std::array<uint8_t, 16> makeBaseLUT() const
+    {
+        std::array<uint8_t, 16> lut{};
+        memcpy(lut.data(), bases_.data(), numBases_);
+        return lut;
+    }
+
+    std::array<uint8_t, 16> makeMaskLUT() const
+    {
+        std::array<uint8_t, 16> lut;
+        for (size_t i = 0; i < 16; ++i) {
+            if (i < numBases_) {
+                lut[i] = (1u << varBits_[i]) - 1;
+                if (0)
+                    fprintf(stderr,
+                            "npartitions = %zu, varbits[%zu] = %u, base = %u\n",
+                            numBases_,
+                            i,
+                            (unsigned)varBits_[i],
+                            (unsigned)bases_[i]);
+                assert(varBits_[i] <= 7);
+            } else {
+                lut[i] = 0;
+            }
+        }
+        return lut;
+    }
+
+    void decode4(
+            poly::span<const uint8_t> fixed,
+            poly::span<const uint8_t> var,
+            uint8_t* out) const
+    {
+        const auto baseLUT = expandLUT(makeBaseLUT());
+        const auto maskLUT = expandLUT(makeMaskLUT());
+        const auto size    = numElts(fixed.size());
+
+        uint8_t* o                = out;
+        const uint8_t* f          = fixed.data();
+        const uint8_t* v          = var.data();
+        const uint8_t* const vEnd = v + var.size();
+
+        constexpr size_t kEltsPerIter = 16;
+        size_t i                      = 0;
+
+        const auto computeLimit = [&] {
+            if (size < kEltsPerIter) {
+                return i;
+            }
+            assert(v <= vEnd);
+            const size_t vSafeNumIters = (8 * (vEnd - v) - 7) / maxVarBits_;
+            if (vSafeNumIters < kEltsPerIter) {
+                return i;
+            }
+            const auto limit = std::min(
+                    size - kEltsPerIter, i + vSafeNumIters - kEltsPerIter);
+            return limit;
+        };
+
+        size_t bitsConsumed = 0;
+        size_t limit        = computeLimit();
+        for (;; i += kEltsPerIter) {
+            if (i >= limit) {
+                limit = computeLimit();
+                if (i >= limit) {
+                    break;
+                }
+            }
+            static_assert(kEltsPerIter % 8 == 0);
+            for (size_t u = 0; u < kEltsPerIter; u += 8) {
+                const uint64_t base = uint64_t(baseLUT[f[0]])
+                        | (uint64_t(baseLUT[f[1]]) << 16)
+                        | (uint64_t(baseLUT[f[2]]) << 32)
+                        | (uint64_t(baseLUT[f[3]]) << 48);
+                const uint64_t mask = uint64_t(maskLUT[f[0]])
+                        | (uint64_t(maskLUT[f[1]]) << 16)
+                        | (uint64_t(maskLUT[f[2]]) << 32)
+                        | (uint64_t(maskLUT[f[3]]) << 48);
+                f += 4;
+
+                const uint64_t vData  = ZL_readLE64(v) >> bitsConsumed;
+                const uint64_t offset = _pdep_u64(vData, mask);
+
+                ZL_writeLE64(o, base + offset);
+                o += 8;
+
+                bitsConsumed += __builtin_popcountll(mask);
+                assert(bitsConsumed <= 64);
+                v += bitsConsumed >> 3;
+                bitsConsumed &= 7;
+            }
+        }
+
+        assert(v <= vEnd);
+        auto varBitstream = ZS_BitDStreamFF_init(v, vEnd - v);
+        ZS_BitDStreamFF_skip(&varBitstream, bitsConsumed);
+        for (; i < size; ++i) {
+            size_t bucket = fixed[i / 2];
+            if (i % 2 == 0) {
+                bucket &= 0xF;
+            } else {
+                bucket >>= 4;
+            }
+
+            auto base = bases_[bucket];
+            auto bits = varBits_[bucket];
+
+            auto offset = ZS_BitDStreamFF_read(&varBitstream, bits);
+            ZS_BitDStreamFF_reload(&varBitstream);
+            out[i] = base + offset;
+        }
+        auto report = ZS_BitDStreamFF_finish(&varBitstream);
+        if (ZL_isError(report)) {
+            throw std::runtime_error("read too many varbits");
+        }
+    }
+
+    void decode(
+            poly::span<const uint8_t> fixed,
+            poly::span<const uint8_t> var,
+            uint8_t* output) const
+    {
+        if (fixedBits_ == 4) {
+            decode4(fixed, var, output);
+            return;
+        }
+        auto fixedBitstream = ZS_BitDStreamFF_init(fixed.data(), fixed.size());
+        auto varBitstream   = ZS_BitDStreamFF_init(var.data(), var.size());
+        const auto size     = numElts(fixed.size());
+
+        for (size_t i = 0; i < size; ++i) {
+            const auto bucket =
+                    ZS_BitDStreamFF_read(&fixedBitstream, fixedBits_);
+            assert(bucket < 256);
+            const auto base = bases_[bucket];
+            const auto offset =
+                    ZS_BitDStreamFF_read(&varBitstream, varBits_[bucket]);
+            output[i] = base + offset;
+
+            ZS_BitDStreamFF_reload(&fixedBitstream);
+            ZS_BitDStreamFF_reload(&varBitstream);
+        }
+    }
+
+   private:
+    size_t getBucketSize(size_t baseIdx) const
+    {
+        if (baseIdx >= numBases_) {
+            return 1;
+        }
+        size_t base = bases_[baseIdx];
+        assert(base < 256);
+        auto end = baseIdx + 1 == numBases_ ? size_t(256)
+                                            : size_t(bases_[baseIdx + 1]);
+        assert(end > base);
+        return end - base;
+    }
+
+    std::array<uint8_t, 256> bases_{};
+    std::array<uint8_t, 256> varBits_{};
+    size_t unusedFixedBits_;
+    size_t fixedBits_;
+    size_t numBases_;
+    size_t maxVarBits_;
+};
+} // namespace
+
+SimpleCodecDescription BucketEncoder::simpleCodecDescription() const
+{
+    return bucketCodecDescription();
+}
+
+void BucketEncoder::encode(EncoderState& encoder) const
+{
+    auto bases = encoder.getLocalParam(0);
+    if (!bases.has_value()) {
+        throw std::runtime_error("bases not present");
+    }
+    BucketEncoderState state(*bases);
+
+    const auto& input    = encoder.inputs()[0];
+    const size_t numElts = input.numElts();
+
+    uint8_t header[257];
+    // first byte is the # of unused bits in the bitstream
+    header[0] = (8 - ((state.fixedBits() * numElts) % 8)) % 8;
+    memcpy(header + 1, state.bases().data(), state.bases().size());
+
+    encoder.sendCodecHeader(header, 1 + state.bases().size());
+
+    auto fixedStream =
+            encoder.createOutput(0, state.fixedStreamSize(numElts), 1);
+    auto varStream = encoder.createOutput(1, state.varStreamBound(numElts), 1);
+
+    auto varStreamSize = state.encode(
+            { (const uint8_t*)input.ptr(), input.numElts() },
+            (uint8_t*)fixedStream.ptr(),
+            (uint8_t*)varStream.ptr());
+
+    fixedStream.commit(state.fixedStreamSize(numElts));
+    varStream.commit(varStreamSize);
+}
+/* static */ Edge::RunNodeResult
+BucketEncoder::runNode(Edge& edge, NodeID node, poly::span<const uint8_t> bases)
+{
+    NodeParameters params;
+    params.localParams.emplace();
+    params.localParams->addRefParam(0, bases.data(), bases.size());
+    auto r = edge.runNode(node, std::move(params));
+    return r;
+}
+
+SimpleCodecDescription BucketDecoder::simpleCodecDescription() const
+{
+    return bucketCodecDescription();
+}
+
+void BucketDecoder::decode(DecoderState& decoder) const
+{
+    BucketDecoderState state(decoder.getCodecHeader());
+
+    const auto& fixedStream = decoder.singletonInputs()[0];
+    const auto& varStream   = decoder.singletonInputs()[1];
+    const auto fixedSize    = fixedStream.numElts();
+
+    auto outStream = decoder.createOutput(0, state.numElts(fixedSize), 1);
+
+    state.decode(
+            { (const uint8_t*)fixedStream.ptr(), fixedSize },
+            { (const uint8_t*)varStream.ptr(), varStream.numElts() },
+            (uint8_t*)outStream.ptr());
+
+    outStream.commit(state.numElts(fixedSize));
+}
+
+/* static */ GraphID BucketGraph::create(
+        Compressor& compressor,
+        bool entropyCompressFixed)
+{
+    auto graph = compressor.getGraph("lz_research.bucket_graph");
+    if (!graph.has_value()) {
+        graph = compressor.registerFunctionGraph(
+                std::make_shared<BucketGraph>());
+    }
+
+    auto node = compressor.getNode("lz_research.bucket");
+    if (!node.has_value()) {
+        node = compressor.registerCustomEncoder(
+                std::make_shared<BucketEncoder>());
+    }
+
+    LocalParams params;
+    params.addIntParam(0, !!entropyCompressFixed);
+
+    return compressor.parameterizeGraph(
+            *graph,
+            GraphParameters{ .customNodes = { { *node } },
+                             .localParams = std::move(params) });
+}
+
+FunctionGraphDescription BucketGraph::functionGraphDescription() const
+{
+    return FunctionGraphDescription{
+        .name           = "!lz_research.bucket_graph",
+        .inputTypeMasks = { TypeMask::Serial },
+    };
+}
+
+namespace {
+constexpr uint32_t kBucketOverheadBits = 40;
+
+uint32_t entropyCompressedBucketCost(
+        poly::span<const uint32_t> bucket,
+        uint32_t totalCount)
+{
+    const uint32_t bucketCount =
+            std::accumulate(bucket.begin(), bucket.end(), 0);
+    if (bucketCount == 0) {
+        return kBucketOverheadBits;
+    }
+    // TODO(terrelln): Replace log2 with an estimate
+    const uint32_t bucketCost = double(bucketCount)
+            * std::log2(double(totalCount) / double(bucketCount));
+    const uint32_t offsetBits = ZL_nextPow2(bucket.size());
+    const uint32_t offsetCost = bucketCount * offsetBits;
+
+    if (0)
+        fprintf(stderr,
+                "totalCount = %u, bucketCount = %u, bucketSize = %zu, bucketCost = %u, offsetCost = %u\n",
+                totalCount,
+                bucketCount,
+                bucket.size(),
+                bucketCost,
+                offsetCost);
+
+    return kBucketOverheadBits + bucketCost + offsetCost;
+}
+
+uint32_t entropyCompressedBucketCost(
+        poly::span<const uint32_t> histogram,
+        poly::span<const uint8_t> partitions)
+{
+    const uint32_t totalCount =
+            std::accumulate(histogram.begin(), histogram.end(), 0);
+    uint32_t cost = 0;
+    for (size_t i = 0; i < partitions.size(); ++i) {
+        const auto b = partitions[i];
+        const auto e = i + 1 == partitions.size() ? histogram.size()
+                                                  : partitions[i + 1];
+        assert(b < e);
+        cost += entropyCompressedBucketCost(
+                histogram.subspan(b, e - b), totalCount);
+    }
+    return cost;
+}
+
+// uint32_t fixedBucketCost(
+//         poly::span<const uint32_t> bucket,
+//         uint32_t totalCount,
+//         uint32_t bucketBits)
+// {
+//     const uint32_t bucketCount =
+//             std::accumulate(bucket.begin(), bucket.end(), 0);
+//     if (bucketCount == 0) {
+//         return 0;
+//     }
+//     const uint32_t entropyCost =
+//             bucketCount * std::log2(double(totalCount) /
+//             double(bucketCount));
+//     // ZL_calculateEntropy(&bucketCount, 0, totalCount);
+//     const uint32_t fixedCost = bucketCount * bucketBits;
+//     const auto cost          = fixedCost - entropyCost;
+//     return cost >= 0 ? cost : -cost;
+// }
+uint32_t fixedBucketCost(poly::span<const uint32_t> bucket, uint32_t fixedCost)
+{
+    const uint32_t bucketCount =
+            std::accumulate(bucket.begin(), bucket.end(), 0);
+    return bucketCount * (fixedCost + ZL_nextPow2(bucket.size()));
+}
+
+uint32_t fixedBucketCost(
+        poly::span<const uint32_t> histogram,
+        poly::span<const uint8_t> partitions)
+{
+    const uint32_t totalCount =
+            std::accumulate(histogram.begin(), histogram.end(), 0);
+    const uint32_t bucketBits = ZL_nextPow2(partitions.size());
+    uint32_t cost             = totalCount * bucketBits;
+    for (size_t i = 0; i < partitions.size(); ++i) {
+        const auto b = partitions[i];
+        const auto e = i + 1 == partitions.size() ? histogram.size()
+                                                  : partitions[i + 1];
+        assert(b < e);
+        const uint32_t bucketCount = std::accumulate(
+                histogram.begin() + b, histogram.begin() + e, 0);
+        const uint32_t offsetBits = ZL_nextPow2(e - b);
+        cost += kBucketOverheadBits + bucketCount * offsetBits;
+    }
+    return cost;
+}
+
+std::vector<uint8_t> toUint8(const std::vector<size_t>& v)
+{
+    std::vector<uint8_t> result;
+    result.reserve(v.size());
+    for (auto i : v) {
+        result.push_back(i);
+    }
+    return result;
+}
+
+std::vector<uint8_t> entropyPartition(poly::span<const uint32_t> histogram)
+{
+    const uint32_t totalCount =
+            std::accumulate(histogram.begin(), histogram.end(), 0);
+    return toUint8(utils::partition(histogram, 16, [totalCount](auto bucket) {
+        return entropyCompressedBucketCost(bucket, totalCount);
+    }));
+}
+
+std::vector<uint8_t> fixedPartition(poly::span<const uint32_t> histogram)
+{
+    const uint32_t totalCount =
+            std::accumulate(histogram.begin(), histogram.end(), 0);
+    std::vector<uint8_t> bestPartitions = { 0 };
+    uint32_t bestCost = fixedBucketCost(histogram, bestPartitions);
+    for (size_t bucketBits = 1; bucketBits < 8; ++bucketBits) {
+        auto partitions =
+                toUint8(utils::partition(
+                        histogram,
+                        1u << bucketBits,
+                        [totalCount, bucketBits](auto bucket) {
+                            return fixedBucketCost(bucket, bucketBits);
+                        }));
+        auto cost = fixedBucketCost(histogram, partitions);
+        if (cost < bestCost) {
+            bestCost       = cost;
+            bestPartitions = std::move(partitions);
+        }
+    }
+    return bestPartitions;
+}
+
+class OptimalFixedPartition {
+   public:
+    OptimalFixedPartition(
+            poly::span<const uint32_t> histogram,
+            size_t numPartitions)
+            : hist_(histogram), numPartitions_(numPartitions)
+    {
+        auto totalCount =
+                std::accumulate(histogram.begin(), histogram.end(), 0);
+        targetCount_ = totalCount / numPartitions;
+    }
+
+    std::vector<uint8_t> run()
+    {
+        assert(partitions_.empty());
+        size_t offset = 0;
+        // TODO: Enable offset > 0
+        // while (offset < hist_.size() && hist_[offset] == 0) {
+        //     ++offset;
+        // }
+        partitions_.push_back(offset);
+        go();
+        partitions_.pop_back();
+        assert(partitions_.empty());
+        assert(bestPartitions_.size() <= numPartitions_);
+        return bestPartitions_;
+    }
+
+   private:
+    void go()
+    {
+        if (partitions_.back() >= 128) {
+            auto c = cost(partitions_);
+            if (c < bestCost_) {
+                bestCost_       = c;
+                bestPartitions_ = partitions_;
+            }
+        }
+        if (partitions_.size() < numPartitions_) {
+            auto smallPartition = getSmallPartition();
+            if (smallPartition < hist_.size()) {
+                partitions_.push_back(smallPartition);
+                if (smallPartition - partitions_.back() <= 128) {
+                    go();
+                }
+                auto largePartition = getLargePartition();
+                if (largePartition < hist_.size()
+                    && largePartition - partitions_.back() <= 128) {
+                    partitions_.back() = getLargePartition();
+                    go();
+                }
+                partitions_.pop_back();
+            }
+        }
+    }
+
+    size_t getSmallPartition() const
+    {
+        uint32_t count = 0;
+        size_t end;
+        for (end = partitions_.back() + 1; end < hist_.size(); ++end) {
+            count += hist_[end];
+            if (count > targetCount_) {
+                break;
+            }
+        }
+        size_t size = end - partitions_.back();
+        while (!ZL_isPow2(size)) {
+            --size;
+        }
+        return partitions_.back() + size;
+    }
+
+    size_t getLargePartition() const
+    {
+        uint32_t count = 0;
+        size_t end;
+        for (end = partitions_.back() + 1; end < hist_.size(); ++end) {
+            count += hist_[end];
+            if (count > targetCount_) {
+                ++end;
+                break;
+            }
+        }
+        size_t size = end - partitions_.back();
+        while (!ZL_isPow2(size)) {
+            ++size;
+        }
+        return partitions_.back() + size;
+    }
+
+    uint32_t cost(poly::span<const uint8_t> partitions) const
+    {
+        auto cost = fixedBucketCost(hist_, partitions);
+        return cost;
+    }
+
+    uint32_t bestCost_{ std::numeric_limits<uint32_t>::max() };
+    std::vector<uint8_t> bestPartitions_ = { 0 };
+    std::vector<uint8_t> partitions_{};
+    poly::span<const uint32_t> hist_;
+    size_t numPartitions_;
+    uint32_t targetCount_;
+};
+} // namespace
+
+void BucketGraph::graph(GraphState& state) const
+{
+    auto& inputEdge         = state.edges()[0];
+    const auto& inputStream = inputEdge.getInput();
+    const size_t numElts    = inputStream.numElts();
+
+    if (numElts < 10) {
+        inputEdge.setDestination(graphs::Store{}());
+        return;
+    }
+
+    ZL_Histogram8 histogram;
+    ZL_Histogram_init(&histogram.base, 255);
+    ZL_Histogram_build(&histogram.base, inputStream.ptr(), numElts, 1);
+
+    std::vector<uint8_t> partitions;
+    uint32_t bitCost;
+
+    poly::span<const uint32_t> hist{ histogram.base.count,
+                                     histogram.base.maxSymbol + 1 };
+    const bool entropyCompressFixed = !!state.getLocalIntParam(0).value_or(0);
+    if (entropyCompressFixed) {
+        partitions = entropyPartition(hist);
+        bitCost    = entropyCompressedBucketCost(hist, partitions);
+    } else {
+        partitions = fixedPartition(hist);
+        // TODO: Allow for 1, 2, 4 #buckets
+        // partitions = OptimalFixedPartition{ hist, 16 }.run();
+        bitCost = fixedBucketCost(hist, partitions);
+        if (0)
+            for (size_t i = 0; i < partitions.size(); ++i) {
+                fprintf(stderr, "p[%zu] = %d\n", i, int(partitions[i]));
+            }
+    }
+    if (0)
+        fprintf(stderr,
+                "numElts = %zu, usingEntropy = %u, #partitions = %u, cost = %u\n",
+                numElts,
+                (unsigned)entropyCompressFixed,
+                (unsigned)partitions.size(),
+                bitCost / 8);
+
+    if (bitCost / 8 >= 95 * numElts / 100) {
+        // Not enough gain => skip
+        if (0)
+            fprintf(stderr, "skipping...\n");
+        inputEdge.setDestination(graphs::Store{}());
+        return;
+    }
+
+    const auto nodes = state.customNodes();
+    if (nodes.size() != 1) {
+        throw std::runtime_error("CustomNodes must have exactly one node");
+    }
+
+    auto outEdges = BucketEncoder::runNode(inputEdge, nodes[0], partitions);
+    assert(outEdges.size() == 2);
+
+    if (entropyCompressFixed) {
+        outEdges[0].setDestination(graphs::Huffman{}());
+    } else {
+        outEdges[0].setDestination(graphs::Store{}());
+    }
+    outEdges[1].setDestination(graphs::Store{}());
+}
+
+} // namespace openzl::lz

--- a/contrib/lz-research/codecs/Bucket.hpp
+++ b/contrib/lz-research/codecs/Bucket.hpp
@@ -1,0 +1,43 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#pragma once
+
+#include <openzl/openzl.hpp>
+
+namespace openzl::lz {
+
+class BucketEncoder : public CustomEncoder {
+   public:
+    SimpleCodecDescription simpleCodecDescription() const override;
+
+    void encode(EncoderState& encoder) const override;
+
+    static Edge::RunNodeResult
+    runNode(Edge& edge, NodeID node, poly::span<const uint8_t> bases);
+
+    ~BucketEncoder() override = default;
+};
+
+class BucketDecoder : public CustomDecoder {
+   public:
+    SimpleCodecDescription simpleCodecDescription() const override;
+
+    void decode(DecoderState& decoder) const override;
+
+    ~BucketDecoder() override = default;
+};
+
+class BucketGraph : public FunctionGraph {
+   public:
+    BucketGraph() = default;
+
+    static GraphID create(Compressor& compressor, bool entropyCompressFixed);
+
+    FunctionGraphDescription functionGraphDescription() const override;
+
+    void graph(GraphState& state) const override;
+
+    virtual ~BucketGraph() override = default;
+};
+
+} // namespace openzl::lz

--- a/contrib/lz-research/codecs/Bucket16.cpp
+++ b/contrib/lz-research/codecs/Bucket16.cpp
@@ -1,0 +1,1025 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#include "Bucket16.hpp"
+
+#include <algorithm>
+#include <array>
+#include <limits>
+#include <numeric>
+
+#include "CodecIDs.hpp"
+
+#include "openzl/codecs/common/bitstream/ff_bitstream.h"
+#include "openzl/common/assertion.h"
+#include "openzl/shared/bits.h"
+#include "openzl/shared/data_stats.h"
+#include "openzl/shared/histogram.h"
+#include "openzl/shared/mem.h"
+#include "openzl/shared/portability.h"
+#include "openzl/shared/utils.h"
+#include "utils/Partition.hpp"
+
+namespace openzl::lz {
+namespace {
+SimpleCodecDescription bucket16CodecDescription()
+{
+    return SimpleCodecDescription{
+        .id          = unsigned(CustomCodecIDs::Bucket16),
+        .name        = "!lz_research.bucket16",
+        .inputType   = Type::Numeric,
+        .outputTypes = { Type::Serial, Type::Serial },
+    };
+}
+
+class Bucket16EncoderState {
+   public:
+    Bucket16EncoderState(poly::span<const uint8_t> param)
+    {
+        if (param.size() % 2 != 0) {
+            throw std::runtime_error("Param is not multiple of 2");
+        }
+        bases_ = { (const uint16_t*)param.data(), param.size() / 2 };
+        if (bases_.empty()) {
+            throw std::runtime_error("bases is empty");
+        }
+        if (bases_.size() > 256) {
+            throw std::runtime_error("bases must be <= 256 entries");
+        }
+        for (size_t i = 1; i < bases_.size(); ++i) {
+            if (bases_[i - 1] >= bases_[i]) {
+                throw std::runtime_error("bases not strictly increasing");
+            }
+        }
+
+        fixedBits_ = ZL_nextPow2(bases_.size());
+
+        size_t nextBaseIdx = 0;
+        size_t bits        = 0;
+        maxVarBits_        = 0;
+        for (size_t byte = 0; byte < 65536; ++byte) {
+            const auto end =
+                    nextBaseIdx == bases_.size() ? 65536 : bases_[nextBaseIdx];
+            if (byte >= end) {
+                bits        = ZL_nextPow2(getBucketSize(nextBaseIdx));
+                maxVarBits_ = std::max(maxVarBits_, bits);
+                ++nextBaseIdx;
+            }
+            valueToVarBits_[byte]  = bits;
+            valueToBucket16_[byte] = nextBaseIdx - 1;
+            valueToBase_[byte]     = bases_[nextBaseIdx - 1];
+        }
+    }
+
+    size_t fixedBits() const
+    {
+        return fixedBits_;
+    }
+
+    size_t maxVarBits() const
+    {
+        return maxVarBits_;
+    }
+
+    poly::span<const uint16_t> bases() const
+    {
+        return bases_;
+    }
+
+    size_t fixedStreamSize(size_t numElts) const
+    {
+        return (fixedBits() * numElts + 7) / 8;
+    }
+
+    size_t varStreamBound(size_t numElts) const
+    {
+        return (maxVarBits() * numElts + 7) / 8;
+    }
+
+    size_t
+    encode(poly::span<const uint16_t> input, uint8_t* fixed, uint8_t* var) const
+    {
+        ZS_BitCStreamFF fixedBitstream =
+                ZS_BitCStreamFF_init(fixed, fixedStreamSize(input.size()));
+        ZS_BitCStreamFF varBitstream =
+                ZS_BitCStreamFF_init(var, varStreamBound(input.size()));
+
+        for (const auto x : input) {
+            const auto varBits = valueToVarBits_[x];
+            if (x - valueToBase_[x] >= (1u << varBits)) {
+                throw std::runtime_error("Invalid bases for input");
+            }
+            assert(x >= valueToBase_[x]);
+            assert(x - valueToBase_[x] < (1u << varBits));
+            ZS_BitCStreamFF_write(
+                    &fixedBitstream, valueToBucket16_[x], fixedBits_);
+            ZS_BitCStreamFF_flush(&fixedBitstream);
+            ZS_BitCStreamFF_write(&varBitstream, x - valueToBase_[x], varBits);
+            ZS_BitCStreamFF_flush(&varBitstream);
+        }
+
+        unwrap(ZS_BitCStreamFF_finish(&fixedBitstream));
+        return unwrap(ZS_BitCStreamFF_finish(&varBitstream));
+    }
+
+   private:
+    size_t getBucketSize(size_t baseIdx) const
+    {
+        if (baseIdx >= bases_.size()) {
+            return 1;
+        }
+        size_t base = bases_[baseIdx];
+        assert(base < 65536);
+        auto end = baseIdx + 1 == bases_.size() ? size_t(65536)
+                                                : size_t(bases_[baseIdx + 1]);
+        assert(end > base);
+        return end - base;
+    }
+
+    poly::span<const uint16_t> bases_;
+    size_t fixedBits_;
+    // TODO(terrelln): Fix this memory usage
+    // Idea: Ensure bases transition when low e.g. 4 bits == 0
+    // Then the LUT can be 2^12 entries. Could also do low 5, 6, 7, 8 bits, etc.
+    std::array<uint16_t, 65536> valueToBucket16_;
+    std::array<uint16_t, 65536> valueToBase_;
+    std::array<uint16_t, 65536> valueToVarBits_;
+    size_t maxVarBits_;
+};
+
+class Bucket16DecoderState {
+   public:
+    Bucket16DecoderState(poly::span<const uint8_t> header)
+    {
+        if (header.empty()) {
+            throw std::runtime_error("header is empty");
+        }
+        unusedFixedBits_ = header[0] % 8;
+        header           = header.subspan(1);
+        if (header.empty()) {
+            throw std::runtime_error("bases is empty");
+        }
+        if (header.size() % 2 != 0) {
+            throw std::runtime_error("not a multiple of 2");
+        }
+        if (header.size() > 2 * bases_.size()) {
+            throw std::runtime_error("bases is > 256");
+        }
+        // TODO: Handle big endian
+        memcpy(bases_.data(), header.data(), header.size());
+        numBases_ = header.size() / 2;
+        for (size_t i = 1; i < numBases_; ++i) {
+            if (bases_[i - 1] >= bases_[i]) {
+                throw std::runtime_error("bases not strictly increasing");
+            }
+        }
+
+        maxVarBits_ = 0;
+        for (size_t i = 0; i < numBases_; ++i) {
+            varBits_[i] = ZL_nextPow2(getBucketSize(i));
+            maxVarBits_ = std::max<size_t>(maxVarBits_, varBits_[i]);
+        }
+        if (maxVarBits_ >= 15) {
+            // Keeping <= 14 means that we can get away with a single 64-bit
+            // load
+            throw std::runtime_error("unsupported varbits >= 15");
+        }
+
+        fixedBits_ = ZL_nextPow2(numBases_);
+        assert(fixedBits_ <= 8);
+    }
+
+    size_t fixedBits() const
+    {
+        return fixedBits_;
+    }
+
+    poly::span<const uint16_t> bases() const
+    {
+        return { bases_.data(), numBases_ };
+    }
+
+    size_t numElts(size_t fixedSize) const
+    {
+        const auto totalFixedBits = fixedSize * 8;
+        if (totalFixedBits < unusedFixedBits_) {
+            throw std::runtime_error("bad number of bits");
+        }
+        if ((totalFixedBits - unusedFixedBits_) % fixedBits_ != 0) {
+            throw std::runtime_error("leftover bits");
+        }
+        return (totalFixedBits - unusedFixedBits_) / fixedBits_;
+    }
+
+    static std::array<uint32_t, 256> expandLUT(poly::span<const uint16_t> lut)
+    {
+        std::array<uint32_t, 256> expanded;
+        for (size_t byte = 0; byte < 256; ++byte) {
+            const size_t lo = byte & 0xF;
+            const size_t hi = byte >> 4;
+            expanded[byte]  = uint32_t(lut[lo]) | (uint32_t(lut[hi]) << 16);
+        }
+        return expanded;
+    }
+
+    std::array<uint16_t, 16> makeBaseLUT() const
+    {
+        std::array<uint16_t, 16> lut{};
+        memcpy(lut.data(), bases_.data(), numBases_ * 2);
+        return lut;
+    }
+
+    std::array<uint16_t, 16> makeMaskLUT() const
+    {
+        std::array<uint16_t, 16> lut;
+        for (size_t i = 0; i < 16; ++i) {
+            if (i < numBases_) {
+                lut[i] = (1u << varBits_[i]) - 1;
+                assert(varBits_[i] <= 14);
+            } else {
+                lut[i] = 0;
+            }
+        }
+        return lut;
+    }
+
+    void decode4(
+            poly::span<const uint8_t> fixed,
+            poly::span<const uint8_t> var,
+            uint16_t* out) const
+    {
+        const auto baseLUT = expandLUT(makeBaseLUT());
+        const auto maskLUT = expandLUT(makeMaskLUT());
+        const auto size    = numElts(fixed.size());
+
+        uint16_t* o               = out;
+        const uint8_t* f          = fixed.data();
+        const uint8_t* v          = var.data();
+        const uint8_t* const vEnd = v + var.size();
+
+        constexpr size_t kEltsPerIter = 16;
+        size_t i                      = 0;
+
+        const auto computeLimit = [&] {
+            if (size < kEltsPerIter) {
+                return i;
+            }
+            assert(v <= vEnd);
+            const size_t vSafeNumIters = (8 * (vEnd - v) - 7) / maxVarBits_;
+            if (vSafeNumIters < kEltsPerIter) {
+                return i;
+            }
+            const auto limit = std::min(
+                    size - kEltsPerIter, i + vSafeNumIters - kEltsPerIter);
+            return limit;
+        };
+
+        size_t bitsConsumed = 0;
+        size_t limit        = computeLimit();
+        for (;; i += kEltsPerIter) {
+            if (i >= limit) {
+                limit = computeLimit();
+                if (i >= limit) {
+                    break;
+                }
+            }
+            static_assert(kEltsPerIter % 4 == 0);
+            for (size_t u = 0; u < kEltsPerIter; u += 4) {
+                const uint64_t base = uint64_t(baseLUT[f[0]])
+                        | (uint64_t(baseLUT[f[1]]) << 32);
+                const uint64_t mask = uint64_t(maskLUT[f[0]])
+                        | (uint64_t(maskLUT[f[1]]) << 32);
+                f += 2;
+
+                const uint64_t vData  = ZL_readLE64(v) >> bitsConsumed;
+                const uint64_t offset = _pdep_u64(vData, mask);
+
+                ZL_writeLE64(o, base + offset);
+                o += 4;
+
+                bitsConsumed += __builtin_popcountll(mask);
+                assert(bitsConsumed <= 64);
+                v += bitsConsumed >> 3;
+                bitsConsumed &= 7;
+            }
+        }
+
+        assert(v <= vEnd);
+        auto varBitstream = ZS_BitDStreamFF_init(v, vEnd - v);
+        ZS_BitDStreamFF_skip(&varBitstream, bitsConsumed);
+        for (; i < size; ++i) {
+            size_t bucket = fixed[i / 2];
+            if (i % 2 == 0) {
+                bucket &= 0xF;
+            } else {
+                bucket >>= 4;
+            }
+
+            auto base = bases_[bucket];
+            auto bits = varBits_[bucket];
+
+            auto offset = ZS_BitDStreamFF_read(&varBitstream, bits);
+            ZS_BitDStreamFF_reload(&varBitstream);
+            out[i] = base + offset;
+        }
+        auto report = ZS_BitDStreamFF_finish(&varBitstream);
+        if (ZL_isError(report)) {
+            throw std::runtime_error("read too many varbits");
+        }
+    }
+
+    static std::array<uint32_t, 1024> expandLUT5(poly::span<const uint16_t> lut)
+    {
+        std::array<uint32_t, 1024> expanded;
+        for (size_t byte = 0; byte < 1024; ++byte) {
+            const size_t lo = byte & 31;
+            const size_t hi = byte >> 5;
+            expanded[byte]  = uint32_t(lut[lo]) | (uint32_t(lut[hi]) << 16);
+        }
+        return expanded;
+    }
+
+    std::array<uint16_t, 32> makeBaseLUT5() const
+    {
+        std::array<uint16_t, 32> lut{};
+        memcpy(lut.data(), bases_.data(), numBases_ * 2);
+        return lut;
+    }
+
+    std::array<uint16_t, 32> makeMaskLUT5() const
+    {
+        std::array<uint16_t, 32> lut;
+        for (size_t i = 0; i < 32; ++i) {
+            if (i < numBases_) {
+                lut[i] = (1u << varBits_[i]) - 1;
+                assert(varBits_[i] <= 14);
+            } else {
+                lut[i] = 0;
+            }
+        }
+        return lut;
+    }
+
+    void decode5(
+            poly::span<const uint8_t> fixed,
+            poly::span<const uint8_t> var,
+            uint16_t* out) const
+    {
+        const auto baseLUT = expandLUT5(makeBaseLUT5());
+        const auto maskLUT = expandLUT5(makeMaskLUT5());
+        const auto size    = numElts(fixed.size());
+
+        uint16_t* o               = out;
+        const uint8_t* f          = fixed.data();
+        const uint8_t* v          = var.data();
+        const uint8_t* const vEnd = v + var.size();
+
+        constexpr size_t kEltsPerIter = 16;
+        size_t i                      = 0;
+
+        const auto computeLimit = [&] {
+            if (size < kEltsPerIter) {
+                return i;
+            }
+            assert(v <= vEnd);
+            const size_t vSafeNumIters = (8 * (vEnd - v) - 7) / maxVarBits_;
+            if (vSafeNumIters < kEltsPerIter) {
+                return i;
+            }
+            const auto limit = std::min(
+                    size - kEltsPerIter, i + vSafeNumIters - kEltsPerIter);
+            return limit;
+        };
+
+        size_t bitsConsumed = 0;
+        size_t limit        = computeLimit();
+        for (;; i += kEltsPerIter) {
+            if (i >= limit) {
+                limit = computeLimit();
+                if (i >= limit) {
+                    break;
+                }
+            }
+            static_assert(kEltsPerIter % 8 == 0);
+            for (size_t u = 0; u < kEltsPerIter; u += 8) {
+                auto const F                     = ZL_readLE64(f);
+                const std::array<uint64_t, 4> fs = {
+                    (F >> 00) & 1023,
+                    (F >> 10) & 1023,
+                    (F >> 20) & 1023,
+                    (F >> 30) & 1023,
+                };
+                f += 5;
+                for (size_t k = 0; k < 4; k += 2) {
+                    const uint64_t base = uint64_t(baseLUT[fs[k + 0]])
+                            | (uint64_t(baseLUT[fs[k + 1]]) << 32);
+                    const uint64_t mask = uint64_t(maskLUT[fs[k + 0]])
+                            | (uint64_t(maskLUT[fs[k + 1]]) << 32);
+
+                    const uint64_t vData  = ZL_readLE64(v) >> bitsConsumed;
+                    const uint64_t offset = _pdep_u64(vData, mask);
+
+                    ZL_writeLE64(o, base + offset);
+                    o += 4;
+
+                    bitsConsumed += __builtin_popcountll(mask);
+                    assert(bitsConsumed <= 64);
+                    v += bitsConsumed >> 3;
+                    bitsConsumed &= 7;
+                }
+            }
+        }
+
+        assert(v <= vEnd);
+        auto fixedBitstream =
+                ZS_BitDStreamFF_init(f, (fixed.data() + fixed.size()) - f);
+        auto varBitstream = ZS_BitDStreamFF_init(v, vEnd - v);
+        ZS_BitDStreamFF_skip(&varBitstream, bitsConsumed);
+        for (; i < size; ++i) {
+            auto bucket = ZS_BitDStreamFF_read(&fixedBitstream, 5);
+            ZS_BitDStreamFF_reload(&fixedBitstream);
+
+            auto base = bases_[bucket];
+            auto bits = varBits_[bucket];
+
+            auto offset = ZS_BitDStreamFF_read(&varBitstream, bits);
+            ZS_BitDStreamFF_reload(&varBitstream);
+            out[i] = base + offset;
+        }
+        auto report = ZS_BitDStreamFF_finish(&varBitstream);
+        if (ZL_isError(report)) {
+            throw std::runtime_error("read too many varbits");
+        }
+    }
+
+    static std::array<uint32_t, 4096> expandLUT6(poly::span<const uint16_t> lut)
+    {
+        std::array<uint32_t, 4096> expanded;
+        for (size_t byte = 0; byte < 4096; ++byte) {
+            const size_t lo = byte & 63;
+            const size_t hi = byte >> 6;
+            expanded[byte]  = uint32_t(lut[lo]) | (uint32_t(lut[hi]) << 16);
+        }
+        return expanded;
+    }
+
+    std::array<uint16_t, 64> makeBaseLUT6() const
+    {
+        std::array<uint16_t, 64> lut{};
+        memcpy(lut.data(), bases_.data(), numBases_ * 2);
+        return lut;
+    }
+
+    std::array<uint16_t, 64> makeMaskLUT6() const
+    {
+        std::array<uint16_t, 64> lut;
+        for (size_t i = 0; i < 64; ++i) {
+            if (i < numBases_) {
+                lut[i] = (1u << varBits_[i]) - 1;
+                assert(varBits_[i] <= 14);
+            } else {
+                lut[i] = 0;
+            }
+        }
+        return lut;
+    }
+
+    void decode6(
+            poly::span<const uint8_t> fixed,
+            poly::span<const uint8_t> var,
+            uint16_t* out) const
+    {
+        const auto baseLUT = expandLUT6(makeBaseLUT6());
+        const auto maskLUT = expandLUT6(makeMaskLUT6());
+        const auto size    = numElts(fixed.size());
+
+        uint16_t* o               = out;
+        const uint8_t* f          = fixed.data();
+        const uint8_t* v          = var.data();
+        const uint8_t* const vEnd = v + var.size();
+
+        constexpr size_t kEltsPerIter = 16;
+        size_t i                      = 0;
+
+        const auto computeLimit = [&] {
+            if (size < kEltsPerIter) {
+                return i;
+            }
+            assert(v <= vEnd);
+            const size_t vSafeNumIters = (8 * (vEnd - v) - 7) / maxVarBits_;
+            if (vSafeNumIters < kEltsPerIter) {
+                return i;
+            }
+            const auto limit = std::min(
+                    size - kEltsPerIter, i + vSafeNumIters - kEltsPerIter);
+            return limit;
+        };
+
+        size_t bitsConsumed = 0;
+        size_t limit        = computeLimit();
+        for (;; i += kEltsPerIter) {
+            if (i >= limit) {
+                limit = computeLimit();
+                if (i >= limit) {
+                    break;
+                }
+            }
+            static_assert(kEltsPerIter % 4 == 0);
+            for (size_t u = 0; u < kEltsPerIter; u += 4) {
+                uint32_t const F = ZL_readLE32(f);
+                const auto f0    = F & 4095;
+                const auto f1    = (F >> 12) & 4095;
+                f += 3;
+                {
+                    const uint64_t base = uint64_t(baseLUT[f0])
+                            | (uint64_t(baseLUT[f1]) << 32);
+                    const uint64_t mask = uint64_t(maskLUT[f0])
+                            | (uint64_t(maskLUT[f1]) << 32);
+
+                    const uint64_t vData  = ZL_readLE64(v) >> bitsConsumed;
+                    const uint64_t offset = _pdep_u64(vData, mask);
+
+                    ZL_writeLE64(o, base + offset);
+                    o += 4;
+
+                    bitsConsumed += __builtin_popcountll(mask);
+                    assert(bitsConsumed <= 64);
+                    v += bitsConsumed >> 3;
+                    bitsConsumed &= 7;
+                }
+            }
+        }
+
+        assert(v <= vEnd);
+        auto fixedBitstream =
+                ZS_BitDStreamFF_init(f, (fixed.data() + fixed.size()) - f);
+        auto varBitstream = ZS_BitDStreamFF_init(v, vEnd - v);
+        ZS_BitDStreamFF_skip(&varBitstream, bitsConsumed);
+        for (; i < size; ++i) {
+            auto bucket = ZS_BitDStreamFF_read(&fixedBitstream, 6);
+            ZS_BitDStreamFF_reload(&fixedBitstream);
+
+            auto base = bases_[bucket];
+            auto bits = varBits_[bucket];
+
+            auto offset = ZS_BitDStreamFF_read(&varBitstream, bits);
+            ZS_BitDStreamFF_reload(&varBitstream);
+            out[i] = base + offset;
+        }
+        auto report = ZS_BitDStreamFF_finish(&varBitstream);
+        if (ZL_isError(report)) {
+            throw std::runtime_error("read too many varbits");
+        }
+    }
+
+    void decode(
+            poly::span<const uint8_t> fixed,
+            poly::span<const uint8_t> var,
+            uint16_t* output) const
+    {
+        if (fixedBits_ == 4) {
+            decode4(fixed, var, output);
+            return;
+        }
+        if (fixedBits_ == 5) {
+            decode5(fixed, var, output);
+            return;
+        }
+        if (fixedBits_ == 6) {
+            decode6(fixed, var, output);
+            return;
+        }
+        auto fixedBitstream = ZS_BitDStreamFF_init(fixed.data(), fixed.size());
+        auto varBitstream   = ZS_BitDStreamFF_init(var.data(), var.size());
+        const auto size     = numElts(fixed.size());
+
+        for (size_t i = 0; i < size; ++i) {
+            const auto bucket =
+                    ZS_BitDStreamFF_read(&fixedBitstream, fixedBits_);
+            assert(bucket < 256);
+            const auto base = bases_[bucket];
+            const auto offset =
+                    ZS_BitDStreamFF_read(&varBitstream, varBits_[bucket]);
+            output[i] = base + offset;
+
+            ZS_BitDStreamFF_reload(&fixedBitstream);
+            ZS_BitDStreamFF_reload(&varBitstream);
+        }
+    }
+
+   private:
+    size_t getBucketSize(size_t baseIdx) const
+    {
+        if (baseIdx >= numBases_) {
+            return 1;
+        }
+        size_t base = bases_[baseIdx];
+        assert(base < 65536);
+        auto end = baseIdx + 1 == numBases_ ? size_t(65536)
+                                            : size_t(bases_[baseIdx + 1]);
+        assert(end > base);
+        return end - base;
+    }
+
+    std::array<uint16_t, 256> bases_{};
+    std::array<uint8_t, 256> varBits_{};
+    size_t unusedFixedBits_;
+    size_t fixedBits_;
+    size_t numBases_;
+    size_t maxVarBits_;
+};
+} // namespace
+
+SimpleCodecDescription Bucket16Encoder::simpleCodecDescription() const
+{
+    return bucket16CodecDescription();
+}
+
+void Bucket16Encoder::encode(EncoderState& encoder) const
+{
+    auto bases = encoder.getLocalParam(0);
+    if (!bases.has_value()) {
+        throw std::runtime_error("bases not present");
+    }
+    Bucket16EncoderState state(*bases);
+
+    const auto& input    = encoder.inputs()[0];
+    const size_t numElts = input.numElts();
+
+    if (input.eltWidth() != 2) {
+        throw std::runtime_error("Unsupported width != 2");
+    }
+
+    uint8_t header[513];
+    // first byte is the # of unused bits in the bitstream
+    header[0] = (8 - ((state.fixedBits() * numElts) % 8)) % 8;
+    // TODO: Handle big endian
+    memcpy(header + 1, state.bases().data(), state.bases().size() * 2);
+
+    encoder.sendCodecHeader(header, 1 + state.bases().size() * 2);
+
+    auto fixedStream =
+            encoder.createOutput(0, state.fixedStreamSize(numElts), 1);
+    auto varStream = encoder.createOutput(1, state.varStreamBound(numElts), 1);
+
+    auto varStreamSize = state.encode(
+            { (const uint16_t*)input.ptr(), input.numElts() },
+            (uint8_t*)fixedStream.ptr(),
+            (uint8_t*)varStream.ptr());
+
+    fixedStream.commit(state.fixedStreamSize(numElts));
+    varStream.commit(varStreamSize);
+}
+/* static */ Edge::RunNodeResult Bucket16Encoder::runNode(
+        Edge& edge,
+        NodeID node,
+        poly::span<const uint16_t> bases)
+{
+    NodeParameters params;
+    params.localParams.emplace();
+    params.localParams->addRefParam(0, bases.data(), bases.size_bytes());
+    auto r = edge.runNode(node, std::move(params));
+    return r;
+}
+
+SimpleCodecDescription Bucket16Decoder::simpleCodecDescription() const
+{
+    return bucket16CodecDescription();
+}
+
+void Bucket16Decoder::decode(DecoderState& decoder) const
+{
+    Bucket16DecoderState state(decoder.getCodecHeader());
+
+    const auto& fixedStream = decoder.singletonInputs()[0];
+    const auto& varStream   = decoder.singletonInputs()[1];
+    const auto fixedSize    = fixedStream.numElts();
+
+    auto outStream = decoder.createOutput(0, state.numElts(fixedSize), 2);
+
+    state.decode(
+            { (const uint8_t*)fixedStream.ptr(), fixedSize },
+            { (const uint8_t*)varStream.ptr(), varStream.numElts() },
+            (uint16_t*)outStream.ptr());
+
+    outStream.commit(state.numElts(fixedSize));
+}
+
+/* static */ GraphID Bucket16Graph::create(Compressor& compressor)
+{
+    auto graph = compressor.getGraph("lz_research.bucket16_graph");
+    if (!graph.has_value()) {
+        graph = compressor.registerFunctionGraph(
+                std::make_shared<Bucket16Graph>());
+    }
+
+    auto node = compressor.getNode("lz_research.bucket16");
+    if (!node.has_value()) {
+        node = compressor.registerCustomEncoder(
+                std::make_shared<Bucket16Encoder>());
+    }
+
+    return compressor.parameterizeGraph(
+            *graph, GraphParameters{ .customNodes = { { *node } } });
+}
+
+FunctionGraphDescription Bucket16Graph::functionGraphDescription() const
+{
+    return FunctionGraphDescription{
+        .name           = "!lz_research.bucket16_graph",
+        .inputTypeMasks = { TypeMask::Numeric },
+    };
+}
+
+namespace {
+constexpr uint32_t kBucket16OverheadBits = 40;
+constexpr size_t kMaxBucketSize          = 1u << 14;
+
+uint32_t fixedBucketCost(poly::span<const uint32_t> bucket, uint32_t fixedCost)
+{
+    const uint32_t bucketCount =
+            std::accumulate(bucket.begin(), bucket.end(), 0);
+    return bucketCount * (fixedCost + ZL_nextPow2(bucket.size()));
+}
+
+uint32_t fixedBucketCost(
+        poly::span<const uint32_t> histogram,
+        poly::span<const uint16_t> partitions)
+{
+    const uint32_t totalCount =
+            std::accumulate(histogram.begin(), histogram.end(), 0);
+    const uint32_t bucketBits = ZL_nextPow2(partitions.size());
+    uint32_t cost             = totalCount * bucketBits;
+    for (size_t i = 0; i < partitions.size(); ++i) {
+        const auto b = partitions[i];
+        const auto e = i + 1 == partitions.size() ? histogram.size()
+                                                  : partitions[i + 1];
+        assert(b < e);
+        const uint32_t bucketCount = std::accumulate(
+                histogram.begin() + b, histogram.begin() + e, 0);
+        const uint32_t offsetBits = ZL_nextPow2(e - b);
+        cost += kBucket16OverheadBits + bucketCount * offsetBits;
+    }
+    return cost;
+}
+
+std::vector<uint16_t> fixedPartition(
+        poly::span<const uint32_t> histogram,
+        size_t numBuckets)
+{
+    constexpr size_t kNumBuckets       = 766;
+    std::array<uint32_t, 8> bitsOffset = {
+        0,
+        0 + 4,
+        0 + 4 + 6,
+        0 + 4 + 6 + 12,
+        0 + 4 + 6 + 12 + 24,
+        0 + 4 + 6 + 12 + 24 + 48,
+        0 + 4 + 6 + 12 + 24 + 48 + 96,
+        0 + 4 + 6 + 12 + 24 + 48 + 96 + 192,
+    };
+    std::array<uint32_t, kNumBuckets + 1> bucketsToBits;
+    for (size_t bucket = 0; bucket < bucketsToBits.size(); ++bucket) {
+        size_t bits = bitsOffset.size() - 1;
+        while (bucket < bitsOffset[bits]) {
+            --bits;
+        }
+        bucketsToBits[bucket] = bits;
+    }
+    auto bitsToBase = [&](size_t bits) {
+        return bits == 0 ? 0 : 1u << (bits << 1);
+    };
+    auto bucketToBase = [&](size_t bucket) {
+        auto bits  = bucketsToBits[bucket];
+        auto base0 = bitsToBase(bits);
+        auto base  = base0 + ((bucket - bitsOffset[bits]) << bits);
+        return base;
+    };
+
+    std::array<uint32_t, kNumBuckets> bucketedHistogram{};
+
+    auto bits = [](size_t val) { return ZL_highbit32(val | 1) >> 1; };
+
+    for (size_t i = 0; i < histogram.size(); ++i) {
+        auto b      = bits(i);
+        auto base   = bitsToBase(b);
+        auto bucket = bitsOffset[b] + ((i - base) >> b);
+        assert(bucket < kNumBuckets);
+        bucketedHistogram[bucket] += histogram[i];
+    }
+
+    auto bucketedPartitions = utils::partition(
+            poly::span<const uint32_t>{ bucketedHistogram },
+            numBuckets,
+            [&, fixed = ZL_highbit32(numBuckets)](auto bucket) {
+                auto beginIdx = bucket.data() - bucketedHistogram.data();
+                auto endIdx   = beginIdx + bucket.size();
+                auto begin    = bucketToBase(beginIdx);
+                auto end      = bucketToBase(endIdx);
+                assert(begin < end);
+                if (end - begin > kMaxBucketSize) {
+                    // Reject buckets that are too big
+                    return std::numeric_limits<float>::infinity();
+                }
+                const uint32_t bucketCount =
+                        std::accumulate(bucket.begin(), bucket.end(), 0);
+                return float(bucketCount * (fixed + ZL_nextPow2(end - begin)));
+            });
+    std::vector<uint16_t> p;
+    for (const auto bucket : bucketedPartitions) {
+        auto base = bucketToBase(bucket);
+        p.push_back(base);
+        // fprintf(stderr, "%zu -> %u\n", bucket, unsigned(base));
+    }
+    return p;
+}
+
+std::vector<uint16_t> fixedPartition(poly::span<const uint32_t> histogram)
+{
+    std::vector<uint16_t> best;
+    uint32_t bestCost = std::numeric_limits<uint32_t>::max();
+    for (const auto numBuckets : { 4, 8, 16, 32, 64 }) {
+        auto partitions = fixedPartition(histogram, numBuckets);
+        auto cost       = fixedBucketCost(histogram, partitions);
+        if (cost < 0.99 * bestCost) {
+            bestCost = cost;
+            best     = std::move(partitions);
+        }
+    }
+    return best;
+}
+
+class OptimalFixedPartition {
+   public:
+    OptimalFixedPartition(
+            poly::span<const uint32_t> histogram,
+            size_t numPartitions)
+            : hist_(histogram), numPartitions_(numPartitions)
+    {
+        auto totalCount =
+                std::accumulate(histogram.begin(), histogram.end(), 0);
+        targetCount_ = totalCount / numPartitions;
+    }
+
+    std::vector<uint16_t> run()
+    {
+        assert(partitions_.empty());
+        size_t offset = 0;
+        // TODO: Enable offset > 0
+        // while (offset < hist_.size() && hist_[offset] == 0) {
+        //     ++offset;
+        // }
+        partitions_.push_back(offset);
+        go();
+        partitions_.pop_back();
+        assert(partitions_.empty());
+        assert(bestPartitions_.size() <= numPartitions_);
+        return bestPartitions_;
+    }
+
+   private:
+    void go()
+    {
+        if (hist_.size() - size_t(partitions_.back()) <= kMaxBucketSize) {
+            auto c = cost(partitions_);
+            if (c < bestCost_) {
+                bestCost_       = c;
+                bestPartitions_ = partitions_;
+            }
+        }
+        if (partitions_.size() < numPartitions_) {
+            auto smallPartition = getSmallPartition();
+            if (smallPartition < hist_.size()) {
+                const auto begin = partitions_.back();
+                partitions_.push_back(smallPartition);
+                if (smallPartition - begin <= kMaxBucketSize) {
+                    go();
+                }
+                auto largePartition = getLargePartition();
+                if (largePartition < hist_.size()
+                    && largePartition - begin <= kMaxBucketSize) {
+                    partitions_.back() = largePartition;
+                    go();
+                }
+                partitions_.pop_back();
+            }
+        }
+    }
+
+    size_t getSmallPartition() const
+    {
+        uint32_t count = 0;
+        size_t end;
+        for (end = partitions_.back() + 1; end < hist_.size(); ++end) {
+            count += hist_[end];
+            if (count > targetCount_) {
+                break;
+            }
+        }
+        size_t size = end - partitions_.back();
+        while (!ZL_isPow2(size)) {
+            --size;
+        }
+        return partitions_.back() + size;
+    }
+
+    size_t getLargePartition() const
+    {
+        uint32_t count = 0;
+        size_t end;
+        for (end = partitions_.back() + 1; end < hist_.size(); ++end) {
+            count += hist_[end];
+            if (count > targetCount_) {
+                ++end;
+                break;
+            }
+        }
+        size_t size = end - partitions_.back();
+        while (!ZL_isPow2(size)) {
+            ++size;
+        }
+        return partitions_.back() + size;
+    }
+
+    uint32_t cost(poly::span<const uint16_t> partitions) const
+    {
+        auto cost = fixedBucketCost(hist_, partitions);
+        return cost;
+    }
+
+    uint32_t bestCost_{ std::numeric_limits<uint32_t>::max() };
+    std::vector<uint16_t> bestPartitions_ = { 0 };
+    std::vector<uint16_t> partitions_{};
+    poly::span<const uint32_t> hist_;
+    size_t numPartitions_;
+    uint32_t targetCount_;
+};
+} // namespace
+
+void Bucket16Graph::graph(GraphState& state) const
+{
+    auto& inputEdge         = state.edges()[0];
+    const auto& inputStream = inputEdge.getInput();
+    const size_t numElts    = inputStream.numElts();
+
+    if (numElts < 10) {
+        inputEdge.setDestination(graphs::Store{}());
+        return;
+    }
+
+    ZL_Histogram16 histogram;
+    ZL_Histogram_init(&histogram.base, 65535);
+    ZL_Histogram_build(&histogram.base, inputStream.ptr(), numElts, 2);
+
+    poly::span<const uint32_t> hist{ histogram.base.count, 65536 };
+    // partitions = fixedPartition(hist);
+    // TODO: Allow for 1, 2, 4, 8, 32, 64, 128, 256 #buckets
+    // const auto partitions = OptimalFixedPartition{ hist, 16 }.run();
+    const auto partitions = fixedPartition(hist);
+    const auto bitCost    = fixedBucketCost(hist, partitions);
+    if (0)
+        for (size_t i = 0; i < partitions.size(); ++i) {
+            const size_t size =
+                    (i + 1 == partitions.size() ? 65536 : partitions[i + 1])
+                    - partitions[i];
+            fprintf(stderr,
+                    "p[%zu] = %d | size = %zu\n",
+                    i,
+                    int(partitions[i]),
+                    size);
+        }
+    if (0)
+        fprintf(stderr,
+                "numElts = %zu, #partitions = %u, cost = %u\n",
+                numElts,
+                (unsigned)partitions.size(),
+                bitCost / 8);
+
+    if (bitCost / 8 >= 2 * 95 * numElts / 100) {
+        // Not enough gain => skip
+        if (0)
+            fprintf(stderr, "skipping...\n");
+        inputEdge.setDestination(graphs::Store{}());
+        return;
+    }
+
+    const auto nodes = state.customNodes();
+    if (nodes.size() != 1) {
+        throw std::runtime_error("CustomNodes must have exactly one node");
+    }
+
+    auto outEdges = Bucket16Encoder::runNode(inputEdge, nodes[0], partitions);
+    assert(outEdges.size() == 2);
+
+    if (0)
+        fprintf(stderr,
+                "actual = %zu: %zu, %zu\n",
+                outEdges[0].getInput().numElts()
+                        + outEdges[1].getInput().numElts(),
+                outEdges[0].getInput().numElts(),
+                outEdges[1].getInput().numElts());
+
+    outEdges[0].setDestination(graphs::Store{}());
+    outEdges[1].setDestination(graphs::Store{}());
+}
+
+} // namespace openzl::lz

--- a/contrib/lz-research/codecs/Bucket16.hpp
+++ b/contrib/lz-research/codecs/Bucket16.hpp
@@ -1,0 +1,43 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#pragma once
+
+#include <openzl/openzl.hpp>
+
+namespace openzl::lz {
+
+class Bucket16Encoder : public CustomEncoder {
+   public:
+    SimpleCodecDescription simpleCodecDescription() const override;
+
+    void encode(EncoderState& encoder) const override;
+
+    static Edge::RunNodeResult
+    runNode(Edge& edge, NodeID node, poly::span<const uint16_t> bases);
+
+    ~Bucket16Encoder() override = default;
+};
+
+class Bucket16Decoder : public CustomDecoder {
+   public:
+    SimpleCodecDescription simpleCodecDescription() const override;
+
+    void decode(DecoderState& decoder) const override;
+
+    ~Bucket16Decoder() override = default;
+};
+
+class Bucket16Graph : public FunctionGraph {
+   public:
+    Bucket16Graph() = default;
+
+    static GraphID create(Compressor& compressor);
+
+    FunctionGraphDescription functionGraphDescription() const override;
+
+    void graph(GraphState& state) const override;
+
+    virtual ~Bucket16Graph() override = default;
+};
+
+} // namespace openzl::lz

--- a/contrib/lz-research/codecs/CodecIDs.hpp
+++ b/contrib/lz-research/codecs/CodecIDs.hpp
@@ -1,0 +1,14 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#pragma once
+
+namespace openzl::lz {
+enum class CustomCodecIDs {
+    LZ       = 0x1337,
+    SmallInt = 0x1338,
+    VarByte  = 0x1339,
+    IsoByte  = 0x133A,
+    Bucket   = 0x133B,
+    Bucket16 = 0x133C,
+};
+}

--- a/contrib/lz-research/codecs/IsoByte.cpp
+++ b/contrib/lz-research/codecs/IsoByte.cpp
@@ -1,0 +1,424 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#include "IsoByte.hpp"
+
+#include <array>
+
+#include "CodecIDs.hpp"
+
+#include "openzl/codecs/common/bitstream/ff_bitstream.h"
+#include "openzl/common/assertion.h"
+#include "openzl/shared/mem.h"
+#include "openzl/shared/portability.h"
+
+namespace openzl::lz {
+namespace {
+VariableOutputCodecDescription isoByteCodecDescription()
+{
+    return VariableOutputCodecDescription{
+        .id                   = unsigned(CustomCodecIDs::IsoByte),
+        .name                 = "!lz_research.iso_byte",
+        .inputType            = Type::Numeric,
+        .singletonOutputTypes = { Type::Serial, Type::Serial },
+        .variableOutputTypes  = { Type::Serial },
+    };
+}
+
+void setBit(uint8_t* bitmap, size_t idx)
+{
+    bitmap[idx / 8] |= (1 << (idx % 8));
+}
+
+bool getBit(const uint8_t* bitmap, size_t idx)
+{
+    return (bitmap[idx / 8] & (1 << (idx % 8))) != 0;
+}
+
+void isoByteDecodeNaive(
+        std::span<uint16_t> dst,
+        std::span<const uint8_t> bits,
+        std::span<const uint8_t> lo,
+        std::span<const uint8_t> hi8,
+        std::span<const uint8_t> hi16)
+{
+    size_t idx8  = 0;
+    size_t idx16 = 0;
+    for (size_t i = 0; i < dst.size(); ++i) {
+        if (getBit(bits.data(), i)) {
+            dst[i] = (uint16_t(hi16[idx16]) << 8) | lo[idx16];
+            ++idx16;
+        } else {
+            dst[i] = hi8[idx8++];
+        }
+    }
+}
+
+template <typename UInt>
+class IsoByteDecode {
+   public:
+    static_assert(sizeof(UInt) == 2);
+    static void print32(char const* name, __m128i vec)
+    {
+        std::array<uint32_t, 4> array;
+        _mm_storeu_si128((__m128i_u*)array.data(), vec);
+        fprintf(stderr, "%s: ", name);
+        for (auto const& val : array) {
+            fprintf(stderr, "0x%x\t", val);
+        }
+        fprintf(stderr, "\n");
+    }
+
+    static void print16(char const* name, __m128i vec)
+    {
+        std::array<uint16_t, 8> array;
+        _mm_storeu_si128((__m128i_u*)array.data(), vec);
+        fprintf(stderr, "%s: ", name);
+        for (auto const& val : array) {
+            fprintf(stderr, "0x%x\t", val);
+        }
+        fprintf(stderr, "\n");
+    }
+
+    static void print8(char const* name, __m128i vec)
+    {
+        std::array<uint8_t, 16> array;
+        _mm_storeu_si128((__m128i_u*)array.data(), vec);
+        fprintf(stderr, "%s: ", name);
+        for (auto const& val : array) {
+            fprintf(stderr, "0x%x\t", val);
+        }
+        fprintf(stderr, "\n");
+    }
+
+    static void decode(
+            std::span<UInt> dst,
+            std::span<const uint8_t> bits,
+            std::span<const uint8_t> lo,
+            std::span<const uint8_t> hi8,
+            std::span<const uint8_t> hi16)
+    {
+        const uint8_t* l              = lo.data();
+        const uint8_t* h8             = hi8.data();
+        const uint8_t* const h8Limit  = h8 + hi8.size() - 16;
+        const uint8_t* h16            = hi16.data();
+        const uint8_t* const h16Limit = h16 + hi16.size() - 16;
+
+        size_t i;
+        // for (i = 0; h8 < h8Limit && h16 < h16Limit; i += 8) {
+        //     // TODO: Can half the number of data loads
+        //     // Reuse the data by adding a constant to the shuffles
+
+        //     const int bitmask = bits[i / 8];
+        //     auto lV = _mm_loadu_si128((const __m128i_u*)l);
+        //     auto lShuffleV =
+        //             _mm_load_si128((const __m128i*)&kLoShuffleLUT_[bitmask]);
+        //     lV = _mm_shuffle_epi8(lV, lShuffleV);
+
+        //     auto h8V        = _mm_loadu_si128((const __m128i_u*)h8);
+        //     auto h8ShuffleV = _mm_load_si128(
+        //             (const __m128i*)&kLoShuffleLUT_[~bitmask & 0xFF]);
+        //     h8V = _mm_shuffle_epi8(h8V, h8ShuffleV);
+
+        //     auto h16V = _mm_loadu_si128((const __m128i_u*)h16);
+        //     auto h16ShuffleV =
+        //             _mm_load_si128((const __m128i*)&kHiShuffleLUT_[bitmask]);
+        //     h16V = _mm_shuffle_epi8(h16V, h16ShuffleV);
+
+        //     auto out = _mm_or_si128(h8V, _mm_or_si128(lV, h16V));
+        //     _mm_storeu_si128((__m128i_u*)&dst[i], out);
+
+        //     const auto count16 = __builtin_popcount(bitmask);
+        //     const auto count8  = 8 - count16;
+
+        //     h16 += count16;
+        //     l += count16;
+        //     h8 += count8;
+        // }
+        for (i = 0; h8 < h8Limit && h16 < h16Limit; i += 16) {
+            // TODO: Could combine the high bits to reduce loads & shuffles by
+            // 33%
+            // auto lV   = _mm_loadu_si128((const __m128i_u*)l);
+            // auto h16V = _mm_loadu_si128((const __m128i_u*)h16);
+            auto lV   = _mm_set_epi64x(0, ZL_readLE64(l));
+            auto h16V = _mm_set_epi64x(0, ZL_readLE64(h16));
+            // auto lV   = _mm_loadu_si128((const __m128i_u*)l);
+            // auto h16V = _mm_loadu_si128((const __m128i_u*)h16);
+            auto h8V = _mm_set_epi64x(0, ZL_readLE64(h8));
+            // auto h8V = _mm_loadu_si128((const __m128i_u*)h8);
+
+            int bitmask  = bits[i / 8];
+            auto count16 = __builtin_popcount(bitmask);
+            auto count8  = 8 - count16;
+            // const auto count16V = _mm_set1_epi8(count16);
+            // const auto count8V = _mm_set1_epi8(count8);
+
+            h16 += count16;
+            l += count16;
+            h8 += count8;
+
+            // if 8-bit:
+            // - high byte should start with 0x80
+            // - low byte should be <= 0xF
+
+            // if 16-bit:
+            // - high byte should be <= 0xF
+            // - low byte should be < 0xF
+
+            // at most 8 bytes
+            auto lhV = _mm_unpacklo_epi8(lV, h16V);
+            lV       = _mm_set_epi64x(0, ZL_readLE64(l));
+            h16V     = _mm_set_epi64x(0, ZL_readLE64(h16));
+
+            auto h8ShuffleV = _mm_load_si128(
+                    (const __m128i*)&kLoShuffleLUT_[~bitmask & 0xFF]);
+            auto outH8V = _mm_shuffle_epi8(h8V, h8ShuffleV);
+            h8V         = _mm_set_epi64x(0, ZL_readLE64(h8));
+
+            auto lhShuffleV =
+                    _mm_load_si128((const __m128i*)&kLoHiShuffleLUT_[bitmask]);
+            auto outLHV = _mm_shuffle_epi8(lhV, lhShuffleV);
+            // auto lShuffleV =
+            //         _mm_load_si128((const __m128i*)&kLoShuffleLUT_[bitmask]);
+            // auto outLV = _mm_shuffle_epi8(lV, lShuffleV);
+
+            // at most 16
+
+            auto out = _mm_or_si128(outLHV, outH8V);
+
+            // at most 8 bytes
+            // auto h16ShuffleV =
+            //         _mm_load_si128((const __m128i*)&kHiShuffleLUT_[bitmask]);
+            // auto outH16V = _mm_shuffle_epi8(h16V, h16ShuffleV);
+
+            // out = _mm_or_si128(out, outH16V);
+            _mm_storeu_si128((__m128i_u*)&dst[i], out);
+
+            bitmask = bits[i / 8 + 1];
+            count16 = __builtin_popcount(bitmask);
+            count8  = 8 - count16;
+
+            lhV = _mm_unpacklo_epi8(lV, h16V);
+            lhShuffleV =
+                    _mm_load_si128((const __m128i*)&kLoHiShuffleLUT_[bitmask]);
+            outLHV = _mm_shuffle_epi8(lhV, lhShuffleV);
+            // auto lShuffleV =
+            //         _mm_load_si128((const __m128i*)&kLoShuffleLUT_[bitmask]);
+            // auto outLV = _mm_shuffle_epi8(lV, lShuffleV);
+
+            // at most 16
+            h8ShuffleV = _mm_load_si128(
+                    (const __m128i*)&kLoShuffleLUT_[~bitmask & 0xFF]);
+            outH8V = _mm_shuffle_epi8(h8V, h8ShuffleV);
+
+            out = _mm_or_si128(outLHV, outH8V);
+
+            // at most 8 bytes
+            // auto h16ShuffleV =
+            //         _mm_load_si128((const __m128i*)&kHiShuffleLUT_[bitmask]);
+            // auto outH16V = _mm_shuffle_epi8(h16V, h16ShuffleV);
+
+            // out = _mm_or_si128(out, outH16V);
+            _mm_storeu_si128((__m128i_u*)&dst[i + 8], out);
+
+            h16 += count16;
+            l += count16;
+            h8 += count8;
+
+            // lShuffleV =
+            //         _mm_load_si128((const __m128i*)&kLoShuffleLUT_[bitmask]);
+            // lShuffleV = _mm_add_epi8(lShuffleV, count16V);
+            // outLV     = _mm_shuffle_epi8(lV, lShuffleV);
+
+            // h8ShuffleV = _mm_load_si128(
+            //         (const __m128i*)&kLoShuffleLUT_[~bitmask & 0xFF]);
+            // h8ShuffleV = _mm_add_epi8(h8ShuffleV, count8V);
+            // outH8V     = _mm_shuffle_epi8(h8V, h8ShuffleV);
+
+            // out = _mm_or_si128(outLV, outH8V);
+
+            // h16ShuffleV =
+            //         _mm_load_si128((const __m128i*)&kHiShuffleLUT_[bitmask]);
+            // h16ShuffleV = _mm_add_epi8(h16ShuffleV, count16V);
+            // outH16V     = _mm_shuffle_epi8(h16V, h16ShuffleV);
+
+            // out = _mm_or_si128(out, outH16V);
+            // _mm_storeu_si128((__m128i_u*)&dst[i + 8], out);
+
+            // h16 += count16;
+            // l += count16;
+            // h8 += count8;
+        }
+
+        for (; i < dst.size(); ++i) {
+            if (getBit(bits.data(), i)) {
+                dst[i] = (uint16_t(*h16++) << 8) | *l++;
+            } else {
+                dst[i] = *h8++;
+            }
+        }
+    }
+
+   private:
+    static std::tuple<__m128i, __m128i, __m128i> getShuffles(uint8_t bitmap)
+    {
+        auto lV = _mm_load_si128((const __m128i*)&kLoShuffleLUT_[bitmap]);
+        auto h8V =
+                _mm_load_si128((const __m128i*)&kLoShuffleLUT_[~bitmap & 0xFF]);
+        auto h16V = _mm_load_si128((const __m128i*)&kHiShuffleLUT_[bitmap]);
+        return { lV, h8V, h16V };
+    }
+
+    static constexpr std::array<std::array<uint8_t, 16>, 256> makeShuffleLUT(
+            bool lo)
+    {
+        std::array<std::array<uint8_t, 16>, 256> lut{};
+        for (size_t byte = 0; byte < 256; ++byte) {
+            size_t offset = 0;
+            for (size_t bit = 0; bit < 8; ++bit) {
+                if ((byte & (1 << bit)) != 0) {
+                    if (lo) {
+                        lut[byte][2 * bit + 0] = offset;
+                        lut[byte][2 * bit + 1] = 0x80;
+                    } else {
+                        lut[byte][2 * bit + 0] = 0x80;
+                        lut[byte][2 * bit + 1] = offset;
+                    }
+                    ++offset;
+                } else {
+                    lut[byte][2 * bit + 0] = 0x80;
+                    lut[byte][2 * bit + 1] = 0x80;
+                }
+            }
+        }
+        return lut;
+    }
+
+    static constexpr std::array<std::array<uint8_t, 16>, 256>
+    makeLoHiShuffleLUT()
+    {
+        std::array<std::array<uint8_t, 16>, 256> lut{};
+        for (size_t byte = 0; byte < 256; ++byte) {
+            size_t offset = 0;
+            for (size_t bit = 0; bit < 8; ++bit) {
+                if ((byte & (1 << bit)) != 0) {
+                    lut[byte][2 * bit + 0] = offset + 0;
+                    lut[byte][2 * bit + 1] = offset + 1;
+                    offset += 2;
+                } else {
+                    lut[byte][2 * bit + 0] = 0x80;
+                    lut[byte][2 * bit + 1] = 0x80;
+                }
+            }
+        }
+        return lut;
+    }
+
+    static constexpr std::array<std::array<uint16_t, 8>, 256> makeIs16LUT()
+    {
+        std::array<std::array<uint16_t, 8>, 256> lut{};
+        for (size_t byte = 0; byte < 256; ++byte) {
+            for (size_t bit = 0; bit < 8; ++bit) {
+                lut[byte][bit] = ((byte & (1 << bit)) != 0) ? 0xFFFF : 0;
+            }
+        }
+        return lut;
+    }
+
+    alignas(16) static constexpr std::
+            array<std::array<uint16_t, 8>, 256> kIs16LUT_{ makeIs16LUT() };
+    alignas(16) static constexpr std::
+            array<std::array<uint8_t, 16>, 256> kLoShuffleLUT_{
+                makeShuffleLUT(true)
+            };
+    alignas(16) static constexpr std::
+            array<std::array<uint8_t, 16>, 256> kHiShuffleLUT_{
+                makeShuffleLUT(false)
+            };
+    alignas(16) static constexpr std::
+            array<std::array<uint8_t, 16>, 256> kLoHiShuffleLUT_{
+                makeLoHiShuffleLUT()
+            };
+};
+
+} // namespace
+
+VariableOutputCodecDescription IsoByteEncoder::variableOutputDescription() const
+{
+    return isoByteCodecDescription();
+}
+
+void IsoByteEncoder::encode(EncoderState& encoder) const
+{
+    auto& input = encoder.inputs()[0];
+
+    uint8_t header = input.eltWidth();
+    encoder.sendCodecHeader(&header, 1);
+
+    if (input.eltWidth() != 2) {
+        throw std::runtime_error("todo");
+    }
+
+    auto bitmap      = encoder.createOutput(0, (input.numElts() + 7) / 8, 1);
+    auto lowBytes    = encoder.createOutput(1, input.numElts(), 1);
+    auto highBytes8  = encoder.createOutput(2, input.numElts(), 1);
+    auto highBytes16 = encoder.createOutput(2, input.numElts(), 1);
+
+    const uint16_t* const src = (uint16_t*)input.ptr();
+    const size_t srcSize      = input.numElts();
+
+    uint8_t* bits = (uint8_t*)bitmap.ptr();
+    uint8_t* hi8  = (uint8_t*)highBytes8.ptr();
+    uint8_t* hi16 = (uint8_t*)highBytes16.ptr();
+    uint8_t* lo   = (uint8_t*)lowBytes.ptr();
+
+    memset(bits, 0, (srcSize + 7) / 8);
+
+    for (size_t i = 0; i < srcSize; ++i) {
+        if (src[i] < 256) {
+            *hi8++ = src[i];
+        } else {
+            setBit(bits, i);
+            *hi16++ = src[i] >> 8;
+            *lo++   = src[i] & 0xFF;
+        }
+    }
+    bitmap.commit((srcSize + 7) / 8);
+    highBytes8.commit(hi8 - (uint8_t*)highBytes8.ptr());
+    highBytes16.commit(hi16 - (uint8_t*)highBytes16.ptr());
+    lowBytes.commit(lo - (uint8_t*)lowBytes.ptr());
+}
+
+VariableOutputCodecDescription IsoByteDecoder::variableOutputDescription() const
+{
+    return isoByteCodecDescription();
+}
+
+void IsoByteDecoder::decode(DecoderState& decoder) const
+{
+    auto header = decoder.getCodecHeader();
+    if (header.size() != 1 || header[0] != 2) {
+        throw std::runtime_error("todo");
+    }
+    if (decoder.variableInputs().size() != 2) {
+        throw std::runtime_error("corruption");
+    }
+
+    auto& bitmap      = decoder.singletonInputs()[0];
+    auto& lowBytes    = decoder.singletonInputs()[1];
+    auto& highBytes8  = decoder.variableInputs()[0];
+    auto& highBytes16 = decoder.variableInputs()[1];
+
+    const size_t srcSize = highBytes8.numElts() + highBytes16.numElts();
+    auto output          = decoder.createOutput(0, srcSize, 2);
+
+    IsoByteDecode<uint16_t>::decode(
+            { (uint16_t*)output.ptr(), srcSize },
+            { (const uint8_t*)bitmap.ptr(), bitmap.numElts() },
+            { (const uint8_t*)lowBytes.ptr(), lowBytes.numElts() },
+            { (const uint8_t*)highBytes8.ptr(), highBytes8.numElts() },
+            { (const uint8_t*)highBytes16.ptr(), highBytes16.numElts() });
+
+    output.commit(srcSize);
+}
+
+} // namespace openzl::lz

--- a/contrib/lz-research/codecs/IsoByte.hpp
+++ b/contrib/lz-research/codecs/IsoByte.hpp
@@ -1,0 +1,27 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#pragma once
+
+#include <openzl/openzl.hpp>
+
+namespace openzl::lz {
+
+class IsoByteEncoder : public CustomEncoder {
+   public:
+    VariableOutputCodecDescription variableOutputDescription() const override;
+
+    void encode(EncoderState& encoder) const override;
+
+    ~IsoByteEncoder() override = default;
+};
+
+class IsoByteDecoder : public CustomDecoder {
+   public:
+    VariableOutputCodecDescription variableOutputDescription() const override;
+
+    void decode(DecoderState& decoder) const override;
+
+    ~IsoByteDecoder() override = default;
+};
+
+} // namespace openzl::lz

--- a/contrib/lz-research/codecs/Lz.cpp
+++ b/contrib/lz-research/codecs/Lz.cpp
@@ -1,0 +1,786 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#include "Lz.hpp"
+
+#include "openzl/codecs/common/copy.h"
+#include "openzl/codecs/common/fast_table.h"
+#include "openzl/shared/portability.h"
+#include "openzl/shared/utils.h"
+#include "openzl/shared/varint.h"
+#include "openzl/zl_errors.h"
+
+#include "CodecIDs.hpp"
+
+namespace openzl::lz {
+
+using offset_t               = uint16_t;
+size_t constexpr kMinMatch   = 7;
+size_t constexpr kSmallMatch = 5;
+size_t constexpr kLargeMatch = 8;
+
+inline uint32_t
+matchLength(uint8_t const* match, uint8_t const* ip, uint8_t const* iend)
+{
+    uint32_t len = 0;
+    while (ip + len < iend && ip[len] == match[len]) {
+        ++len;
+    }
+    // if (ip - match < len) {
+    //   len = ip - match;
+    // }
+    return len;
+}
+
+template <bool kIsIndex, size_t kLLBits, size_t kMLBits>
+class Transform {
+    static uint8_t constexpr kLLMask = ((1 << kLLBits) - 1);
+    static uint8_t constexpr kMLMask = ((1 << kMLBits) - 1);
+
+    static_assert(!kIsIndex, "Currently unsupported");
+
+    template <typename T>
+    static ZL_Report
+    writeStream(ZL_Encoder* eictx, size_t idx, std::vector<T> const& data)
+    {
+        ZL_RESULT_DECLARE_SCOPE_REPORT(eictx);
+
+        auto stream = ZL_Encoder_createTypedStream(
+                eictx, idx, data.size(), sizeof(T));
+        ZL_ERR_IF_NULL(stream, allocation);
+        memcpy(ZL_Output_ptr(stream), data.data(), data.size() * sizeof(T));
+        ZL_ERR_IF_ERR(ZL_Output_commit(stream, data.size()));
+        return ZL_returnSuccess();
+    }
+
+   public:
+    static void encode1(
+            std::vector<uint8_t>& lits,
+            std::vector<uint32_t>& litLens,
+            std::vector<offset_t>& offsets,
+            std::vector<uint32_t>& matchLens,
+            uint8_t const* const istart,
+            uint8_t const* const iend)
+    {
+        auto mem = std::make_unique<uint8_t[]>(ZS_FastTable_tableSize(14));
+        ZS_FastTable table{};
+        ZS_FastTable_init(&table, mem.get(), 14, kMinMatch);
+        uint8_t const* anchor       = istart;
+        uint8_t const* ip           = istart + 1;
+        uint8_t const* const ilimit = iend - (kMinMatch + 1);
+
+        while (ip < ilimit) {
+            uint8_t const* match = istart
+                    + ZS_FastTable_getAndUpdateT(
+                                           &table, ip, ip - istart, kMinMatch);
+            uint32_t const distance = ip - match;
+            if (ZL_read32(match) == ZL_read32(ip)
+                && ZL_uintFits(distance, sizeof(offset_t))) {
+                uint32_t ml = matchLength(match, ip, iend);
+                while (match > istart && ip > anchor && match[-1] == ip[-1]) {
+                    --match;
+                    --ip;
+                    ++ml;
+                }
+                uint32_t const ll = ip - anchor;
+                offset_t const offset =
+                        kIsIndex ? (match - istart) : (ip - match);
+
+                lits.insert(lits.end(), anchor, ip);
+                litLens.push_back(ll);
+                offsets.push_back(offset);
+                matchLens.push_back(ml);
+                ZS_FastTable_putT(&table, ip + 2, ip + 2 - istart, kMinMatch);
+                ip += ml;
+                if (ip < ilimit) {
+                    ZS_FastTable_putT(
+                            &table, ip - 2, ip - 2 - istart, kMinMatch);
+                }
+                anchor = ip;
+            } else {
+                ip += 1;
+            }
+        }
+        lits.insert(lits.end(), anchor, iend);
+    }
+
+    static void encode2(
+            std::vector<uint8_t>& lits,
+            std::vector<uint32_t>& litLens,
+            std::vector<offset_t>& offsets,
+            std::vector<uint32_t>& matchLens,
+            uint8_t const* const istart,
+            uint8_t const* const iend)
+    {
+        auto smallMem = std::make_unique_for_overwrite<uint8_t[]>(
+                ZS_FastTable_tableSize(16));
+        auto largeMem = std::make_unique_for_overwrite<uint8_t[]>(
+                ZS_FastTable_tableSize(17));
+        ZS_FastTable smallT{};
+        ZS_FastTable_init(&smallT, smallMem.get(), 16, kSmallMatch);
+        ZS_FastTable largeT{};
+        ZS_FastTable_init(&largeT, largeMem.get(), 17, kLargeMatch);
+        uint8_t const* anchor       = istart;
+        uint8_t const* ip           = istart + 1;
+        uint8_t const* const ilimit = iend - kLargeMatch;
+
+        auto emitMatch = [&](uint8_t const* match, uint8_t const* ptr) {
+            uint32_t ml = matchLength(match, ptr, iend);
+            if (ml < 4) {
+                ZL_REQUIRE(false);
+                ++ip;
+                return;
+            }
+            ZL_ASSERT_GE(
+                    ml,
+                    4,
+                    "%u to %u",
+                    unsigned(match - istart),
+                    unsigned(ptr - istart));
+            while (match > istart && ptr > anchor && match[-1] == ptr[-1]) {
+                --match;
+                --ptr;
+                ++ml;
+            }
+            uint32_t const ll     = ptr - anchor;
+            offset_t const offset = kIsIndex ? (match - istart) : (ptr - match);
+
+            lits.insert(lits.end(), anchor, ptr);
+            litLens.push_back(ll);
+            offsets.push_back(offset);
+            matchLens.push_back(ml);
+            //   ZS_FastTable_putT(&largeT, ip + 1, ip + 1 - istart,
+            //   kLargeMatch);
+
+            ZS_FastTable_putT(&smallT, ip + 2, ip + 2 - istart, kSmallMatch);
+            ZS_FastTable_putT(&largeT, ip + 2, ip + 2 - istart, kLargeMatch);
+
+            ip     = ptr + ml;
+            anchor = ip;
+
+            if (ip <= ilimit) {
+                ZS_FastTable_putT(
+                        &smallT, ip - 1, ip - 1 - istart, kSmallMatch);
+                ZS_FastTable_putT(
+                        &largeT, ip - 2, ip - 2 - istart, kLargeMatch);
+            }
+        };
+        while (ip < ilimit) {
+            uint8_t const* matchL =
+                    istart
+                    + ZS_FastTable_getAndUpdateT(
+                            &largeT, ip, ip - istart, kLargeMatch);
+            uint8_t const* matchS =
+                    istart
+                    + ZS_FastTable_getAndUpdateT(
+                            &smallT, ip, ip - istart, kSmallMatch);
+            if (ZL_read64(matchL) == ZL_read64(ip)
+                && ZL_uintFits(ip - matchL, sizeof(offset_t))) {
+                ZS_FastTable_putT(
+                        &largeT, ip + 1, ip + 1 - istart, kLargeMatch);
+                emitMatch(matchL, ip);
+            } else if (
+                    ZL_read32(matchS) == ZL_read32(ip)
+                    && ZL_uintFits(ip - matchS, sizeof(offset_t))) {
+                uint8_t const* matchL1 =
+                        istart
+                        + ZS_FastTable_getAndUpdateT(
+                                &largeT, ip + 1, ip + 1 - istart, kLargeMatch);
+                if (ZL_read64(matchL1) == ZL_read64(ip + 1)
+                    && ZL_uintFits(ip + 1 - matchL1, sizeof(offset_t))) {
+                    emitMatch(matchL1, ip + 1);
+                } else {
+                    emitMatch(matchS, ip);
+                }
+            } else {
+                ip += 1;
+            }
+        }
+
+        lits.insert(lits.end(), anchor, iend);
+    }
+
+    static ZL_Report encode(ZL_Encoder* eictx, ZL_Input const* input) noexcept
+    {
+        ZL_RESULT_DECLARE_SCOPE_REPORT(eictx);
+        if (kIsIndex && ZL_Input_numElts(input) >= 65536) {
+            ZL_ERR(GENERIC, "Input too large for index mode");
+        }
+
+        auto level = ZL_Encoder_getCParam(eictx, ZL_CParam_compressionLevel);
+
+        std::vector<uint8_t> lits;
+        std::vector<uint32_t> litLens;
+        std::vector<uint32_t> matchLens;
+        std::vector<offset_t> offsets;
+        uint8_t const* const istart = (uint8_t const*)ZL_Input_ptr(input);
+        uint8_t const* const iend   = istart + ZL_Input_numElts(input);
+
+        if (level == 1) {
+            encode1(lits, litLens, offsets, matchLens, istart, iend);
+        } else {
+            encode2(lits, litLens, offsets, matchLens, istart, iend);
+        }
+
+        std::array<uint32_t, 256> llStats{ 0 };
+        std::array<uint32_t, 256> mlStats{ 0 };
+        for (size_t i = 0; i < litLens.size(); ++i) {
+            ++llStats[std::min<uint32_t>(litLens[i], 255)];
+            ++mlStats[std::min<uint32_t>(matchLens[i], 255)];
+        }
+
+        size_t llParam = ZL_Encoder_getLocalIntParam(eictx, 0).paramValue;
+        if (llParam == 0) {
+            size_t bestLLBits    = 0;
+            size_t bestExtraLens = 2 * litLens.size() + 1;
+            for (size_t llBits = 1; llBits < 8; ++llBits) {
+                const size_t mlBits = 8 - llBits;
+                const size_t llMask = (1u << llBits) - 1;
+                const size_t mlMask = (1u << mlBits) - 1;
+
+                size_t numExtraLL = 0;
+                for (size_t i = llMask; i < llStats.size(); ++i) {
+                    numExtraLL += llStats[i];
+                }
+                size_t numExtraML = 0;
+                for (size_t i = mlMask; i < mlStats.size(); ++i) {
+                    numExtraML += mlStats[i];
+                }
+                size_t numExtraLens = numExtraLL + numExtraML;
+
+                // Need some way to take branch predictibility into account.
+                // Weigh in favor of predictable branches when it is relatively
+                // close.
+                const size_t predictableCutoff = litLens.size() / 64;
+                if (numExtraLL < predictableCutoff) {
+                    numExtraLens -= numExtraLens / 16;
+                }
+                if (numExtraML < predictableCutoff) {
+                    numExtraLens -= numExtraLens / 16;
+                }
+
+                // fprintf(stderr,
+                //         "%zu: %zu -> %zu = %zu + %zu (%zu)\n",
+                //         litLens.size(),
+                //         llBits,
+                //         numExtraLens,
+                //         numExtraLL,
+                //         numExtraML,
+                //         bestExtraLens);
+                if (numExtraLens < bestExtraLens) {
+                    bestExtraLens = numExtraLens;
+                    bestLLBits    = llBits;
+                }
+            }
+            llParam = bestLLBits;
+        }
+
+        size_t llBits = llParam;
+        size_t mlBits = 8 - llBits;
+        // fprintf(stderr, "Selected llbits = %zu\n", llBits);
+
+        std::vector<uint8_t> tokens;
+        std::vector<uint32_t> extraLens;
+        tokens.reserve(litLens.size());
+
+        const uint32_t llMask = (1u << llBits) - 1;
+        const uint32_t mlMask = (1u << mlBits) - 1;
+
+        for (size_t i = 0; i < litLens.size(); ++i) {
+            const uint32_t ll     = litLens[i];
+            const uint32_t ml     = matchLens[i];
+            uint8_t const llToken = ll < llMask ? ll : llMask;
+            uint8_t const mlToken = ml < mlMask ? ml : mlMask;
+            uint8_t const token   = llToken | (mlToken << llBits);
+
+            tokens.push_back(token);
+            if (llToken == llMask) {
+                extraLens.push_back(ll - llMask);
+            }
+            if (mlToken == mlMask) {
+                extraLens.push_back(ml - mlMask);
+            }
+        }
+
+        uint8_t header[ZL_VARINT_LENGTH_64 + 1];
+        header[0]               = llBits | (mlBits << 4);
+        uint32_t const srcSize  = ZL_Input_numElts(input);
+        const size_t headerSize = 1 + ZL_varintEncode(srcSize, header + 1);
+        ZL_Encoder_sendCodecHeader(eictx, &header, headerSize);
+
+        ZL_ERR_IF_ERR(writeStream(eictx, 0, lits));
+        ZL_ERR_IF_ERR(writeStream(eictx, 1, tokens));
+        ZL_ERR_IF_ERR(writeStream(eictx, 2, offsets));
+        ZL_ERR_IF_ERR(writeStream(eictx, 3, extraLens));
+
+        return ZL_returnSuccess();
+    }
+
+    template <size_t kLen>
+    static void copy(void* dst, void const* src)
+    {
+        char tmp[kLen];
+        memcpy(tmp, src, kLen);
+        memcpy(dst, tmp, kLen);
+    }
+
+   public:
+    static size_t decodeImpl2(
+            uint8_t const* __restrict lits,
+            size_t numLits,
+            uint8_t const* __restrict tokens,
+            offset_t const* __restrict offsets,
+            uint32_t const* __restrict extraLens,
+            size_t numSeqs,
+            uint8_t* __restrict out,
+            size_t outCapacity)
+    {
+        ZL_REQUIRE(kIsIndex);
+        static_assert(kLLBits + kMLBits == 8, "");
+        uint8_t* const base           = out;
+        auto litEnd                   = lits + numLits;
+        uint8_t const* const outLimit = out + outCapacity
+                - 4 * std::max(16, 1 << std::max(kLLBits, kMLBits));
+        uint8_t const* const litLimit =
+                lits + numLits - 4 * std::max(16, 1 << kLLBits);
+        size_t i = 0;
+        for (;;) {
+            if (i + 4 > numSeqs) {
+                break;
+            }
+            if (out > outLimit) {
+                break;
+            }
+            if (lits > litLimit) {
+                break;
+            }
+            std::array<std::array<uint8_t, 1 << kMLBits>, 4> matches;
+#pragma clang loop unroll(full)
+            for (size_t u = 0; u < 4; ++u) {
+                memcpy(matches[u].data(), base + offsets[i + u], 1 << kMLBits);
+            }
+
+            // TODO: If I control this loop carefully with intrinsics, can it be
+            // faster?
+#pragma clang loop unroll(full)
+            for (size_t u = 0; u < 4; ++u) {
+                size_t ll = tokens[i] & kLLMask;
+                size_t ml = (tokens[i] >> kLLBits) & kMLMask;
+                memcpy(out, lits, 1 << kLLBits);
+                if (ZL_UNLIKELY(ll == kLLMask)) {
+                    memcpy(out + kLLMask, lits + kLLMask, *extraLens);
+                    ll += *extraLens++;
+                    if (ZL_UNLIKELY(
+                                out + ll > outLimit || lits + ll > litLimit)) {
+                        out += ll;
+                        lits += ll;
+                        if (ZL_UNLIKELY(ml == kMLMask)) {
+                            ml += *extraLens++;
+                        }
+                        memcpy(out, base + offsets[i], ml);
+                        out += ml;
+                        ++i;
+                        break;
+                    }
+                }
+                out += ll;
+                lits += ll;
+
+                memcpy(out, matches[u].data(), 1 << kMLBits);
+                if (ZL_UNLIKELY(ml == kMLMask)) {
+                    memcpy(out + kMLMask,
+                           base + offsets[i] + kMLMask,
+                           *extraLens);
+                    ml += *extraLens++;
+                    if (ZL_UNLIKELY(out + ml > outLimit)) {
+                        out += ml;
+                        ++i;
+                        break;
+                    }
+                }
+                out += ml;
+                ++i;
+            }
+        }
+        while (i < numSeqs) {
+            size_t ll = tokens[i] & kLLMask;
+            size_t ml = (tokens[i] >> kLLBits) & kMLMask;
+            if (ll == kLLMask) {
+                ll += *extraLens++;
+            }
+            if (ml == kMLMask) {
+                ml += *extraLens++;
+            }
+            memcpy(out, lits, ll);
+            out += ll;
+            lits += ll;
+            uint8_t const* const match =
+                    kIsIndex ? base + offsets[i] : out - offsets[i];
+            memcpy(out, match, ml);
+            out += ml;
+            ++i;
+        }
+        memcpy(out, lits, (litEnd - lits));
+        out += litEnd - lits;
+        return out - base;
+    }
+
+    // TODO: Lost speed here when fixing it
+    static size_t decodeImpl(
+            uint8_t const* __restrict lits,
+            size_t numLits,
+            uint8_t const* __restrict tokens,
+            offset_t const* __restrict offsets,
+            uint32_t const* __restrict extraLens,
+            size_t numSeqs,
+            uint8_t* __restrict out,
+            size_t outCapacity)
+    {
+        static_assert(kLLBits + kMLBits == 8, "");
+        uint8_t* const base           = out;
+        auto litEnd                   = lits + numLits;
+        uint8_t const* const outLimit = out + outCapacity
+                - std::max(16, 1 << std::max(kLLBits, kMLBits)) - 16;
+        uint8_t const* const litLimit =
+                lits + numLits - std::max(16, 1 << kLLBits);
+        for (size_t i = 0; i < numSeqs; ++i) {
+            size_t ll = tokens[i] & kLLMask;
+            size_t ml = (tokens[i] >> kLLBits) & kMLMask;
+            if (ZL_LIKELY(out < outLimit && lits < litLimit)) {
+                copy<1 << kLLBits>(out, lits);
+            } else {
+                ZS_safecopy(out, lits, ll, ZS_wo_no_overlap);
+            }
+            if (ZL_UNLIKELY(ll == kLLMask)) {
+                ll += *extraLens;
+                if (ZL_LIKELY(out + ll <= outLimit && lits + ll <= litLimit)) {
+                    ZS_wildcopy(
+                            out + kLLMask,
+                            lits + kLLMask,
+                            *extraLens,
+                            ZS_wo_no_overlap);
+                } else {
+                    ZS_safecopy(
+                            out + kLLMask,
+                            lits + kLLMask,
+                            *extraLens,
+                            ZS_wo_no_overlap);
+                }
+                ++extraLens;
+            }
+            lits += ll;
+            out += ll;
+            uint8_t const* const match =
+                    kIsIndex ? base + offsets[i] : out - offsets[i];
+            if (ZL_LIKELY(out < outLimit)) {
+                // copy<1 << kMLBits>(out, match);
+                if (ZL_LIKELY(offsets[i] >= 16)) {
+                    for (size_t i_2 = 0; i_2 < (1 << kMLBits); i_2 += 16) {
+                        memcpy(out + i_2, match + i_2, 16);
+                    }
+                } else {
+                    ZS_wildcopy(out, match, 1 << kMLBits, ZS_wo_src_before_dst);
+                }
+            } else {
+                ZS_safecopy(out, match, ml, ZS_wo_src_before_dst);
+            }
+            if (ZL_UNLIKELY(ml == kMLMask)) {
+                ml += *extraLens;
+                if (ZL_LIKELY(out + ml <= outLimit)) {
+                    ZS_wildcopy(
+                            out + kMLMask,
+                            match + kMLMask,
+                            *extraLens,
+                            ZS_wo_src_before_dst);
+                } else {
+                    ZS_safecopy(
+                            out + kMLMask,
+                            match + kMLMask,
+                            *extraLens,
+                            ZS_wo_src_before_dst);
+                }
+                ++extraLens;
+            }
+            out += ml;
+        }
+        memcpy(out, lits, (litEnd - lits));
+        out += litEnd - lits;
+        return out - base;
+    }
+
+   private:
+    static ZL_Report decode(
+            ZL_Decoder* dictx,
+            ZL_Input const* inputs[]) noexcept
+    {
+        ZL_RESULT_DECLARE_SCOPE_REPORT(dictx);
+
+        auto lits      = inputs[0];
+        auto tokens    = inputs[1];
+        auto offsets   = inputs[2];
+        auto extraLens = inputs[3];
+
+        auto header      = ZL_Decoder_getCodecHeader(dictx);
+        const uint8_t* h = (const uint8_t*)header.start;
+        ZL_ERR_IF_LT(header.size, 2, corruption);
+        auto llBits = *h & 0xf;
+        ++h;
+        ZL_TRY_LET_CONST(
+                uint64_t, srcSize, ZL_varintDecode(&h, h + header.size - 1));
+
+        ZL_Output* out = ZL_Decoder_create1OutStream(dictx, srcSize, 1);
+        // auto impl = kIsIndex ? decodeImpl2 : decodeImpl;
+
+        auto impl = decodeImpl;
+        if (llBits == 1) {
+            impl = Transform<kIsIndex, 1, 8 - 1>::decodeImpl;
+        } else if (llBits == 2) {
+            impl = Transform<kIsIndex, 2, 8 - 2>::decodeImpl;
+        } else if (llBits == 3) {
+            impl = Transform<kIsIndex, 3, 8 - 3>::decodeImpl;
+        } else if (llBits == 4) {
+            impl = Transform<kIsIndex, 4, 8 - 4>::decodeImpl;
+        } else if (llBits == 5) {
+            impl = Transform<kIsIndex, 5, 8 - 5>::decodeImpl;
+        } else {
+            ZL_ERR(GENERIC, "Unsupported LLBits %u", llBits);
+        }
+        size_t const size =
+                impl((uint8_t const*)ZL_Input_ptr(lits),
+                     ZL_Input_numElts(lits),
+                     (uint8_t const*)ZL_Input_ptr(tokens),
+                     (offset_t const*)ZL_Input_ptr(offsets),
+                     (uint32_t const*)ZL_Input_ptr(extraLens),
+                     ZL_Input_numElts(tokens),
+                     (uint8_t*)ZL_Output_ptr(out),
+                     srcSize);
+        ZL_ERR_IF_ERR(ZL_Output_commit(out, srcSize));
+        ZL_ERR_IF_NE(size, srcSize, corruption);
+
+        return ZL_returnSuccess();
+    }
+
+    static std::array<ZL_Type, 4> constexpr kOutTypes = {
+        ZL_Type_serial,
+        ZL_Type_serial,
+        ZL_Type_numeric,
+        ZL_Type_numeric,
+    };
+
+    static ZL_TypedGraphDesc gd()
+    {
+        ZL_TypedGraphDesc desc = { .CTid = int(CustomCodecIDs::LZ)
+                                           | (kIsIndex ? 1 : 0),
+                                   .inStreamType   = ZL_Type_serial,
+                                   .outStreamTypes = kOutTypes.data(),
+                                   .nbOutStreams   = kOutTypes.size() };
+        return desc;
+    }
+
+   public:
+    static ZL_NodeID create(ZL_Compressor* cgraph, LzParameters params)
+    {
+        ZL_NodeID node = ZL_Compressor_getNode(cgraph, "lz_research.lz");
+        if (node == ZL_NODE_ILLEGAL) {
+            ZL_TypedEncoderDesc desc = {
+                .gd          = gd(),
+                .transform_f = encode,
+                .name        = "!lz_research.lz",
+            };
+            node = ZL_Compressor_registerTypedEncoder(cgraph, &desc);
+        }
+        LocalParams lp;
+        lp.addIntParam(0, params.llBits);
+        return ZL_Compressor_cloneNode(cgraph, node, lp.get());
+    }
+
+    // static ZL_GraphID storeGraph(ZL_Compressor* cgraph)
+    // {
+    //     auto node                     = create(cgraph);
+    //     std::array<ZL_GraphID, 4> out = {
+    //         ZL_GRAPH_STORE, ZL_GRAPH_STORE, ZL_GRAPH_STORE,
+    //         ZL_GRAPH_STORE
+    //     };
+    //     return ZL_Compressor_registerStaticGraph_fromNode(
+    //             cgraph, node, out.data(), out.size());
+    // }
+
+    // static ZL_GraphID compressGraph(ZL_Compressor* cgraph, bool fast)
+    // {
+    //     std::array<ZL_GraphID, 2> q = { ZL_GRAPH_FSE, ZL_GRAPH_STORE };
+    //     ZL_GraphID const quantize =
+    //     ZL_Compressor_registerStaticGraph_fromNode(
+    //             cgraph, ZL_NODE_QUANTIZE_LENGTHS, q.data(), q.size());
+    //     auto node = create(cgraph);
+    //     // std::array<ZL_GraphID, 4> out = {
+    //     //     ZL_GRAPH_HUFFMAN, ZL_GRAPH_HUFFMAN, ZL_GRAPH_STORE,
+    //     quantize}; std::array<ZL_GraphID, 4> out = {
+    //         ZL_GRAPH_HUFFMAN,
+    //         ZL_GRAPH_HUFFMAN,
+    //         fast ? ZL_GRAPH_STORE : varByteGraph(cgraph),
+    //         smallIntGraph(
+    //                 cgraph, fast ? ZL_GRAPH_STORE : ZL_GRAPH_HUFFMAN,
+    //                 quantize)
+    //     };
+    //     return ZL_Compressor_registerStaticGraph_fromNode(
+    //             cgraph, node, out.data(), out.size());
+    // }
+
+    // static ZL_GraphID lz4Graph(ZL_Compressor* cgraph, bool huff)
+    // {
+    //     std::array<ZL_GraphID, 2> q = { ZL_GRAPH_FSE, ZL_GRAPH_STORE };
+    //     ZL_Compressor_registerStaticGraph_fromNode(
+    //             cgraph, ZL_NODE_QUANTIZE_LENGTHS, q.data(), q.size());
+    //     auto node      = create(cgraph);
+    //     auto rangePack = ZL_Compressor_registerStaticGraph_fromNode1o(
+    //             cgraph, ZL_NODE_RANGE_PACK, ZL_GRAPH_STORE);
+    //     // std::array<ZL_GraphID, 4> out = {
+    //     //     ZL_GRAPH_STORE, ZL_GRAPH_STORE, ZL_GRAPH_STORE, quantize};
+    //     std::array<ZL_GraphID, 4> out = {
+    //         huff ? ZL_GRAPH_HUFFMAN : ZL_GRAPH_STORE,
+    //         ZL_GRAPH_STORE,
+    //         ZL_GRAPH_STORE,
+    //         smallIntGraph(cgraph, ZL_GRAPH_STORE, rangePack)
+    //     };
+    //     return ZL_Compressor_registerStaticGraph_fromNode(
+    //             cgraph, node, out.data(), out.size());
+    // }
+
+   public:
+    static void registerDecoder(ZL_DCtx* dctx)
+    {
+        ZL_TypedDecoderDesc desc = {
+            .gd          = gd(),
+            .transform_f = decode,
+            .name        = "!zl_research.lz",
+        };
+        ZL_REQUIRE_SUCCESS(ZL_DCtx_registerTypedDecoder(dctx, &desc));
+    }
+
+    // static char const* str(Mode mode)
+    // {
+    //     switch (mode) {
+    //         case Mode::kStore:
+    //             return "store";
+    //             break;
+    //         case Mode::kLz4:
+    //             return "lz4";
+    //             break;
+    //         case Mode::kLz4Huf:
+    //             return "lz4-huf";
+    //             break;
+    //         case Mode::kZstdFast:
+    //             return "zstd-fast";
+    //             break;
+    //         case Mode::kZstdSlow:
+    //             return "zstd-slow";
+    //             break;
+    //     };
+    // }
+
+    // static std::vector<uint8_t>
+    // compress(uint8_t const* src, size_t srcSize, Mode mode, int level)
+    // {
+    //     std::vector<uint8_t> compressed(srcSize * 4);
+    //     auto cgraph = ZL_Compressor_create();
+    //     ZL_GraphID graph;
+    //     switch (mode) {
+    //         case Mode::kStore:
+    //             graph = storeGraph(cgraph);
+    //             break;
+    //         case Mode::kLz4:
+    //             graph = lz4Graph(cgraph, false);
+    //             break;
+    //         case Mode::kLz4Huf:
+    //             graph = lz4Graph(cgraph, true);
+    //             break;
+    //         case Mode::kZstdFast:
+    //             graph = compressGraph(cgraph, true);
+    //             break;
+    //         case Mode::kZstdSlow:
+    //             graph = compressGraph(cgraph, false);
+    //             break;
+    //     };
+    //     // auto graph = store ? storeGraph(cgraph) : lz4Graph(cgraph);
+    //     ZL_REQUIRE_SUCCESS(ZL_Compressor_selectStartingGraphID(cgraph,
+    //     graph)); ZL_REQUIRE_SUCCESS(ZL_Compressor_setParameter(
+    //             cgraph, ZL_CParam_formatVersion, ZL_MAX_FORMAT_VERSION));
+    //     ZL_REQUIRE_SUCCESS(ZL_Compressor_setParameter(
+    //             cgraph, ZL_CParam_compressedChecksum,
+    //             ZL_TernaryParam_disable));
+    //     ZL_REQUIRE_SUCCESS(ZL_Compressor_setParameter(
+    //             cgraph, ZL_CParam_contentChecksum,
+    //             ZL_TernaryParam_disable));
+    //     ZL_REQUIRE_SUCCESS(ZL_Compressor_setParameter(
+    //             cgraph, ZL_CParam_compressionLevel, level));
+    //     auto ret = ZL_compress_usingCompressor(
+    //             compressed.data(), compressed.size(), src, srcSize,
+    //             cgraph);
+    //     ZL_REQUIRE_SUCCESS(ret);
+    //     ZL_Compressor_free(cgraph);
+    //     compressed.resize(ZL_validResult(ret));
+    //     return compressed;
+    // }
+
+    // static void
+    // benchmark(uint8_t const* src, size_t srcSize, Mode mode, int level)
+    // {
+    //     auto compressed = compress(src, srcSize, mode, level);
+    //     std::vector<uint8_t> decompressed(srcSize);
+    //     ZL_DCtx* dctx = ZL_DCtx_create();
+    //     ZL_REQUIRE_SUCCESS(
+    //             ZL_DCtx_setStreamArena(dctx, ZL_DataArenaType_stack));
+    //     registerCustomTransforms(dctx);
+    //     auto start = std::chrono::steady_clock::now();
+    //     for (size_t i = 0; i < kIters; ++i) {
+    //         ZL_REQUIRE_SUCCESS(ZL_DCtx_decompress(
+    //                 dctx,
+    //                 decompressed.data(),
+    //                 decompressed.size(),
+    //                 compressed.data(),
+    //                 compressed.size()));
+    //     }
+    //     auto stop                         =
+    //     std::chrono::steady_clock::now(); std::chrono::nanoseconds
+    //     duration = stop - start; double const mbps  = (srcSize * kIters *
+    //     1000.0) / duration.count(); double const ratio = double(srcSize)
+    //     / compressed.size(); ZL_REQUIRE(!memcmp(src, decompressed.data(),
+    //     srcSize)); fprintf(stderr,
+    //             "llbits = %zu, mlbits = %zu, index = %u, mode = %9s,
+    //             level = %d, ratio = %.2f, MB/s = %.2f\n", kLLBits,
+    //             kMLBits, unsigned(kIsIndex ? 1 : 0), str(mode), level,
+    //             ratio,
+    //             mbps);
+    //     ZL_DCtx_free(dctx);
+    // }
+
+    // static void write(
+    //         char const* prefix,
+    //         uint8_t const* src,
+    //         size_t srcSize,
+    //         Mode mode,
+    //         int level)
+    // {
+    //     auto name = fmt::format(
+    //             "{}.{}.{}.{}.{}.{}.zs",
+    //             prefix,
+    //             str(mode),
+    //             level,
+    //             kIsIndex ? 1 : 0,
+    //             kLLBits,
+    //             kMLBits);
+    //     auto compressed = compress(src, srcSize, mode, level);
+    //     ZL_REQUIRE(folly::writeFile(compressed, name.c_str()));
+    // }
+};
+
+NodeID registerLz(Compressor& compressor, LzParameters params)
+{
+    return Transform<false, 0, 8>::create(compressor.get(), params);
+}
+
+void registerLz(DCtx& dctx)
+{
+    Transform<false, 0, 8>::registerDecoder(dctx.get());
+}
+
+} // namespace openzl::lz

--- a/contrib/lz-research/codecs/Lz.hpp
+++ b/contrib/lz-research/codecs/Lz.hpp
@@ -1,0 +1,17 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#pragma once
+
+#include <openzl/openzl.hpp>
+
+namespace openzl::lz {
+
+struct LzParameters {
+    int llBits{ 3 };
+};
+
+NodeID registerLz(Compressor& compressor, LzParameters params);
+
+void registerLz(DCtx& dctx);
+
+} // namespace openzl::lz

--- a/contrib/lz-research/codecs/SmallInt.cpp
+++ b/contrib/lz-research/codecs/SmallInt.cpp
@@ -1,0 +1,161 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#include "SmallInt.hpp"
+#include "CodecIDs.hpp"
+
+#include "openzl/common/assertion.h"
+#include "openzl/shared/mem.h"
+#include "openzl/shared/portability.h"
+#include "openzl/shared/simd_wrapper.h"
+
+namespace openzl::lz {
+namespace {
+SimpleCodecDescription smallIntCodecDescription()
+{
+    return SimpleCodecDescription{
+        .id          = unsigned(CustomCodecIDs::SmallInt),
+        .name        = "!lz_research.small_int",
+        .inputType   = Type::Numeric,
+        .outputTypes = { Type::Serial, Type::Numeric },
+    };
+}
+} // namespace
+
+SimpleCodecDescription SmallIntEncoder::simpleCodecDescription() const
+{
+    return smallIntCodecDescription();
+}
+
+void SmallIntEncoder::encode(EncoderState& encoder) const
+{
+    auto& input         = encoder.inputs()[0];
+    auto const nbElts   = input.numElts();
+    auto const eltWidth = input.eltWidth();
+    auto smallStream    = encoder.createOutput(0, nbElts, 1);
+    auto largeStream    = encoder.createOutput(1, nbElts, eltWidth);
+
+    uint8_t* const smallOut = (uint8_t*)smallStream.ptr();
+
+    auto const encodeImpl = [nbElts, smallOut](auto* largeOut, auto const* in) {
+        size_t nbLarge = 0;
+        for (size_t i = 0; i < nbElts; ++i) {
+            if (in[i] < 255) {
+                smallOut[i] = in[i];
+            } else {
+                smallOut[i]         = 255;
+                largeOut[nbLarge++] = in[i] - 255;
+            }
+        }
+        return nbLarge;
+    };
+
+    size_t nbLarge;
+    void* largePtr    = largeStream.ptr();
+    void const* inPtr = input.ptr();
+    switch (eltWidth) {
+        case 1:
+            memcpy(smallOut, inPtr, nbElts);
+            nbLarge = 0;
+            break;
+        case 2:
+            nbLarge = encodeImpl((uint16_t*)largePtr, (uint16_t const*)inPtr);
+            break;
+        case 4:
+            nbLarge = encodeImpl((uint32_t*)largePtr, (uint32_t const*)inPtr);
+            break;
+        case 8:
+            nbLarge = encodeImpl((uint64_t*)largePtr, (uint64_t const*)inPtr);
+            break;
+    };
+
+    smallStream.commit(nbElts);
+    largeStream.commit(nbLarge);
+}
+
+SimpleCodecDescription SmallIntDecoder::simpleCodecDescription() const
+{
+    return smallIntCodecDescription();
+}
+
+void SmallIntDecoder::decode(DecoderState& decoder) const
+{
+    auto& smallStream = decoder.singletonInputs()[0];
+    auto& largeStream = decoder.singletonInputs()[1];
+
+    size_t const nbElts   = smallStream.numElts();
+    size_t const eltWidth = largeStream.eltWidth();
+    size_t const nbLarge  = largeStream.numElts();
+
+    auto outStream = decoder.createOutput(0, nbElts, eltWidth);
+
+    uint8_t const* const smallIn = (uint8_t const*)smallStream.ptr();
+
+    auto decodeImpl = [&decoder, nbElts, nbLarge](
+                              auto* out,
+                              uint8_t const* __restrict smallIn,
+                              auto const* largeIn) {
+        size_t const nbLargeNeeded =
+                std::count_if(smallIn, smallIn + nbElts, [](uint8_t val) {
+                    return val == 255;
+                });
+        if (nbLarge != nbLargeNeeded) {
+            throw std::runtime_error("nbLarge != nbLargeNeeded");
+        }
+
+        size_t const prefix = nbElts & 15;
+
+        size_t largeIdx = 0;
+        for (size_t i = 0; i < prefix; ++i) {
+            if (ZL_LIKELY(smallIn[i] != 255)) {
+                out[i] = smallIn[i];
+            } else {
+                out[i] = 255 + largeIn[largeIdx++];
+            }
+        }
+
+        const ZL_Vec128 v255 = ZL_Vec128_set8(255);
+
+        ZL_ASSERT_EQ((nbElts - prefix) % 16, 0);
+        for (size_t i = prefix; i < nbElts; i += 16) {
+            const int anyLarge = ZL_Vec128_mask8(
+                    ZL_Vec128_cmp8(ZL_Vec128_read(smallIn + i), v255));
+            if (ZL_LIKELY(anyLarge == 0)) {
+                for (size_t j = 0; j < 16; ++j) {
+                    out[i + j] = smallIn[i + j];
+                }
+            } else {
+                for (size_t j = 0; j < 16; ++j) {
+                    if (smallIn[i + j] != 255) {
+                        out[i + j] = smallIn[i + j];
+                    } else {
+                        out[i + j] = 255 + largeIn[largeIdx++];
+                    }
+                }
+            }
+        }
+    };
+
+    void* const outPtr         = outStream.ptr();
+    void const* const largePtr = largeStream.ptr();
+    switch (eltWidth) {
+        case 1:
+            if (nbLarge != 0) {
+                throw std::runtime_error("nbLarge != 0");
+            }
+            memcpy(outPtr, smallIn, nbElts);
+            break;
+        case 2:
+            decodeImpl((uint16_t*)outPtr, smallIn, (uint16_t const*)largePtr);
+            break;
+        case 4:
+            decodeImpl((uint32_t*)outPtr, smallIn, (uint32_t const*)largePtr);
+            break;
+        case 8:
+            decodeImpl((uint64_t*)outPtr, smallIn, (uint64_t const*)largePtr);
+            break;
+    }
+
+    outStream.commit(nbElts);
+}
+
+} // namespace openzl::lz

--- a/contrib/lz-research/codecs/SmallInt.hpp
+++ b/contrib/lz-research/codecs/SmallInt.hpp
@@ -1,0 +1,27 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#pragma once
+
+#include <openzl/openzl.hpp>
+
+namespace openzl::lz {
+
+class SmallIntEncoder : public CustomEncoder {
+   public:
+    SimpleCodecDescription simpleCodecDescription() const override;
+
+    void encode(EncoderState& encoder) const override;
+
+    ~SmallIntEncoder() override = default;
+};
+
+class SmallIntDecoder : public CustomDecoder {
+   public:
+    SimpleCodecDescription simpleCodecDescription() const override;
+
+    void decode(DecoderState& decoder) const override;
+
+    ~SmallIntDecoder() override = default;
+};
+
+} // namespace openzl::lz

--- a/contrib/lz-research/codecs/VarByte.cpp
+++ b/contrib/lz-research/codecs/VarByte.cpp
@@ -1,0 +1,648 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#include "VarByte.hpp"
+#include "CodecIDs.hpp"
+
+#include "openzl/codecs/common/bitstream/ff_bitstream.h"
+#include "openzl/common/assertion.h"
+#include "openzl/shared/mem.h"
+#include "openzl/shared/portability.h"
+
+namespace openzl::lz {
+namespace {
+SimpleCodecDescription varByteCodecDescription()
+{
+    return SimpleCodecDescription{
+        .id          = unsigned(CustomCodecIDs::VarByte),
+        .name        = "!lz_research.var_byte",
+        .inputType   = Type::Numeric,
+        .outputTypes = { Type::Serial, Type::Serial },
+    };
+}
+
+// using LUT = std::array<std::array<uint32_t, 4>, 256>;
+// using LUTx2 = std::pair<LUT, LUT>;
+
+// using DualLUT = std::array<uint32_t, 4 * 256 + 2>;
+
+// using LUT = std::span<uint32_t const, 4 * 256>;
+// using MutLUT = std::span<uint32_t, 4 * 256>;
+
+// std::pair<LUT, LUT> getLUTs(DualLUT const& lut) {
+//   return std::pair{LUT{lut.data() + 2, 4 * 256}, LUT{lut.data(), 4 * 256}};
+// }
+
+// std::pair<MutLUT, MutLUT> getLUTs(DualLUT& lut) {
+//   return std::pair{
+//       MutLUT{lut.data() + 2, 4 * 256}, MutLUT{lut.data(), 4 * 256}};
+// }
+
+class alignas(16) DualLUT {
+   public:
+    constexpr explicit DualLUT(
+            std::array<std::array<uint32_t, 4>, 256> const& lo)
+    {
+        for (size_t i = 0; i < lo.size(); ++i) {
+            for (size_t j = 0; j < lo[i].size(); ++j) {
+                for (size_t k = 0; k < 4; ++k) {
+                    data_[16 * i + 4 * j + k] = lo[i][j] >> (8 * k);
+                }
+            }
+        }
+    }
+
+    constexpr explicit DualLUT(
+            std::array<std::array<uint8_t, 16>, 256> const& lo)
+    {
+        for (size_t i = 0; i < lo.size(); ++i) {
+            for (size_t j = 0; j < lo[i].size(); ++j) {
+                data_[16 * i + j] = lo[i][j];
+            }
+        }
+    }
+
+    __m128i at(size_t loIdx, size_t hiIdx) const
+    {
+        auto lo = loAt(loIdx);
+        auto hi = hiAt(hiIdx);
+        return _mm_add_epi8(lo, hi);
+    }
+
+    __m128i loAt(size_t idx) const
+    {
+        assert(idx < 256);
+        return load(16 * idx);
+    }
+
+    __m128i hiAt(size_t idx) const
+    {
+        assert(idx < 256);
+        // auto const mask = _mm_set_epi64x(-1, 0);
+        // return _mm_and_si128(load(16 * idx), mask);
+        return _mm_bslli_si128(loAt(idx), 8);
+    }
+
+   private:
+    __m128i load(size_t idx) const
+    {
+        return _mm_load_si128((__m128i const*)&data_[idx]);
+    }
+
+    std::array<uint8_t, 16 * 256> data_;
+};
+
+template <
+        uint32_t B0,
+        uint32_t B1,
+        uint32_t B2,
+        uint32_t B3,
+        uint32_t B4,
+        uint32_t B5,
+        uint32_t B6,
+        uint32_t B7,
+        uint32_t B8,
+        uint32_t B9,
+        uint32_t B10,
+        uint32_t B11,
+        uint32_t B12,
+        uint32_t B13,
+        uint32_t B14,
+        uint32_t B15>
+class VarByteCoder {
+   public:
+    constexpr VarByteCoder() {}
+
+    static void print32(char const* name, __m128i vec)
+    {
+        std::array<uint32_t, 4> array;
+        _mm_storeu_si128((__m128i_u*)array.data(), vec);
+        fprintf(stderr, "%s: ", name);
+        for (auto const& val : array) {
+            fprintf(stderr, "0x%x\t", val);
+        }
+        fprintf(stderr, "\n");
+    }
+
+    static void print16(char const* name, __m128i vec)
+    {
+        std::array<uint16_t, 8> array;
+        _mm_storeu_si128((__m128i_u*)array.data(), vec);
+        fprintf(stderr, "%s: ", name);
+        for (auto const& val : array) {
+            fprintf(stderr, "0x%x\t", val);
+        }
+        fprintf(stderr, "\n");
+    }
+
+    static void print8(char const* name, __m128i vec)
+    {
+        std::array<uint8_t, 16> array;
+        _mm_storeu_si128((__m128i_u*)array.data(), vec);
+        fprintf(stderr, "%s: ", name);
+        for (auto const& val : array) {
+            fprintf(stderr, "0x%x\t", val);
+        }
+        fprintf(stderr, "\n");
+    }
+
+    __m128i decode4(
+            uint8_t control0,
+            uint8_t control1,
+            __m128i data,
+            size_t& bitsConsumed) const
+    {
+        auto const [shuffle, shift] =
+                getShuffleAndShift(control0, control1, bitsConsumed);
+        auto const mask     = getMask(control0, control1);
+        auto const base     = getBase(control0, control1);
+        auto const shuffled = _mm_shuffle_epi8(data, shuffle);
+        auto const shifted  = _mm_srlv_epi32(shuffled, shift);
+        auto const masked   = _mm_and_si128(shifted, mask);
+        auto const based    = _mm_add_epi32(masked, base);
+        // static size_t idx = 0;
+        // if (idx++ < 2) {
+        //   fprintf(
+        //       stderr,
+        //       "consumed = %zu | control0 = 0x%x | control1 = 0x%x\n",
+        //       bitsConsumed,
+        //       control0,
+        //       control1);
+        //   print8("shuffleLO", shuffleShiftLUT_.loAt(control0));
+        //   print8("shuffleHI", shuffleShiftLUT_.hiAt(control1));
+        //   print8("shuffle", shuffle);
+        //   print32("shift", shift);
+        //   print32("mask", mask);
+        //   print32("shuffled", shuffled);
+        //   print32("shifted", shifted);
+        //   print32("masked", masked);
+        //   fprintf(stderr, "bitsConsumed0 = %u\n",
+        //   bitsConsumedLUT_[control0]); fprintf(stderr, "bitsConsumed1 =
+        //   %u\n", bitsConsumedLUT_[control1]);
+        // }
+        bitsConsumed += bitsConsumedLUT_[control0];
+        bitsConsumed += bitsConsumedLUT_[control1];
+        return based;
+    }
+
+    uint32_t decode1(uint8_t control, uint32_t data, size_t& bitsConsumed) const
+    {
+        assert(control < 16);
+        auto const bits  = bits_[control];
+        auto const value = (data >> (bitsConsumed % 8)) & ((1u << bits) - 1);
+        bitsConsumed += bits;
+        return baseLUT_[control] + value;
+    }
+
+    void decode8xU16(
+            uint16_t* out,
+            const uint8_t* control,
+            const uint8_t* bytes,
+            size_t& bitsConsumed) const
+    {
+        for (size_t i = 0; i < 2; ++i) {
+            const size_t bytesOffset = bitsConsumed / 8;
+            const size_t bitsOffset  = bitsConsumed % 8;
+
+            uint64_t data = ZL_readLE64(bytes + bytesOffset) >> bitsOffset;
+
+            const uint8_t c0    = control[2 * i + 0];
+            const uint8_t c1    = control[2 * i + 1];
+            const uint64_t mask = uint64_t(mask2xLUTU16_[c0])
+                    | (uint64_t(mask2xLUTU16_[c1]) << 32);
+            const uint64_t base = uint64_t(base2xLUTU16_[c0])
+                    | (uint64_t(base2xLUTU16_[c1]) << 32);
+
+            const int bitsNeeded = __builtin_popcountll(mask);
+            if (ZL_LIKELY(bitsNeeded <= 56) || bitsOffset == 0) {
+                ZL_writeLE64(out + 4 * i, base + _pdep_u64(data, mask));
+            } else {
+                data |= uint64_t(bytes[bytesOffset + 8]) << (64 - bitsOffset);
+                ZL_writeLE64(out + 4 * i, base + _pdep_u64(data, mask));
+            }
+            bitsConsumed += bitsNeeded;
+        }
+    }
+
+    template <typename UInt>
+    void decode(
+            std::span<UInt> out,
+            std::span<uint8_t const> control,
+            std::span<uint8_t const> bytes) const
+    {
+        // fprintf(
+        //     stderr,
+        //     "nbElts = %zu, control = %zu, bytes = %zu\n",
+        //     out.size(),
+        //     control.size(),
+        //     bytes.size());
+        static_assert(sizeof(UInt) > 1);
+        static_assert(sizeof(UInt) <= 4);
+        assert((out.size() + 1) / 2 == control.size());
+        size_t bitsConsumed     = 0;
+        size_t outIdx           = 0;
+        size_t constexpr kLimit = 16 + (sizeof(UInt) == 2 ? 8 : 16);
+        if (bytes.size() >= kLimit) {
+            size_t const bitsLimit = 8 * (bytes.size() - kLimit);
+            size_t const outLimit  = out.size() - 8;
+            while (bitsConsumed < bitsLimit && outIdx < outLimit) {
+                size_t const controlIdx = outIdx / 2;
+                // fprintf(
+                //     stderr,
+                //     "bitsConsumed = %zu | limit = %zu | outIdx = %zu |
+                //     ctrlIdx = %zu\n", bitsConsumed, bitsLimit, outIdx,
+                //     controlIdx);
+                if constexpr (1 && sizeof(UInt) == 2) {
+                    decode8xU16(
+                            &out[outIdx],
+                            control.data() + controlIdx,
+                            bytes.data(),
+                            bitsConsumed);
+                } else {
+                    auto outVec0 = decode4(
+                            control[controlIdx + 0],
+                            control[controlIdx + 1],
+                            _mm_loadu_si128(
+                                    (__m128i_u const*)&bytes[bitsConsumed / 8]),
+                            bitsConsumed);
+                    auto outVec1 = decode4(
+                            control[controlIdx + 2],
+                            control[controlIdx + 3],
+                            _mm_loadu_si128(
+                                    (__m128i_u const*)&bytes[bitsConsumed / 8]),
+                            bitsConsumed);
+                    if constexpr (sizeof(UInt) == 4) {
+                        _mm_storeu_si128((__m128i_u*)&out[outIdx + 0], outVec0);
+                        _mm_storeu_si128((__m128i_u*)&out[outIdx + 4], outVec1);
+                    } else {
+                        auto const outVec = _mm_packus_epi32(outVec0, outVec1);
+                        _mm_storeu_si128((__m128i_u*)&out[outIdx], outVec);
+                    }
+                }
+                outIdx += 8;
+            }
+        }
+        for (; outIdx < out.size(); ++outIdx) {
+            uint8_t const ctrl =
+                    (control[outIdx / 2] >> (outIdx % 2 == 0 ? 0 : 4)) % 16;
+            out[outIdx] =
+                    decode1(ctrl,
+                            safeRead(bytes.subspan(bitsConsumed / 8)),
+                            bitsConsumed);
+        }
+        ZL_REQUIRE_EQ((bitsConsumed + 7) / 8, bytes.size());
+    }
+
+    template <typename UInt>
+    size_t encode(
+            std::span<uint8_t> control,
+            std::span<uint8_t> bytes,
+            std::span<UInt const> data) const
+    {
+        assert(control.size() == (data.size() + 1) / 2);
+        assert(bytes.size() >= data.size() * sizeof(UInt));
+        static_assert(sizeof(UInt) <= 4);
+        auto const clzLUT = makeClzLUT();
+
+        // static bool printed = false;
+        // if (!printed) {
+        //   for (size_t i = 0; i < 16; ++i) {
+        //     fprintf(stderr, "base[%zu] = %u\n", i, baseLUT_[i]);
+        //   }
+        //   printed = true;
+        // }
+
+        ZS_BitCStreamFF controlStream =
+                ZS_BitCStreamFF_init(control.data(), control.size());
+        ZS_BitCStreamFF bytesStream =
+                ZS_BitCStreamFF_init(bytes.data(), bytes.size());
+
+        // size_t idx = 0;
+        for (auto const val : data) {
+            ZL_REQUIRE_LT(val, (1u << 24));
+            auto const ctrl = clzLUT[__builtin_clz(uint32_t(val))];
+            assert(ctrl < 16);
+            auto const bits = bits_[ctrl];
+            assert(bits <= 32);
+            // if (idx < 10) {
+            //   fprintf(
+            //       stderr, "encoding %u as control %u = %u bits\n", val, ctrl,
+            //       bits);
+            //   ++idx;
+            // }
+            ZS_BitCStreamFF_write(&controlStream, ctrl, 4);
+            ZS_BitCStreamFF_write(&bytesStream, val - baseLUT_[ctrl], bits);
+            ZS_BitCStreamFF_flush(&controlStream);
+            ZS_BitCStreamFF_flush(&bytesStream);
+        }
+
+        // shuffle needs bits for adding
+        // shuffle + shift
+        // mask
+
+        auto const controlResult = ZS_BitCStreamFF_finish(&controlStream);
+        auto const bytesResult   = ZS_BitCStreamFF_finish(&bytesStream);
+        ZL_REQUIRE_SUCCESS(controlResult);
+        ZL_REQUIRE_SUCCESS(bytesResult);
+        assert(ZL_validResult(controlResult) == control.size());
+        assert(ZL_validResult(bytesResult) <= bytes.size());
+
+        std::vector<uint32_t> out;
+        out.resize(data.size());
+        decode(std::span{ out },
+               control,
+               bytes.subspan(0, ZL_validResult(bytesResult)));
+        for (size_t i = 0; i < data.size(); ++i) {
+            ZL_REQUIRE_EQ(data[i], out[i], "error at idx %zu", i);
+        }
+
+        return ZL_validResult(bytesResult);
+    }
+
+   private:
+    std::pair<__m128i, __m128i> getShuffleAndShift(
+            uint8_t control0,
+            uint8_t control1,
+            size_t bitsConsumed) const
+    {
+        auto const entry = shuffleShiftLUT_.at(control0, control1);
+        auto const shuffleShift =
+                _mm_add_epi8(entry, _mm_set1_epi8(bitsConsumed % 8));
+        auto const shuffle = _mm_and_si128(
+                _mm_srli_epi16(shuffleShift, 3), _mm_set1_epi8(0xF));
+        auto const shift = _mm_and_si128(shuffleShift, _mm_set1_epi32(0x7));
+        return { shuffle, shift };
+    }
+
+    __m128i getMask(uint8_t control0, uint8_t control1) const
+    {
+        return _mm_set_epi64x(maskLUT_[control1], maskLUT_[control0]);
+    }
+
+    __m128i getBase(uint8_t control0, uint8_t control1) const
+    {
+        return _mm_set_epi64x(base2xLUT_[control1], base2xLUT_[control0]);
+    }
+
+    constexpr std::array<uint8_t, 32> makeClzLUT() const
+    {
+        std::array<uint8_t, 32> clzLUT;
+        for (size_t i = 0; i < 8; ++i) {
+            clzLUT[i] = 0;
+        }
+        for (size_t clz = 8; clz < clzLUT.size(); ++clz) {
+            size_t const numBits = 32 - clz;
+            size_t const maxVal  = (1u << numBits) - 1;
+            for (size_t i = 0; i < bits_.size(); ++i) {
+#ifndef NDEBUG
+                auto const exclusiveEnd = baseLUT_[i] + (1u << bits_[i]);
+                assert((exclusiveEnd & (exclusiveEnd - 1)) == 0);
+#endif
+                if (maxVal < baseLUT_[i] + (1u << bits_[i])) {
+                    clzLUT[clz] = i;
+                    break;
+                }
+            }
+        }
+        return clzLUT;
+    }
+
+    static uint32_t safeRead(std::span<uint8_t const> bytes)
+    {
+        uint32_t value      = 0;
+        size_t const toRead = std::min<size_t>(bytes.size(), 4);
+        for (size_t i = 0; i < toRead; ++i) {
+            value |= bytes[i] << (8 * i);
+        }
+        return value;
+    }
+
+    static constexpr std::array<uint8_t, 256> makeBitsConsumedLUT()
+    {
+        std::array<uint8_t, 16> constexpr kBits = { B0,  B1,  B2,  B3, B4,  B5,
+                                                    B6,  B7,  B8,  B9, B10, B11,
+                                                    B12, B13, B14, B15 };
+        std::array<uint8_t, 256> lut;
+        for (int byte = 0; byte < 256; ++byte) {
+            uint32_t const bits0 = kBits[byte & 0xF];
+            uint32_t const bits1 = kBits[byte >> 4];
+            lut[byte]            = (bits0 + bits1);
+        }
+
+        return lut;
+    }
+
+    static constexpr DualLUT makeShuffleShiftLUT()
+    {
+        std::array<uint8_t, 16> constexpr kBits = { B0,  B1,  B2,  B3, B4,  B5,
+                                                    B6,  B7,  B8,  B9, B10, B11,
+                                                    B12, B13, B14, B15 };
+        std::array<std::array<uint8_t, 16>, 256> lo;
+        for (int byte = 0; byte < 256; ++byte) {
+            uint32_t const bits0     = kBits[byte & 0xF];
+            uint32_t const bits1     = kBits[byte >> 4];
+            uint32_t const bitsTotal = bits0 + bits1;
+
+            auto fillU32 = [&lo, byte](size_t idx, size_t bitOffset, bool add) {
+                for (size_t i = 0; i < 4; ++i) {
+                    lo[byte][4 * idx + i] = bitOffset + (add ? 8 * i : 0);
+                }
+            };
+
+            fillU32(0, 0, true);
+            fillU32(1, bits0, true);
+            fillU32(2, bitsTotal, false);
+            fillU32(3, bitsTotal, false);
+        }
+        return DualLUT{ lo };
+    }
+
+    constexpr static DualLUT makeShiftMaskLUT()
+    {
+        std::array<uint32_t, 16> constexpr kBits = {
+            B0, B1, B2, B3, B4, B5, B6, B7, B8, B9, B10, B11, B12, B13, B14, B15
+        };
+        std::array<std::array<uint32_t, 4>, 256> lo;
+        for (int byte = 0; byte < 256; ++byte) {
+            uint32_t const bits0     = kBits[byte & 0xF];
+            uint32_t const bits1     = kBits[byte >> 4];
+            uint32_t const bitsTotal = bits0 + bits1;
+
+            auto const toEntry = [](uint32_t bitOffset, uint32_t mask) {
+                assert((mask >> 24) == 0);
+                assert(bitOffset < 128);
+                return bitOffset | (mask << 8);
+            };
+
+            lo[byte][0] = toEntry(0, (1u << bits0) - 1);
+            lo[byte][1] = toEntry(bits0, (1u << bits1) - 1);
+            lo[byte][2] = toEntry(bitsTotal, 0);
+            lo[byte][3] = toEntry(bitsTotal, 0);
+        }
+        return DualLUT{ lo };
+    }
+
+    constexpr static std::array<uint64_t, 256> expandLUT(
+            std::array<uint32_t, 16> const& lut)
+    {
+        std::array<uint64_t, 256> expanded;
+        for (int byte = 0; byte < 256; ++byte) {
+            uint64_t const val0 = lut[byte & 0xF];
+            uint64_t const val1 = lut[byte >> 4];
+
+            expanded[byte] = val0 | (val1 << 32);
+        }
+        return expanded;
+    }
+
+    constexpr static std::array<uint32_t, 256> expandLUTU16(
+            std::array<uint32_t, 16> const& lut)
+    {
+        std::array<uint32_t, 256> expanded;
+        for (int byte = 0; byte < 256; ++byte) {
+            uint64_t const val0 = lut[byte & 0xF];
+            uint64_t const val1 = lut[byte >> 4];
+
+            expanded[byte] = (val0 & 0xFFFF) | (val1 << 16);
+        }
+        return expanded;
+    }
+
+    constexpr static std::array<uint32_t, 16> makeMaskLUT()
+    {
+        std::array<uint32_t, 16> constexpr kBits = {
+            B0, B1, B2, B3, B4, B5, B6, B7, B8, B9, B10, B11, B12, B13, B14, B15
+        };
+        std::array<uint32_t, 16> lut;
+        for (int nibble = 0; nibble < 16; ++nibble) {
+            uint32_t const bits = kBits[nibble];
+            lut[nibble]         = (1u << bits) - 1;
+        }
+        return lut;
+    }
+
+    constexpr static std::array<uint32_t, 16> makeBaseLUT()
+    {
+        std::array<uint32_t, 16> lut;
+        lut[0] = 0;
+        for (int nibble = 1; nibble < 16; ++nibble) {
+            lut[nibble] = lut[nibble - 1] + (1u << bits_[nibble - 1]);
+            if (lut[nibble] != (1u << bits_[nibble])) {
+                lut[nibble] = 0;
+            }
+        }
+        return lut;
+    }
+
+    static constexpr DualLUT shuffleShiftLUT_{ makeShuffleShiftLUT() };
+    static constexpr std::array<uint64_t, 256> base2xLUT_{ expandLUT(
+            makeBaseLUT()) };
+    static constexpr std::array<uint64_t, 256> maskLUT_{ expandLUT(
+            makeMaskLUT()) };
+    static constexpr std::array<uint8_t, 256> const bitsConsumedLUT_{
+        makeBitsConsumedLUT()
+    };
+    static constexpr std::array<uint32_t, 16> baseLUT_{ makeBaseLUT() };
+    static constexpr std::array<uint8_t, 16> bits_{ B0,  B1,  B2,  B3, B4,  B5,
+                                                    B6,  B7,  B8,  B9, B10, B11,
+                                                    B12, B13, B14, B15 };
+
+    static constexpr std::array<uint32_t, 256> base2xLUTU16_{ expandLUTU16(
+            makeBaseLUT()) };
+    static constexpr std::array<uint32_t, 256> mask2xLUTU16_{ expandLUTU16(
+            makeMaskLUT()) };
+};
+
+using VarByteCoder16 =
+        VarByteCoder<1, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15>;
+using VarByteCoder32 =
+        VarByteCoder<5, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 16, 18, 20, 22, 24>;
+} // namespace
+
+SimpleCodecDescription VarByteEncoder::simpleCodecDescription() const
+{
+    return varByteCodecDescription();
+}
+
+void VarByteEncoder::encode(EncoderState& encoder) const
+{
+    auto& inputStream           = encoder.inputs()[0];
+    auto const nbElts           = inputStream.numElts();
+    auto const eltWidth         = inputStream.eltWidth();
+    size_t const controlSize    = (nbElts + 1) / 2;
+    size_t const packedCapacity = nbElts * eltWidth;
+    auto controlStream          = encoder.createOutput(0, controlSize, 1);
+    auto packedStream           = encoder.createOutput(1, packedCapacity, 1);
+    if (eltWidth <= 1 || eltWidth > 4) {
+        throw std::runtime_error("eltWidth must be in [2, 4]");
+    }
+
+    uint8_t* const control  = (uint8_t*)controlStream.ptr();
+    uint8_t* const packed   = (uint8_t*)packedStream.ptr();
+    void const* const input = inputStream.ptr();
+
+    size_t packedSize;
+    if (eltWidth == 2) {
+        packedSize = VarByteCoder16().encode(
+                std::span{ control, controlSize },
+                std::span{ packed, packedCapacity },
+                std::span{ (uint16_t const*)input, nbElts });
+    } else {
+        assert(eltWidth == 4);
+        packedSize = VarByteCoder32().encode(
+                std::span{ control, controlSize },
+                std::span{ packed, packedCapacity },
+                std::span{ (uint32_t const*)input, nbElts });
+    }
+
+    uint8_t unfilledElts = nbElts % 2;
+    uint8_t header[2]    = { unfilledElts, (uint8_t)eltWidth };
+    encoder.sendCodecHeader(header, sizeof(header));
+
+    controlStream.commit(controlSize);
+    packedStream.commit(packedSize);
+}
+
+SimpleCodecDescription VarByteDecoder::simpleCodecDescription() const
+{
+    return varByteCodecDescription();
+}
+
+void VarByteDecoder::decode(DecoderState& decoder) const
+{
+    auto& controlStream = decoder.singletonInputs()[0];
+    auto& packedStream  = decoder.singletonInputs()[1];
+
+    auto const controlSize = controlStream.numElts();
+    auto const packedSize  = packedStream.numElts();
+
+    auto header = decoder.getCodecHeader();
+    if (header.size() != 2) {
+        throw std::runtime_error("header size must be 2");
+    }
+
+    size_t const nbElts   = 2 * controlSize - header[0];
+    size_t const eltWidth = header[1];
+
+    auto outStream = decoder.createOutput(0, nbElts, eltWidth);
+
+    uint8_t const* control = (uint8_t const*)controlStream.ptr();
+    uint8_t const* packed  = (uint8_t const*)packedStream.ptr();
+    void* out              = outStream.ptr();
+
+    if (eltWidth == 2) {
+        VarByteCoder16().decode(
+                std::span{ (uint16_t*)out, nbElts },
+                std::span{ control, controlSize },
+                std::span{ packed, packedSize });
+    } else {
+        assert(eltWidth == 4);
+        VarByteCoder32().decode(
+                std::span{ (uint32_t*)out, nbElts },
+                std::span{ control, controlSize },
+                std::span{ packed, packedSize });
+    }
+
+    outStream.commit(nbElts);
+}
+
+} // namespace openzl::lz

--- a/contrib/lz-research/codecs/VarByte.hpp
+++ b/contrib/lz-research/codecs/VarByte.hpp
@@ -1,0 +1,27 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#pragma once
+
+#include <openzl/openzl.hpp>
+
+namespace openzl::lz {
+
+class VarByteEncoder : public CustomEncoder {
+   public:
+    SimpleCodecDescription simpleCodecDescription() const override;
+
+    void encode(EncoderState& encoder) const override;
+
+    ~VarByteEncoder() override = default;
+};
+
+class VarByteDecoder : public CustomDecoder {
+   public:
+    SimpleCodecDescription simpleCodecDescription() const override;
+
+    void decode(DecoderState& decoder) const override;
+
+    ~VarByteDecoder() override = default;
+};
+
+} // namespace openzl::lz

--- a/contrib/lz-research/codecs/utils/Partition.hpp
+++ b/contrib/lz-research/codecs/utils/Partition.hpp
@@ -1,0 +1,103 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#pragma once
+
+namespace openzl::lz::utils {
+
+/**
+ * Compute the optimal partition of data to minimize costFn.
+ *
+ * This algorithm is O(histogram.size()^2) in the worst case, and uses
+ * O(histogram.size()) memory.
+ *
+ * @returns The beginning of each partition. The last partition implicitly
+ * ends at data.size(). The first partition will start at 0.
+ */
+template <typename T, typename CostFn>
+std::vector<size_t> partition(poly::span<const T> histogram, CostFn&& costFn)
+{
+    const size_t N  = histogram.size();
+    const size_t N1 = N + 1;
+    // opt[e] = The optimal cost to partion [1, e)
+    std::vector<uint32_t> opt(N1, 0);
+    // begin[e] = map from bucket end index to the optimal begin index
+    std::vector<uint32_t> begin(N1, 0);
+    // numBuckets[e] = number of buckets in the optimal partion of [0, e)
+    // NOTE: This does not include a bucket for the remaining indices [e, N).
+    std::vector<uint32_t> numBuckets(N1, 0);
+
+    // NOTE: opt[0] = 0
+    // NOTE: numBuckets[0] = 0
+    for (size_t e = 1; e < N1; ++e) {
+        for (size_t b = 0; b < e; ++b) {
+            const auto endCost = costFn(histogram.subspan(b, e - b));
+            const auto cost    = opt[b] + endCost;
+            if (b == 0 || cost < opt[e]) {
+                opt[e]   = cost;
+                begin[e] = b;
+            }
+        }
+        numBuckets[e] = numBuckets[begin[e]] + 1;
+    }
+
+    std::vector<size_t> partitions(numBuckets[N]);
+    for (size_t e = N, pos = partitions.size(); e > 0; e = begin[e]) {
+        partitions[--pos] = begin[e];
+    }
+    return partitions;
+}
+
+/**
+ * Optimally partition a histogram into at most numBuckets buckets so that
+ * `costFn()` is minimized. The cost of each bucket must depend only on the
+ * histogram values in that bucket.
+ *
+ * This algorithm is O(histogram.size()^3) in the worst case, and uses
+ * O(histogram.size() * numBuckets) memory.
+
+ * @returns The beginning of each partition. The last partition implicitly
+ * ends at histogram.size(). The first partition will start at 0.
+ */
+template <typename T, typename CostFn>
+std::vector<size_t>
+partition(poly::span<const T> histogram, size_t numBuckets, CostFn&& costFn)
+{
+    const size_t B  = numBuckets;
+    const size_t B1 = B + 1;
+    const size_t N  = histogram.size();
+    const size_t N1 = N + 1;
+    // opt[N1 * k + e] = The optimal cost to partion [0, e) with k buckets
+    std::vector<float> opt(N1 * B1, std::numeric_limits<float>::infinity());
+    // begin[N1 * k + e] = The beginning index for e with k buckets
+    std::vector<uint32_t> begin(N1 * B1, std::numeric_limits<uint32_t>::max());
+
+    opt[N1 * 0 + 0]   = 0;
+    begin[N1 * 0 + 0] = 0;
+    for (size_t e = 1; e < N1; ++e) {
+        const size_t maxPossibleBuckets = std::min(e, B);
+        for (size_t k = 1; k <= maxPossibleBuckets; ++k) {
+            for (size_t b = e; b-- > k - 1;) {
+                const float oldCost = opt[N1 * k + e];
+                const float endCost = costFn(histogram.subspan(b, e - b));
+                if (endCost > oldCost) {
+                    break;
+                }
+                const float newCost = opt[N1 * (k - 1) + b] + endCost;
+                if (newCost < oldCost) {
+                    opt[N1 * k + e]   = newCost;
+                    begin[N1 * k + e] = b;
+                }
+            }
+        }
+    }
+
+    std::vector<size_t> partitions(numBuckets, 0);
+    for (size_t e = N, pos = partitions.size(); e > 0;) {
+        auto b = begin[N1 * pos-- + e];
+        assert(b < e);
+        partitions[pos] = b;
+        e               = b;
+    }
+    return partitions;
+}
+} // namespace openzl::lz::utils

--- a/contrib/lz-research/compressors.json
+++ b/contrib/lz-research/compressors.json
@@ -1,0 +1,102 @@
+[
+    {
+        "algorithm": "lz4",
+        "level": 1
+    },
+    {
+        "algorithm": "zstd",
+        "level": 1
+    },
+    {
+        "algorithm": "zstd",
+        "level": 1,
+        "params": {
+            "windowLog": 16,
+            "hashLog": 14
+        }
+    },
+    {
+        "algorithm": "openzl",
+        "params": {
+            "CompressionLevel": 1
+        },
+        "compressor_name": "lz-zstd-iso"
+    },
+    {
+        "algorithm": "openzl",
+        "params": {
+            "CompressionLevel": 1
+        },
+        "compressor_name": "lz-zstd-buc"
+    },
+    {
+        "algorithm": "openzl",
+        "params": {
+            "CompressionLevel": 1
+        },
+        "compressor_name": "lz-zstd-slow"
+    },
+    {
+        "algorithm": "openzl",
+        "params": {
+            "CompressionLevel": 1
+        },
+        "compressor_name": "lz-zstd-fast"
+    },
+    {
+        "algorithm": "openzl",
+        "params": {
+            "CompressionLevel": 1
+        },
+        "compressor_name": "lz-zstd-iso[llbits=4]"
+    },
+    {
+        "algorithm": "openzl",
+        "params": {
+            "CompressionLevel": 1
+        },
+        "compressor_name": "lz-zstd-buc[llbits=4]"
+    },
+    {
+        "algorithm": "openzl",
+        "params": {
+            "CompressionLevel": 1
+        },
+        "compressor_name": "lz-zstd-slow[llbits=4]"
+    },
+    {
+        "algorithm": "openzl",
+        "params": {
+            "CompressionLevel": 1
+        },
+        "compressor_name": "lz-zstd-fast[llbits=4]"
+    },
+    {
+        "algorithm": "openzl",
+        "params": {
+            "CompressionLevel": 1
+        },
+        "compressor_name": "lz-zstd-iso[llbits=3]"
+    },
+    {
+        "algorithm": "openzl",
+        "params": {
+            "CompressionLevel": 1
+        },
+        "compressor_name": "lz-zstd-buc[llbits=3]"
+    },
+    {
+        "algorithm": "openzl",
+        "params": {
+            "CompressionLevel": 1
+        },
+        "compressor_name": "lz-zstd-slow[llbits=3]"
+    },
+    {
+        "algorithm": "openzl",
+        "params": {
+            "CompressionLevel": 1
+        },
+        "compressor_name": "lz-zstd-fast[llbits=3]"
+    }
+]


### PR DESCRIPTION
Summary: Adds a block size flag to cut the input into smaller blocks to test on smaller inputs.

Differential Revision: D92095506


