### PR TITLE
Evolve the sddl compiler to support the new syntax

### DIFF
--- a/tools/sddl2/compiler/Compiler.h
+++ b/tools/sddl2/compiler/Compiler.h
@@ -113,7 +113,7 @@ class Compiler {
         bool include_debug_info{ true };
     };
 
-   private:
+   protected:
     const Options options_;
 
     const detail::Logger logger_;

--- a/tools/sddl2/compiler/Syntax.cpp
+++ b/tools/sddl2/compiler/Syntax.cpp
@@ -50,101 +50,6 @@ const std::map<Symbol, ListSymSet> list_sym_sets{ []() {
     return m;
 }() };
 
-static const std::map<Symbol, SymbolType> sym_types{
-    { Symbol::NL, SymbolType::GROUPING },
-    { Symbol::COMMA, SymbolType::GROUPING },
-    { Symbol::PAREN_OPEN, SymbolType::GROUPING },
-    { Symbol::PAREN_CLOSE, SymbolType::GROUPING },
-    { Symbol::CURLY_OPEN, SymbolType::GROUPING },
-    { Symbol::CURLY_CLOSE, SymbolType::GROUPING },
-    { Symbol::SQUARE_OPEN, SymbolType::GROUPING },
-    { Symbol::SQUARE_CLOSE, SymbolType::GROUPING },
-
-    { Symbol::DIE, SymbolType::OPERATOR },
-    { Symbol::EXPECT, SymbolType::OPERATOR },
-    { Symbol::LOG, SymbolType::OPERATOR },
-
-    { Symbol::CONSUME, SymbolType::OPERATOR },
-    { Symbol::SIZEOF, SymbolType::OPERATOR },
-    { Symbol::SEND, SymbolType::OPERATOR },
-    { Symbol::ASSIGN, SymbolType::OPERATOR },
-    { Symbol::ASSUME, SymbolType::OPERATOR },
-    { Symbol::MEMBER, SymbolType::OPERATOR },
-    { Symbol::BIND, SymbolType::OPERATOR },
-
-    { Symbol::NEG, SymbolType::OPERATOR },
-
-    { Symbol::EQ, SymbolType::OPERATOR },
-    { Symbol::NE, SymbolType::OPERATOR },
-    { Symbol::GT, SymbolType::OPERATOR },
-    { Symbol::GE, SymbolType::OPERATOR },
-    { Symbol::LT, SymbolType::OPERATOR },
-    { Symbol::LE, SymbolType::OPERATOR },
-    { Symbol::ADD, SymbolType::OPERATOR },
-    { Symbol::SUB, SymbolType::OPERATOR },
-    { Symbol::MUL, SymbolType::OPERATOR },
-    { Symbol::DIV, SymbolType::OPERATOR },
-    { Symbol::MOD, SymbolType::OPERATOR },
-
-    { Symbol::BIT_AND, SymbolType::OPERATOR },
-    { Symbol::BIT_OR, SymbolType::OPERATOR },
-    { Symbol::BIT_XOR, SymbolType::OPERATOR },
-    { Symbol::BIT_NOT, SymbolType::OPERATOR },
-
-    { Symbol::LOG_AND, SymbolType::OPERATOR },
-    { Symbol::LOG_OR, SymbolType::OPERATOR },
-    { Symbol::LOG_NOT, SymbolType::OPERATOR },
-
-    { Symbol::BYTE, SymbolType::KEYWORD },
-    { Symbol::U8, SymbolType::KEYWORD },
-    { Symbol::I8, SymbolType::KEYWORD },
-    { Symbol::U16LE, SymbolType::KEYWORD },
-    { Symbol::U16BE, SymbolType::KEYWORD },
-    { Symbol::I16LE, SymbolType::KEYWORD },
-    { Symbol::I16BE, SymbolType::KEYWORD },
-    { Symbol::U32LE, SymbolType::KEYWORD },
-    { Symbol::U32BE, SymbolType::KEYWORD },
-    { Symbol::I32LE, SymbolType::KEYWORD },
-    { Symbol::I32BE, SymbolType::KEYWORD },
-    { Symbol::U64LE, SymbolType::KEYWORD },
-    { Symbol::U64BE, SymbolType::KEYWORD },
-    { Symbol::I64LE, SymbolType::KEYWORD },
-    { Symbol::I64BE, SymbolType::KEYWORD },
-
-    { Symbol::F8, SymbolType::KEYWORD },
-    { Symbol::F16LE, SymbolType::KEYWORD },
-    { Symbol::F16BE, SymbolType::KEYWORD },
-    { Symbol::F32LE, SymbolType::KEYWORD },
-    { Symbol::F32BE, SymbolType::KEYWORD },
-    { Symbol::F64LE, SymbolType::KEYWORD },
-    { Symbol::F64BE, SymbolType::KEYWORD },
-
-    { Symbol::BF8, SymbolType::KEYWORD },
-    { Symbol::BF16LE, SymbolType::KEYWORD },
-    { Symbol::BF16BE, SymbolType::KEYWORD },
-    { Symbol::BF32LE, SymbolType::KEYWORD },
-    { Symbol::BF32BE, SymbolType::KEYWORD },
-    { Symbol::BF64LE, SymbolType::KEYWORD },
-    { Symbol::BF64BE, SymbolType::KEYWORD },
-
-    { Symbol::POISON, SymbolType::KEYWORD },
-    { Symbol::ATOM, SymbolType::KEYWORD },
-    { Symbol::RECORD, SymbolType::KEYWORD },
-    { Symbol::ARRAY, SymbolType::KEYWORD },
-    { Symbol::DEST, SymbolType::KEYWORD },
-};
-
-SymbolType sym_type(Symbol sym)
-{
-    try {
-        return sym_types.at(sym);
-    } catch (const std::out_of_range&) {
-        throw InvariantViolation(
-                "Lookup failed in sym_type(Symbol::"
-                + std::string{ sym_to_debug_str(sym) } + ")");
-    }
-}
-
 static const std::map<Symbol, poly::string_view> syms_to_debug_strs{
     { Symbol::NL, "NL" },
     { Symbol::COMMA, "COMMA" },
@@ -155,20 +60,11 @@ static const std::map<Symbol, poly::string_view> syms_to_debug_strs{
     { Symbol::SQUARE_OPEN, "SQUARE_OPEN" },
     { Symbol::SQUARE_CLOSE, "SQUARE_CLOSE" },
 
-    { Symbol::DIE, "DIE" },
     { Symbol::EXPECT, "EXPECT" },
-    { Symbol::LOG, "LOG" },
-
-    { Symbol::CONSUME, "CONSUME" },
     { Symbol::SIZEOF, "SIZEOF" },
-    { Symbol::SEND, "SEND" },
     { Symbol::ASSIGN, "ASSIGN" },
-
     { Symbol::ASSUME, "ASSUME" },
     { Symbol::MEMBER, "MEMBER" },
-    { Symbol::BIND, "BIND" },
-
-    { Symbol::NEG, "NEG" },
 
     { Symbol::EQ, "EQ" },
     { Symbol::NE, "NE" },
@@ -223,11 +119,7 @@ static const std::map<Symbol, poly::string_view> syms_to_debug_strs{
     { Symbol::BF64LE, "BF64LE" },
     { Symbol::BF64BE, "BF64BE" },
 
-    { Symbol::POISON, "POISON" },
-    { Symbol::ATOM, "ATOM" },
     { Symbol::RECORD, "RECORD" },
-    { Symbol::ARRAY, "ARRAY" },
-    { Symbol::DEST, "DEST" },
 };
 
 poly::string_view sym_to_debug_str(Symbol sym)
@@ -237,7 +129,6 @@ poly::string_view sym_to_debug_str(Symbol sym)
     } catch (const std::out_of_range&) {
         static const poly::string_view unknown{ "UNKNOWN???" };
         return unknown;
-        // throw InvariantViolation("Lookup failed in sym_to_debug_str()");
     }
 }
 
@@ -271,12 +162,9 @@ const std::vector<std::pair<poly::string_view, Symbol>> strs_to_syms{
     { "~", Symbol::BIT_NOT },
     { ":", Symbol::ASSUME },
     { ".", Symbol::MEMBER },
-    { "die", Symbol::DIE },
     { "expect", Symbol::EXPECT },
-    { "log", Symbol::LOG },
-    { "consume", Symbol::CONSUME },
     { "sizeof", Symbol::SIZEOF },
-    { "sendto", Symbol::SEND },
+
     { "Byte", Symbol::BYTE },
     { "UInt8", Symbol::U8 },
     { "Int8", Symbol::I8 },
@@ -306,16 +194,14 @@ const std::vector<std::pair<poly::string_view, Symbol>> strs_to_syms{
     { "BFloat32BE", Symbol::BF32BE },
     { "BFloat64LE", Symbol::BF64LE },
     { "BFloat64BE", Symbol::BF64BE },
-    { "Poison", Symbol::POISON },
+    { "Record", Symbol::RECORD },
 };
 
 /* These symbols can't actually be accessed via these names. */
 static const std::vector<std::pair<poly::string_view, Symbol>>
         addl_strs_to_syms{
-            { "\\n", Symbol::NL },        { "Atom", Symbol::ATOM },
-            { "Record", Symbol::RECORD }, { "Array", Symbol::ARRAY },
-            { "Dest", Symbol::DEST },     { "bind", Symbol::BIND },
-            { "-", Symbol::NEG },
+            { "\\n", Symbol::NL },
+
         };
 
 static const std::map<Symbol, poly::string_view> syms_to_repr_strs{ []() {

--- a/tools/sddl2/compiler/Syntax.h
+++ b/tools/sddl2/compiler/Syntax.h
@@ -10,7 +10,9 @@
 namespace openzl::sddl2 {
 
 enum class Symbol {
-    // Grouping Tokens
+    /*
+     * Grouping Tokens
+     */
     NL,           // \n
     COMMA,        // ,
     PAREN_OPEN,   // (
@@ -20,25 +22,18 @@ enum class Symbol {
     SQUARE_OPEN,  // [
     SQUARE_CLOSE, // ]
 
-    // Operators
-    DIE,
+    /*
+     * Operators
+     */
     EXPECT,
-    LOG,
-
-    CONSUME,
     SIZEOF,
-    SEND,
     ASSIGN,
 
     ASSUME, // fused assign and consume
 
     MEMBER,
 
-    BIND,
-
-    NEG, // `-` is tokenized as SUB, but the unary form is converted into this
-         // during parsing.
-
+    // Arithmetic Operators
     EQ,
     NE,
     GT,
@@ -51,17 +46,20 @@ enum class Symbol {
     DIV,
     MOD,
 
+    // Bitwise Operators
     BIT_AND,
     BIT_OR,
     BIT_XOR,
     BIT_NOT,
 
+    // Logical Operators
     LOG_AND,
     LOG_OR,
     LOG_NOT,
 
-    // Keywords
-
+    /*
+     * Keywords
+     */
     // Integer Numeric Types
     BYTE,
     U8,
@@ -96,21 +94,8 @@ enum class Symbol {
     BF64BE,
 
     // Other Fields
-    POISON,
-    ATOM,
     RECORD,
-    ARRAY,
-
-    DEST,
 };
-
-enum class SymbolType {
-    GROUPING,
-    OPERATOR,
-    KEYWORD,
-};
-
-SymbolType sym_type(Symbol symbol);
 
 /// @returns a name string for a symbol.
 /// (E.g., Symbol::ADD -> "ADD")

--- a/tools/sddl2/compiler/grouper/Grouper.cpp
+++ b/tools/sddl2/compiler/grouper/Grouper.cpp
@@ -116,29 +116,6 @@ class GrouperImpl {
         return group_list_inner(it, end, lss_it->second);
     }
 
-    void check_token_legal_in_expr(
-            const SourceLocation& expr_loc,
-            GroupingPtr ptr) const
-    {
-        const auto* const token = some(ptr).as_token();
-        if (token != nullptr) {
-            if ((**token).is_sym()) {
-                const auto sym = (**token).sym();
-                if (sym_type(sym) == SymbolType::GROUPING) {
-                    log_(0) << InfoError(
-                                       expr_loc,
-                                       "While parsing this expression:")
-                                       .what();
-                    throw SyntaxError(
-                            some(ptr).loc(),
-                            "Unexpected separator token '"
-                                    + std::string{ sym_to_repr_str(sym) }
-                                    + "' in the middle of an expression.");
-                }
-            }
-        }
-    }
-
     // @p nodes includes statement terminator
     GroupingPtr group_expr(GroupingVec nodes) const
     {
@@ -159,12 +136,6 @@ class GrouperImpl {
                 grouped.push_back(std::move(maybe_list));
                 continue;
             }
-
-            if (it + 1 != end) {
-                check_token_legal_in_expr(full_loc, *it);
-            }
-
-            // otherwise
             grouped.push_back(*it);
         }
 

--- a/tools/sddl2/compiler/parser/AST.cpp
+++ b/tools/sddl2/compiler/parser/AST.cpp
@@ -36,6 +36,11 @@ bool ASTNode::operator==(const Symbol& sym) const
     return **tok == sym;
 }
 
+bool ASTNode::operator!=(const Symbol& sym) const
+{
+    return !(*this == sym);
+}
+
 ASTSym::ASTSym(const Token& token)
         : ASTUnconverted(token.loc()), sym_(token.sym())
 {
@@ -172,83 +177,35 @@ void ASTVar::print(std::ostream& os, size_t indent) const
     os << std::string(indent, ' ') << "Var: " << name_ << std::endl;
 }
 
-// TODO: message
-ASTPoison::ASTPoison(const Token& token, const ASTPtr& paren_ptr)
-        : ASTField(token.loc() + maybe_loc(paren_ptr))
-{
-    // validate_args(paren_ptr);
-}
-
-void ASTPoison::print(std::ostream& os, size_t indent) const
-{
-    os << std::string(indent, ' ') << "Field: POISON" << std::endl;
-}
-
-void ASTPoison::validate_args(const ASTPtr& paren_ptr)
-{
-    const auto* paren = paren_ptr->as_list();
-    if (paren == nullptr) {
-        throw InvariantViolation(
-                loc(),
-                "Field declaration must be given a parenthesized argument list.");
-    }
-    if (paren->nodes().size() != 0) {
-        throw ParseError(loc(), "Poison field declaration takes 0 arguments.");
-    }
-}
-
-ASTAtom::ASTAtom(const Token& token, const ASTPtr& paren_ptr)
-        : ASTField(token.loc() + some(paren_ptr).loc()),
-          width_(extract_width_arg(loc(), paren_ptr))
-{
-}
-
-void ASTAtom::print(std::ostream& os, size_t indent) const
-{
-    os << std::string(indent, ' ') << "Field: ATOM:" << std::endl;
-    width_->print(os, indent + 2);
-}
-
-ASTPtr ASTAtom::extract_width_arg(
-        const SourceLocation& loc,
-        const ASTPtr& paren_ptr)
-{
-    const auto* paren = paren_ptr->as_list();
-    if (paren == nullptr) {
-        throw InvariantViolation(
-                loc,
-                "Field declaration must be given a parenthesized argument list.");
-    }
-    const auto& nodes = paren->nodes();
-    if (nodes.size() != 1) {
-        throw ParseError(
-                loc, "Atom field declaration requires exactly 1 argument.");
-    }
-    return nodes[0];
-}
-
-ASTBuiltinField::ASTBuiltinField(const Token& token)
-        : ASTField(token.loc()), kw_(token.sym())
+ASTBuiltinField::ASTBuiltinField(const SourceLocation& loc, const Op& op)
+        : ASTField(loc), kw_(op)
 {
 }
 
 void ASTBuiltinField::print(std::ostream& os, size_t indent) const
 {
-    os << std::string(indent, ' ') << "Field: " << sym_to_debug_str(kw_)
+    os << std::string(indent, ' ') << "Field: " << op_to_debug_str(kw_)
        << std::endl;
 }
 
-ASTRecord::ASTRecord(const ASTPtr& paren_ptr)
-        : ASTField(some(paren_ptr).loc()),
-          fields_(extract_fields(loc(), paren_ptr))
+ASTRecord::ASTRecord(const ASTPtr& params, const ASTPtr& fields)
+        : ASTField(params->loc() + fields->loc()),
+          params_(extract_params(loc(), params)),
+          fields_(extract_fields(loc(), fields))
+
 {
 }
 
 void ASTRecord::print(std::ostream& os, size_t indent) const
 {
-    os << std::string(indent, ' ') << "Field: RECORD:" << std::endl;
+    os << std::string(indent, ' ') << "Field: Record:" << std::endl;
+    os << std::string(indent + 2, ' ') << "Captures: " << std::endl;
+    for (const auto& capture : params_) {
+        capture->print(os, indent + 4);
+    }
+    os << std::string(indent + 2, ' ') << "Fields: " << std::endl;
     for (const auto& field : fields_) {
-        field->print(os, indent + 2);
+        field->print(os, indent + 4);
     }
 }
 
@@ -259,11 +216,27 @@ ASTVec ASTRecord::extract_fields(
     const auto* list = paren_ptr->as_list();
     if (list == nullptr) {
         throw InvariantViolation(
-                loc, "Record declaration must be given a list as argument.");
+                loc, "Record declaration must be given a list of fields.");
     }
     if (list->list_type() != ListType::CURLY) {
         throw InvariantViolation(
-                loc, "Record declaration argument list must be curly-braced.");
+                loc, "Record declaration fields list must be curly-braced.");
+    }
+    return unwrap_parens(list->nodes());
+}
+
+ASTVec ASTRecord::extract_params(
+        const SourceLocation& loc,
+        const ASTPtr& paren_ptr)
+{
+    const auto* list = paren_ptr->as_list();
+    if (list == nullptr) {
+        throw InvariantViolation(
+                loc, "Record declaration must be given a list of params.");
+    }
+    if (list->list_type() != ListType::PAREN) {
+        throw InvariantViolation(
+                loc, "Record declaration params list must be parens.");
     }
     return unwrap_parens(list->nodes());
 }
@@ -282,92 +255,17 @@ void ASTArray::print(std::ostream& os, size_t indent) const
     len_->print(os, indent + 2);
 }
 
-ASTDest::ASTDest(const Token& token, const ASTPtr& paren_ptr)
-        : ASTConverted(token.loc() + maybe_loc(paren_ptr))
-{
-    // validate_args(paren_ptr);
-}
-
-void ASTDest::print(std::ostream& os, size_t indent) const
-{
-    os << std::string(indent, ' ') << "Dest" << std::endl;
-}
-
-void ASTDest::validate_args(const ASTPtr& paren_ptr)
-{
-    const auto* paren = paren_ptr->as_list();
-    if (paren == nullptr) {
-        throw InvariantViolation(
-                loc(),
-                "Dest declaration must be given a parenthesized argument list.");
-    }
-    if (paren->nodes().size() != 0) {
-        throw ParseError(loc(), "Dest declaration takes 0 arguments.");
-    }
-}
-
-ASTOp::ASTOp(const Token& token, ASTVec args)
-        : ASTConverted(token.loc() + join_locs(args)),
-          op_(token.sym()),
-          args_(std::move(args))
+ASTOp::ASTOp(const SourceLocation& loc, const Op& op, ASTVec args)
+        : ASTConverted(loc + join_locs(args)), op_(op), args_(std::move(args))
 {
 }
 
 void ASTOp::print(std::ostream& os, size_t indent) const
 {
-    os << std::string(indent, ' ') << "Op: " << sym_to_debug_str(op_)
+    os << std::string(indent, ' ') << "Op: " << op_to_debug_str(op_)
        << std::endl;
     for (const auto& arg : args_) {
         arg->print(os, indent + 2);
     }
-}
-
-ASTFunc::ASTFunc(ASTVec args, ASTVec body)
-        : ASTConverted(join_locs(args) + join_locs(body)),
-          args_(std::move(args)),
-          body_(std::move(body))
-{
-}
-
-void ASTFunc::print(std::ostream& os, size_t indent) const
-{
-    os << std::string(indent, ' ') << "Func:" << std::endl;
-    os << std::string(indent + 2, ' ') << "Args:" << std::endl;
-    for (const auto& arg : args_) {
-        arg->print(os, indent + 4);
-    }
-    os << std::string(indent + 2, ' ') << "Body:" << std::endl;
-    for (const auto& expr : body_) {
-        expr->print(os, indent + 4);
-    }
-}
-
-ASTTuple::ASTTuple(ASTPtr list)
-        : ASTConverted(some(list).loc()), tuple_(extract_exprs(loc(), list))
-{
-}
-
-void ASTTuple::print(std::ostream& os, size_t indent) const
-{
-    os << std::string(indent, ' ') << "Tuple:" << std::endl;
-    for (const auto& expr : tuple_) {
-        expr->print(os, indent + 2);
-    }
-}
-
-ASTVec ASTTuple::extract_exprs(
-        const SourceLocation& loc,
-        const ASTPtr& paren_ptr)
-{
-    const auto* list = paren_ptr->as_list();
-    if (list == nullptr) {
-        throw InvariantViolation(
-                loc, "Tuple declaration must be given a list as argument.");
-    }
-    if (list->list_type() != ListType::PAREN) {
-        throw InvariantViolation(
-                loc, "Tuple declaration argument list must be curly-braced.");
-    }
-    return unwrap_parens(list->nodes());
 }
 } // namespace openzl::sddl2

--- a/tools/sddl2/compiler/parser/AST.h
+++ b/tools/sddl2/compiler/parser/AST.h
@@ -8,6 +8,7 @@
 #include "openzl/shared/a1cbor.h"
 
 #include "tools/sddl2/compiler/Source.h"
+#include "tools/sddl2/compiler/parser/Ops.h"
 #include "tools/sddl2/compiler/tokenizer/Token.h"
 
 namespace openzl::sddl2 {
@@ -36,6 +37,7 @@ class ASTNode {
     virtual const ASTList* as_list() const;
 
     bool operator==(const Symbol& symbol) const;
+    bool operator!=(const Symbol& symbol) const;
 
     virtual void print(std::ostream& os, size_t indent = 0) const = 0;
 
@@ -145,45 +147,19 @@ class ASTField : public ASTConverted {
     using ASTConverted::ASTConverted;
 };
 
-class ASTPoison : public ASTField {
-   public:
-    explicit ASTPoison(
-            const Token& token,
-            const ASTPtr& paren_ptr = { nullptr });
-
-    void print(std::ostream& os, size_t indent) const override;
-
-   private:
-    void validate_args(const ASTPtr& paren_ptr);
-};
-
-class ASTAtom : public ASTField {
-   public:
-    explicit ASTAtom(const Token& token, const ASTPtr& paren_ptr);
-
-    void print(std::ostream& os, size_t indent) const override;
-
-   private:
-    static ASTPtr extract_width_arg(
-            const SourceLocation& loc,
-            const ASTPtr& paren_ptr);
-
-    const ASTPtr width_;
-};
-
 class ASTBuiltinField : public ASTField {
    public:
-    explicit ASTBuiltinField(const Token& token);
+    explicit ASTBuiltinField(const SourceLocation& loc, const Op& op);
 
     void print(std::ostream& os, size_t indent) const override;
 
    private:
-    const Symbol kw_;
+    const Op kw_;
 };
 
 class ASTRecord : public ASTField {
    public:
-    explicit ASTRecord(const ASTPtr& paren_ptr);
+    explicit ASTRecord(const ASTPtr& params, const ASTPtr& fields);
 
     void print(std::ostream& os, size_t indent) const override;
 
@@ -192,6 +168,11 @@ class ASTRecord : public ASTField {
             const SourceLocation& loc,
             const ASTPtr& paren_ptr);
 
+    static ASTVec extract_params(
+            const SourceLocation& loc,
+            const ASTPtr& paren_ptr);
+
+    const ASTVec params_;
     const ASTVec fields_;
 };
 
@@ -206,50 +187,153 @@ class ASTArray : public ASTField {
     const ASTPtr len_;
 };
 
-class ASTDest : public ASTConverted {
-   public:
-    explicit ASTDest(const Token& token, const ASTPtr& paren_ptr);
-
-    void print(std::ostream& os, size_t indent) const override;
-
-   private:
-    void validate_args(const ASTPtr& paren_ptr);
-};
-
 class ASTOp : public ASTConverted {
    public:
-    explicit ASTOp(const Token& token, ASTVec args);
+    explicit ASTOp(const SourceLocation& loc, const Op& op, ASTVec args);
 
     void print(std::ostream& os, size_t indent) const override;
 
    private:
-    const Symbol op_;
+    const Op op_;
     const ASTVec args_;
 };
 
-class ASTFunc : public ASTConverted {
+/**
+ * Helper to build a synthetic AST tree rather than translating tokens 1:1.
+ */
+class Codegen {
    public:
-    explicit ASTFunc(ASTVec args, ASTVec body);
+    explicit Codegen(SourceLocation loc) : loc_(std::move(loc)) {}
 
-    void print(std::ostream& os, size_t indent) const override;
+    Token token(Symbol sym) const
+    {
+        return Token{ loc_, sym };
+    }
+
+    template <typename... Args>
+    ASTVec vec(Args... args) const
+    {
+        return ASTVec{ std::move(args)... };
+    }
+
+    template <typename... Args>
+    ASTPtr op(Op op, Args... args) const
+    {
+        return std::make_shared<ASTOp>(
+                SourceLocation::null(), op, vec(std::move(args)...));
+    }
+
+    // Ops
+    ASTPtr expect(ASTPtr arg) const
+    {
+        return op(Op::EXPECT, std::move(arg));
+    }
+
+    ASTPtr consume(ASTPtr arg) const
+    {
+        return op(Op::CONSUME, std::move(arg));
+    }
+
+    ASTPtr size_of(ASTPtr arg) const
+    {
+        return op(Op::SIZEOF, std::move(arg));
+    }
+
+    ASTPtr assign(ASTPtr lhs, ASTPtr rhs) const
+    {
+        return op(Op::ASSIGN, std::move(lhs), std::move(rhs));
+    }
+
+    ASTPtr eq(ASTPtr lhs, ASTPtr rhs) const
+    {
+        return op(Op::EQ, std::move(lhs), std::move(rhs));
+    }
+
+    ASTPtr ne(ASTPtr lhs, ASTPtr rhs) const
+    {
+        return op(Op::NE, std::move(lhs), std::move(rhs));
+    }
+
+    ASTPtr add(ASTPtr lhs, ASTPtr rhs) const
+    {
+        return op(Op::ADD, std::move(lhs), std::move(rhs));
+    }
+
+    ASTPtr sub(ASTPtr lhs, ASTPtr rhs) const
+    {
+        return op(Op::SUB, std::move(lhs), std::move(rhs));
+    }
+
+    ASTPtr mul(ASTPtr lhs, ASTPtr rhs) const
+    {
+        return op(Op::MUL, std::move(lhs), std::move(rhs));
+    }
+
+    ASTPtr div(ASTPtr lhs, ASTPtr rhs) const
+    {
+        return op(Op::DIV, std::move(lhs), std::move(rhs));
+    }
+
+    ASTPtr mod(ASTPtr lhs, ASTPtr rhs) const
+    {
+        return op(Op::MOD, std::move(lhs), std::move(rhs));
+    }
+
+    // Other types of things
+
+    ASTPtr num(int64_t val) const
+    {
+        return std::make_shared<ASTNum>(Token{ loc_, val });
+    }
+
+    ASTPtr builtin_field(Op op) const
+    {
+        return std::make_shared<ASTBuiltinField>(loc_, op);
+    }
+
+    ASTPtr array(ASTPtr field, ASTPtr len) const
+    {
+        return std::make_shared<ASTArray>(std::move(field), std::move(len));
+    }
+
+    ASTPtr record(ASTVec params, ASTVec fields) const
+    {
+        return std::make_shared<ASTRecord>(
+                paren_list(std::move(params)), curly_list(std::move(fields)));
+    }
+
+    ASTPtr var(poly::string_view name) const
+    {
+        return std::make_shared<ASTVar>(Token{ loc_, name });
+    }
+
+    ASTPtr list(Symbol open_sym, ASTVec elts) const
+    {
+        const auto& list_sym_set = list_sym_sets.at(open_sym);
+        return std::make_shared<ASTList>(
+                list_sym_set.type,
+                std::make_shared<ASTSym>(token(list_sym_set.open)),
+                std::make_shared<ASTSym>(token(list_sym_set.close)),
+                std::move(elts));
+    }
+
+    ASTPtr paren_list(ASTVec elts) const
+    {
+        return list(Symbol::PAREN_OPEN, std::move(elts));
+    }
+
+    ASTPtr square_list(ASTVec elts) const
+    {
+        return list(Symbol::SQUARE_OPEN, std::move(elts));
+    }
+
+    ASTPtr curly_list(ASTVec elts) const
+    {
+        return list(Symbol::CURLY_OPEN, std::move(elts));
+    }
 
    private:
-    const ASTVec args_;
-    const ASTVec body_;
-};
-
-class ASTTuple : public ASTConverted {
-   public:
-    explicit ASTTuple(ASTPtr list);
-
-    void print(std::ostream& os, size_t indent) const override;
-
-   private:
-    static ASTVec extract_exprs(
-            const SourceLocation& loc,
-            const ASTPtr& paren_ptr);
-
-    const ASTVec tuple_;
+    const SourceLocation loc_;
 };
 
 } // namespace openzl::sddl2

--- a/tools/sddl2/compiler/parser/Grammar.cpp
+++ b/tools/sddl2/compiler/parser/Grammar.cpp
@@ -16,23 +16,7 @@ namespace openzl::sddl2 {
 
 namespace {
 
-Arity arity_of(ArgType lhs_type, ArgType rhs_type)
-{
-    if (lhs_type == ArgType::NONE) {
-        if (rhs_type == ArgType::NONE) {
-            return Arity::NULLARY;
-        } else {
-            return Arity::PREFIX_UNARY;
-        }
-    } else {
-        if (rhs_type == ArgType::NONE) {
-            throw InvariantViolation(
-                    "Postfix unary operators aren't supported!");
-        } else {
-            return Arity::INFIX_BINARY;
-        }
-    }
-}
+using ArgsVec = std::vector<ASTPtr>;
 
 Token token_of(const ASTPtr& node)
 {
@@ -108,195 +92,12 @@ const std::map<Associativity, poly::string_view> associativities_to_strs{
     { Associativity::RIGHT_TO_LEFT, "RIGHT_TO_LEFT" },
 };
 
-const std::map<Arity, poly::string_view> arities_to_strs{
-    { Arity::NULLARY, "NULLARY" },
-    { Arity::PREFIX_UNARY, "PREFIX_UNARY" },
-    { Arity::INFIX_BINARY, "INFIX_BINARY" },
-};
-
 const std::map<ArgType, poly::string_view> arg_types_to_strs{
-    { ArgType::NONE, "NONE" },
+    { ArgType::SYM, "SYM" },
     { ArgType::LIST_PAREN, "LIST_PAREN" },
     { ArgType::LIST_SQUARE, "LIST_SQUARE" },
     { ArgType::LIST_CURLY, "LIST_CURLY" },
     { ArgType::EXPR, "EXPR" },
-};
-
-/**
- * Helper to build a synthetic AST tree rather than translating tokens 1:1.
- */
-class Codegen {
-   public:
-    explicit Codegen(SourceLocation loc) : loc_(std::move(loc)) {}
-
-    Token token(Symbol sym) const
-    {
-        return Token{ loc_, sym };
-    }
-
-    template <typename... Args>
-    ASTVec vec(Args... args) const
-    {
-        return ASTVec{ std::move(args)... };
-    }
-
-    template <typename... Args>
-    ASTPtr op(Symbol sym, Args... args) const
-    {
-        return std::make_shared<ASTOp>(token(sym), vec(std::move(args)...));
-    }
-
-    // Ops
-
-    ASTPtr expect(ASTPtr arg) const
-    {
-        return op(Symbol::EXPECT, std::move(arg));
-    }
-
-    ASTPtr consume(ASTPtr arg) const
-    {
-        return op(Symbol::CONSUME, std::move(arg));
-    }
-
-    ASTPtr size_of(ASTPtr arg) const
-    {
-        return op(Symbol::SIZEOF, std::move(arg));
-    }
-
-    ASTPtr send(ASTPtr lhs, ASTPtr rhs) const
-    {
-        return op(Symbol::SEND, std::move(lhs), std::move(rhs));
-    }
-
-    ASTPtr assign(ASTPtr lhs, ASTPtr rhs) const
-    {
-        return op(Symbol::ASSIGN, std::move(lhs), std::move(rhs));
-    }
-
-    ASTPtr member(ASTPtr lhs, ASTPtr rhs) const
-    {
-        return op(Symbol::MEMBER, std::move(lhs), std::move(rhs));
-    }
-
-    ASTPtr bind(ASTPtr lhs, ASTPtr rhs) const
-    {
-        return op(Symbol::BIND, std::move(lhs), std::move(rhs));
-    }
-
-    ASTPtr neg(ASTPtr arg) const
-    {
-        return op(Symbol::NEG, std::move(arg));
-    }
-
-    ASTPtr eq(ASTPtr lhs, ASTPtr rhs) const
-    {
-        return op(Symbol::EQ, std::move(lhs), std::move(rhs));
-    }
-
-    ASTPtr ne(ASTPtr lhs, ASTPtr rhs) const
-    {
-        return op(Symbol::NE, std::move(lhs), std::move(rhs));
-    }
-
-    ASTPtr add(ASTPtr lhs, ASTPtr rhs) const
-    {
-        return op(Symbol::ADD, std::move(lhs), std::move(rhs));
-    }
-
-    ASTPtr sub(ASTPtr lhs, ASTPtr rhs) const
-    {
-        return op(Symbol::SUB, std::move(lhs), std::move(rhs));
-    }
-
-    ASTPtr mul(ASTPtr lhs, ASTPtr rhs) const
-    {
-        return op(Symbol::MUL, std::move(lhs), std::move(rhs));
-    }
-
-    ASTPtr div(ASTPtr lhs, ASTPtr rhs) const
-    {
-        return op(Symbol::DIV, std::move(lhs), std::move(rhs));
-    }
-
-    ASTPtr mod(ASTPtr lhs, ASTPtr rhs) const
-    {
-        return op(Symbol::MOD, std::move(lhs), std::move(rhs));
-    }
-
-    // Other types of things
-
-    ASTPtr num(int64_t val) const
-    {
-        return std::make_shared<ASTNum>(Token{ loc_, val });
-    }
-
-    ASTPtr array(ASTPtr field, ASTPtr len) const
-    {
-        return std::make_shared<ASTArray>(std::move(field), std::move(len));
-    }
-
-    ASTPtr record(ASTVec fields) const
-    {
-        return std::make_shared<ASTRecord>(curly_list(std::move(fields)));
-    }
-
-    ASTPtr dest() const
-    {
-        return std::make_shared<ASTDest>(Token{ loc_, 0 }, nullptr);
-    }
-
-    ASTPtr var(poly::string_view name) const
-    {
-        return std::make_shared<ASTVar>(Token{ loc_, name });
-    }
-
-    ASTPtr tuple(poly::string_view name) const
-    {
-        return std::make_shared<ASTVar>(Token{ loc_, name });
-    }
-
-    ASTPtr list(Symbol open_sym, ASTVec elts) const
-    {
-        const auto& list_sym_set = list_sym_sets.at(open_sym);
-        return std::make_shared<ASTList>(
-                list_sym_set.type,
-                std::make_shared<ASTSym>(token(list_sym_set.open)),
-                std::make_shared<ASTSym>(token(list_sym_set.close)),
-                std::move(elts));
-    }
-
-    ASTPtr paren_list(ASTVec elts) const
-    {
-        return list(Symbol::PAREN_OPEN, std::move(elts));
-    }
-
-    ASTPtr square_list(ASTVec elts) const
-    {
-        return list(Symbol::SQUARE_OPEN, std::move(elts));
-    }
-
-    ASTPtr curly_list(ASTVec elts) const
-    {
-        return list(Symbol::CURLY_OPEN, std::move(elts));
-    }
-
-    ASTPtr tuple(ASTVec elts) const
-    {
-        return std::make_shared<ASTTuple>(paren_list(std::move(elts)));
-    }
-
-    ASTPtr func(ASTVec args, ASTVec body) const
-    {
-        const auto args_ast   = paren_list(std::move(args));
-        const auto body_ast   = curly_list(std::move(body));
-        const auto& args_list = some(args_ast).as_list();
-        const auto& body_list = some(body_ast).as_list();
-        return std::make_shared<ASTFunc>(
-                args_list->nodes(), body_list->nodes());
-    }
-
-   private:
-    const SourceLocation loc_;
 };
 
 Associativity associativity_of(Precedence precedence)
@@ -309,6 +110,44 @@ Associativity associativity_of(Precedence precedence)
                 + std::string{ precedence_to_str(precedence) } + ")");
     }
 }
+
+const std::map<Symbol, Op> builtin_field_syms_to_ops{
+    { Symbol::BYTE, Op::BYTE },     { Symbol::U8, Op::U8 },
+    { Symbol::I8, Op::I8 },         { Symbol::U16LE, Op::U16LE },
+    { Symbol::U16BE, Op::U16BE },   { Symbol::I16LE, Op::I16LE },
+    { Symbol::I16BE, Op::I16BE },   { Symbol::U32LE, Op::U32LE },
+    { Symbol::U32BE, Op::U32BE },   { Symbol::I32LE, Op::I32LE },
+    { Symbol::I32BE, Op::I32BE },   { Symbol::U64LE, Op::U64LE },
+    { Symbol::U64BE, Op::U64BE },   { Symbol::I64LE, Op::I64LE },
+    { Symbol::I64BE, Op::I64BE },   { Symbol::F8, Op::F8 },
+    { Symbol::F16LE, Op::F16LE },   { Symbol::F16BE, Op::F16BE },
+    { Symbol::F32LE, Op::F32LE },   { Symbol::F32BE, Op::F32BE },
+    { Symbol::F64LE, Op::F64LE },   { Symbol::F64BE, Op::F64BE },
+    { Symbol::BF8, Op::BF8 },       { Symbol::BF16LE, Op::BF16LE },
+    { Symbol::BF16BE, Op::BF16BE }, { Symbol::BF32LE, Op::BF32LE },
+    { Symbol::BF32BE, Op::BF32BE }, { Symbol::BF64LE, Op::BF64LE },
+    { Symbol::BF64BE, Op::BF64BE },
+};
+
+const std::map<Symbol, Op> syms_to_ops{
+    { Symbol::EXPECT, Op::EXPECT },   { Symbol::ASSIGN, Op::ASSIGN },
+    { Symbol::SIZEOF, Op::SIZEOF },
+
+    { Symbol::EQ, Op::EQ },           { Symbol::NE, Op::NE },
+
+    { Symbol::ADD, Op::ADD },         { Symbol::SUB, Op::SUB },
+    { Symbol::MUL, Op::MUL },         { Symbol::DIV, Op::DIV },
+    { Symbol::MOD, Op::MOD },
+
+    { Symbol::GT, Op::GT },           { Symbol::GE, Op::GE },
+    { Symbol::LT, Op::LT },           { Symbol::LE, Op::LE },
+
+    { Symbol::LOG_AND, Op::LOG_AND }, { Symbol::LOG_OR, Op::LOG_OR },
+    { Symbol::LOG_NOT, Op::LOG_NOT },
+
+    { Symbol::BIT_AND, Op::BIT_AND }, { Symbol::BIT_XOR, Op::BIT_XOR },
+    { Symbol::BIT_OR, Op::BIT_OR },   { Symbol::BIT_NOT, Op::BIT_NOT },
+};
 
 } // anonymous namespace
 
@@ -330,15 +169,6 @@ poly::string_view associativity_to_str(Associativity associativity)
     }
 }
 
-poly::string_view arity_to_str(Arity arity)
-{
-    try {
-        return arities_to_strs.at(arity);
-    } catch (const std::out_of_range&) {
-        throw InvariantViolation("Lookup failed in arity_to_str()");
-    }
-}
-
 poly::string_view arg_type_to_str(ArgType arg_type)
 {
     try {
@@ -349,22 +179,21 @@ poly::string_view arg_type_to_str(ArgType arg_type)
 }
 
 GrammarRule::GrammarRule(
-        Symbol op,
+        Symbol sym,
         Precedence precedence,
-        ArgType lhs_type,
-        ArgType rhs_type)
-        : op_(op),
+        std::vector<ArgType> arg_types,
+        bool has_lhs_arg)
+        : sym_(sym),
           precedence_(precedence),
           associativity_(associativity_of(precedence)),
-          arity_(arity_of(lhs_type, rhs_type)),
-          lhs_type_(lhs_type),
-          rhs_type_(rhs_type)
+          arg_types_(std::move(arg_types)),
+          has_lhs_arg_(has_lhs_arg)
 {
 }
 
-Symbol GrammarRule::op() const
+Symbol GrammarRule::sym() const
 {
-    return op_;
+    return sym_;
 }
 
 Precedence GrammarRule::precedence() const
@@ -377,24 +206,29 @@ Associativity GrammarRule::associativity() const
     return associativity_;
 }
 
-Arity GrammarRule::arity() const
+std::vector<ArgType> GrammarRule::arg_types() const&
 {
-    return arity_;
+    return arg_types_;
 }
 
-ArgType GrammarRule::lhs_type() const
+size_t GrammarRule::num_args() const
 {
-    return lhs_type_;
+    return arg_types_.size();
 }
 
-ArgType GrammarRule::rhs_type() const
+size_t GrammarRule::num_rhs_args() const
 {
-    return rhs_type_;
+    return num_args() - (has_lhs_arg_ ? 1 : 0);
 }
 
-poly::string_view GrammarRule::op_str() const
+bool GrammarRule::has_lhs_arg() const
 {
-    return sym_to_debug_str(op());
+    return has_lhs_arg_;
+}
+
+poly::string_view GrammarRule::sym_str() const
+{
+    return sym_to_debug_str(sym());
 }
 
 poly::string_view GrammarRule::precedence_str() const
@@ -407,96 +241,59 @@ poly::string_view GrammarRule::associativity_str() const
     return associativity_to_str(associativity());
 }
 
-poly::string_view GrammarRule::arity_str() const
+std::string GrammarRule::arg_types_str() const
 {
-    return arity_to_str(arity());
-}
-
-poly::string_view GrammarRule::lhs_type_str() const
-{
-    return arg_type_to_str(lhs_type());
-}
-
-poly::string_view GrammarRule::rhs_type_str() const
-{
-    return arg_type_to_str(rhs_type());
+    std::stringstream ss;
+    ss << "[";
+    for (const auto& arg_type : arg_types()) {
+        ss << arg_type_to_str(arg_type) << ", ";
+    }
+    ss << "]";
+    return std::move(ss).str();
 }
 
 std::string GrammarRule::info_str() const
 {
     std::stringstream ss;
     ss << "GrammarRule(";
-    ss << "Symbol::" << op_str() << ", ";
+    ss << "Symbol::" << sym_str() << ", ";
     ss << "Precedence::" << precedence_str() << ", ";
     ss << "Associativity::" << associativity_str() << ", ";
-    ss << "Arity::" << arity_str() << ", ";
-    ss << "ArgType::" << lhs_type_str() << ", ";
-    ss << "ArgType::" << rhs_type_str();
+    ss << "ArgTypes: " << arg_types_str();
     ss << ")";
     return std::move(ss).str();
 }
 
-ASTPtr GrammarRule::gen(ASTPtr op, ASTPtr lhs, ASTPtr rhs) const
+ASTPtr GrammarRule::gen(ASTPtr op, ArgsVec args) const
 {
-    const auto lt = lhs_type();
-    const auto rt = rhs_type();
-    if ((lt == ArgType::NONE) != (lhs == nullptr)) {
-        if (lhs) {
-            throw InvariantViolation(
-                    some(op).loc(),
-                    "Unexpectedly received left-hand argument when this rule doesn't expect one.");
-        } else {
-            throw InvariantViolation(
-                    some(op).loc(),
-                    "Got null left-hand argument when this rule expects one.");
-        }
-    }
-    if ((rt == ArgType::NONE) != (rhs == nullptr)) {
-        if (rhs) {
-            throw InvariantViolation(
-                    some(op).loc(),
-                    "Unexpectedly received right-hand argument when this rule doesn't expect one.");
-        } else {
-            throw InvariantViolation(
-                    some(op).loc(),
-                    "Got null right-hand argument when this rule expects one.");
-        }
+    if (args.size() != arg_types().size()) {
+        throw InvariantViolation(
+                some(op).loc(),
+                "Expected " + std::to_string(arg_types().size())
+                        + " arguments, but got " + std::to_string(args.size())
+                        + "!");
     }
 
-    {
-        auto maybe_lhs = match_lhs(op, std::move(lhs));
-        if (!maybe_lhs) {
+    for (size_t i = 0; i < args.size(); ++i) {
+        auto& arg      = args.at(i);
+        auto maybe_arg = match_arg(op, std::move(arg), i);
+        if (!maybe_arg) {
             throw InvariantViolation(
                     some(op).loc(),
-                    "Left-hand argument failed to match while the op was being generated, i.e., after it should already have successfully been matched!");
+                    "Argument failed to match while the op was being generated, i.e., after it should already have successfully been matched!");
         }
-        lhs = std::move(maybe_lhs).value();
+        args.at(i) = std::move(maybe_arg).value();
     }
-    {
-        auto maybe_rhs = match_rhs(op, std::move(rhs));
-        if (!maybe_rhs) {
-            throw InvariantViolation(
-                    some(op).loc(),
-                    "Right-hand argument failed to match while the op was being generated, i.e., after it should already have successfully been matched!");
-        }
-        rhs = std::move(maybe_rhs).value();
-    }
-
-    auto result = do_gen(std::move(op), std::move(lhs), std::move(rhs));
+    auto result = do_gen(std::move(op), std::move(args));
     some(result);
     return result;
 }
 
-poly::optional<ASTPtr> GrammarRule::match_lhs(const ASTPtr& op, ASTPtr arg)
-        const
+poly::optional<ASTPtr>
+GrammarRule::match_arg(const ASTPtr& op, ASTPtr arg, size_t idx) const
 {
-    const auto type = lhs_type();
+    const auto type = arg_types().at(idx);
     switch (type) {
-        case ArgType::NONE:
-            if (arg != nullptr) {
-                return poly::nullopt;
-            }
-            break;
         case ArgType::LIST_SQUARE:
         case ArgType::LIST_CURLY:
             arg = unwrap_parens(std::move(arg));
@@ -522,45 +319,8 @@ poly::optional<ASTPtr> GrammarRule::match_lhs(const ASTPtr& op, ASTPtr arg)
             }
             break;
         }
-        default:
-            throw InvariantViolation(
-                    some(op).loc() + some(arg).loc(), "Illegal ArgType!");
-    }
-
-    return do_match_lhs(op, std::move(arg));
-}
-
-poly::optional<ASTPtr> GrammarRule::match_rhs(const ASTPtr& op, ASTPtr arg)
-        const
-{
-    const auto type = rhs_type();
-    switch (type) {
-        case ArgType::NONE:
-            if (arg != nullptr) {
-                return poly::nullopt;
-            }
-            break;
-        case ArgType::LIST_SQUARE:
-        case ArgType::LIST_CURLY:
-            arg = unwrap_parens(std::move(arg));
-            ZL_FALLTHROUGH;
-        case ArgType::LIST_PAREN: {
-            const auto* const list = some(arg).as_list();
-            if (list == nullptr) {
-                return poly::nullopt;
-            }
-            const auto list_type = arg_types_to_list_types.at(type);
-            if (list->list_type() != list_type) {
-                return poly::nullopt;
-            }
-            break;
-        }
-        case ArgType::EXPR: {
-            if (some(arg).as_sym() != nullptr) {
-                return poly::nullopt;
-            }
-            arg = unwrap_parens(arg);
-            if (some(arg).as_list() != nullptr) {
+        case ArgType::SYM: {
+            if (some(arg).as_sym() == nullptr) {
                 return poly::nullopt;
             }
             break;
@@ -570,17 +330,11 @@ poly::optional<ASTPtr> GrammarRule::match_rhs(const ASTPtr& op, ASTPtr arg)
                     some(op).loc() + some(arg).loc(), "Illegal ArgType!");
     }
 
-    return do_match_rhs(op, std::move(arg));
+    return do_match_arg(op, std::move(arg), idx);
 }
 
-poly::optional<ASTPtr> GrammarRule::do_match_lhs(const ASTPtr&, ASTPtr arg)
-        const
-{
-    return std::move(arg);
-}
-
-poly::optional<ASTPtr> GrammarRule::do_match_rhs(const ASTPtr&, ASTPtr arg)
-        const
+poly::optional<ASTPtr>
+GrammarRule::do_match_arg(const ASTPtr&, ASTPtr arg, size_t) const
 {
     return std::move(arg);
 }
@@ -589,145 +343,17 @@ namespace {
 
 class BuiltInFieldRule : public GrammarRule {
    public:
-    explicit BuiltInFieldRule(Symbol op)
-            : GrammarRule(op, Precedence::NULLARY, ArgType::NONE, ArgType::NONE)
+    explicit BuiltInFieldRule(Symbol sym)
+            : GrammarRule(sym, Precedence::NULLARY, std::vector<ArgType>())
     {
     }
 
    private:
-    ASTPtr do_gen(ASTPtr op, ASTPtr, ASTPtr) const override
+    ASTPtr do_gen(ASTPtr op, ArgsVec) const override
     {
-        ASTVec args{
-            std::make_shared<ASTBuiltinField>(token_of(op)),
-            std::make_shared<ASTDest>(token_of(op), nullptr),
-        };
-
-        return std::make_shared<ASTOp>(
-                Token{ op->loc(), Symbol::SEND }, std::move(args));
-    }
-};
-
-class PoisonRule : public GrammarRule {
-   public:
-    explicit PoisonRule()
-            : GrammarRule(
-                      Symbol::POISON,
-                      Precedence::NULLARY,
-                      ArgType::NONE,
-                      ArgType::NONE)
-    {
-    }
-
-   private:
-    ASTPtr do_gen(ASTPtr op, ASTPtr, ASTPtr) const override
-    {
-        return std::make_shared<ASTPoison>(token_of(op));
-    }
-};
-
-class RecordRule : public GrammarRule {
-   public:
-    explicit RecordRule()
-            : GrammarRule(
-                      Symbol::RECORD,
-                      Precedence::UNARY,
-                      ArgType::NONE,
-                      ArgType::LIST_CURLY)
-    {
-    }
-
-   private:
-    ASTPtr do_gen(ASTPtr, ASTPtr, ASTPtr rhs) const override
-    {
-        return std::make_shared<ASTRecord>(std::move(rhs));
-    }
-};
-
-class FuncRule : public GrammarRule {
-   public:
-    explicit FuncRule()
-            : GrammarRule(
-                      Symbol::RECORD,
-                      Precedence::ACCESS,
-                      ArgType::LIST_PAREN,
-                      ArgType::LIST_CURLY)
-    {
-    }
-
-   private:
-    ASTPtr do_gen(ASTPtr, ASTPtr lhs, ASTPtr rhs) const override
-    {
-        const auto& args = some(lhs).as_list();
-        const auto& body = some(rhs).as_list();
-        return std::make_shared<ASTFunc>(args->nodes(), body->nodes());
-    }
-};
-
-class ArrayRule : public GrammarRule {
-   public:
-    explicit ArrayRule()
-            : GrammarRule(
-                      Symbol::ARRAY,
-                      Precedence::ACCESS,
-                      ArgType::EXPR,
-                      ArgType::LIST_SQUARE)
-    {
-    }
-
-   private:
-    ASTPtr do_gen(ASTPtr, ASTPtr lhs, ASTPtr rhs) const override
-    {
-        const auto& rhs_nodes                      = unwrap_square(rhs);
-        constexpr bool allow_implicit_array_sizing = true;
-        if (allow_implicit_array_sizing && rhs_nodes.size() == 0) {
-            const Codegen cg{ maybe_loc(lhs) + maybe_loc(rhs) };
-
-            /**
-             * This expands:
-             * ```
-             * field[]
-             * ```
-             * into
-             * ```
-             * (: (__field, __rem) {
-             *   __size = sizeof __field
-             *   expect __rem % __size == 0
-             *   __len = __rem / __size
-             *   __resolved = __field[__len]
-             * } (field, _rem)).__resolved
-             * ```
-             */
-
-            const auto field_var    = cg.var("__field");
-            const auto rem_var      = cg.var("__rem");
-            const auto size_var     = cg.var("__size");
-            const auto len_var      = cg.var("__len");
-            const auto resolved_var = cg.var("__resolved");
-            return cg.member(
-                    cg.consume(cg.bind(
-                            cg.func(cg.vec(field_var, rem_var),
-                                    cg.vec(cg.assign(
-                                                   size_var,
-                                                   cg.size_of(field_var)),
-                                           cg.assign(
-                                                   len_var,
-                                                   cg.div(rem_var, size_var)),
-                                           cg.expect(cg.eq(
-                                                   cg.mod(rem_var, size_var),
-                                                   cg.num(0))),
-                                           cg.assign(
-                                                   resolved_var,
-                                                   cg.array(
-                                                           field_var,
-                                                           len_var)))),
-                            cg.tuple(cg.vec(std::move(lhs), cg.var("_rem"))))),
-                    resolved_var);
-        } else if (rhs_nodes.size() != 1) {
-            throw ParseError(
-                    some(rhs).loc(),
-                    "Array declaration right-hand side list must have single element.");
-        }
-        return std::make_shared<ASTArray>(std::move(lhs), rhs_nodes[0]);
+        auto token = token_of(op);
+        return std::make_shared<ASTBuiltinField>(
+                token.loc(), builtin_field_syms_to_ops.at(token.sym()));
     }
 };
 
@@ -739,38 +365,21 @@ class OpRule : public GrammarRule {
     }
 
    protected:
-    ASTPtr do_gen(ASTPtr op, ASTPtr lhs, ASTPtr rhs) const override
+    ASTPtr do_gen(ASTPtr op, ArgsVec args) const override
     {
-        std::vector<ASTPtr> args;
-        switch (arity()) {
-            case Arity::INFIX_BINARY:
-                args.push_back(std::move(lhs));
-                ZL_FALLTHROUGH;
-            case Arity::PREFIX_UNARY:
-                args.push_back(std::move(rhs));
-                ZL_FALLTHROUGH;
-            case Arity::NULLARY:
-                break;
-        }
+        auto token = op->as_sym()
+                ? token_of(op)
+                : Token{ SourceLocation::null(), this->sym() };
 
-        auto token = op->as_sym() ? token_of(op)
-                                  : Token{ SourceLocation::null(), this->op() };
-        return std::make_shared<ASTOp>(token, std::move(args));
-    }
-};
-
-class NullaryOpRule : public OpRule {
-   public:
-    explicit NullaryOpRule(Symbol op)
-            : OpRule(op, Precedence::NULLARY, ArgType::NONE, ArgType::NONE)
-    {
+        return std::make_shared<ASTOp>(
+                token.loc(), syms_to_ops.at(token.sym()), std::move(args));
     }
 };
 
 class UnaryOpRule : public OpRule {
    public:
     explicit UnaryOpRule(Symbol op, Precedence precedence = Precedence::UNARY)
-            : OpRule(op, precedence, ArgType::NONE, ArgType::EXPR)
+            : OpRule(op, precedence, std::vector<ArgType>({ ArgType::EXPR }))
     {
     }
 };
@@ -778,7 +387,10 @@ class UnaryOpRule : public OpRule {
 class BinaryOpRule : public OpRule {
    public:
     explicit BinaryOpRule(Symbol op, Precedence precedence)
-            : OpRule(op, precedence, ArgType::EXPR, ArgType::EXPR)
+            : OpRule(op,
+                     precedence,
+                     std::vector<ArgType>({ ArgType::EXPR, ArgType::EXPR }),
+                     true)
     {
     }
 };
@@ -790,16 +402,13 @@ class BinaryAssumeRule : public BinaryOpRule {
     {
     }
 
-    ASTPtr do_gen(ASTPtr op, ASTPtr lhs, ASTPtr rhs) const override
+    ASTPtr do_gen(ASTPtr op, ArgsVec args) const override
     {
-        ASTVec args{ std::move(rhs) };
-        rhs = std::make_shared<ASTOp>(
-                Token{ some(op).loc(), Symbol::CONSUME }, std::move(args));
-        args.clear();
-        args.push_back(std::move(lhs));
-        args.push_back(std::move(rhs));
-        return std::make_shared<ASTOp>(
-                Token{ some(op).loc(), Symbol::ASSIGN }, std::move(args));
+        auto& name = args.at(0);
+        auto& val  = args.at(1);
+
+        Codegen cg{ some(op).loc() };
+        return cg.assign(std::move(name), cg.consume(std::move(val)));
     }
 };
 
@@ -810,11 +419,10 @@ class UnaryAssumeRule : public UnaryOpRule {
     {
     }
 
-    ASTPtr do_gen(ASTPtr op, ASTPtr, ASTPtr rhs) const override
+    ASTPtr do_gen(ASTPtr op, ArgsVec args) const override
     {
-        ASTVec args{ std::move(rhs) };
         return std::make_shared<ASTOp>(
-                Token{ some(op).loc(), Symbol::CONSUME }, std::move(args));
+                some(op).loc(), Op::CONSUME, std::move(args));
     }
 };
 
@@ -822,51 +430,81 @@ class NegationRule : public UnaryOpRule {
    public:
     explicit NegationRule() : UnaryOpRule(Symbol::SUB, Precedence::UNARY) {}
 
-    ASTPtr do_gen(ASTPtr op, ASTPtr, ASTPtr rhs) const override
+    ASTPtr do_gen(ASTPtr op, ArgsVec args) const override
     {
-        const auto* const rhs_num = dynamic_cast<const ASTNum*>(&some(rhs));
-        if (rhs_num != NULL) {
-            // Optimization: if the rhs is a literal number, fold the negation
-            // into the literal rather than emit a negation operation on the
-            // positive literal.
+        const auto& arg           = args.at(0);
+        const auto* const arg_num = dynamic_cast<const ASTNum*>(&some(arg));
+        if (arg_num != NULL) {
+            // Optimization: if the rhs is a literal number, fold the
+            // negation into the literal rather than emit a negation
+            // operation on the positive literal.
             return std::make_shared<ASTNum>(
-                    Token{ some(op).loc() + rhs->loc(), -rhs_num->val() });
+                    Token{ some(op).loc() + arg->loc(), -arg_num->val() });
         }
 
-        ASTVec args{ std::move(rhs) };
         return std::make_shared<ASTOp>(
-                Token{ some(op).loc(), Symbol::NEG }, std::move(args));
+                some(op).loc(), Op::NEG, std::move(args));
     }
 };
 
-class BindRule : public OpRule {
+class ArrayRule : public GrammarRule {
    public:
-    explicit BindRule()
-            : OpRule(Symbol::BIND,
-                     Precedence::ACCESS,
-                     ArgType::EXPR,
-                     ArgType::LIST_PAREN)
+    explicit ArrayRule()
+            : GrammarRule(
+                      Symbol::PAREN_OPEN, /* bit weird */
+                      Precedence::ACCESS,
+                      std::vector<ArgType>({ ArgType::EXPR }),
+                      true)
     {
     }
 
-    ASTPtr do_gen(ASTPtr op, ASTPtr lhs, ASTPtr rhs) const override
+   private:
+    ASTPtr do_gen(ASTPtr op, ArgsVec args) const override
     {
-        return OpRule::do_gen(
-                std::move(op),
-                std::move(lhs),
-                std::make_shared<ASTTuple>(std::move(rhs)));
+        auto& type      = args.at(0);
+        auto& len_nodes = unwrap_square(op);
+
+        // TODO: allow implicit array sizing
+        if (len_nodes.size() != 1) {
+            throw ParseError(
+                    some(op).loc(),
+                    "Array declaration square must have single element.");
+        }
+        return std::make_shared<ASTArray>(std::move(type), len_nodes.at(0));
     }
 };
 
-const std::vector<Symbol> builtin_field_ops{
-    Symbol::BYTE,   Symbol::U8,     Symbol::I8,     Symbol::U16LE,
-    Symbol::U16BE,  Symbol::I16LE,  Symbol::I16BE,  Symbol::U32LE,
-    Symbol::U32BE,  Symbol::I32LE,  Symbol::I32BE,  Symbol::U64LE,
-    Symbol::U64BE,  Symbol::I64LE,  Symbol::I64BE,  Symbol::F8,
-    Symbol::F16LE,  Symbol::F16BE,  Symbol::F32LE,  Symbol::F32BE,
-    Symbol::F64LE,  Symbol::F64BE,  Symbol::BF8,    Symbol::BF16LE,
-    Symbol::BF16BE, Symbol::BF32LE, Symbol::BF32BE, Symbol::BF64LE,
-    Symbol::BF64BE,
+class RecordRule : public GrammarRule {
+   public:
+    explicit RecordRule()
+            : GrammarRule(
+                      Symbol::RECORD,
+                      Precedence::NULLARY,
+                      std::vector<ArgType>({ ArgType::EXPR,
+                                             ArgType::LIST_PAREN,
+                                             ArgType::SYM,
+                                             ArgType::LIST_CURLY }))
+    {
+    }
+
+    ASTPtr do_gen(ASTPtr op, ArgsVec args) const override
+    {
+        auto& name   = args.at(0);
+        auto& params = args.at(1);
+        auto& assign = args.at(2);
+        auto& fields = args.at(3);
+
+        if (some(assign) != Symbol::ASSIGN) {
+            throw InvariantViolation(
+                    some(op).loc(),
+                    "Expected assignment operator in record declaration!");
+        }
+
+        return Codegen{ some(op).loc() }.assign(
+                std::move(name),
+                std::make_shared<ASTRecord>(
+                        std::move(params), std::move(fields)));
+    }
 };
 
 template <typename RuleT, typename... Args>
@@ -880,37 +518,19 @@ void add_rule(
 const std::vector<std::unique_ptr<const GrammarRule>> grammar_rules{ []() {
     std::vector<std::unique_ptr<const GrammarRule>> r;
 
-    // Types and Dests
-
-    // Built-ins
-    for (const auto op : builtin_field_ops) {
-        add_rule<BuiltInFieldRule>(r, op);
+    // Built-in fields
+    for (const auto& [sym, _] : builtin_field_syms_to_ops) {
+        add_rule<BuiltInFieldRule>(r, sym);
     }
 
-    // Compound type ops
-    // add_rule<RecordRule>(r);
-    add_rule<ArrayRule>(r);
-
-    add_rule<PoisonRule>(r);
-    // add_rule<AtomRule>(r);
-    // add_rule<RecordRule>(r);
-    // add_rule<ArrayRule>(r);
-
-    // add_rule<DestRule>(r);
+    // Complex fields
+    add_rule<RecordRule>(r);
 
     // Ops
-
-    add_rule<NullaryOpRule>(r, Symbol::DIE);
-
     add_rule<UnaryOpRule>(r, Symbol::EXPECT, Precedence::ASSIGNMENT);
-    add_rule<UnaryOpRule>(r, Symbol::LOG);
-
-    add_rule<UnaryOpRule>(r, Symbol::CONSUME);
     add_rule<UnaryOpRule>(r, Symbol::SIZEOF);
-
     add_rule<NegationRule>(r);
 
-    add_rule<BinaryOpRule>(r, Symbol::SEND, Precedence::ASSIGNMENT);
     add_rule<BinaryOpRule>(r, Symbol::ASSIGN, Precedence::ASSIGNMENT);
     add_rule<BinaryAssumeRule>(r);
     add_rule<UnaryAssumeRule>(r);
@@ -945,47 +565,32 @@ const std::vector<std::unique_ptr<const GrammarRule>> grammar_rules{ []() {
     return r;
 }() };
 
-const std::map<Symbol, std::vector<std::reference_wrapper<const GrammarRule>>>
-        syms_to_rules{ []() {
-            std::map<
-                    Symbol,
-                    std::vector<std::reference_wrapper<const GrammarRule>>>
-                    m;
-            for (const auto& rule_ptr : grammar_rules) {
-                const auto& rule = *rule_ptr;
-                m[rule.op()].emplace_back(rule);
-            }
-            return m;
-        }() };
+using GrammarRuleRefs = std::vector<std::reference_wrapper<const GrammarRule>>;
 
-const std::map<ListType, std::vector<std::reference_wrapper<const GrammarRule>>>
-        list_types_to_implicit_rules{ []() {
-            std::map<
-                    ListType,
-                    std::vector<std::reference_wrapper<const GrammarRule>>>
-                    m;
+const std::map<Symbol, GrammarRuleRefs> syms_to_rules{ []() {
+    std::map<Symbol, GrammarRuleRefs> m;
+    for (const auto& rule_ptr : grammar_rules) {
+        const auto& rule = *rule_ptr;
+        m[rule.sym()].emplace_back(rule);
+    }
+    return m;
+}() };
 
-            static const std::unique_ptr<const GrammarRule> bind_rule =
-                    std::make_unique<BindRule>();
-            m[ListType::PAREN].emplace_back(*bind_rule);
+const std::map<ListType, GrammarRuleRefs> list_types_to_rules{ []() {
+    std::map<ListType, GrammarRuleRefs> m;
 
-            static const std::unique_ptr<const GrammarRule> array_rule =
-                    std::make_unique<ArrayRule>();
-            m[ListType::SQUARE].emplace_back(*array_rule);
+    m[ListType::PAREN] = {};
 
-            static const std::unique_ptr<const GrammarRule> record_rule =
-                    std::make_unique<RecordRule>();
-            m[ListType::CURLY].emplace_back(*record_rule);
-            static const std::unique_ptr<const GrammarRule> func_rule =
-                    std::make_unique<FuncRule>();
-            m[ListType::CURLY].emplace_back(*func_rule);
-            return m;
-        }() };
+    static const std::unique_ptr<const GrammarRule> array_rule =
+            std::make_unique<ArrayRule>();
+    m[ListType::SQUARE] = { *array_rule };
+    m[ListType::CURLY]  = {};
+    return m;
+}() };
 
 } // anonymous namespace
 
-const std::vector<std::reference_wrapper<const GrammarRule>>& sym_to_rules(
-        const Symbol sym)
+const GrammarRuleRefs& sym_to_rules(const Symbol sym)
 {
     try {
         return syms_to_rules.at(sym);
@@ -996,27 +601,14 @@ const std::vector<std::reference_wrapper<const GrammarRule>>& sym_to_rules(
     }
 }
 
-const std::vector<std::reference_wrapper<const GrammarRule>>&
-list_type_to_implicit_rules(const ListType list_type)
+const GrammarRuleRefs& list_type_to_rules(const ListType list_type)
 {
     try {
-        return list_types_to_implicit_rules.at(list_type);
+        return list_types_to_rules.at(list_type);
     } catch (const std::out_of_range&) {
         throw InvariantViolation(
-                "Lookup failed in list_type_to_implicit_rules(ListType::"
+                "Lookup failed in list_type_to_rules(ListType::"
                 + std::string{ list_type_to_debug_str(list_type) } + ")");
     }
 }
-
-bool sym_is_always_binary_op(Symbol sym)
-{
-    const auto& rules = sym_to_rules(sym);
-    for (const auto& rule : rules) {
-        if (rule.get().arity() != Arity::INFIX_BINARY) {
-            return false;
-        }
-    }
-    return true;
-}
-
 } // namespace openzl::sddl2

--- a/tools/sddl2/compiler/parser/Grammar.h
+++ b/tools/sddl2/compiler/parser/Grammar.h
@@ -44,14 +44,8 @@ enum class Associativity {
     RIGHT_TO_LEFT,
 };
 
-enum class Arity {
-    NULLARY,
-    PREFIX_UNARY,
-    INFIX_BINARY,
-};
-
 enum class ArgType {
-    NONE,
+    SYM,
     LIST_PAREN,
     LIST_SQUARE,
     LIST_CURLY,
@@ -62,27 +56,27 @@ poly::string_view precedence_to_str(Precedence precedence);
 
 poly::string_view associativity_to_str(Associativity associativity);
 
-poly::string_view arity_to_str(Arity arity);
-
 poly::string_view arg_type_to_str(ArgType arg_type);
 
 class GrammarRule {
    public:
     virtual ~GrammarRule() = default;
 
-    Symbol op() const;
+    Symbol sym() const;
     Precedence precedence() const;
     Associativity associativity() const;
-    Arity arity() const;
-    ArgType lhs_type() const;
-    ArgType rhs_type() const;
 
-    poly::string_view op_str() const;
+    /// The types of arguments that this rule accepts.
+    std::vector<ArgType> arg_types() const&;
+    size_t num_args() const;
+    size_t num_rhs_args() const;
+    bool has_lhs_arg() const;
+
+    poly::string_view sym_str() const;
     poly::string_view precedence_str() const;
     poly::string_view associativity_str() const;
-    poly::string_view arity_str() const;
-    poly::string_view lhs_type_str() const;
-    poly::string_view rhs_type_str() const;
+
+    std::string arg_types_str() const;
 
     /// An assemblage of the above strings into one record.
     std::string info_str() const;
@@ -90,47 +84,40 @@ class GrammarRule {
     /**
      * Apply this rule and construct an ASTNode from the op and args.
      */
-    ASTPtr gen(ASTPtr op, ASTPtr lhs, ASTPtr rhs) const;
+    ASTPtr gen(ASTPtr op, std::vector<ASTPtr> args) const;
 
-    poly::optional<ASTPtr> match_lhs(const ASTPtr& op, ASTPtr arg) const;
-
-    poly::optional<ASTPtr> match_rhs(const ASTPtr& op, ASTPtr arg) const;
+    poly::optional<ASTPtr> match_arg(const ASTPtr& op, ASTPtr arg, size_t idx)
+            const;
 
    protected:
     GrammarRule(
-            Symbol op,
+            Symbol sym,
             Precedence precedence,
-            ArgType lhs_type,
-            ArgType rhs_type);
+            std::vector<ArgType> arg_types,
+            bool has_lhs_arg = false);
 
    private:
-    virtual ASTPtr do_gen(ASTPtr op, ASTPtr lhs, ASTPtr rhs) const = 0;
+    virtual ASTPtr do_gen(ASTPtr op, std::vector<ASTPtr> args) const = 0;
 
-    /// Can set custom matching logic on top of the matching done in @ref
-    /// lhs_matches, defaults to permissive.
-    virtual poly::optional<ASTPtr> do_match_lhs(const ASTPtr& op, ASTPtr arg)
-            const;
-
-    /// Can set custom matching logic on top of the matching done in @ref
-    /// rhs_matches, defaults to permissive.
-    virtual poly::optional<ASTPtr> do_match_rhs(const ASTPtr& op, ASTPtr arg)
-            const;
+    virtual poly::optional<ASTPtr>
+    do_match_arg(const ASTPtr& op, ASTPtr arg, size_t idx) const;
 
    private:
-    const Symbol op_;
+    /// The symbol that this rule matches.
+    const Symbol sym_;
+
     const Precedence precedence_;
     const Associativity associativity_;
-    const Arity arity_;
-    const ArgType lhs_type_;
-    const ArgType rhs_type_;
+    const std::vector<ArgType> arg_types_;
+
+    /// True if the first argument is the left-hand side of the operator.
+    bool has_lhs_arg_ = false;
 };
 
 const std::vector<std::reference_wrapper<const GrammarRule>>& sym_to_rules(
         Symbol symbol);
 
 const std::vector<std::reference_wrapper<const GrammarRule>>&
-list_type_to_implicit_rules(ListType list_type);
-
-bool sym_is_always_binary_op(Symbol symbol);
+list_type_to_rules(ListType list_type);
 
 } // namespace openzl::sddl2

--- a/tools/sddl2/compiler/parser/Ops.cpp
+++ b/tools/sddl2/compiler/parser/Ops.cpp
@@ -1,0 +1,88 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#include <map>
+#include <stdexcept>
+
+#include "tools/sddl2/compiler/parser/Ops.h"
+
+namespace openzl::sddl2 {
+
+static const std::map<Op, poly::string_view> ops_to_debug_strs{
+    { Op::EXPECT, "EXPECT" },
+    { Op::ASSIGN, "ASSIGN" },
+    { Op::CONSUME, "CONSUME" },
+    { Op::ASSUME, "ASSUME" },
+    { Op::SEND, "SEND" },
+    { Op::SIZEOF, "SIZEOF" },
+
+    // Arithmetic Operators
+    { Op::NEG, "NEG" },
+    { Op::EQ, "EQ" },
+    { Op::NE, "NE" },
+    { Op::GT, "GT" },
+    { Op::GE, "GE" },
+    { Op::LT, "LT" },
+    { Op::LE, "LE" },
+    { Op::ADD, "ADD" },
+    { Op::SUB, "SUB" },
+    { Op::MUL, "MUL" },
+    { Op::DIV, "DIV" },
+    { Op::MOD, "MOD" },
+
+    // Bitwise Operators
+    { Op::BIT_AND, "BIT_AND" },
+    { Op::BIT_OR, "BIT_OR" },
+    { Op::BIT_XOR, "BIT_XOR" },
+    { Op::BIT_NOT, "BIT_NOT" },
+
+    // Logical Operators
+    { Op::LOG_AND, "LOG_AND" },
+    { Op::LOG_OR, "LOG_OR" },
+    { Op::LOG_NOT, "LOG_NOT" },
+
+    // Integer Numeric Types
+    { Op::BYTE, "BYTE" },
+    { Op::U8, "U8" },
+    { Op::I8, "I8" },
+    { Op::U16LE, "U16LE" },
+    { Op::U16BE, "U16BE" },
+    { Op::I16LE, "I16LE" },
+    { Op::I16BE, "I16BE" },
+    { Op::U32LE, "U32LE" },
+    { Op::U32BE, "U32BE" },
+    { Op::I32LE, "I32LE" },
+    { Op::I32BE, "I32BE" },
+    { Op::U64LE, "U64LE" },
+    { Op::U64BE, "U64BE" },
+    { Op::I64LE, "I64LE" },
+    { Op::I64BE, "I64BE" },
+
+    // Float Numeric Types
+    { Op::F8, "F8" },
+    { Op::F16LE, "F16LE" },
+    { Op::F16BE, "F16BE" },
+    { Op::F32LE, "F32LE" },
+    { Op::F32BE, "F32BE" },
+    { Op::F64LE, "F64LE" },
+    { Op::F64BE, "F64BE" },
+    { Op::BF8, "BF8" },
+    { Op::BF16LE, "BF16LE" },
+    { Op::BF16BE, "BF16BE" },
+    { Op::BF32LE, "BF32LE" },
+    { Op::BF32BE, "BF32BE" },
+    { Op::BF64LE, "BF64LE" },
+    { Op::BF64BE, "BF64BE" },
+
+};
+
+poly::string_view op_to_debug_str(Op op)
+{
+    try {
+        return ops_to_debug_strs.at(op);
+    } catch (const std::out_of_range&) {
+        static const poly::string_view unknown{ "UNKNOWN???" };
+        return unknown;
+    }
+}
+
+} // namespace openzl::sddl2

--- a/tools/sddl2/compiler/parser/Ops.h
+++ b/tools/sddl2/compiler/parser/Ops.h
@@ -1,0 +1,81 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#pragma once
+
+#include "openzl/cpp/poly/StringView.hpp"
+
+namespace openzl::sddl2 {
+
+enum class Op {
+    EXPECT,
+    ASSIGN,
+    SIZEOF,
+    CONSUME,
+    ASSUME,
+    SEND,
+
+    // Arithmetic Operators
+    NEG,
+    EQ,
+    NE,
+    GT,
+    GE,
+    LT,
+    LE,
+    ADD,
+    SUB,
+    MUL,
+    DIV,
+    MOD,
+
+    // Bitwise Operators
+    BIT_AND,
+    BIT_OR,
+    BIT_XOR,
+    BIT_NOT,
+
+    // Logical Operators
+    LOG_AND,
+    LOG_OR,
+    LOG_NOT,
+
+    // Integer Numeric Types
+    BYTE,
+    U8,
+    I8,
+    U16LE,
+    U16BE,
+    I16LE,
+    I16BE,
+    U32LE,
+    U32BE,
+    I32LE,
+    I32BE,
+    U64LE,
+    U64BE,
+    I64LE,
+    I64BE,
+
+    // Float Numeric Types
+    F8,
+    F16LE,
+    F16BE,
+    F32LE,
+    F32BE,
+    F64LE,
+    F64BE,
+    BF8,
+    BF16LE,
+    BF16BE,
+    BF32LE,
+    BF32BE,
+    BF64LE,
+    BF64BE,
+
+};
+
+/// @returns a name string for an op.
+/// (E.g., Op::ADD -> "ADD")
+poly::string_view op_to_debug_str(Op op);
+
+} // namespace openzl::sddl2

--- a/tools/sddl2/compiler/parser/Parser.cpp
+++ b/tools/sddl2/compiler/parser/Parser.cpp
@@ -4,9 +4,6 @@
 
 #include <algorithm>
 #include <list>
-#include <set>
-
-#include "openzl/shared/portability.h"
 
 #include "tools/sddl2/compiler/Exception.h"
 #include "tools/sddl2/compiler/Utils.h"
@@ -41,140 +38,73 @@ bool operator==(const GroupType& a, const uint32_t& b)
     return static_cast<uint32_t>(a) == b;
 }
 
+struct PendingOp {
+    PendingOp(
+            const std::reference_wrapper<const GrammarRule>& rule,
+            size_t pos,
+            std::list<ASTPtr>::iterator iter)
+            : iter_(iter), pos_(pos), rule_(rule)
+    {
+    }
+
+    std::list<ASTPtr>::iterator iter_;
+    size_t pos_;
+    std::reference_wrapper<const GrammarRule> rule_;
+
+    bool operator<(const PendingOp& other) const
+    {
+        auto const lprecedence = rule_.get().precedence();
+        auto const rprecedence = other.rule_.get().precedence();
+
+        if (lprecedence != rprecedence) {
+            return lprecedence < rprecedence;
+        };
+
+        auto const lassoc = rule_.get().associativity();
+        auto const rassoc = other.rule_.get().associativity();
+        if (lassoc != rassoc) {
+            throw InvariantViolation(
+                    maybe_loc(*this->iter_) + maybe_loc(*other.iter_),
+                    "Two symbols ('"
+                            + std::string{ sym_to_debug_str(
+                                    (this->rule_.get().sym())) }
+                            + "' and '"
+                            + std::string{ sym_to_debug_str(
+                                    other.rule_.get().sym()) }
+                            + "') with the same precedence can't have different associativities.");
+        }
+
+        switch (lassoc) {
+            case Associativity::LEFT_TO_RIGHT:
+                return this->pos_ < other.pos_;
+            case Associativity::RIGHT_TO_LEFT:
+                return this->pos_ > other.pos_;
+            default:
+                throw InvariantViolation("Illegal associativity!");
+        }
+    }
+};
+
+/**
+ * Remove all ops from the list that are associated with the given iterator.
+ */
+void remove_from_ops(
+        std::list<PendingOp>& ops,
+        const std::list<ASTPtr>::iterator& iter)
+{
+    ops.erase(
+            std::remove_if(
+                    ops.begin(),
+                    ops.end(),
+                    [&iter](const PendingOp& op) { return op.iter_ == iter; }),
+            ops.end());
+}
+
 class ParserImpl {
    public:
     explicit ParserImpl(const Logger& logger) : log_(logger) {}
 
    private:
-    struct PendingOp {
-        PendingOp(
-                std::list<ASTPtr>::iterator _node_it,
-                size_t _pos,
-                const GrammarRule& _rule)
-                : node_it(_node_it), pos(_pos), rule(_rule)
-        {
-        }
-
-        void print(std::ostream& os, size_t indent = 0) const
-        {
-            os << std::string(indent, ' ') << "PendingOp(\n";
-            os << std::string(indent + 2, ' ') << "AST Node:\n";
-            some(*node_it).print(os, indent + 4);
-            os << std::string(indent + 2, ' ') << "AST Pos: " << pos << ":\n";
-            const auto& loc = some(*node_it).loc();
-            os << std::string(indent + 4, ' ') << loc.pos_str() << "\n";
-            os << loc.contents_str(indent + 4);
-            os << std::string(indent + 2, ' ') << "Rule:\n";
-            os << std::string(indent + 4, ' ') << rule.get().info_str() << "\n";
-            os << std::string(indent, ' ') << ")\n";
-        }
-
-        std::list<ASTPtr>::iterator node_it;
-        size_t pos;
-        std::reference_wrapper<const GrammarRule> rule;
-    };
-
-    void check_partially_parsed_expr_has_no_unmergeable_adjacent_exprs(
-            const SourceLocation& full_loc,
-            const std::list<ASTPtr>& nodes) const
-    {
-        auto it1       = nodes.cbegin();
-        auto it2       = nodes.cbegin();
-        const auto end = nodes.cend();
-
-        if (it1 == nodes.end()) {
-            throw InvariantViolation(full_loc, "Empty expression!?");
-        }
-
-        ++it2;
-        while (it2 != end) {
-            const auto& lhs = some(*it1);
-            const auto& rhs = some(*it2);
-
-            const auto lhs_is_sym  = lhs.as_sym() != nullptr;
-            const auto rhs_is_sym  = rhs.as_sym() != nullptr;
-            const auto rhs_is_list = rhs.as_list() != nullptr;
-
-            if (!lhs_is_sym && !rhs_is_sym && !rhs_is_list) {
-                // TODO: actually consult implicit operators list?
-                throw ParseError(
-                        lhs.loc() + rhs.loc(),
-                        "Expected operator between expressions.");
-            }
-
-            if (lhs_is_sym && rhs_is_sym) {
-                const auto lhs_sym = **lhs.as_sym();
-                const auto rhs_sym = **rhs.as_sym();
-
-                if (sym_is_always_binary_op(lhs_sym)
-                    && sym_is_always_binary_op(rhs_sym)) {
-                    throw ParseError(
-                            lhs.loc() + rhs.loc(),
-                            "Expected expression between operators.");
-                }
-            }
-
-            it1 = it2;
-            ++it2;
-        }
-    }
-
-    poly::optional<Arity> resolve_arity(
-            const SourceLocation& loc,
-            const std::vector<std::reference_wrapper<const GrammarRule>>& rules,
-            const GrammarRule& rule,
-            const ASTPtr& lhs) const
-    {
-        const auto arity = rule.arity();
-
-        if (rules.size() == 1) {
-            if (&rules[0].get() != &rule) {
-                throw InvariantViolation(
-                        loc,
-                        "Processing a rule not in the list of rules for that op!");
-            }
-            return arity;
-        }
-
-        if (rules.size() != 2) {
-            throw InvariantViolation(loc, "More than two rules!");
-        }
-
-        std::set<Arity> arities;
-        for (const auto& r : rules) {
-            arities.insert(r.get().arity());
-        }
-
-        if (arities
-            != std::set<Arity>{
-                    { Arity::PREFIX_UNARY, Arity::INFIX_BINARY } }) {
-            throw InvariantViolation(
-                    loc,
-                    "Can only handle operators with more than one interpretation when the possible interpretations are (1) prefix-unary or (2) infix-binary!");
-        }
-
-        if (lhs == nullptr) {
-            return Arity::PREFIX_UNARY;
-        }
-
-        if (lhs->as_sym() == nullptr) {
-            return Arity::INFIX_BINARY;
-        }
-
-        const auto& lhs_sym     = *lhs->as_sym();
-        const auto lhs_sym_type = sym_type(*lhs_sym);
-
-        if (lhs_sym_type == SymbolType::OPERATOR) {
-            // TODO: handle postfix-unary ops if/when they're
-            // added.
-            // const auto& lhs_rules = sym_to_rules(*lhs_sym);
-            return Arity::PREFIX_UNARY;
-        } else {
-            // This... shouldn't happen?
-            return poly::nullopt;
-        }
-    }
-
     /**
      * The goal of this method is to take a list of nodes we got from the
      * grouping stage (i.e., a mostly-flat list of tokens, with the exception
@@ -197,40 +127,6 @@ class ParserImpl {
      *         outer loop.
      *   - If we don't find any collapsible operators, throw an error.
      *
-     * An additional complexity arises in the case of operators
-     * which can either be unary or binary (i.e., `+` and `-`). It's tricky
-     * because the unary versions of those operators actually have higher
-     * precedence than their binary equivalents. So if you didn't otherwise
-     * impose a control to subvert the purely precedence and associativity
-     * based parse of the expression, you would always select the unary version
-     * and then the parse would fail if the user actually wanted the binary
-     * operators.
-     *
-     * So we modify the application of operator transformation rules by
-     * inspecting the expressions adjacent to the operator. Note that:
-     *
-     * 1. Two expressions must have an operator between them to be reduced into
-     *    one expression.
-     * 2. A value (a variable, a number, an expression) will never turn back
-     *    into an operator, no matter what folding happens between it and other
-     *    nodes on its other side.
-     * 3. All unary/binary ambiguous operators are either prefix-unary or
-     *    infix-binary. There are no postfix-unary operators that can also be
-     *    interpreted as infix-binary.
-     *
-     * That means that we can apply the following rule. When looking at an
-     * operator that can be interpreted either as a prefix-unary or as a
-     * infix-binary operator, look at the adjacent expression on the left hand
-     * side:
-     *
-     * - If it's an operator:
-     *   - If it's a prefix op, resolve this operator as prefix-unary.
-     *   - If it's a binary op, resolve this operator as prefix-unary.
-     *   - If it's a postfix op, resolve this operator as infix-binary.
-     * - If it's a value, resolve this operator as infix-binary.
-     * - If there is no LHS, because this is the first token, resolve it as
-     *   prefix-unary, duh.
-     *
      * During parsing, the node list maintains the partially converted list of
      * sub-expressions. It can contain the following kinds of things:
      *
@@ -249,346 +145,152 @@ class ParserImpl {
      */
     ASTPtr parse_expr(const GroupingExpr& expr_group) const
     {
-        // Should include expression terminator
-        const auto& full_loc = expr_group.loc();
-        // Doesn't include expression terminator
         const auto all_nodes_loc = join_locs(expr_group.nodes());
-
         log_(3) << InfoError(all_nodes_loc, "Parsing expression:").what();
 
+        // Parse sub-expressions
         std::list<ASTPtr> nodes{};
-        try {
-            for (const auto& group_node : expr_group.nodes()) {
-                nodes.push_back(parse_node(
-                        some(group_node), GroupType::TOKEN | GroupType::LIST));
+        for (const auto& group_node : expr_group.nodes()) {
+            nodes.push_back(parse_node(
+                    some(group_node), GroupType::TOKEN | GroupType::LIST));
+        }
+
+        // Check for empty top-level expression
+        if (nodes.size() == 0) {
+            const auto& full_loc = expr_group.loc();
+            throw ParseError(full_loc, "Empty expression.");
+        }
+
+        // Find all the symbols and their rules
+        std::list<PendingOp> pending_ops{};
+
+        size_t pos = 0;
+        for (auto it = nodes.begin(); it != nodes.end(); ++it, pos++) {
+            auto sym  = (*it)->as_sym();
+            auto list = (*it)->as_list();
+            if (sym) {
+                for (const auto& rule : sym_to_rules(**sym)) {
+                    pending_ops.emplace_back(rule, pos, it);
+                }
+            }
+            if (list) {
+                for (const auto& rule : list_type_to_rules(list->list_type())) {
+                    pending_ops.emplace_back(rule, pos, it);
+                }
+            }
+        }
+        pending_ops.sort();
+
+        // Helper to throw or log an error message depending on the
+        // state of throw_on_failure_to_match.
+        bool throw_on_failure_to_match = false;
+        auto throw_or_log              = [&](const std::string& msg) -> void {
+            if (throw_on_failure_to_match) {
+                throw ParseError(all_nodes_loc, msg);
+            }
+            log_(3) << InfoError(all_nodes_loc, msg).what();
+        };
+
+        // Apply the rules
+        while (!pending_ops.empty()) {
+            bool changed = false;
+
+            log_(3) << "Current Nodes:" << std::endl;
+            for (const auto& node : nodes) {
+                node->print(log_(3), 4);
             }
 
-            if (nodes.size() == 0) {
-                throw ParseError(full_loc, "Empty expression.");
-            }
-
-            std::vector<PendingOp> sorted_pending_ops;
-            size_t i = 0;
-            for (auto it = nodes.begin(); it != nodes.end(); ++it) {
-                const auto ast_sym  = some(*it).as_sym();
-                const auto ast_list = some(*it).as_list();
-                if (ast_sym != nullptr) {
-                    const auto sym    = **ast_sym;
-                    const auto& rules = sym_to_rules(sym);
-                    if (rules.empty()) {
-                        throw ParseError(
-                                (*it)->loc(),
-                                "Symbol '"
-                                        + std::string{ sym_to_debug_str(sym) }
-                                        + "' has no associated grammar rules.");
-                    }
-                    for (const auto& rule : rules) {
-                        // log_(3) << InfoError("Adding rule:\n" +
-                        // rule.get().info_str()).what();
-                        sorted_pending_ops.emplace_back(it, i, rule);
-                    }
-                } else if (ast_list != nullptr) {
-                    const auto& implicit_rules =
-                            list_type_to_implicit_rules(ast_list->list_type());
-                    for (const auto& rule : implicit_rules) {
-                        sorted_pending_ops.emplace_back(it, i, rule);
-                    }
-                }
-                i++;
-            }
-
-            const auto pending_op_comparator = [](const PendingOp& lhs,
-                                                  const PendingOp& rhs) {
-                const auto& lrule = lhs.rule.get();
-                const auto& rrule = rhs.rule.get();
-
-                if (lrule.precedence() != rrule.precedence()) {
-                    return lrule.precedence() < rrule.precedence();
-                }
-                if (lrule.associativity() != rrule.associativity()) {
-                    throw ParseError(
-                            maybe_loc(*lhs.node_it) + maybe_loc(*rhs.node_it),
-                            "Two symbols ('"
-                                    + std::string{ sym_to_debug_str(
-                                            lrule.op()) }
-                                    + "' and '"
-                                    + std::string{ sym_to_debug_str(
-                                            rrule.op()) }
-                                    + "') with the same precedence can't have different associativities.");
-                }
-                const auto associativity = lrule.associativity();
-                switch (associativity) {
-                    case Associativity::LEFT_TO_RIGHT:
-                        return lhs.pos < rhs.pos;
-                    case Associativity::RIGHT_TO_LEFT:
-                        return lhs.pos > rhs.pos;
-                    default:
-                        throw InvariantViolation("Illegal associativity!");
-                }
-            };
-
-            std::sort(
-                    sorted_pending_ops.begin(),
-                    sorted_pending_ops.end(),
-                    pending_op_comparator);
-
-            for (const auto& pending_op : sorted_pending_ops) {
-                auto& log = log_(3);
-                log << "Grammar rule to consider applying to this expression:\n";
-                pending_op.print(log, 2);
-            }
-
-            // In order to handle operators that can parse multiple different
-            // ways, or operators whose arguments haven't yet resolved, we
-            // normally allow pending ops to fail to match their arguments.
-            // However, if we stop making forward progress, that means we no
-            // longer have hope that future iterations of the loop will make ops
-            // viable, and we can pick one to throw an error.
-            bool throw_on_failure_to_match = false;
-
-            while (true) {
-                bool changed = false;
-
+            for (const auto& op : pending_ops) {
                 {
-                    auto& log = log_(3);
-                    log << "Current top-level nodes in this pass:" << std::endl;
-                    for (const auto& node : nodes) {
-                        node->print(log, 2);
-                    }
-                }
-
-                check_partially_parsed_expr_has_no_unmergeable_adjacent_exprs(
-                        full_loc, nodes);
-
-                for (const auto& pending_op : sorted_pending_ops) {
-                    const auto& rule   = pending_op.rule.get();
-                    const auto node_it = pending_op.node_it;
-                    auto op            = *node_it;
-                    auto next          = node_it;
-
-                    if (op->as_sym() != nullptr) {
-                        // Otherwise, it's an implicit rule and *this* is the
-                        // arg.
-                        ++next;
-                    }
+                    auto& rule    = op.rule_.get();
+                    auto iter     = op.iter_;
+                    auto num_args = rule.num_args();
+                    auto num_rhs  = rule.num_rhs_args();
 
                     log_(3) << InfoError(
-                                       some(op).loc(),
+                                       (*iter)->loc(),
                                        "Considering rule:\n  "
                                                + rule.info_str())
                                        .what();
 
-                    const auto is_first = node_it == nodes.begin();
-                    const auto is_end   = next == nodes.end();
+                    std::vector<std::list<ASTPtr>::iterator> arg_iters;
 
-                    auto prev = node_it;
-                    if (!is_first) {
-                        --prev;
+                    // Get the lhs arg (if any)
+                    if (rule.has_lhs_arg()) {
+                        if (iter == nodes.begin()) {
+                            throw_or_log(
+                                    "Rule requires a lhs arg but none found.");
+                            goto next_op;
+                        }
+                        arg_iters.push_back(std::prev(iter));
                     }
 
-                    ASTPtr lhs{};
-                    ASTPtr rhs{};
-
-                    std::vector<std::reference_wrapper<const GrammarRule>>
-                            all_rules_for_this_node;
-                    for (const auto& potential_pending_op :
-                         sorted_pending_ops) {
-                        if (potential_pending_op.node_it == node_it) {
-                            all_rules_for_this_node.push_back(
-                                    potential_pending_op.rule);
+                    // Get the rhs args
+                    if (num_rhs) {
+                        if (num_args == 1 && iter != nodes.begin()) {
+                            // For prefix unary operators: if there's a valid
+                            // expression to the left, skip this unary rule
+                            // in favor of a binary rule.
+                            if ((*std::prev(iter))->as_sym() == nullptr) {
+                                throw_or_log(
+                                        "Skipping prefix unary rule because there's a "
+                                        "valid lhs expression.");
+                                goto next_op;
+                            }
+                        }
+                        auto arg_iter = iter;
+                        for (size_t i = 0; i < num_rhs; ++i) {
+                            arg_iter = std::next(arg_iter);
+                            if (arg_iter == nodes.end()) {
+                                throw_or_log(
+                                        "Rule requires "
+                                        + std::to_string(num_rhs)
+                                        + " rhs args but " + std::to_string(i)
+                                        + " found.");
+                                goto next_op;
+                            }
+                            arg_iters.push_back(arg_iter);
                         }
                     }
 
-                    const auto opt_arity = resolve_arity(
-                            some(op).loc(),
-                            all_rules_for_this_node,
-                            rule,
-                            is_first ? lhs : *prev);
-
-                    if (!opt_arity.has_value()) {
-                        continue;
-                    }
-
-                    if (opt_arity.value() != rule.arity()) {
-                        continue;
-                    }
-
-                    ASTPtr result;
-                    switch (rule.arity()) {
-                        case Arity::INFIX_BINARY: {
-                            if (is_first) {
-                                if (throw_on_failure_to_match) {
-                                    throw ParseError(
-                                            some(op).loc(),
-                                            "Operator missing left-hand argument.");
-                                }
-                                // Can't collapse infix op with no lhs expr!
-                                continue;
-                            }
-                            auto maybe_lhs = rule.match_lhs(op, *prev);
-                            if (!maybe_lhs) {
-                                continue;
-                            }
-                            lhs = std::move(*maybe_lhs);
-                            if (lhs->as_sym() != nullptr) {
-                                // Still a bare symbol, must be parsed into an
-                                // expression before it can be an argument.
-                                continue;
-                            }
-                            ZL_FALLTHROUGH;
+                    for (size_t i = 0; i < num_args; ++i) {
+                        auto arg = rule.match_arg(*iter, *arg_iters.at(i), i);
+                        if (!arg) {
+                            throw_or_log(
+                                    "Failed to match args for rule: "
+                                    + rule.info_str());
+                            goto next_op;
                         }
-                        case Arity::PREFIX_UNARY: {
-                            if (is_end) {
-                                if (throw_on_failure_to_match) {
-                                    throw ParseError(
-                                            some(op).loc(),
-                                            "Operator missing right-hand argument.");
-                                }
-                                // Can't collapse arg-taking op with no rhs
-                                // expr!
-                                continue;
-                            }
-                            auto maybe_rhs = rule.match_rhs(op, *next);
-                            if (!maybe_rhs) {
-                                continue;
-                            }
-                            rhs = std::move(*maybe_rhs);
-                            if (rhs->as_sym() != nullptr) {
-                                // Still a bare symbol, must be parsed into an
-                                // expression before it can be an argument.
-                                continue;
-                            }
-                            ZL_FALLTHROUGH;
-                        }
-                        case Arity::NULLARY: {
-                            auto& log = log_(3);
-                            log << InfoError(
-                                           maybe_loc(op),
-                                           "Applying rule:\n  "
-                                                   + rule.info_str())
-                                            .what();
-                            pending_op.print(log, 2);
-                            if (lhs) {
-                                log << InfoError(maybe_loc(lhs), "With lhs:")
-                                                .what();
-                                lhs->print(log, 2);
-                            }
-                            if (rhs) {
-                                log << InfoError(maybe_loc(rhs), "With rhs:")
-                                                .what();
-                                rhs->print(log, 2);
-                            }
-                        }
-                            result = rule.gen(
-                                    std::move(op),
-                                    std::move(lhs),
-                                    std::move(rhs));
-                            break;
-                        default:
-                            throw InvariantViolation(
-                                    some(op).loc(), "Illegal arity!");
+                        *arg_iters.at(i) = *std::move(arg);
                     }
 
-                    // Erase all inserted pending ops for this symbol and for
-                    // its arguments. (There might be multiple if there are
-                    // multiple possible interpretations of this symbol).
-                    //
-                    // DANGER: Note that we are mutating the vector of pending
-                    // ops while this scope holds references to stuff in that
-                    // vector! All those refs are invalid once we start
-                    // mutating the vector. Anything accessed after this point
-                    // can't be a ref into the pending ops vector.
-                    auto erase_pending_ops_for_node = [this,
-                                                       &sorted_pending_ops](
-                                                              const std::list<
-                                                                      ASTPtr>::
-                                                                      iterator&
-                                                                              it) {
-                        auto predicate = [this, &it](const PendingOp& pop) {
-                            const auto erase = pop.node_it == it;
-                            if (erase) {
-                                log_(4) << InfoError(
-                                                   maybe_loc(*pop.node_it),
-                                                   "Erasing rule:\n  "
-                                                           + pop.rule.get()
-                                                                     .info_str())
-                                                   .what();
-                            }
-                            return erase;
-                        };
-                        const auto new_end = std::remove_if(
-                                sorted_pending_ops.begin(),
-                                sorted_pending_ops.end(),
-                                std::move(predicate));
-                        sorted_pending_ops.erase(
-                                new_end, sorted_pending_ops.end());
-                    };
-
-                    erase_pending_ops_for_node(node_it);
-
-                    *node_it = std::move(result);
-
-                    switch (rule.arity()) {
-                        case Arity::INFIX_BINARY:
-                            erase_pending_ops_for_node(prev);
-                            nodes.erase(prev);
-                            ZL_FALLTHROUGH;
-                        case Arity::PREFIX_UNARY:
-                            if (node_it != next) {
-                                erase_pending_ops_for_node(next);
-                                nodes.erase(next);
-                            }
-                            ZL_FALLTHROUGH;
-                        case Arity::NULLARY:
-                            break;
-                        default:
-                            throw InvariantViolation(
-                                    some(op).loc(), "Illegal arity!");
+                    log_(3) << "Applying rule." << std::endl;
+                    std::vector<ASTPtr> args(num_args);
+                    for (size_t i = 0; i < num_args; i++) {
+                        args.at(i) = *arg_iters.at(i);
                     }
+                    auto result = rule.gen(*iter, std::move(args));
+
+                    for (auto& arg_iter : arg_iters) {
+                        remove_from_ops(pending_ops, arg_iter);
+                        nodes.erase(arg_iter);
+                    }
+                    remove_from_ops(pending_ops, iter);
+                    *iter   = result;
                     changed = true;
-                    log_(3) << "\n";
                     break;
                 }
 
-                if (nodes.size() == 0) {
-                    throw InvariantViolation(
-                            full_loc,
-                            "Expression reduced to 0 nodes somehow??");
-                }
-
-                if (!changed) {
-                    if (!throw_on_failure_to_match) {
-                        // Run through them one more time to try to produce a
-                        // more specific error message.
-                        throw_on_failure_to_match = true;
-                        continue;
-                    }
-
-                    if (nodes.size() > 1) {
-                        for (const auto& node : nodes) {
-                            log_(0) << InfoError(
-                                               some(node).loc(),
-                                               "Uncombined sub-expression:")
-                                               .what();
-                            node->print(log_(0), 0);
-                        }
-
-                        throw ParseError(
-                                full_loc,
-                                "Couldn't reduce expression to a single AST node.");
-                    } else {
-                        return std::move(*nodes.begin());
-                    }
-                }
+            next_op:;
             }
-        } catch (const CompilerException&) {
-            for (const auto& node : nodes) {
-                log_(0) << InfoError(some(node).loc(), "With sub-expression:")
-                                   .what();
-                some(node).print(log_(0), 1);
-            }
-            throw;
+            // Stopped making forward progress.
+            throw_on_failure_to_match = changed == false;
         }
+        if (nodes.size() != 1) {
+            throw InvariantViolation(
+                    all_nodes_loc, "Expected operator between expressions.");
+        }
+        return nodes.front();
     }
 
     ASTPtr parse_token(const Token& token) const
@@ -598,8 +300,8 @@ class ParserImpl {
             if constexpr (std::is_same_v<T, Symbol>) {
                 return std::make_shared<ASTSym>(token);
             } else if constexpr (std::is_same_v<T, poly::string_view>) {
-                // All string tokens are treated as identifiers. All operators
-                // and keywords have already been parsed out.
+                // All string tokens are treated as identifiers. All
+                // operators and keywords have already been parsed out.
                 return std::make_shared<ASTVar>(token);
             } else if constexpr (std::is_same_v<T, int64_t>) {
                 return std::make_shared<ASTNum>(token);

--- a/tools/sddl2/compiler/tests/CompilerTest.cpp
+++ b/tools/sddl2/compiler/tests/CompilerTest.cpp
@@ -2,19 +2,56 @@
 
 #include <gtest/gtest.h>
 #include <iomanip>
+#include <sstream>
 
 #include "tools/sddl2/compiler/Compiler.h"
 #include "tools/sddl2/compiler/Exception.h"
+#include "tools/sddl2/compiler/parser/AST.h"
 
 using namespace testing;
 
 namespace openzl::sddl2::tests {
+
+namespace {
+using ArgVec = std::vector<ASTPtr>;
+
+// Helper class to check that the tokenization/grouper/parser steps are working
+// as expected
+class ASTCompiler : public Compiler {
+   public:
+    explicit ASTCompiler(Compiler::Options options)
+            : Compiler{ std::move(options) }
+    {
+    }
+
+    ASTVec compile(std::string_view source, std::string_view filename)
+    {
+        const Source src{ source, filename };
+        const auto tokens = tokenizer_.tokenize(src);
+        const auto groups = grouper_.group(tokens);
+        const auto tree   = parser_.parse(groups);
+
+        return tree;
+    }
+};
+
+void expect_node_eq(const ASTNode& lhs, const ASTNode& rhs)
+{
+    // Compare by printing to string - this works for all AST node types
+    std::ostringstream lhs_ss, rhs_ss;
+    lhs.print(lhs_ss, 0);
+    rhs.print(rhs_ss, 0);
+    EXPECT_EQ(lhs_ss.str(), rhs_ss.str());
+}
+} // namespace
 
 class CompilerTest : public Test {
    protected:
     void SetUp() override
     {
         compiler_ = std::make_unique<Compiler>(
+                Compiler::Options{}.with_log(logs_).with_verbosity(verbosity_));
+        ast_compiler_ = std::make_unique<ASTCompiler>(
                 Compiler::Options{}.with_log(logs_).with_verbosity(verbosity_));
     }
 
@@ -42,15 +79,28 @@ class CompilerTest : public Test {
                 << logs_.str();
     }
 
+    void expect_ast(std::string_view source, ASTVec expected)
+    {
+        const auto actual = ast_compiler_->compile(source, "[local_input]");
+
+        EXPECT_EQ(actual.size(), expected.size());
+        for (size_t i = 0; i < actual.size(); ++i) {
+            auto& actual_node   = *actual.at(i);
+            auto& expected_node = *expected.at(i);
+            expect_node_eq(actual_node, expected_node);
+        }
+    }
+
     int verbosity_{ 3 };
     std::stringstream logs_;
     std::unique_ptr<Compiler> compiler_;
+    std::unique_ptr<ASTCompiler> ast_compiler_;
 };
 
 TEST_F(CompilerTest, ErrorMsgOpsMissingArgs)
 {
-    expect_error("foo = \n", "right-hand argument");
-    expect_error("= foo\n", "left-hand argument");
+    expect_error("foo = \n", "Rule requires 1 rhs args but 0 found.");
+    expect_error("= foo\n", "Rule requires a lhs arg but none found.");
 }
 
 TEST_F(CompilerTest, ErrorMsgEmptyExpr)
@@ -71,15 +121,168 @@ TEST_F(CompilerTest, ErrorMsgTwoOperatorsBetweenSubExpressions)
     const auto prog = R"(
         tmp = 9 + 10 + + 11 + 12
     )";
-    expect_error(prog, "Expected expression between operators");
+    expect_error(prog, "Failed to match args for rule");
 }
 
-TEST_F(CompilerTest, UnaryNegation)
+TEST_F(CompilerTest, ParseSimpleOps)
+{
+    const auto prog = R"(
+        # arithmetic operators
+        tmp = 1 + 2
+        tmp = 1 - 2
+        tmp = 1 * 2
+        tmp = 1 / 2
+        tmp = 1 % 2
+
+        # conditional operators
+        expect 1 < 2
+        expect 1 <= 2
+        expect 1 > 2 == 0
+        expect 1 >= 2 == 0
+        expect 2 == 2
+        expect 1 != 2
+
+        # logical operators
+        expect 1 && 2
+        expect 1 || 2
+        expect !0
+
+        # bitwise operators
+        tmp = 1 & 2
+        tmp = 1 | 2
+        tmp = 1 ^ 2
+        tmp = ~1
+    )";
+    expect_success(prog);
+}
+
+TEST_F(CompilerTest, MildlyVexingParsing)
+{
+    const auto prog = R"(
+        b : B = Byte
+        expect b == 1
+        b = - : B
+        expect b == -2
+        : B
+        b : B
+        expect b == 4
+        : B = Byte
+        b : B
+        expect b == 6
+        : B
+        A = B[--:B]
+        : A
+    )";
+
+    expect_success(prog);
+}
+
+TEST_F(CompilerTest, UnaryNegationAST)
 {
     const auto prog = R"(
         tmp = 10 - - 11
     )";
-    expect_success(prog);
+
+    const auto cg       = Codegen(SourceLocation::null());
+    const auto expected = std::vector<ASTPtr>({
+            cg.assign(cg.var("tmp"), cg.sub(cg.num(10), cg.num(-11))),
+    });
+    expect_ast(prog, expected);
+}
+
+TEST_F(CompilerTest, SimpleArithmeticAST)
+{
+    const auto prog = R"(
+       expect 1 + 2 == 3
+    )";
+
+    const auto cg       = Codegen(SourceLocation::null());
+    const auto expected = std::vector<ASTPtr>({
+            cg.expect(cg.eq(cg.add(cg.num(1), cg.num(2)), cg.num(3))),
+    });
+    expect_ast(prog, expected);
+}
+
+TEST_F(CompilerTest, ArrayAST)
+{
+    const auto prog = R"(
+        len =  1 + 2
+        : Byte[len]
+    )";
+
+    const auto cg       = Codegen(SourceLocation::null());
+    const auto expected = std::vector<ASTPtr>(
+            { cg.assign(cg.var("len"), cg.add(cg.num(1), cg.num(2))),
+              cg.consume(
+                      cg.array(cg.builtin_field(Op::BYTE), cg.var("len"))) });
+
+    expect_ast(prog, expected);
+}
+
+TEST_F(CompilerTest, RecordAST)
+{
+    const auto prog = R"(
+        Record Entry() = {
+            id: Int32LE,
+        }
+    )";
+
+    const auto cg       = Codegen(SourceLocation::null());
+    const auto expected = std::vector<ASTPtr>({ cg.assign(
+            cg.var("Entry"),
+            cg.record(
+                    ArgVec{},
+                    ArgVec{ cg.assign(
+                            cg.var("id"),
+                            cg.consume(cg.builtin_field(Op::I32LE))) })) });
+    expect_ast(prog, expected);
+}
+
+TEST_F(CompilerTest, ParenthesesOverridePrecedenceAST)
+{
+    const auto prog = R"(
+        tmp = (1 - 2) * 3
+    )";
+
+    const auto cg       = Codegen(SourceLocation::null());
+    const auto expected = std::vector<ASTPtr>({
+            cg.assign(
+                    cg.var("tmp"),
+                    cg.mul(cg.sub(cg.num(1), cg.num(2)), cg.num(3))),
+    });
+    expect_ast(prog, expected);
+}
+
+TEST_F(CompilerTest, NestedParenthesesAST)
+{
+    const auto prog = R"(
+        tmp = ((1 + 2) * (3 + 4))
+    )";
+
+    const auto cg       = Codegen(SourceLocation::null());
+    const auto expected = std::vector<ASTPtr>({
+            cg.assign(
+                    cg.var("tmp"),
+                    cg.mul(cg.add(cg.num(1), cg.num(2)),
+                           cg.add(cg.num(3), cg.num(4)))),
+    });
+    expect_ast(prog, expected);
+}
+
+TEST_F(CompilerTest, ComplexArithmeticExpressionAST)
+{
+    const auto prog = R"(
+        tmp = 1 + 2 * 3 - 4 / 2
+    )";
+
+    const auto cg       = Codegen(SourceLocation::null());
+    const auto expected = std::vector<ASTPtr>({
+            cg.assign(
+                    cg.var("tmp"),
+                    cg.sub(cg.add(cg.num(1), cg.mul(cg.num(2), cg.num(3))),
+                           cg.div(cg.num(4), cg.num(2)))),
+    });
+    expect_ast(prog, expected);
 }
 
 } // namespace openzl::sddl2::tests


### PR DESCRIPTION
Summary:
This introduces a set of changes to the SDDL compiler to support the syntax evolution described in the north-star proposal. While the patch spans multiple layers of the pipeline, the guiding goals are to (1) align the compiler with the updated surface syntax, and (2) make the implementation easier to reason about by removing legacy behavior that no longer maps to the long-term direction.

Concretely, the changes focus on the following areas:

## Syntax
- Remove symbols that are not supported in the new syntax.
- Clarify the boundary between *syntax* and *ops* (ex: `NEG` is not a distinct symbol in the syntax, but it's an op).
- Remove unused constructs (e.g. `sym_types`).

## Grammar
- Update productions to support operations with _0–1_ LHS arguments and _N_ RHS arguments.

## Parser
- Extend parsing logic to match the new arity model (0–1 LHS, N RHS).
- General cleanup of `parse_expr`. The refactor aims to reduce the amount of legacy branching and “special-case” behavior in expression parsing.

Differential Revision: D92427604
