### PR TITLE
implement materialized params for graphs, selectors, and segmenters

### DIFF
--- a/include/openzl/zl_graph_api.h
+++ b/include/openzl/zl_graph_api.h
@@ -11,6 +11,7 @@
 #include "openzl/zl_errors.h"   // ZL_Report
 #include "openzl/zl_input.h"
 #include "openzl/zl_localParams.h"  // ZL_LocalParams
+#include "openzl/zl_materializer.h" // ZL_MaterializerDesc
 #include "openzl/zl_opaque_types.h" // ZL_GraphID
 #include "openzl/zl_portability.h"  // ZL_NOEXCEPT_FUNC_PTR
 
@@ -87,6 +88,12 @@ struct ZL_FunctionGraphDesc {
     const ZL_NodeID* customNodes;   // can be NULL when none employed
     size_t nbCustomNodes;           // Must be zero when customNodes==NULL
     ZL_LocalParams localParams;
+    /**
+     * Optional materializer descriptor for materialized local params.
+     * If both materializeFn and dematerializeFn are non-null, the materializer
+     * will be used to create materialized objects from local params.
+     */
+    ZL_MaterializerDesc materializer;
     /**
      * Optionally an opaque pointer that can be queried with
      * ZL_Graph_getOpaquePtr().

--- a/include/openzl/zl_segmenter.h
+++ b/include/openzl/zl_segmenter.h
@@ -10,6 +10,7 @@
 #include "openzl/zl_compress.h"     // ZL_CParam
 #include "openzl/zl_graph_api.h"    // ZL_RuntimeGraphParameters
 #include "openzl/zl_localParams.h"  // ZL_LocalParams
+#include "openzl/zl_materializer.h" // ZL_MaterializerDesc
 #include "openzl/zl_opaque_types.h" // ZL_GraphID
 
 #if defined(__cplusplus)
@@ -81,6 +82,12 @@ typedef struct {
     const ZL_GraphID* customGraphs; // can be NULL when none employed
     size_t numCustomGraphs;         // Must be zero when customGraphs==NULL
     ZL_LocalParams localParams;
+    /**
+     * Optional materializer descriptor for materialized local params.
+     * If both materializeFn and dematerializeFn are non-null, the materializer
+     * will be used to create materialized objects from local params.
+     */
+    ZL_MaterializerDesc materializer;
     /**
      * Optionally an opaque pointer that can be queried with
      * ZL_Graph_getOpaquePtr().

--- a/include/openzl/zl_selector.h
+++ b/include/openzl/zl_selector.h
@@ -19,6 +19,7 @@
 #include "openzl/zl_data.h"     // ZL_Data
 #include "openzl/zl_input.h"
 #include "openzl/zl_localParams.h"  // ZL_LocalParams
+#include "openzl/zl_materializer.h" // ZL_MaterializerDesc
 #include "openzl/zl_opaque_types.h" // ZL_GraphID, ZL_Selector
 #include "openzl/zl_portability.h"  // ZL_NOEXCEPT_FUNC_PTR
 
@@ -179,6 +180,12 @@ typedef struct {
                            // successors, can be NULL when none employed
     size_t nbCustomGraphs; // Must be zero when customGraphs==NULL
     ZL_LocalParams localParams;
+    /**
+     * Optional materializer descriptor for materialized local params.
+     * If both materializeFn and dematerializeFn are non-null, the materializer
+     * will be used to create materialized objects from local params.
+     */
+    ZL_MaterializerDesc materializer;
     /**
      * Optional, the name of the graph rooted by the selector.
      */

--- a/src/openzl/compress/graphmgr.c
+++ b/src/openzl/compress/graphmgr.c
@@ -11,9 +11,11 @@
 #include "openzl/compress/graph_registry.h" // ZL_PrivateStandardGraphID_end, GR_standardGraphs, InternalGraphDesc
 #include "openzl/compress/implicit_conversion.h" // ICONV_isCompatible for type checking
 #include "openzl/compress/localparams.h" // LP_transferLocalParams for parameter management
+#include "openzl/compress/materializer.h" // MPM_* functions for materializer operations
 #include "openzl/compress/name.h" // ZL_Name_*, ZS2_Name_* for graph name handling
 #include "openzl/shared/mem.h" // ZL_malloc, ZL_free, ZL_memcpy memory utilities
 #include "openzl/shared/overflow.h" // ZL_overflowMulST for integer overflow checks
+#include "openzl/zl_ctransform.h" // ZL_MaterializerDesc, ZL_Materializer for materialization
 #include "openzl/zl_opaque_types.h" // Opaque type definitions used by the API
 #include "openzl/zl_reflection.h" // ZL_MIGraphDesc and type reflection utilities
 
@@ -30,6 +32,7 @@ struct GraphsMgr_s {
     Arena* allocator;
     const Nodes_manager* nmgr;
     ZL_OpaquePtrRegistry opaquePtrs;
+    MaterializedParamMap materializedParams;
     ZL_OperationContext* opCtx;
 }; // note: typedef'd to GraphsMgr
 
@@ -68,6 +71,8 @@ GraphsMgr* GM_create(const Nodes_manager* nmgr)
         GM_free(gm);
         return NULL;
     }
+    gm->materializedParams =
+            MaterializedParamMap_create(ZL_ENCODER_GRAPH_LIMIT);
     VECTOR_INIT(gm->gdv, ZL_ENCODER_GRAPH_LIMIT);
     gm->nameMap = GraphMap_create(ZL_ENCODER_GRAPH_LIMIT);
     if (ZL_isError(GM_fillStandardGraphs(gm))) {
@@ -82,6 +87,8 @@ void GM_free(GraphsMgr* gm)
 {
     if (gm == NULL)
         return;
+    MPM_dematerializeAllParams(&gm->materializedParams, gm->allocator);
+    MaterializedParamMap_destroy(&gm->materializedParams);
     ZL_OpaquePtrRegistry_destroy(&gm->opaquePtrs);
     VECTOR_DESTROY(gm->gdv);
     GraphMap_destroy(&gm->nameMap);
@@ -298,7 +305,23 @@ static ZL_RESULT_OF(ZL_GraphID) GM_registerInternalGraph(
             &gdi.migd.customGraphs));
     ZL_ERR_IF_ERR(GM_transferCustomNIDs(
             gm, migd->customNodes, migd->nbCustomNodes, &gdi.migd.customNodes));
+
+    // do materialization here
     ZL_ERR_IF_ERR(GM_transferLocalParameters(gm, &gdi.migd.localParams));
+    // Materialize params if materializer is provided (with deduplication)
+    if (migd->materializer.materializeFn != NULL) {
+        // Validate provided params don't contain the paramId reserved for the
+        // materializer
+        ZL_ERR_IF_ERR(MPM_validateMaterializedParamId(
+                &gdi.migd.localParams, migd->materializer.paramId));
+        // Add the materialized object to refParams
+        ZL_ERR_IF_ERR(MPM_addOrReuseMaterializedParam(
+                gm->allocator,
+                &gm->materializedParams,
+                gm->opCtx,
+                &gdi.migd.localParams,
+                &migd->materializer));
+    }
 
     if (ppSize == 0) {
         // No need to transfer, just copy the pointer
@@ -373,6 +396,7 @@ GM_registerTypedSelectorGraph(GraphsMgr* gm, const ZL_SelectorDesc* tsd)
         .customGraphs   = tsd->customGraphs,
         .nbCustomGraphs = tsd->nbCustomGraphs,
         .localParams    = tsd->localParams,
+        .materializer   = tsd->materializer,
         .opaque         = { .ptr = tsd->opaque.ptr },
     };
     return GM_registerInternalGraph(
@@ -680,7 +704,23 @@ static ZL_RESULT_OF(ZL_GraphID) GM_registerSegmenter_internal(
             segDesc->customGraphs,
             segDesc->numCustomGraphs,
             &gdi.segDesc.customGraphs));
+
+    // do materialization here
     ZL_ERR_IF_ERR(GM_transferLocalParameters(gm, &gdi.segDesc.localParams));
+    // Materialize params if materializer is provided (with deduplication)
+    if (segDesc->materializer.materializeFn != NULL) {
+        // Validate provided params don't contain the paramId reserved for the
+        // materializer
+        ZL_ERR_IF_ERR(MPM_validateMaterializedParamId(
+                &gdi.segDesc.localParams, segDesc->materializer.paramId));
+        // Add the materialized object to refParams
+        ZL_ERR_IF_ERR(MPM_addOrReuseMaterializedParam(
+                gm->allocator,
+                &gm->materializedParams,
+                gm->opCtx,
+                &gdi.segDesc.localParams,
+                &segDesc->materializer));
+    }
 
     if (ppSize == 0) {
         // No need to transfer, just copy the pointer

--- a/tests/integrationtest/CompressorIntegrationTest.cpp
+++ b/tests/integrationtest/CompressorIntegrationTest.cpp
@@ -10,6 +10,9 @@
 #include "openzl/zl_compress.h"
 #include "openzl/zl_compressor.h"
 #include "openzl/zl_ctransform.h"
+#include "openzl/zl_graph_api.h"
+#include "openzl/zl_segmenter.h"
+#include "openzl/zl_selector.h"
 
 using namespace ::testing;
 
@@ -477,6 +480,242 @@ TEST_F(CompressorIntegrationTest,
             encoderWithoutMaterializedParam, {}, nullptr);
     buildAndSelectGraph(encoderNode);
     compressData();
+}
+
+// ========================================================================
+// Some (Limited) Graph Materialization Tests
+// ========================================================================
+
+TEST_F(CompressorIntegrationTest,
+       GIVENaFunctionGraphWithMaterializedParamWHENinvokedTHENitIsAccessible)
+{
+    const auto graphFunction =
+            [](ZL_Graph* graph, ZL_Edge* inputs[], size_t nbInputs)
+                    ZL_NOEXCEPT_FUNC_PTR -> ZL_Report {
+        ZL_RESULT_DECLARE_SCOPE_REPORT(graph);
+        ZL_ERR_IF_NE(nbInputs, 1, GENERIC);
+
+        // Access the materialized param
+        const MaterializedDictionary* materialized =
+                (const MaterializedDictionary*)ZL_Graph_getLocalRefParam(
+                        graph, MATERIALIZED_PARAM_ID)
+                        .paramRef;
+        ZL_ERR_IF_NULL(
+                materialized,
+                GENERIC,
+                "Expected materialized object to be nonnull");
+
+        // Verify materialized data is correct
+        memcpy(materialized->ptr,
+               materialized->str.data(),
+               materialized->str.size());
+
+        // Forward the input to STORE
+        return ZL_Edge_setDestination(inputs[0], ZL_GRAPH_STORE);
+    };
+
+    std::string str = "Graph materialized params!";
+    std::string str2(str.size(), 0);
+    ZL_IntParam ip = {
+        .paramId    = 1,
+        .paramValue = (int)str.size(),
+    };
+    ZL_CopyParam cp = {
+        .paramId   = 2,
+        .paramPtr  = str.data(),
+        .paramSize = str.size(),
+    };
+    ZL_RefParam rp = {
+        .paramId  = 3,
+        .paramRef = str2.data(),
+    };
+    ZL_LocalParams lp = {
+        .intParams = {
+            .intParams   = &ip,
+            .nbIntParams = 1,
+        },
+        .copyParams = {
+            .copyParams   = &cp,
+            .nbCopyParams = 1,
+        },
+        .refParams = {
+            .refParams   = &rp,
+            .nbRefParams = 1,
+        },
+    };
+
+    static ZL_Type inputType       = ZL_Type_serial;
+    ZL_FunctionGraphDesc graphDesc = {
+        .name           = "test_graph_with_materializer",
+        .graph_f        = graphFunction,
+        .inputTypeMasks = &inputType,
+        .nbInputs       = 1,
+        .localParams    = lp,
+        .materializer   = defaultMaterializer_,
+    };
+
+    auto graphId = compressor_.registerFunctionGraph(graphDesc);
+    ASSERT_NE(graphId.gid, ZL_GRAPH_ILLEGAL.gid);
+    compressor_.selectStartingGraph(graphId);
+
+    compressData();
+    EXPECT_EQ(str, str2);
+}
+
+TEST_F(CompressorIntegrationTest,
+       GIVENaSegmenterWithMaterializedParamWHENinvokedTHENitIsAccessible)
+{
+    const auto segmenterFunction = [](ZL_Segmenter* segmenter)
+                                           ZL_NOEXCEPT_FUNC_PTR -> ZL_Report {
+        ZL_RESULT_DECLARE_SCOPE_REPORT(segmenter);
+
+        // Access the materialized param
+        const MaterializedDictionary* materialized =
+                (const MaterializedDictionary*)ZL_Segmenter_getLocalRefParam(
+                        segmenter, MATERIALIZED_PARAM_ID)
+                        .paramRef;
+        ZL_ERR_IF_NULL(
+                materialized,
+                GENERIC,
+                "Expected materialized object to be nonnull");
+
+        // Verify materialized data is correct
+        memcpy(materialized->ptr,
+               materialized->str.data(),
+               materialized->str.size());
+
+        // Process all input as a single chunk to STORE graph
+        size_t numInputs = ZL_Segmenter_numInputs(segmenter);
+        size_t* numElts  = (size_t*)ZL_Segmenter_getScratchSpace(
+                segmenter, numInputs * sizeof(size_t));
+        ZL_ERR_IF_NULL(numElts, allocation);
+        ZL_ERR_IF_ERR(ZL_Segmenter_getNumElts(segmenter, numElts, numInputs));
+        ZL_ERR_IF_ERR(ZL_Segmenter_processChunk(
+                segmenter, numElts, numInputs, ZL_GRAPH_STORE, nullptr));
+
+        return ZL_returnSuccess();
+    };
+
+    std::string str = "Segmenter materialized params!";
+    std::string str2(str.size(), 0);
+    ZL_IntParam ip = {
+        .paramId    = 1,
+        .paramValue = (int)str.size(),
+    };
+    ZL_CopyParam cp = {
+        .paramId   = 2,
+        .paramPtr  = str.data(),
+        .paramSize = str.size(),
+    };
+    ZL_RefParam rp = {
+        .paramId  = 3,
+        .paramRef = str2.data(),
+    };
+    ZL_LocalParams lp = {
+        .intParams = {
+            .intParams   = &ip,
+            .nbIntParams = 1,
+        },
+        .copyParams = {
+            .copyParams   = &cp,
+            .nbCopyParams = 1,
+        },
+        .refParams = {
+            .refParams   = &rp,
+            .nbRefParams = 1,
+        },
+    };
+
+    static ZL_Type inputType = ZL_Type_serial;
+    ZL_SegmenterDesc segDesc = {
+        .name                = "test_segmenter_with_materializer",
+        .segmenterFn         = segmenterFunction,
+        .inputTypeMasks      = &inputType,
+        .numInputs           = 1,
+        .lastInputIsVariable = false,
+        .localParams         = lp,
+        .materializer        = defaultMaterializer_,
+    };
+
+    // Use C API for segmenter registration
+    auto graphId = ZL_Compressor_registerSegmenter(compressor_.get(), &segDesc);
+    ASSERT_NE(graphId.gid, ZL_GRAPH_ILLEGAL.gid);
+    compressor_.selectStartingGraph(graphId);
+
+    compressData();
+    EXPECT_EQ(str, str2);
+}
+
+TEST_F(CompressorIntegrationTest,
+       GIVENaSelectorWithMaterializedParamWHENinvokedTHENitIsAccessible)
+{
+    const auto selectorFunction = [](const ZL_Selector* selector,
+                                     const ZL_Input*,
+                                     const ZL_GraphID*,
+                                     size_t)
+                                          ZL_NOEXCEPT_FUNC_PTR -> ZL_GraphID {
+        // Access the materialized param
+        const MaterializedDictionary* materialized =
+                (const MaterializedDictionary*)ZL_Selector_getLocalParam(
+                        selector, MATERIALIZED_PARAM_ID)
+                        .paramRef;
+        if (materialized == nullptr) {
+            return ZL_GRAPH_ILLEGAL;
+        }
+
+        // Verify materialized data is correct
+        memcpy(materialized->ptr,
+               materialized->str.data(),
+               materialized->str.size());
+
+        // Always select STORE graph
+        return ZL_GRAPH_STORE;
+    };
+
+    std::string str = "Selector materialized params!";
+    std::string str2(str.size(), 0);
+    ZL_IntParam ip = {
+        .paramId    = 1,
+        .paramValue = (int)str.size(),
+    };
+    ZL_CopyParam cp = {
+        .paramId   = 2,
+        .paramPtr  = str.data(),
+        .paramSize = str.size(),
+    };
+    ZL_RefParam rp = {
+        .paramId  = 3,
+        .paramRef = str2.data(),
+    };
+    ZL_LocalParams lp = {
+        .intParams = {
+            .intParams   = &ip,
+            .nbIntParams = 1,
+        },
+        .copyParams = {
+            .copyParams   = &cp,
+            .nbCopyParams = 1,
+        },
+        .refParams = {
+            .refParams   = &rp,
+            .nbRefParams = 1,
+        },
+    };
+
+    ZL_SelectorDesc selDesc = {
+        .selector_f   = selectorFunction,
+        .inStreamType = ZL_Type_serial,
+        .localParams  = lp,
+        .materializer = defaultMaterializer_,
+        .name         = "test_selector_with_materializer",
+    };
+
+    auto graphId = compressor_.registerSelectorGraph(selDesc);
+    ASSERT_NE(graphId.gid, ZL_GRAPH_ILLEGAL.gid);
+    compressor_.selectStartingGraph(graphId);
+
+    compressData();
+    EXPECT_EQ(str, str2);
 }
 
 } // namespace openzl


### PR DESCRIPTION
Summary:
Copy the existing logic for materialization on nodes to graphs and segmenters. By extension, this also supports selectors.

Note: we need a different strategy for the `tryGraph` scenario. Reusing local params to do materialization is very messy in this case.

Reviewed By: terrelln

Differential Revision: D91842235


