### PR TITLE
Fuzz Compressor Deserialization

### DIFF
--- a/tests/datagen/structures/CompressorProducer.cpp
+++ b/tests/datagen/structures/CompressorProducer.cpp
@@ -42,18 +42,21 @@ CompressorProducer::make_multi(
             num_full_compressors, num_base_compressors);
 }
 
-std::string RandomCompressorMultiBuilder::make_name(const std::string& prefix)
+std::string RandomCompressorMultiBuilder::make_unique_name(
+        const std::string& prefix)
 {
     std::string suffix{ "123456789" };
-    ZL_REQUIRE_EQ(
-            snprintf(
-                    suffix.data(),
-                    suffix.size(),
-                    "%08x",
-                    rw_->u32("component_name")),
-            8);
-    suffix.resize(8);
-    return prefix + suffix;
+    std::string name;
+    uint32_t component_name = rw_->u32("component_name");
+    do {
+        ZL_REQUIRE_EQ(
+                snprintf(
+                        suffix.data(), suffix.size(), "%08x", component_name++),
+                8);
+        name = prefix + suffix.substr(0, 8);
+    } while (names_.count(name) != 0);
+    names_.insert(name);
+    return name;
 }
 
 ZL_IDType RandomCompressorMultiBuilder::make_ctid()
@@ -272,7 +275,7 @@ std::vector<std::string> RandomCompressorMultiBuilder::register_pipe_node()
                 memcpy(dst, src, srcSize);
                 return srcSize;
             };
-    const auto name = make_name("!tests.rand_graph.nodes.pipe.");
+    const auto name = make_unique_name("!tests.rand_graph.nodes.pipe.");
     const auto desc = (ZL_PipeEncoderDesc){
         .CTid        = make_ctid(),
         .transform_f = transform,
@@ -291,7 +294,7 @@ std::vector<std::string> RandomCompressorMultiBuilder::register_pipe_node()
 
 std::vector<std::string> RandomCompressorMultiBuilder::register_split_node()
 {
-    const auto name = make_name("!tests.rand_graph.nodes.split.");
+    const auto name = make_unique_name("!tests.rand_graph.nodes.split.");
     const auto transform =
             [](ZL_Encoder*, size_t[], const void*, size_t) noexcept {
                 ZL_RET_R_ERR(GENERIC, "Unimplemented! Can't actually run.");
@@ -317,7 +320,7 @@ std::vector<std::string> RandomCompressorMultiBuilder::register_split_node()
 std::vector<std::string> RandomCompressorMultiBuilder::register_typed_node(
         const TypeSpec ts)
 {
-    const auto name      = make_name("!tests.rand_graph.nodes.typed.");
+    const auto name      = make_unique_name("!tests.rand_graph.nodes.typed.");
     const auto transform = [](ZL_Encoder*, const ZL_Input*) noexcept {
         ZL_RET_R_ERR(GENERIC, "Unimplemented! Can't actually run.");
     };
@@ -354,7 +357,7 @@ std::vector<std::string> RandomCompressorMultiBuilder::register_typed_node(
 std::vector<std::string> RandomCompressorMultiBuilder::register_vo_node(
         const TypeSpec ts)
 {
-    const auto name      = make_name("!tests.rand_graph.nodes.vo.");
+    const auto name      = make_unique_name("!tests.rand_graph.nodes.vo.");
     const auto transform = [](ZL_Encoder*, const ZL_Input*) noexcept {
         ZL_RET_R_ERR(GENERIC, "Unimplemented! Can't actually run.");
     };
@@ -393,7 +396,7 @@ std::vector<std::string> RandomCompressorMultiBuilder::register_vo_node(
 
 std::vector<std::string> RandomCompressorMultiBuilder::register_mi_node()
 {
-    const auto name      = make_name("!tests.rand_graph.nodes.mi.");
+    const auto name      = make_unique_name("!tests.rand_graph.nodes.mi.");
     const auto transform = [](ZL_Encoder*, const ZL_Input*[], size_t) noexcept {
         ZL_RET_R_ERR(GENERIC, "Unimplemented! Can't actually run.");
     };
@@ -774,7 +777,7 @@ std::vector<std::string> RandomCompressorMultiBuilder::make_multi_input_graph(
         const TypeSpec ts,
         size_t depth)
 {
-    const auto name       = make_name("!tests.rand_graph.graphs.multi.");
+    const auto name       = make_unique_name("!tests.rand_graph.graphs.multi.");
     const auto graph_func = [](ZL_Graph*, ZL_Edge*[], size_t) noexcept {
         ZL_RET_R_ERR(GENERIC, "Unimplemented! Can't actually run.");
     };

--- a/tests/datagen/structures/CompressorProducer.h
+++ b/tests/datagen/structures/CompressorProducer.h
@@ -4,6 +4,7 @@
 
 #include <memory>
 #include <ostream>
+#include <unordered_set>
 
 #include "openzl/zl_compressor.h"
 
@@ -195,7 +196,7 @@ class RandomCompressorMultiBuilder {
         bool multi_{ false };
     };
 
-    std::string make_name(const std::string& prefix);
+    std::string make_unique_name(const std::string& prefix);
 
     ZL_IDType make_ctid();
 
@@ -284,6 +285,8 @@ class RandomCompressorMultiBuilder {
         }
         return results;
     }
+    // An set that tracks names of components to ensure reuse does not happen.
+    std::unordered_set<std::string> names_;
 
     std::shared_ptr<RandWrapper> rw_;
 

--- a/tests/serialization/BUCK
+++ b/tests/serialization/BUCK
@@ -1,0 +1,45 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+
+load("@fbcode_macros//build_defs:fbcode_configured_alias.bzl", "fbcode_configured_alias")
+load("@fbsource//tools/build_defs:default_platform_defs.bzl", "get_host_target_platform")
+load("../../defs.bzl", "zs_cxxbinary", "zs_fuzzers")
+
+oncall("data_compression")
+
+FUZZER_DEPS = [
+    "../..:zstronglib",
+    "..:fuzz_utils",
+    "../datagen:datagen",
+]
+
+zs_cxxbinary(
+    name = "fuzz_compressor_serialization_generator",
+    srcs = ["fuzz_compressor_serialization_generator.cpp"],
+    deps = [
+        "../../cpp:openzl_cpp",
+        "../datagen:datagen",
+        "//folly:file_util",
+        "//folly:string",
+    ],
+    external_deps = [
+        ("openssl", None, "crypto"),
+    ],
+)
+
+fbcode_configured_alias(
+    name = "fuzz_compressor_serialization_generator_host",
+    actual = ":fuzz_compressor_serialization_generator",
+    platform = get_host_target_platform(),
+)
+
+zs_fuzzers(
+    srcs = [
+        "fuzz_compressor_serialization.cpp",
+    ],
+    ftest_names = [
+        ("CompressorSerializationTest", "FuzzDeserialization"),
+        ("CompressorSerializationTest", "FuzzRandomCompressorDeserializesSuccessfully"),
+    ],
+    generator = ":fuzz_compressor_serialization_generator_host",
+    deps = FUZZER_DEPS,
+)

--- a/tests/serialization/fuzz_compressor_serialization.cpp
+++ b/tests/serialization/fuzz_compressor_serialization.cpp
@@ -1,0 +1,36 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#include "openzl/cpp/Compressor.hpp"
+
+#include "security/lionhead/utils/lib_ftest/ftest.h" // @manual
+#include "tests/datagen/structures/CompressorProducer.h"
+#include "tests/fuzz_utils.h"
+
+namespace openzl::tests {
+namespace {
+
+FUZZ(CompressorSerializationTest, FuzzDeserialization)
+{
+    std::string input = gen_str(f, "input_data", InputLengthInBytes(1));
+
+    try {
+        Compressor compressor;
+        compressor.deserialize(input);
+    } catch (const Exception&) {
+        // Ignore the exception as long as ZL_Result is returned since it is
+        // valid to deserialize unsucessfully
+    }
+}
+
+FUZZ(CompressorSerializationTest, FuzzRandomCompressorDeserializesSuccessfully)
+{
+    datagen::DataGen dg = fromFDP(f);
+    auto rw             = dg.getRandWrapper();
+    auto producer       = datagen::CompressorProducer(rw);
+    auto zlCompressor   = producer.make();
+    CompressorRef compressor(zlCompressor.get());
+    auto serialized = compressor.serialize();
+    compressor.deserialize(serialized);
+}
+} // namespace
+} // namespace openzl::tests

--- a/tests/serialization/fuzz_compressor_serialization_generator.cpp
+++ b/tests/serialization/fuzz_compressor_serialization_generator.cpp
@@ -1,0 +1,96 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#include <cstdio>
+#include <filesystem>
+#include <optional>
+#include <string_view>
+
+#include <openssl/sha.h>
+
+#include <folly/FileUtil.h>
+#include <folly/String.h>
+
+#include "openzl/cpp/Compressor.hpp"
+
+#include "tests/datagen/random_producer/PRNGWrapper.h"
+#include "tests/datagen/structures/CompressorProducer.h"
+
+namespace {
+
+using namespace openzl::tests;
+namespace fs = std::filesystem;
+
+std::vector<std::string> generateFuzzDeserializationCorpus()
+{
+    auto gen                = std::make_shared<std::mt19937>(0xdeadbeef);
+    auto rw                 = std::make_shared<datagen::PRNGWrapper>(gen);
+    auto compressorProducer = datagen::CompressorProducer{ rw };
+
+    std::vector<std::string> corpus;
+    corpus.reserve(1000);
+    for (uint32_t i = 0; i < 1000; ++i) {
+        auto zlCompressor = compressorProducer.make();
+        openzl::CompressorRef compressor(zlCompressor.get());
+        corpus.emplace_back(compressor.serialize());
+    }
+    return corpus;
+}
+
+std::optional<std::vector<std::string>> generateCorpus(std::string_view harness)
+{
+    if (harness == "FuzzDeserialization") {
+        return generateFuzzDeserializationCorpus();
+    } else {
+        return std::nullopt;
+    }
+}
+
+std::string sha256(std::string_view data)
+{
+    std::vector<uint8_t> digest;
+    digest.resize(SHA256_DIGEST_LENGTH, 0);
+    SHA256(reinterpret_cast<uint8_t const*>(data.data()),
+           data.size(),
+           digest.data());
+    return folly::hexlify(digest);
+}
+
+} // namespace
+
+int main(int argc, char** argv)
+{
+    if (argc != 4) {
+        std::fprintf(
+                stderr,
+                "USAGE: %s TEST_SUITE TEST_CASE OUTPUT_DIRECTORY\n",
+                argv[0]);
+        return 1;
+    }
+
+    std::string const testSuite = argv[1];
+    std::string const testCase  = argv[2];
+    fs::path const outDir       = argv[3];
+
+    if (testSuite != "CompressorSerializationTest") {
+        fprintf(stderr, "Unknown test suite: %s\n", testSuite.c_str());
+        return 2;
+    }
+
+    auto const corpus = generateCorpus(testCase);
+    if (!corpus.has_value()) {
+        std::fprintf(stderr, "Unknown test case: %s\n", testCase.c_str());
+        return 3;
+    }
+
+    fs::create_directories(outDir);
+
+    for (auto const& blob : *corpus) {
+        auto const path = outDir / sha256(blob);
+        if (!folly::writeFile(blob, path.c_str())) {
+            std::fprintf(stderr, "Failed to write path: %s\n", path.c_str());
+            return 4;
+        }
+    }
+
+    return 0;
+}


### PR DESCRIPTION
Summary:
Add fuzzing for compressor serialization and one minor bugfix.

CompressorProducer:
- The CompressorProducer allows using repeat names, which cause the library to return an error (fixed by adding a check to ensure uniqueness. Implementation could use reflection API but this would be messier)
- The CompressorProducer consumes too much randomness which causes zeroes to be generated fairly quickly (unfixed)
- The CompressorProducer has limitations in what types of graphs it produces. (unfixed)

Differential Revision: D92317658


