### PR TITLE
Fix "Hash length too large" related decompression fuzzer crashes

### DIFF
--- a/src/openzl/codecs/rolz/decode_experimental_dec.c
+++ b/src/openzl/codecs/rolz/decode_experimental_dec.c
@@ -588,6 +588,28 @@ static ZL_Report ZS_experimentalDecoder_decompress(
     uint32_t const numLiterals        = ZL_RC_popLE32(&in);
     uint32_t const numSequences       = ZL_RC_popLE32(&in);
 
+    switch (rolzContextDepth) {
+        case 2:
+        case 3:
+        case 4:
+        case 5:
+        case 6:
+        case 7:
+        case 8:
+        case 12:
+        case 16:
+            break;
+        default:
+            ZL_RET_R_ERR(
+                    node_invalid_input,
+                    "Invalid contextDepth %u",
+                    rolzContextDepth);
+    }
+    ZL_RET_R_IF_EQ(
+            node_invalid_input,
+            rolzContextLog,
+            0,
+            "contextLog must be greater than 0");
     ZL_RET_R_IF_GE(GENERIC, numSequences, (1 << 30), "too many sequences");
     ZL_RET_R_IF_GE(GENERIC, numLiterals, (1 << 30), "too many literals");
 


### PR DESCRIPTION
Summary: Fix fuzzer by returning an `ZL_Error` when reading an invalid contextDepth. This is propagated to the codec which then throws. The alternative is to introduce some error propogation to https://www.internalfb.com/code/fbsource/[239d0d8fa230]/fbcode/openzl/dev/src/openzl/shared/hash.h?lines=117.

Differential Revision: D92572732


