### PR TITLE
Add ZL_MAX_GRAPH_DEPTH limit to cap graph growth

### DIFF
--- a/src/openzl/common/limits.h
+++ b/src/openzl/common/limits.h
@@ -29,6 +29,12 @@ size_t ZL_runtimeNodeInputLimit(unsigned formatVersion);
 /// impacting the format version.
 #define ZL_ENCODER_GRAPH_LIMIT 131072
 
+/// Maximum depth of a compression graph. Graphs deeper than this are
+/// rejected, as excessive depth typically indicates an infinite loop.
+/// NOTE: This limit is encoder only, so it can be increased any time without
+/// impacting the format version.
+#define ZL_MAX_GRAPH_DEPTH 1024
+
 /// ZStrong will refuse to encode/decode graphs that contain more transforms
 /// than this.
 size_t ZL_runtimeNodeLimit(unsigned formatVersion);

--- a/src/openzl/compress/cctx.c
+++ b/src/openzl/compress/cctx.c
@@ -1197,7 +1197,8 @@ ZL_Report CCTX_runSuccessor(
             depth,
             ZL_MAX_GRAPH_DEPTH,
             temporaryLibraryLimitation,
-            "Graph depth limit exceeded (depth=%u)", depth);
+            "Graph depth limit exceeded (depth=%u)",
+            depth);
     ZL_DLOG(BLOCK, "CCTX_runSuccessor (graphid=%u)", graphid.gid);
     int const isSegmentable =
             (rtInputs[0].rtsid == 0 && nbInputs == cctx->nbInputs

--- a/src/openzl/compress/cctx.c
+++ b/src/openzl/compress/cctx.c
@@ -1193,6 +1193,11 @@ ZL_Report CCTX_runSuccessor(
         unsigned depth)
 {
     ZL_RESULT_DECLARE_SCOPE_REPORT(cctx);
+    ZL_ERR_IF_GE(
+            depth,
+            ZL_MAX_GRAPH_DEPTH,
+            temporaryLibraryLimitation,
+            "Graph depth limit exceeded (depth=%u)", depth);
     ZL_DLOG(BLOCK, "CCTX_runSuccessor (graphid=%u)", graphid.gid);
     int const isSegmentable =
             (rtInputs[0].rtsid == 0 && nbInputs == cctx->nbInputs

--- a/src/openzl/compress/cctx.c
+++ b/src/openzl/compress/cctx.c
@@ -1193,12 +1193,11 @@ ZL_Report CCTX_runSuccessor(
         unsigned depth)
 {
     ZL_RESULT_DECLARE_SCOPE_REPORT(cctx);
-    ZL_ERR_IF_GE(
-            depth,
-            ZL_MAX_GRAPH_DEPTH,
-            temporaryLibraryLimitation,
-            "Graph depth limit exceeded (depth=%u)",
-            depth);
+    if (depth >= ZL_MAX_GRAPH_DEPTH && !cctx->inBackupMode) {
+        ZL_ERR(temporaryLibraryLimitation,
+               "Graph depth limit exceeded (depth=%u)",
+               depth);
+    }
     ZL_DLOG(BLOCK, "CCTX_runSuccessor (graphid=%u)", graphid.gid);
     int const isSegmentable =
             (rtInputs[0].rtsid == 0 && nbInputs == cctx->nbInputs

--- a/src/openzl/compress/cctx.c
+++ b/src/openzl/compress/cctx.c
@@ -1193,6 +1193,13 @@ ZL_Report CCTX_runSuccessor(
         unsigned depth)
 {
     ZL_RESULT_DECLARE_SCOPE_REPORT(cctx);
+    /* Depth limit: catch runaway recursion in user-defined graphs.
+     * Skipped in backup mode, where the library runs its own fallback graph
+     * (currently ZL_GRAPH_COMPRESS_GENERIC). This is safe as long as the
+     * backup graph has deterministic bounded depth (no dynamic decisions
+     * that could loop). If the backup graph ever gains dynamic routing,
+     * this assumption must be revisited — e.g. by introducing a dedicated
+     * ZL_GRAPH_COMPRESS_BACKUP with static-only decisions. */
     if (depth >= ZL_MAX_GRAPH_DEPTH && !cctx->inBackupMode) {
         ZL_ERR(temporaryLibraryLimitation,
                "Graph depth limit exceeded (depth=%u)",

--- a/tests/round_trip/test_functionGraphs.cpp
+++ b/tests/round_trip/test_functionGraphs.cpp
@@ -1486,19 +1486,6 @@ TEST(DynGraphs, graphFailure_deep_permissive)
     permissiveTest(registerDynGraph_deep, g_dynGraph_dgdPtr->name);
 }
 
-/* Permissive mode rescues the self-loop:
- * the depth limit fires, permissive mode catches the error,
- * and the backup graph (ZL_GRAPH_COMPRESS_GENERIC) is allowed past
- * the depth limit because inBackupMode is set. */
-static ZL_GraphID registerSelfLoopGraph_permissive(ZL_Compressor* cgraph) noexcept
-{
-    ZL_Report const spp = ZL_Compressor_setParameter(
-            cgraph, ZL_CParam_permissiveCompression, 1);
-    if (ZL_isError(spp))
-        abort();
-    return registerSelfLoopGraph(cgraph);
-}
-
 TEST(DynGraphs, graphDepthLimitExceeded_permissive)
 {
     permissiveTest(

--- a/tests/round_trip/test_functionGraphs.cpp
+++ b/tests/round_trip/test_functionGraphs.cpp
@@ -966,6 +966,26 @@ static ZL_FunctionGraphDesc const dyngraph_failDeep_dgd = {
     .lastInputIsVariable = false,
 };
 
+/* ------ self-loop: graph that always routes back to itself ------ */
+
+static ZL_GraphID g_selfLoop_graphid = ZL_GRAPH_ILLEGAL;
+
+static ZL_Report
+selfLoopGraphFn(ZL_Graph*, ZL_Edge* inputs[], size_t nbIns) noexcept
+{
+    assert(nbIns == 1);
+    ZL_RET_R_IF_ERR(ZL_Edge_setDestination(inputs[0], g_selfLoop_graphid));
+    return ZL_returnSuccess();
+}
+
+static ZL_FunctionGraphDesc const selfLoop_dgd = {
+    .name                = "self-loop function graph (infinite recursion)",
+    .graph_f             = selfLoopGraphFn,
+    .inputTypeMasks      = &serialInputType,
+    .nbInputs            = 1,
+    .lastInputIsVariable = false,
+};
+
 /* ------   create the cgraph   -------- */
 
 // This graph function follows the ZL_GraphFn definition
@@ -1019,6 +1039,17 @@ static ZL_GraphID registerDynGraph_deep(ZL_Compressor* cgraph) noexcept
             transforms,
             2,
             ZL_Compressor_registerFunctionGraph(cgraph, g_dynGraph_dgdPtr));
+}
+
+static ZL_GraphID registerSelfLoopGraph(ZL_Compressor* cgraph) noexcept
+{
+    ZL_Report const setr = ZL_Compressor_setParameter(
+            cgraph, ZL_CParam_formatVersion, ZL_MAX_FORMAT_VERSION);
+    if (ZL_isError(setr))
+        abort();
+    g_selfLoop_graphid =
+            ZL_Compressor_registerFunctionGraph(cgraph, &selfLoop_dgd);
+    return g_selfLoop_graphid;
 }
 
 /* ------   compress, using provided graph function   -------- */
@@ -1374,6 +1405,13 @@ TEST(DynGraphs, graphFailure_deep)
 {
     g_dynGraph_dgdPtr = &dyngraph_failDeep_dgd;
     cFailTest(registerDynGraph_deep, g_dynGraph_dgdPtr->name);
+}
+
+TEST(DynGraphs, graphDepthLimitExceeded)
+{
+    cFailTest(
+            registerSelfLoopGraph,
+            "self-loop function graph triggers ZL_MAX_GRAPH_DEPTH limit");
 }
 
 TEST(DynGraphs, invalidNodeVersion_permissive)

--- a/tests/round_trip/test_functionGraphs.cpp
+++ b/tests/round_trip/test_functionGraphs.cpp
@@ -1486,6 +1486,26 @@ TEST(DynGraphs, graphFailure_deep_permissive)
     permissiveTest(registerDynGraph_deep, g_dynGraph_dgdPtr->name);
 }
 
+/* Permissive mode rescues the self-loop:
+ * the depth limit fires, permissive mode catches the error,
+ * and the backup graph (ZL_GRAPH_COMPRESS_GENERIC) is allowed past
+ * the depth limit because inBackupMode is set. */
+static ZL_GraphID registerSelfLoopGraph_permissive(ZL_Compressor* cgraph) noexcept
+{
+    ZL_Report const spp = ZL_Compressor_setParameter(
+            cgraph, ZL_CParam_permissiveCompression, 1);
+    if (ZL_isError(spp))
+        abort();
+    return registerSelfLoopGraph(cgraph);
+}
+
+TEST(DynGraphs, graphDepthLimitExceeded_permissive)
+{
+    permissiveTest(
+            registerSelfLoopGraph,
+            "self-loop function graph triggers ZL_MAX_GRAPH_DEPTH limit (permissive)");
+}
+
 // ---------------------------------------------
 // Testing ZL_Edge_setParameterizedDestination()
 // ---------------------------------------------


### PR DESCRIPTION
## Summary

Introduce a depth limit (currently set to 1024) used in `CCTX_runSuccessor()` to catch runaway recursion in user-defined function graphs. Without this, a graph that routes back to itself (or forms a cycle) would recurse until stack overflow.

The depth check is bypassed in backup mode (`inBackupMode`), so that permissive compression can still recover: the backup graph (`ZL_GRAPH_COMPRESS_GENERIC`) has deterministic bounded depth and needs a few extra levels to complete. This invariant is documented in `cctx.c` — if the backup graph ever gains dynamic routing, a dedicated `ZL_GRAPH_COMPRESS_BACKUP` with static-only decisions should be introduced.

## Test Plan

Tests: self-loop function graph that unconditionally routes back to itself, verified both as expected failure (non-permissive) and as successful round-trip (permissive mode fallback to generic).
