### PR TITLE
Easy: More-intuitive input/output specification in the compiler cli

### DIFF
--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -1,5 +1,37 @@
 # Copyright (c) Meta Platforms, Inc. and affiliates.
 
+# ── Flag computations ────────────────────────────────────────────────────────
+# Computed here (parent scope) so that all flags are available before any
+# add_subdirectory() call, regardless of inclusion order.
+
+set(OPENZL_BUILD_ARG_TOOLS OFF)
+set(OPENZL_BUILD_IO_TOOLS OFF)
+set(OPENZL_BUILD_SDDL_TOOLS OFF)
+set(OPENZL_BUILD_TRAINING_TOOLS OFF)
+
+if(NOT DEFINED OPENZL_BUILD_LOGGER)
+  set(OPENZL_BUILD_LOGGER OFF)
+endif()
+
+if(OPENZL_BUILD_TOOLS)
+  set(OPENZL_BUILD_ARG_TOOLS ON)
+  set(OPENZL_BUILD_IO_TOOLS ON)
+  set(OPENZL_BUILD_SDDL_TOOLS ON)
+  set(OPENZL_BUILD_TRAINING_TOOLS ON)
+endif()
+if(OPENZL_BUILD_CLI)
+  set(OPENZL_BUILD_ARG_TOOLS ON)
+  set(OPENZL_BUILD_IO_TOOLS ON)
+  set(OPENZL_BUILD_LOGGER ON)
+  set(OPENZL_BUILD_SDDL_TOOLS ON)
+  set(OPENZL_BUILD_TRAINING_TOOLS ON)
+endif()
+if(OPENZL_BUILD_PYTHON_EXT)
+  set(OPENZL_BUILD_LOGGER ON)
+  set(OPENZL_BUILD_IO_TOOLS ON)
+  set(OPENZL_BUILD_SDDL_TOOLS ON)
+endif()
+
 # Common Utilities
 add_subdirectory(arg)
 add_subdirectory(fileio)

--- a/tools/arg/CMakeLists.txt
+++ b/tools/arg/CMakeLists.txt
@@ -1,14 +1,5 @@
 # Copyright (c) Meta Platforms, Inc. and affiliates.
 
-set(OPENZL_BUILD_ARG_TOOLS OFF)
-
-if(OPENZL_BUILD_TOOLS)
-  set(OPENZL_BUILD_ARG_TOOLS ON)
-endif()
-if(OPENZL_BUILD_CLI)
-  set(OPENZL_BUILD_ARG_TOOLS ON)
-endif()
-
 if (OPENZL_BUILD_ARG_TOOLS)
     file(
         GLOB_RECURSE arg_sources

--- a/tools/io/CMakeLists.txt
+++ b/tools/io/CMakeLists.txt
@@ -1,14 +1,4 @@
 # Copyright (c) Meta Platforms, Inc. and affiliates.
-
-set(OPENZL_BUILD_IO_TOOLS OFF)
-
-if(OPENZL_BUILD_TOOLS)
-  set(OPENZL_BUILD_IO_TOOLS ON)
-endif()
-if(OPENZL_BUILD_CLI)
-  set(OPENZL_BUILD_IO_TOOLS ON)
-endif()
-
 if (OPENZL_BUILD_IO_TOOLS)
     file(
         GLOB tools_io_sources

--- a/tools/logger/CMakeLists.txt
+++ b/tools/logger/CMakeLists.txt
@@ -1,13 +1,5 @@
 # Copyright (c) Meta Platforms, Inc. and affiliates.
 
-if(NOT DEFINED OPENZL_BUILD_LOGGER)
-  set(OPENZL_BUILD_LOGGER OFF)
-endif()
-
-if(OPENZL_BUILD_CLI)
-  set(OPENZL_BUILD_LOGGER ON)
-endif()
-
 if (OPENZL_BUILD_LOGGER)
 
 add_library(logger

--- a/tools/sddl/CMakeLists.txt
+++ b/tools/sddl/CMakeLists.txt
@@ -1,17 +1,5 @@
 # Copyright (c) Meta Platforms, Inc. and affiliates.
 
-set(OPENZL_BUILD_SDDL_TOOLS OFF)
-
-if(OPENZL_BUILD_TOOLS)
-  set(OPENZL_BUILD_SDDL_TOOLS ON)
-endif()
-if(OPENZL_BUILD_CLI)
-  set(OPENZL_BUILD_SDDL_TOOLS ON)
-endif()
-if(OPENZL_BUILD_PYTHON_EXT)
-  set(OPENZL_BUILD_SDDL_TOOLS ON)
-endif()
-
 if (OPENZL_BUILD_SDDL_TOOLS)
     file(
         GLOB sddl_compiler_lib_sources

--- a/tools/sddl2/CMakeLists.txt
+++ b/tools/sddl2/CMakeLists.txt
@@ -1,17 +1,5 @@
 # Copyright (c) Meta Platforms, Inc. and affiliates.
 
-set(OPENZL_BUILD_SDDL_TOOLS OFF)
-
-if(OPENZL_BUILD_TOOLS)
-  set(OPENZL_BUILD_SDDL_TOOLS ON)
-endif()
-if(OPENZL_BUILD_CLI)
-  set(OPENZL_BUILD_SDDL_TOOLS ON)
-endif()
-if(OPENZL_BUILD_PYTHON_EXT)
-  set(OPENZL_BUILD_SDDL_TOOLS ON)
-endif()
-
 if (OPENZL_BUILD_SDDL_TOOLS)
         file(
         GLOB sddl2_compiler_lib_sources
@@ -44,7 +32,9 @@ if (OPENZL_BUILD_SDDL_TOOLS)
     target_link_libraries(sddl2_compiler_lib
         openzl_cpp
     )
-    add_dependencies(sddl2_compiler_lib openzl_cpp)
+    add_dependencies(sddl2_compiler_lib
+        openzl_cpp
+    )
     apply_openzl_compile_options_to_target(sddl2_compiler_lib)
 
 
@@ -55,10 +45,16 @@ if (OPENZL_BUILD_SDDL_TOOLS)
         ${PROJECT_BINARY_DIR}/include
         ${PROJECT_SOURCE_DIR}
     )
-    target_link_libraries(sddl2_compiler
+    target_link_libraries(sddl2_compiler PRIVATE
         sddl2_compiler_lib
+        tools_io
+        openzl_cpp
     )
-    add_dependencies(sddl2_compiler sddl2_compiler_lib)
+    add_dependencies(sddl2_compiler
+        sddl2_compiler_lib
+        tools_io
+        openzl_cpp
+    )
     apply_openzl_compile_options_to_target(sddl2_compiler)
 
     if (OPENZL_BUILD_TESTS)

--- a/tools/sddl2/compiler/BUCK
+++ b/tools/sddl2/compiler/BUCK
@@ -30,6 +30,7 @@ zs_cxxbinary(
     name = "compiler",
     srcs = ["main.cpp"],
     deps = [
+        "../../../tools:io",
         ":lib",
     ],
 )

--- a/tools/sddl2/compiler/main.cpp
+++ b/tools/sddl2/compiler/main.cpp
@@ -1,12 +1,14 @@
 // Copyright (c) Meta Platforms, Inc. and affiliates.
-
-#include <iostream>
-#include <iterator>
+#include <filesystem>
 #include <string>
 
 #include "tools/sddl2/compiler/Compiler.h"
 #include "tools/sddl2/compiler/Exception.h"
 
+#include "tools/io/InputFile.h"
+#include "tools/io/OutputFile.h"
+
+using namespace openzl;
 using namespace openzl::sddl2;
 
 namespace {
@@ -17,13 +19,17 @@ const char* const help_message =
         "Options:\n"
         "  -h  Print this help message.\n"
         "  -v  Increase verbosity.\n"
-        "  -q  Decrease verbosity.\n";
+        "  -q  Decrease verbosity.\n"
+        "  -i  Input file.\n"
+        "  -o  Output file.\n";
 
 }
 
 int main(int argc, char* argv[])
 {
     int verbosity = 0;
+    std::shared_ptr<tools::io::InputFile> input_file;
+    std::shared_ptr<tools::io::OutputFile> output_file;
     for (int i = 1; i < argc; i++) {
         if (argv[i] == std::string{ "-v" }) {
             verbosity++;
@@ -32,6 +38,20 @@ int main(int argc, char* argv[])
         } else if (argv[i] == std::string{ "-h" }) {
             std::cerr << help_message << std::endl;
             return 0;
+        } else if (argv[i] == std::string{ "-i" }) {
+            if (i + 1 >= argc) {
+                std::cerr << "Missing input file." << std::endl;
+                std::cerr << help_message << std::endl;
+                return 1;
+            }
+            input_file = std::make_shared<tools::io::InputFile>(argv[++i]);
+        } else if (argv[i] == std::string{ "-o" }) {
+            if (i + 1 >= argc) {
+                std::cerr << "Missing output file." << std::endl;
+                std::cerr << help_message << std::endl;
+                return 1;
+            }
+            output_file = std::make_shared<tools::io::OutputFile>(argv[++i]);
         } else {
             std::cerr << "Unrecognized option." << std::endl;
             std::cerr << help_message << std::endl;
@@ -40,12 +60,22 @@ int main(int argc, char* argv[])
     }
 
     try {
-        std::istreambuf_iterator<char> begin{ std::cin }, end;
-        const auto input = std::string{ begin, end };
+        if (!input_file) {
+            std::cerr << "No input file specified. Please specify with -i"
+                      << std::endl;
+            return 1;
+        }
+        if (!output_file) {
+            std::filesystem::path path{ std::string(input_file->name()) };
+            output_file = std::make_shared<tools::io::OutputFile>(
+                    path.replace_extension("asm"));
+        }
         const auto compiler =
                 Compiler{ Compiler::Options{}.with_verbosity(verbosity) };
-        const auto compiled = compiler.compile(input, "[stdin]");
-        std::cout << compiled;
+        const auto compiled =
+                compiler.compile(input_file->contents(), input_file->name());
+
+        output_file->write(compiled);
     } catch (const CompilerException& ex) {
         if (verbosity >= -1) {
             std::cerr << "Compilation failed:\n";

--- a/tools/sddl2/compiler/parser/AST.cpp
+++ b/tools/sddl2/compiler/parser/AST.cpp
@@ -177,14 +177,14 @@ void ASTVar::print(std::ostream& os, size_t indent) const
     os << std::string(indent, ' ') << "Var: " << name_ << std::endl;
 }
 
-ASTBuiltinField::ASTBuiltinField(const SourceLocation& loc, const Op& op)
-        : ASTField(loc), kw_(op)
+ASTBuiltinField::ASTBuiltinField(const SourceLocation& loc, const Symbol& sym)
+        : ASTField(loc), kw_(sym)
 {
 }
 
 void ASTBuiltinField::print(std::ostream& os, size_t indent) const
 {
-    os << std::string(indent, ' ') << "Field: " << op_to_debug_str(kw_)
+    os << std::string(indent, ' ') << "Field: " << sym_to_debug_str(kw_)
        << std::endl;
 }
 

--- a/tools/sddl2/compiler/parser/AST.h
+++ b/tools/sddl2/compiler/parser/AST.h
@@ -149,12 +149,12 @@ class ASTField : public ASTConverted {
 
 class ASTBuiltinField : public ASTField {
    public:
-    explicit ASTBuiltinField(const SourceLocation& loc, const Op& op);
+    explicit ASTBuiltinField(const SourceLocation& loc, const Symbol& op);
 
     void print(std::ostream& os, size_t indent) const override;
 
    private:
-    const Op kw_;
+    const Symbol kw_;
 };
 
 class ASTBytes : public ASTField {
@@ -298,9 +298,9 @@ class Codegen {
         return std::make_shared<ASTNum>(Token{ loc_, val });
     }
 
-    ASTPtr builtin_field(Op op) const
+    ASTPtr builtin_field(Symbol sym) const
     {
-        return std::make_shared<ASTBuiltinField>(loc_, op);
+        return std::make_shared<ASTBuiltinField>(loc_, sym);
     }
 
     ASTPtr array(ASTPtr field, ASTPtr len) const

--- a/tools/sddl2/compiler/parser/Grammar.cpp
+++ b/tools/sddl2/compiler/parser/Grammar.cpp
@@ -111,22 +111,15 @@ Associativity associativity_of(Precedence precedence)
     }
 }
 
-const std::map<Symbol, Op> builtin_field_syms_to_ops{
-    { Symbol::BYTE, Op::BYTE },     { Symbol::U8, Op::U8 },
-    { Symbol::I8, Op::I8 },         { Symbol::U16LE, Op::U16LE },
-    { Symbol::U16BE, Op::U16BE },   { Symbol::I16LE, Op::I16LE },
-    { Symbol::I16BE, Op::I16BE },   { Symbol::U32LE, Op::U32LE },
-    { Symbol::U32BE, Op::U32BE },   { Symbol::I32LE, Op::I32LE },
-    { Symbol::I32BE, Op::I32BE },   { Symbol::U64LE, Op::U64LE },
-    { Symbol::U64BE, Op::U64BE },   { Symbol::I64LE, Op::I64LE },
-    { Symbol::I64BE, Op::I64BE },   { Symbol::F8, Op::F8 },
-    { Symbol::F16LE, Op::F16LE },   { Symbol::F16BE, Op::F16BE },
-    { Symbol::F32LE, Op::F32LE },   { Symbol::F32BE, Op::F32BE },
-    { Symbol::F64LE, Op::F64LE },   { Symbol::F64BE, Op::F64BE },
-    { Symbol::BF8, Op::BF8 },       { Symbol::BF16LE, Op::BF16LE },
-    { Symbol::BF16BE, Op::BF16BE }, { Symbol::BF32LE, Op::BF32LE },
-    { Symbol::BF32BE, Op::BF32BE }, { Symbol::BF64LE, Op::BF64LE },
-    { Symbol::BF64BE, Op::BF64BE },
+const std::vector<Symbol> builtin_field_syms{
+    Symbol::BYTE,   Symbol::U8,     Symbol::I8,     Symbol::U16LE,
+    Symbol::U16BE,  Symbol::I16LE,  Symbol::I16BE,  Symbol::U32LE,
+    Symbol::U32BE,  Symbol::I32LE,  Symbol::I32BE,  Symbol::U64LE,
+    Symbol::U64BE,  Symbol::I64LE,  Symbol::I64BE,  Symbol::F8,
+    Symbol::F16LE,  Symbol::F16BE,  Symbol::F32LE,  Symbol::F32BE,
+    Symbol::F64LE,  Symbol::F64BE,  Symbol::BF8,    Symbol::BF16LE,
+    Symbol::BF16BE, Symbol::BF32LE, Symbol::BF32BE, Symbol::BF64LE,
+    Symbol::BF64BE,
 };
 
 const std::map<Symbol, Op> syms_to_ops{
@@ -352,8 +345,7 @@ class BuiltInFieldRule : public GrammarRule {
     ASTPtr do_gen(ASTPtr op, ArgsVec) const override
     {
         auto token = token_of(op);
-        return std::make_shared<ASTBuiltinField>(
-                token.loc(), builtin_field_syms_to_ops.at(token.sym()));
+        return std::make_shared<ASTBuiltinField>(token.loc(), token.sym());
     }
 };
 
@@ -537,7 +529,7 @@ const std::vector<std::unique_ptr<const GrammarRule>> grammar_rules{ []() {
     std::vector<std::unique_ptr<const GrammarRule>> r;
 
     // Built-in fields
-    for (const auto& [sym, _] : builtin_field_syms_to_ops) {
+    for (const auto& sym : builtin_field_syms) {
         add_rule<BuiltInFieldRule>(r, sym);
     }
 

--- a/tools/sddl2/compiler/parser/Ops.cpp
+++ b/tools/sddl2/compiler/parser/Ops.cpp
@@ -39,40 +39,6 @@ static const std::map<Op, poly::string_view> ops_to_debug_strs{
     { Op::LOG_AND, "LOG_AND" },
     { Op::LOG_OR, "LOG_OR" },
     { Op::LOG_NOT, "LOG_NOT" },
-
-    // Integer Numeric Types
-    { Op::BYTE, "BYTE" },
-    { Op::U8, "U8" },
-    { Op::I8, "I8" },
-    { Op::U16LE, "U16LE" },
-    { Op::U16BE, "U16BE" },
-    { Op::I16LE, "I16LE" },
-    { Op::I16BE, "I16BE" },
-    { Op::U32LE, "U32LE" },
-    { Op::U32BE, "U32BE" },
-    { Op::I32LE, "I32LE" },
-    { Op::I32BE, "I32BE" },
-    { Op::U64LE, "U64LE" },
-    { Op::U64BE, "U64BE" },
-    { Op::I64LE, "I64LE" },
-    { Op::I64BE, "I64BE" },
-
-    // Float Numeric Types
-    { Op::F8, "F8" },
-    { Op::F16LE, "F16LE" },
-    { Op::F16BE, "F16BE" },
-    { Op::F32LE, "F32LE" },
-    { Op::F32BE, "F32BE" },
-    { Op::F64LE, "F64LE" },
-    { Op::F64BE, "F64BE" },
-    { Op::BF8, "BF8" },
-    { Op::BF16LE, "BF16LE" },
-    { Op::BF16BE, "BF16BE" },
-    { Op::BF32LE, "BF32LE" },
-    { Op::BF32BE, "BF32BE" },
-    { Op::BF64LE, "BF64LE" },
-    { Op::BF64BE, "BF64BE" },
-
 };
 
 poly::string_view op_to_debug_str(Op op)

--- a/tools/sddl2/compiler/parser/Ops.h
+++ b/tools/sddl2/compiler/parser/Ops.h
@@ -38,40 +38,6 @@ enum class Op {
     LOG_AND,
     LOG_OR,
     LOG_NOT,
-
-    // Integer Numeric Types
-    BYTE,
-    U8,
-    I8,
-    U16LE,
-    U16BE,
-    I16LE,
-    I16BE,
-    U32LE,
-    U32BE,
-    I32LE,
-    I32BE,
-    U64LE,
-    U64BE,
-    I64LE,
-    I64BE,
-
-    // Float Numeric Types
-    F8,
-    F16LE,
-    F16BE,
-    F32LE,
-    F32BE,
-    F64LE,
-    F64BE,
-    BF8,
-    BF16LE,
-    BF16BE,
-    BF32LE,
-    BF32BE,
-    BF64LE,
-    BF64BE,
-
 };
 
 /// @returns a name string for an op.

--- a/tools/sddl2/compiler/tests/CompilerTest.cpp
+++ b/tools/sddl2/compiler/tests/CompilerTest.cpp
@@ -156,6 +156,45 @@ TEST_F(CompilerTest, ParseSimpleOps)
     expect_success(prog);
 }
 
+TEST_F(CompilerTest, ParseBuiltinFields)
+{
+    const auto prog = R"(
+        # integer numeric types
+        :Byte
+        :U8
+        :I8
+        :U16LE
+        :U16BE
+        :I16LE
+        :I16BE
+        :U32LE
+        :U32BE
+        :I32LE
+        :I32BE
+        :U64LE
+        :U64BE
+        :I64LE
+        :I64BE
+
+        # float numeric types
+        :F8
+        :F16LE
+        :F16BE
+        :F32LE
+        :F32BE
+        :F64LE
+        :F64BE
+        :BF8
+        :BF16LE
+        :BF16BE
+        :BF32LE
+        :BF32BE
+        :BF64LE
+        :BF64BE
+    )";
+    expect_success(prog);
+}
+
 TEST_F(CompilerTest, MildlyVexingParsing)
 {
     const auto prog = R"(
@@ -213,8 +252,8 @@ TEST_F(CompilerTest, ArrayAST)
     const auto cg       = Codegen(SourceLocation::null());
     const auto expected = std::vector<ASTPtr>(
             { cg.assign(cg.var("len"), cg.add(cg.num(1), cg.num(2))),
-              cg.consume(
-                      cg.array(cg.builtin_field(Op::BYTE), cg.var("len"))) });
+              cg.consume(cg.array(
+                      cg.builtin_field(Symbol::BYTE), cg.var("len"))) });
 
     expect_ast(prog, expected);
 }
@@ -234,7 +273,7 @@ TEST_F(CompilerTest, RecordAST)
                     ArgVec{},
                     ArgVec{ cg.assign(
                             cg.var("id"),
-                            cg.consume(cg.builtin_field(Op::I32LE))) })) });
+                            cg.consume(cg.builtin_field(Symbol::I32LE))) })) });
     expect_ast(prog, expected);
 }
 
@@ -314,26 +353,26 @@ TEST_F(CompilerTest, SimpleSaoAST)
                                     cg.assign(
                                             cg.var("SRA0"),
                                             cg.consume(cg.builtin_field(
-                                                    Op::F64LE))),
+                                                    Symbol::F64LE))),
                                     cg.assign(
                                             cg.var("SDEC0"),
                                             cg.consume(cg.builtin_field(
-                                                    Op::F64LE))),
+                                                    Symbol::F64LE))),
                                     cg.assign(
                                             cg.var("ISP"),
                                             cg.consume(cg.bytes(cg.num(2)))),
                                     cg.assign(
                                             cg.var("MAG"),
                                             cg.consume(cg.builtin_field(
-                                                    Op::I16LE))),
+                                                    Symbol::I16LE))),
                                     cg.assign(
                                             cg.var("XRPM"),
                                             cg.consume(cg.builtin_field(
-                                                    Op::F32LE))),
+                                                    Symbol::F32LE))),
                                     cg.assign(
                                             cg.var("XDPM"),
                                             cg.consume(cg.builtin_field(
-                                                    Op::F32LE))),
+                                                    Symbol::F32LE))),
                             })),
             cg.assign(cg.var("header"), cg.consume(cg.bytes(cg.num(28)))),
             cg.assign(

--- a/tools/training/CMakeLists.txt
+++ b/tools/training/CMakeLists.txt
@@ -1,14 +1,5 @@
 # Copyright (c) Meta Platforms, Inc. and affiliates.
 
-set(OPENZL_BUILD_TRAINING_TOOLS OFF)
-
-if(OPENZL_BUILD_TOOLS)
-  set(OPENZL_BUILD_TRAINING_TOOLS ON)
-endif()
-if(OPENZL_BUILD_CLI)
-  set(OPENZL_BUILD_TRAINING_TOOLS ON)
-endif()
-
 if (OPENZL_BUILD_TRAINING_TOOLS)
   file(
       GLOB_RECURSE training_sources


### PR DESCRIPTION
Summary: Modifies the cli to specify input/output files as flagged arguments. Requires an input to be specified, but generates a canonical output if unspecified.

Differential Revision: D92720731


