### PR TITLE
Add ZL_Selector_getGraphDepth() and ZL_Graph_getDepth() APIs

### DIFF
--- a/include/openzl/zl_graph_api.h
+++ b/include/openzl/zl_graph_api.h
@@ -159,6 +159,18 @@ bool ZL_Graph_isNodeSupported(const ZL_Graph* gctx, ZL_NodeID nodeid);
 
 const void* ZL_Graph_getOpaquePtr(const ZL_Graph* graph);
 
+/**
+ * @brief Query the current graph execution depth.
+ *
+ * Returns the depth at which the current graph is executing.
+ * Depth 1 is the root graph; each successor level increments by 1.
+ * This can be used to detect runaway graph growth.
+ *
+ * @param gctx  Graph context, must be non-NULL.
+ * @return Current graph execution depth (>= 1).
+ */
+unsigned ZL_Graph_getDepth(const ZL_Graph* gctx);
+
 /* access the content of an Edge */
 const ZL_Input* ZL_Edge_getData(const ZL_Edge* sctx);
 

--- a/include/openzl/zl_selector.h
+++ b/include/openzl/zl_selector.h
@@ -241,6 +241,19 @@ ZL_Type ZL_Selector_getInput0MaskForGraph(
 
 const void* ZL_Selector_getOpaquePtr(const ZL_Selector* selector);
 
+/**
+ * @brief Query the current graph execution depth.
+ *
+ * Returns the depth at which the current graph is executing.
+ * Depth 1 is the root graph; each successor level increments by 1.
+ * This can be used by a selector/transformer to detect runaway
+ * graph growth.
+ *
+ * @param selCtx  Selector context, must be non-NULL.
+ * @return Current graph execution depth (>= 1).
+ */
+unsigned ZL_Selector_getGraphDepth(const ZL_Selector* selCtx);
+
 /* =======================================================
  * tryGraph:
  * =======================================================

--- a/src/openzl/compress/cctx.c
+++ b/src/openzl/compress/cctx.c
@@ -947,6 +947,7 @@ static ZL_Report CCTX_runGraphDesc(
 
     ZL_Graph graphCtx     = GCTX_init(cctx, migd);
     graphCtx.privateParam = privateParam;
+    graphCtx.depth        = depth;
 
     for (unsigned n = 0; n < nbInputs; n++) {
         const ZL_Report ret =

--- a/src/openzl/compress/dyngraph_interface.c
+++ b/src/openzl/compress/dyngraph_interface.c
@@ -451,6 +451,12 @@ const void* ZL_Graph_getOpaquePtr(const ZL_Graph* gctx)
     return gctx->dgd->opaque.ptr;
 }
 
+unsigned ZL_Graph_getDepth(const ZL_Graph* gctx)
+{
+    ZL_ASSERT_NN(gctx);
+    return gctx->depth;
+}
+
 ZL_RESULT_OF(ZL_GraphPerformance)
 ZL_Graph_tryMultiInputGraph(
         const ZL_Graph* gctx,

--- a/src/openzl/compress/dyngraph_interface.c
+++ b/src/openzl/compress/dyngraph_interface.c
@@ -454,6 +454,7 @@ const void* ZL_Graph_getOpaquePtr(const ZL_Graph* gctx)
 unsigned ZL_Graph_getDepth(const ZL_Graph* gctx)
 {
     ZL_ASSERT_NN(gctx);
+    ZL_ASSERT_GE(gctx->depth, 1);
     return gctx->depth;
 }
 

--- a/src/openzl/compress/dyngraph_interface.h
+++ b/src/openzl/compress/dyngraph_interface.h
@@ -94,6 +94,7 @@ struct ZL_Graph_s {
     VECTOR(RTStreamID)
     rtsids;           /**< Runtime stream IDs for destination routing */
     ZL_Report status; /**< Error status during graph execution */
+    unsigned depth;   /**< Current graph execution depth */
 
     /** @name Memory Allocators
      *  Allocators with specified lifetime durations

--- a/src/openzl/compress/graph_registry.c
+++ b/src/openzl/compress/graph_registry.c
@@ -412,7 +412,8 @@ GR_selectorWrapper(ZL_Graph* gctx, ZL_Edge* inputCtxs[], size_t nbInputs)
             gctx->graphArena,
             lparams,
             successorParams,
-            ZL_Graph_getOpaquePtr(gctx)));
+            ZL_Graph_getOpaquePtr(gctx),
+            gctx->depth));
     ZL_ASSERT_NN(selector_f);
     ZL_GraphID selectedSuccessor = selector_f(
             &siState,

--- a/src/openzl/compress/selector.c
+++ b/src/openzl/compress/selector.c
@@ -14,7 +14,8 @@ ZL_Report SelCtx_initSelectorCtx(
         Arena* wkspArena,
         const ZL_LocalParams* lparams,
         SelectorSuccessorParams* successorLParams,
-        const void* opaque)
+        const void* opaque,
+        unsigned depth)
 {
     ZL_ASSERT_NN(selCtx);
     ZL_ASSERT_NN(wkspArena);
@@ -22,7 +23,8 @@ ZL_Report SelCtx_initSelectorCtx(
                              .wkspArena        = wkspArena,
                              .lparams          = lparams,
                              .successorLParams = successorLParams,
-                             .opaque           = opaque };
+                             .opaque           = opaque,
+                             .depth            = depth };
     return ZL_returnSuccess();
 }
 
@@ -125,4 +127,10 @@ void* ZL_Selector_getScratchSpace(const ZL_Selector* selCtx, size_t size)
 const void* ZL_Selector_getOpaquePtr(const ZL_Selector* selector)
 {
     return selector->opaque;
+}
+
+unsigned ZL_Selector_getGraphDepth(const ZL_Selector* selCtx)
+{
+    ZL_ASSERT_NN(selCtx);
+    return selCtx->depth;
 }

--- a/src/openzl/compress/selector.c
+++ b/src/openzl/compress/selector.c
@@ -132,5 +132,6 @@ const void* ZL_Selector_getOpaquePtr(const ZL_Selector* selector)
 unsigned ZL_Selector_getGraphDepth(const ZL_Selector* selCtx)
 {
     ZL_ASSERT_NN(selCtx);
+    ZL_ASSERT_GE(selCtx->depth, 1);
     return selCtx->depth;
 }

--- a/src/openzl/compress/selector.h
+++ b/src/openzl/compress/selector.h
@@ -27,6 +27,8 @@ struct ZL_Selector_s {
     /// are scoped to the current context
     Arena* wkspArena;
     const void* opaque;
+    /// Current graph execution depth
+    unsigned depth;
 }; /// typedef'd to ZL_Selector within zs2_transform_api.h
 
 ZL_Report SelCtx_initSelectorCtx(
@@ -35,7 +37,8 @@ ZL_Report SelCtx_initSelectorCtx(
         Arena* wkspArena,
         const ZL_LocalParams* lparams,
         SelectorSuccessorParams* successorLParams,
-        const void* opaque);
+        const void* opaque,
+        unsigned depth);
 
 void SelCtx_destroySelectorCtx(ZL_Selector* selCtx);
 

--- a/tests/zstrong/test_graph_depth.cpp
+++ b/tests/zstrong/test_graph_depth.cpp
@@ -149,8 +149,7 @@ TEST_F(GraphDepthTest, FunctionGraphDepthNested)
         .customGraphs   = &innerGraph,
         .nbCustomGraphs = 1,
     };
-    auto rootGraph =
-            ZL_Compressor_registerSelectorGraph(compressor_, &selDesc);
+    auto rootGraph = ZL_Compressor_registerSelectorGraph(compressor_, &selDesc);
     ASSERT_NE(rootGraph, ZL_GRAPH_ILLEGAL);
     testRoundTrip(rootGraph);
 }

--- a/tests/zstrong/test_graph_depth.cpp
+++ b/tests/zstrong/test_graph_depth.cpp
@@ -1,0 +1,156 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#include <gtest/gtest.h>
+
+#include "openzl/common/assertion.h"
+#include "openzl/zl_compress.h"
+#include "openzl/zl_compressor.h"
+#include "openzl/zl_graph_api.h"
+#include "openzl/zl_selector.h"
+
+#include "tests/utils.h"
+
+using namespace ::testing;
+
+class GraphDepthTest : public ::testing::Test {
+   public:
+    void SetUp() override
+    {
+        compressor_ = ZL_Compressor_create();
+        cctx_       = ZL_CCtx_create();
+        dctx_       = ZL_DCtx_create();
+    }
+
+    void TearDown() override
+    {
+        ZL_Compressor_free(compressor_);
+        compressor_ = nullptr;
+        ZL_CCtx_free(cctx_);
+        cctx_ = nullptr;
+        ZL_DCtx_free(dctx_);
+        dctx_ = nullptr;
+    }
+
+    void testRoundTrip(ZL_GraphID graph)
+    {
+        ZL_REQUIRE_SUCCESS(ZL_Compressor_setParameter(
+                compressor_, ZL_CParam_formatVersion, ZL_MAX_FORMAT_VERSION));
+        ZL_REQUIRE_SUCCESS(
+                ZL_Compressor_selectStartingGraphID(compressor_, graph));
+        ZL_REQUIRE_SUCCESS(ZL_CCtx_refCompressor(cctx_, compressor_));
+        std::string data(10000, 'a');
+        std::string compressed(ZL_compressBound(data.size()), '\0');
+        auto report = ZL_CCtx_compress(
+                cctx_,
+                compressed.data(),
+                compressed.size(),
+                data.data(),
+                data.size());
+        ZL_REQUIRE_SUCCESS(report);
+        std::string roundTripped(10000, 'b');
+        report = ZL_DCtx_decompress(
+                dctx_,
+                roundTripped.data(),
+                roundTripped.size(),
+                compressed.data(),
+                ZL_validResult(report));
+        ZL_REQUIRE_SUCCESS(report);
+        ZL_REQUIRE_EQ(ZL_validResult(report), data.size());
+        ZL_REQUIRE(data == roundTripped);
+    }
+
+   protected:
+    ZL_Compressor* compressor_ = nullptr;
+    ZL_CCtx* cctx_             = nullptr;
+    ZL_DCtx* dctx_             = nullptr;
+};
+
+/* A root-level selector should see depth == 1 */
+TEST_F(GraphDepthTest, SelectorDepthAtRoot)
+{
+    ZL_SelectorDesc desc = {
+        .selector_f =
+                [](const ZL_Selector* selector,
+                   const ZL_Input*,
+                   const ZL_GraphID*,
+                   size_t) noexcept {
+                    unsigned depth = ZL_Selector_getGraphDepth(selector);
+                    ZL_REQUIRE_EQ(depth, 1);
+                    return ZL_GRAPH_STORE;
+                },
+        .inStreamType = ZL_Type_serial,
+    };
+    auto graph = ZL_Compressor_registerSelectorGraph(compressor_, &desc);
+    ASSERT_NE(graph, ZL_GRAPH_ILLEGAL);
+    testRoundTrip(graph);
+}
+
+/* A root-level function graph should see depth == 1 */
+TEST_F(GraphDepthTest, FunctionGraphDepthAtRoot)
+{
+    ZL_Type type              = ZL_Type_serial;
+    ZL_FunctionGraphDesc desc = {
+        .graph_f =
+                [](ZL_Graph* graph,
+                   ZL_Edge* edges[],
+                   size_t numEdges) noexcept {
+                    unsigned depth = ZL_Graph_getDepth(graph);
+                    ZL_REQUIRE_EQ(depth, 1);
+                    for (size_t i = 0; i < numEdges; ++i) {
+                        ZL_REQUIRE_SUCCESS(ZL_Edge_setDestination(
+                                edges[i], ZL_GRAPH_STORE));
+                    }
+                    return ZL_returnSuccess();
+                },
+        .inputTypeMasks = &type,
+        .nbInputs       = 1,
+    };
+    auto graph = ZL_Compressor_registerFunctionGraph(compressor_, &desc);
+    ASSERT_NE(graph, ZL_GRAPH_ILLEGAL);
+    testRoundTrip(graph);
+}
+
+/* A selector at root picks a function graph successor;
+ * the successor should see depth == 2. */
+TEST_F(GraphDepthTest, FunctionGraphDepthNested)
+{
+    ZL_Type type              = ZL_Type_serial;
+    ZL_FunctionGraphDesc desc = {
+        .graph_f =
+                [](ZL_Graph* graph,
+                   ZL_Edge* edges[],
+                   size_t numEdges) noexcept {
+                    unsigned depth = ZL_Graph_getDepth(graph);
+                    ZL_REQUIRE_EQ(depth, 2);
+                    for (size_t i = 0; i < numEdges; ++i) {
+                        ZL_REQUIRE_SUCCESS(ZL_Edge_setDestination(
+                                edges[i], ZL_GRAPH_STORE));
+                    }
+                    return ZL_returnSuccess();
+                },
+        .inputTypeMasks = &type,
+        .nbInputs       = 1,
+    };
+    auto innerGraph = ZL_Compressor_registerFunctionGraph(compressor_, &desc);
+    ASSERT_NE(innerGraph, ZL_GRAPH_ILLEGAL);
+
+    ZL_SelectorDesc selDesc = {
+        .selector_f =
+                [](const ZL_Selector* selector,
+                   const ZL_Input*,
+                   const ZL_GraphID* customGraphs,
+                   size_t nbCustomGraphs) noexcept {
+                    unsigned depth = ZL_Selector_getGraphDepth(selector);
+                    ZL_REQUIRE_EQ(depth, 1);
+                    ZL_REQUIRE_EQ(nbCustomGraphs, 1);
+                    return customGraphs[0];
+                },
+        .inStreamType   = ZL_Type_serial,
+        .customGraphs   = &innerGraph,
+        .nbCustomGraphs = 1,
+    };
+    auto rootGraph =
+            ZL_Compressor_registerSelectorGraph(compressor_, &selDesc);
+    ASSERT_NE(rootGraph, ZL_GRAPH_ILLEGAL);
+    testRoundTrip(rootGraph);
+}


### PR DESCRIPTION
Expose the graph execution depth (already tracked on the call stack) to selectors and function graphs, so user code can detect runaway graph growth.

Thread the depth value through:
  `CCTX_runGraphDesc()` → `ZL_Graph_s.depth` →
  `GR_selectorWrapper()` → `SelCtx_initSelectorCtx()` → `ZL_Selector_s.depth`

New public API:
  `unsigned ZL_Graph_getDepth(const ZL_Graph*)`
  `unsigned ZL_Selector_getGraphDepth(const ZL_Selector*)`
