### PR TITLE
do not assign static graph wrappers the head node's local params by default

### DIFF
--- a/src/openzl/compress/graphmgr.c
+++ b/src/openzl/compress/graphmgr.c
@@ -490,10 +490,10 @@ GM_registerStaticGraph(GraphsMgr* gm, const ZL_StaticGraphDesc* sgDesc)
         .nbCustomNodes       = 1,
         .customGraphs        = successors,
         .nbCustomGraphs      = nbSuccessors,
-        .localParams         = sgDesc->localParams
-                        ? sgDesc->localParams[0]
-                        : cnode->transformDesc.publicDesc.localParams,
     };
+    if (sgDesc->localParams) {
+        migd.localParams = *sgDesc->localParams;
+    }
     unsigned const nsParam = (unsigned)nbSingletons;
     return GM_registerInternalGraph(
             gm,


### PR DESCRIPTION
Summary:
A static encoder can receive its params either from the surrounding static graph wrapper or by querying the params it was registered with. The latter happens automatically if its graph wrapper has no parameters of its own. Typically, graph wrappers should *not* have any params. However, in the code, these are provided by default by taking the params of the head node... which are then passed into the encoder, bypassing the fallback query with an identical copy of params.

Anyways, this shouldn't be happening.

Reviewed By: terrelln

Differential Revision: D92099757


