### PR TITLE
Add accessors for ASTNode values

### DIFF
--- a/tools/sddl2/compiler/parser/AST.cpp
+++ b/tools/sddl2/compiler/parser/AST.cpp
@@ -222,6 +222,11 @@ void ASTVar::print(std::ostream& os, size_t indent) const
     os << std::string(indent, ' ') << "Var: " << name_ << std::endl;
 }
 
+const std::string& ASTVar::name() const
+{
+    return name_;
+}
+
 ASTBuiltinField::ASTBuiltinField(const SourceLocation& loc, const Symbol& sym)
         : ASTField(loc), kw_(sym)
 {
@@ -236,6 +241,11 @@ void ASTBuiltinField::print(std::ostream& os, size_t indent) const
 {
     os << std::string(indent, ' ') << "Field: " << sym_to_debug_str(kw_)
        << std::endl;
+}
+
+const Symbol& ASTBuiltinField::kw() const
+{
+    return kw_;
 }
 
 ASTBytes::ASTBytes(const SourceLocation& loc, const ASTPtr& len)
@@ -253,6 +263,11 @@ void ASTBytes::print(std::ostream& os, size_t indent) const
     os << std::string(indent, ' ') << "Field: BYTES:" << std::endl;
     os << std::string(indent + 2, ' ') << "Len: " << std::endl;
     len_->print(os, indent + 4);
+}
+
+const ASTPtr& ASTBytes::len() const
+{
+    return len_;
 }
 
 ASTPtr ASTBytes::extract_len(const ASTPtr& paren_ptr)
@@ -300,6 +315,16 @@ void ASTRecord::print(std::ostream& os, size_t indent) const
     for (const auto& field : fields_) {
         field->print(os, indent + 4);
     }
+}
+
+const ASTVec& ASTRecord::params() const
+{
+    return params_;
+}
+
+const ASTVec& ASTRecord::fields() const
+{
+    return fields_;
 }
 
 ASTVec ASTRecord::extract_fields(
@@ -360,6 +385,16 @@ void ASTArray::print(std::ostream& os, size_t indent) const
     }
 }
 
+const ASTPtr& ASTArray::field() const
+{
+    return field_;
+}
+
+const ASTPtr& ASTArray::len() const
+{
+    return len_;
+}
+
 ASTOp::ASTOp(const SourceLocation& loc, const Op& op, ASTVec args)
         : ASTConverted(loc + join_locs(args)), op_(op), args_(std::move(args))
 {
@@ -378,4 +413,15 @@ void ASTOp::print(std::ostream& os, size_t indent) const
         arg->print(os, indent + 2);
     }
 }
+
+const Op& ASTOp::op() const
+{
+    return op_;
+}
+
+const ASTVec& ASTOp::args() const
+{
+    return args_;
+}
+
 } // namespace openzl::sddl2

--- a/tools/sddl2/compiler/parser/AST.h
+++ b/tools/sddl2/compiler/parser/AST.h
@@ -182,6 +182,8 @@ class ASTVar : public ASTConverted {
         return ConvertedNodeType::VAR;
     }
 
+    const std::string& name() const;
+
    private:
     const std::string name_;
 };
@@ -204,6 +206,8 @@ class ASTBuiltinField : public ASTField {
         return ConvertedNodeType::BUILTIN_FIELD;
     }
 
+    const Symbol& kw() const;
+
    private:
     const Symbol kw_;
 };
@@ -220,6 +224,8 @@ class ASTBytes : public ASTField {
     {
         return ConvertedNodeType::BYTES;
     }
+
+    const ASTPtr& len() const;
 
    private:
     static ASTPtr extract_len(const ASTPtr& paren_ptr);
@@ -239,6 +245,9 @@ class ASTRecord : public ASTField {
     {
         return ConvertedNodeType::RECORD;
     }
+
+    const ASTVec& params() const;
+    const ASTVec& fields() const;
 
    private:
     static ASTVec extract_fields(
@@ -267,6 +276,9 @@ class ASTArray : public ASTField {
         return ConvertedNodeType::ARRAY;
     }
 
+    const ASTPtr& field() const;
+    const ASTPtr& len() const;
+
    private:
     const ASTPtr field_;
     const ASTPtr len_;
@@ -284,6 +296,9 @@ class ASTOp : public ASTConverted {
     {
         return ConvertedNodeType::OP;
     }
+
+    const Op& op() const;
+    const ASTVec& args() const;
 
    private:
     const Op op_;


### PR DESCRIPTION
Summary: This diff adds some public accessors for ASTNode values. We will need to be able to access these during codegen.

Differential Revision: D93788248


