### PR TITLE
[Workflow]Windows precompiled binaries

### DIFF
--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -37,53 +37,64 @@ jobs:
   build-windows-x64:
     name: Windows X64 CLI Binary
     runs-on: windows-latest
+    defaults:
+      run:
+        shell: msys2 {0}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      - name: Setup MSBuild
-        uses: microsoft/setup-msbuild@v2
+      - name: Setup MSYS2 with MinGW-w64
+        uses: msys2/setup-msys2@v2
+        with:
+          msystem: MINGW64
+          install: make diffutils cmake git mingw-w64-x86_64-clang
+          update: true
 
-      - name: Verify clang-cl availability
+      - name: Show build environment
         run: |
-          echo "=== Verifying clang-cl availability ==="
-          where clang-cl
-          echo "=== clang-cl availability verified ==="
-        shell: cmd
+          echo "=== Build environment ==="
+          echo "CC: gcc"
+          echo "CXX: g++"
+          gcc --version
+          g++ --version
+          make --version
+          echo "=== Build environment verified ==="
 
-      - name: Configure CMake with clang-cl
+
+      - name: Build dependencies
         run: |
-          echo "=== Configuring CMake with clang-cl ==="
-          cmake -S . -B build ^
-            -G "Visual Studio 17 2022" ^
-            -A x64 ^
-            -T ClangCL ^
-            -DCMAKE_BUILD_TYPE=${{ env.BUILD_TYPE }} ^
-            -DCMAKE_C_FLAGS="/W2" ^
-            -DCMAKE_CXX_FLAGS="/W2" ^
-            -DOPENZL_BUILD_SHARED_LIBS=OFF ^
-            -DCMAKE_INSTALL_PREFIX="./install"
-          echo "=== CMake configuration completed ==="
-        shell: cmd
+          echo "=== Building dependencies ==="
+          make -j builddeps
+          echo "=== Dependencies built ==="
+
 
       - name: Build zli CLI
         run: |
           echo "=== Building zli CLI executable ==="
-          cmake --build build --config ${{ env.BUILD_TYPE }} --target zli --verbose
+          make -j zli BUILD_TYPE=OPT V=1
           echo "=== zli CLI executable build completed ==="
-        shell: cmd
 
-      - name: Create release artifact
+
+      - name: Prepare release artifact
         run: |
           echo "=== Preparing release artifact ==="
           mkdir release
-          copy build\cli\${{ env.BUILD_TYPE }}\zli.exe release\openzl-cli-windows-x64.exe
+          cp cli/zli.exe release/openzl-cli-windows-x64.exe
           echo "=== Release artifact prepared ==="
-          dir release
-        shell: cmd
+          ls -la release
+
+      - name: Verify release artifact
+        run: |
+          echo "=== Verifying release artifact ==="
+          ./release/openzl-cli-windows-x64.exe
+          echo "=== Checking binary size ==="
+          ls -lh release/openzl-cli-windows-x64.exe
+          echo "=== Binary size verified ==="
+
 
       - name: Upload binary to Github Releases
-        if: github.event_name == 'release' && github.event.action == 'published'
+        if: github.event_name == 'release'
         uses: softprops/action-gh-release@v2
         with:
           files: release\openzl-cli-windows-x64.exe

--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -1,0 +1,104 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+
+name: Release Binaries
+
+# This workflow builds pre-compiled binaries and attaches them to github releases
+# It is triggered by a release event, this builds and uploads binaries to that release
+
+# Usage:
+# 1. Go to Github -> Releases -> Create a new release
+# 2. Create a new tag (e.g., v1.0.0) and publish the release
+# 3. This workflow automatically runs and attaches binaries
+
+# You can also manually trigger the workflow via workflow_dispatch for testing
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      build_type:
+        description: "Build type (Release or Debug)"
+        required: false
+        default: "Release"
+        type: choice
+        options:
+          - Release
+          - Debug
+
+env:
+  BUILD_TYPE: ${{ github.event.inputs.build_type || 'Release' }}
+
+
+jobs:
+  # =============================================================================#
+  # WINDOWS X64 BINARY
+  # =============================================================================#
+  build-windows-x64:
+    name: Windows X64 CLI Binary
+    runs-on: windows-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup MSBuild
+        uses: microsoft/setup-msbuild@v2
+
+      - name: Verify clang-cl availability
+        run: |
+          echo "=== Verifying clang-cl availability ==="
+          where clang-cl
+          echo "=== clang-cl availability verified ==="
+        shell: cmd
+
+      - name: Configure CMake with clang-cl
+        run: |
+          echo "=== Configuring CMake with clang-cl ==="
+          cmake -S . -B build ^
+            -G "Visual Studio 17 2022" ^
+            -A x64 ^
+            -T ClangCL ^
+            -DCMAKE_BUILD_TYPE=${{ env.BUILD_TYPE }} ^
+            -DCMAKE_C_FLAGS="/W2" ^
+            -DCMAKE_CXX_FLAGS="/W2" ^
+            -DOPENZL_BUILD_SHARED_LIBS=OFF ^
+            -DCMAKE_INSTALL_PREFIX="./install"
+          echo "=== CMake configuration completed ==="
+        shell: cmd
+
+      - name: Build zli CLI
+        run: |
+          echo "=== Building zli CLI executable ==="
+          cmake --build build --config ${{ env.BUILD_TYPE }} --target zli --verbose
+          echo "=== zli CLI executable build completed ==="
+        shell: cmd
+
+      - name: Create release artifact
+        run: |
+          echo "=== Preparing release artifact ==="
+          mkdir release
+          copy build\cli\${{ env.BUILD_TYPE }}\zli.exe release\openzl-cli-windows-x64.exe
+          echo "=== Release artifact prepared ==="
+          dir release
+        shell: cmd
+
+      - name: Upload binary to Github Releases
+        if: github.event_name == 'release' && github.event.action == 'published'
+        uses: softprops/action-gh-release@v2
+        with:
+          files: release\openzl-cli-windows-x64.exe
+
+      - name: Upload artifact (for manual workflow runs)
+        uses: actions/upload-artifact@v4
+        with:
+          name: openzl-cli-windows-x64
+          path: release\openzl-cli-windows-x64.exe
+          retention-days: 30
+
+# =============================================================================#
+# Future platform support will go here
+# =============================================================================#
+
+
+
+

--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -16,18 +16,6 @@ on:
   release:
     types: [published]
   workflow_dispatch:
-    inputs:
-      build_type:
-        description: "Build type (Release or Debug)"
-        required: false
-        default: "Release"
-        type: choice
-        options:
-          - Release
-          - Debug
-
-env:
-  BUILD_TYPE: ${{ github.event.inputs.build_type || 'Release' }}
 
 
 jobs:
@@ -48,14 +36,12 @@ jobs:
         uses: msys2/setup-msys2@v2
         with:
           msystem: MINGW64
-          install: make diffutils cmake git mingw-w64-x86_64-clang
+          install: make diffutils cmake git mingw-w64-x86_64-gcc
           update: true
 
       - name: Show build environment
         run: |
           echo "=== Build environment ==="
-          echo "CC: gcc"
-          echo "CXX: g++"
           gcc --version
           g++ --version
           make --version
@@ -80,17 +66,17 @@ jobs:
         run: |
           echo "=== Preparing release artifact ==="
           mkdir release
-          cp cli/zli.exe release/openzl-cli-windows-x64.exe
+          cp zli.exe release/openzl-cli-windows-x64.exe
           echo "=== Release artifact prepared ==="
           ls -la release
 
       - name: Verify release artifact
         run: |
           echo "=== Verifying release artifact ==="
-          ./release/openzl-cli-windows-x64.exe
+          ./release/openzl-cli-windows-x64.exe --version
           echo "=== Checking binary size ==="
           ls -lh release/openzl-cli-windows-x64.exe
-          echo "=== Binary size verified ==="
+          echo "=== Release artifact verified ==="
 
 
       - name: Upload binary to Github Releases

--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -55,10 +55,10 @@ jobs:
           echo "=== Dependencies built ==="
 
 
-      - name: Build zli CLI
+      - name: Build zli CLI (statically linked)
         run: |
           echo "=== Building zli CLI executable ==="
-          make -j zli BUILD_TYPE=OPT V=1
+          LDFLAGS="-static" make -j zli BUILD_TYPE=OPT V=1
           echo "=== zli CLI executable build completed ==="
 
 
@@ -72,8 +72,10 @@ jobs:
 
       - name: Verify release artifact
         run: |
-          echo "=== Verifying release artifact ==="
+          echo "=== Verifying binary runs standalone ==="
           ./release/openzl-cli-windows-x64.exe --version
+          echo "=== Checking for non-system DLL dependencies ==="
+          objdump -p release/openzl-cli-windows-x64.exe | grep "DLL Name" || true
           echo "=== Checking binary size ==="
           ls -lh release/openzl-cli-windows-x64.exe
           echo "=== Release artifact verified ==="

--- a/.github/workflows/windows-release-binaries.yml
+++ b/.github/workflows/windows-release-binaries.yml
@@ -1,16 +1,10 @@
 # Copyright (c) Meta Platforms, Inc. and affiliates.
 
-name: Release Binaries
+name: Windows Release Binaries
 
-# This workflow builds pre-compiled binaries and attaches them to github releases
-# It is triggered by a release event, this builds and uploads binaries to that release
-
-# Usage:
-# 1. Go to Github -> Releases -> Create a new release
-# 2. Create a new tag (e.g., v1.0.0) and publish the release
-# 3. This workflow automatically runs and attaches binaries
-
-# You can also manually trigger the workflow via workflow_dispatch for testing
+# This workflow builds pre-compiled Windows x64 CLI binaries (zli).
+# Triggered on release publish or manually via workflow_dispatch.
+# Binaries are uploaded as GitHub Actions artifacts for download.
 
 on:
   release:
@@ -81,23 +75,10 @@ jobs:
           echo "=== Release artifact verified ==="
 
 
-      - name: Upload binary to Github Releases
-        if: github.event_name == 'release'
-        uses: softprops/action-gh-release@v2
-        with:
-          files: release\openzl-cli-windows-x64.exe
-
-      - name: Upload artifact (for manual workflow runs)
+      - name: Upload artifact
         uses: actions/upload-artifact@v4
         with:
           name: openzl-cli-windows-x64
           path: release\openzl-cli-windows-x64.exe
           retention-days: 30
-
-# =============================================================================#
-# Future platform support will go here
-# =============================================================================#
-
-
-
 


### PR DESCRIPTION
## Summary

Add a GitHub Actions workflow to build and publish pre-compiled Windows x64 CLI binaries (`zli`) as release assets. When a GitHub Release is published, the workflow automatically builds the binary and attaches it to the release. Manual triggering via `workflow_dispatch` is also supported for testing.

<img width="616" height="28" alt="image" src="https://github.com/user-attachments/assets/957ca5cc-a331-4dd1-9c84-c5a7f82b3275" />

We can extend this workflow by appending binary build instruction for linux / macos in the same workflow file,

Fixes #306

## Type of Change

- Build/CI changes

## Design Decisions

### MinGW-w64 (GCC) over Visual Studio (clang-cl)

The initial implementation used CMake with the Visual Studio 2022 generator and clang-cl toolset, matching the existing `windows-ci.yml` pattern. However, the `zli` CLI target depends on XGBoost (via the ML selector), and **XGBoost fails to build with clang-cl on Windows**. The existing `windows-ci.yml` only builds `--target openzl` (the library) with clang-cl — it never builds `zli`.

The MinGW-w64 GCC toolchain (via MSYS2) is already proven to build and test `zli` successfully in the `mingw-builds` job of `windows-ci.yml`, so this workflow uses the same approach: `msys2/setup-msys2@v2` with `MINGW64` and the project's Makefile-based build system.

### Static Linking (`LDFLAGS="-static"`)

MinGW GCC produces binaries that dynamically link to GCC runtime DLLs (`libgcc_s_seh-1.dll`, `libstdc++-6.dll`, `libwinpthread-1.dll`). These DLLs exist on the CI runner but not on end-user machines, causing "DLL not found" errors.

The build uses `LDFLAGS="-static"` to statically embed all GCC/C++ runtime libraries into the binary, producing a fully self-contained `.exe` that runs on any Windows x64 machine with zero external dependencies. (before that I went into a `libgcc_s_seh-1.dll not found` problem, but making everything static solved that.


### Upload Strategy

- **Release trigger** (`release: published`): Attaches the binary to the GitHub Release via `softprops/action-gh-release@v2`.
- **Manual trigger** (`workflow_dispatch`): Uploads as a GitHub Actions artifact (30-day retention) for testing without creating a release.

## Test Plan

- Triggered the workflow manually via `workflow_dispatch` on a fork
Here is the link to the github action triggered by workflow dispatch https://github.com/zhiningli/openzl/actions/runs/22238815710/job/64337054435

Artifact download url generated
Artifact download URL: https://github.com/zhiningli/openzl/actions/runs/22238815710/artifacts/5595610792

- Downloaded the produced artifact (`openzl-cli-windows-x64.exe`, ~5.8 MB)
- Verified the binary runs on a Windows x64 machine without MinGW/MSYS2 installed
- Tested CLI commands end-to-end:

```
PS C:\Users\Zhining\Downloads\openzl-cli-windows-x64> .\openzl-cli-windows-x64.exe compress -p serial "C:\Users\Zhining\Downloads\test.txt"
Compressed 19 -> 41 (0.46x) in 0.349 ms, 0.05 MB/s
PS C:\Users\Zhining\Downloads\openzl-cli-windows-x64> .\openzl-cli-windows-x64.exe decompress "C:\Users\Zhining\Downloads\test.txt.zl" -o restored.txt
Decompressed: 215.79% (  41.00 B ->   19.00 B) in 0.195 ms, 0.10 MB/s
PS C:\Users\Zhining\Downloads\openzl-cli-windows-x64>
```

### Test Configuration

- Compiler: MinGW-w64 GCC (via MSYS2 MINGW64)
- Build type: OPT (optimized release build)
- Platform(s): Windows x64 (`windows-latest` GitHub Actions runner), verified on local Windows 10/11 x64
- 
<img width="1111" height="624" alt="image" src="https://github.com/user-attachments/assets/93cc62ab-3f31-426d-85db-7bc11036fb23" />
