### PR TITLE
[EZ][CI errors] addres CI OOM errors in dev-ci.yml

### DIFF
--- a/.github/workflows/dev-ci.yml
+++ b/.github/workflows/dev-ci.yml
@@ -273,7 +273,7 @@ jobs:
           sudo apt-get install -y clang-tools
       - name: Run scan-build
         continue-on-error: true
-        run: CFLAGS="-Og -g" scan-build --status-bugs -v make -j unitBench V=1
+        run: CFLAGS="-Og -g" scan-build --status-bugs -v make -j2 unitBench V=1
 
   # =============================================================================
   # FUTURE WORK / DISABLED JOBS


### PR DESCRIPTION
## Summary

- The `Static Analysis (scan-build)` job has been consistently failing across PRs (#414, #413, #412, #410 and many many more) due to an OOM (Out of Memory) error during xgboost dependency compilation.
- The root cause is `make -j` (unlimited parallelism), which spawns too many concurrent g++ processes for the `ubuntu-latest` runner's ~7 GB RAM. The Linux OOM killer terminates g++ with `Killed signal`, aborting the entire build.
- Fix: limit parallelism to `-j2`, which fits within the runner's memory constraints.

## Test plan

- ~~Trust me bro :D~~
- [ ] CI `Static Analysis (scan-build)` job completes without OOM