### PR TITLE
Rename zl_bitsplit.h to zl_bitsplit_top8.h for clearer naming

### DIFF
--- a/cpp/include/openzl/cpp/codecs/BitsplitTop8.hpp
+++ b/cpp/include/openzl/cpp/codecs/BitsplitTop8.hpp
@@ -2,7 +2,7 @@
 
 #pragma once
 
-#include "openzl/codecs/zl_bitsplit.h"
+#include "openzl/codecs/zl_bitsplit_top8.h"
 #include "openzl/cpp/Compressor.hpp"
 #include "openzl/cpp/codecs/Metadata.hpp"
 #include "openzl/cpp/codecs/Node.hpp"

--- a/include/openzl/codecs/zl_bitsplit_top8.h
+++ b/include/openzl/codecs/zl_bitsplit_top8.h
@@ -1,7 +1,7 @@
 // Copyright (c) Meta Platforms, Inc. and affiliates.
 
-#ifndef OPENZL_CODECS_BITSPLIT_H
-#define OPENZL_CODECS_BITSPLIT_H
+#ifndef OPENZL_CODECS_BITSPLIT_TOP8_H
+#define OPENZL_CODECS_BITSPLIT_TOP8_H
 
 #include "openzl/zl_nodes.h"
 

--- a/include/openzl/zl_public_nodes.h
+++ b/include/openzl/zl_public_nodes.h
@@ -13,7 +13,7 @@
 
 #include "openzl/codecs/zl_ace.h"                  // IWYU pragma: export
 #include "openzl/codecs/zl_bitpack.h"              // IWYU pragma: export
-#include "openzl/codecs/zl_bitsplit.h"             // IWYU pragma: export
+#include "openzl/codecs/zl_bitsplit_top8.h"        // IWYU pragma: export
 #include "openzl/codecs/zl_bitunpack.h"            // IWYU pragma: export
 #include "openzl/codecs/zl_brute_force_selector.h" // IWYU pragma: export
 #include "openzl/codecs/zl_concat.h"               // IWYU pragma: export


### PR DESCRIPTION
Summary: I think this file was supposed to be named differently, but I could have made a mistake? Unsure if it was supposed to be generic bitsplit or bitsplit_top8.

Differential Revision: D94094080
