### PR TITLE
Add bitsplit_fp32 codec and tests

### DIFF
--- a/cpp/include/openzl/cpp/Codecs.hpp
+++ b/cpp/include/openzl/cpp/Codecs.hpp
@@ -4,6 +4,7 @@
 
 #include "openzl/cpp/codecs/ACE.hpp"              // IWYU pragma: export
 #include "openzl/cpp/codecs/Bitpack.hpp"          // IWYU pragma: export
+#include "openzl/cpp/codecs/BitsplitFP32.hpp"     // IWYU pragma: export
 #include "openzl/cpp/codecs/BitsplitTop8.hpp"     // IWYU pragma: export
 #include "openzl/cpp/codecs/Bitunpack.hpp"        // IWYU pragma: export
 #include "openzl/cpp/codecs/BruteForce.hpp"       // IWYU pragma: export

--- a/cpp/include/openzl/cpp/codecs/BitsplitFP32.hpp
+++ b/cpp/include/openzl/cpp/codecs/BitsplitFP32.hpp
@@ -1,0 +1,24 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#pragma once
+
+#include "openzl/codecs/zl_bitsplit_fp32.h"
+#include "openzl/cpp/Compressor.hpp"
+#include "openzl/cpp/codecs/Metadata.hpp"
+#include "openzl/cpp/codecs/Node.hpp"
+
+namespace openzl {
+namespace nodes {
+struct BitsplitFP32 : public SimplePipeNode<BitsplitFP32> {
+   public:
+    static constexpr NodeID node = ZL_NODE_BITSPLIT_FP32;
+
+    static constexpr NodeMetadata<1, 0, 1> metadata = {
+        .inputs          = { InputMetadata{ .type = Type::Numeric } },
+        .variableOutputs = { OutputMetadata{ .type = Type::Numeric,
+                                             .name = "bit_ranges" } },
+        .description     = "Split float32 into sign, exponent, and mantissa"
+    };
+};
+} // namespace nodes
+} // namespace openzl

--- a/cpp/include/openzl/cpp/codecs/BitsplitTop8.hpp
+++ b/cpp/include/openzl/cpp/codecs/BitsplitTop8.hpp
@@ -2,7 +2,7 @@
 
 #pragma once
 
-#include "openzl/codecs/zl_bitsplit.h"
+#include "openzl/codecs/zl_bitsplit_top8.h"
 #include "openzl/cpp/Compressor.hpp"
 #include "openzl/cpp/codecs/Metadata.hpp"
 #include "openzl/cpp/codecs/Node.hpp"

--- a/include/openzl/codecs/zl_bitsplit_fp32.h
+++ b/include/openzl/codecs/zl_bitsplit_fp32.h
@@ -1,0 +1,22 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#ifndef OPENZL_CODECS_BITSPLIT_FP32_H
+#define OPENZL_CODECS_BITSPLIT_FP32_H
+
+#include "openzl/zl_nodes.h"
+
+#if defined(__cplusplus)
+extern "C" {
+#endif
+
+// bitsplit transforms
+// Input : 1 numeric stream (32 bit float)
+// Output : 3 numeric streams (sign, exponent, mantissa)
+
+#define ZL_NODE_BITSPLIT_FP32 ZL_MAKE_NODE_ID(ZL_StandardNodeID_bitsplit_fp32)
+
+#if defined(__cplusplus)
+}
+#endif
+
+#endif

--- a/include/openzl/codecs/zl_bitsplit_top8.h
+++ b/include/openzl/codecs/zl_bitsplit_top8.h
@@ -1,7 +1,7 @@
 // Copyright (c) Meta Platforms, Inc. and affiliates.
 
-#ifndef OPENZL_CODECS_BITSPLIT_H
-#define OPENZL_CODECS_BITSPLIT_H
+#ifndef OPENZL_CODECS_BITSPLIT_TOP8_H
+#define OPENZL_CODECS_BITSPLIT_TOP8_H
 
 #include "openzl/zl_nodes.h"
 

--- a/include/openzl/zl_nodes.h
+++ b/include/openzl/zl_nodes.h
@@ -81,6 +81,7 @@ typedef enum {
     ZL_StandardNodeID_quantize_lengths,
 
     ZL_StandardNodeID_bitsplit_top8,
+    ZL_StandardNodeID_bitsplit_fp32,
 
     ZL_StandardNodeID_public_end // last id, used to detect end of public range
 } ZL_StandardNodeID;

--- a/include/openzl/zl_public_nodes.h
+++ b/include/openzl/zl_public_nodes.h
@@ -13,7 +13,7 @@
 
 #include "openzl/codecs/zl_ace.h"                  // IWYU pragma: export
 #include "openzl/codecs/zl_bitpack.h"              // IWYU pragma: export
-#include "openzl/codecs/zl_bitsplit.h"             // IWYU pragma: export
+#include "openzl/codecs/zl_bitsplit_top8.h"        // IWYU pragma: export
 #include "openzl/codecs/zl_bitunpack.h"            // IWYU pragma: export
 #include "openzl/codecs/zl_brute_force_selector.h" // IWYU pragma: export
 #include "openzl/codecs/zl_concat.h"               // IWYU pragma: export

--- a/include/openzl/zl_public_nodes.h
+++ b/include/openzl/zl_public_nodes.h
@@ -13,6 +13,7 @@
 
 #include "openzl/codecs/zl_ace.h"                  // IWYU pragma: export
 #include "openzl/codecs/zl_bitpack.h"              // IWYU pragma: export
+#include "openzl/codecs/zl_bitsplit_fp32.h"        // IWYU pragma: export
 #include "openzl/codecs/zl_bitsplit_top8.h"        // IWYU pragma: export
 #include "openzl/codecs/zl_bitunpack.h"            // IWYU pragma: export
 #include "openzl/codecs/zl_brute_force_selector.h" // IWYU pragma: export

--- a/src/openzl/codecs/bitSplit/encode_bitsplit_fp32_binding.c
+++ b/src/openzl/codecs/bitSplit/encode_bitsplit_fp32_binding.c
@@ -1,0 +1,28 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#include "openzl/codecs/bitSplit/encode_bitsplit_fp32_binding.h"
+#include "openzl/codecs/bitSplit/encode_bitSplit_binding.h" /* EI_bitSplit_withWidths */
+#include "openzl/common/assertion.h"                        /* ZL_ASSERT */
+#include "openzl/zl_data.h"                                 /* ZL_Input_type */
+#include "openzl/zl_errors.h"                               /* ZL_RET_R_IF_NE */
+#include "openzl/zl_input.h" /* ZL_Input_ptr, ZL_Input_eltWidth, ZL_Input_numElts */
+
+ZL_Report
+EI_bitsplit_fp32(ZL_Encoder* eictx, const ZL_Input* ins[], size_t nbIns)
+{
+    ZL_ASSERT_NN(eictx);
+    ZL_ASSERT_EQ(nbIns, 1);
+    ZL_ASSERT_NN(ins);
+    const ZL_Input* in = ins[0];
+    ZL_ASSERT_NN(in);
+    ZL_ASSERT_EQ(ZL_Input_type(in), ZL_Type_numeric);
+    ZL_RET_R_IF_NE(
+            node_invalid_input,
+            ZL_Input_eltWidth(in),
+            4,
+            "bitsplit_fp32 requires 4-byte (float32) elements");
+
+    uint8_t bitWidths[3] = { 23, 8, 1 };
+
+    return EI_bitSplit_withWidths(eictx, in, bitWidths, 3);
+}

--- a/src/openzl/codecs/bitSplit/encode_bitsplit_fp32_binding.h
+++ b/src/openzl/codecs/bitSplit/encode_bitsplit_fp32_binding.h
@@ -1,0 +1,37 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#ifndef OPENZL_CODECS_BITSPLIT_ENCODE_BITSPLIT_FP32_BINDING_H
+#define OPENZL_CODECS_BITSPLIT_ENCODE_BITSPLIT_FP32_BINDING_H
+
+#include "openzl/codecs/common/graph_vo.h" /* GRAPH_VO_NUM */
+#include "openzl/shared/portability.h"
+#include "openzl/zl_ctransform.h" /* ZL_Encoder */
+#include "openzl/zl_errors.h"     /* ZL_Report */
+#include "openzl/zl_opaque_types.h"
+
+ZL_BEGIN_C_DECLS
+
+/**
+ * bitsplit_fp32 encoder
+ *
+ * Decomposes 32-bit IEEE 754 floats into 3 separate streams:
+ * sign (1 bit), exponent (8 bits), and mantissa (23 bits).
+ *
+ * Input: 1 numeric stream (4-byte elements, interpreted as float32)
+ * Output: 3 numeric streams (mantissa, exponent, sign)
+ *
+ * Parameters: none (parameter-free node)
+ *
+ * Wire format: reuses bitSplit transform ID and codec header.
+ */
+ZL_Report
+EI_bitsplit_fp32(ZL_Encoder* eictx, const ZL_Input* ins[], size_t nbIns);
+
+#define EI_BITSPLIT_FP32(id)           \
+    { .gd          = GRAPH_VO_NUM(id), \
+      .transform_f = EI_bitsplit_fp32, \
+      .name        = "!zl.bitsplit_fp32" }
+
+ZL_END_C_DECLS
+
+#endif // OPENZL_CODECS_BITSPLIT_ENCODE_BITSPLIT_FP32_BINDING_H

--- a/src/openzl/codecs/encoder_registry.c
+++ b/src/openzl/codecs/encoder_registry.c
@@ -3,6 +3,7 @@
 #include "openzl/codecs/encoder_registry.h"
 
 #include "openzl/codecs/bitSplit/encode_bitSplit_binding.h"
+#include "openzl/codecs/bitSplit/encode_bitsplit_fp32_binding.h"
 #include "openzl/codecs/bitSplit/encode_bitsplit_top8_binding.h"
 #include "openzl/codecs/bitpack/encode_bitpack_binding.h"
 #include "openzl/codecs/bitunpack/encode_bitunpack_binding.h"
@@ -108,6 +109,7 @@ const CNode ER_standardNodes[STANDARD_ENCODERS_NB] = {
     REGISTER_TRANSFORM(ZL_StandardNodeID_quantize_offsets, ZL_StandardTransformID_quantize_offsets, 3, EI_QUANTIZE_OFFSETS),
     REGISTER_TRANSFORM(ZL_StandardNodeID_quantize_lengths, ZL_StandardTransformID_quantize_lengths, 3, EI_QUANTIZE_LENGTHS),
     REGISTER_TRANSFORM(ZL_StandardNodeID_bitsplit_top8, ZL_StandardTransformID_bitSplit, 24, EI_BITSPLIT_TOP8),
+    REGISTER_TRANSFORM(ZL_StandardNodeID_bitsplit_fp32, ZL_StandardTransformID_bitSplit, 24, EI_BITSPLIT_FP32),
 
     // Private Nodes
     REGISTER_TRANSFORM(ZL_PrivateStandardNodeID_set_string_lens,           ZL_StandardTransformID_convert_serial_string, 10, EI_SETSTRINGLENS),

--- a/tests/codecs/test_bitsplit_fp32.cpp
+++ b/tests/codecs/test_bitsplit_fp32.cpp
@@ -1,0 +1,113 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#include <cstdint>
+#include <vector>
+
+#include <gtest/gtest.h>
+
+#include "openzl/openzl.hpp"
+#include "tests/codecs/test_codec.h"
+
+namespace openzl {
+namespace tests {
+
+class BitsplitFP32Test : public CodecTest {
+   public:
+    /**
+     * Tests round-trip compression/decompression using bitsplit_fp32.
+     *
+     * @param input Float input data (4-byte elements required)
+     */
+    void testBitsplitFP32RoundTrip(const std::vector<float>& input)
+    {
+        compressor_.setParameter(CParam::FormatVersion, ZL_MAX_FORMAT_VERSION);
+
+        // bitsplit_FP32 is parameter-free, use ZL_NODE_BITSPLIT_FP32 directly
+        auto graph = compressor_.buildStaticGraph(
+                ZL_NODE_BITSPLIT_FP32, { graphs::Compress{}() });
+        compressor_.selectStartingGraph(graph);
+
+        Input numericInput =
+                Input::refNumeric(poly::span<const float>{ input });
+        testRoundTrip(numericInput);
+    }
+};
+
+TEST_F(BitsplitFP32Test, RoundTrip_Floats)
+{
+    std::vector<float> input(1000);
+    for (size_t i = 0; i < input.size(); i++) {
+        input[i] = (float)i * 0.1f;
+    }
+    testBitsplitFP32RoundTrip(input);
+}
+
+TEST_F(BitsplitFP32Test, RoundTrip_AllZero_32bit)
+{
+    std::vector<float> input(1000, 0);
+    testBitsplitFP32RoundTrip(input);
+}
+
+// =============================================================================
+// Edge Cases
+// =============================================================================
+
+TEST_F(BitsplitFP32Test, RoundTrip_EmptyInput)
+{
+    std::vector<float> input;
+    testBitsplitFP32RoundTrip(input);
+}
+
+TEST_F(BitsplitFP32Test, RoundTrip_SingleElement)
+{
+    std::vector<float> input{ 999.999f };
+    testBitsplitFP32RoundTrip(input);
+}
+
+TEST_F(BitsplitFP32Test, RoundTrip_NaN)
+{
+    std::vector<float> input{ std::numeric_limits<float>::quiet_NaN() };
+    testBitsplitFP32RoundTrip(input);
+}
+
+TEST_F(BitsplitFP32Test, RoundTrip_Infinity)
+{
+    std::vector<float> input{
+        std::numeric_limits<float>::infinity(),
+        -std::numeric_limits<float>::infinity(),
+    };
+    testBitsplitFP32RoundTrip(input);
+}
+
+TEST_F(BitsplitFP32Test, RoundTrip_NegativeZero)
+{
+    std::vector<float> input{ -0.0f };
+    testBitsplitFP32RoundTrip(input);
+}
+
+TEST_F(BitsplitFP32Test, RoundTrip_FloatMin)
+{
+    // Smallest normal float (exponent = 1, mantissa = 0)
+    std::vector<float> input{ std::numeric_limits<float>::min() };
+    testBitsplitFP32RoundTrip(input);
+}
+
+TEST_F(BitsplitFP32Test, RoundTrip_FloatMax)
+{
+    // Largest finite float (exponent = 254, mantissa = all ones)
+    std::vector<float> input{ std::numeric_limits<float>::max() };
+    testBitsplitFP32RoundTrip(input);
+}
+
+TEST_F(BitsplitFP32Test, RoundTrip_Subnormals)
+{
+    // Subnormal floats have exponent = 0 and nonzero mantissa
+    std::vector<float> input(1000);
+    float subnormal = std::numeric_limits<float>::denorm_min();
+    for (size_t i = 0; i < input.size(); i++) {
+        input[i] = subnormal * (float)(i + 1);
+    }
+    testBitsplitFP32RoundTrip(input);
+}
+} // namespace tests
+} // namespace openzl

--- a/tools/training/ace/ace_compressors.cpp
+++ b/tools/training/ace/ace_compressors.cpp
@@ -6,6 +6,7 @@
 #include "openzl/zl_reflection.h"
 #include "tools/training/ace/ace_sampling.h"
 
+#include "openzl/cpp/codecs/BitsplitFP32.hpp"
 #include "openzl/cpp/codecs/BitsplitTop8.hpp"
 
 namespace openzl {
@@ -90,6 +91,7 @@ std::vector<ACENode> makeAllNodes()
     n.push_back(buildNode(nodes::QuantizeOffsets{}));
     n.push_back(buildNode(nodes::QuantizeLengths{}));
     n.push_back(buildNode(nodes::TransposeSplit{}));
+    n.push_back(buildNode(nodes::BitsplitFP32{}));
     n.push_back(buildNode(nodes::BitsplitTop8{}));
     n.push_back(buildNode(nodes::Zigzag{}));
     n.push_back(buildNode(nodes::ConvertSerialToNum8{}));
@@ -155,6 +157,8 @@ std::vector<ACECompressor> makePrebuiltNumericCompressors()
     ACECompressor entropy(buildGraph(graphs::Entropy{}));
     ACECompressor top8bitsEntropy(
             buildNode(nodes::BitsplitTop8{}), { entropy });
+    ACECompressor FP32bitsEntropy(
+            buildNode(nodes::BitsplitFP32{}), { entropy });
     ACECompressor fse(buildGraph(graphs::Fse{}));
     ACECompressor store(buildGraph(graphs::Store{}));
     ACECompressor quantizeOffsets(
@@ -174,6 +178,7 @@ std::vector<ACECompressor> makePrebuiltNumericCompressors()
         rangePackFieldLz,
         rangePackDeltaFieldLz,
         top8bitsEntropy,
+        FP32bitsEntropy,
         quantizeOffsets,
         quantizeLengths,
     };


### PR DESCRIPTION
Summary:
Adds a bitsplit_fp32 compression codec to split fp32 data into three ranges (sign, exponent, mantissa).

This codec only accepts 4 byte wide  number, and will throw an error if the incoming data does not meet that specification.

Originally I was asserting this, but that was causing issues with ACE discovery, as it appears only the type of NUMBER can be guaranteed as an input, but I can't go as granular as 4 byte width or float_32, or something like that. Do we want support for something like this? (I imagine we would already have it if so)

Tests test normal usage as well as whatever edge cases I could cook up

Differential Revision: D94094081
