### PR TITLE
add a cmake 3.20.2 build test

### DIFF
--- a/.github/workflows/cmake-ci.yml
+++ b/.github/workflows/cmake-ci.yml
@@ -113,10 +113,12 @@ jobs:
         run: cmake --build . --target unitBench
 
       - name: Test
+        if: ${{ matrix.cmake_version == '' }}
         working-directory: ${{github.workspace}}/build
         run: ctest --output-on-failure
 
       - name: Install
+        if: ${{ matrix.cmake_version == '' }}
         working-directory: ${{github.workspace}}/build
         run: make install
 

--- a/.github/workflows/cmake-ci.yml
+++ b/.github/workflows/cmake-ci.yml
@@ -30,6 +30,10 @@ jobs:
             os: ubuntu-latest
             build_mode: dev
             extra_flags: "-Werror"
+          - name: "CMake Linux (Ubuntu 22.04, cmake 3.22)"
+            os: ubuntu-22.04
+            build_mode: dev
+            extra_flags: "-Werror"
           - name: "CMake macOS"
             os: macos-latest
             build_mode: dev
@@ -52,6 +56,9 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+
+      - name: Check CMake version
+        run: cmake --version
 
       - name: Configure CMake
         run: |

--- a/.github/workflows/cmake-ci.yml
+++ b/.github/workflows/cmake-ci.yml
@@ -30,10 +30,11 @@ jobs:
             os: ubuntu-latest
             build_mode: dev
             extra_flags: "-Werror"
-          - name: "CMake Linux (Ubuntu 22.04, cmake 3.22)"
-            os: ubuntu-22.04
+          - name: "CMake Linux (cmake 3.22)"
+            os: ubuntu-latest
             build_mode: dev
             extra_flags: "-Werror"
+            cmake_version: "3.22.6"
           - name: "CMake macOS"
             os: macos-latest
             build_mode: dev
@@ -56,6 +57,12 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+
+      - name: Install specific CMake version
+        if: ${{ matrix.cmake_version != '' }}
+        run: |
+          sudo apt-get remove --purge -y cmake
+          pip install cmake==${{ matrix.cmake_version }}
 
       - name: Check CMake version
         run: cmake --version

--- a/.github/workflows/cmake-ci.yml
+++ b/.github/workflows/cmake-ci.yml
@@ -30,11 +30,11 @@ jobs:
             os: ubuntu-latest
             build_mode: dev
             extra_flags: "-Werror"
-          - name: "CMake Linux (cmake 3.22)"
+          - name: "CMake Linux (cmake 3.20.2)"
             os: ubuntu-latest
             build_mode: dev
             extra_flags: "-Werror"
-            cmake_version: "3.22.6"
+            cmake_version: "3.20.2"
           - name: "CMake macOS"
             os: macos-latest
             build_mode: dev

--- a/.github/workflows/cmake-ci.yml
+++ b/.github/workflows/cmake-ci.yml
@@ -105,12 +105,12 @@ jobs:
 
       - name: Build
         working-directory: ${{github.workspace}}/build
-        run: make
+        run: make -j2
 
       - name: Build unitBench
         if: ${{ matrix.name == 'CMake Linux' }}
         working-directory: ${{github.workspace}}/build
-        run: cmake --build . --target unitBench
+        run: cmake --build . --parallel --target unitBench
 
       - name: Test
         if: ${{ matrix.cmake_version == '' }}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -214,10 +214,8 @@ if (OPENZL_BUILD_TESTS)
         googletest # v1.14.0
         URL https://github.com/google/googletest/archive/refs/tags/v1.14.0.zip
         URL_HASH SHA256=1f357c27ca988c3f7c6b4bf68a9395005ac6761f034046e9dde0896e3aba00e4
-        OVERRIDE_FIND_PACKAGE
     )
     FetchContent_MakeAvailable(googletest)
-    find_package(googletest REQUIRED)
     include(GoogleTest)
     enable_testing()
 


### PR DESCRIPTION
This new test is designed to detect issues like https://github.com/facebook/openzl/pull/282

In the process, it was discovered that #282 was not enough to fix compatibility issues,
so this PR bundles an additional `cmake` fix.
