### PR TITLE
Add SplitByParam component

### DIFF
--- a/src/openzl/codecs/splitN/encode_splitN_binding.c
+++ b/src/openzl/codecs/splitN/encode_splitN_binding.c
@@ -43,11 +43,6 @@ static ZL_RESULT_OF(ZL_SplitInstructions)
         getSplitInstructions(ZL_Encoder* eictx, const ZL_Input* in)
 {
     ZL_DLOG(SEQ, "getSplitInstructions()");
-    if (ZL_Input_numElts(in) == 0) {
-        // Special case: Empty input means no segments
-        ZL_SplitInstructions si = { NULL, 0 };
-        return ZL_RESULT_WRAP_VALUE(ZL_SplitInstructions, si);
-    }
 
     ZL_SplitState allocState = { eictx };
 
@@ -81,17 +76,15 @@ static ZL_RESULT_OF(ZL_SplitInstructions)
             nbSegments.paramId,
             ZL_LP_INVALID_PARAMID,
             "can't find any instruction to split");
+    if (nbSegments.paramValue == 0) {
+        ZL_SplitInstructions r = { NULL, 0 };
+        return ZL_RESULT_WRAP_VALUE(ZL_SplitInstructions, r);
+    }
     ZL_RET_T_IF_NULL(
             ZL_SplitInstructions,
             nodeParameter_invalid,
             segmentSizes.paramRef,
             "instructions to split are NULL");
-    ZL_RET_T_IF_EQ(
-            ZL_SplitInstructions,
-            nodeParameter_invalidValue,
-            nbSegments.paramValue,
-            0,
-            "instructions to split are empty");
     ZL_SplitInstructions r;
     r.segmentSizes = segmentSizes.paramRef;
     r.nbSegments   = (size_t)nbSegments.paramValue;

--- a/src/openzl/decompress/dtransforms.c
+++ b/src/openzl/decompress/dtransforms.c
@@ -420,7 +420,8 @@ ZL_Report DT_voTransformWrapper(
             dictx,
             ZL_codemodDatasAsInputs(ins),
             nbO1s,
-            ZL_codemodDatasAsInputs(ins) + nbO1s,
+            nbO1s ? ZL_codemodDatasAsInputs(ins) + nbO1s
+                  : ZL_codemodDatasAsInputs(ins),
             nbIns - nbO1s);
 }
 

--- a/tests/datagen/DataGen.h
+++ b/tests/datagen/DataGen.h
@@ -62,6 +62,16 @@ class DataGen {
         return (StringProducer(rw_, maxLength))(name, quantizationBytes);
     }
 
+    std::string randStringWithLength(RandWrapper::NameType name, size_t length)
+    {
+        std::string res;
+        res.reserve(length);
+        for (size_t i = 0; i < length; ++i) {
+            res.push_back(rw_->u8("char"));
+        }
+        return res;
+    }
+
     template <class Res>
     Res randVal(
             RandWrapper::NameType name,

--- a/tests/registry/OpenZLComponents.h
+++ b/tests/registry/OpenZLComponents.h
@@ -71,6 +71,7 @@ enum class OpenZLComponentID {
     CompressGeneric,
     BitSplit,
     BitSplitTop8,
+    TryParseInt,
     // Must be last enum value
     NumComponents,
 };
@@ -128,6 +129,7 @@ std::unique_ptr<OpenZLComponent> makeFieldLzComponent();
 std::unique_ptr<OpenZLComponent> makeCompressGenericComponent();
 std::unique_ptr<OpenZLComponent> makeBitSplitComponent();
 std::unique_ptr<OpenZLComponent> makeBitSplitTop8Component();
+std::unique_ptr<OpenZLComponent> makeTryParseIntComponent();
 } // namespace components
 
 inline std::unique_ptr<OpenZLComponent> makeOpenZLComponent(
@@ -226,6 +228,8 @@ inline std::unique_ptr<OpenZLComponent> makeOpenZLComponent(
             return components::makeBitSplitComponent();
         case OpenZLComponentID::BitSplitTop8:
             return components::makeBitSplitTop8Component();
+        case OpenZLComponentID::TryParseInt:
+            return components::makeTryParseIntComponent();
         case OpenZLComponentID::NumComponents:
         default:
             throw std::runtime_error("Invalid component");

--- a/tests/registry/OpenZLComponents.h
+++ b/tests/registry/OpenZLComponents.h
@@ -72,6 +72,9 @@ enum class OpenZLComponentID {
     BitSplit,
     BitSplitTop8,
     TryParseInt,
+    SplitByParam,
+    SplitStructByParam,
+    SplitNumericByParam,
     // Must be last enum value
     NumComponents,
 };
@@ -130,6 +133,9 @@ std::unique_ptr<OpenZLComponent> makeCompressGenericComponent();
 std::unique_ptr<OpenZLComponent> makeBitSplitComponent();
 std::unique_ptr<OpenZLComponent> makeBitSplitTop8Component();
 std::unique_ptr<OpenZLComponent> makeTryParseIntComponent();
+std::unique_ptr<OpenZLComponent> makeSplitByParamComponent();
+std::unique_ptr<OpenZLComponent> makeSplitStructByParamComponent();
+std::unique_ptr<OpenZLComponent> makeSplitNumericByParamComponent();
 } // namespace components
 
 inline std::unique_ptr<OpenZLComponent> makeOpenZLComponent(
@@ -230,6 +236,12 @@ inline std::unique_ptr<OpenZLComponent> makeOpenZLComponent(
             return components::makeBitSplitTop8Component();
         case OpenZLComponentID::TryParseInt:
             return components::makeTryParseIntComponent();
+        case OpenZLComponentID::SplitByParam:
+            return components::makeSplitByParamComponent();
+        case OpenZLComponentID::SplitStructByParam:
+            return components::makeSplitStructByParamComponent();
+        case OpenZLComponentID::SplitNumericByParam:
+            return components::makeSplitNumericByParamComponent();
         case OpenZLComponentID::NumComponents:
         default:
             throw std::runtime_error("Invalid component");

--- a/tests/registry/components/FieldLz.cpp
+++ b/tests/registry/components/FieldLz.cpp
@@ -33,6 +33,8 @@ class FieldLzComponent : public OpenZLComponent {
         return {
             graphs::FieldLz{}(compressor),
             graphs::FieldLz{ 7 }(compressor),
+            graphs::FieldLz{ graphs::FieldLz::Parameters{
+                    .literalsGraph = ZL_GRAPH_STORE } }(compressor),
         };
     }
 

--- a/tests/registry/components/MergeSorted.cpp
+++ b/tests/registry/components/MergeSorted.cpp
@@ -2,6 +2,8 @@
 
 #include <algorithm>
 
+#include "openzl/codecs/zl_merge_sorted.h"
+#include "openzl/codecs/zl_store.h"
 #include "openzl/cpp/codecs/MergeSorted.hpp"
 #include "tests/registry/OpenZLComponents.h"
 #include "tests/registry/OpenZLInput.h"
@@ -34,6 +36,17 @@ class MergeSortedComponent : public OpenZLComponent {
     std::vector<NodeID> predefinedNodes(Compressor& compressor) const override
     {
         return { nodes::MergeSorted{}.parameterize(compressor) };
+    }
+
+    std::vector<GraphID> predefinedGraphs(Compressor& compressor) const override
+    {
+        return {
+            ZL_Compressor_registerMergeSortedGraph(
+                    compressor.get(),
+                    ZL_GRAPH_STORE,
+                    ZL_GRAPH_STORE,
+                    ZL_GRAPH_STORE),
+        };
     }
 
     std::vector<std::unique_ptr<OpenZLInput>> predefinedInputs() const override

--- a/tests/registry/components/Split.cpp
+++ b/tests/registry/components/Split.cpp
@@ -1,0 +1,510 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#include <numeric>
+
+#include "openzl/codecs/zl_split.h"
+#include "openzl/codecs/zl_store.h"
+#include "openzl/zl_reflection.h"
+#include "tests/datagen/structures/CompressibleStringProducer.h"
+#include "tests/registry/OpenZLComponents.h"
+#include "tests/registry/OpenZLInput.h"
+#include "tests/utils.h"
+
+namespace openzl::tests::components {
+namespace {
+
+std::vector<size_t> randomSegmentSizes(datagen::DataGen& gen)
+{
+    auto nbSegments = gen.usize_range("nb_segments", 0, 100);
+    std::vector<size_t> sizes;
+    size_t remaining = gen.usize_range("total_fixed", 0, 4096);
+    for (size_t j = 0; j + 1 < nbSegments; ++j) {
+        auto sz = gen.usize_range("seg_size", 0, remaining);
+        sizes.push_back(sz);
+        remaining -= sz;
+    }
+    if (gen.boolean("last_is_zero")) {
+        // Last segment = 0 means "rest of input"
+        sizes.push_back(0);
+    }
+    return sizes;
+}
+
+ZL_NodeID getSplitNode(const Compressor& compressor, GraphID graphID)
+{
+    // Static graph (nodes wrapped by test framework): head node is the
+    // SplitN node
+    auto nodeID = ZL_Compressor_Graph_getHeadNode(compressor.get(), graphID);
+    if (nodeID.nid != ZL_NODE_ILLEGAL.nid) {
+        return nodeID;
+    }
+    // Parameterized graph (from registerSplitGraph): SplitN node is a
+    // custom node
+    auto customNodes =
+            ZL_Compressor_Graph_getCustomNodes(compressor.get(), graphID);
+    if (customNodes.nbNodeIDs > 0) {
+        return customNodes.nodeids[0];
+    }
+    return ZL_NODE_ILLEGAL;
+}
+
+// Returns the minimum number of elements required by the split graph.
+// For serial, one element = one byte.
+// For struct/numeric, one element = one struct/numeric element.
+std::pair<size_t, size_t> getMinMaxInputElements(
+        const Compressor& compressor,
+        GraphID graphID,
+        size_t maxInputSize)
+{
+    auto nodeID = getSplitNode(compressor, graphID);
+    if (nodeID.nid == ZL_NODE_ILLEGAL.nid) {
+        return { 0, 0 };
+    }
+    auto params = ZL_Compressor_Node_getLocalParams(compressor.get(), nodeID);
+    if (params.copyParams.nbCopyParams < 1) {
+        return { 0, 0 };
+    }
+    auto nbSegments =
+            params.copyParams.copyParams[0].paramSize / sizeof(size_t);
+    poly::span<const size_t> segSizes{
+        (const size_t*)params.copyParams.copyParams[0].paramPtr, nbSegments
+    };
+    size_t sum = 0;
+    for (auto sz : segSizes) {
+        sum += sz;
+    }
+    // If the last segment is 0 ("rest"), the minimum is the sum of
+    // the other segments. If all are non-zero, input must be exactly
+    // the sum.
+    auto lastIsZero = !segSizes.empty() && segSizes.back() == 0;
+    return { sum, lastIsZero ? std::max(sum, maxInputSize) : sum };
+}
+
+// ---- SplitByParam (Serial, min format version 9) ----
+
+class SplitByParamComponent : public OpenZLComponent {
+   public:
+    std::string name() const override
+    {
+        return "SplitByParam";
+    }
+
+    int minFormatVersion() const override
+    {
+        return 9;
+    }
+
+    bool isStandardComponent() const override
+    {
+        return false;
+    }
+
+    std::vector<NodeID> predefinedNodes(Compressor& compressor) const override
+    {
+        std::vector<NodeID> nodes;
+        // 0 segments: only accepts 0-element input
+        nodes.push_back(ZL_Compressor_registerSplitNode_withParams(
+                compressor.get(), ZL_Type_serial, nullptr, 0));
+        {
+            size_t sizes[] = { 0 };
+            nodes.push_back(ZL_Compressor_registerSplitNode_withParams(
+                    compressor.get(), ZL_Type_serial, sizes, 1));
+        }
+        {
+            size_t sizes[] = { 4, 0 };
+            nodes.push_back(ZL_Compressor_registerSplitNode_withParams(
+                    compressor.get(), ZL_Type_serial, sizes, 2));
+        }
+        {
+            size_t sizes[] = { 2, 2, 0 };
+            nodes.push_back(ZL_Compressor_registerSplitNode_withParams(
+                    compressor.get(), ZL_Type_serial, sizes, 3));
+        }
+        return nodes;
+    }
+
+    std::vector<GraphID> predefinedGraphs(Compressor& compressor) const override
+    {
+        std::vector<GraphID> graphs;
+        // 0 segments, 0 successors: only accepts 0-element input
+        graphs.push_back(ZL_Compressor_registerSplitGraph(
+                compressor.get(), ZL_Type_serial, nullptr, nullptr, 0));
+        {
+            size_t sizes[]          = { 0 };
+            ZL_GraphID successors[] = { ZL_GRAPH_STORE };
+            graphs.push_back(ZL_Compressor_registerSplitGraph(
+                    compressor.get(), ZL_Type_serial, sizes, successors, 1));
+        }
+        {
+            size_t sizes[]          = { 4, 0 };
+            ZL_GraphID successors[] = { ZL_GRAPH_STORE, ZL_GRAPH_STORE };
+            graphs.push_back(ZL_Compressor_registerSplitGraph(
+                    compressor.get(), ZL_Type_serial, sizes, successors, 2));
+        }
+        {
+            size_t sizes[]          = { 2, 2, 0 };
+            ZL_GraphID successors[] = { ZL_GRAPH_STORE,
+                                        ZL_GRAPH_STORE,
+                                        ZL_GRAPH_STORE };
+            graphs.push_back(ZL_Compressor_registerSplitGraph(
+                    compressor.get(), ZL_Type_serial, sizes, successors, 3));
+        }
+        return graphs;
+    }
+
+    std::vector<NodeID> generateNodes(
+            Compressor& compressor,
+            datagen::DataGen& gen,
+            size_t num) const override
+    {
+        std::vector<NodeID> nodes;
+        for (size_t i = 0; i < num; ++i) {
+            auto sizes = randomSegmentSizes(gen);
+            nodes.push_back(ZL_Compressor_registerSplitNode_withParams(
+                    compressor.get(),
+                    ZL_Type_serial,
+                    sizes.data(),
+                    sizes.size()));
+        }
+        return nodes;
+    }
+
+    std::vector<GraphID> generateGraphs(
+            Compressor& compressor,
+            datagen::DataGen& gen,
+            size_t num) const override
+    {
+        std::vector<GraphID> graphs;
+        for (size_t i = 0; i < num; ++i) {
+            auto sizes = randomSegmentSizes(gen);
+            std::vector<ZL_GraphID> successors(sizes.size(), ZL_GRAPH_STORE);
+            graphs.push_back(ZL_Compressor_registerSplitGraph(
+                    compressor.get(),
+                    ZL_Type_serial,
+                    sizes.data(),
+                    successors.data(),
+                    sizes.size()));
+        }
+        return graphs;
+    }
+
+    std::vector<std::unique_ptr<OpenZLInput>> predefinedInputs() const override
+    {
+        // Only generateInputs() can work correctly because we need to know
+        // how large the input needs to be.
+        return {};
+    }
+
+    std::vector<std::unique_ptr<OpenZLInput>> generateInputs(
+            datagen::DataGen& gen,
+            size_t num,
+            size_t maxInputSize,
+            const Compressor& compressor,
+            GraphID graphID) const override
+    {
+        std::vector<std::unique_ptr<OpenZLInput>> inputs;
+        inputs.reserve(num);
+        auto [minSize, maxSize] =
+                getMinMaxInputElements(compressor, graphID, maxInputSize);
+        for (size_t i = 0; i < num; ++i) {
+            auto inputSize = gen.usize_range("input_size", minSize, maxSize);
+            inputs.push_back(
+                    SerialOpenZLInput::make(
+                            gen.randStringWithLength("input", inputSize)));
+        }
+        return inputs;
+    }
+};
+
+// ---- SplitStructByParam (Struct, min format version 15) ----
+
+class SplitStructByParamComponent : public OpenZLComponent {
+   public:
+    std::string name() const override
+    {
+        return "SplitStructByParam";
+    }
+
+    int minFormatVersion() const override
+    {
+        return 15;
+    }
+
+    bool isStandardComponent() const override
+    {
+        return false;
+    }
+
+    std::vector<NodeID> predefinedNodes(Compressor& compressor) const override
+    {
+        std::vector<NodeID> nodes;
+        // 0 segments: only accepts 0-element input
+        nodes.push_back(ZL_Compressor_registerSplitNode_withParams(
+                compressor.get(), ZL_Type_struct, nullptr, 0));
+        {
+            size_t sizes[] = { 0 };
+            nodes.push_back(ZL_Compressor_registerSplitNode_withParams(
+                    compressor.get(), ZL_Type_struct, sizes, 1));
+        }
+        {
+            size_t sizes[] = { 2, 0 };
+            nodes.push_back(ZL_Compressor_registerSplitNode_withParams(
+                    compressor.get(), ZL_Type_struct, sizes, 2));
+        }
+        {
+            size_t sizes[] = { 1, 1, 0 };
+            nodes.push_back(ZL_Compressor_registerSplitNode_withParams(
+                    compressor.get(), ZL_Type_struct, sizes, 3));
+        }
+        return nodes;
+    }
+
+    std::vector<GraphID> predefinedGraphs(Compressor& compressor) const override
+    {
+        std::vector<GraphID> graphs;
+        // 0 segments, 0 successors: only accepts 0-element input
+        graphs.push_back(ZL_Compressor_registerSplitGraph(
+                compressor.get(), ZL_Type_struct, nullptr, nullptr, 0));
+        {
+            size_t sizes[]          = { 0 };
+            ZL_GraphID successors[] = { ZL_GRAPH_STORE };
+            graphs.push_back(ZL_Compressor_registerSplitGraph(
+                    compressor.get(), ZL_Type_struct, sizes, successors, 1));
+        }
+        {
+            size_t sizes[]          = { 2, 0 };
+            ZL_GraphID successors[] = { ZL_GRAPH_STORE, ZL_GRAPH_STORE };
+            graphs.push_back(ZL_Compressor_registerSplitGraph(
+                    compressor.get(), ZL_Type_struct, sizes, successors, 2));
+        }
+        {
+            size_t sizes[]          = { 1, 1, 0 };
+            ZL_GraphID successors[] = { ZL_GRAPH_STORE,
+                                        ZL_GRAPH_STORE,
+                                        ZL_GRAPH_STORE };
+            graphs.push_back(ZL_Compressor_registerSplitGraph(
+                    compressor.get(), ZL_Type_struct, sizes, successors, 3));
+        }
+        return graphs;
+    }
+
+    std::vector<NodeID> generateNodes(
+            Compressor& compressor,
+            datagen::DataGen& gen,
+            size_t num) const override
+    {
+        std::vector<NodeID> nodes;
+        for (size_t i = 0; i < num; ++i) {
+            auto sizes = randomSegmentSizes(gen);
+            nodes.push_back(ZL_Compressor_registerSplitNode_withParams(
+                    compressor.get(),
+                    ZL_Type_struct,
+                    sizes.data(),
+                    sizes.size()));
+        }
+        return nodes;
+    }
+
+    std::vector<GraphID> generateGraphs(
+            Compressor& compressor,
+            datagen::DataGen& gen,
+            size_t num) const override
+    {
+        std::vector<GraphID> graphs;
+        for (size_t i = 0; i < num; ++i) {
+            auto sizes = randomSegmentSizes(gen);
+            std::vector<ZL_GraphID> successors(sizes.size(), ZL_GRAPH_STORE);
+            graphs.push_back(ZL_Compressor_registerSplitGraph(
+                    compressor.get(),
+                    ZL_Type_struct,
+                    sizes.data(),
+                    successors.data(),
+                    sizes.size()));
+        }
+        return graphs;
+    }
+
+    std::vector<std::unique_ptr<OpenZLInput>> predefinedInputs() const override
+    {
+        // Only generateInputs() can work correctly because we need to know
+        // how large the input needs to be.
+        return {};
+    }
+
+    std::vector<std::unique_ptr<OpenZLInput>> generateInputs(
+            datagen::DataGen& gen,
+            size_t num,
+            size_t maxInputSize,
+            const Compressor& compressor,
+            GraphID graphID) const override
+    {
+        std::vector<std::unique_ptr<OpenZLInput>> inputs;
+        inputs.reserve(num);
+        for (size_t i = 0; i < num; ++i) {
+            // constexpr size_t widths[] = { 1, 2, 4, 8 };
+            // auto widthIdx             = gen.usize_range("width_idx", 0, 3);
+            // auto width                = widths[widthIdx];
+            auto width                      = gen.usize_range("width", 1, 10);
+            auto [minElements, maxElements] = getMinMaxInputElements(
+                    compressor, graphID, maxInputSize / width);
+            auto numElements =
+                    gen.usize_range("num_elements", minElements, maxElements);
+            auto input = gen.randStringWithLength("input", numElements * width);
+            inputs.push_back(StructOpenZLInput::make(std::move(input), width));
+        }
+        return inputs;
+    }
+};
+
+// ---- SplitNumericByParam (Numeric, min format version 15) ----
+
+class SplitNumericByParamComponent : public OpenZLComponent {
+   public:
+    std::string name() const override
+    {
+        return "SplitNumericByParam";
+    }
+
+    int minFormatVersion() const override
+    {
+        return 15;
+    }
+
+    bool isStandardComponent() const override
+    {
+        return false;
+    }
+
+    std::vector<NodeID> predefinedNodes(Compressor& compressor) const override
+    {
+        std::vector<NodeID> nodes;
+        // 0 segments: only accepts 0-element input
+        nodes.push_back(ZL_Compressor_registerSplitNode_withParams(
+                compressor.get(), ZL_Type_numeric, nullptr, 0));
+        {
+            size_t sizes[] = { 0 };
+            nodes.push_back(ZL_Compressor_registerSplitNode_withParams(
+                    compressor.get(), ZL_Type_numeric, sizes, 1));
+        }
+        {
+            size_t sizes[] = { 2, 0 };
+            nodes.push_back(ZL_Compressor_registerSplitNode_withParams(
+                    compressor.get(), ZL_Type_numeric, sizes, 2));
+        }
+        {
+            size_t sizes[] = { 1, 1, 0 };
+            nodes.push_back(ZL_Compressor_registerSplitNode_withParams(
+                    compressor.get(), ZL_Type_numeric, sizes, 3));
+        }
+        return nodes;
+    }
+
+    std::vector<GraphID> predefinedGraphs(Compressor& compressor) const override
+    {
+        std::vector<GraphID> graphs;
+        // 0 segments, 0 successors: only accepts 0-element input
+        graphs.push_back(ZL_Compressor_registerSplitGraph(
+                compressor.get(), ZL_Type_numeric, nullptr, nullptr, 0));
+        {
+            size_t sizes[]          = { 0 };
+            ZL_GraphID successors[] = { ZL_GRAPH_STORE };
+            graphs.push_back(ZL_Compressor_registerSplitGraph(
+                    compressor.get(), ZL_Type_numeric, sizes, successors, 1));
+        }
+        {
+            size_t sizes[]          = { 2, 0 };
+            ZL_GraphID successors[] = { ZL_GRAPH_STORE, ZL_GRAPH_STORE };
+            graphs.push_back(ZL_Compressor_registerSplitGraph(
+                    compressor.get(), ZL_Type_numeric, sizes, successors, 2));
+        }
+        {
+            size_t sizes[]          = { 1, 1, 0 };
+            ZL_GraphID successors[] = { ZL_GRAPH_STORE,
+                                        ZL_GRAPH_STORE,
+                                        ZL_GRAPH_STORE };
+            graphs.push_back(ZL_Compressor_registerSplitGraph(
+                    compressor.get(), ZL_Type_numeric, sizes, successors, 3));
+        }
+        return graphs;
+    }
+
+    std::vector<NodeID> generateNodes(
+            Compressor& compressor,
+            datagen::DataGen& gen,
+            size_t num) const override
+    {
+        std::vector<NodeID> nodes;
+        for (size_t i = 0; i < num; ++i) {
+            auto sizes = randomSegmentSizes(gen);
+            nodes.push_back(ZL_Compressor_registerSplitNode_withParams(
+                    compressor.get(),
+                    ZL_Type_numeric,
+                    sizes.data(),
+                    sizes.size()));
+        }
+        return nodes;
+    }
+
+    std::vector<GraphID> generateGraphs(
+            Compressor& compressor,
+            datagen::DataGen& gen,
+            size_t num) const override
+    {
+        std::vector<GraphID> graphs;
+        for (size_t i = 0; i < num; ++i) {
+            auto sizes = randomSegmentSizes(gen);
+            std::vector<ZL_GraphID> successors(sizes.size(), ZL_GRAPH_STORE);
+            graphs.push_back(ZL_Compressor_registerSplitGraph(
+                    compressor.get(),
+                    ZL_Type_numeric,
+                    sizes.data(),
+                    successors.data(),
+                    sizes.size()));
+        }
+        return graphs;
+    }
+
+    std::vector<std::unique_ptr<OpenZLInput>> predefinedInputs() const override
+    {
+        // Only generateInputs() can work correctly because we need to know
+        // how large the input needs to be.
+        return {};
+    }
+
+    std::vector<std::unique_ptr<OpenZLInput>> generateInputs(
+            datagen::DataGen& gen,
+            size_t num,
+            size_t maxInputSize,
+            const Compressor& compressor,
+            GraphID graphID) const override
+    {
+        std::vector<std::unique_ptr<OpenZLInput>> inputs;
+        inputs.reserve(num);
+        for (size_t i = 0; i < num; ++i) {
+            size_t width = gen.choices<size_t>("width", { 1, 2, 4, 8 });
+            auto [minElements, maxElements] = getMinMaxInputElements(
+                    compressor, graphID, maxInputSize / width);
+            auto numElements =
+                    gen.usize_range("num_elements", minElements, maxElements);
+            auto input = gen.randStringWithLength("input", numElements * width);
+            inputs.push_back(makeNumericInput(std::move(input), width));
+        }
+        return inputs;
+    }
+};
+
+} // namespace
+
+std::unique_ptr<OpenZLComponent> makeSplitByParamComponent()
+{
+    return std::make_unique<SplitByParamComponent>();
+}
+std::unique_ptr<OpenZLComponent> makeSplitStructByParamComponent()
+{
+    return std::make_unique<SplitStructByParamComponent>();
+}
+std::unique_ptr<OpenZLComponent> makeSplitNumericByParamComponent()
+{
+    return std::make_unique<SplitNumericByParamComponent>();
+}
+} // namespace openzl::tests::components

--- a/tests/registry/components/Transpose.cpp
+++ b/tests/registry/components/Transpose.cpp
@@ -1,6 +1,8 @@
 // Copyright (c) Meta Platforms, Inc. and affiliates.
 
 #include "openzl/cpp/codecs/Transpose.hpp"
+#include "openzl/codecs/zl_store.h"
+#include "openzl/codecs/zl_transpose.h"
 #include "tests/registry/OpenZLComponents.h"
 #include "tests/registry/OpenZLInput.h"
 
@@ -21,6 +23,14 @@ class TransposeComponent : public OpenZLComponent {
     std::vector<NodeID> predefinedNodes(Compressor& compressor) const override
     {
         return { nodes::TransposeSplit{}.parameterize(compressor) };
+    }
+
+    std::vector<GraphID> predefinedGraphs(Compressor& compressor) const override
+    {
+        return {
+            ZL_Compressor_registerTransposeSplitGraph(
+                    compressor.get(), ZL_GRAPH_STORE),
+        };
     }
 
     std::vector<std::unique_ptr<OpenZLInput>> predefinedInputs() const override

--- a/tests/registry/components/TryParseInt.cpp
+++ b/tests/registry/components/TryParseInt.cpp
@@ -1,0 +1,125 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#include <string>
+
+#include "openzl/codecs/zl_generic.h"
+#include "openzl/codecs/zl_parse_int.h"
+#include "openzl/codecs/zl_store.h"
+#include "tests/registry/OpenZLComponents.h"
+#include "tests/registry/OpenZLInput.h"
+
+namespace openzl::tests::components {
+namespace {
+
+static std::unique_ptr<OpenZLInput> makeStringList(
+        std::initializer_list<const char*> strs)
+{
+    std::vector<std::string> v(strs.begin(), strs.end());
+    return StringOpenZLInput::make(
+            poly::span<const std::string>(v.data(), v.size()));
+}
+
+class TryParseIntComponent : public OpenZLComponent {
+   public:
+    std::string name() const override
+    {
+        return "TryParseInt";
+    }
+
+    int minFormatVersion() const override
+    {
+        // parse_int transform is version 19, but 16-bit dispatch_string
+        // indices (used internally by TryParseInt) require version 21+.
+        return 21;
+    }
+
+    // TryParseInt can expand short strings like "0" (1 byte) into int64_t
+    // (8 bytes), plus dispatch indices overhead. Use a generous bound.
+    size_t compressBound(poly::span<const Input> inputs) const override
+    {
+        return 10 * this->OpenZLComponent::compressBound(inputs);
+    }
+
+    std::vector<GraphID> predefinedGraphs(Compressor& compressor) const override
+    {
+        std::vector<GraphID> graphs;
+        graphs.push_back(
+                compressor.unwrap(ZL_Compressor_parameterizeTryParseIntGraph(
+                        compressor.get(),
+                        ZL_GRAPH_COMPRESS_GENERIC,
+                        ZL_GRAPH_COMPRESS_GENERIC)));
+        graphs.push_back(
+                compressor.unwrap(ZL_Compressor_parameterizeTryParseIntGraph(
+                        compressor.get(), ZL_GRAPH_STORE, ZL_GRAPH_STORE)));
+        return graphs;
+    }
+
+    std::vector<std::unique_ptr<OpenZLInput>> predefinedInputs() const override
+    {
+        std::vector<std::unique_ptr<OpenZLInput>> inputs;
+        // Mix of parseable and unparseable
+        inputs.push_back(makeStringList({ "0", "1", "-1", "42", "hello" }));
+        // All parseable
+        inputs.push_back(makeStringList({ "0", "1", "2", "3" }));
+        // All unparseable
+        inputs.push_back(makeStringList({ "hello", "world", "foo" }));
+        // Edge cases
+        inputs.push_back(makeStringList(
+                { "-0", "00", "+0", "+1", "-01", "0h", "0x5", "0b1" }));
+        // INT64_MAX
+        inputs.push_back(makeStringList({ "9223372036854775807" }));
+        // INT64_MIN
+        inputs.push_back(makeStringList({ "-9223372036854775808" }));
+        // INT64_MAX + 1
+        inputs.push_back(makeStringList({ "9223372036854775808" }));
+        // INT64_MIN - 1
+        inputs.push_back(makeStringList({ "-9223372036854775809" }));
+        // Empty string (should fail to parse)
+        inputs.push_back(makeStringList({ "" }));
+        // Single parseable
+        inputs.push_back(makeStringList({ "0" }));
+        return inputs;
+    }
+
+    std::vector<std::unique_ptr<OpenZLInput>> generateInputs(
+            datagen::DataGen& gen,
+            size_t num,
+            size_t maxInputSize,
+            const Compressor&,
+            GraphID) const override
+    {
+        std::vector<std::unique_ptr<OpenZLInput>> inputs;
+        inputs.reserve(num);
+        for (size_t i = 0; i < num; ++i) {
+            auto numStrings = gen.randLength("num_strings", maxInputSize);
+            std::string data;
+            std::vector<uint32_t> lens;
+            lens.reserve(numStrings);
+            for (size_t j = 0; j < numStrings && gen.has_more_data()
+                 && data.size() < maxInputSize;
+                 ++j) {
+                auto isParseable = gen.boolean("is_parseable");
+                std::string str;
+                if (isParseable) {
+                    auto val = gen.i64_range("value", INT64_MIN, INT64_MAX);
+                    str      = std::to_string(val);
+                } else {
+                    str = gen.randString("str", maxInputSize - data.size());
+                }
+                data += str;
+                lens.push_back(str.size());
+            }
+            inputs.push_back(
+                    std::make_unique<StringOpenZLInput>(
+                            std::move(data), std::move(lens)));
+        }
+        return inputs;
+    }
+};
+} // namespace
+
+std::unique_ptr<OpenZLComponent> makeTryParseIntComponent()
+{
+    return std::make_unique<TryParseIntComponent>();
+}
+} // namespace openzl::tests::components


### PR DESCRIPTION
Summary:
Add `SplitByParam` components to the registry for `Serial`, `Numeric`, and `Struct` inputs.

This does not yet test either:
* The runtime split node: `ZL_Edge_runSplitNode()`
* Split with a parser: `ZL_Compressor_registerSplitNode_withParser()`

Differential Revision: D94530880


