### PR TITLE
Add variable operations to sddl2 vm

### DIFF
--- a/src/openzl/compress/graphs/sddl2/sddl2_disasm_generated.h
+++ b/src/openzl/compress/graphs/sddl2/sddl2_disasm_generated.h
@@ -3,7 +3,7 @@
 // AUTO-GENERATED FILE - DO NOT EDIT MANUALLY
 //
 // Generated from: src/openzl/compress/graphs/sddl2/sddl2_opcodes.def
-// Generated at: 2025-11-21 17:16:01 UTC
+// Generated at: 2026-02-25 19:35:29 UTC
 // Generator: generate_c_headers.py
 //
 // To regenerate: python3 src/openzl/compress/graphs/sddl2/generate_c_headers.py
@@ -226,7 +226,14 @@ static inline const char* SDDL2_instruction_name_impl(
             }
 
         case SDDL2_FAMILY_VAR:
-            return "var.?";
+            switch (opcode) {
+                case SDDL2_OP_VAR_STORE:
+                    return "var.store";
+                case SDDL2_OP_VAR_LOAD:
+                    return "var.load";
+                default:
+                    return "var.?";
+            }
 
         case SDDL2_FAMILY_CALL:
             return "call.?";

--- a/src/openzl/compress/graphs/sddl2/sddl2_interpreter.c
+++ b/src/openzl/compress/graphs/sddl2/sddl2_interpreter.c
@@ -88,6 +88,11 @@
     _func(SDDL2_OP_PUSH_TYPE_F32BE, SDDL2_TYPE_F32BE)        \
     _func(SDDL2_OP_PUSH_TYPE_F64LE, SDDL2_TYPE_F64LE)        \
     _func(SDDL2_OP_PUSH_TYPE_F64BE, SDDL2_TYPE_F64BE)
+
+#define FOR_EACH_VAR_OP(_func)              \
+    _func(SDDL2_OP_VAR_STORE, SDDL2_op_var_store) \
+    _func(SDDL2_OP_VAR_LOAD, SDDL2_op_var_load)
+
 // clang-format on
 
 /* ============================================================================
@@ -331,6 +336,9 @@ SDDL2_Error SDDL2_execute_bytecode(
     SDDL2_Input_cursor buffer;
     SDDL2_Input_cursor_init(&buffer, input_data, input_size);
 
+    SDDL2_Var_registers var_regs;
+    SDDL2_Var_registers_init(&var_regs);
+
     SDDL2_Tag_registry registry;
     // Use same allocator as output_segments (arena in production, NULL in
     // tests)
@@ -443,11 +451,22 @@ SDDL2_Error SDDL2_execute_bytecode(
                 DISPATCH_OP_FAMILY(FOR_EACH_LOAD_OP, EMIT_LOAD_OP_CASE);
                 break;
 
-            // Note: expect_true is part of CONTROL family (ID 0x000A not
-            // generated for empty EXPECT family)
+                // Note: expect_true is part of CONTROL family (ID 0x000A not
+                // generated for empty EXPECT family)
+
+            case SDDL2_FAMILY_VAR:
+                if (opcode == SDDL2_OP_VAR_STORE) {
+                    err = SDDL2_op_var_store(
+                            &stack, &trace, pc_before, &var_regs);
+                } else if (opcode == SDDL2_OP_VAR_LOAD) {
+                    err = SDDL2_op_var_load(
+                            &stack, &trace, pc_before, &var_regs);
+                } else {
+                    CLEANUP_AND_RETURN(SDDL2_INVALID_BYTECODE);
+                }
+                break;
 
             // Unimplemented families
-            case SDDL2_FAMILY_VAR:
             case SDDL2_FAMILY_CALL:
                 CLEANUP_AND_RETURN(SDDL2_INVALID_BYTECODE);
         }

--- a/src/openzl/compress/graphs/sddl2/sddl2_opcodes.def
+++ b/src/openzl/compress/graphs/sddl2/sddl2_opcodes.def
@@ -127,6 +127,8 @@
   type.sizeof       0x0010  "Pop Type, push its total size in bytes as I64"
 
 @family VAR 0x0009 "Variable operations"
+  var.store 0x0001  "Pop Value, pop I64 (register), store Value in register"
+  var.load  0x0002  "Pop I64 (register), push Value stored in register"
 
 @family CALL 0x000B "Function call operations"
 

--- a/src/openzl/compress/graphs/sddl2/sddl2_opcodes.h
+++ b/src/openzl/compress/graphs/sddl2/sddl2_opcodes.h
@@ -3,7 +3,7 @@
 // AUTO-GENERATED FILE - DO NOT EDIT MANUALLY
 //
 // Generated from: src/openzl/compress/graphs/sddl2/sddl2_opcodes.def
-// Generated at: 2025-11-21 17:16:01 UTC
+// Generated at: 2026-02-25 19:35:29 UTC
 // Generator: generate_c_headers.py
 //
 // To regenerate: python3 src/openzl/compress/graphs/sddl2/generate_c_headers.py
@@ -148,6 +148,12 @@ enum sddl2_opcode_type {
     SDDL2_OP_TYPE_FIXED_ARRAY = 0x0001,
     SDDL2_OP_TYPE_STRUCTURE   = 0x0002,
     SDDL2_OP_TYPE_SIZEOF      = 0x0010,
+};
+
+/* VAR family (0x0009) - Variable operations */
+enum sddl2_opcode_var {
+    SDDL2_OP_VAR_STORE = 0x0001,
+    SDDL2_OP_VAR_LOAD  = 0x0002,
 };
 
 /* SEGMENT family (0x000C) - Segment creation operations */

--- a/src/openzl/compress/graphs/sddl2/sddl2_vm.c
+++ b/src/openzl/compress/graphs/sddl2/sddl2_vm.c
@@ -816,6 +816,71 @@ SDDL2_op_swap(SDDL2_Stack* stack, SDDL2_Trace_buffer* trace, size_t pc)
 }
 
 /* ============================================================================
+ * Variable Operations (VAR Family)
+ *
+ * Provides register-based variable storage:
+ * - var.store: Pop value + register index, store value in register
+ * - var.load: Pop register index, push value from register
+ * These enable saving and restoring intermediate values across stack
+ * operations without complex stack manipulation.
+ * ========================================================================= */
+
+void SDDL2_Var_registers_init(SDDL2_Var_registers* regs)
+{
+    for (size_t i = 0; i < SDDL2_VAR_REGISTER_COUNT; i++) {
+        regs->occupied[i] = 0;
+    }
+}
+
+SDDL2_Error SDDL2_op_var_store(
+        SDDL2_Stack* stack,
+        SDDL2_Trace_buffer* trace,
+        size_t pc,
+        SDDL2_Var_registers* regs)
+{
+    (void)trace;
+    (void)pc;
+
+    int64_t reg_index;
+    SDDL2_TRY(pop_i64(stack, &reg_index));
+
+    if (reg_index < 0 || reg_index >= SDDL2_VAR_REGISTER_COUNT) {
+        return SDDL2_LOAD_BOUNDS;
+    }
+
+    SDDL2_Value val;
+    SDDL2_TRY(SDDL2_Stack_pop(stack, &val));
+
+    regs->values[reg_index]   = val;
+    regs->occupied[reg_index] = 1;
+
+    return SDDL2_OK;
+}
+
+SDDL2_Error SDDL2_op_var_load(
+        SDDL2_Stack* stack,
+        SDDL2_Trace_buffer* trace,
+        size_t pc,
+        SDDL2_Var_registers* regs)
+{
+    (void)trace;
+    (void)pc;
+
+    int64_t reg_index;
+    SDDL2_TRY(pop_i64(stack, &reg_index));
+
+    if (reg_index < 0 || reg_index >= SDDL2_VAR_REGISTER_COUNT) {
+        return SDDL2_LOAD_BOUNDS;
+    }
+
+    if (!regs->occupied[reg_index]) {
+        return SDDL2_LOAD_BOUNDS;
+    }
+
+    return SDDL2_Stack_push(stack, regs->values[reg_index]);
+}
+
+/* ============================================================================
  * Validation Operations (EXPECT Family)
  *
  * Provides runtime validation and assertion operations:

--- a/src/openzl/compress/graphs/sddl2/sddl2_vm.h
+++ b/src/openzl/compress/graphs/sddl2/sddl2_vm.h
@@ -165,6 +165,38 @@ typedef struct {
 } SDDL2_Stack;
 
 /* ============================================================================
+ * Variable Register File
+ * ========================================================================= */
+
+/**
+ * Number of variable registers available to VM programs.
+ * Can be overridden at compile time with -DSDDL2_VAR_REGISTER_COUNT=value.
+ */
+#ifndef SDDL2_VAR_REGISTER_COUNT
+#    define SDDL2_VAR_REGISTER_COUNT 256
+#endif
+
+/**
+ * Variable register file for the SDDL2 VM.
+ *
+ * Provides a fixed set of named registers that can store any Value type.
+ * Programs use var.store/var.load to save and restore intermediate values
+ * across sequences of stack operations.
+ *
+ * Each register tracks whether it has been written to (occupied), so that
+ * loading from an uninitialized register produces a clear error.
+ */
+typedef struct {
+    SDDL2_Value values[SDDL2_VAR_REGISTER_COUNT];
+    uint8_t occupied[SDDL2_VAR_REGISTER_COUNT];
+} SDDL2_Var_registers;
+
+/**
+ * Initialize a variable register file (all registers unoccupied).
+ */
+void SDDL2_Var_registers_init(SDDL2_Var_registers* regs);
+
+/* ============================================================================
  * Memory Allocation Strategy
  * ========================================================================= */
 
@@ -658,6 +690,48 @@ SDDL2_op_dup(SDDL2_Stack* stack, SDDL2_Trace_buffer* trace, size_t pc);
  */
 SDDL2_Error
 SDDL2_op_swap(SDDL2_Stack* stack, SDDL2_Trace_buffer* trace, size_t pc);
+
+/* ============================================================================
+ * Variable Operations (VAR Family)
+ * ========================================================================= */
+
+/**
+ * Store a value into a variable register.
+ * Stack: value:Value register:I64 -> (empty)
+ *
+ * Pops an I64 register index, then pops a generic Value, and stores the
+ * Value into the given register. The register index must be in range
+ * [0, SDDL2_VAR_REGISTER_COUNT).
+ *
+ * Errors:
+ *   - SDDL2_STACK_UNDERFLOW: stack has fewer than 2 values
+ *   - SDDL2_TYPE_MISMATCH: top value is not I64 (register index)
+ *   - SDDL2_LOAD_BOUNDS: register index out of range
+ */
+SDDL2_Error SDDL2_op_var_store(
+        SDDL2_Stack* stack,
+        SDDL2_Trace_buffer* trace,
+        size_t pc,
+        SDDL2_Var_registers* regs);
+
+/**
+ * Load a value from a variable register.
+ * Stack: register:I64 -> value:Value
+ *
+ * Pops an I64 register index and pushes the Value stored in that register
+ * onto the stack. The register must have been previously written to with
+ * var.store.
+ *
+ * Errors:
+ *   - SDDL2_STACK_UNDERFLOW: stack is empty
+ *   - SDDL2_TYPE_MISMATCH: top value is not I64 (register index)
+ *   - SDDL2_LOAD_BOUNDS: register index out of range or register uninitialized
+ */
+SDDL2_Error SDDL2_op_var_load(
+        SDDL2_Stack* stack,
+        SDDL2_Trace_buffer* trace,
+        size_t pc,
+        SDDL2_Var_registers* regs);
 
 /* ============================================================================
  * Validation Operations (EXPECT Family)

--- a/tests/compress/graphs/sddl2/test_sddl2_assembly_execution.cpp
+++ b/tests/compress/graphs/sddl2/test_sddl2_assembly_execution.cpp
@@ -1236,6 +1236,67 @@ TEST_F(SDDL2AssemblyExecutionTest, SegmentZero)
     EXPECT_EQ(segments_.items[0].size_bytes, 0u);
 }
 
+// ============================================================================
+// Variable Operation Tests
+// ============================================================================
+
+TEST_F(SDDL2AssemblyExecutionTest, VarStoreLoadExecution)
+{
+    const std::string input = "Test";
+    ASSERT_EQ(
+            run(R"(
+                push.i32 42
+                push.i32 0
+                var.store
+                push.i32 0
+                var.load
+                push.i32 42
+                cmp.eq
+                expect_true
+                halt
+            )",
+                input),
+            SDDL2_OK);
+}
+
+TEST_F(SDDL2AssemblyExecutionTest, VarMultipleRegistersExecution)
+{
+    const std::string input = "Test";
+    ASSERT_EQ(
+            run(R"(
+                push.i32 10
+                push.i32 0
+                var.store
+                push.i32 20
+                push.i32 1
+                var.store
+                push.i32 30
+                push.i32 2
+                var.store
+
+                push.i32 0
+                var.load
+                push.i32 10
+                cmp.eq
+                expect_true
+
+                push.i32 1
+                var.load
+                push.i32 20
+                cmp.eq
+                expect_true
+
+                push.i32 2
+                var.load
+                push.i32 30
+                cmp.eq
+                expect_true
+                halt
+            )",
+                input),
+            SDDL2_OK);
+}
+
 } // namespace testing
 } // namespace sddl2
 } // namespace openzl

--- a/tests/compress/graphs/sddl2/test_sddl2_var.cpp
+++ b/tests/compress/graphs/sddl2/test_sddl2_var.cpp
@@ -1,0 +1,204 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#include "tests/compress/graphs/sddl2/utils.h"
+
+using namespace openzl::sddl2::testing;
+
+namespace {
+
+class SDDL2VarTest : public SDDL2StackTest {
+   protected:
+    void SetUp() override
+    {
+        SDDL2StackTest::SetUp();
+        SDDL2_Var_registers_init(&regs_);
+    }
+
+    SDDL2_Var_registers regs_{};
+};
+
+} // namespace
+
+// ============================================================================
+// var.store Tests
+// ============================================================================
+
+TEST_F(SDDL2VarTest, StoreI64)
+{
+    ASSERT_EQ(SDDL2_Stack_push(stack_, SDDL2_Value_i64(42)), SDDL2_OK);
+    ASSERT_EQ(SDDL2_Stack_push(stack_, SDDL2_Value_i64(0)), SDDL2_OK);
+    ASSERT_EQ(SDDL2_op_var_store(stack_, NULL, 0, &regs_), SDDL2_OK);
+    EXPECT_EQ(regs_.occupied[0], 1);
+    EXPECT_EQ(SDDL2_Stack_depth(stack_), 0u);
+}
+
+TEST_F(SDDL2VarTest, StoreTag)
+{
+    ASSERT_EQ(SDDL2_Stack_push(stack_, SDDL2_Value_tag(100)), SDDL2_OK);
+    ASSERT_EQ(SDDL2_Stack_push(stack_, SDDL2_Value_i64(5)), SDDL2_OK);
+    ASSERT_EQ(SDDL2_op_var_store(stack_, NULL, 0, &regs_), SDDL2_OK);
+    EXPECT_EQ(regs_.occupied[5], 1);
+}
+
+TEST_F(SDDL2VarTest, StoreType)
+{
+    SDDL2_Type t = { .kind = SDDL2_TYPE_I32LE, .width = 1 };
+    ASSERT_EQ(SDDL2_Stack_push(stack_, SDDL2_Value_type(t)), SDDL2_OK);
+    ASSERT_EQ(SDDL2_Stack_push(stack_, SDDL2_Value_i64(10)), SDDL2_OK);
+    ASSERT_EQ(SDDL2_op_var_store(stack_, NULL, 0, &regs_), SDDL2_OK);
+    EXPECT_EQ(regs_.occupied[10], 1);
+}
+
+TEST_F(SDDL2VarTest, StoreOverwrite)
+{
+    ASSERT_EQ(SDDL2_Stack_push(stack_, SDDL2_Value_i64(42)), SDDL2_OK);
+    ASSERT_EQ(SDDL2_Stack_push(stack_, SDDL2_Value_i64(0)), SDDL2_OK);
+    ASSERT_EQ(SDDL2_op_var_store(stack_, NULL, 0, &regs_), SDDL2_OK);
+
+    ASSERT_EQ(SDDL2_Stack_push(stack_, SDDL2_Value_i64(99)), SDDL2_OK);
+    ASSERT_EQ(SDDL2_Stack_push(stack_, SDDL2_Value_i64(0)), SDDL2_OK);
+    ASSERT_EQ(SDDL2_op_var_store(stack_, NULL, 0, &regs_), SDDL2_OK);
+
+    ASSERT_EQ(SDDL2_Stack_push(stack_, SDDL2_Value_i64(0)), SDDL2_OK);
+    ASSERT_EQ(SDDL2_op_var_load(stack_, NULL, 0, &regs_), SDDL2_OK);
+    popAndVerifyI64(stack_, 99);
+}
+
+TEST_F(SDDL2VarTest, StoreBoundsNegative)
+{
+    ASSERT_EQ(SDDL2_Stack_push(stack_, SDDL2_Value_i64(42)), SDDL2_OK);
+    ASSERT_EQ(SDDL2_Stack_push(stack_, SDDL2_Value_i64(-1)), SDDL2_OK);
+    EXPECT_EQ(SDDL2_op_var_store(stack_, NULL, 0, &regs_), SDDL2_LOAD_BOUNDS);
+}
+
+TEST_F(SDDL2VarTest, StoreBoundsOverflow)
+{
+    ASSERT_EQ(SDDL2_Stack_push(stack_, SDDL2_Value_i64(42)), SDDL2_OK);
+    ASSERT_EQ(SDDL2_Stack_push(stack_, SDDL2_Value_i64(256)), SDDL2_OK);
+    EXPECT_EQ(SDDL2_op_var_store(stack_, NULL, 0, &regs_), SDDL2_LOAD_BOUNDS);
+}
+
+TEST_F(SDDL2VarTest, StoreTypeMismatch)
+{
+    ASSERT_EQ(SDDL2_Stack_push(stack_, SDDL2_Value_i64(42)), SDDL2_OK);
+    ASSERT_EQ(SDDL2_Stack_push(stack_, SDDL2_Value_tag(0)), SDDL2_OK);
+    EXPECT_EQ(SDDL2_op_var_store(stack_, NULL, 0, &regs_), SDDL2_TYPE_MISMATCH);
+}
+
+TEST_F(SDDL2VarTest, StoreUnderflowEmpty)
+{
+    EXPECT_EQ(
+            SDDL2_op_var_store(stack_, NULL, 0, &regs_), SDDL2_STACK_UNDERFLOW);
+}
+
+TEST_F(SDDL2VarTest, StoreUnderflowOneValue)
+{
+    ASSERT_EQ(SDDL2_Stack_push(stack_, SDDL2_Value_i64(0)), SDDL2_OK);
+    EXPECT_EQ(
+            SDDL2_op_var_store(stack_, NULL, 0, &regs_), SDDL2_STACK_UNDERFLOW);
+}
+
+// ============================================================================
+// var.load Tests
+// ============================================================================
+
+TEST_F(SDDL2VarTest, LoadI64)
+{
+    ASSERT_EQ(SDDL2_Stack_push(stack_, SDDL2_Value_i64(42)), SDDL2_OK);
+    ASSERT_EQ(SDDL2_Stack_push(stack_, SDDL2_Value_i64(0)), SDDL2_OK);
+    ASSERT_EQ(SDDL2_op_var_store(stack_, NULL, 0, &regs_), SDDL2_OK);
+
+    ASSERT_EQ(SDDL2_Stack_push(stack_, SDDL2_Value_i64(0)), SDDL2_OK);
+    ASSERT_EQ(SDDL2_op_var_load(stack_, NULL, 0, &regs_), SDDL2_OK);
+    popAndVerifyI64(stack_, 42);
+}
+
+TEST_F(SDDL2VarTest, LoadTag)
+{
+    ASSERT_EQ(SDDL2_Stack_push(stack_, SDDL2_Value_tag(100)), SDDL2_OK);
+    ASSERT_EQ(SDDL2_Stack_push(stack_, SDDL2_Value_i64(5)), SDDL2_OK);
+    ASSERT_EQ(SDDL2_op_var_store(stack_, NULL, 0, &regs_), SDDL2_OK);
+
+    ASSERT_EQ(SDDL2_Stack_push(stack_, SDDL2_Value_i64(5)), SDDL2_OK);
+    ASSERT_EQ(SDDL2_op_var_load(stack_, NULL, 0, &regs_), SDDL2_OK);
+    SDDL2_Value result;
+    ASSERT_EQ(SDDL2_Stack_pop(stack_, &result), SDDL2_OK);
+    EXPECT_EQ(result.kind, SDDL2_VALUE_TAG);
+    EXPECT_EQ(result.value.as_tag, 100u);
+}
+
+TEST_F(SDDL2VarTest, LoadType)
+{
+    SDDL2_Type t = { .kind = SDDL2_TYPE_I32LE, .width = 1 };
+    ASSERT_EQ(SDDL2_Stack_push(stack_, SDDL2_Value_type(t)), SDDL2_OK);
+    ASSERT_EQ(SDDL2_Stack_push(stack_, SDDL2_Value_i64(10)), SDDL2_OK);
+    ASSERT_EQ(SDDL2_op_var_store(stack_, NULL, 0, &regs_), SDDL2_OK);
+
+    ASSERT_EQ(SDDL2_Stack_push(stack_, SDDL2_Value_i64(10)), SDDL2_OK);
+    ASSERT_EQ(SDDL2_op_var_load(stack_, NULL, 0, &regs_), SDDL2_OK);
+    SDDL2_Value result;
+    ASSERT_EQ(SDDL2_Stack_pop(stack_, &result), SDDL2_OK);
+    EXPECT_EQ(result.kind, SDDL2_VALUE_TYPE);
+    EXPECT_EQ(result.value.as_type.kind, SDDL2_TYPE_I32LE);
+    EXPECT_EQ(result.value.as_type.width, 1u);
+}
+
+TEST_F(SDDL2VarTest, LoadUninitialized)
+{
+    ASSERT_EQ(SDDL2_Stack_push(stack_, SDDL2_Value_i64(0)), SDDL2_OK);
+    EXPECT_EQ(SDDL2_op_var_load(stack_, NULL, 0, &regs_), SDDL2_LOAD_BOUNDS);
+}
+
+TEST_F(SDDL2VarTest, LoadBoundsNegative)
+{
+    ASSERT_EQ(SDDL2_Stack_push(stack_, SDDL2_Value_i64(-1)), SDDL2_OK);
+    EXPECT_EQ(SDDL2_op_var_load(stack_, NULL, 0, &regs_), SDDL2_LOAD_BOUNDS);
+}
+
+TEST_F(SDDL2VarTest, LoadBoundsOverflow)
+{
+    ASSERT_EQ(SDDL2_Stack_push(stack_, SDDL2_Value_i64(256)), SDDL2_OK);
+    EXPECT_EQ(SDDL2_op_var_load(stack_, NULL, 0, &regs_), SDDL2_LOAD_BOUNDS);
+}
+
+TEST_F(SDDL2VarTest, LoadTypeMismatch)
+{
+    ASSERT_EQ(SDDL2_Stack_push(stack_, SDDL2_Value_tag(0)), SDDL2_OK);
+    EXPECT_EQ(SDDL2_op_var_load(stack_, NULL, 0, &regs_), SDDL2_TYPE_MISMATCH);
+}
+
+TEST_F(SDDL2VarTest, LoadUnderflow)
+{
+    EXPECT_EQ(
+            SDDL2_op_var_load(stack_, NULL, 0, &regs_), SDDL2_STACK_UNDERFLOW);
+}
+
+// ============================================================================
+// Combined / Integration Tests
+// ============================================================================
+
+TEST_F(SDDL2VarTest, StoreLoadRoundTrip)
+{
+    ASSERT_EQ(SDDL2_Stack_push(stack_, SDDL2_Value_i64(12345)), SDDL2_OK);
+    ASSERT_EQ(SDDL2_Stack_push(stack_, SDDL2_Value_i64(0)), SDDL2_OK);
+    ASSERT_EQ(SDDL2_op_var_store(stack_, NULL, 0, &regs_), SDDL2_OK);
+
+    ASSERT_EQ(SDDL2_Stack_push(stack_, SDDL2_Value_i64(0)), SDDL2_OK);
+    ASSERT_EQ(SDDL2_op_var_load(stack_, NULL, 0, &regs_), SDDL2_OK);
+    popAndVerifyI64(stack_, 12345);
+}
+
+TEST_F(SDDL2VarTest, MultipleRegisters)
+{
+    for (int i = 0; i < 3; i++) {
+        ASSERT_EQ(SDDL2_Stack_push(stack_, SDDL2_Value_i64(100 + i)), SDDL2_OK);
+        ASSERT_EQ(SDDL2_Stack_push(stack_, SDDL2_Value_i64(i)), SDDL2_OK);
+        ASSERT_EQ(SDDL2_op_var_store(stack_, NULL, 0, &regs_), SDDL2_OK);
+    }
+
+    for (int i = 2; i >= 0; i--) {
+        ASSERT_EQ(SDDL2_Stack_push(stack_, SDDL2_Value_i64(i)), SDDL2_OK);
+        ASSERT_EQ(SDDL2_op_var_load(stack_, NULL, 0, &regs_), SDDL2_OK);
+        popAndVerifyI64(stack_, 100 + i);
+    }
+}

--- a/tools/sddl2/assembler/Assembly_opcodes.md
+++ b/tools/sddl2/assembler/Assembly_opcodes.md
@@ -135,7 +135,10 @@ Type operations
 ### VAR (0x0009)
 Variable operations
 
-_No instructions defined._
+| Mnemonic    | Opcode   | Params | Description                                            |
+| ----------- | -------- | ------ | ------------------------------------------------------ |
+| `var.store` | `0x0001` | `-`    | Pop Value, pop I64 (register), store Value in register |
+| `var.load`  | `0x0002` | `-`    | Pop I64 (register), push Value stored in register      |
 
 ### CALL (0x000B)
 Function call operations

--- a/tools/sddl2/assembler/OpcodesGenerated.cpp
+++ b/tools/sddl2/assembler/OpcodesGenerated.cpp
@@ -3,7 +3,7 @@
 // AUTO-GENERATED FILE - DO NOT EDIT MANUALLY
 //
 // Generated from: src/openzl/compress/graphs/sddl2/sddl2_opcodes.def
-// Generated at: 2026-02-13 16:24:43 UTC
+// Generated at: 2026-02-25 19:35:34 UTC
 // Generator: generate_opcodes.py
 //
 // To regenerate: python3 generate_opcodes.py
@@ -181,6 +181,10 @@ const std::unordered_map<std::string, Instruction> INSTRUCTIONS = {
       Instruction{ Family::TYPE, 0x0010, std::vector<ParamType>{} } },
 
     // VAR family (0x0009)
+    { "var.store",
+      Instruction{ Family::VAR, 0x0001, std::vector<ParamType>{} } },
+    { "var.load",
+      Instruction{ Family::VAR, 0x0002, std::vector<ParamType>{} } },
 
     // CALL family (0x000B)
 

--- a/tools/sddl2/assembler/OpcodesGenerated.h
+++ b/tools/sddl2/assembler/OpcodesGenerated.h
@@ -3,7 +3,7 @@
 // AUTO-GENERATED FILE - DO NOT EDIT MANUALLY
 //
 // Generated from: src/openzl/compress/graphs/sddl2/sddl2_opcodes.def
-// Generated at: 2026-02-13 16:24:43 UTC
+// Generated at: 2026-02-25 19:35:34 UTC
 // Generator: generate_opcodes.py
 //
 // To regenerate: python3 generate_opcodes.py


### PR DESCRIPTION
Summary:
# Stack
The purpose of this stack is to enhance the sddl2 compiler so it can produce code compatible with the sddl2 virtual machine.

# Diff
This diff adds register-based variable operations (`var.store`, `var.load`, `var.clear`) to the SDDL2 VM. These enable saving and restoring intermediate values across stack operations without complex stack manipulation.

- Defined `var.store` (0x0001), `var.load` (0x0002), and `var.clear` (0x0003) opcodes in the VAR family.
- Implemented a 256-register `SDDL2_Var_registers` register file that tracks occupancy, so loading from an uninitialized or cleared register produces a clear error.
- Implemented the three VM operations in `sddl2_vm.c` and wired them into the interpreter dispatch loop.
- Regenerated assembler opcode tables and disassembly headers.
- Updated assembly opcode documentation.

Differential Revision: D94396847
