### PR TITLE
Migrate ZL_RET_R_* to ZL_ERR_* in src/openzl/codecs/ bindings (part 1/4: bitSplit through delta)

### DIFF
--- a/src/openzl/codecs/bitSplit/decode_bitSplit_binding.c
+++ b/src/openzl/codecs/bitSplit/decode_bitSplit_binding.c
@@ -14,6 +14,7 @@ ZL_Report DI_bitSplit(
         const ZL_Input* variableSrcs[],
         size_t nbVariableSrcs)
 {
+    ZL_RESULT_DECLARE_SCOPE_REPORT(dictx);
     ZL_ASSERT_NN(dictx);
     ZL_ASSERT_EQ(nbCompulsorySrcs, 0);
     (void)compulsorySrcs;
@@ -24,10 +25,10 @@ ZL_Report DI_bitSplit(
     ZL_RBuffer const header = ZL_Decoder_getCodecHeader(dictx);
 
     // Validate: header must have at least outputEltWidth byte
-    ZL_RET_R_IF_LT(
-            corruption,
+    ZL_ERR_IF_LT(
             header.size,
             1,
+            corruption,
             "bitSplit: header must contain outputEltWidth");
 
     // Parse header
@@ -36,19 +37,19 @@ ZL_Report DI_bitSplit(
     const uint8_t* storedWidths  = (const uint8_t*)header.start + 1;
 
     // Validate outputEltWidth
-    ZL_RET_R_IF_NOT(
-            corruption,
+    ZL_ERR_IF_NOT(
             outputEltWidth == 1 || outputEltWidth == 2 || outputEltWidth == 4
                     || outputEltWidth == 8,
+            corruption,
             "bitSplit: invalid outputEltWidth in header");
 
     // Compute sum of stored widths and determine last width
     size_t sumStoredWidths = 0;
     for (size_t i = 0; i < nbStoredWidths; i++) {
-        ZL_RET_R_IF_EQ(
-                corruption,
+        ZL_ERR_IF_EQ(
                 storedWidths[i],
                 0,
+                corruption,
                 "bitSplit: bit width cannot be zero");
         sumStoredWidths += storedWidths[i];
     }
@@ -56,10 +57,10 @@ ZL_Report DI_bitSplit(
     size_t const outputEltWidthBits = (size_t)outputEltWidth * 8;
 
     // Validate sum doesn't exceed output width
-    ZL_RET_R_IF_GT(
-            corruption,
+    ZL_ERR_IF_GT(
             sumStoredWidths,
             outputEltWidthBits,
+            corruption,
             "bitSplit: sum of stored widths exceeds output element width");
 
     // Determine coverage based on number of input streams:
@@ -78,10 +79,10 @@ ZL_Report DI_bitSplit(
     } else if (nbVariableSrcs == nbStoredWidths + 1) {
         // Full coverage: add computed last width
         ZL_ASSERT_LE(nbStoredWidths, 64); // already checked via sumStoredWidths
-        ZL_RET_R_IF_EQ(
-                corruption,
+        ZL_ERR_IF_EQ(
                 lastWidth,
                 0,
+                corruption,
                 "bitSplit: invalid last width (set to 0)");
         ZL_memcpy(bitWidths_local, storedWidths, nbStoredWidths);
         bitWidths_local[nbStoredWidths] = (uint8_t)lastWidth;
@@ -89,11 +90,11 @@ ZL_Report DI_bitSplit(
         bitWidths = bitWidths_local;
         nbWidths  = nbStoredWidths + 1;
     } else {
-        ZL_RET_R_IF_NOT(corruption, 0, "bitSplit: input stream count mismatch");
+        ZL_ERR_IF_NOT(0, corruption, "bitSplit: input stream count mismatch");
     }
 
     // Validate: must have at least one width
-    ZL_RET_R_IF_EQ(corruption, nbWidths, 0, "bitSplit: no bit widths present");
+    ZL_ERR_IF_EQ(nbWidths, 0, corruption, "bitSplit: no bit widths present");
 
     // Validate all input streams, and collect their pointers
     size_t nbElts = 0;
@@ -111,27 +112,27 @@ ZL_Report DI_bitSplit(
         if (i == 0) {
             nbElts = streamNbElts;
         } else {
-            ZL_RET_R_IF_NE(
-                    corruption,
+            ZL_ERR_IF_NE(
                     streamNbElts,
                     nbElts,
+                    corruption,
                     "bitSplit: all input streams must have same element count");
         }
 
         // Verify bit width doesn't exceed input stream capacity
         size_t const inputEltWidthBits = ZL_Input_eltWidth(in) * 8;
-        ZL_RET_R_IF_GT(
-                corruption,
+        ZL_ERR_IF_GT(
                 bitWidths[i],
                 inputEltWidthBits,
+                corruption,
                 "bitSplit: bit width exceeds input stream element width");
 
         // Verify element width matches expected
         size_t const expectedWidth = ZL_bitSplit_outputEltWidth(bitWidths[i]);
-        ZL_RET_R_IF_NE(
-                corruption,
+        ZL_ERR_IF_NE(
                 ZL_Input_eltWidth(in),
                 expectedWidth,
+                corruption,
                 "bitSplit: input stream element width mismatch");
 
         inputPtrs[i]   = ZL_Input_ptr(in);
@@ -141,7 +142,7 @@ ZL_Report DI_bitSplit(
     // Create output stream
     ZL_Output* const out =
             ZL_Decoder_create1OutStream(dictx, nbElts, outputEltWidth);
-    ZL_RET_R_IF_NULL(allocation, out);
+    ZL_ERR_IF_NULL(out, allocation);
 
     // Kernel owns the hot loop - single call processes all elements
     ZL_bitSplitDecode(
@@ -153,6 +154,6 @@ ZL_Report DI_bitSplit(
             bitWidths,
             nbWidths);
 
-    ZL_RET_R_IF_ERR(ZL_Output_commit(out, nbElts));
+    ZL_ERR_IF_ERR(ZL_Output_commit(out, nbElts));
     return ZL_returnSuccess();
 }

--- a/src/openzl/codecs/bitSplit/encode_bitSplit_binding.c
+++ b/src/openzl/codecs/bitSplit/encode_bitSplit_binding.c
@@ -22,6 +22,7 @@ ZL_Report EI_bitSplit_withWidths(
         const uint8_t* bitWidths,
         size_t nbWidths)
 {
+    ZL_RESULT_DECLARE_SCOPE_REPORT(eictx);
     ZL_ASSERT_NN(eictx);
     ZL_ASSERT_NN(in);
     ZL_ASSERT_EQ(ZL_Input_type(in), ZL_Type_numeric);
@@ -38,18 +39,18 @@ ZL_Report EI_bitSplit_withWidths(
 
     // Validate parameters
     size_t sumWidths = 0;
-    ZL_RET_R_IF(
-            nodeParameter_invalid,
+    ZL_ERR_IF(
             !ZL_bitSplit_paramsAreValid(
                     bitWidths, nbWidths, inputEltWidthBits, &sumWidths),
+            nodeParameter_invalid,
             "bitSplit parameter validation failed");
 
     // Validate top bits are zero if partial coverage
     if (sumWidths < inputEltWidthBits) {
-        ZL_RET_R_IF(
-                corruption,
+        ZL_ERR_IF(
                 !ZL_bitSplit_topBitsAreZero(
                         ZL_Input_ptr(in), inputEltWidth, nbElts, sumWidths),
+                corruption,
                 "bitSplit: top bits must be zero for partial coverage");
     }
 
@@ -81,7 +82,7 @@ ZL_Report EI_bitSplit_withWidths(
         outputWidths[i] = ZL_bitSplit_outputEltWidth(bitWidths[i]);
         outputs[i] =
                 ZL_Encoder_createTypedStream(eictx, 0, nbElts, outputWidths[i]);
-        ZL_RET_R_IF_NULL(allocation, outputs[i]);
+        ZL_ERR_IF_NULL(outputs[i], allocation);
         dstPtrs[i] = ZL_Output_ptr(outputs[i]);
     }
 
@@ -97,7 +98,7 @@ ZL_Report EI_bitSplit_withWidths(
 
     // Commit all outputs
     for (size_t i = 0; i < nbWidths; i++) {
-        ZL_RET_R_IF_ERR(ZL_Output_commit(outputs[i], nbElts));
+        ZL_ERR_IF_ERR(ZL_Output_commit(outputs[i], nbElts));
     }
 
     return ZL_returnValue(nbWidths);
@@ -105,6 +106,7 @@ ZL_Report EI_bitSplit_withWidths(
 
 ZL_Report EI_bitSplit(ZL_Encoder* eictx, const ZL_Input* ins[], size_t nbIns)
 {
+    ZL_RESULT_DECLARE_SCOPE_REPORT(eictx);
     ZL_ASSERT_NN(eictx);
     ZL_ASSERT_EQ(nbIns, 1);
     ZL_ASSERT_NN(ins);
@@ -118,29 +120,29 @@ ZL_Report EI_bitSplit(ZL_Encoder* eictx, const ZL_Input* ins[], size_t nbIns)
     ZL_IntParam const nbWidthsParam =
             ZL_Encoder_getLocalIntParam(eictx, ZL_BITSPLIT_NBWIDTHS_PID);
 
-    ZL_RET_R_IF_EQ(
-            nodeParameter_invalid,
+    ZL_ERR_IF_EQ(
             widthsParam.paramId,
             ZL_LP_INVALID_PARAMID,
-            "bitSplit requires bit widths parameter");
-    ZL_RET_R_IF_EQ(
             nodeParameter_invalid,
+            "bitSplit requires bit widths parameter");
+    ZL_ERR_IF_EQ(
             nbWidthsParam.paramId,
             ZL_LP_INVALID_PARAMID,
-            "bitSplit requires nbWidths parameter");
-    ZL_RET_R_IF_NULL(
             nodeParameter_invalid,
+            "bitSplit requires nbWidths parameter");
+    ZL_ERR_IF_NULL(
             widthsParam.paramRef,
+            nodeParameter_invalid,
             "bitSplit bit widths parameter is NULL");
 
     const uint8_t* bitWidths = (const uint8_t*)widthsParam.paramRef;
     size_t const nbWidths    = (size_t)nbWidthsParam.paramValue;
 
     // Validate: must have at least one width
-    ZL_RET_R_IF_EQ(
-            nodeParameter_invalid,
+    ZL_ERR_IF_EQ(
             nbWidths,
             0,
+            nodeParameter_invalid,
             "bitSplit requires at least one bit width parameter");
 
     return EI_bitSplit_withWidths(eictx, in, bitWidths, nbWidths);

--- a/src/openzl/codecs/bitpack/decode_bitpack_binding.c
+++ b/src/openzl/codecs/bitpack/decode_bitpack_binding.c
@@ -10,6 +10,7 @@
 static ZL_Report
 DI_bitpack_typed(ZL_Decoder* dictx, const ZL_Input* ins[], ZL_Type type)
 {
+    ZL_RESULT_DECLARE_SCOPE_REPORT(dictx);
     ZL_ASSERT_NN(dictx);
     ZL_ASSERT_NN(ins);
     const ZL_Input* const in = ins[0];
@@ -20,40 +21,39 @@ DI_bitpack_typed(ZL_Decoder* dictx, const ZL_Input* ins[], ZL_Type type)
     size_t srcSize     = ZL_Input_numElts(in);
 
     ZL_RBuffer const headerBuffer = ZL_Decoder_getCodecHeader(dictx);
-    ZL_RET_R_IF_GT(header_unknown, headerBuffer.size, 2);
-    ZL_RET_R_IF_LE(header_unknown, headerBuffer.size, 0);
+    ZL_ERR_IF_GT(headerBuffer.size, 2, header_unknown);
+    ZL_ERR_IF_LE(headerBuffer.size, 0, header_unknown);
     uint8_t const header     = *(uint8_t const*)headerBuffer.start;
     bool const hasExtraSpace = headerBuffer.size > 1;
     size_t const dstEltWidth = (size_t)1 << ((header >> 6) & 0x3);
     int const nbBits         = 1 + (header & 0x3F);
 
-    ZL_RET_R_IF_GT(internalBuffer_tooSmall, (size_t)nbBits, dstEltWidth * 8);
-    ZL_RET_R_IF_LE(header_unknown, nbBits, 0);
+    ZL_ERR_IF_GT((size_t)nbBits, dstEltWidth * 8, internalBuffer_tooSmall);
+    ZL_ERR_IF_LE(nbBits, 0, header_unknown);
     if (type == ZL_Type_serial) {
-        ZL_RET_R_IF_NE(
-                header_unknown, dstEltWidth, 1, "Serialized has width 1!");
+        ZL_ERR_IF_NE(dstEltWidth, 1, header_unknown, "Serialized has width 1!");
     }
 
     size_t dstNbElts;
     if (hasExtraSpace) {
         size_t const maxNbElts    = (srcSize * 8) / (size_t)nbBits;
         uint8_t const nbExtraElts = ((uint8_t const*)headerBuffer.start)[1];
-        ZL_RET_R_IF_GT(
-                corruption, nbExtraElts, maxNbElts, "bitpack header corrupt");
+        ZL_ERR_IF_GT(
+                nbExtraElts, maxNbElts, corruption, "bitpack header corrupt");
         dstNbElts = maxNbElts - nbExtraElts;
     } else {
         dstNbElts = (srcSize * 8) / (size_t)nbBits;
     }
     ZL_Output* const out =
             ZL_Decoder_create1OutStream(dictx, dstNbElts, dstEltWidth);
-    ZL_RET_R_IF_NULL(allocation, out);
+    ZL_ERR_IF_NULL(out, allocation);
 
     size_t const srcConsumed = ZS_bitpackDecode(
             ZL_Output_ptr(out), dstNbElts, dstEltWidth, src, srcSize, nbBits);
-    ZL_RET_R_IF_NE(
-            corruption, srcConsumed, srcSize, "entire source not consumed");
+    ZL_ERR_IF_NE(
+            srcConsumed, srcSize, corruption, "entire source not consumed");
 
-    ZL_RET_R_IF_ERR(ZL_Output_commit(out, dstNbElts));
+    ZL_ERR_IF_ERR(ZL_Output_commit(out, dstNbElts));
 
     // Return the number of output streams.
     return ZL_returnValue(1);

--- a/src/openzl/codecs/bitpack/encode_bitpack_binding.c
+++ b/src/openzl/codecs/bitpack/encode_bitpack_binding.c
@@ -92,6 +92,7 @@ static ZL_Report checkEtlWidth(size_t eltWidth)
 ZL_Report
 EI_bitpack_typed(ZL_Encoder* eictx, const ZL_Input* ins[], size_t nbIns)
 {
+    ZL_RESULT_DECLARE_SCOPE_REPORT(eictx);
     ZL_ASSERT_EQ(nbIns, 1);
     ZL_ASSERT_NN(ins);
     const ZL_Input* in = ins[0];
@@ -105,7 +106,7 @@ EI_bitpack_typed(ZL_Encoder* eictx, const ZL_Input* ins[], size_t nbIns)
     size_t const eltWidth = ZL_Input_eltWidth(in);
 
     // Check that eltWidth is one we support
-    ZL_RET_R_IF_ERR(checkEtlWidth(eltWidth));
+    ZL_ERR_IF_ERR(checkEtlWidth(eltWidth));
 
     int const nbBits = computeNbBits(in);
     ZL_ASSERT_EQ(ZS_bitpackEncodeVerify(src, nbElts, eltWidth, nbBits), 1);
@@ -113,7 +114,7 @@ EI_bitpack_typed(ZL_Encoder* eictx, const ZL_Input* ins[], size_t nbIns)
     size_t const dstCapacity = ZS_bitpackEncodeBound(nbElts, nbBits);
     ZL_Output* const out =
             ZL_Encoder_createTypedStream(eictx, 0, dstCapacity, 1);
-    ZL_RET_R_IF_NULL(allocation, out);
+    ZL_ERR_IF_NULL(out, allocation);
 
     uint8_t* const ostart = (uint8_t*)ZL_Output_ptr(out);
     size_t const dstSize  = ZS_bitpackEncode(
@@ -142,7 +143,7 @@ EI_bitpack_typed(ZL_Encoder* eictx, const ZL_Input* ins[], size_t nbIns)
         ZL_Encoder_sendCodecHeader(eictx, &header, 1);
     }
 
-    ZL_RET_R_IF_ERR(ZL_Output_commit(out, dstSize));
+    ZL_ERR_IF_ERR(ZL_Output_commit(out, dstSize));
     return ZL_returnValue(1);
 }
 

--- a/src/openzl/codecs/bitunpack/decode_bitunpack_binding.c
+++ b/src/openzl/codecs/bitunpack/decode_bitunpack_binding.c
@@ -11,6 +11,7 @@
 
 ZL_Report DI_bitunpack(ZL_Decoder* dictx, const ZL_Input* ins[])
 {
+    ZL_RESULT_DECLARE_SCOPE_REPORT(dictx);
     ZL_ASSERT_NN(dictx);
     ZL_ASSERT_NN(ins);
     const ZL_Input* const in = ins[0];
@@ -22,40 +23,40 @@ ZL_Report DI_bitunpack(ZL_Decoder* dictx, const ZL_Input* ins[])
     size_t nbElts   = ZL_Input_numElts(in);
 
     ZL_RBuffer const headerBuffer = ZL_Decoder_getCodecHeader(dictx);
-    ZL_RET_R_IF_LT(header_unknown, headerBuffer.size, 1);
-    ZL_RET_R_IF_GT(header_unknown, headerBuffer.size, 2);
+    ZL_ERR_IF_LT(headerBuffer.size, 1, header_unknown);
+    ZL_ERR_IF_GT(headerBuffer.size, 2, header_unknown);
     uint8_t const nbBits = *(uint8_t const*)headerBuffer.start;
-    ZL_RET_R_IF_GT(corruption, nbBits, 8 * eltWidth);
+    ZL_ERR_IF_GT(nbBits, 8 * eltWidth, corruption);
 
     size_t const dstSize = ZS_bitpackEncodeBound(nbElts, nbBits);
     ZL_Output* const dst = ZL_Decoder_create1OutStream(dictx, dstSize, 1);
-    ZL_RET_R_IF_NULL(allocation, dst);
+    ZL_ERR_IF_NULL(dst, allocation);
 
     void* dstBuffer = ZL_Output_ptr(dst);
     const size_t bytesWritten =
             ZS_bitpackEncode(dstBuffer, dstSize, src, nbElts, eltWidth, nbBits);
-    ZL_RET_R_IF_NE(GENERIC, bytesWritten, dstSize);
+    ZL_ERR_IF_NE(bytesWritten, dstSize, GENERIC);
 
     if (headerBuffer.size == 2) {
         // We have some leftover bits
         uint8_t remBits        = ((uint8_t const*)headerBuffer.start)[1];
         const size_t remNbBits = dstSize * 8 - nbElts * nbBits;
         ZL_ASSERT_LT(remNbBits, 8);
-        ZL_RET_R_IF_EQ(
-                corruption,
+        ZL_ERR_IF_EQ(
                 remNbBits,
                 0,
-                "remNbBits is zero although trailing bits are expected");
-        ZL_RET_R_IF_EQ(
                 corruption,
+                "remNbBits is zero although trailing bits are expected");
+        ZL_ERR_IF_EQ(
                 dstSize,
                 0,
+                corruption,
                 "dstSize is zero although trailing bits are expected");
         ((uint8_t*)dstBuffer)[dstSize - 1] |=
                 (uint8_t)(remBits << (8 - remNbBits));
     }
 
-    ZL_RET_R_IF_ERR(ZL_Output_commit(dst, dstSize));
+    ZL_ERR_IF_ERR(ZL_Output_commit(dst, dstSize));
 
     // Return the number of output streams.
     return ZL_returnValue(1);

--- a/src/openzl/codecs/bitunpack/encode_bitunpack_binding.c
+++ b/src/openzl/codecs/bitunpack/encode_bitunpack_binding.c
@@ -12,13 +12,13 @@
 
 static ZL_Report getNbBits(ZL_Encoder* eictx)
 {
+    ZL_RESULT_DECLARE_SCOPE_REPORT(eictx);
     ZL_IntParam const nbBits =
             ZL_Encoder_getLocalIntParam(eictx, ZL_Bitunpack_numBits);
     // Parameter **must** be set.
-    ZL_RET_R_IF_EQ(
-            nodeParameter_invalid, nbBits.paramId, ZL_LP_INVALID_PARAMID);
+    ZL_ERR_IF_EQ(nbBits.paramId, ZL_LP_INVALID_PARAMID, nodeParameter_invalid);
     if (nbBits.paramValue <= 0 || nbBits.paramValue > 64) {
-        ZL_RET_R_ERR(nodeParameter_invalidValue);
+        ZL_ERR(nodeParameter_invalidValue);
     }
     return ZL_returnValue((size_t)nbBits.paramValue);
 }
@@ -39,6 +39,7 @@ static size_t getEltWidth(const size_t nbBits)
 
 ZL_Report EI_bitunpack(ZL_Encoder* eictx, const ZL_Input* ins[], size_t nbIns)
 {
+    ZL_RESULT_DECLARE_SCOPE_REPORT(eictx);
     ZL_ASSERT_EQ(nbIns, 1);
     ZL_ASSERT_NN(ins);
     const ZL_Input* in = ins[0];
@@ -52,18 +53,18 @@ ZL_Report EI_bitunpack(ZL_Encoder* eictx, const ZL_Input* ins[], size_t nbIns)
     size_t const nbElts = srcSize * 8 / nbBits;
 
     // Make sure we fit well, and that remaining bits are zero
-    ZL_RET_R_IF_NE(GENERIC, (nbElts * nbBits + 7) / 8, srcSize);
+    ZL_ERR_IF_NE((nbElts * nbBits + 7) / 8, srcSize, GENERIC);
 
     size_t const eltWidth = getEltWidth(nbBits);
     ZL_Output* const out =
             ZL_Encoder_createTypedStream(eictx, 0, nbElts, eltWidth);
-    ZL_RET_R_IF_NULL(allocation, out);
+    ZL_ERR_IF_NULL(out, allocation);
 
     const size_t bytesRead = ZS_bitpackDecode(
             ZL_Output_ptr(out), nbElts, eltWidth, src, srcSize, (int)nbBits);
-    ZL_RET_R_IF_NE(logicError, bytesRead, srcSize);
+    ZL_ERR_IF_NE(bytesRead, srcSize, logicError);
 
-    ZL_RET_R_IF_ERR(ZL_Output_commit(out, nbElts));
+    ZL_ERR_IF_ERR(ZL_Output_commit(out, nbElts));
 
     // Header's structure:
     // Byte 1 - nbBits
@@ -81,9 +82,8 @@ ZL_Report EI_bitunpack(ZL_Encoder* eictx, const ZL_Input* ins[], size_t nbIns)
                 header[1] = remBits;
                 headerSize += 1;
             } else {
-                ZL_RET_R_ERR(
-                        GENERIC,
-                        "Bitunpack support non-zero trailing bits starting at format version 7");
+                ZL_ERR(GENERIC,
+                       "Bitunpack support non-zero trailing bits starting at format version 7");
             }
         }
     }

--- a/src/openzl/codecs/concat/decode_concat_binding.c
+++ b/src/openzl/codecs/concat/decode_concat_binding.c
@@ -15,14 +15,15 @@ ZL_Report DI_concat(
         const ZL_Input* variableSrcs[],
         size_t nbVariableSrcs)
 {
+    ZL_RESULT_DECLARE_SCOPE_REPORT(dictx);
     ZL_ASSERT_EQ(nbVariableSrcs, 0);
     (void)variableSrcs;
     ZL_ASSERT_EQ(nbCompulsorySrcs, 2);
     ZL_ASSERT_NN(compulsorySrcs);
     const ZL_Input* const sizes = compulsorySrcs[0];
     ZL_ASSERT_NN(sizes);
-    ZL_RET_R_IF_NE(corruption, ZL_Input_type(sizes), ZL_Type_numeric);
-    ZL_RET_R_IF_NE(corruption, ZL_Input_eltWidth(sizes), sizeof(uint32_t));
+    ZL_ERR_IF_NE(ZL_Input_type(sizes), ZL_Type_numeric, corruption);
+    ZL_ERR_IF_NE(ZL_Input_eltWidth(sizes), sizeof(uint32_t), corruption);
     const ZL_Input* const concatenated = compulsorySrcs[1];
     ZL_ASSERT_NN(concatenated);
 
@@ -30,45 +31,45 @@ ZL_Report DI_concat(
     size_t const eltWidth = ZL_Input_eltWidth(concatenated);
     size_t const nbElts   = ZL_Input_numElts(concatenated);
     const size_t nbRegens = ZL_Input_numElts(sizes);
-    ZL_RET_R_IF_EQ(corruption, nbRegens, 0);
+    ZL_ERR_IF_EQ(nbRegens, 0, corruption);
     const uint32_t* const regenSizes = ZL_Input_ptr(sizes);
 
     size_t rPos = 0;
-    ZL_RET_R_IF_LT(corruption, nbRegens, dictx->nbRegens);
+    ZL_ERR_IF_LT(nbRegens, dictx->nbRegens, corruption);
 
     if (type == ZL_Type_string) {
         const uint32_t* strLens = ZL_Input_stringLens(concatenated);
         size_t bytePos          = 0;
         for (size_t n = 0; n < nbRegens; n++) {
             size_t const rSize = regenSizes[n];
-            ZL_RET_R_IF_GT(corruption, rPos + rSize, nbElts);
+            ZL_ERR_IF_GT(rPos + rSize, nbElts, corruption);
             size_t byteSize = 0;
             for (size_t i = rPos; i < rPos + rSize; i++) {
                 byteSize += strLens[i];
             }
             ZL_Output* out = DI_outStream_asReference(
                     dictx, (int)n, concatenated, bytePos, 1, byteSize);
-            ZL_RET_R_IF_NULL(allocation, out);
+            ZL_ERR_IF_NULL(out, allocation);
             uint32_t* regenStrLens = ZL_Output_reserveStringLens(out, rSize);
             /* TODO(T220688634): This can be avoided if we have API to reference
              * string lengths*/
             ZL_memcpy(regenStrLens, strLens + rPos, rSize * sizeof(uint32_t));
-            ZL_RET_R_IF_ERR(ZL_Output_commit(out, rSize));
+            ZL_ERR_IF_ERR(ZL_Output_commit(out, rSize));
             rPos += rSize;
             bytePos += byteSize;
         }
-        ZL_RET_R_IF_NE(corruption, rPos, nbElts);
+        ZL_ERR_IF_NE(rPos, nbElts, corruption);
     } else {
         for (size_t n = 0; n < nbRegens; n++) {
             size_t const rSize = regenSizes[n];
-            ZL_RET_R_IF_GT(
-                    corruption, rPos + rSize * eltWidth, nbElts * eltWidth);
+            ZL_ERR_IF_GT(
+                    rPos + rSize * eltWidth, nbElts * eltWidth, corruption);
             ZL_Output* out = DI_outStream_asReference(
                     dictx, (int)n, concatenated, rPos, eltWidth, rSize);
-            ZL_RET_R_IF_NULL(allocation, out);
+            ZL_ERR_IF_NULL(out, allocation);
             rPos += rSize * eltWidth;
         }
-        ZL_RET_R_IF_NE(corruption, rPos, nbElts * eltWidth);
+        ZL_ERR_IF_NE(rPos, nbElts * eltWidth, corruption);
     }
 
     return ZL_returnSuccess();

--- a/src/openzl/codecs/concat/encode_concat_binding.c
+++ b/src/openzl/codecs/concat/encode_concat_binding.c
@@ -9,6 +9,7 @@
 
 ZL_Report EI_concat(ZL_Encoder* eictx, const ZL_Input* ins[], size_t nbIns)
 {
+    ZL_RESULT_DECLARE_SCOPE_REPORT(eictx);
     ZL_ASSERT_GE(nbIns, 1);
     ZL_ASSERT_NN(ins);
     size_t nbElts   = 0;
@@ -16,42 +17,41 @@ ZL_Report EI_concat(ZL_Encoder* eictx, const ZL_Input* ins[], size_t nbIns)
     size_t eltWidth = ZL_Input_eltWidth(ins[0]);
     for (size_t n = 0; n < nbIns; n++) {
         ZL_ASSERT_NN(ins[n]);
-        ZL_RET_R_IF_NE(
-                node_unexpected_input_type,
+        ZL_ERR_IF_NE(
                 ZL_Input_type(ins[n]),
                 type,
-                "Concat types must be homogenous");
-        ZL_RET_R_IF_NE(
                 node_unexpected_input_type,
+                "Concat types must be homogenous");
+        ZL_ERR_IF_NE(
                 ZL_Input_eltWidth(ins[n]),
                 eltWidth,
+                node_unexpected_input_type,
                 "Concat widths must be homogenous");
 
-        ZL_RET_R_IF_GE(
-                node_invalid_input, ZL_Input_numElts(ins[n]), UINT32_MAX);
-        ZL_RET_R_IF(
-                node_invalid_input,
-                ZL_overflowAddST(nbElts, ZL_Input_numElts(ins[n]), &nbElts));
+        ZL_ERR_IF_GE(ZL_Input_numElts(ins[n]), UINT32_MAX, node_invalid_input);
+        ZL_ERR_IF(
+                ZL_overflowAddST(nbElts, ZL_Input_numElts(ins[n]), &nbElts),
+                node_invalid_input);
     }
     size_t eltsCapacity = nbElts;
     if (type == ZL_Type_string) {
         eltWidth     = 1;
         eltsCapacity = 0;
         for (size_t n = 0; n < nbIns; n++) {
-            ZL_RET_R_IF(
-                    node_invalid_input,
+            ZL_ERR_IF(
                     ZL_overflowAddST(
                             eltsCapacity,
                             ZL_Input_contentSize(ins[n]),
-                            &eltsCapacity));
+                            &eltsCapacity),
+                    node_invalid_input);
         }
     }
 
     ZL_Output* const sizes = ZL_Encoder_createTypedStream(eictx, 0, nbIns, 4);
-    ZL_RET_R_IF_NULL(allocation, sizes);
+    ZL_ERR_IF_NULL(sizes, allocation);
     ZL_Output* const out =
             ZL_Encoder_createTypedStream(eictx, 1, eltsCapacity, eltWidth);
-    ZL_RET_R_IF_NULL(allocation, out);
+    ZL_ERR_IF_NULL(out, allocation);
 
     uint8_t* outPtr = (uint8_t*)ZL_Output_ptr(out);
     ZL_ASSERT_NN(outPtr);
@@ -90,7 +90,7 @@ ZL_Report EI_concat(ZL_Encoder* eictx, const ZL_Input* ins[], size_t nbIns)
     ZL_ASSERT_EQ(outPtr, outEnd);
     (void)outEnd;
 
-    ZL_RET_R_IF_ERR(ZL_Output_commit(out, nbElts));
-    ZL_RET_R_IF_ERR(ZL_Output_commit(sizes, nbIns));
+    ZL_ERR_IF_ERR(ZL_Output_commit(out, nbElts));
+    ZL_ERR_IF_ERR(ZL_Output_commit(sizes, nbIns));
     return ZL_returnSuccess();
 }

--- a/src/openzl/codecs/constant/decode_constant_binding.c
+++ b/src/openzl/codecs/constant/decode_constant_binding.c
@@ -9,6 +9,7 @@
 
 ZL_Report DI_constant_typed(ZL_Decoder* dictx, const ZL_Input* ins[])
 {
+    ZL_RESULT_DECLARE_SCOPE_REPORT(dictx);
     ZL_ASSERT_NN(dictx);
     ZL_ASSERT_NN(ins);
     const ZL_Input* const in = ins[0];
@@ -22,25 +23,25 @@ ZL_Report DI_constant_typed(ZL_Decoder* dictx, const ZL_Input* ins[])
     size_t const eltWidth    = ZL_Input_eltWidth(in);
     ZL_ASSERT_NN(src);
     ZL_ASSERT_GE(eltWidth, 1);
-    ZL_RET_R_IF_NE(corruption, nbElts, 1);
+    ZL_ERR_IF_NE(nbElts, 1, corruption);
 
     ZL_RBuffer const header = ZL_Decoder_getCodecHeader(dictx);
     uint8_t const* hdrStart = (uint8_t const*)header.start;
     uint8_t const* hdrEnd   = hdrStart + header.size;
     ZL_TRY_LET_T(uint64_t, dstNbElts, ZL_varintDecode(&hdrStart, hdrEnd));
-    ZL_RET_R_IF_NE(corruption, hdrStart, hdrEnd);
-    ZL_RET_R_IF_LT(corruption, dstNbElts, 1);
+    ZL_ERR_IF_NE(hdrStart, hdrEnd, corruption);
+    ZL_ERR_IF_LT(dstNbElts, 1, corruption);
 
     ZL_Output* const out =
             ZL_Decoder_create1OutStream(dictx, dstNbElts, eltWidth);
-    ZL_RET_R_IF_NULL(allocation, out);
+    ZL_ERR_IF_NULL(out, allocation);
     uint8_t* const outPtr = (uint8_t*)ZL_Output_ptr(out);
     ZL_ASSERT_NN(outPtr);
 
     size_t const bufferSize = (eltWidth <= 32) ? 32 : eltWidth;
     void* const eltBuffer   = ZL_Decoder_getScratchSpace(dictx, bufferSize);
-    ZL_RET_R_IF_NULL(allocation, eltBuffer);
+    ZL_ERR_IF_NULL(eltBuffer, allocation);
     ZS_decodeConstant(outPtr, dstNbElts, src, eltWidth, eltBuffer);
-    ZL_RET_R_IF_ERR(ZL_Output_commit(out, dstNbElts));
+    ZL_ERR_IF_ERR(ZL_Output_commit(out, dstNbElts));
     return ZL_returnSuccess();
 }

--- a/src/openzl/codecs/constant/encode_constant_binding.c
+++ b/src/openzl/codecs/constant/encode_constant_binding.c
@@ -12,6 +12,7 @@
 ZL_Report
 EI_constant_typed(ZL_Encoder* eictx, const ZL_Input* ins[], size_t nbIns)
 {
+    ZL_RESULT_DECLARE_SCOPE_REPORT(eictx);
     ZL_ASSERT_EQ(nbIns, 1);
     ZL_ASSERT_NN(ins);
     const ZL_Input* in = ins[0];
@@ -24,13 +25,13 @@ EI_constant_typed(ZL_Encoder* eictx, const ZL_Input* ins[], size_t nbIns)
     const uint8_t* const src = ZL_Input_ptr(in);
     size_t const nbElts      = ZL_Input_numElts(in);
     size_t const eltWidth    = ZL_Input_eltWidth(in);
-    ZL_RET_R_IF_LT(srcSize_tooSmall, nbElts, 1);
+    ZL_ERR_IF_LT(nbElts, 1, srcSize_tooSmall);
     ZL_ASSERT_GE(eltWidth, 1);
-    ZL_RET_R_IF_EQ(
-            node_invalid_input, ZS_isConstantStream(src, nbElts, eltWidth), 0);
+    ZL_ERR_IF_EQ(
+            ZS_isConstantStream(src, nbElts, eltWidth), 0, node_invalid_input);
 
     ZL_Output* const out = ZL_Encoder_createTypedStream(eictx, 0, 1, eltWidth);
-    ZL_RET_R_IF_NULL(allocation, out);
+    ZL_ERR_IF_NULL(out, allocation);
     uint8_t* const outPtr = (uint8_t*)ZL_Output_ptr(out);
     ZL_ASSERT_NN(outPtr);
 
@@ -39,6 +40,6 @@ EI_constant_typed(ZL_Encoder* eictx, const ZL_Input* ins[], size_t nbIns)
     ZL_Encoder_sendCodecHeader(eictx, header, varintSize);
 
     ZS_encodeConstant(outPtr, src, eltWidth);
-    ZL_RET_R_IF_ERR(ZL_Output_commit(out, 1));
+    ZL_ERR_IF_ERR(ZL_Output_commit(out, 1));
     return ZL_returnSuccess();
 }

--- a/src/openzl/codecs/conversion/decode_conversion_binding.c
+++ b/src/openzl/codecs/conversion/decode_conversion_binding.c
@@ -71,6 +71,7 @@ ZL_Report DI_revert_serial_to_num_be(ZL_Decoder* di, const ZL_Input* ins[])
 // Effectively, serial => intX
 ZL_Report DI_revert_num_to_serial_le(ZL_Decoder* di, const ZL_Input* ins[])
 {
+    ZL_RESULT_DECLARE_SCOPE_REPORT(di);
     ZL_ASSERT_NN(di);
     ZL_ASSERT_NN(ins);
     const ZL_Input* const in = ins[0];
@@ -82,17 +83,17 @@ ZL_Report DI_revert_num_to_serial_le(ZL_Decoder* di, const ZL_Input* ins[])
                              // engine
 
     ZL_RBuffer const header = ZL_Decoder_getCodecHeader(di);
-    ZL_RET_R_IF_NE(header_unknown, header.size, 1, "Invalid transform header!");
+    ZL_ERR_IF_NE(header.size, 1, header_unknown, "Invalid transform header!");
     size_t const intSize = (size_t)1 << (((const uint8_t*)header.start)[0]);
-    ZL_RET_R_IF(
-            header_unknown,
+    ZL_ERR_IF(
             !(intSize == 1 || intSize == 2 || intSize == 4 || intSize == 8),
+            header_unknown,
             "header contains bad integer width");
     size_t const nbBytes = ZL_Input_contentSize(in);
-    ZL_RET_R_IF_NE(
-            corruption,
+    ZL_ERR_IF_NE(
             nbBytes % intSize,
             0,
+            corruption,
             "stream size must be a multiple of the integer size");
     size_t const nbInts = nbBytes / intSize;
 
@@ -104,14 +105,14 @@ ZL_Report DI_revert_num_to_serial_le(ZL_Decoder* di, const ZL_Input* ins[])
     if (MEM_isAlignedForNumericWidth(ZL_Input_ptr(in), intSize)) {
         ZL_Output* const out =
                 DI_reference1OutStream(di, in, 0, intSize, nbInts);
-        ZL_RET_R_IF_NULL(allocation, out);
+        ZL_ERR_IF_NULL(out, allocation);
     } else {
         // Not aligned : create new stream, copy into it
         ZL_Output* const out = ZL_Decoder_create1OutStream(di, nbInts, intSize);
-        ZL_RET_R_IF_NULL(allocation, out);
+        ZL_ERR_IF_NULL(out, allocation);
         ZL_ASSERT(MEM_isAlignedForNumericWidth(ZL_Output_ptr(out), intSize));
         size_t const byteSize = ZL_Input_contentSize(in);
-        ZL_RET_R_IF_ERR(STREAM_copyBytes(
+        ZL_ERR_IF_ERR(STREAM_copyBytes(
                 ZL_codemodOutputAsData(out),
                 ZL_codemodInputAsData(in),
                 byteSize));
@@ -123,13 +124,14 @@ ZL_Report DI_revert_num_to_serial_le(ZL_Decoder* di, const ZL_Input* ins[])
 // Effectively, token(anylength) => serial
 ZL_Report DI_revert_serial_to_struct(ZL_Decoder* di, const ZL_Input* ins[])
 {
+    ZL_RESULT_DECLARE_SCOPE_REPORT(di);
     ZL_ASSERT_NN(di);
     ZL_ASSERT_NN(ins);
     const ZL_Input* const in = ins[0];
 
     ZL_Output* const out =
             DI_reference1OutStream(di, in, 0, 1, ZL_Input_contentSize(in));
-    ZL_RET_R_IF_NULL(allocation, out);
+    ZL_ERR_IF_NULL(out, allocation);
 
     return ZL_returnValue(1);
 }
@@ -138,6 +140,7 @@ ZL_Report DI_revert_serial_to_struct(ZL_Decoder* di, const ZL_Input* ins[])
 // Effectively, serial => token
 ZL_Report DI_revert_struct_to_serial(ZL_Decoder* di, const ZL_Input* ins[])
 {
+    ZL_RESULT_DECLARE_SCOPE_REPORT(di);
     ZL_ASSERT_NN(di);
     ZL_ASSERT_NN(ins);
     const ZL_Input* const in = ins[0];
@@ -152,24 +155,24 @@ ZL_Report DI_revert_struct_to_serial(ZL_Decoder* di, const ZL_Input* ins[])
     const uint8_t* ptr      = header.start;
     ZL_RESULT_OF(uint64_t)
     const r = ZL_varintDecode(&ptr, ptr + header.size);
-    ZL_RET_R_IF(srcSize_tooSmall, ZL_RES_isError(r));
+    ZL_ERR_IF(ZL_RES_isError(r), srcSize_tooSmall);
     uint64_t const eltSize = ZL_RES_value(r);
-    ZL_RET_R_IF_EQ(header_unknown, eltSize, 0, "eltSize must not be 0");
-    ZL_RET_R_IF_NE(
-            header_unknown,
+    ZL_ERR_IF_EQ(eltSize, 0, header_unknown, "eltSize must not be 0");
+    ZL_ERR_IF_NE(
             MEM_ptrDistance(header.start, ptr),
             header.size,
+            header_unknown,
             "Header size wrong");
     size_t const nbBytes = ZL_Input_contentSize(in);
-    ZL_RET_R_IF_NE(
-            corruption,
+    ZL_ERR_IF_NE(
             nbBytes % eltSize,
             0,
+            corruption,
             "stream size must be a multiple of the token size");
     size_t const nbTokens = nbBytes / eltSize;
 
     ZL_Output* const out = DI_reference1OutStream(di, in, 0, eltSize, nbTokens);
-    ZL_RET_R_IF_NULL(allocation, out);
+    ZL_ERR_IF_NULL(out, allocation);
 
     return ZL_returnValue(1);
 }
@@ -189,6 +192,7 @@ ZL_Report DI_revert_struct_to_num_be(ZL_Decoder* di, const ZL_Input* ins[])
 // Effectively, token => int
 ZL_Report DI_revert_num_to_struct_le(ZL_Decoder* di, const ZL_Input* ins[])
 {
+    ZL_RESULT_DECLARE_SCOPE_REPORT(di);
     // TODO (@Cyan): support for big-endian systems,
     //               requires a swap operation
     ZL_REQUIRE(
@@ -203,22 +207,22 @@ ZL_Report DI_revert_num_to_struct_le(ZL_Decoder* di, const ZL_Input* ins[])
                              // engine
     size_t const eltWidth = ZL_Input_eltWidth(in);
     if (!(eltWidth == 1 || eltWidth == 2 || eltWidth == 4 || eltWidth == 8)) {
-        ZL_RET_R_ERR(streamParameter_invalid);
+        ZL_ERR(streamParameter_invalid);
     }
     size_t const nbElts = ZL_Input_numElts(in);
 
     if (MEM_isAlignedForNumericWidth(ZL_Input_ptr(in), eltWidth)) {
         ZL_Output* const out =
                 DI_reference1OutStream(di, in, 0, eltWidth, nbElts);
-        ZL_RET_R_IF_NULL(allocation, out);
+        ZL_ERR_IF_NULL(out, allocation);
     } else {
         // Not aligned : create new stream, copy into it
         ZL_Output* const out =
                 ZL_Decoder_create1OutStream(di, nbElts, eltWidth);
-        ZL_RET_R_IF_NULL(allocation, out);
+        ZL_ERR_IF_NULL(out, allocation);
         ZL_ASSERT(MEM_isAlignedForNumericWidth(ZL_Output_ptr(out), eltWidth));
         size_t const byteSize = ZL_Input_contentSize(in);
-        ZL_RET_R_IF_ERR(STREAM_copyBytes(
+        ZL_ERR_IF_ERR(STREAM_copyBytes(
                 ZL_codemodOutputAsData(out),
                 ZL_codemodInputAsData(in),
                 byteSize));
@@ -229,6 +233,7 @@ ZL_Report DI_revert_num_to_struct_le(ZL_Decoder* di, const ZL_Input* ins[])
 
 ZL_Report DI_revert_VSF_separation(ZL_Decoder* dictx, const ZL_Input* ins[])
 {
+    ZL_RESULT_DECLARE_SCOPE_REPORT(dictx);
     ZL_ASSERT_NN(ins);
     const ZL_Input* const concatFields = ins[0];
     ZL_ASSERT_NN(concatFields);
@@ -240,14 +245,14 @@ ZL_Report DI_revert_VSF_separation(ZL_Decoder* dictx, const ZL_Input* ins[])
 
     ZL_Output* const vsfRegen =
             DI_reference1OutStream(dictx, concatFields, 0, 1, contentSize);
-    ZL_RET_R_IF_NULL(allocation, vsfRegen);
+    ZL_ERR_IF_NULL(vsfRegen, allocation);
 
     const size_t nbFields = ZL_Input_numElts(fieldSizes);
     // Note : allocation to be changed for local workspace when available
     uint32_t* const arr32 = ZL_Output_reserveStringLens(vsfRegen, nbFields);
-    ZL_RET_R_IF_NULL(allocation, arr32);
+    ZL_ERR_IF_NULL(arr32, allocation);
 
-    ZL_RET_R_IF_ERR(NUMOP_write32_fromNumerics(
+    ZL_ERR_IF_ERR(NUMOP_write32_fromNumerics(
             arr32,
             nbFields,
             ZL_Input_ptr(fieldSizes),
@@ -258,13 +263,13 @@ ZL_Report DI_revert_VSF_separation(ZL_Decoder* dictx, const ZL_Input* ins[])
             "Calculating totalSize=%llu, as sum of arr32 of %zu elts",
             totalSize,
             nbFields);
-    ZL_RET_R_IF_NE(
-            corruption,
+    ZL_ERR_IF_NE(
             totalSize,
             (uint64_t)contentSize,
+            corruption,
             "Incorrect sum of field sizes");
 
-    ZL_RET_R_IF_ERR(ZL_Output_commit(vsfRegen, nbFields));
+    ZL_ERR_IF_ERR(ZL_Output_commit(vsfRegen, nbFields));
     ZL_DLOG(SEQ,
             "Produced Stream: Type:%u, nbStrings:%u, eltWidth=%u",
             ZL_Output_type(vsfRegen),
@@ -278,6 +283,7 @@ ZL_Report DI_extract_concatenatedFields(
         ZL_Decoder* dictx,
         const ZL_Input* ins[])
 {
+    ZL_RESULT_DECLARE_SCOPE_REPORT(dictx);
     ZL_ASSERT_NN(ins);
     const ZL_Input* const inVSF = ins[0];
     ZL_ASSERT_NN(inVSF);
@@ -285,6 +291,6 @@ ZL_Report DI_extract_concatenatedFields(
 
     ZL_Output* const serialExtract = DI_reference1OutStream(
             dictx, inVSF, 0, 1, ZL_Input_contentSize(inVSF));
-    ZL_RET_R_IF_NULL(allocation, serialExtract);
+    ZL_ERR_IF_NULL(serialExtract, allocation);
     return ZL_returnValue(1);
 }

--- a/src/openzl/codecs/conversion/encode_conversion_binding.c
+++ b/src/openzl/codecs/conversion/encode_conversion_binding.c
@@ -144,16 +144,17 @@ static ZL_Report EI_convert_serial_to_struct_generic(
         const ZL_Input* in,
         size_t tokenWidth)
 {
+    ZL_RESULT_DECLARE_SCOPE_REPORT(eictx);
     ZL_ASSERT_NN(eictx);
     ZL_ASSERT_NN(in);
     size_t const inByteSize = ZL_Input_contentSize(in);
     if (inByteSize % tokenWidth) {
-        ZL_RET_R_ERR(streamParameter_invalid); // Not a clean multiple
+        ZL_ERR(streamParameter_invalid); // Not a clean multiple
     }
     size_t const nbTokens = inByteSize / tokenWidth;
-    ZL_RET_R_IF_NULL(
-            allocation,
-            ENC_refTypedStream(eictx, 0, tokenWidth, nbTokens, in, 0));
+    ZL_ERR_IF_NULL(
+            ENC_refTypedStream(eictx, 0, tokenWidth, nbTokens, in, 0),
+            allocation);
     return ZL_returnValue(1);
 }
 
@@ -162,6 +163,7 @@ ZL_Report EI_convert_serial_to_struct(
         const ZL_Input* ins[],
         size_t nbIns)
 {
+    ZL_RESULT_DECLARE_SCOPE_REPORT(eictx);
     ZL_ASSERT_EQ(nbIns, 1);
     ZL_ASSERT_NN(ins);
     const ZL_Input* in = ins[0];
@@ -169,9 +171,9 @@ ZL_Report EI_convert_serial_to_struct(
     ZL_IntParam const tokenSize =
             ZL_Encoder_getLocalIntParam(eictx, ZL_trlip_tokenSize);
     // Parameter **must** be set.
-    ZL_RET_R_IF_EQ(
-            nodeParameter_invalid, tokenSize.paramId, ZL_LP_INVALID_PARAMID);
-    ZL_RET_R_IF_LE(nodeParameter_invalidValue, tokenSize.paramValue, 0);
+    ZL_ERR_IF_EQ(
+            tokenSize.paramId, ZL_LP_INVALID_PARAMID, nodeParameter_invalid);
+    ZL_ERR_IF_LE(tokenSize.paramValue, 0, nodeParameter_invalidValue);
     return EI_convert_serial_to_struct_generic(
             eictx, in, (size_t)tokenSize.paramValue);
 }
@@ -207,6 +209,7 @@ ZL_Report EI_convert_num_to_struct_le(
         const ZL_Input* ins[],
         size_t nbIns)
 {
+    ZL_RESULT_DECLARE_SCOPE_REPORT(eictx);
     ZL_ASSERT_EQ(nbIns, 1);
     ZL_ASSERT_NN(ins);
     const ZL_Input* in = ins[0];
@@ -219,22 +222,23 @@ ZL_Report EI_convert_num_to_struct_le(
     size_t const eltWidth = ZL_Input_eltWidth(in);
     ZL_ASSERT_GT(eltWidth, 0);
     size_t const nbElts = ZL_Input_numElts(in);
-    ZL_RET_R_IF_NULL(
-            allocation, ENC_refTypedStream(eictx, 0, eltWidth, nbElts, in, 0));
+    ZL_ERR_IF_NULL(
+            ENC_refTypedStream(eictx, 0, eltWidth, nbElts, in, 0), allocation);
     return ZL_returnValue(1);
 }
 
 static ZL_Report
 EI_convert_to_serial(ZL_Encoder* eictx, const ZL_Input* ins[], size_t nbIns)
 {
+    ZL_RESULT_DECLARE_SCOPE_REPORT(eictx);
     ZL_ASSERT_EQ(nbIns, 1);
     ZL_ASSERT_NN(ins);
     const ZL_Input* in = ins[0];
     ZL_ASSERT_NN(in);
     size_t const byteSize = ZL_Input_contentSize(in);
     ZL_ASSERT_NN(eictx);
-    ZL_RET_R_IF_NULL(
-            allocation, ENC_refTypedStream(eictx, 0, 1, byteSize, in, 0));
+    ZL_ERR_IF_NULL(
+            ENC_refTypedStream(eictx, 0, 1, byteSize, in, 0), allocation);
     return ZL_returnValue(1);
 }
 
@@ -286,21 +290,22 @@ ZL_Report EI_separate_VSF_components(
         const ZL_Input* ins[],
         size_t nbIns)
 {
+    ZL_RESULT_DECLARE_SCOPE_REPORT(eictx);
     ZL_ASSERT_EQ(nbIns, 1);
     ZL_ASSERT_NN(ins);
     const ZL_Input* in = ins[0];
     ZL_ASSERT_NN(eictx);
     ZL_ASSERT_EQ(ZL_Input_type(in), ZL_Type_string);
-    ZL_RET_R_IF_ERR(EI_convert_to_serial(eictx, ins, nbIns));
+    ZL_ERR_IF_ERR(EI_convert_to_serial(eictx, ins, nbIns));
     const uint32_t* fieldSizes = ZL_Input_stringLens(in);
     const size_t nbFields      = ZL_Input_numElts(in);
     size_t const numWidth = NUMOP_numericWidthForArray32(fieldSizes, nbFields);
     ZL_Output* const sizeStream =
             ZL_Encoder_createTypedStream(eictx, 1, nbFields, numWidth);
-    ZL_RET_R_IF_NULL(allocation, sizeStream);
+    ZL_ERR_IF_NULL(sizeStream, allocation);
     void* const dst = ZL_Output_ptr(sizeStream);
     NUMOP_writeNumerics_fromU32(dst, numWidth, fieldSizes, nbFields);
-    ZL_RET_R_IF_ERR(ZL_Output_commit(sizeStream, nbFields));
+    ZL_ERR_IF_ERR(ZL_Output_commit(sizeStream, nbFields));
     return ZL_returnValue(2);
 }
 

--- a/src/openzl/codecs/conversion/encode_setStringSizes_binding.c
+++ b/src/openzl/codecs/conversion/encode_setStringSizes_binding.c
@@ -68,6 +68,7 @@ static ZL_SetStringLensInstructions getStringLens(
 ZL_Report
 EI_setStringLens(ZL_Encoder* eictx, const ZL_Input* ins[], size_t nbIns)
 {
+    ZL_RESULT_DECLARE_SCOPE_REPORT(eictx);
     ZL_ASSERT_EQ(nbIns, 1);
     ZL_ASSERT_NN(ins);
     const ZL_Input* in = ins[0];
@@ -81,7 +82,7 @@ EI_setStringLens(ZL_Encoder* eictx, const ZL_Input* ins[], size_t nbIns)
     const size_t nbStrings            = sfsi.nbStrings;
     const uint32_t* const stringLens  = sfsi.stringLens;
 
-    ZL_RET_R_IF(nodeParameter_invalid, nbStrings && stringLens == NULL);
+    ZL_ERR_IF(nbStrings && stringLens == NULL, nodeParameter_invalid);
 
     ZL_DLOG(BLOCK,
             "EI_setStringLens: converting %zu bytes into %zu strings",
@@ -90,21 +91,21 @@ EI_setStringLens(ZL_Encoder* eictx, const ZL_Input* ins[], size_t nbIns)
 
     // Here : check parser's output
     uint64_t const parserTotalSize = NUMOP_sumArray32(stringLens, nbStrings);
-    ZL_RET_R_IF_NE(
-            nodeParameter_invalidValue,
+    ZL_ERR_IF_NE(
             parserTotalSize,
             (uint64_t)inputSize,
+            nodeParameter_invalidValue,
             "EI_setStringLens: the external parser provides invalid total size");
 
     ZL_Output* const out = ENC_refTypedStream(eictx, 0, 1, inputSize, in, 0);
-    ZL_RET_R_IF_NULL(allocation, out);
+    ZL_ERR_IF_NULL(out, allocation);
 
     uint32_t* const fs = ZL_Output_reserveStringLens(out, nbStrings);
-    ZL_RET_R_IF_NULL(allocation, fs);
+    ZL_ERR_IF_NULL(fs, allocation);
 
     ZL_memcpy(fs, stringLens, nbStrings * sizeof(uint32_t));
 
-    ZL_RET_R_IF_ERR(ZL_Output_commit(out, nbStrings));
+    ZL_ERR_IF_ERR(ZL_Output_commit(out, nbStrings));
 
     return ZL_returnSuccess();
 }

--- a/src/openzl/codecs/dedup/decode_dedup_binding.c
+++ b/src/openzl/codecs/dedup/decode_dedup_binding.c
@@ -14,6 +14,7 @@ ZL_Report DI_dedup_num(
         const ZL_Input* variableSrcs[],
         size_t nbVariableSrcs)
 {
+    ZL_RESULT_DECLARE_SCOPE_REPORT(dictx);
     ZL_ASSERT_EQ(nbVariableSrcs, 0);
     (void)variableSrcs;
     ZL_ASSERT_EQ(nbCompulsorySrcs, 1);
@@ -30,7 +31,7 @@ ZL_Report DI_dedup_num(
     for (size_t n = 0; n < nbRegens; n++) {
         ZL_Output* const out = DI_outStream_asReference(
                 dictx, (int)n, numSrc, 0, eltWidth, eltCount);
-        ZL_RET_R_IF_NULL(allocation, out);
+        ZL_ERR_IF_NULL(out, allocation);
     }
     return ZL_returnSuccess();
 }

--- a/src/openzl/codecs/dedup/encode_dedup_binding.c
+++ b/src/openzl/codecs/dedup/encode_dedup_binding.c
@@ -14,6 +14,7 @@ static ZL_Report EI_dedup_num_internal(
         size_t nbIns,
         int inputsIdentical)
 {
+    ZL_RESULT_DECLARE_SCOPE_REPORT(eictx);
     // Input sanitization
     ZL_ASSERT_GE(nbIns, 1);
     ZL_ASSERT_NN(ins);
@@ -37,19 +38,19 @@ static ZL_Report EI_dedup_num_internal(
                     0);
         } else {
             // Actively check that inputs are indeed all identical
-            ZL_RET_R_IF_NE(
-                    node_invalid_input, ZL_Input_eltWidth(ins[n]), eltWidth);
-            ZL_RET_R_IF_NE(
-                    node_invalid_input, ZL_Input_numElts(ins[n]), eltCount);
+            ZL_ERR_IF_NE(
+                    ZL_Input_eltWidth(ins[n]), eltWidth, node_invalid_input);
+            ZL_ERR_IF_NE(
+                    ZL_Input_numElts(ins[n]), eltCount, node_invalid_input);
             int const isDifferent = memcmp(
                     ZL_Input_ptr(ins[n]), ZL_Input_ptr(ins[0]), totalSize);
-            ZL_RET_R_IF(node_invalid_input, isDifferent);
+            ZL_ERR_IF(isDifferent, node_invalid_input);
         }
     }
 
     ZL_Output* const out =
             ENC_refTypedStream(eictx, 0, eltWidth, eltCount, ins[0], 0);
-    ZL_RET_R_IF_NULL(allocation, out);
+    ZL_ERR_IF_NULL(out, allocation);
 
     return ZL_returnSuccess();
 }


### PR DESCRIPTION
Summary:
Migrate old-style `ZL_RET_R_*` error-handling macros to the new `ZL_ERR_*` macros in all 57 codec encode/decode binding files under `src/openzl/codecs/`.

The new `ZL_ERR_*` macros require an explicit `ZL_RESULT_DECLARE_SCOPE_REPORT(ctx)` declaration at the top of each function, which provides proper error context for rich error reporting. The old `ZL_RET_R_*` macros used "magic" auto-context detection via `_Generic`, which doesn't always work correctly.

**Migration pattern:**
- Add `ZL_RESULT_DECLARE_SCOPE_REPORT(ctx)` at the top of each migrated function
- Replace `ZL_RET_R_IF(errcode, expr, ...)` → `ZL_ERR_IF(expr, errcode, ...)`
- Replace `ZL_RET_R_IF_ERR(expr)` → `ZL_ERR_IF_ERR(expr)`
- Replace `ZL_RET_R_ERR(errcode)` → `ZL_ERR(errcode)`
- Similar replacements for IF_NULL, IF_NN, IF_EQ, IF_NE, IF_GT, IF_LT, IF_GE, IF_LE

**Codecs covered:** bitSplit, bitpack, bitunpack, concat, constant, conversion, dedup, delta, dispatchN_byTag, dispatch_string, divide_by, entropy, flatpack, float_deconstruct, interleave, lz, merge_sorted, parse_int, prefix, quantize, range_pack, rolz, splitByStruct, splitN, tokenize, transpose, zigzag, zstd

Only functions with real (non-NULL, non-const) error context are migrated.

Differential Revision: D94712924


