### PR TITLE
Migrate ZL_RET_R_* to ZL_ERR_* in src/openzl/codecs/ bindings (part 3/4: interleave through range_pack)

### DIFF
--- a/src/openzl/codecs/bitSplit/decode_bitSplit_binding.c
+++ b/src/openzl/codecs/bitSplit/decode_bitSplit_binding.c
@@ -14,6 +14,7 @@ ZL_Report DI_bitSplit(
         const ZL_Input* variableSrcs[],
         size_t nbVariableSrcs)
 {
+    ZL_RESULT_DECLARE_SCOPE_REPORT(dictx);
     ZL_ASSERT_NN(dictx);
     ZL_ASSERT_EQ(nbCompulsorySrcs, 0);
     (void)compulsorySrcs;
@@ -24,10 +25,10 @@ ZL_Report DI_bitSplit(
     ZL_RBuffer const header = ZL_Decoder_getCodecHeader(dictx);
 
     // Validate: header must have at least outputEltWidth byte
-    ZL_RET_R_IF_LT(
-            corruption,
+    ZL_ERR_IF_LT(
             header.size,
             1,
+            corruption,
             "bitSplit: header must contain outputEltWidth");
 
     // Parse header
@@ -36,19 +37,19 @@ ZL_Report DI_bitSplit(
     const uint8_t* storedWidths  = (const uint8_t*)header.start + 1;
 
     // Validate outputEltWidth
-    ZL_RET_R_IF_NOT(
-            corruption,
+    ZL_ERR_IF_NOT(
             outputEltWidth == 1 || outputEltWidth == 2 || outputEltWidth == 4
                     || outputEltWidth == 8,
+            corruption,
             "bitSplit: invalid outputEltWidth in header");
 
     // Compute sum of stored widths and determine last width
     size_t sumStoredWidths = 0;
     for (size_t i = 0; i < nbStoredWidths; i++) {
-        ZL_RET_R_IF_EQ(
-                corruption,
+        ZL_ERR_IF_EQ(
                 storedWidths[i],
                 0,
+                corruption,
                 "bitSplit: bit width cannot be zero");
         sumStoredWidths += storedWidths[i];
     }
@@ -56,10 +57,10 @@ ZL_Report DI_bitSplit(
     size_t const outputEltWidthBits = (size_t)outputEltWidth * 8;
 
     // Validate sum doesn't exceed output width
-    ZL_RET_R_IF_GT(
-            corruption,
+    ZL_ERR_IF_GT(
             sumStoredWidths,
             outputEltWidthBits,
+            corruption,
             "bitSplit: sum of stored widths exceeds output element width");
 
     // Determine coverage based on number of input streams:
@@ -78,10 +79,10 @@ ZL_Report DI_bitSplit(
     } else if (nbVariableSrcs == nbStoredWidths + 1) {
         // Full coverage: add computed last width
         ZL_ASSERT_LE(nbStoredWidths, 64); // already checked via sumStoredWidths
-        ZL_RET_R_IF_EQ(
-                corruption,
+        ZL_ERR_IF_EQ(
                 lastWidth,
                 0,
+                corruption,
                 "bitSplit: invalid last width (set to 0)");
         ZL_memcpy(bitWidths_local, storedWidths, nbStoredWidths);
         bitWidths_local[nbStoredWidths] = (uint8_t)lastWidth;
@@ -89,11 +90,11 @@ ZL_Report DI_bitSplit(
         bitWidths = bitWidths_local;
         nbWidths  = nbStoredWidths + 1;
     } else {
-        ZL_RET_R_IF_NOT(corruption, 0, "bitSplit: input stream count mismatch");
+        ZL_ERR_IF_NOT(0, corruption, "bitSplit: input stream count mismatch");
     }
 
     // Validate: must have at least one width
-    ZL_RET_R_IF_EQ(corruption, nbWidths, 0, "bitSplit: no bit widths present");
+    ZL_ERR_IF_EQ(nbWidths, 0, corruption, "bitSplit: no bit widths present");
 
     // Validate all input streams, and collect their pointers
     size_t nbElts = 0;
@@ -111,27 +112,27 @@ ZL_Report DI_bitSplit(
         if (i == 0) {
             nbElts = streamNbElts;
         } else {
-            ZL_RET_R_IF_NE(
-                    corruption,
+            ZL_ERR_IF_NE(
                     streamNbElts,
                     nbElts,
+                    corruption,
                     "bitSplit: all input streams must have same element count");
         }
 
         // Verify bit width doesn't exceed input stream capacity
         size_t const inputEltWidthBits = ZL_Input_eltWidth(in) * 8;
-        ZL_RET_R_IF_GT(
-                corruption,
+        ZL_ERR_IF_GT(
                 bitWidths[i],
                 inputEltWidthBits,
+                corruption,
                 "bitSplit: bit width exceeds input stream element width");
 
         // Verify element width matches expected
         size_t const expectedWidth = ZL_bitSplit_outputEltWidth(bitWidths[i]);
-        ZL_RET_R_IF_NE(
-                corruption,
+        ZL_ERR_IF_NE(
                 ZL_Input_eltWidth(in),
                 expectedWidth,
+                corruption,
                 "bitSplit: input stream element width mismatch");
 
         inputPtrs[i]   = ZL_Input_ptr(in);
@@ -141,7 +142,7 @@ ZL_Report DI_bitSplit(
     // Create output stream
     ZL_Output* const out =
             ZL_Decoder_create1OutStream(dictx, nbElts, outputEltWidth);
-    ZL_RET_R_IF_NULL(allocation, out);
+    ZL_ERR_IF_NULL(out, allocation);
 
     // Kernel owns the hot loop - single call processes all elements
     ZL_bitSplitDecode(
@@ -153,6 +154,6 @@ ZL_Report DI_bitSplit(
             bitWidths,
             nbWidths);
 
-    ZL_RET_R_IF_ERR(ZL_Output_commit(out, nbElts));
+    ZL_ERR_IF_ERR(ZL_Output_commit(out, nbElts));
     return ZL_returnSuccess();
 }

--- a/src/openzl/codecs/bitSplit/encode_bitSplit_binding.c
+++ b/src/openzl/codecs/bitSplit/encode_bitSplit_binding.c
@@ -22,6 +22,7 @@ ZL_Report EI_bitSplit_withWidths(
         const uint8_t* bitWidths,
         size_t nbWidths)
 {
+    ZL_RESULT_DECLARE_SCOPE_REPORT(eictx);
     ZL_ASSERT_NN(eictx);
     ZL_ASSERT_NN(in);
     ZL_ASSERT_EQ(ZL_Input_type(in), ZL_Type_numeric);
@@ -38,18 +39,18 @@ ZL_Report EI_bitSplit_withWidths(
 
     // Validate parameters
     size_t sumWidths = 0;
-    ZL_RET_R_IF(
-            nodeParameter_invalid,
+    ZL_ERR_IF(
             !ZL_bitSplit_paramsAreValid(
                     bitWidths, nbWidths, inputEltWidthBits, &sumWidths),
+            nodeParameter_invalid,
             "bitSplit parameter validation failed");
 
     // Validate top bits are zero if partial coverage
     if (sumWidths < inputEltWidthBits) {
-        ZL_RET_R_IF(
-                corruption,
+        ZL_ERR_IF(
                 !ZL_bitSplit_topBitsAreZero(
                         ZL_Input_ptr(in), inputEltWidth, nbElts, sumWidths),
+                corruption,
                 "bitSplit: top bits must be zero for partial coverage");
     }
 
@@ -81,7 +82,7 @@ ZL_Report EI_bitSplit_withWidths(
         outputWidths[i] = ZL_bitSplit_outputEltWidth(bitWidths[i]);
         outputs[i] =
                 ZL_Encoder_createTypedStream(eictx, 0, nbElts, outputWidths[i]);
-        ZL_RET_R_IF_NULL(allocation, outputs[i]);
+        ZL_ERR_IF_NULL(outputs[i], allocation);
         dstPtrs[i] = ZL_Output_ptr(outputs[i]);
     }
 
@@ -97,7 +98,7 @@ ZL_Report EI_bitSplit_withWidths(
 
     // Commit all outputs
     for (size_t i = 0; i < nbWidths; i++) {
-        ZL_RET_R_IF_ERR(ZL_Output_commit(outputs[i], nbElts));
+        ZL_ERR_IF_ERR(ZL_Output_commit(outputs[i], nbElts));
     }
 
     return ZL_returnValue(nbWidths);
@@ -105,6 +106,7 @@ ZL_Report EI_bitSplit_withWidths(
 
 ZL_Report EI_bitSplit(ZL_Encoder* eictx, const ZL_Input* ins[], size_t nbIns)
 {
+    ZL_RESULT_DECLARE_SCOPE_REPORT(eictx);
     ZL_ASSERT_NN(eictx);
     ZL_ASSERT_EQ(nbIns, 1);
     ZL_ASSERT_NN(ins);
@@ -118,29 +120,29 @@ ZL_Report EI_bitSplit(ZL_Encoder* eictx, const ZL_Input* ins[], size_t nbIns)
     ZL_IntParam const nbWidthsParam =
             ZL_Encoder_getLocalIntParam(eictx, ZL_BITSPLIT_NBWIDTHS_PID);
 
-    ZL_RET_R_IF_EQ(
-            nodeParameter_invalid,
+    ZL_ERR_IF_EQ(
             widthsParam.paramId,
             ZL_LP_INVALID_PARAMID,
-            "bitSplit requires bit widths parameter");
-    ZL_RET_R_IF_EQ(
             nodeParameter_invalid,
+            "bitSplit requires bit widths parameter");
+    ZL_ERR_IF_EQ(
             nbWidthsParam.paramId,
             ZL_LP_INVALID_PARAMID,
-            "bitSplit requires nbWidths parameter");
-    ZL_RET_R_IF_NULL(
             nodeParameter_invalid,
+            "bitSplit requires nbWidths parameter");
+    ZL_ERR_IF_NULL(
             widthsParam.paramRef,
+            nodeParameter_invalid,
             "bitSplit bit widths parameter is NULL");
 
     const uint8_t* bitWidths = (const uint8_t*)widthsParam.paramRef;
     size_t const nbWidths    = (size_t)nbWidthsParam.paramValue;
 
     // Validate: must have at least one width
-    ZL_RET_R_IF_EQ(
-            nodeParameter_invalid,
+    ZL_ERR_IF_EQ(
             nbWidths,
             0,
+            nodeParameter_invalid,
             "bitSplit requires at least one bit width parameter");
 
     return EI_bitSplit_withWidths(eictx, in, bitWidths, nbWidths);

--- a/src/openzl/codecs/bitpack/decode_bitpack_binding.c
+++ b/src/openzl/codecs/bitpack/decode_bitpack_binding.c
@@ -10,6 +10,7 @@
 static ZL_Report
 DI_bitpack_typed(ZL_Decoder* dictx, const ZL_Input* ins[], ZL_Type type)
 {
+    ZL_RESULT_DECLARE_SCOPE_REPORT(dictx);
     ZL_ASSERT_NN(dictx);
     ZL_ASSERT_NN(ins);
     const ZL_Input* const in = ins[0];
@@ -20,40 +21,39 @@ DI_bitpack_typed(ZL_Decoder* dictx, const ZL_Input* ins[], ZL_Type type)
     size_t srcSize     = ZL_Input_numElts(in);
 
     ZL_RBuffer const headerBuffer = ZL_Decoder_getCodecHeader(dictx);
-    ZL_RET_R_IF_GT(header_unknown, headerBuffer.size, 2);
-    ZL_RET_R_IF_LE(header_unknown, headerBuffer.size, 0);
+    ZL_ERR_IF_GT(headerBuffer.size, 2, header_unknown);
+    ZL_ERR_IF_LE(headerBuffer.size, 0, header_unknown);
     uint8_t const header     = *(uint8_t const*)headerBuffer.start;
     bool const hasExtraSpace = headerBuffer.size > 1;
     size_t const dstEltWidth = (size_t)1 << ((header >> 6) & 0x3);
     int const nbBits         = 1 + (header & 0x3F);
 
-    ZL_RET_R_IF_GT(internalBuffer_tooSmall, (size_t)nbBits, dstEltWidth * 8);
-    ZL_RET_R_IF_LE(header_unknown, nbBits, 0);
+    ZL_ERR_IF_GT((size_t)nbBits, dstEltWidth * 8, internalBuffer_tooSmall);
+    ZL_ERR_IF_LE(nbBits, 0, header_unknown);
     if (type == ZL_Type_serial) {
-        ZL_RET_R_IF_NE(
-                header_unknown, dstEltWidth, 1, "Serialized has width 1!");
+        ZL_ERR_IF_NE(dstEltWidth, 1, header_unknown, "Serialized has width 1!");
     }
 
     size_t dstNbElts;
     if (hasExtraSpace) {
         size_t const maxNbElts    = (srcSize * 8) / (size_t)nbBits;
         uint8_t const nbExtraElts = ((uint8_t const*)headerBuffer.start)[1];
-        ZL_RET_R_IF_GT(
-                corruption, nbExtraElts, maxNbElts, "bitpack header corrupt");
+        ZL_ERR_IF_GT(
+                nbExtraElts, maxNbElts, corruption, "bitpack header corrupt");
         dstNbElts = maxNbElts - nbExtraElts;
     } else {
         dstNbElts = (srcSize * 8) / (size_t)nbBits;
     }
     ZL_Output* const out =
             ZL_Decoder_create1OutStream(dictx, dstNbElts, dstEltWidth);
-    ZL_RET_R_IF_NULL(allocation, out);
+    ZL_ERR_IF_NULL(out, allocation);
 
     size_t const srcConsumed = ZS_bitpackDecode(
             ZL_Output_ptr(out), dstNbElts, dstEltWidth, src, srcSize, nbBits);
-    ZL_RET_R_IF_NE(
-            corruption, srcConsumed, srcSize, "entire source not consumed");
+    ZL_ERR_IF_NE(
+            srcConsumed, srcSize, corruption, "entire source not consumed");
 
-    ZL_RET_R_IF_ERR(ZL_Output_commit(out, dstNbElts));
+    ZL_ERR_IF_ERR(ZL_Output_commit(out, dstNbElts));
 
     // Return the number of output streams.
     return ZL_returnValue(1);

--- a/src/openzl/codecs/bitpack/encode_bitpack_binding.c
+++ b/src/openzl/codecs/bitpack/encode_bitpack_binding.c
@@ -92,6 +92,7 @@ static ZL_Report checkEtlWidth(size_t eltWidth)
 ZL_Report
 EI_bitpack_typed(ZL_Encoder* eictx, const ZL_Input* ins[], size_t nbIns)
 {
+    ZL_RESULT_DECLARE_SCOPE_REPORT(eictx);
     ZL_ASSERT_EQ(nbIns, 1);
     ZL_ASSERT_NN(ins);
     const ZL_Input* in = ins[0];
@@ -105,7 +106,7 @@ EI_bitpack_typed(ZL_Encoder* eictx, const ZL_Input* ins[], size_t nbIns)
     size_t const eltWidth = ZL_Input_eltWidth(in);
 
     // Check that eltWidth is one we support
-    ZL_RET_R_IF_ERR(checkEtlWidth(eltWidth));
+    ZL_ERR_IF_ERR(checkEtlWidth(eltWidth));
 
     int const nbBits = computeNbBits(in);
     ZL_ASSERT_EQ(ZS_bitpackEncodeVerify(src, nbElts, eltWidth, nbBits), 1);
@@ -113,7 +114,7 @@ EI_bitpack_typed(ZL_Encoder* eictx, const ZL_Input* ins[], size_t nbIns)
     size_t const dstCapacity = ZS_bitpackEncodeBound(nbElts, nbBits);
     ZL_Output* const out =
             ZL_Encoder_createTypedStream(eictx, 0, dstCapacity, 1);
-    ZL_RET_R_IF_NULL(allocation, out);
+    ZL_ERR_IF_NULL(out, allocation);
 
     uint8_t* const ostart = (uint8_t*)ZL_Output_ptr(out);
     size_t const dstSize  = ZS_bitpackEncode(
@@ -142,7 +143,7 @@ EI_bitpack_typed(ZL_Encoder* eictx, const ZL_Input* ins[], size_t nbIns)
         ZL_Encoder_sendCodecHeader(eictx, &header, 1);
     }
 
-    ZL_RET_R_IF_ERR(ZL_Output_commit(out, dstSize));
+    ZL_ERR_IF_ERR(ZL_Output_commit(out, dstSize));
     return ZL_returnValue(1);
 }
 

--- a/src/openzl/codecs/bitunpack/decode_bitunpack_binding.c
+++ b/src/openzl/codecs/bitunpack/decode_bitunpack_binding.c
@@ -11,6 +11,7 @@
 
 ZL_Report DI_bitunpack(ZL_Decoder* dictx, const ZL_Input* ins[])
 {
+    ZL_RESULT_DECLARE_SCOPE_REPORT(dictx);
     ZL_ASSERT_NN(dictx);
     ZL_ASSERT_NN(ins);
     const ZL_Input* const in = ins[0];
@@ -22,40 +23,40 @@ ZL_Report DI_bitunpack(ZL_Decoder* dictx, const ZL_Input* ins[])
     size_t nbElts   = ZL_Input_numElts(in);
 
     ZL_RBuffer const headerBuffer = ZL_Decoder_getCodecHeader(dictx);
-    ZL_RET_R_IF_LT(header_unknown, headerBuffer.size, 1);
-    ZL_RET_R_IF_GT(header_unknown, headerBuffer.size, 2);
+    ZL_ERR_IF_LT(headerBuffer.size, 1, header_unknown);
+    ZL_ERR_IF_GT(headerBuffer.size, 2, header_unknown);
     uint8_t const nbBits = *(uint8_t const*)headerBuffer.start;
-    ZL_RET_R_IF_GT(corruption, nbBits, 8 * eltWidth);
+    ZL_ERR_IF_GT(nbBits, 8 * eltWidth, corruption);
 
     size_t const dstSize = ZS_bitpackEncodeBound(nbElts, nbBits);
     ZL_Output* const dst = ZL_Decoder_create1OutStream(dictx, dstSize, 1);
-    ZL_RET_R_IF_NULL(allocation, dst);
+    ZL_ERR_IF_NULL(dst, allocation);
 
     void* dstBuffer = ZL_Output_ptr(dst);
     const size_t bytesWritten =
             ZS_bitpackEncode(dstBuffer, dstSize, src, nbElts, eltWidth, nbBits);
-    ZL_RET_R_IF_NE(GENERIC, bytesWritten, dstSize);
+    ZL_ERR_IF_NE(bytesWritten, dstSize, GENERIC);
 
     if (headerBuffer.size == 2) {
         // We have some leftover bits
         uint8_t remBits        = ((uint8_t const*)headerBuffer.start)[1];
         const size_t remNbBits = dstSize * 8 - nbElts * nbBits;
         ZL_ASSERT_LT(remNbBits, 8);
-        ZL_RET_R_IF_EQ(
-                corruption,
+        ZL_ERR_IF_EQ(
                 remNbBits,
                 0,
-                "remNbBits is zero although trailing bits are expected");
-        ZL_RET_R_IF_EQ(
                 corruption,
+                "remNbBits is zero although trailing bits are expected");
+        ZL_ERR_IF_EQ(
                 dstSize,
                 0,
+                corruption,
                 "dstSize is zero although trailing bits are expected");
         ((uint8_t*)dstBuffer)[dstSize - 1] |=
                 (uint8_t)(remBits << (8 - remNbBits));
     }
 
-    ZL_RET_R_IF_ERR(ZL_Output_commit(dst, dstSize));
+    ZL_ERR_IF_ERR(ZL_Output_commit(dst, dstSize));
 
     // Return the number of output streams.
     return ZL_returnValue(1);

--- a/src/openzl/codecs/bitunpack/encode_bitunpack_binding.c
+++ b/src/openzl/codecs/bitunpack/encode_bitunpack_binding.c
@@ -12,13 +12,13 @@
 
 static ZL_Report getNbBits(ZL_Encoder* eictx)
 {
+    ZL_RESULT_DECLARE_SCOPE_REPORT(eictx);
     ZL_IntParam const nbBits =
             ZL_Encoder_getLocalIntParam(eictx, ZL_Bitunpack_numBits);
     // Parameter **must** be set.
-    ZL_RET_R_IF_EQ(
-            nodeParameter_invalid, nbBits.paramId, ZL_LP_INVALID_PARAMID);
+    ZL_ERR_IF_EQ(nbBits.paramId, ZL_LP_INVALID_PARAMID, nodeParameter_invalid);
     if (nbBits.paramValue <= 0 || nbBits.paramValue > 64) {
-        ZL_RET_R_ERR(nodeParameter_invalidValue);
+        ZL_ERR(nodeParameter_invalidValue);
     }
     return ZL_returnValue((size_t)nbBits.paramValue);
 }
@@ -39,6 +39,7 @@ static size_t getEltWidth(const size_t nbBits)
 
 ZL_Report EI_bitunpack(ZL_Encoder* eictx, const ZL_Input* ins[], size_t nbIns)
 {
+    ZL_RESULT_DECLARE_SCOPE_REPORT(eictx);
     ZL_ASSERT_EQ(nbIns, 1);
     ZL_ASSERT_NN(ins);
     const ZL_Input* in = ins[0];
@@ -52,18 +53,18 @@ ZL_Report EI_bitunpack(ZL_Encoder* eictx, const ZL_Input* ins[], size_t nbIns)
     size_t const nbElts = srcSize * 8 / nbBits;
 
     // Make sure we fit well, and that remaining bits are zero
-    ZL_RET_R_IF_NE(GENERIC, (nbElts * nbBits + 7) / 8, srcSize);
+    ZL_ERR_IF_NE((nbElts * nbBits + 7) / 8, srcSize, GENERIC);
 
     size_t const eltWidth = getEltWidth(nbBits);
     ZL_Output* const out =
             ZL_Encoder_createTypedStream(eictx, 0, nbElts, eltWidth);
-    ZL_RET_R_IF_NULL(allocation, out);
+    ZL_ERR_IF_NULL(out, allocation);
 
     const size_t bytesRead = ZS_bitpackDecode(
             ZL_Output_ptr(out), nbElts, eltWidth, src, srcSize, (int)nbBits);
-    ZL_RET_R_IF_NE(logicError, bytesRead, srcSize);
+    ZL_ERR_IF_NE(bytesRead, srcSize, logicError);
 
-    ZL_RET_R_IF_ERR(ZL_Output_commit(out, nbElts));
+    ZL_ERR_IF_ERR(ZL_Output_commit(out, nbElts));
 
     // Header's structure:
     // Byte 1 - nbBits
@@ -81,9 +82,8 @@ ZL_Report EI_bitunpack(ZL_Encoder* eictx, const ZL_Input* ins[], size_t nbIns)
                 header[1] = remBits;
                 headerSize += 1;
             } else {
-                ZL_RET_R_ERR(
-                        GENERIC,
-                        "Bitunpack support non-zero trailing bits starting at format version 7");
+                ZL_ERR(GENERIC,
+                       "Bitunpack support non-zero trailing bits starting at format version 7");
             }
         }
     }

--- a/src/openzl/codecs/concat/decode_concat_binding.c
+++ b/src/openzl/codecs/concat/decode_concat_binding.c
@@ -15,14 +15,15 @@ ZL_Report DI_concat(
         const ZL_Input* variableSrcs[],
         size_t nbVariableSrcs)
 {
+    ZL_RESULT_DECLARE_SCOPE_REPORT(dictx);
     ZL_ASSERT_EQ(nbVariableSrcs, 0);
     (void)variableSrcs;
     ZL_ASSERT_EQ(nbCompulsorySrcs, 2);
     ZL_ASSERT_NN(compulsorySrcs);
     const ZL_Input* const sizes = compulsorySrcs[0];
     ZL_ASSERT_NN(sizes);
-    ZL_RET_R_IF_NE(corruption, ZL_Input_type(sizes), ZL_Type_numeric);
-    ZL_RET_R_IF_NE(corruption, ZL_Input_eltWidth(sizes), sizeof(uint32_t));
+    ZL_ERR_IF_NE(ZL_Input_type(sizes), ZL_Type_numeric, corruption);
+    ZL_ERR_IF_NE(ZL_Input_eltWidth(sizes), sizeof(uint32_t), corruption);
     const ZL_Input* const concatenated = compulsorySrcs[1];
     ZL_ASSERT_NN(concatenated);
 
@@ -30,45 +31,45 @@ ZL_Report DI_concat(
     size_t const eltWidth = ZL_Input_eltWidth(concatenated);
     size_t const nbElts   = ZL_Input_numElts(concatenated);
     const size_t nbRegens = ZL_Input_numElts(sizes);
-    ZL_RET_R_IF_EQ(corruption, nbRegens, 0);
+    ZL_ERR_IF_EQ(nbRegens, 0, corruption);
     const uint32_t* const regenSizes = ZL_Input_ptr(sizes);
 
     size_t rPos = 0;
-    ZL_RET_R_IF_LT(corruption, nbRegens, dictx->nbRegens);
+    ZL_ERR_IF_LT(nbRegens, dictx->nbRegens, corruption);
 
     if (type == ZL_Type_string) {
         const uint32_t* strLens = ZL_Input_stringLens(concatenated);
         size_t bytePos          = 0;
         for (size_t n = 0; n < nbRegens; n++) {
             size_t const rSize = regenSizes[n];
-            ZL_RET_R_IF_GT(corruption, rPos + rSize, nbElts);
+            ZL_ERR_IF_GT(rPos + rSize, nbElts, corruption);
             size_t byteSize = 0;
             for (size_t i = rPos; i < rPos + rSize; i++) {
                 byteSize += strLens[i];
             }
             ZL_Output* out = DI_outStream_asReference(
                     dictx, (int)n, concatenated, bytePos, 1, byteSize);
-            ZL_RET_R_IF_NULL(allocation, out);
+            ZL_ERR_IF_NULL(out, allocation);
             uint32_t* regenStrLens = ZL_Output_reserveStringLens(out, rSize);
             /* TODO(T220688634): This can be avoided if we have API to reference
              * string lengths*/
             ZL_memcpy(regenStrLens, strLens + rPos, rSize * sizeof(uint32_t));
-            ZL_RET_R_IF_ERR(ZL_Output_commit(out, rSize));
+            ZL_ERR_IF_ERR(ZL_Output_commit(out, rSize));
             rPos += rSize;
             bytePos += byteSize;
         }
-        ZL_RET_R_IF_NE(corruption, rPos, nbElts);
+        ZL_ERR_IF_NE(rPos, nbElts, corruption);
     } else {
         for (size_t n = 0; n < nbRegens; n++) {
             size_t const rSize = regenSizes[n];
-            ZL_RET_R_IF_GT(
-                    corruption, rPos + rSize * eltWidth, nbElts * eltWidth);
+            ZL_ERR_IF_GT(
+                    rPos + rSize * eltWidth, nbElts * eltWidth, corruption);
             ZL_Output* out = DI_outStream_asReference(
                     dictx, (int)n, concatenated, rPos, eltWidth, rSize);
-            ZL_RET_R_IF_NULL(allocation, out);
+            ZL_ERR_IF_NULL(out, allocation);
             rPos += rSize * eltWidth;
         }
-        ZL_RET_R_IF_NE(corruption, rPos, nbElts * eltWidth);
+        ZL_ERR_IF_NE(rPos, nbElts * eltWidth, corruption);
     }
 
     return ZL_returnSuccess();

--- a/src/openzl/codecs/concat/encode_concat_binding.c
+++ b/src/openzl/codecs/concat/encode_concat_binding.c
@@ -9,6 +9,7 @@
 
 ZL_Report EI_concat(ZL_Encoder* eictx, const ZL_Input* ins[], size_t nbIns)
 {
+    ZL_RESULT_DECLARE_SCOPE_REPORT(eictx);
     ZL_ASSERT_GE(nbIns, 1);
     ZL_ASSERT_NN(ins);
     size_t nbElts   = 0;
@@ -16,42 +17,41 @@ ZL_Report EI_concat(ZL_Encoder* eictx, const ZL_Input* ins[], size_t nbIns)
     size_t eltWidth = ZL_Input_eltWidth(ins[0]);
     for (size_t n = 0; n < nbIns; n++) {
         ZL_ASSERT_NN(ins[n]);
-        ZL_RET_R_IF_NE(
-                node_unexpected_input_type,
+        ZL_ERR_IF_NE(
                 ZL_Input_type(ins[n]),
                 type,
-                "Concat types must be homogenous");
-        ZL_RET_R_IF_NE(
                 node_unexpected_input_type,
+                "Concat types must be homogenous");
+        ZL_ERR_IF_NE(
                 ZL_Input_eltWidth(ins[n]),
                 eltWidth,
+                node_unexpected_input_type,
                 "Concat widths must be homogenous");
 
-        ZL_RET_R_IF_GE(
-                node_invalid_input, ZL_Input_numElts(ins[n]), UINT32_MAX);
-        ZL_RET_R_IF(
-                node_invalid_input,
-                ZL_overflowAddST(nbElts, ZL_Input_numElts(ins[n]), &nbElts));
+        ZL_ERR_IF_GE(ZL_Input_numElts(ins[n]), UINT32_MAX, node_invalid_input);
+        ZL_ERR_IF(
+                ZL_overflowAddST(nbElts, ZL_Input_numElts(ins[n]), &nbElts),
+                node_invalid_input);
     }
     size_t eltsCapacity = nbElts;
     if (type == ZL_Type_string) {
         eltWidth     = 1;
         eltsCapacity = 0;
         for (size_t n = 0; n < nbIns; n++) {
-            ZL_RET_R_IF(
-                    node_invalid_input,
+            ZL_ERR_IF(
                     ZL_overflowAddST(
                             eltsCapacity,
                             ZL_Input_contentSize(ins[n]),
-                            &eltsCapacity));
+                            &eltsCapacity),
+                    node_invalid_input);
         }
     }
 
     ZL_Output* const sizes = ZL_Encoder_createTypedStream(eictx, 0, nbIns, 4);
-    ZL_RET_R_IF_NULL(allocation, sizes);
+    ZL_ERR_IF_NULL(sizes, allocation);
     ZL_Output* const out =
             ZL_Encoder_createTypedStream(eictx, 1, eltsCapacity, eltWidth);
-    ZL_RET_R_IF_NULL(allocation, out);
+    ZL_ERR_IF_NULL(out, allocation);
 
     uint8_t* outPtr = (uint8_t*)ZL_Output_ptr(out);
     ZL_ASSERT_NN(outPtr);
@@ -90,7 +90,7 @@ ZL_Report EI_concat(ZL_Encoder* eictx, const ZL_Input* ins[], size_t nbIns)
     ZL_ASSERT_EQ(outPtr, outEnd);
     (void)outEnd;
 
-    ZL_RET_R_IF_ERR(ZL_Output_commit(out, nbElts));
-    ZL_RET_R_IF_ERR(ZL_Output_commit(sizes, nbIns));
+    ZL_ERR_IF_ERR(ZL_Output_commit(out, nbElts));
+    ZL_ERR_IF_ERR(ZL_Output_commit(sizes, nbIns));
     return ZL_returnSuccess();
 }

--- a/src/openzl/codecs/constant/decode_constant_binding.c
+++ b/src/openzl/codecs/constant/decode_constant_binding.c
@@ -9,6 +9,7 @@
 
 ZL_Report DI_constant_typed(ZL_Decoder* dictx, const ZL_Input* ins[])
 {
+    ZL_RESULT_DECLARE_SCOPE_REPORT(dictx);
     ZL_ASSERT_NN(dictx);
     ZL_ASSERT_NN(ins);
     const ZL_Input* const in = ins[0];
@@ -22,25 +23,25 @@ ZL_Report DI_constant_typed(ZL_Decoder* dictx, const ZL_Input* ins[])
     size_t const eltWidth    = ZL_Input_eltWidth(in);
     ZL_ASSERT_NN(src);
     ZL_ASSERT_GE(eltWidth, 1);
-    ZL_RET_R_IF_NE(corruption, nbElts, 1);
+    ZL_ERR_IF_NE(nbElts, 1, corruption);
 
     ZL_RBuffer const header = ZL_Decoder_getCodecHeader(dictx);
     uint8_t const* hdrStart = (uint8_t const*)header.start;
     uint8_t const* hdrEnd   = hdrStart + header.size;
     ZL_TRY_LET_T(uint64_t, dstNbElts, ZL_varintDecode(&hdrStart, hdrEnd));
-    ZL_RET_R_IF_NE(corruption, hdrStart, hdrEnd);
-    ZL_RET_R_IF_LT(corruption, dstNbElts, 1);
+    ZL_ERR_IF_NE(hdrStart, hdrEnd, corruption);
+    ZL_ERR_IF_LT(dstNbElts, 1, corruption);
 
     ZL_Output* const out =
             ZL_Decoder_create1OutStream(dictx, dstNbElts, eltWidth);
-    ZL_RET_R_IF_NULL(allocation, out);
+    ZL_ERR_IF_NULL(out, allocation);
     uint8_t* const outPtr = (uint8_t*)ZL_Output_ptr(out);
     ZL_ASSERT_NN(outPtr);
 
     size_t const bufferSize = (eltWidth <= 32) ? 32 : eltWidth;
     void* const eltBuffer   = ZL_Decoder_getScratchSpace(dictx, bufferSize);
-    ZL_RET_R_IF_NULL(allocation, eltBuffer);
+    ZL_ERR_IF_NULL(eltBuffer, allocation);
     ZS_decodeConstant(outPtr, dstNbElts, src, eltWidth, eltBuffer);
-    ZL_RET_R_IF_ERR(ZL_Output_commit(out, dstNbElts));
+    ZL_ERR_IF_ERR(ZL_Output_commit(out, dstNbElts));
     return ZL_returnSuccess();
 }

--- a/src/openzl/codecs/constant/encode_constant_binding.c
+++ b/src/openzl/codecs/constant/encode_constant_binding.c
@@ -12,6 +12,7 @@
 ZL_Report
 EI_constant_typed(ZL_Encoder* eictx, const ZL_Input* ins[], size_t nbIns)
 {
+    ZL_RESULT_DECLARE_SCOPE_REPORT(eictx);
     ZL_ASSERT_EQ(nbIns, 1);
     ZL_ASSERT_NN(ins);
     const ZL_Input* in = ins[0];
@@ -24,13 +25,13 @@ EI_constant_typed(ZL_Encoder* eictx, const ZL_Input* ins[], size_t nbIns)
     const uint8_t* const src = ZL_Input_ptr(in);
     size_t const nbElts      = ZL_Input_numElts(in);
     size_t const eltWidth    = ZL_Input_eltWidth(in);
-    ZL_RET_R_IF_LT(srcSize_tooSmall, nbElts, 1);
+    ZL_ERR_IF_LT(nbElts, 1, srcSize_tooSmall);
     ZL_ASSERT_GE(eltWidth, 1);
-    ZL_RET_R_IF_EQ(
-            node_invalid_input, ZS_isConstantStream(src, nbElts, eltWidth), 0);
+    ZL_ERR_IF_EQ(
+            ZS_isConstantStream(src, nbElts, eltWidth), 0, node_invalid_input);
 
     ZL_Output* const out = ZL_Encoder_createTypedStream(eictx, 0, 1, eltWidth);
-    ZL_RET_R_IF_NULL(allocation, out);
+    ZL_ERR_IF_NULL(out, allocation);
     uint8_t* const outPtr = (uint8_t*)ZL_Output_ptr(out);
     ZL_ASSERT_NN(outPtr);
 
@@ -39,6 +40,6 @@ EI_constant_typed(ZL_Encoder* eictx, const ZL_Input* ins[], size_t nbIns)
     ZL_Encoder_sendCodecHeader(eictx, header, varintSize);
 
     ZS_encodeConstant(outPtr, src, eltWidth);
-    ZL_RET_R_IF_ERR(ZL_Output_commit(out, 1));
+    ZL_ERR_IF_ERR(ZL_Output_commit(out, 1));
     return ZL_returnSuccess();
 }

--- a/src/openzl/codecs/conversion/decode_conversion_binding.c
+++ b/src/openzl/codecs/conversion/decode_conversion_binding.c
@@ -81,18 +81,19 @@ ZL_Report DI_revert_num_to_serial_le(ZL_Decoder* di, const ZL_Input* ins[])
             ZL_Type_serial); // should already be validated by the graph
                              // engine
 
+    ZL_RESULT_DECLARE_SCOPE_REPORT(di);
     ZL_RBuffer const header = ZL_Decoder_getCodecHeader(di);
-    ZL_RET_R_IF_NE(header_unknown, header.size, 1, "Invalid transform header!");
+    ZL_ERR_IF_NE(header.size, 1, header_unknown, "Invalid transform header!");
     size_t const intSize = (size_t)1 << (((const uint8_t*)header.start)[0]);
-    ZL_RET_R_IF(
-            header_unknown,
+    ZL_ERR_IF(
             !(intSize == 1 || intSize == 2 || intSize == 4 || intSize == 8),
+            header_unknown,
             "header contains bad integer width");
     size_t const nbBytes = ZL_Input_contentSize(in);
-    ZL_RET_R_IF_NE(
-            corruption,
+    ZL_ERR_IF_NE(
             nbBytes % intSize,
             0,
+            corruption,
             "stream size must be a multiple of the integer size");
     size_t const nbInts = nbBytes / intSize;
 
@@ -104,14 +105,14 @@ ZL_Report DI_revert_num_to_serial_le(ZL_Decoder* di, const ZL_Input* ins[])
     if (MEM_isAlignedForNumericWidth(ZL_Input_ptr(in), intSize)) {
         ZL_Output* const out =
                 DI_reference1OutStream(di, in, 0, intSize, nbInts);
-        ZL_RET_R_IF_NULL(allocation, out);
+        ZL_ERR_IF_NULL(out, allocation);
     } else {
         // Not aligned : create new stream, copy into it
         ZL_Output* const out = ZL_Decoder_create1OutStream(di, nbInts, intSize);
-        ZL_RET_R_IF_NULL(allocation, out);
+        ZL_ERR_IF_NULL(out, allocation);
         ZL_ASSERT(MEM_isAlignedForNumericWidth(ZL_Output_ptr(out), intSize));
         size_t const byteSize = ZL_Input_contentSize(in);
-        ZL_RET_R_IF_ERR(STREAM_copyBytes(
+        ZL_ERR_IF_ERR(STREAM_copyBytes(
                 ZL_codemodOutputAsData(out),
                 ZL_codemodInputAsData(in),
                 byteSize));
@@ -123,13 +124,14 @@ ZL_Report DI_revert_num_to_serial_le(ZL_Decoder* di, const ZL_Input* ins[])
 // Effectively, token(anylength) => serial
 ZL_Report DI_revert_serial_to_struct(ZL_Decoder* di, const ZL_Input* ins[])
 {
+    ZL_RESULT_DECLARE_SCOPE_REPORT(di);
     ZL_ASSERT_NN(di);
     ZL_ASSERT_NN(ins);
     const ZL_Input* const in = ins[0];
 
     ZL_Output* const out =
             DI_reference1OutStream(di, in, 0, 1, ZL_Input_contentSize(in));
-    ZL_RET_R_IF_NULL(allocation, out);
+    ZL_ERR_IF_NULL(out, allocation);
 
     return ZL_returnValue(1);
 }
@@ -138,6 +140,7 @@ ZL_Report DI_revert_serial_to_struct(ZL_Decoder* di, const ZL_Input* ins[])
 // Effectively, serial => token
 ZL_Report DI_revert_struct_to_serial(ZL_Decoder* di, const ZL_Input* ins[])
 {
+    ZL_RESULT_DECLARE_SCOPE_REPORT(di);
     ZL_ASSERT_NN(di);
     ZL_ASSERT_NN(ins);
     const ZL_Input* const in = ins[0];
@@ -152,24 +155,24 @@ ZL_Report DI_revert_struct_to_serial(ZL_Decoder* di, const ZL_Input* ins[])
     const uint8_t* ptr      = header.start;
     ZL_RESULT_OF(uint64_t)
     const r = ZL_varintDecode(&ptr, ptr + header.size);
-    ZL_RET_R_IF(srcSize_tooSmall, ZL_RES_isError(r));
+    ZL_ERR_IF(ZL_RES_isError(r), srcSize_tooSmall);
     uint64_t const eltSize = ZL_RES_value(r);
-    ZL_RET_R_IF_EQ(header_unknown, eltSize, 0, "eltSize must not be 0");
-    ZL_RET_R_IF_NE(
-            header_unknown,
+    ZL_ERR_IF_EQ(eltSize, 0, header_unknown, "eltSize must not be 0");
+    ZL_ERR_IF_NE(
             MEM_ptrDistance(header.start, ptr),
             header.size,
+            header_unknown,
             "Header size wrong");
     size_t const nbBytes = ZL_Input_contentSize(in);
-    ZL_RET_R_IF_NE(
-            corruption,
+    ZL_ERR_IF_NE(
             nbBytes % eltSize,
             0,
+            corruption,
             "stream size must be a multiple of the token size");
     size_t const nbTokens = nbBytes / eltSize;
 
     ZL_Output* const out = DI_reference1OutStream(di, in, 0, eltSize, nbTokens);
-    ZL_RET_R_IF_NULL(allocation, out);
+    ZL_ERR_IF_NULL(out, allocation);
 
     return ZL_returnValue(1);
 }
@@ -189,6 +192,7 @@ ZL_Report DI_revert_struct_to_num_be(ZL_Decoder* di, const ZL_Input* ins[])
 // Effectively, token => int
 ZL_Report DI_revert_num_to_struct_le(ZL_Decoder* di, const ZL_Input* ins[])
 {
+    ZL_RESULT_DECLARE_SCOPE_REPORT(di);
     // TODO (@Cyan): support for big-endian systems,
     //               requires a swap operation
     ZL_REQUIRE(
@@ -203,22 +207,22 @@ ZL_Report DI_revert_num_to_struct_le(ZL_Decoder* di, const ZL_Input* ins[])
                              // engine
     size_t const eltWidth = ZL_Input_eltWidth(in);
     if (!(eltWidth == 1 || eltWidth == 2 || eltWidth == 4 || eltWidth == 8)) {
-        ZL_RET_R_ERR(streamParameter_invalid);
+        ZL_ERR(streamParameter_invalid);
     }
     size_t const nbElts = ZL_Input_numElts(in);
 
     if (MEM_isAlignedForNumericWidth(ZL_Input_ptr(in), eltWidth)) {
         ZL_Output* const out =
                 DI_reference1OutStream(di, in, 0, eltWidth, nbElts);
-        ZL_RET_R_IF_NULL(allocation, out);
+        ZL_ERR_IF_NULL(out, allocation);
     } else {
         // Not aligned : create new stream, copy into it
         ZL_Output* const out =
                 ZL_Decoder_create1OutStream(di, nbElts, eltWidth);
-        ZL_RET_R_IF_NULL(allocation, out);
+        ZL_ERR_IF_NULL(out, allocation);
         ZL_ASSERT(MEM_isAlignedForNumericWidth(ZL_Output_ptr(out), eltWidth));
         size_t const byteSize = ZL_Input_contentSize(in);
-        ZL_RET_R_IF_ERR(STREAM_copyBytes(
+        ZL_ERR_IF_ERR(STREAM_copyBytes(
                 ZL_codemodOutputAsData(out),
                 ZL_codemodInputAsData(in),
                 byteSize));
@@ -229,6 +233,7 @@ ZL_Report DI_revert_num_to_struct_le(ZL_Decoder* di, const ZL_Input* ins[])
 
 ZL_Report DI_revert_VSF_separation(ZL_Decoder* dictx, const ZL_Input* ins[])
 {
+    ZL_RESULT_DECLARE_SCOPE_REPORT(dictx);
     ZL_ASSERT_NN(ins);
     const ZL_Input* const concatFields = ins[0];
     ZL_ASSERT_NN(concatFields);
@@ -240,14 +245,14 @@ ZL_Report DI_revert_VSF_separation(ZL_Decoder* dictx, const ZL_Input* ins[])
 
     ZL_Output* const vsfRegen =
             DI_reference1OutStream(dictx, concatFields, 0, 1, contentSize);
-    ZL_RET_R_IF_NULL(allocation, vsfRegen);
+    ZL_ERR_IF_NULL(vsfRegen, allocation);
 
     const size_t nbFields = ZL_Input_numElts(fieldSizes);
     // Note : allocation to be changed for local workspace when available
     uint32_t* const arr32 = ZL_Output_reserveStringLens(vsfRegen, nbFields);
-    ZL_RET_R_IF_NULL(allocation, arr32);
+    ZL_ERR_IF_NULL(arr32, allocation);
 
-    ZL_RET_R_IF_ERR(NUMOP_write32_fromNumerics(
+    ZL_ERR_IF_ERR(NUMOP_write32_fromNumerics(
             arr32,
             nbFields,
             ZL_Input_ptr(fieldSizes),
@@ -258,13 +263,13 @@ ZL_Report DI_revert_VSF_separation(ZL_Decoder* dictx, const ZL_Input* ins[])
             "Calculating totalSize=%llu, as sum of arr32 of %zu elts",
             totalSize,
             nbFields);
-    ZL_RET_R_IF_NE(
-            corruption,
+    ZL_ERR_IF_NE(
             totalSize,
             (uint64_t)contentSize,
+            corruption,
             "Incorrect sum of field sizes");
 
-    ZL_RET_R_IF_ERR(ZL_Output_commit(vsfRegen, nbFields));
+    ZL_ERR_IF_ERR(ZL_Output_commit(vsfRegen, nbFields));
     ZL_DLOG(SEQ,
             "Produced Stream: Type:%u, nbStrings:%u, eltWidth=%u",
             ZL_Output_type(vsfRegen),
@@ -278,6 +283,7 @@ ZL_Report DI_extract_concatenatedFields(
         ZL_Decoder* dictx,
         const ZL_Input* ins[])
 {
+    ZL_RESULT_DECLARE_SCOPE_REPORT(dictx);
     ZL_ASSERT_NN(ins);
     const ZL_Input* const inVSF = ins[0];
     ZL_ASSERT_NN(inVSF);
@@ -285,6 +291,6 @@ ZL_Report DI_extract_concatenatedFields(
 
     ZL_Output* const serialExtract = DI_reference1OutStream(
             dictx, inVSF, 0, 1, ZL_Input_contentSize(inVSF));
-    ZL_RET_R_IF_NULL(allocation, serialExtract);
+    ZL_ERR_IF_NULL(serialExtract, allocation);
     return ZL_returnValue(1);
 }

--- a/src/openzl/codecs/conversion/encode_conversion_binding.c
+++ b/src/openzl/codecs/conversion/encode_conversion_binding.c
@@ -144,16 +144,17 @@ static ZL_Report EI_convert_serial_to_struct_generic(
         const ZL_Input* in,
         size_t tokenWidth)
 {
+    ZL_RESULT_DECLARE_SCOPE_REPORT(eictx);
     ZL_ASSERT_NN(eictx);
     ZL_ASSERT_NN(in);
     size_t const inByteSize = ZL_Input_contentSize(in);
     if (inByteSize % tokenWidth) {
-        ZL_RET_R_ERR(streamParameter_invalid); // Not a clean multiple
+        ZL_ERR(streamParameter_invalid); // Not a clean multiple
     }
     size_t const nbTokens = inByteSize / tokenWidth;
-    ZL_RET_R_IF_NULL(
-            allocation,
-            ENC_refTypedStream(eictx, 0, tokenWidth, nbTokens, in, 0));
+    ZL_ERR_IF_NULL(
+            ENC_refTypedStream(eictx, 0, tokenWidth, nbTokens, in, 0),
+            allocation);
     return ZL_returnValue(1);
 }
 
@@ -162,6 +163,7 @@ ZL_Report EI_convert_serial_to_struct(
         const ZL_Input* ins[],
         size_t nbIns)
 {
+    ZL_RESULT_DECLARE_SCOPE_REPORT(eictx);
     ZL_ASSERT_EQ(nbIns, 1);
     ZL_ASSERT_NN(ins);
     const ZL_Input* in = ins[0];
@@ -169,9 +171,9 @@ ZL_Report EI_convert_serial_to_struct(
     ZL_IntParam const tokenSize =
             ZL_Encoder_getLocalIntParam(eictx, ZL_trlip_tokenSize);
     // Parameter **must** be set.
-    ZL_RET_R_IF_EQ(
-            nodeParameter_invalid, tokenSize.paramId, ZL_LP_INVALID_PARAMID);
-    ZL_RET_R_IF_LE(nodeParameter_invalidValue, tokenSize.paramValue, 0);
+    ZL_ERR_IF_EQ(
+            tokenSize.paramId, ZL_LP_INVALID_PARAMID, nodeParameter_invalid);
+    ZL_ERR_IF_LE(tokenSize.paramValue, 0, nodeParameter_invalidValue);
     return EI_convert_serial_to_struct_generic(
             eictx, in, (size_t)tokenSize.paramValue);
 }
@@ -207,6 +209,7 @@ ZL_Report EI_convert_num_to_struct_le(
         const ZL_Input* ins[],
         size_t nbIns)
 {
+    ZL_RESULT_DECLARE_SCOPE_REPORT(eictx);
     ZL_ASSERT_EQ(nbIns, 1);
     ZL_ASSERT_NN(ins);
     const ZL_Input* in = ins[0];
@@ -219,22 +222,23 @@ ZL_Report EI_convert_num_to_struct_le(
     size_t const eltWidth = ZL_Input_eltWidth(in);
     ZL_ASSERT_GT(eltWidth, 0);
     size_t const nbElts = ZL_Input_numElts(in);
-    ZL_RET_R_IF_NULL(
-            allocation, ENC_refTypedStream(eictx, 0, eltWidth, nbElts, in, 0));
+    ZL_ERR_IF_NULL(
+            ENC_refTypedStream(eictx, 0, eltWidth, nbElts, in, 0), allocation);
     return ZL_returnValue(1);
 }
 
 static ZL_Report
 EI_convert_to_serial(ZL_Encoder* eictx, const ZL_Input* ins[], size_t nbIns)
 {
+    ZL_RESULT_DECLARE_SCOPE_REPORT(eictx);
     ZL_ASSERT_EQ(nbIns, 1);
     ZL_ASSERT_NN(ins);
     const ZL_Input* in = ins[0];
     ZL_ASSERT_NN(in);
     size_t const byteSize = ZL_Input_contentSize(in);
     ZL_ASSERT_NN(eictx);
-    ZL_RET_R_IF_NULL(
-            allocation, ENC_refTypedStream(eictx, 0, 1, byteSize, in, 0));
+    ZL_ERR_IF_NULL(
+            ENC_refTypedStream(eictx, 0, 1, byteSize, in, 0), allocation);
     return ZL_returnValue(1);
 }
 
@@ -286,21 +290,22 @@ ZL_Report EI_separate_VSF_components(
         const ZL_Input* ins[],
         size_t nbIns)
 {
+    ZL_RESULT_DECLARE_SCOPE_REPORT(eictx);
     ZL_ASSERT_EQ(nbIns, 1);
     ZL_ASSERT_NN(ins);
     const ZL_Input* in = ins[0];
     ZL_ASSERT_NN(eictx);
     ZL_ASSERT_EQ(ZL_Input_type(in), ZL_Type_string);
-    ZL_RET_R_IF_ERR(EI_convert_to_serial(eictx, ins, nbIns));
+    ZL_ERR_IF_ERR(EI_convert_to_serial(eictx, ins, nbIns));
     const uint32_t* fieldSizes = ZL_Input_stringLens(in);
     const size_t nbFields      = ZL_Input_numElts(in);
     size_t const numWidth = NUMOP_numericWidthForArray32(fieldSizes, nbFields);
     ZL_Output* const sizeStream =
             ZL_Encoder_createTypedStream(eictx, 1, nbFields, numWidth);
-    ZL_RET_R_IF_NULL(allocation, sizeStream);
+    ZL_ERR_IF_NULL(sizeStream, allocation);
     void* const dst = ZL_Output_ptr(sizeStream);
     NUMOP_writeNumerics_fromU32(dst, numWidth, fieldSizes, nbFields);
-    ZL_RET_R_IF_ERR(ZL_Output_commit(sizeStream, nbFields));
+    ZL_ERR_IF_ERR(ZL_Output_commit(sizeStream, nbFields));
     return ZL_returnValue(2);
 }
 

--- a/src/openzl/codecs/conversion/encode_setStringSizes_binding.c
+++ b/src/openzl/codecs/conversion/encode_setStringSizes_binding.c
@@ -68,6 +68,7 @@ static ZL_SetStringLensInstructions getStringLens(
 ZL_Report
 EI_setStringLens(ZL_Encoder* eictx, const ZL_Input* ins[], size_t nbIns)
 {
+    ZL_RESULT_DECLARE_SCOPE_REPORT(eictx);
     ZL_ASSERT_EQ(nbIns, 1);
     ZL_ASSERT_NN(ins);
     const ZL_Input* in = ins[0];
@@ -81,7 +82,7 @@ EI_setStringLens(ZL_Encoder* eictx, const ZL_Input* ins[], size_t nbIns)
     const size_t nbStrings            = sfsi.nbStrings;
     const uint32_t* const stringLens  = sfsi.stringLens;
 
-    ZL_RET_R_IF(nodeParameter_invalid, nbStrings && stringLens == NULL);
+    ZL_ERR_IF(nbStrings && stringLens == NULL, nodeParameter_invalid);
 
     ZL_DLOG(BLOCK,
             "EI_setStringLens: converting %zu bytes into %zu strings",
@@ -90,21 +91,21 @@ EI_setStringLens(ZL_Encoder* eictx, const ZL_Input* ins[], size_t nbIns)
 
     // Here : check parser's output
     uint64_t const parserTotalSize = NUMOP_sumArray32(stringLens, nbStrings);
-    ZL_RET_R_IF_NE(
-            nodeParameter_invalidValue,
+    ZL_ERR_IF_NE(
             parserTotalSize,
             (uint64_t)inputSize,
+            nodeParameter_invalidValue,
             "EI_setStringLens: the external parser provides invalid total size");
 
     ZL_Output* const out = ENC_refTypedStream(eictx, 0, 1, inputSize, in, 0);
-    ZL_RET_R_IF_NULL(allocation, out);
+    ZL_ERR_IF_NULL(out, allocation);
 
     uint32_t* const fs = ZL_Output_reserveStringLens(out, nbStrings);
-    ZL_RET_R_IF_NULL(allocation, fs);
+    ZL_ERR_IF_NULL(fs, allocation);
 
     ZL_memcpy(fs, stringLens, nbStrings * sizeof(uint32_t));
 
-    ZL_RET_R_IF_ERR(ZL_Output_commit(out, nbStrings));
+    ZL_ERR_IF_ERR(ZL_Output_commit(out, nbStrings));
 
     return ZL_returnSuccess();
 }

--- a/src/openzl/codecs/dedup/decode_dedup_binding.c
+++ b/src/openzl/codecs/dedup/decode_dedup_binding.c
@@ -14,6 +14,7 @@ ZL_Report DI_dedup_num(
         const ZL_Input* variableSrcs[],
         size_t nbVariableSrcs)
 {
+    ZL_RESULT_DECLARE_SCOPE_REPORT(dictx);
     ZL_ASSERT_EQ(nbVariableSrcs, 0);
     (void)variableSrcs;
     ZL_ASSERT_EQ(nbCompulsorySrcs, 1);
@@ -30,7 +31,7 @@ ZL_Report DI_dedup_num(
     for (size_t n = 0; n < nbRegens; n++) {
         ZL_Output* const out = DI_outStream_asReference(
                 dictx, (int)n, numSrc, 0, eltWidth, eltCount);
-        ZL_RET_R_IF_NULL(allocation, out);
+        ZL_ERR_IF_NULL(out, allocation);
     }
     return ZL_returnSuccess();
 }

--- a/src/openzl/codecs/dedup/encode_dedup_binding.c
+++ b/src/openzl/codecs/dedup/encode_dedup_binding.c
@@ -14,6 +14,7 @@ static ZL_Report EI_dedup_num_internal(
         size_t nbIns,
         int inputsIdentical)
 {
+    ZL_RESULT_DECLARE_SCOPE_REPORT(eictx);
     // Input sanitization
     ZL_ASSERT_GE(nbIns, 1);
     ZL_ASSERT_NN(ins);
@@ -37,19 +38,19 @@ static ZL_Report EI_dedup_num_internal(
                     0);
         } else {
             // Actively check that inputs are indeed all identical
-            ZL_RET_R_IF_NE(
-                    node_invalid_input, ZL_Input_eltWidth(ins[n]), eltWidth);
-            ZL_RET_R_IF_NE(
-                    node_invalid_input, ZL_Input_numElts(ins[n]), eltCount);
+            ZL_ERR_IF_NE(
+                    ZL_Input_eltWidth(ins[n]), eltWidth, node_invalid_input);
+            ZL_ERR_IF_NE(
+                    ZL_Input_numElts(ins[n]), eltCount, node_invalid_input);
             int const isDifferent = memcmp(
                     ZL_Input_ptr(ins[n]), ZL_Input_ptr(ins[0]), totalSize);
-            ZL_RET_R_IF(node_invalid_input, isDifferent);
+            ZL_ERR_IF(isDifferent, node_invalid_input);
         }
     }
 
     ZL_Output* const out =
             ENC_refTypedStream(eictx, 0, eltWidth, eltCount, ins[0], 0);
-    ZL_RET_R_IF_NULL(allocation, out);
+    ZL_ERR_IF_NULL(out, allocation);
 
     return ZL_returnSuccess();
 }

--- a/src/openzl/codecs/delta/decode_delta_binding.c
+++ b/src/openzl/codecs/delta/decode_delta_binding.c
@@ -9,6 +9,7 @@
 // This variant is compatible with any allowed integer width
 ZL_Report DI_delta_int(ZL_Decoder* dictx, const ZL_Input* ins[])
 {
+    ZL_RESULT_DECLARE_SCOPE_REPORT(dictx);
     ZL_ASSERT_NN(dictx);
     ZL_ASSERT_NN(ins);
     const ZL_Input* const in = ins[0];
@@ -32,10 +33,10 @@ ZL_Report DI_delta_int(ZL_Decoder* dictx, const ZL_Input* ins[])
         // New variant: First element is written into the transform header.
         ZL_RBuffer const header = ZL_Decoder_getCodecHeader(dictx);
         if (header.size != 0) {
-            ZL_RET_R_IF_NE(
-                    corruption,
+            ZL_ERR_IF_NE(
                     header.size,
                     intWidth,
+                    corruption,
                     "Header must be a single int");
             first  = header.start;
             deltas = ZL_Input_ptr(in);
@@ -43,20 +44,20 @@ ZL_Report DI_delta_int(ZL_Decoder* dictx, const ZL_Input* ins[])
         } else {
             // Special case: If the transform header is empty, then we must have
             // nbDeltas == 0, and then nbInts == 0.
-            ZL_RET_R_IF_NE(
-                    corruption,
+            ZL_ERR_IF_NE(
                     nbDeltas,
                     0,
+                    corruption,
                     "Empty header but non-empty deltas");
         }
     }
 
     ZL_Output* const out = ZL_Decoder_create1OutStream(dictx, nbInts, intWidth);
-    ZL_RET_R_IF_NULL(allocation, out);
+    ZL_ERR_IF_NULL(out, allocation);
 
     // Note : proper alignment is guaranteed by graph engine
     ZS_deltaDecode(ZL_Output_ptr(out), first, deltas, nbInts, intWidth);
 
-    ZL_RET_R_IF_ERR(ZL_Output_commit(out, nbInts));
+    ZL_ERR_IF_ERR(ZL_Output_commit(out, nbInts));
     return ZL_returnValue(1);
 }

--- a/src/openzl/codecs/delta/encode_delta_binding.c
+++ b/src/openzl/codecs/delta/encode_delta_binding.c
@@ -10,6 +10,7 @@
 // This variant is compatible with any allowed integer width
 ZL_Report EI_delta_int(ZL_Encoder* eictx, const ZL_Input* ins[], size_t nbIns)
 {
+    ZL_RESULT_DECLARE_SCOPE_REPORT(eictx);
     ZL_ASSERT_NN(eictx);
     ZL_ASSERT_EQ(nbIns, 1);
     ZL_ASSERT_NN(ins);
@@ -21,17 +22,17 @@ ZL_Report EI_delta_int(ZL_Encoder* eictx, const ZL_Input* ins[], size_t nbIns)
     size_t const nbInts = ZL_Input_numElts(in);
     ZL_Output* const out =
             ZL_Encoder_createTypedStream(eictx, 0, nbInts, intWidth);
-    ZL_RET_R_IF_NULL(allocation, out);
+    ZL_ERR_IF_NULL(out, allocation);
     const void* src = ZL_Input_ptr(in);
     // Note : proper alignment is guaranteed by graph engine
     void* dst = ZL_Output_ptr(out);
     if (nbInts == 0) {
         // Special case: Zero ints behaves the same for both variants.
-        ZL_RET_R_IF_ERR(ZL_Output_commit(out, 0));
+        ZL_ERR_IF_ERR(ZL_Output_commit(out, 0));
     } else if (ZL_Encoder_getCParam(eictx, ZL_CParam_formatVersion) < 13) {
         // Old variant: Write the first element to the first value in the stream
         ZS_deltaEncode(dst, (char*)dst + intWidth, src, nbInts, intWidth);
-        ZL_RET_R_IF_ERR(ZL_Output_commit(out, nbInts));
+        ZL_ERR_IF_ERR(ZL_Output_commit(out, nbInts));
     } else {
         // New variant: Write the first element to the stream header
         uint8_t header[8];
@@ -39,7 +40,7 @@ ZL_Report EI_delta_int(ZL_Encoder* eictx, const ZL_Input* ins[], size_t nbIns)
         ZL_ASSERT_LE(intWidth, sizeof(header));
         ZS_deltaEncode(header, dst, src, nbInts, intWidth);
         ZL_Encoder_sendCodecHeader(eictx, header, intWidth);
-        ZL_RET_R_IF_ERR(ZL_Output_commit(out, nbInts - 1));
+        ZL_ERR_IF_ERR(ZL_Output_commit(out, nbInts - 1));
     }
     return ZL_returnValue(1);
 }

--- a/src/openzl/codecs/dispatchN_byTag/decode_dispatchN_byTag_binding.c
+++ b/src/openzl/codecs/dispatchN_byTag/decode_dispatchN_byTag_binding.c
@@ -23,6 +23,7 @@ ZL_Report DI_dispatchN_byTag(
         const ZL_Input* inVariable[],
         size_t nbInVariable)
 {
+    ZL_RESULT_DECLARE_SCOPE_REPORT(dictx);
     ZL_DLOG(BLOCK, "DI_dispatchN_byTag (%zu inputs to join)", nbInVariable);
     ZL_ASSERT_NN(dictx);
     ZL_ASSERT_EQ(nbInFixed, 2);
@@ -37,26 +38,25 @@ ZL_Report DI_dispatchN_byTag(
     const ZL_Input* tags     = inFixed[dnbt_tags];
     const ZL_Input* segSizes = inFixed[dnbt_segSizes];
     size_t const nbSegments  = ZL_Input_numElts(segSizes);
-    ZL_RET_R_IF_NE(corruption, ZL_Input_numElts(tags), nbSegments);
+    ZL_ERR_IF_NE(ZL_Input_numElts(tags), nbSegments, corruption);
 
     if (DI_getFrameFormatVersion(dictx) < 20) {
-        ZL_RET_R_IF_GE(temporaryLibraryLimitation, nbInVariable, 256);
-        ZL_RET_R_IF_GT(temporaryLibraryLimitation, ZL_Input_eltWidth(tags), 1);
+        ZL_ERR_IF_GE(nbInVariable, 256, temporaryLibraryLimitation);
+        ZL_ERR_IF_GT(ZL_Input_eltWidth(tags), 1, temporaryLibraryLimitation);
     } else {
-        ZL_RET_R_IF_GE(temporaryLibraryLimitation, nbInVariable, 1 << 16);
-        ZL_RET_R_IF_GT(temporaryLibraryLimitation, ZL_Input_eltWidth(tags), 2);
+        ZL_ERR_IF_GE(nbInVariable, 1 << 16, temporaryLibraryLimitation);
+        ZL_ERR_IF_GT(ZL_Input_eltWidth(tags), 2, temporaryLibraryLimitation);
     }
 
     size_t total = 0;
     for (size_t n = 0; n < nbInVariable; n++) {
         // Must be validated
         ZL_ASSERT_NN(inVariable[n]);
-        ZL_RET_R_IF_NE(
-                corruption, ZL_Input_type(inVariable[n]), ZL_Type_serial);
+        ZL_ERR_IF_NE(ZL_Input_type(inVariable[n]), ZL_Type_serial, corruption);
         total += ZL_Input_numElts(inVariable[n]);
     }
     ZL_Output* const out = ZL_Decoder_create1OutStream(dictx, total, 1);
-    ZL_RET_R_IF_NULL(allocation, out);
+    ZL_ERR_IF_NULL(out, allocation);
 
     // Note : reserving scratch buffers should be a property offered by DICtx*.
     // Currently it doesn't exist, so allocate directly instead.
@@ -74,7 +74,7 @@ ZL_Report DI_dispatchN_byTag(
             ZL_Decoder_getScratchSpace(dictx, sizeof(*bufIndex) * nbSegments);
 
     if (!srcs || !srcSizes || !segmentSizes || !bufIndex) {
-        ZL_RET_R_ERR(allocation);
+        ZL_ERR(allocation);
     }
 
     /* prepare arrays for raw transform */
@@ -98,9 +98,8 @@ ZL_Report DI_dispatchN_byTag(
 
     /* Check validity of tags */
     if (!NUMOP_underLimitU16(bufIndex, nbSegments, (unsigned)nbInVariable)) {
-        ZL_RET_R_ERR(
-                corruption,
-                "vector of tags incorrect : some value(s) > nb srcs");
+        ZL_ERR(corruption,
+               "vector of tags incorrect : some value(s) > nb srcs");
     }
 
     /* Check validity of segment sizes */
@@ -109,10 +108,9 @@ ZL_Report DI_dispatchN_byTag(
     }
     for (size_t n = 0; n < nbInVariable; n++) {
         if (srcSizes[n] != ZL_Input_numElts(inVariable[n])) {
-            ZL_RET_R_ERR(
-                    corruption,
-                    "segment sizes incorrect : invalid total size for stream %zu",
-                    n);
+            ZL_ERR(corruption,
+                   "segment sizes incorrect : invalid total size for stream %zu",
+                   n);
         }
     }
 
@@ -127,7 +125,7 @@ ZL_Report DI_dispatchN_byTag(
 
     ZL_ASSERT_EQ(r, total);
 
-    ZL_RET_R_IF_ERR(ZL_Output_commit(out, total));
+    ZL_ERR_IF_ERR(ZL_Output_commit(out, total));
 
     return ZL_returnSuccess();
 }

--- a/src/openzl/codecs/dispatchN_byTag/encode_dispatchN_byTag_binding.c
+++ b/src/openzl/codecs/dispatchN_byTag/encode_dispatchN_byTag_binding.c
@@ -106,6 +106,7 @@ static ZL_RESULT_OF(ZL_DispatchInstructions)
 ZL_Report
 EI_dispatchN_byTag(ZL_Encoder* eictx, const ZL_Input* ins[], size_t nbIns)
 {
+    ZL_RESULT_DECLARE_SCOPE_REPORT(eictx);
     ZL_ASSERT_EQ(nbIns, 1);
     ZL_ASSERT_NN(ins);
     const ZL_Input* in = ins[0];
@@ -128,26 +129,26 @@ EI_dispatchN_byTag(ZL_Encoder* eictx, const ZL_Input* ins[], size_t nbIns)
             NUMOP_findMaxST(si.segmentSizes, si.nbSegments);
     // Must check too see if any are too large to guard against overflow
     if (ZL_Encoder_getCParam(eictx, ZL_CParam_formatVersion) < 20) {
-        ZL_RET_R_IF_GE(temporaryLibraryLimitation, si.nbTags, 256);
+        ZL_ERR_IF_GE(si.nbTags, 256, temporaryLibraryLimitation);
     } else {
-        ZL_RET_R_IF_GE(temporaryLibraryLimitation, si.nbTags, 1 << 16);
+        ZL_ERR_IF_GE(si.nbTags, 1 << 16, temporaryLibraryLimitation);
     }
-    ZL_RET_R_IF_GT(
-            nodeParameter_invalidValue,
+    ZL_ERR_IF_GT(
             maxSegmentSize,
             inputSize,
+            nodeParameter_invalidValue,
             "EI_dispatchN_byTag: One of the segment sizes is bigger than the input size");
     size_t const parserTotalSize =
             NUMOP_sumArrayST(si.segmentSizes, si.nbSegments);
-    ZL_RET_R_IF_NE(
-            nodeParameter_invalidValue,
+    ZL_ERR_IF_NE(
             parserTotalSize,
             inputSize,
+            nodeParameter_invalidValue,
             "EI_dispatchN_byTag: the external parser provides invalid total size");
 
-    ZL_RET_R_IF(
-            nodeParameter_invalidValue,
+    ZL_ERR_IF(
             !NUMOP_underLimit(si.tags, si.nbSegments, si.nbTags),
+            nodeParameter_invalidValue,
             "EI_dispatchN_byTag: external parser returns invalid tags!");
 
     // Dimension and allocate output streams
@@ -158,27 +159,27 @@ EI_dispatchN_byTag(ZL_Encoder* eictx, const ZL_Input* ins[], size_t nbIns)
 
     ZL_Output* const outTags = ZL_Encoder_createTypedStream(
             eictx, dnbt_tags, si.nbSegments, tagsWidth);
-    ZL_RET_R_IF_NULL(allocation, outTags);
+    ZL_ERR_IF_NULL(outTags, allocation);
     NUMOP_writeNumerics_fromU32(
             ZL_Output_ptr(outTags), tagsWidth, si.tags, si.nbSegments);
-    ZL_RET_R_IF_ERR(ZL_Output_commit(outTags, si.nbSegments));
+    ZL_ERR_IF_ERR(ZL_Output_commit(outTags, si.nbSegments));
 
     ZL_Output* const segSizes = ZL_Encoder_createTypedStream(
             eictx, dnbt_segSizes, si.nbSegments, segSizesWidth);
-    ZL_RET_R_IF_NULL(allocation, segSizes);
+    ZL_ERR_IF_NULL(segSizes, allocation);
     NUMOP_writeNumerics_fromST(
             ZL_Output_ptr(segSizes),
             segSizesWidth,
             si.segmentSizes,
             si.nbSegments);
-    ZL_RET_R_IF_ERR(ZL_Output_commit(segSizes, si.nbSegments));
+    ZL_ERR_IF_ERR(ZL_Output_commit(segSizes, si.nbSegments));
 
     ZL_STATIC_ASSERT(
             sizeof(size_t) == sizeof(void*),
             "not necessarily true, will revisit if a platform that doesn't respect this assumption is needed");
     size_t const workSize = 2 * si.nbTags * sizeof(size_t);
     void* const workspace = ZL_Encoder_getScratchSpace(eictx, workSize);
-    ZL_RET_R_IF_NULL(allocation, workspace);
+    ZL_ERR_IF_NULL(workspace, allocation);
     ZL_ASSERT((size_t)workspace % sizeof(size_t) == 0);
     size_t* const outSizes  = workspace;
     void** const outBuffers = ((void**)workspace) + si.nbTags;
@@ -188,10 +189,10 @@ EI_dispatchN_byTag(ZL_Encoder* eictx, const ZL_Input* ins[], size_t nbIns)
     for (size_t n = 0; n < si.nbTags; n++) {
         ZL_Output* const out = ZL_Encoder_createTypedStream(
                 eictx, dnbt_segments, outSizes[n], 1);
-        ZL_RET_R_IF_NULL(allocation, out);
+        ZL_ERR_IF_NULL(out, allocation);
         outBuffers[n] = ZL_Output_ptr(out);
-        ZL_RET_R_IF_ERR(ZL_Output_commit(out, outSizes[n]));
-        ZL_RET_R_IF_ERR(
+        ZL_ERR_IF_ERR(ZL_Output_commit(out, outSizes[n]));
+        ZL_ERR_IF_ERR(
                 ZL_Output_setIntMetadata(out, ZL_DISPATCH_CHANNEL_ID, (int)n));
     }
 

--- a/src/openzl/codecs/dispatch_string/decode_dispatch_string_binding.c
+++ b/src/openzl/codecs/dispatch_string/decode_dispatch_string_binding.c
@@ -15,6 +15,7 @@ ZL_Report DI_dispatch_string(
         const ZL_Input* variableSrcs[],
         size_t nbVariableSrcs)
 {
+    ZL_RESULT_DECLARE_SCOPE_REPORT(dictx);
     ZL_ASSERT_NN(dictx);
     ZL_ASSERT_EQ(nbCompulsorySrcs, 1);
     ZL_ASSERT_NN(compulsorySrcs);
@@ -28,22 +29,22 @@ ZL_Report DI_dispatch_string(
     }
 
     if (is16bitDispatch) {
-        ZL_RET_R_IF_NE(
-                node_invalid_input,
+        ZL_ERR_IF_NE(
                 ZL_Input_eltWidth(compulsorySrcs[0]),
-                2); // dispatch indices are 16-bit
-        ZL_RET_R_IF_GT(
-                node_invalid,
+                2,
+                node_invalid_input); // dispatch indices are 16-bit
+        ZL_ERR_IF_GT(
                 nbVariableSrcs,
                 ZL_DISPATCH_STRING_MAX_DISPATCHES,
+                node_invalid,
                 "Invalid number of streams");
     } else {
-        ZL_RET_R_IF_NE(
-                node_invalid_input, ZL_Input_eltWidth(compulsorySrcs[0]), 1);
-        ZL_RET_R_IF_GT(
-                node_invalid,
+        ZL_ERR_IF_NE(
+                ZL_Input_eltWidth(compulsorySrcs[0]), 1, node_invalid_input);
+        ZL_ERR_IF_GT(
                 nbVariableSrcs,
                 ZL_DISPATCH_STRING_MAX_DISPATCHES_V20,
+                node_invalid,
                 "Invalid number of streams");
     }
     ZL_ASSERT_NN(variableSrcs);
@@ -55,9 +56,9 @@ ZL_Report DI_dispatch_string(
     // validate index, src streams + build total buffer size
     const size_t nbStrs = ZL_Input_numElts(compulsorySrcs[0]);
 
-    ZL_RET_R_IF(
-            node_invalid_input,
+    ZL_ERR_IF(
             (nbStrs != 0) && (nbVariableSrcs == 0),
+            node_invalid_input,
             "Number of indices incompatible with number of streams");
 
     size_t totalSize = 0;
@@ -70,10 +71,10 @@ ZL_Report DI_dispatch_string(
                     ZL_Decoder_getScratchSpace(dictx, sizeof(ZL_Histogram16));
             ZL_Histogram_init(histogram, ZL_DISPATCH_STRING_MAX_DISPATCHES);
             ZL_Histogram_build(histogram, inputIndices, nbStrs, 2);
-            ZL_RET_R_IF_GE(
-                    node_invalid_input,
+            ZL_ERR_IF_GE(
                     histogram->maxSymbol,
                     nbVariableSrcs,
+                    node_invalid_input,
                     "Invalid index stream");
         } else {
             const uint8_t* inputIndices = ZL_Input_ptr(compulsorySrcs[0]);
@@ -82,18 +83,18 @@ ZL_Report DI_dispatch_string(
                     ZL_Decoder_getScratchSpace(dictx, sizeof(ZL_Histogram8));
             ZL_Histogram_init(histogram, 255);
             ZL_Histogram_build(histogram, inputIndices, nbStrs, 1);
-            ZL_RET_R_IF_GE(
-                    node_invalid_input,
+            ZL_ERR_IF_GE(
                     histogram->maxSymbol,
                     nbVariableSrcs,
+                    node_invalid_input,
                     "Invalid index stream");
         }
         for (size_t i = 0; i < nbVariableSrcs; i++) {
             totalSize += ZL_Input_contentSize(variableSrcs[i]);
-            ZL_RET_R_IF_NE(
-                    node_invalid_input,
+            ZL_ERR_IF_NE(
                     ZL_Input_numElts(variableSrcs[i]),
                     histogram->count[i],
+                    node_invalid_input,
                     "Index stream requires different input length than provided src[%u]",
                     i);
         }
@@ -102,13 +103,13 @@ ZL_Report DI_dispatch_string(
     // input stream massaging
     const char** srcBuffers =
             ZL_Decoder_getScratchSpace(dictx, nbVariableSrcs * sizeof(void*));
-    ZL_RET_R_IF_NULL(allocation, srcBuffers);
+    ZL_ERR_IF_NULL(srcBuffers, allocation);
     const uint32_t** srcStrLens = ZL_Decoder_getScratchSpace(
             dictx, nbVariableSrcs * sizeof(uint32_t*));
-    ZL_RET_R_IF_NULL(allocation, srcStrLens);
+    ZL_ERR_IF_NULL(srcStrLens, allocation);
     size_t* srcNbStrs =
             ZL_Decoder_getScratchSpace(dictx, nbVariableSrcs * sizeof(size_t));
-    ZL_RET_R_IF_NULL(allocation, srcNbStrs);
+    ZL_ERR_IF_NULL(srcNbStrs, allocation);
     for (size_t i = 0; i < nbVariableSrcs; i++) {
         srcBuffers[i] = ZL_Input_ptr(variableSrcs[i]);
         srcStrLens[i] = ZL_Input_stringLens(variableSrcs[i]);
@@ -117,7 +118,7 @@ ZL_Report DI_dispatch_string(
 
     ZL_Output* const dst = ZL_Decoder_create1StringStream(
             dictx, nbStrs, totalSize + ZL_DISPATCH_STRING_BLK_SIZE);
-    ZL_RET_R_IF_NULL(allocation, dst);
+    ZL_ERR_IF_NULL(dst, allocation);
 
     if (is16bitDispatch) {
         ZL_DispatchString_decode16(
@@ -140,7 +141,7 @@ ZL_Report DI_dispatch_string(
                 srcNbStrs,
                 ZL_Input_ptr(compulsorySrcs[0]));
     }
-    ZL_RET_R_IF_ERR(ZL_Output_commit(dst, nbStrs));
+    ZL_ERR_IF_ERR(ZL_Output_commit(dst, nbStrs));
 
     return ZL_returnSuccess();
 }

--- a/src/openzl/codecs/dispatch_string/encode_dispatch_string_binding.c
+++ b/src/openzl/codecs/dispatch_string/encode_dispatch_string_binding.c
@@ -18,6 +18,7 @@ size_t ZL_DispatchString_maxDispatches(void)
 ZL_Report
 EI_dispatch_string(ZL_Encoder* eictx, const ZL_Input* ins[], size_t nbIns)
 {
+    ZL_RESULT_DECLARE_SCOPE_REPORT(eictx);
     ZL_ASSERT_EQ(nbIns, 1);
     ZL_ASSERT_NN(ins);
     const ZL_Input* const in = ins[0];
@@ -30,14 +31,14 @@ EI_dispatch_string(ZL_Encoder* eictx, const ZL_Input* ins[], size_t nbIns)
                                      eictx, ZL_DISPATCH_STRING_NUM_OUTPUTS_PID)
                                      .paramValue;
     const size_t nbOutputs = (size_t)nbOutputsInt;
-    ZL_RET_R_IF_GT(
-            streamParameter_invalid,
+    ZL_ERR_IF_GT(
             nbOutputs,
             ZL_DISPATCH_STRING_MAX_DISPATCHES,
-            "dispatch_string: invalid number of outputs");
-    ZL_RET_R_IF(
             streamParameter_invalid,
+            "dispatch_string: invalid number of outputs");
+    ZL_ERR_IF(
             nbElts > 0 && nbOutputs == 0,
+            streamParameter_invalid,
             "dispatch_string: ill-formed degenerate case (%u, %i)",
             nbElts,
             nbOutputsInt);
@@ -45,9 +46,9 @@ EI_dispatch_string(ZL_Encoder* eictx, const ZL_Input* ins[], size_t nbIns)
     const uint16_t* indices = (const uint16_t*)ZL_Encoder_getLocalParam(
                                       eictx, ZL_DISPATCH_STRING_INDICES_PID)
                                       .paramRef;
-    ZL_RET_R_IF_NULL(
-            streamParameter_invalid,
+    ZL_ERR_IF_NULL(
             indices,
+            streamParameter_invalid,
             "dispatch_string: indices pointer is null");
 
     // validate indices stream and calculate output sizes
@@ -57,15 +58,15 @@ EI_dispatch_string(ZL_Encoder* eictx, const ZL_Input* ins[], size_t nbIns)
         indicesValid &= (indices[i] < nbOutputs);
     }
 
-    ZL_RET_R_IF_NOT(
-            streamParameter_invalid,
+    ZL_ERR_IF_NOT(
             indicesValid == 1,
+            streamParameter_invalid,
             "Dispatch index out of bounds. Expected all to be in range [0,%u)",
             nbOutputs);
 
     size_t* outputSizes =
             ZL_Encoder_getScratchSpace(eictx, nbOutputs * sizeof(size_t));
-    ZL_RET_R_IF_NULL(allocation, outputSizes);
+    ZL_ERR_IF_NULL(outputSizes, allocation);
     memset(outputSizes, 0, nbOutputs * sizeof(size_t));
     for (size_t i = 0; i < nbElts; ++i) {
         outputSizes[indices[i]] += srcStrLens[i];
@@ -79,24 +80,24 @@ EI_dispatch_string(ZL_Encoder* eictx, const ZL_Input* ins[], size_t nbIns)
     // create streams for outputs
     ZL_Output* indices_out =
             ZL_Encoder_createTypedStream(eictx, 0, nbElts, sizeof(uint16_t));
-    ZL_RET_R_IF_NULL(allocation, indices_out);
+    ZL_ERR_IF_NULL(indices_out, allocation);
 
     // allocate space for output streams and raw handles
     ZL_Output** outs =
             ZL_Encoder_getScratchSpace(eictx, nbOutputs * sizeof(ZL_Output*));
-    ZL_RET_R_IF_NULL(allocation, outs);
+    ZL_ERR_IF_NULL(outs, allocation);
 
     void** dstBuffers =
             ZL_Encoder_getScratchSpace(eictx, nbOutputs * sizeof(void*));
-    ZL_RET_R_IF_NULL(allocation, dstBuffers);
+    ZL_ERR_IF_NULL(dstBuffers, allocation);
 
     uint32_t** dstStrLens =
             ZL_Encoder_getScratchSpace(eictx, nbOutputs * sizeof(uint32_t*));
-    ZL_RET_R_IF_NULL(allocation, dstStrLens);
+    ZL_ERR_IF_NULL(dstStrLens, allocation);
 
     size_t* dstNbStrs =
             ZL_Encoder_getScratchSpace(eictx, nbOutputs * sizeof(size_t));
-    ZL_RET_R_IF_NULL(allocation, dstNbStrs);
+    ZL_ERR_IF_NULL(dstNbStrs, allocation);
     if (nbElts > 0) {
         for (int i = 0; i < (int)nbOutputs; ++i) {
             ZL_Output* out = ZL_Encoder_createStringStream(
@@ -104,7 +105,7 @@ EI_dispatch_string(ZL_Encoder* eictx, const ZL_Input* ins[], size_t nbIns)
                     1,
                     nbElts,
                     outputSizes[i] + ZL_DISPATCH_STRING_BLK_SIZE);
-            ZL_RET_R_IF_NULL(allocation, out);
+            ZL_ERR_IF_NULL(out, allocation);
             outs[i]       = out;
             dstBuffers[i] = ZL_Output_ptr(out);
             dstStrLens[i] = ZL_Output_stringLens(out);
@@ -121,7 +122,7 @@ EI_dispatch_string(ZL_Encoder* eictx, const ZL_Input* ins[], size_t nbIns)
                 indices);
 
         for (size_t i = 0u; i < nbOutputs; ++i) {
-            ZL_RET_R_IF_ERR(ZL_Output_commit(outs[i], dstNbStrs[i]));
+            ZL_ERR_IF_ERR(ZL_Output_commit(outs[i], dstNbStrs[i]));
         }
     }
 
@@ -129,7 +130,7 @@ EI_dispatch_string(ZL_Encoder* eictx, const ZL_Input* ins[], size_t nbIns)
     if (nbElts > 0) {
         memcpy(ZL_Output_ptr(indices_out), indices, nbElts * sizeof(uint16_t));
     }
-    ZL_RET_R_IF_ERR(ZL_Output_commit(indices_out, nbElts));
+    ZL_ERR_IF_ERR(ZL_Output_commit(indices_out, nbElts));
 
     return ZL_returnSuccess();
 }

--- a/src/openzl/codecs/divide_by/decode_divide_by_binding.c
+++ b/src/openzl/codecs/divide_by/decode_divide_by_binding.c
@@ -9,6 +9,7 @@
 
 ZL_Report DI_divide_by_int(ZL_Decoder* dictx, const ZL_Input* ins[])
 {
+    ZL_RESULT_DECLARE_SCOPE_REPORT(dictx);
     ZL_ASSERT_NN(dictx);
     ZL_ASSERT_NN(ins);
     const ZL_Input* const in = ins[0];
@@ -21,57 +22,57 @@ ZL_Report DI_divide_by_int(ZL_Decoder* dictx, const ZL_Input* ins[])
 
     void const* quotients = ZL_Input_ptr(in);
     if (header.size == 0) {
-        ZL_RET_R_ERR(corruption);
+        ZL_ERR(corruption);
     }
 
     ZL_Output* const out = ZL_Decoder_create1OutStream(dictx, nbElts, intWidth);
-    ZL_RET_R_IF_NULL(allocation, out);
+    ZL_ERR_IF_NULL(out, allocation);
     const uint8_t* headerPtr = (const uint8_t*)header.start;
     ZL_RESULT_OF(uint64_t)
     const varint = ZL_varintDecode(
             &headerPtr, (const uint8_t*)header.start + header.size);
     ZL_TRY_LET_T(uint64_t, divisor, varint);
-    ZL_RET_R_IF_EQ(node_invalid_input, divisor, 0, "Attempt to divide by 0");
+    ZL_ERR_IF_EQ(divisor, 0, node_invalid_input, "Attempt to divide by 0");
     switch (intWidth) {
         case 1:
-            ZL_RET_R_IF_GT(node_invalid_input, divisor, UCHAR_MAX);
+            ZL_ERR_IF_GT(divisor, UCHAR_MAX, node_invalid_input);
             for (size_t i = 0; i < nbElts; ++i) {
-                ZL_RET_R_IF_GT(
-                        node_invalid_input,
+                ZL_ERR_IF_GT(
                         ((const uint8_t*)quotients)[i],
-                        UCHAR_MAX / divisor);
+                        UCHAR_MAX / divisor,
+                        node_invalid_input);
             }
             break;
         case 2:
-            ZL_RET_R_IF_GT(node_invalid_input, divisor, USHRT_MAX);
+            ZL_ERR_IF_GT(divisor, USHRT_MAX, node_invalid_input);
             for (size_t i = 0; i < nbElts; ++i) {
-                ZL_RET_R_IF_GT(
-                        node_invalid_input,
+                ZL_ERR_IF_GT(
                         ((const uint16_t*)quotients)[i],
-                        USHRT_MAX / divisor);
+                        USHRT_MAX / divisor,
+                        node_invalid_input);
             }
             break;
         case 4:
-            ZL_RET_R_IF_GT(node_invalid_input, divisor, UINT_MAX);
+            ZL_ERR_IF_GT(divisor, UINT_MAX, node_invalid_input);
             for (size_t i = 0; i < nbElts; ++i) {
-                ZL_RET_R_IF_GT(
-                        node_invalid_input,
+                ZL_ERR_IF_GT(
                         ((const uint32_t*)quotients)[i],
-                        UINT_MAX / divisor);
+                        UINT_MAX / divisor,
+                        node_invalid_input);
             }
             break;
         case 8:
             for (size_t i = 0; i < nbElts; ++i) {
-                ZL_RET_R_IF_GT(
-                        node_invalid_input,
+                ZL_ERR_IF_GT(
                         ((const uint64_t*)quotients)[i],
-                        ULLONG_MAX / divisor);
+                        ULLONG_MAX / divisor,
+                        node_invalid_input);
             }
             break;
         default:
             ZL_ASSERT_FAIL("Unsupported int width");
     }
     ZS_divideByDecode(ZL_Output_ptr(out), quotients, nbElts, divisor, intWidth);
-    ZL_RET_R_IF_ERR(ZL_Output_commit(out, nbElts));
+    ZL_ERR_IF_ERR(ZL_Output_commit(out, nbElts));
     return ZL_returnSuccess();
 }

--- a/src/openzl/codecs/divide_by/encode_divide_by_binding.c
+++ b/src/openzl/codecs/divide_by/encode_divide_by_binding.c
@@ -81,6 +81,7 @@ static ZL_RESULT_OF(uint64_t) getDivisor(
 ZL_Report
 EI_divide_by_int(ZL_Encoder* eictx, const ZL_Input* ins[], size_t nbIns)
 {
+    ZL_RESULT_DECLARE_SCOPE_REPORT(eictx);
     ZL_ASSERT_EQ(nbIns, 1);
     ZL_ASSERT_NN(ins);
     const ZL_Input* in = ins[0];
@@ -92,7 +93,7 @@ EI_divide_by_int(ZL_Encoder* eictx, const ZL_Input* ins[], size_t nbIns)
     size_t const nbInts = ZL_Input_numElts(in);
     ZL_Output* const out =
             ZL_Encoder_createTypedStream(eictx, 0, nbInts, intWidth);
-    ZL_RET_R_IF_NULL(allocation, out);
+    ZL_ERR_IF_NULL(out, allocation);
     const void* src = ZL_Input_ptr(in);
     void* dst       = ZL_Output_ptr(out);
 
@@ -104,12 +105,12 @@ EI_divide_by_int(ZL_Encoder* eictx, const ZL_Input* ins[], size_t nbIns)
             nbInts,
             div.paramRef ? *(const uint64_t*)div.paramRef : 0,
             src);
-    ZL_RET_R_IF_ERR(divisor);
+    ZL_ERR_IF_ERR(divisor);
     uint64_t divisorValue = ZL_RES_value(divisor);
     ZS_divideByEncode(dst, src, nbInts, divisorValue, intWidth);
     size_t encodeSize = ZL_varintEncode64Fast(divisorValue, header);
     ZL_Encoder_sendCodecHeader(eictx, header, encodeSize);
-    ZL_RET_R_IF_ERR(ZL_Output_commit(out, nbInts));
+    ZL_ERR_IF_ERR(ZL_Output_commit(out, nbInts));
 
     return ZL_returnSuccess();
 }

--- a/src/openzl/codecs/entropy/decode_entropy_binding.c
+++ b/src/openzl/codecs/entropy/decode_entropy_binding.c
@@ -63,38 +63,39 @@ buildFSEDTable(ZL_Decoder* dictx, int16_t const* norm, size_t nbSymbols)
 
 ZL_Report DI_fse_v2(ZL_Decoder* dictx, const ZL_Input* in[])
 {
+    ZL_RESULT_DECLARE_SCOPE_REPORT(dictx);
     ZL_Input const* const normStream = in[0];
     ZL_Input const* const bitsStream = in[1];
 
     ZL_ASSERT_EQ(ZL_Input_type(normStream), ZL_Type_numeric);
     ZL_ASSERT_EQ(ZL_Input_type(bitsStream), ZL_Type_serial);
 
-    ZL_RET_R_IF_NE(corruption, ZL_Input_eltWidth(normStream), 2);
+    ZL_ERR_IF_NE(ZL_Input_eltWidth(normStream), 2, corruption);
 
     FSE_DTable const* dtable = buildFSEDTable(
             dictx,
             (int16_t const*)ZL_Input_ptr(normStream),
             ZL_Input_numElts(normStream));
-    ZL_RET_R_IF_NULL(corruption, dtable);
+    ZL_ERR_IF_NULL(dtable, corruption);
 
     unsigned nbStates;
     size_t dstSize;
     {
         ZL_RBuffer const header = ZL_Decoder_getCodecHeader(dictx);
-        ZL_RET_R_IF_LT(corruption, header.size, 2, "Min size = 2 bytes");
-        ZL_RET_R_IF_GT(corruption, header.size, 9, "Max size = 9 bytes");
+        ZL_ERR_IF_LT(header.size, 2, corruption, "Min size = 2 bytes");
+        ZL_ERR_IF_GT(header.size, 9, corruption, "Max size = 9 bytes");
         uint8_t const* ptr = (uint8_t const*)header.start;
         nbStates           = *ptr++;
-        ZL_RET_R_IF_NOT(
-                corruption,
+        ZL_ERR_IF_NOT(
                 nbStates == 2 || nbStates == 4,
+                corruption,
                 "Unsupported number of states");
         dstSize = ZL_readLE64_N(ptr, header.size - 1);
-        ZL_RET_R_IF_LT(corruption, dstSize, 2, "Must have at least 2 elements");
+        ZL_ERR_IF_LT(dstSize, 2, corruption, "Must have at least 2 elements");
     }
 
     ZL_Output* const outStream = ZL_Decoder_create1OutStream(dictx, dstSize, 1);
-    ZL_RET_R_IF_NULL(allocation, outStream);
+    ZL_ERR_IF_NULL(outStream, allocation);
 
     size_t const ret = FSE_decompress_usingDTable(
             ZL_Output_ptr(outStream),
@@ -103,25 +104,26 @@ ZL_Report DI_fse_v2(ZL_Decoder* dictx, const ZL_Input* in[])
             ZL_Input_numElts(bitsStream),
             dtable,
             nbStates);
-    ZL_RET_R_IF(
-            corruption,
+    ZL_ERR_IF(
             FSE_isError(ret),
+            corruption,
             "FSE decoding failed: %s",
             FSE_getErrorName(ret));
-    ZL_RET_R_IF_NE(corruption, ret, dstSize);
+    ZL_ERR_IF_NE(ret, dstSize, corruption);
 
-    ZL_RET_R_IF_ERR(ZL_Output_commit(outStream, dstSize));
+    ZL_ERR_IF_ERR(ZL_Output_commit(outStream, dstSize));
 
     return ZL_returnSuccess();
 }
 
 ZL_Report DI_fse_ncount(ZL_Decoder* dictx, const ZL_Input* in[])
 {
+    ZL_RESULT_DECLARE_SCOPE_REPORT(dictx);
     ZL_Input const* const srcStream = in[0];
 
     ZL_Output* ncountStream =
             ZL_Decoder_create1OutStream(dictx, 256, sizeof(short));
-    ZL_RET_R_IF_NULL(allocation, ncountStream);
+    ZL_ERR_IF_NULL(ncountStream, allocation);
 
     unsigned maxSymbolValue = 255;
     unsigned tableLog       = FSE_MAX_TABLELOG;
@@ -131,14 +133,14 @@ ZL_Report DI_fse_ncount(ZL_Decoder* dictx, const ZL_Input* in[])
             &tableLog,
             ZL_Input_ptr(srcStream),
             ZL_Input_numElts(srcStream));
-    ZL_RET_R_IF(
-            corruption,
+    ZL_ERR_IF(
             FSE_isError(ncountSize),
+            corruption,
             "Failed to read nCount: %s",
             FSE_getErrorName(ncountSize));
-    ZL_RET_R_IF_NE(corruption, ncountSize, ZL_Input_numElts(srcStream));
+    ZL_ERR_IF_NE(ncountSize, ZL_Input_numElts(srcStream), corruption);
 
-    ZL_RET_R_IF_ERR(ZL_Output_commit(ncountStream, 1 + maxSymbolValue));
+    ZL_ERR_IF_ERR(ZL_Output_commit(ncountStream, 1 + maxSymbolValue));
 
     return ZL_returnSuccess();
 }
@@ -285,6 +287,7 @@ static HUF_DTable const* buildHUFDTable(
 
 ZL_Report DI_huffman_v2(ZL_Decoder* dictx, const ZL_Input* in[])
 {
+    ZL_RESULT_DECLARE_SCOPE_REPORT(dictx);
     ZL_Input const* const weightsStream = in[0];
     ZL_Input const* const bitsStream    = in[1];
 
@@ -293,19 +296,19 @@ ZL_Report DI_huffman_v2(ZL_Decoder* dictx, const ZL_Input* in[])
     ZL_ASSERT_EQ(ZL_Input_type(weightsStream), ZL_Type_numeric);
     ZL_ASSERT_EQ(ZL_Input_type(bitsStream), ZL_Type_serial);
 
-    ZL_RET_R_IF_NE(corruption, ZL_Input_eltWidth(weightsStream), 1);
+    ZL_ERR_IF_NE(ZL_Input_eltWidth(weightsStream), 1, corruption);
 
     bool x4;
     size_t dstSize;
     {
         ZL_RBuffer const header = ZL_Decoder_getCodecHeader(dictx);
-        ZL_RET_R_IF_LT(corruption, header.size, 2, "Min size = 2 bytes");
-        ZL_RET_R_IF_GT(corruption, header.size, 9, "Max size = 9 bytes");
+        ZL_ERR_IF_LT(header.size, 2, corruption, "Min size = 2 bytes");
+        ZL_ERR_IF_GT(header.size, 9, corruption, "Max size = 9 bytes");
         uint8_t const* ptr = (uint8_t const*)header.start;
         x4                 = (*ptr & 0x1) != 0;
         ++ptr;
         dstSize = ZL_readLE64_N(ptr, header.size - 1);
-        ZL_RET_R_IF_LT(corruption, dstSize, 2, "Must have at least 2 elements");
+        ZL_ERR_IF_LT(dstSize, 2, corruption, "Must have at least 2 elements");
     }
 
     bool const x2 = x4
@@ -317,10 +320,10 @@ ZL_Report DI_huffman_v2(ZL_Decoder* dictx, const ZL_Input* in[])
             (uint8_t const*)ZL_Input_ptr(weightsStream),
             ZL_Input_numElts(weightsStream),
             x2);
-    ZL_RET_R_IF_NULL(corruption, dtable);
+    ZL_ERR_IF_NULL(dtable, corruption);
 
     ZL_Output* const outStream = ZL_Decoder_create1OutStream(dictx, dstSize, 1);
-    ZL_RET_R_IF_NULL(allocation, outStream);
+    ZL_ERR_IF_NULL(outStream, allocation);
 
     {
         void* dst            = ZL_Output_ptr(outStream);
@@ -333,15 +336,15 @@ ZL_Report DI_huffman_v2(ZL_Decoder* dictx, const ZL_Input* in[])
                 : HUF_decompress1X1_usingDTable;
         ZL_ASSERT_EQ(!x4 && x2, false);
         size_t const ret = decode(dst, dstSize, src, srcSize, dtable);
-        ZL_RET_R_IF(
-                corruption,
+        ZL_ERR_IF(
                 HUF_isError(ret),
+                corruption,
                 "HUF decoding failed: %s",
                 HUF_getErrorName(ret));
-        ZL_RET_R_IF_NE(corruption, ret, dstSize);
+        ZL_ERR_IF_NE(ret, dstSize, corruption);
     }
 
-    ZL_RET_R_IF_ERR(ZL_Output_commit(outStream, dstSize));
+    ZL_ERR_IF_ERR(ZL_Output_commit(outStream, dstSize));
 
     return ZL_returnSuccess();
 }
@@ -414,6 +417,7 @@ static ZS_Huf16DElt const* buildHUF16DTable(
 
 ZL_Report DI_huffman_struct_v2(ZL_Decoder* dictx, const ZL_Input* in[])
 {
+    ZL_RESULT_DECLARE_SCOPE_REPORT(dictx);
     ZL_Input const* const weightsStream = in[0];
     ZL_Input const* const bitsStream    = in[1];
 
@@ -422,19 +426,19 @@ ZL_Report DI_huffman_struct_v2(ZL_Decoder* dictx, const ZL_Input* in[])
     ZL_ASSERT_EQ(ZL_Input_type(weightsStream), ZL_Type_numeric);
     ZL_ASSERT_EQ(ZL_Input_type(bitsStream), ZL_Type_serial);
 
-    ZL_RET_R_IF_NE(corruption, ZL_Input_eltWidth(weightsStream), 1);
+    ZL_ERR_IF_NE(ZL_Input_eltWidth(weightsStream), 1, corruption);
 
     bool x4;
     size_t dstSize;
     {
         ZL_RBuffer const header = ZL_Decoder_getCodecHeader(dictx);
-        ZL_RET_R_IF_LT(corruption, header.size, 2, "Min size = 2 bytes");
-        ZL_RET_R_IF_GT(corruption, header.size, 9, "Max size = 9 bytes");
+        ZL_ERR_IF_LT(header.size, 2, corruption, "Min size = 2 bytes");
+        ZL_ERR_IF_GT(header.size, 9, corruption, "Max size = 9 bytes");
         uint8_t const* ptr = (uint8_t const*)header.start;
         x4                 = (*ptr & 0x1) != 0;
         ++ptr;
         dstSize = ZL_readLE64_N(ptr, header.size - 1);
-        ZL_RET_R_IF_LT(corruption, dstSize, 2, "Must have at least 2 elements");
+        ZL_ERR_IF_LT(dstSize, 2, corruption, "Must have at least 2 elements");
     }
 
     int tableLog;
@@ -443,10 +447,10 @@ ZL_Report DI_huffman_struct_v2(ZL_Decoder* dictx, const ZL_Input* in[])
             (uint8_t const*)ZL_Input_ptr(weightsStream),
             ZL_Input_numElts(weightsStream),
             &tableLog);
-    ZL_RET_R_IF_NULL(corruption, dtable);
+    ZL_ERR_IF_NULL(dtable, corruption);
 
     ZL_Output* const outStream = ZL_Decoder_create1OutStream(dictx, dstSize, 2);
-    ZL_RET_R_IF_NULL(allocation, outStream);
+    ZL_ERR_IF_NULL(outStream, allocation);
 
     {
         ZL_RC src = ZL_RC_wrap(
@@ -456,12 +460,12 @@ ZL_Report DI_huffman_struct_v2(ZL_Decoder* dictx, const ZL_Input* in[])
                                         dst, dstSize, &src, dtable, tableLog)
                               : ZS_largeHuffmanDecodeUsingDTable(
                                         dst, dstSize, &src, dtable, tableLog);
-        ZL_RET_R_IF_ERR(report);
-        ZL_RET_R_IF_NE(corruption, ZL_validResult(report), dstSize);
-        ZL_RET_R_IF_NE(corruption, ZL_RC_avail(&src), 0);
+        ZL_ERR_IF_ERR(report);
+        ZL_ERR_IF_NE(ZL_validResult(report), dstSize, corruption);
+        ZL_ERR_IF_NE(ZL_RC_avail(&src), 0, corruption);
     }
 
-    ZL_RET_R_IF_ERR(ZL_Output_commit(outStream, dstSize));
+    ZL_ERR_IF_ERR(ZL_Output_commit(outStream, dstSize));
 
     return ZL_returnSuccess();
 }
@@ -509,6 +513,7 @@ static ZL_Report DI_entropyDecode(
 static ZL_Report
 DI_huffman_typed(ZL_Decoder* dictx, const ZL_Input* ins[], bool hasHeader)
 {
+    ZL_RESULT_DECLARE_SCOPE_REPORT(dictx);
     ZL_ASSERT_NN(dictx);
     ZL_ASSERT_NN(ins);
     const ZL_Input* const in = ins[0];
@@ -533,15 +538,15 @@ DI_huffman_typed(ZL_Decoder* dictx, const ZL_Input* ins[], bool hasHeader)
         ZL_RBuffer const header = ZL_Decoder_getCodecHeader(dictx);
         uint8_t const* hdr      = (uint8_t const*)header.start;
         uint8_t const* hdrEnd   = hdr + header.size;
-        ZL_RET_R_IF_LT(header_unknown, header.size, 2);
+        ZL_ERR_IF_LT(header.size, 2, header_unknown);
 
         bool const isTransposed        = *hdr++ != 0;
         ZL_RESULT_OF(uint64_t) const r = ZL_varintDecode(&hdr, hdrEnd);
-        ZL_RET_R_IF(header_unknown, ZL_RES_isError(r));
-        ZL_RET_R_IF_NE(header_unknown, hdr, hdrEnd);
+        ZL_ERR_IF(ZL_RES_isError(r), header_unknown);
+        ZL_ERR_IF_NE(hdr, hdrEnd, header_unknown);
         uint64_t const eltWidth = ZL_RES_value(r);
 
-        ZL_RET_R_IF_EQ(header_unknown, eltWidth, 0, "Invalid element width!");
+        ZL_ERR_IF_EQ(eltWidth, 0, header_unknown, "Invalid element width!");
 
         entropyEltWidth = isTransposed ? 1 : eltWidth;
         ZL_TRY_LET_R(nbElts, DI_entropyDstBound(src, srcSize, entropyEltWidth));
@@ -556,24 +561,24 @@ DI_huffman_typed(ZL_Decoder* dictx, const ZL_Input* ins[], bool hasHeader)
         dstEltWidth   = 1;
         dstNbElts     = entropyNbElts;
     }
-    ZL_RET_R_IF_NE(
-            header_unknown,
+    ZL_ERR_IF_NE(
             entropyNbElts * entropyEltWidth,
             dstNbElts * dstEltWidth,
+            header_unknown,
             "Overflow computing element widths");
 
     if (DI_getFrameFormatVersion(dictx) >= 11) {
-        ZL_RET_R_IF_GT(
-                corruption,
+        ZL_ERR_IF_GT(
                 dstEltWidth,
                 2,
+                corruption,
                 "eltWidth > 2 is not supported in version 11 or newer.");
     }
 
     //> Create the output stream.
     ZL_Output* const out =
             ZL_Decoder_create1OutStream(dictx, dstNbElts, dstEltWidth);
-    ZL_RET_R_IF_NULL(allocation, out);
+    ZL_ERR_IF_NULL(out, allocation);
 
     //> Decode & tell how much we wrote to the output buffer.
     ZL_TRY_LET_R(
@@ -585,8 +590,8 @@ DI_huffman_typed(ZL_Decoder* dictx, const ZL_Input* ins[], bool hasHeader)
                     srcSize,
                     entropyEltWidth,
                     NULL));
-    ZL_RET_R_IF_NE(corruption, dSize, entropyNbElts, "Entropy decoding failed");
-    ZL_RET_R_IF_ERR(ZL_Output_commit(out, dstNbElts));
+    ZL_ERR_IF_NE(dSize, entropyNbElts, corruption, "Entropy decoding failed");
+    ZL_ERR_IF_ERR(ZL_Output_commit(out, dstNbElts));
 
     //> Return the number of output streams.
     return ZL_returnValue(1);
@@ -604,6 +609,7 @@ ZL_Report DI_huffman_fixed(ZL_Decoder* dictx, const ZL_Input* ins[])
 
 ZL_Report DI_fse_typed(ZL_Decoder* dictx, const ZL_Input* ins[])
 {
+    ZL_RESULT_DECLARE_SCOPE_REPORT(dictx);
     ZL_ASSERT_NN(dictx);
     ZL_ASSERT_NN(ins);
     const ZL_Input* const in = ins[0];
@@ -620,18 +626,18 @@ ZL_Report DI_fse_typed(ZL_Decoder* dictx, const ZL_Input* ins[])
     if (header.size) {
         // Header should be only 1 bytes, anything else is probably a
         // corruption
-        ZL_RET_R_IF_NE(
-                corruption,
+        ZL_ERR_IF_NE(
                 header.size,
                 1,
+                corruption,
                 "FSE header size should be at most 1, got unexpected header size - %d",
                 header.size);
         nbStates = *(uint8_t const*)header.start;
         // We support only 2 or 4 states, anything else is probably a
         // corruption
-        ZL_RET_R_IF(
-                corruption,
+        ZL_ERR_IF(
                 nbStates != 2 && nbStates != 4,
+                corruption,
                 "FSE supports only 2 or 4 states, got unexpected number of states - %d",
                 nbStates);
     }
@@ -640,7 +646,7 @@ ZL_Report DI_fse_typed(ZL_Decoder* dictx, const ZL_Input* ins[])
 
     // Create the output stream.
     ZL_Output* const out = ZL_Decoder_create1OutStream(dictx, nbElts, 1);
-    ZL_RET_R_IF_NULL(allocation, out);
+    ZL_ERR_IF_NULL(out, allocation);
 
     // Decode & tell how much we wrote to the output buffer.
     ZS_Entropy_DecodeParameters params = ZS_Entropy_DecodeParameters_default();
@@ -649,8 +655,8 @@ ZL_Report DI_fse_typed(ZL_Decoder* dictx, const ZL_Input* ins[])
             dSize,
             DI_entropyDecode(
                     ZL_Output_ptr(out), nbElts, src, srcSize, 1, &params));
-    ZL_RET_R_IF_NE(corruption, dSize, nbElts, "FSE decoding failed");
-    ZL_RET_R_IF_ERR(ZL_Output_commit(out, nbElts));
+    ZL_ERR_IF_NE(dSize, nbElts, corruption, "FSE decoding failed");
+    ZL_ERR_IF_ERR(ZL_Output_commit(out, nbElts));
 
     // Return the number of output streams.
     return ZL_returnValue(1);

--- a/src/openzl/codecs/entropy/encode_entropy_binding.c
+++ b/src/openzl/codecs/entropy/encode_entropy_binding.c
@@ -50,6 +50,7 @@ static ZL_Histogram const* getHistogram(ZL_Encoder* eictx, const ZL_Input* in)
 
 ZL_Report EI_fse_v2(ZL_Encoder* eictx, const ZL_Input* ins[], size_t nbIns)
 {
+    ZL_RESULT_DECLARE_SCOPE_REPORT(eictx);
     ZL_ASSERT_EQ(nbIns, 1);
     ZL_ASSERT_NN(ins);
     const ZL_Input* in = ins[0];
@@ -58,15 +59,15 @@ ZL_Report EI_fse_v2(ZL_Encoder* eictx, const ZL_Input* ins[], size_t nbIns)
     size_t const srcSize          = ZL_Input_numElts(in);
     ZL_Histogram const* histogram = getHistogram(eictx, in);
 
-    ZL_RET_R_IF_LT(
-            node_invalid_input,
+    ZL_ERR_IF_LT(
             srcSize,
             2,
-            "Must not use FSE for 0 or 1 element (should be impossible for users to trigger)");
-    ZL_RET_R_IF_EQ(
             node_invalid_input,
+            "Must not use FSE for 0 or 1 element (should be impossible for users to trigger)");
+    ZL_ERR_IF_EQ(
             histogram->count[histogram->maxSymbol],
             histogram->total,
+            node_invalid_input,
             "Must not use FSE on constant data (should be impossible for users to trigger)");
 
     // 1. Decide on number of states & send header
@@ -86,39 +87,39 @@ ZL_Report EI_fse_v2(ZL_Encoder* eictx, const ZL_Input* ins[], size_t nbIns)
         size_t const normSize = histogram->maxSymbol + 1;
         ZL_Output* const normStream =
                 ZL_Encoder_createTypedStream(eictx, 0, normSize, 2);
-        ZL_RET_R_IF_NULL(allocation, normStream);
+        ZL_ERR_IF_NULL(normStream, allocation);
         int16_t* const normCount = ZL_Output_ptr(normStream);
 
         unsigned const tableLog = FSE_optimalTableLog(
                 FSE_DEFAULT_TABLELOG, srcSize, histogram->maxSymbol);
         ctable = ZL_Encoder_getScratchSpace(
                 eictx, FSE_CTABLE_SIZE(tableLog, histogram->maxSymbol));
-        ZL_RET_R_IF_NULL(allocation, ctable);
+        ZL_ERR_IF_NULL(ctable, allocation);
 
-        ZL_RET_R_IF(
-                GENERIC,
+        ZL_ERR_IF(
                 FSE_isError(FSE_normalizeCount(
                         normCount,
                         tableLog,
                         histogram->count,
                         srcSize,
                         histogram->maxSymbol,
-                        true)));
+                        true)),
+                GENERIC);
 
-        ZL_RET_R_IF(
-                GENERIC,
+        ZL_ERR_IF(
                 FSE_isError(FSE_buildCTable(
-                        ctable, normCount, histogram->maxSymbol, tableLog)));
+                        ctable, normCount, histogram->maxSymbol, tableLog)),
+                GENERIC);
 
-        ZL_RET_R_IF_ERR(ZL_Output_setIntMetadata(normStream, 0, (int)tableLog));
-        ZL_RET_R_IF_ERR(ZL_Output_commit(normStream, normSize));
+        ZL_ERR_IF_ERR(ZL_Output_setIntMetadata(normStream, 0, (int)tableLog));
+        ZL_ERR_IF_ERR(ZL_Output_commit(normStream, normSize));
     }
 
     // 3. Encode
     size_t const bitCapacity = FSE_compressBound(srcSize);
     ZL_Output* bitStream =
             ZL_Encoder_createTypedStream(eictx, 1, bitCapacity, 1);
-    ZL_RET_R_IF_NULL(allocation, bitStream);
+    ZL_ERR_IF_NULL(bitStream, allocation);
 
     size_t const bitSize = FSE_compress_usingCTable(
             ZL_Output_ptr(bitStream),
@@ -127,31 +128,32 @@ ZL_Report EI_fse_v2(ZL_Encoder* eictx, const ZL_Input* ins[], size_t nbIns)
             srcSize,
             ctable,
             nbStates);
-    ZL_RET_R_IF(node_invalid_input, FSE_isError(bitSize));
-    ZL_RET_R_IF_EQ(
-            node_invalid_input,
+    ZL_ERR_IF(FSE_isError(bitSize), node_invalid_input);
+    ZL_ERR_IF_EQ(
             bitSize,
             0,
+            node_invalid_input,
             "FSE source is not compressible (should be impossible to trigger for user)");
-    ZL_RET_R_IF_ERR(ZL_Output_commit(bitStream, bitSize));
+    ZL_ERR_IF_ERR(ZL_Output_commit(bitStream, bitSize));
 
     return ZL_returnSuccess();
 }
 
 ZL_Report EI_fse_ncount(ZL_Encoder* eictx, const ZL_Input* ins[], size_t nbIns)
 {
+    ZL_RESULT_DECLARE_SCOPE_REPORT(eictx);
     ZL_ASSERT_EQ(nbIns, 1);
     ZL_ASSERT_NN(ins);
     const ZL_Input* in = ins[0];
     ZL_ASSERT(ZL_Input_type(in) == ZL_Type_numeric);
-    ZL_RET_R_IF_NE(node_invalid_input, ZL_Input_eltWidth(in), 2);
+    ZL_ERR_IF_NE(ZL_Input_eltWidth(in), 2, node_invalid_input);
 
     short const* const ncount = ZL_Input_ptr(in);
     size_t const nbCounts     = ZL_Input_numElts(in);
 
-    ZL_RET_R_IF_EQ(node_invalid_input, nbCounts, 0);
-    ZL_RET_R_IF_GT(node_invalid_input, nbCounts, 256);
-    ZL_RET_R_IF_EQ(node_invalid_input, ncount[nbCounts - 1], 0);
+    ZL_ERR_IF_EQ(nbCounts, 0, node_invalid_input);
+    ZL_ERR_IF_GT(nbCounts, 256, node_invalid_input);
+    ZL_ERR_IF_EQ(ncount[nbCounts - 1], 0, node_invalid_input);
 
     bool invalid = false;
     uint64_t sum = 0;
@@ -159,17 +161,17 @@ ZL_Report EI_fse_ncount(ZL_Encoder* eictx, const ZL_Input* ins[], size_t nbIns)
         sum += ncount[i] == -1 ? (uint64_t)1 : (uint64_t)ncount[i];
         invalid |= ncount[i] < -1;
     }
-    ZL_RET_R_IF(node_invalid_input, invalid, "Ncount must not be less than -1");
-    ZL_RET_R_IF_NOT(node_invalid_input, ZL_isPow2(sum));
-    ZL_RET_R_IF_EQ(node_invalid_input, sum, 0);
+    ZL_ERR_IF(invalid, node_invalid_input, "Ncount must not be less than -1");
+    ZL_ERR_IF_NOT(ZL_isPow2(sum), node_invalid_input);
+    ZL_ERR_IF_EQ(sum, 0, node_invalid_input);
     unsigned const tableLog = (unsigned)ZL_highbit64(sum);
 
-    ZL_RET_R_IF_LT(node_invalid_input, tableLog, FSE_MIN_TABLELOG);
-    ZL_RET_R_IF_GT(node_invalid_input, tableLog, FSE_MAX_TABLELOG);
+    ZL_ERR_IF_LT(tableLog, FSE_MIN_TABLELOG, node_invalid_input);
+    ZL_ERR_IF_GT(tableLog, FSE_MAX_TABLELOG, node_invalid_input);
 
     ZL_Output* const dstStream =
             ZL_Encoder_createTypedStream(eictx, 0, FSE_NCOUNTBOUND, 1);
-    ZL_RET_R_IF_NULL(allocation, dstStream);
+    ZL_ERR_IF_NULL(dstStream, allocation);
 
     size_t const ncountSize = FSE_writeNCount(
             ZL_Output_ptr(dstStream),
@@ -177,19 +179,20 @@ ZL_Report EI_fse_ncount(ZL_Encoder* eictx, const ZL_Input* ins[], size_t nbIns)
             ncount,
             (unsigned)nbCounts - 1,
             tableLog);
-    ZL_RET_R_IF(
-            GENERIC,
+    ZL_ERR_IF(
             FSE_isError(ncountSize),
+            GENERIC,
             "%s",
             FSE_getErrorName(ncountSize));
 
-    ZL_RET_R_IF_ERR(ZL_Output_commit(dstStream, ncountSize));
+    ZL_ERR_IF_ERR(ZL_Output_commit(dstStream, ncountSize));
 
     return ZL_returnSuccess();
 }
 
 ZL_Report EI_huffman_v2(ZL_Encoder* eictx, const ZL_Input* ins[], size_t nbIns)
 {
+    ZL_RESULT_DECLARE_SCOPE_REPORT(eictx);
     ZL_ASSERT_EQ(nbIns, 1);
     ZL_ASSERT_NN(ins);
     const ZL_Input* in = ins[0];
@@ -198,15 +201,15 @@ ZL_Report EI_huffman_v2(ZL_Encoder* eictx, const ZL_Input* ins[], size_t nbIns)
     size_t const srcSize          = ZL_Input_numElts(in);
     ZL_Histogram const* histogram = getHistogram(eictx, in);
 
-    ZL_RET_R_IF_LT(
-            node_invalid_input,
+    ZL_ERR_IF_LT(
             srcSize,
             2,
-            "Must not use Huffman for 0 or 1 element (should be impossible for users to trigger)");
-    ZL_RET_R_IF_EQ(
             node_invalid_input,
+            "Must not use Huffman for 0 or 1 element (should be impossible for users to trigger)");
+    ZL_ERR_IF_EQ(
             histogram->count[histogram->maxSymbol],
             histogram->total,
+            node_invalid_input,
             "Must not use Huffman on constant data (should be impossible for users to trigger)");
 
     // 1. Build table
@@ -215,20 +218,20 @@ ZL_Report EI_huffman_v2(ZL_Encoder* eictx, const ZL_Input* ins[], size_t nbIns)
         size_t const weightsSize = histogram->maxSymbol + 1;
         ZL_Output* const weightsStream =
                 ZL_Encoder_createTypedStream(eictx, 0, weightsSize, 1);
-        ZL_RET_R_IF_NULL(allocation, weightsStream);
+        ZL_ERR_IF_NULL(weightsStream, allocation);
         uint8_t* const weights = ZL_Output_ptr(weightsStream);
 
         size_t tableLog = HUF_optimalTableLog(
                 HUF_TABLELOG_DEFAULT, srcSize, histogram->maxSymbol);
         ctable = ZL_Encoder_getScratchSpace(
                 eictx, HUF_CTABLE_SIZE(histogram->maxSymbol));
-        ZL_RET_R_IF_NULL(allocation, ctable);
+        ZL_ERR_IF_NULL(ctable, allocation);
         tableLog = HUF_buildCTable(
                 ctable,
                 histogram->count,
                 histogram->maxSymbol,
                 (unsigned)tableLog);
-        ZL_RET_R_IF(GENERIC, HUF_isError(tableLog));
+        ZL_ERR_IF(HUF_isError(tableLog), GENERIC);
 
         HUF_CElt const* ct = ctable + 1;
         for (size_t i = 0; i < weightsSize; ++i) {
@@ -238,9 +241,9 @@ ZL_Report EI_huffman_v2(ZL_Encoder* eictx, const ZL_Input* ins[], size_t nbIns)
             ZL_ASSERT_EQ(weights[i] == 0, histogram->count[i] == 0);
         }
 
-        ZL_RET_R_IF_ERR(
+        ZL_ERR_IF_ERR(
                 ZL_Output_setIntMetadata(weightsStream, 0, (int)tableLog));
-        ZL_RET_R_IF_ERR(ZL_Output_commit(weightsStream, weightsSize));
+        ZL_ERR_IF_ERR(ZL_Output_commit(weightsStream, weightsSize));
     }
 
     // 2. Decide on 4x streams & send header
@@ -258,7 +261,7 @@ ZL_Report EI_huffman_v2(ZL_Encoder* eictx, const ZL_Input* ins[], size_t nbIns)
     size_t const bitCapacity = HUF_compressBound(srcSize);
     ZL_Output* bitStream =
             ZL_Encoder_createTypedStream(eictx, 1, bitCapacity, 1);
-    ZL_RET_R_IF_NULL(allocation, bitStream);
+    ZL_ERR_IF_NULL(bitStream, allocation);
 
     size_t const bitSize = x4 ? HUF_compress4X_usingCTable(
                                         ZL_Output_ptr(bitStream),
@@ -272,13 +275,13 @@ ZL_Report EI_huffman_v2(ZL_Encoder* eictx, const ZL_Input* ins[], size_t nbIns)
                                         src,
                                         srcSize,
                                         ctable);
-    ZL_RET_R_IF(node_invalid_input, HUF_isError(bitSize));
-    ZL_RET_R_IF_EQ(
-            node_invalid_input,
+    ZL_ERR_IF(HUF_isError(bitSize), node_invalid_input);
+    ZL_ERR_IF_EQ(
             bitSize,
             0,
+            node_invalid_input,
             "Huffman source is not compressible (should be impossible to trigger for user)");
-    ZL_RET_R_IF_ERR(ZL_Output_commit(bitStream, bitSize));
+    ZL_ERR_IF_ERR(ZL_Output_commit(bitStream, bitSize));
 
     return ZL_returnSuccess();
 }
@@ -286,25 +289,26 @@ ZL_Report EI_huffman_v2(ZL_Encoder* eictx, const ZL_Input* ins[], size_t nbIns)
 ZL_Report
 EI_huffman_struct_v2(ZL_Encoder* eictx, const ZL_Input* ins[], size_t nbIns)
 {
+    ZL_RESULT_DECLARE_SCOPE_REPORT(eictx);
     ZL_ASSERT_EQ(nbIns, 1);
     ZL_ASSERT_NN(ins);
     const ZL_Input* in = ins[0];
-    ZL_RET_R_IF_NE(node_invalid_input, ZL_Input_eltWidth(in), 2);
+    ZL_ERR_IF_NE(ZL_Input_eltWidth(in), 2, node_invalid_input);
 
     ZL_ASSERT(ZL_Input_type(in) == ZL_Type_struct);
     uint16_t const* src           = ZL_Input_ptr(in);
     size_t const srcSize          = ZL_Input_numElts(in);
     ZL_Histogram const* histogram = getHistogram(eictx, in);
 
-    ZL_RET_R_IF_LT(
-            node_invalid_input,
+    ZL_ERR_IF_LT(
             srcSize,
             2,
-            "Must not use Huffman for 0 or 1 element (should be impossible for users to trigger)");
-    ZL_RET_R_IF_EQ(
             node_invalid_input,
+            "Must not use Huffman for 0 or 1 element (should be impossible for users to trigger)");
+    ZL_ERR_IF_EQ(
             histogram->count[histogram->maxSymbol],
             histogram->total,
+            node_invalid_input,
             "Must not use Huffman on constant data (should be impossible for users to trigger)");
 
     // 1. Build table
@@ -314,15 +318,15 @@ EI_huffman_struct_v2(ZL_Encoder* eictx, const ZL_Input* ins[], size_t nbIns)
         size_t const weightsSize = histogram->maxSymbol + 1;
         ZL_Output* const weightsStream =
                 ZL_Encoder_createTypedStream(eictx, 0, weightsSize, 1);
-        ZL_RET_R_IF_NULL(allocation, weightsStream);
+        ZL_ERR_IF_NULL(weightsStream, allocation);
         uint8_t* const weights = ZL_Output_ptr(weightsStream);
 
         ctable = ZL_Encoder_getScratchSpace(
                 eictx, sizeof(ZS_Huf16CElt) * weightsSize);
-        ZL_RET_R_IF_NULL(allocation, ctable);
+        ZL_ERR_IF_NULL(ctable, allocation);
         ZL_Report tableLogRet = ZS_largeHuffmanBuildCTable(
                 ctable, histogram->count, (uint16_t)histogram->maxSymbol, 0);
-        ZL_RET_R_IF_ERR(tableLogRet);
+        ZL_ERR_IF_ERR(tableLogRet);
         tableLog = (int)ZL_validResult(tableLogRet);
 
         for (size_t i = 0; i < weightsSize; ++i) {
@@ -331,9 +335,9 @@ EI_huffman_struct_v2(ZL_Encoder* eictx, const ZL_Input* ins[], size_t nbIns)
             ZL_ASSERT_EQ(weights[i] == 0, histogram->count[i] == 0);
         }
 
-        ZL_RET_R_IF_ERR(
+        ZL_ERR_IF_ERR(
                 ZL_Output_setIntMetadata(weightsStream, 0, (int)tableLog));
-        ZL_RET_R_IF_ERR(ZL_Output_commit(weightsStream, weightsSize));
+        ZL_ERR_IF_ERR(ZL_Output_commit(weightsStream, weightsSize));
     }
 
     // 2. Decide on 4x streams & send header
@@ -351,7 +355,7 @@ EI_huffman_struct_v2(ZL_Encoder* eictx, const ZL_Input* ins[], size_t nbIns)
     size_t const bitCapacity = 2 * srcSize + 32;
     ZL_Output* bitStream =
             ZL_Encoder_createTypedStream(eictx, 1, bitCapacity, 1);
-    ZL_RET_R_IF_NULL(allocation, bitStream);
+    ZL_ERR_IF_NULL(bitStream, allocation);
 
     ZL_WC bits             = ZL_WC_wrap(ZL_Output_ptr(bitStream), bitCapacity);
     ZL_Report const report = x4
@@ -359,9 +363,9 @@ EI_huffman_struct_v2(ZL_Encoder* eictx, const ZL_Input* ins[], size_t nbIns)
                       &bits, src, srcSize, ctable, tableLog)
             : ZS_largeHuffmanEncodeUsingCTable(
                       &bits, src, srcSize, ctable, tableLog);
-    ZL_RET_R_IF_ERR(report);
+    ZL_ERR_IF_ERR(report);
     ZL_ASSERT_LE(ZL_WC_size(&bits), bitCapacity);
-    ZL_RET_R_IF_ERR(ZL_Output_commit(bitStream, ZL_WC_size(&bits)));
+    ZL_ERR_IF_ERR(ZL_Output_commit(bitStream, ZL_WC_size(&bits)));
 
     return ZL_returnSuccess();
 }
@@ -369,6 +373,7 @@ EI_huffman_struct_v2(ZL_Encoder* eictx, const ZL_Input* ins[], size_t nbIns)
 // ZL_TypedEncoderFn
 ZL_Report EI_fse_typed(ZL_Encoder* eictx, const ZL_Input* ins[], size_t nbIns)
 {
+    ZL_RESULT_DECLARE_SCOPE_REPORT(eictx);
     ZL_ASSERT_EQ(nbIns, 1);
     ZL_ASSERT_NN(ins);
     const ZL_Input* in = ins[0];
@@ -377,14 +382,14 @@ ZL_Report EI_fse_typed(ZL_Encoder* eictx, const ZL_Input* ins[], size_t nbIns)
     ZL_ASSERT(
             ZL_Input_type(in) == ZL_Type_serial
             || ZL_Input_type(in) == ZL_Type_struct);
-    ZL_RET_R_IF_NE(GENERIC, ZL_Input_eltWidth(in), 1);
+    ZL_ERR_IF_NE(ZL_Input_eltWidth(in), 1, GENERIC);
     const void* const src = ZL_Input_ptr(in);
     size_t const srcSize  = ZL_Input_numElts(in);
     size_t const dstCapacity =
             ZS_Entropy_encodedSizeBound(srcSize, /* elementSize */ 1);
     ZL_Output* const out =
             ZL_Encoder_createTypedStream(eictx, 0, dstCapacity, 1);
-    ZL_RET_R_IF_NULL(allocation, out);
+    ZL_ERR_IF_NULL(out, allocation);
     // Starting version 5 we can support more than two states and we send the
     // number of states in the header, otherwise we conform to older versions
     // that only support 2 states.
@@ -398,11 +403,11 @@ ZL_Report EI_fse_typed(ZL_Encoder* eictx, const ZL_Input* ins[], size_t nbIns)
     // ZL_WriteCursor API, it should be updated to no longer depends on this
     // abstraction
     ZL_WriteCursor wc = ZL_WC_wrap(ZL_Output_ptr(out), dstCapacity);
-    ZL_RET_R_IF(
-            GENERIC,
+    ZL_ERR_IF(
             ZL_isError(ZS_Entropy_encodeFse(
-                    &wc, src, srcSize, /* elementSize */ 1, nbStates)));
-    ZL_RET_R_IF_ERR(ZL_Output_commit(out, ZL_WC_size(&wc)));
+                    &wc, src, srcSize, /* elementSize */ 1, nbStates)),
+            GENERIC);
+    ZL_ERR_IF_ERR(ZL_Output_commit(out, ZL_WC_size(&wc)));
     return ZL_returnValue(1);
 }
 
@@ -427,6 +432,7 @@ static void EI_huffman_header(ZL_Encoder* eictx, ZL_Input const* in)
 ZL_Report
 EI_huffman_typed(ZL_Encoder* eictx, const ZL_Input* ins[], size_t nbIns)
 {
+    ZL_RESULT_DECLARE_SCOPE_REPORT(eictx);
     ZL_ASSERT_EQ(nbIns, 1);
     ZL_ASSERT_NN(ins);
     const ZL_Input* in = ins[0];
@@ -440,16 +446,16 @@ EI_huffman_typed(ZL_Encoder* eictx, const ZL_Input* ins[], size_t nbIns)
     size_t const eltWidth = ZL_Input_eltWidth(in);
     size_t const nbElts   = ZL_Input_numElts(in);
 
-    ZL_RET_R_IF_GT(
-            node_invalid_input,
+    ZL_ERR_IF_GT(
             eltWidth,
             2,
+            node_invalid_input,
             "eltWidth > 2 is no longer supported for encoding.");
 
     ZL_ASSERT(
             ZL_Input_type(in) == ZL_Type_serial
             || ZL_Input_type(in) == ZL_Type_struct);
-    ZL_RET_R_IF_GT(GENERIC, eltWidth, 2);
+    ZL_ERR_IF_GT(eltWidth, 2, GENERIC);
 
     //> Tell the entropy compressor to use Huffman, or a raw-bits mode,
     //> and allow block splitting.
@@ -463,20 +469,20 @@ EI_huffman_typed(ZL_Encoder* eictx, const ZL_Input* ins[], size_t nbIns)
     size_t const dstCapacity = ZS_Entropy_encodedSizeBound(nbElts, eltWidth);
     ZL_Output* const out     = ZL_Encoder_createTypedStream(
             eictx, 0, dstCapacity, /* eltWidth */ 1);
-    ZL_RET_R_IF_NULL(allocation, out);
+    ZL_ERR_IF_NULL(out, allocation);
     ZL_WriteCursor wc = ZL_WC_wrap(ZL_Output_ptr(out), dstCapacity);
 
     //> Write our header & encode
     EI_huffman_header(eictx, in);
     if (nbElts > 0) {
-        ZL_RET_R_IF(
-                GENERIC,
-                ZL_isError(ZS_Entropy_encode(
-                        &wc, src, nbElts, eltWidth, &params)));
+        ZL_ERR_IF(
+                ZL_isError(
+                        ZS_Entropy_encode(&wc, src, nbElts, eltWidth, &params)),
+                GENERIC);
     }
 
     //> Tell how large the output stream is.
-    ZL_RET_R_IF_ERR(ZL_Output_commit(out, ZL_WC_size(&wc)));
+    ZL_ERR_IF_ERR(ZL_Output_commit(out, ZL_WC_size(&wc)));
 
     //> Return the number of output streams.
     return ZL_returnValue(1);
@@ -601,6 +607,7 @@ static ZL_Report runBitpack(ZL_Edge* input)
 static ZL_Report
 entropyCompressChunk(ZL_Graph* gctx, ZL_Edge* chunk, EntropyBackendMode mode)
 {
+    ZL_RESULT_DECLARE_SCOPE_REPORT(gctx);
     ZL_Input const* input = ZL_Edge_getData(chunk);
     size_t const nbElts   = ZL_Input_numElts(input);
     size_t const eltWidth = ZL_Input_eltWidth(input);
@@ -614,7 +621,7 @@ entropyCompressChunk(ZL_Graph* gctx, ZL_Edge* chunk, EntropyBackendMode mode)
         ZL_ASSERT_EQ(ZL_Input_type(input), ZL_Type_struct);
         ZL_Histogram* histogram = (ZL_Histogram*)ZL_Graph_getScratchSpace(
                 gctx, sizeof(ZL_Histogram16));
-        ZL_RET_R_IF_NULL(allocation, histogram);
+        ZL_ERR_IF_NULL(histogram, allocation);
         ZL_Histogram_init(histogram, 65535);
         ZL_Histogram_build(histogram, ZL_Input_ptr(input), nbElts, eltWidth);
 
@@ -655,12 +662,12 @@ entropyCompressChunk(ZL_Graph* gctx, ZL_Edge* chunk, EntropyBackendMode mode)
                     ZL_Edge_runNode(chunk, ZL_NODE_TOKENIZE));
             ZL_ASSERT_EQ(streams.nbEdges, 2);
             // Bitpack the values stream if possible
-            ZL_RET_R_IF_ERR(
+            ZL_ERR_IF_ERR(
                     nbBits < 16 ? runBitpack(streams.edges[0])
                                 : ZL_Edge_setDestination(
                                           streams.edges[0], ZL_GRAPH_STORE));
             // Huffman compress the tokenized stream
-            ZL_RET_R_IF_ERR(
+            ZL_ERR_IF_ERR(
                     ZL_Edge_setDestination(streams.edges[1], ZL_GRAPH_HUFFMAN));
             return ZL_returnSuccess();
         }
@@ -675,9 +682,8 @@ entropyCompressChunk(ZL_Graph* gctx, ZL_Edge* chunk, EntropyBackendMode mode)
                                 ZL_PrivateStandardNodeID_huffman_struct_v2 },
                         histogram));
         ZL_ASSERT_EQ(streams.nbEdges, 2);
-        ZL_RET_R_IF_ERR(ZL_Edge_setDestination(streams.edges[0], ZL_GRAPH_FSE));
-        ZL_RET_R_IF_ERR(
-                ZL_Edge_setDestination(streams.edges[1], ZL_GRAPH_STORE));
+        ZL_ERR_IF_ERR(ZL_Edge_setDestination(streams.edges[0], ZL_GRAPH_FSE));
+        ZL_ERR_IF_ERR(ZL_Edge_setDestination(streams.edges[1], ZL_GRAPH_STORE));
         return ZL_returnSuccess();
     }
 
@@ -730,9 +736,8 @@ entropyCompressChunk(ZL_Graph* gctx, ZL_Edge* chunk, EntropyBackendMode mode)
                         (ZL_NodeID){ ZL_PrivateStandardNodeID_huffman_v2 },
                         histogram));
         ZL_ASSERT_EQ(streams.nbEdges, 2);
-        ZL_RET_R_IF_ERR(ZL_Edge_setDestination(streams.edges[0], ZL_GRAPH_FSE));
-        ZL_RET_R_IF_ERR(
-                ZL_Edge_setDestination(streams.edges[1], ZL_GRAPH_STORE));
+        ZL_ERR_IF_ERR(ZL_Edge_setDestination(streams.edges[0], ZL_GRAPH_FSE));
+        ZL_ERR_IF_ERR(ZL_Edge_setDestination(streams.edges[1], ZL_GRAPH_STORE));
         return ZL_returnSuccess();
     } else {
         ZL_TRY_LET_T(
@@ -743,11 +748,10 @@ entropyCompressChunk(ZL_Graph* gctx, ZL_Edge* chunk, EntropyBackendMode mode)
                         (ZL_NodeID){ ZL_PrivateStandardNodeID_fse_v2 },
                         histogram));
         ZL_ASSERT_EQ(streams.nbEdges, 2);
-        ZL_RET_R_IF_ERR(ZL_Edge_setDestination(
+        ZL_ERR_IF_ERR(ZL_Edge_setDestination(
                 streams.edges[0],
                 (ZL_GraphID){ ZL_PrivateStandardGraphID_fse_ncount }));
-        ZL_RET_R_IF_ERR(
-                ZL_Edge_setDestination(streams.edges[1], ZL_GRAPH_STORE));
+        ZL_ERR_IF_ERR(ZL_Edge_setDestination(streams.edges[1], ZL_GRAPH_STORE));
         return ZL_returnSuccess();
     }
 }
@@ -755,15 +759,17 @@ entropyCompressChunk(ZL_Graph* gctx, ZL_Edge* chunk, EntropyBackendMode mode)
 static ZL_Report
 entropyDynamicGraph(ZL_Graph* gctx, ZL_Edge* sctx, EntropyBackendMode mode)
 {
+    ZL_RESULT_DECLARE_SCOPE_REPORT(gctx);
     ZL_TRY_LET_T(ZL_EdgeList, chunks, chunkInputStream(gctx, &sctx));
     for (size_t i = 0; i < chunks.nbEdges; ++i) {
-        ZL_RET_R_IF_ERR(entropyCompressChunk(gctx, chunks.edges[i], mode));
+        ZL_ERR_IF_ERR(entropyCompressChunk(gctx, chunks.edges[i], mode));
     }
     return ZL_returnSuccess();
 }
 
 static ZL_Report doEntropyConversion(ZL_Graph* gctx, ZL_Edge** sctx)
 {
+    ZL_RESULT_DECLARE_SCOPE_REPORT(gctx);
     (void)gctx;
 
     ZL_Input const* const input = ZL_Edge_getData(*sctx);
@@ -783,7 +789,7 @@ static ZL_Report doEntropyConversion(ZL_Graph* gctx, ZL_Edge** sctx)
         }
     } else {
         ZL_ASSERT_GT(eltWidth, 1);
-        ZL_RET_R_IF_NE(node_invalid_input, eltWidth, 2);
+        ZL_ERR_IF_NE(eltWidth, 2, node_invalid_input);
 
         if (type == ZL_Type_numeric) {
             // Accept numeric inputs so we don't get a conversion from
@@ -813,9 +819,10 @@ static ZL_Report doEntropyConversion(ZL_Graph* gctx, ZL_Edge** sctx)
 
 ZL_Report EI_fseDynamicGraph(ZL_Graph* gctx, ZL_Edge* inputs[], size_t nbIns)
 {
-    ZL_RET_R_IF(graph_invalidNumInputs, nbIns != 1);
+    ZL_RESULT_DECLARE_SCOPE_REPORT(gctx);
+    ZL_ERR_IF(nbIns != 1, graph_invalidNumInputs);
     ZL_Edge* input = inputs[0];
-    ZL_RET_R_IF_ERR(doEntropyConversion(gctx, &input));
+    ZL_ERR_IF_ERR(doEntropyConversion(gctx, &input));
     if (ZL_Graph_getCParam(gctx, ZL_CParam_formatVersion) < 15) {
         ZL_TRY_LET_T(
                 ZL_EdgeList,
@@ -833,9 +840,10 @@ ZL_Report EI_fseDynamicGraph(ZL_Graph* gctx, ZL_Edge* inputs[], size_t nbIns)
 ZL_Report
 EI_huffmanDynamicGraph(ZL_Graph* gctx, ZL_Edge* inputs[], size_t nbIns)
 {
-    ZL_RET_R_IF(graph_invalidNumInputs, nbIns != 1);
+    ZL_RESULT_DECLARE_SCOPE_REPORT(gctx);
+    ZL_ERR_IF(nbIns != 1, graph_invalidNumInputs);
     ZL_Edge* input = inputs[0];
-    ZL_RET_R_IF_ERR(doEntropyConversion(gctx, &input));
+    ZL_ERR_IF_ERR(doEntropyConversion(gctx, &input));
     if (ZL_Graph_getCParam(gctx, ZL_CParam_formatVersion) < 15) {
         ZL_NodeID const node =
                 ZL_Input_type(ZL_Edge_getData(input)) == ZL_Type_serial
@@ -853,9 +861,10 @@ EI_huffmanDynamicGraph(ZL_Graph* gctx, ZL_Edge* inputs[], size_t nbIns)
 ZL_Report
 EI_entropyDynamicGraph(ZL_Graph* gctx, ZL_Edge* inputs[], size_t nbIns)
 {
-    ZL_RET_R_IF(graph_invalidNumInputs, nbIns != 1);
+    ZL_RESULT_DECLARE_SCOPE_REPORT(gctx);
+    ZL_ERR_IF(nbIns != 1, graph_invalidNumInputs);
     ZL_Edge* input = inputs[0];
-    ZL_RET_R_IF_ERR(doEntropyConversion(gctx, &input));
+    ZL_ERR_IF_ERR(doEntropyConversion(gctx, &input));
     if (ZL_Graph_getCParam(gctx, ZL_CParam_formatVersion) < 15) {
         ZL_Input const* stream = ZL_Edge_getData(input);
         if (ZL_Input_type(stream) != ZL_Type_serial) {

--- a/src/openzl/codecs/flatpack/decode_flatpack_binding.c
+++ b/src/openzl/codecs/flatpack/decode_flatpack_binding.c
@@ -6,6 +6,7 @@
 
 ZL_Report DI_flatpack(ZL_Decoder* dictx, const ZL_Input* ins[])
 {
+    ZL_RESULT_DECLARE_SCOPE_REPORT(dictx);
     ZL_Input const* const alphabet = ins[0];
     ZL_Input const* const packed   = ins[1];
 
@@ -15,13 +16,13 @@ ZL_Report DI_flatpack(ZL_Decoder* dictx, const ZL_Input* ins[])
     size_t const alphabetSize = ZL_Input_numElts(alphabet);
     size_t const packedSize   = ZL_Input_numElts(packed);
 
-    ZL_RET_R_IF_GT(corruption, alphabetSize, 256, "Alphabet too large!");
+    ZL_ERR_IF_GT(alphabetSize, 256, corruption, "Alphabet too large!");
 
     size_t const nbElts = ZS_FlatPack_nbElts(
             alphabetSize, (uint8_t const*)ZL_Input_ptr(packed), packedSize);
 
     ZL_Output* const out = ZL_Decoder_create1OutStream(dictx, nbElts, 1);
-    ZL_RET_R_IF_NULL(allocation, out);
+    ZL_ERR_IF_NULL(out, allocation);
 
     ZS_FlatPackSize const size = ZS_flatpackDecode(
             (uint8_t*)ZL_Output_ptr(out),
@@ -30,10 +31,10 @@ ZL_Report DI_flatpack(ZL_Decoder* dictx, const ZL_Input* ins[])
             alphabetSize,
             (uint8_t const*)ZL_Input_ptr(packed),
             packedSize);
-    ZL_RET_R_IF(
-            corruption, ZS_FlatPack_isError(size), "Flatpack decoding failed!");
+    ZL_ERR_IF(
+            ZS_FlatPack_isError(size), corruption, "Flatpack decoding failed!");
 
-    ZL_RET_R_IF_ERR(ZL_Output_commit(out, nbElts));
+    ZL_ERR_IF_ERR(ZL_Output_commit(out, nbElts));
 
     return ZL_returnValue(1);
 }

--- a/src/openzl/codecs/flatpack/encode_flatpack_binding.c
+++ b/src/openzl/codecs/flatpack/encode_flatpack_binding.c
@@ -6,6 +6,7 @@
 
 ZL_Report EI_flatpack(ZL_Encoder* eictx, const ZL_Input* ins[], size_t nbIns)
 {
+    ZL_RESULT_DECLARE_SCOPE_REPORT(eictx);
     ZL_ASSERT_EQ(nbIns, 1);
     ZL_ASSERT_NN(ins);
     const ZL_Input* in = ins[0];
@@ -20,7 +21,7 @@ ZL_Report EI_flatpack(ZL_Encoder* eictx, const ZL_Input* ins[], size_t nbIns)
             ZL_Encoder_createTypedStream(eictx, 1, packedCapacity, 1);
 
     if (alphabet == NULL || packed == NULL) {
-        ZL_RET_R_ERR(allocation);
+        ZL_ERR(allocation);
     }
 
     ZS_FlatPackSize const size = ZS_flatpackEncode(
@@ -32,8 +33,8 @@ ZL_Report EI_flatpack(ZL_Encoder* eictx, const ZL_Input* ins[], size_t nbIns)
             nbElts);
     ZL_ASSERT(!ZS_FlatPack_isError(size));
 
-    ZL_RET_R_IF_ERR(ZL_Output_commit(alphabet, ZS_FlatPack_alphabetSize(size)));
-    ZL_RET_R_IF_ERR(
+    ZL_ERR_IF_ERR(ZL_Output_commit(alphabet, ZS_FlatPack_alphabetSize(size)));
+    ZL_ERR_IF_ERR(
             ZL_Output_commit(packed, ZS_FlatPack_packedSize(size, nbElts)));
 
     return ZL_returnValue(2);

--- a/src/openzl/codecs/float_deconstruct/decode_float_deconstruct_binding.c
+++ b/src/openzl/codecs/float_deconstruct/decode_float_deconstruct_binding.c
@@ -12,6 +12,7 @@
 
 ZL_Report DI_float_deconstruct(ZL_Decoder* dictx, const ZL_Input* ins[])
 {
+    ZL_RESULT_DECLARE_SCOPE_REPORT(dictx);
     ZL_Input const* const signFracStream = ins[0];
     ZL_Input const* const exponentStream = ins[1];
 
@@ -19,27 +20,25 @@ ZL_Report DI_float_deconstruct(ZL_Decoder* dictx, const ZL_Input* ins[])
     ZL_ASSERT_EQ(ZL_Input_type(signFracStream), ZL_Type_struct);
 
     size_t const nbElts = ZL_Input_numElts(exponentStream);
-    ZL_RET_R_IF_NE(corruption, nbElts, ZL_Input_numElts(signFracStream));
+    ZL_ERR_IF_NE(nbElts, ZL_Input_numElts(signFracStream), corruption);
 
     FLTDECON_ElementType_e eltType = FLTDECON_ElementType_float32;
     if (DI_getFrameFormatVersion(dictx) >= 5) {
         ZL_RBuffer const header = ZL_Decoder_getCodecHeader(dictx);
-        ZL_RET_R_IF_NE(corruption, header.size, 1);
+        ZL_ERR_IF_NE(header.size, 1, corruption);
         uint8_t const* const hdr = (uint8_t const*)header.start;
-        ZL_RET_R_IF_GT(corruption, *hdr, FLTDECON_ElementTypeEnumMaxValue);
+        ZL_ERR_IF_GT(*hdr, FLTDECON_ElementTypeEnumMaxValue, corruption);
         eltType = (FLTDECON_ElementType_e)(*hdr);
     }
 
     ZL_TRY_LET_R(signFracWidth, FLTDECON_SignFracWidth(eltType));
     ZL_TRY_LET_R(exponentWidth, FLTDECON_ExponentWidth(eltType));
-    ZL_RET_R_IF_NE(
-            corruption, ZL_Input_eltWidth(signFracStream), signFracWidth);
-    ZL_RET_R_IF_NE(
-            corruption, ZL_Input_eltWidth(exponentStream), exponentWidth);
+    ZL_ERR_IF_NE(ZL_Input_eltWidth(signFracStream), signFracWidth, corruption);
+    ZL_ERR_IF_NE(ZL_Input_eltWidth(exponentStream), exponentWidth, corruption);
 
     ZL_TRY_LET_R(eltWidth, FLTDECON_ElementWidth(eltType));
     ZL_Output* const out = ZL_Decoder_create1OutStream(dictx, nbElts, eltWidth);
-    ZL_RET_R_IF_NULL(allocation, out);
+    ZL_ERR_IF_NULL(out, allocation);
 
     uint8_t const* const exponent =
             (uint8_t const*)ZL_Input_ptr(exponentStream);
@@ -63,6 +62,6 @@ ZL_Report DI_float_deconstruct(ZL_Decoder* dictx, const ZL_Input* ins[])
             break;
     }
 
-    ZL_RET_R_IF_ERR(ZL_Output_commit(out, nbElts));
+    ZL_ERR_IF_ERR(ZL_Output_commit(out, nbElts));
     return ZL_returnValue(1);
 }

--- a/src/openzl/codecs/float_deconstruct/encode_float_deconstruct_binding.c
+++ b/src/openzl/codecs/float_deconstruct/encode_float_deconstruct_binding.c
@@ -11,10 +11,11 @@ ZL_INLINE_KEYWORD ZL_Report float_deconstruct(
         const ZL_Input* in,
         FLTDECON_ElementType_e eltType)
 {
-    ZL_RET_R_IF_GT(logicError, eltType, FLTDECON_ElementTypeEnumMaxValue);
+    ZL_RESULT_DECLARE_SCOPE_REPORT(eictx);
+    ZL_ERR_IF_GT(eltType, FLTDECON_ElementTypeEnumMaxValue, logicError);
     ZL_TRY_LET_R(expectedEltWidth, FLTDECON_ElementWidth(eltType));
-    ZL_RET_R_IF_NE(
-            streamParameter_invalid, ZL_Input_eltWidth(in), expectedEltWidth);
+    ZL_ERR_IF_NE(
+            ZL_Input_eltWidth(in), expectedEltWidth, streamParameter_invalid);
     ZL_ASSERT_EQ(ZL_Input_type(in), ZL_Type_numeric);
 
     size_t const nbElts = ZL_Input_numElts(in);
@@ -25,7 +26,7 @@ ZL_INLINE_KEYWORD ZL_Report float_deconstruct(
         uint8_t safeEltType = (uint8_t)eltType;
         ZL_Encoder_sendCodecHeader(eictx, &safeEltType, sizeof(safeEltType));
     } else {
-        ZL_RET_R_IF_NE(logicError, eltType, FLTDECON_ElementType_float32);
+        ZL_ERR_IF_NE(eltType, FLTDECON_ElementType_float32, logicError);
     }
 
     ZL_TRY_LET_R(signFracWidth, FLTDECON_SignFracWidth(eltType));
@@ -37,7 +38,7 @@ ZL_INLINE_KEYWORD ZL_Report float_deconstruct(
             ZL_Encoder_createTypedStream(eictx, 1, nbElts, exponentWidth);
 
     if (signFracStream == NULL || exponentStream == NULL) {
-        ZL_RET_R_ERR(allocation);
+        ZL_ERR(allocation);
     }
 
     uint8_t* const exponent = (uint8_t*)ZL_Output_ptr(exponentStream);
@@ -60,8 +61,8 @@ ZL_INLINE_KEYWORD ZL_Report float_deconstruct(
             break;
     }
 
-    ZL_RET_R_IF_ERR(ZL_Output_commit(exponentStream, nbElts));
-    ZL_RET_R_IF_ERR(ZL_Output_commit(signFracStream, nbElts));
+    ZL_ERR_IF_ERR(ZL_Output_commit(exponentStream, nbElts));
+    ZL_ERR_IF_ERR(ZL_Output_commit(signFracStream, nbElts));
 
     return ZL_returnValue(2);
 }

--- a/src/openzl/codecs/interleave/decode_interleave_binding.c
+++ b/src/openzl/codecs/interleave/decode_interleave_binding.c
@@ -88,7 +88,7 @@ ZL_Report DI_interleave(
         }
     }
     for (size_t i = 0; i < nbStreams; ++i) {
-        ZL_RET_R_IF_ERR(ZL_Output_commit(regen[i], nbStringsPerStream));
+        ZL_ERR_IF_ERR(ZL_Output_commit(regen[i], nbStringsPerStream));
     }
 
     return ZL_WRAP_VALUE(0);

--- a/src/openzl/codecs/interleave/encode_interleave_binding.c
+++ b/src/openzl/codecs/interleave/encode_interleave_binding.c
@@ -15,7 +15,7 @@ ZL_Report EI_interleave(ZL_Encoder* eictx, const ZL_Input* ins[], size_t nbIns)
             node_invalid_input,
             "Too many inputs. Only support up to 512 inputs for now");
     for (size_t i = 0; i < nbIns; i++) {
-        ZL_RET_R_IF_NULL(node_invalid_input, ins[i]);
+        ZL_ERR_IF_NULL(ins[i], node_invalid_input);
         ZL_ERR_IF_NE(
                 ZL_Input_type(ins[i]),
                 ZL_Type_string,
@@ -37,7 +37,7 @@ ZL_Report EI_interleave(ZL_Encoder* eictx, const ZL_Input* ins[], size_t nbIns)
     ZL_Encoder_sendCodecHeader(eictx, &nbInsU32, sizeof(nbInsU32));
     ZL_Output* out = ZL_Encoder_createStringStream(
             eictx, 0, nbStrsPerInput * nbIns, totSize);
-    ZL_RET_R_IF_NULL(allocation, out);
+    ZL_ERR_IF_NULL(out, allocation);
 
     char* ptr           = ZL_Output_ptr(out);
     uint32_t* strLenPtr = ZL_Output_stringLens(out);
@@ -60,6 +60,6 @@ ZL_Report EI_interleave(ZL_Encoder* eictx, const ZL_Input* ins[], size_t nbIns)
             ++strLenPtr;
         }
     }
-    ZL_RET_R_IF_ERR(ZL_Output_commit(out, nbStrsPerInput * nbIns));
+    ZL_ERR_IF_ERR(ZL_Output_commit(out, nbStrsPerInput * nbIns));
     return ZL_returnSuccess();
 }

--- a/src/openzl/codecs/lz/decode_lz_binding.c
+++ b/src/openzl/codecs/lz/decode_lz_binding.c
@@ -11,6 +11,7 @@
 
 ZL_Report DI_fieldLz(ZL_Decoder* dictx, const ZL_Input* ins[])
 {
+    ZL_RESULT_DECLARE_SCOPE_REPORT(dictx);
     ZL_Input const* const literals            = ins[0];
     ZL_Input const* const tokens              = ins[1];
     ZL_Input const* const offsets             = ins[2];
@@ -24,32 +25,32 @@ ZL_Report DI_fieldLz(ZL_Decoder* dictx, const ZL_Input* ins[])
     ZL_ASSERT_NN(ins[4]);
 
     size_t const eltWidth = ZL_Input_eltWidth(literals);
-    ZL_RET_R_IF_NOT(corruption, ZL_isPow2(eltWidth));
+    ZL_ERR_IF_NOT(ZL_isPow2(eltWidth), corruption);
 
-    ZL_RET_R_IF_NE(corruption, 2, ZL_Input_eltWidth(tokens));
-    ZL_RET_R_IF_NE(corruption, 4, ZL_Input_eltWidth(offsets));
-    ZL_RET_R_IF_NE(corruption, 4, ZL_Input_eltWidth(extraLiteralLengths));
-    ZL_RET_R_IF_NE(corruption, 4, ZL_Input_eltWidth(extraMatchLengths));
+    ZL_ERR_IF_NE(2, ZL_Input_eltWidth(tokens), corruption);
+    ZL_ERR_IF_NE(4, ZL_Input_eltWidth(offsets), corruption);
+    ZL_ERR_IF_NE(4, ZL_Input_eltWidth(extraLiteralLengths), corruption);
+    ZL_ERR_IF_NE(4, ZL_Input_eltWidth(extraMatchLengths), corruption);
 
-    ZL_RET_R_IF_NE(
-            corruption,
+    ZL_ERR_IF_NE(
             ZL_Input_eltWidth(tokens),
             2,
-            "FieldLz tokens should be 2 bytes width");
-    ZL_RET_R_IF_NE(
             corruption,
+            "FieldLz tokens should be 2 bytes width");
+    ZL_ERR_IF_NE(
             ZL_Input_eltWidth(offsets),
             4,
-            "FieldLz offsets should be 4 bytes width");
-    ZL_RET_R_IF_NE(
             corruption,
+            "FieldLz offsets should be 4 bytes width");
+    ZL_ERR_IF_NE(
             ZL_Input_eltWidth(extraLiteralLengths),
             4,
-            "FieldLz extraLiteralLengths should be 4 bytes width");
-    ZL_RET_R_IF_NE(
             corruption,
+            "FieldLz extraLiteralLengths should be 4 bytes width");
+    ZL_ERR_IF_NE(
             ZL_Input_eltWidth(extraMatchLengths),
             4,
+            corruption,
             "FieldLz extraMatchLengths should be 4 bytes width");
 
     ZL_FieldLz_InSequences src = {
@@ -78,18 +79,18 @@ ZL_Report DI_fieldLz(ZL_Decoder* dictx, const ZL_Input* ins[])
         ZL_RESULT_OF(uint64_t) const r = ZL_varintDecode(&hdr, end);
         if (ZL_RES_isError(r)) {
             ZL_DLOG(ERROR, "header decoding failed");
-            ZL_RET_R_ERR(srcSize_tooSmall);
+            ZL_ERR(srcSize_tooSmall);
         }
         if (hdr < end) {
             ZL_DLOG(ERROR, "header leftover bytes");
-            ZL_RET_R_ERR(GENERIC);
+            ZL_ERR(GENERIC);
         }
         dstEltsCapacity = ZL_RES_value(r);
     }
 
     ZL_Output* dst =
             ZL_Decoder_create1OutStream(dictx, dstEltsCapacity, eltWidth);
-    ZL_RET_R_IF_NULL(allocation, dst);
+    ZL_ERR_IF_NULL(dst, allocation);
 
     ZL_Report const dstSize = ZS2_FieldLz_decompress(
             ZL_Output_ptr(dst), dstEltsCapacity, eltWidth, &src);
@@ -97,7 +98,7 @@ ZL_Report DI_fieldLz(ZL_Decoder* dictx, const ZL_Input* ins[])
         return dstSize;
     }
 
-    ZL_RET_R_IF_ERR(ZL_Output_commit(dst, ZL_validResult(dstSize)));
+    ZL_ERR_IF_ERR(ZL_Output_commit(dst, ZL_validResult(dstSize)));
 
     return ZL_returnValue(1);
 }

--- a/src/openzl/codecs/lz/encode_lz_binding.c
+++ b/src/openzl/codecs/lz/encode_lz_binding.c
@@ -145,6 +145,7 @@ static ZL_Report tokensDynGraph(ZL_Graph* gctx, ZL_Edge* tokens)
 static ZL_Report
 quantizeDynGraph(ZL_Graph* gctx, ZL_Edge* stream, ZL_NodeID quantizeNode)
 {
+    ZL_RESULT_DECLARE_SCOPE_REPORT(gctx);
     ZL_TRY_LET_T(ZL_EdgeList, streams, ZL_Edge_runNode(stream, quantizeNode));
     ZL_ASSERT_EQ(streams.nbEdges, 2);
 
@@ -155,10 +156,10 @@ quantizeDynGraph(ZL_Graph* gctx, ZL_Edge* stream, ZL_NodeID quantizeNode)
     } else {
         codesGraph = ZL_GRAPH_FSE;
     }
-    ZL_RET_R_IF_ERR(ZL_Edge_setDestination(codes, codesGraph));
+    ZL_ERR_IF_ERR(ZL_Edge_setDestination(codes, codesGraph));
 
     ZL_Edge* const extraBits = streams.edges[1];
-    ZL_RET_R_IF_ERR(ZL_Edge_setDestination(extraBits, ZL_GRAPH_STORE));
+    ZL_ERR_IF_ERR(ZL_Edge_setDestination(extraBits, ZL_GRAPH_STORE));
 
     return ZL_returnSuccess();
 }
@@ -173,7 +174,8 @@ static size_t getMinStreamSize(ZL_Graph* gctx)
 
 ZL_Report EI_fieldLzDynGraph(ZL_Graph* gctx, ZL_Edge* inputs[], size_t nbIns)
 {
-    ZL_RET_R_IF(graph_invalidNumInputs, nbIns != 1);
+    ZL_RESULT_DECLARE_SCOPE_REPORT(gctx);
+    ZL_ERR_IF(nbIns != 1, graph_invalidNumInputs);
     ZL_Edge* input     = inputs[0];
     ZL_Input const* in = ZL_Edge_getData(input);
     ZL_ASSERT_NE(ZL_Input_type(in) & (ZL_Type_struct | ZL_Type_numeric), 0);
@@ -226,7 +228,7 @@ ZL_Report EI_fieldLzDynGraph(ZL_Graph* gctx, ZL_Edge* inputs[], size_t nbIns)
         size_t const streamSize =
                 ZL_Input_contentSize(ZL_Edge_getData(streams.edges[i]));
         if (streamSize < streamSizeLimit) {
-            ZL_RET_R_IF_ERR(
+            ZL_ERR_IF_ERR(
                     ZL_Edge_setDestination(streams.edges[i], ZL_GRAPH_STORE));
             successorSet[i] = 1;
             continue;
@@ -234,13 +236,13 @@ ZL_Report EI_fieldLzDynGraph(ZL_Graph* gctx, ZL_Edge* inputs[], size_t nbIns)
 
         ZL_IntParam const param = ZL_Graph_getLocalIntParam(gctx, i);
         if (param.paramId == i) {
-            ZL_RET_R_IF_LT(nodeParameter_invalid, param.paramValue, 0);
-            ZL_RET_R_IF_GT(
-                    nodeParameter_invalid,
+            ZL_ERR_IF_LT(param.paramValue, 0, nodeParameter_invalid);
+            ZL_ERR_IF_GT(
                     (size_t)param.paramValue,
-                    customGraphs.nbGraphIDs);
+                    customGraphs.nbGraphIDs,
+                    nodeParameter_invalid);
             ZL_GraphID const graph = customGraphs.graphids[param.paramValue];
-            ZL_RET_R_IF_ERR(ZL_Edge_setDestination(streams.edges[i], graph));
+            ZL_ERR_IF_ERR(ZL_Edge_setDestination(streams.edges[i], graph));
             successorSet[i] = 1;
         }
     }
@@ -256,22 +258,22 @@ ZL_Report EI_fieldLzDynGraph(ZL_Graph* gctx, ZL_Edge* inputs[], size_t nbIns)
 
     // Run the successors
     if (literals != NULL) {
-        ZL_RET_R_IF_ERR(
+        ZL_ERR_IF_ERR(
                 ZL_Edge_setDestination(literals, ZL_GRAPH_FIELD_LZ_LITERALS));
     }
     if (tokens != NULL) {
-        ZL_RET_R_IF_ERR(tokensDynGraph(gctx, tokens));
+        ZL_ERR_IF_ERR(tokensDynGraph(gctx, tokens));
     }
     if (offsets != NULL) {
-        ZL_RET_R_IF_ERR(
+        ZL_ERR_IF_ERR(
                 quantizeDynGraph(gctx, offsets, ZL_NODE_QUANTIZE_OFFSETS));
     }
     if (extraLiteralLengths != NULL) {
-        ZL_RET_R_IF_ERR(quantizeDynGraph(
+        ZL_ERR_IF_ERR(quantizeDynGraph(
                 gctx, extraLiteralLengths, ZL_NODE_QUANTIZE_LENGTHS));
     }
     if (extraMatchLengths != NULL) {
-        ZL_RET_R_IF_ERR(quantizeDynGraph(
+        ZL_ERR_IF_ERR(quantizeDynGraph(
                 gctx, extraMatchLengths, ZL_NODE_QUANTIZE_LENGTHS));
     }
 
@@ -281,15 +283,16 @@ ZL_Report EI_fieldLzDynGraph(ZL_Graph* gctx, ZL_Edge* inputs[], size_t nbIns)
 ZL_Report
 EI_fieldLzLiteralsDynGraph(ZL_Graph* gctx, ZL_Edge* inputs[], size_t nbIns)
 {
+    ZL_RESULT_DECLARE_SCOPE_REPORT(gctx);
     (void)gctx;
-    ZL_RET_R_IF(graph_invalidNumInputs, nbIns != 1);
+    ZL_ERR_IF(nbIns != 1, graph_invalidNumInputs);
     ZL_Edge* literals = inputs[0];
     // Transpose
     // TODO(terrelln): Determine if we should transpose at all.
     // E.g. if we have a small number of literals don't transpose.
     size_t const eltWidth = ZL_Input_eltWidth(ZL_Edge_getData(literals));
     if (eltWidth == 1) {
-        ZL_RET_R_IF_ERR(ZL_Edge_setDestination(
+        ZL_ERR_IF_ERR(ZL_Edge_setDestination(
                 literals, ZL_GRAPH_FIELD_LZ_LITERALS_CHANNEL));
         return ZL_returnSuccess();
     }
@@ -301,7 +304,7 @@ EI_fieldLzLiteralsDynGraph(ZL_Graph* gctx, ZL_Edge* inputs[], size_t nbIns)
     // E.g. if stream i is uncompressible, then stream i+1 is likely to be
     // uncompressible, if we're compressing numeric data.
     for (size_t i = 0; i < streams.nbEdges; ++i) {
-        ZL_RET_R_IF_ERR(ZL_Edge_setDestination(
+        ZL_ERR_IF_ERR(ZL_Edge_setDestination(
                 streams.edges[i], ZL_GRAPH_FIELD_LZ_LITERALS_CHANNEL));
     }
 

--- a/src/openzl/codecs/merge_sorted/decode_merge_sorted_binding.c
+++ b/src/openzl/codecs/merge_sorted/decode_merge_sorted_binding.c
@@ -13,10 +13,11 @@ static ZL_Report fillDstPtrsFromHeader(
         size_t bitsetWidth,
         size_t nbElts)
 {
+    ZL_RESULT_DECLARE_SCOPE_REPORT(dictx);
     uint64_t maxDstSize = 0;
-    ZL_RET_R_IF(
-            corruption,
+    ZL_ERR_IF(
             ZL_overflowMulU64(bitsetWidth * 8, nbElts, &maxDstSize),
+            corruption,
             "Multiplication overflowed");
 
     ZL_RBuffer const header = ZL_Decoder_getCodecHeader(dictx);
@@ -26,22 +27,22 @@ static ZL_Report fillDstPtrsFromHeader(
     uint64_t dstSize        = 0;
     while (hp != he) {
         ZL_TRY_LET_T(uint64_t, size, ZL_varintDecode(&hp, he));
-        ZL_RET_R_IF(
-                corruption,
+        ZL_ERR_IF(
                 ZL_overflowAddU64(dstSize, size, &dstSize),
+                corruption,
                 "Addition overflowed");
     }
-    ZL_RET_R_IF_GT(
-            corruption, dstSize, maxDstSize, "dstSize bigger than possible!");
+    ZL_ERR_IF_GT(
+            dstSize, maxDstSize, corruption, "dstSize bigger than possible!");
 
     ZL_Output* dst = ZL_Decoder_create1OutStream(dictx, dstSize, 4);
-    ZL_RET_R_IF_NULL(allocation, dst);
+    ZL_ERR_IF_NULL(dst, allocation);
     uint32_t* dstPtr = ZL_Output_ptr(dst);
-    ZL_RET_R_IF_ERR(ZL_Output_commit(dst, dstSize));
+    ZL_ERR_IF_ERR(ZL_Output_commit(dst, dstSize));
     hp            = hs;
     size_t nbDsts = 0;
     while (hp != he) {
-        ZL_RET_R_IF_EQ(corruption, nbDsts, 64);
+        ZL_ERR_IF_EQ(nbDsts, 64, corruption);
         ZL_RESULT_OF(uint64_t) size = ZL_varintDecode(&hp, he);
         ZL_ASSERT(!ZL_RES_isError(size));
         dsts[nbDsts] = dstPtr;
@@ -50,10 +51,10 @@ static ZL_Report fillDstPtrsFromHeader(
         ++nbDsts;
     }
 
-    ZL_RET_R_IF_GT(
-            corruption,
+    ZL_ERR_IF_GT(
             nbDsts,
             bitsetWidth * 8,
+            corruption,
             "Too many dsts for the width of the bitset");
 
     return ZL_returnValue(nbDsts);
@@ -61,19 +62,20 @@ static ZL_Report fillDstPtrsFromHeader(
 
 ZL_Report DI_mergeSorted(ZL_Decoder* dictx, ZL_Input const* ins[])
 {
+    ZL_RESULT_DECLARE_SCOPE_REPORT(dictx);
     ZL_Input const* bitset = ins[0];
     ZL_Input const* merged = ins[1];
 
-    ZL_RET_R_IF_NE(
-            corruption, ZL_Input_numElts(merged), ZL_Input_numElts(bitset));
-    ZL_RET_R_IF_NE(corruption, ZL_Input_eltWidth(merged), 4);
+    ZL_ERR_IF_NE(
+            ZL_Input_numElts(merged), ZL_Input_numElts(bitset), corruption);
+    ZL_ERR_IF_NE(ZL_Input_eltWidth(merged), 4, corruption);
     size_t const bitsetWidth = ZL_Input_eltWidth(bitset);
 
     uint32_t* dsts[64];
     uint32_t* dstEnds[64];
     ZL_Report const nbDsts = fillDstPtrsFromHeader(
             dictx, dsts, dstEnds, bitsetWidth, ZL_Input_numElts(bitset));
-    ZL_RET_R_IF_ERR(nbDsts);
+    ZL_ERR_IF_ERR(nbDsts);
 
     bool success;
     switch (bitsetWidth) {
@@ -114,9 +116,9 @@ ZL_Report DI_mergeSorted(ZL_Decoder* dictx, ZL_Input const* ins[])
                     ZL_Input_numElts(merged));
             break;
         default:
-            ZL_RET_R_ERR(corruption, "Bad bitset width!");
+            ZL_ERR(corruption, "Bad bitset width!");
     }
-    ZL_RET_R_IF_NOT(corruption, success);
+    ZL_ERR_IF_NOT(success, corruption);
 
     return ZL_returnSuccess();
 }

--- a/src/openzl/codecs/merge_sorted/encode_merge_sorted_binding.c
+++ b/src/openzl/codecs/merge_sorted/encode_merge_sorted_binding.c
@@ -50,10 +50,11 @@ static ZL_Report writeHeader(
         uint32_t const* srcEnds[64],
         size_t nbSrcs)
 {
+    ZL_RESULT_DECLARE_SCOPE_REPORT(eictx);
     uint8_t* header =
             ZL_Encoder_getScratchSpace(eictx, nbSrcs * ZL_VARINT_LENGTH_64);
     uint8_t* hp = header;
-    ZL_RET_R_IF_NULL(allocation, header);
+    ZL_ERR_IF_NULL(header, allocation);
     for (size_t i = 0; i < nbSrcs; ++i) {
         uint64_t const srcSize = (uint64_t)(srcEnds[i] - srcs[i]);
         hp += ZL_varintEncode(srcSize, hp);
@@ -64,11 +65,12 @@ static ZL_Report writeHeader(
 
 ZL_Report EI_mergeSorted(ZL_Encoder* eictx, const ZL_Input* ins[], size_t nbIns)
 {
+    ZL_RESULT_DECLARE_SCOPE_REPORT(eictx);
     ZL_ASSERT_EQ(nbIns, 1);
     ZL_ASSERT_NN(ins);
     const ZL_Input* in  = ins[0];
     size_t const nbElts = ZL_Input_numElts(in);
-    ZL_RET_R_IF_NE(node_invalid_input, ZL_Input_eltWidth(in), 4);
+    ZL_ERR_IF_NE(ZL_Input_eltWidth(in), 4, node_invalid_input);
     uint32_t const* srcs[64];
     uint32_t const* srcEnds[64];
     ZL_TRY_LET_R(nbSrcs, getSortedRuns(in, srcs, srcEnds));
@@ -80,10 +82,10 @@ ZL_Report EI_mergeSorted(ZL_Encoder* eictx, const ZL_Input* ins[], size_t nbIns)
             ZL_Encoder_createTypedStream(eictx, 0, nbElts, bitsetWidth);
     ZL_Output* merged = ZL_Encoder_createTypedStream(eictx, 1, nbElts, 4);
 
-    ZL_RET_R_IF_NULL(allocation, bitset);
-    ZL_RET_R_IF_NULL(allocation, merged);
+    ZL_ERR_IF_NULL(bitset, allocation);
+    ZL_ERR_IF_NULL(merged, allocation);
 
-    ZL_RET_R_IF_ERR(writeHeader(eictx, srcs, srcEnds, nbSrcs));
+    ZL_ERR_IF_ERR(writeHeader(eictx, srcs, srcEnds, nbSrcs));
 
     ZL_Report nbUniqueValues = ZL_returnValue(0);
     if (nbSrcs > 0) {
@@ -126,10 +128,10 @@ ZL_Report EI_mergeSorted(ZL_Encoder* eictx, const ZL_Input* ins[], size_t nbIns)
         }
     }
 
-    ZL_RET_R_IF_ERR(nbUniqueValues);
+    ZL_ERR_IF_ERR(nbUniqueValues);
 
-    ZL_RET_R_IF_ERR(ZL_Output_commit(bitset, ZL_validResult(nbUniqueValues)));
-    ZL_RET_R_IF_ERR(ZL_Output_commit(merged, ZL_validResult(nbUniqueValues)));
+    ZL_ERR_IF_ERR(ZL_Output_commit(bitset, ZL_validResult(nbUniqueValues)));
+    ZL_ERR_IF_ERR(ZL_Output_commit(merged, ZL_validResult(nbUniqueValues)));
 
     return ZL_returnSuccess();
 }

--- a/src/openzl/codecs/parse_int/decode_parse_int_binding.c
+++ b/src/openzl/codecs/parse_int/decode_parse_int_binding.c
@@ -11,25 +11,25 @@
 
 ZL_Report DI_parseInt(ZL_Decoder* decoder, const ZL_Input* ins[])
 {
+    ZL_RESULT_DECLARE_SCOPE_REPORT(decoder);
     ZL_Input const* numbers = ins[0];
     const size_t eltWidth   = ZL_Input_eltWidth(numbers);
-    ZL_RET_R_IF(node_invalid_input, eltWidth != 8);
+    ZL_ERR_IF(eltWidth != 8, node_invalid_input);
     size_t const nbElts = ZL_Input_numElts(numbers);
     size_t outBound;
-    ZL_RET_R_IF(
-            allocation,
-            ZL_overflowMulST(
-                    nbElts, ZL_PARSE_INT_MAX_STRING_LENGTH, &outBound));
+    ZL_ERR_IF(
+            ZL_overflowMulST(nbElts, ZL_PARSE_INT_MAX_STRING_LENGTH, &outBound),
+            allocation);
     ZL_Output* outStream =
             ZL_Decoder_create1StringStream(decoder, nbElts, outBound);
-    ZL_RET_R_IF_NULL(allocation, outStream);
+    ZL_ERR_IF_NULL(outStream, allocation);
     uint32_t* fieldSizes = ZL_Output_stringLens(outStream);
-    ZL_RET_R_IF_NULL(allocation, fieldSizes);
+    ZL_ERR_IF_NULL(fieldSizes, allocation);
     int64_t const* nums = ZL_Input_ptr(numbers);
     size_t outSize = ZL_DecodeParseInt_fillFieldSizes(fieldSizes, nbElts, nums);
     ZL_ASSERT_LE(outSize, outBound);
     ZL_DecodeParseInt_fillContent(
             ZL_Output_ptr(outStream), outSize, nbElts, nums, fieldSizes);
-    ZL_RET_R_IF_ERR(ZL_Output_commit(outStream, nbElts));
+    ZL_ERR_IF_ERR(ZL_Output_commit(outStream, nbElts));
     return ZL_returnSuccess();
 }

--- a/src/openzl/codecs/parse_int/encode_parse_int_binding.c
+++ b/src/openzl/codecs/parse_int/encode_parse_int_binding.c
@@ -9,6 +9,7 @@
 
 ZL_Report EI_parseInt(ZL_Encoder* encoder, const ZL_Input* ins[], size_t nbIns)
 {
+    ZL_RESULT_DECLARE_SCOPE_REPORT(encoder);
     ZL_ASSERT_EQ(nbIns, 1);
     ZL_ASSERT_NN(ins);
     char const* data      = (char const*)ZL_Input_ptr(ins[0]);
@@ -17,19 +18,19 @@ ZL_Report EI_parseInt(ZL_Encoder* encoder, const ZL_Input* ins[], size_t nbIns)
     size_t const eltWidth = 8;
     ZL_Output* numbers =
             ZL_Encoder_createTypedStream(encoder, 0, nbElts, eltWidth);
-    ZL_RET_R_IF_NULL(allocation, numbers);
+    ZL_ERR_IF_NULL(numbers, allocation);
     int64_t* const nums = (int64_t*)ZL_Output_ptr(numbers);
     const ZL_RefParam parsedInts =
             ZL_Encoder_getLocalParam(encoder, ZL_PARSE_INT_PREPARSED_PARAMS);
     if (nbElts > 0 && parsedInts.paramRef) {
-        ZL_RET_R_IF_NE(nodeParameter_invalid, nbElts * 8, parsedInts.paramSize);
+        ZL_ERR_IF_NE(nbElts * 8, parsedInts.paramSize, nodeParameter_invalid);
         // Copy the prepared list of ints to the output
         memcpy(nums, parsedInts.paramRef, parsedInts.paramSize);
     } else {
-        ZL_RET_R_IF_NOT(
-                node_invalid_input, ZL_parseInt(nums, data, sizes, nbElts));
+        ZL_ERR_IF_NOT(
+                ZL_parseInt(nums, data, sizes, nbElts), node_invalid_input);
     }
-    ZL_RET_R_IF_ERR(ZL_Output_commit(numbers, nbElts));
+    ZL_ERR_IF_ERR(ZL_Output_commit(numbers, nbElts));
     return ZL_returnSuccess();
 }
 

--- a/src/openzl/codecs/prefix/decode_prefix_binding.c
+++ b/src/openzl/codecs/prefix/decode_prefix_binding.c
@@ -6,6 +6,7 @@
 
 ZL_Report DI_prefix(ZL_Decoder* dictx, const ZL_Input* ins[])
 {
+    ZL_RESULT_DECLARE_SCOPE_REPORT(dictx);
     ZL_ASSERT_NN(dictx);
     ZL_ASSERT_NN(ins);
     const ZL_Input* const in         = ins[0];
@@ -14,9 +15,9 @@ ZL_Report DI_prefix(ZL_Decoder* dictx, const ZL_Input* ins[])
             ZL_Input_type(in) == ZL_Type_string
             && ZL_Input_type(matchSizes) == ZL_Type_numeric);
 
-    ZL_RET_R_IF_NE(
-            corruption, ZL_Input_numElts(matchSizes), ZL_Input_numElts(in));
-    ZL_RET_R_IF_NE(corruption, ZL_Input_eltWidth(matchSizes), sizeof(uint32_t));
+    ZL_ERR_IF_NE(
+            ZL_Input_numElts(matchSizes), ZL_Input_numElts(in), corruption);
+    ZL_ERR_IF_NE(ZL_Input_eltWidth(matchSizes), sizeof(uint32_t), corruption);
 
     const uint8_t* const src            = ZL_Input_ptr(in);
     const uint32_t* const matchSizesSrc = ZL_Input_ptr(matchSizes);
@@ -29,25 +30,25 @@ ZL_Report DI_prefix(ZL_Decoder* dictx, const ZL_Input* ins[])
     size_t const dstSize =
             ZS_calcOriginalPrefixSize(matchSizesSrc, eltWidthsSum, nbElts);
     ZL_Output* const out = ZL_Decoder_create1OutStream(dictx, dstSize, 1);
-    ZL_RET_R_IF_NULL(
-            allocation,
+    ZL_ERR_IF_NULL(
             out,
+            allocation,
             "allocation error in prefix (DI) while trying to create an output stream of size %zu",
             dstSize);
     uint32_t* const dstFieldSizes = ZL_Output_reserveStringLens(out, nbElts);
-    ZL_RET_R_IF_NULL(
-            allocation,
+    ZL_ERR_IF_NULL(
             dstFieldSizes,
+            allocation,
             "allocation error in prefix DI while trying to create an array of size %zu",
             nbElts);
 
-    ZL_RET_R_IF_ERR(ZS_decodePrefix(
+    ZL_ERR_IF_ERR(ZS_decodePrefix(
             (uint8_t* const)ZL_Output_ptr(out),
             dstFieldSizes,
             src,
             nbElts,
             eltWidths,
             matchSizesSrc));
-    ZL_RET_R_IF_ERR(ZL_Output_commit(out, nbElts));
+    ZL_ERR_IF_ERR(ZL_Output_commit(out, nbElts));
     return ZL_returnSuccess();
 }

--- a/src/openzl/codecs/prefix/encode_prefix_binding.c
+++ b/src/openzl/codecs/prefix/encode_prefix_binding.c
@@ -10,6 +10,7 @@
 
 ZL_Report EI_prefix(ZL_Encoder* eictx, const ZL_Input* ins[], size_t nbIns)
 {
+    ZL_RESULT_DECLARE_SCOPE_REPORT(eictx);
     ZL_ASSERT_EQ(nbIns, 1);
     ZL_ASSERT_NN(ins);
     const ZL_Input* in = ins[0];
@@ -25,22 +26,22 @@ ZL_Report EI_prefix(ZL_Encoder* eictx, const ZL_Input* ins[], size_t nbIns)
 
     ZL_Output* const out =
             ZL_Encoder_createTypedStream(eictx, 0, fieldSizesSum, 1);
-    ZL_RET_R_IF_NULL(
-            allocation,
+    ZL_ERR_IF_NULL(
             out,
+            allocation,
             "allocation error in prefix while trying to create an output stream of size %zu",
             fieldSizesSum);
     uint32_t* const fieldSizes = ZL_Output_reserveStringLens(out, nbElts);
-    ZL_RET_R_IF_NULL(
-            allocation,
+    ZL_ERR_IF_NULL(
             fieldSizes,
+            allocation,
             "allocation error in prefix while trying to create a field size array of size %zu",
             nbElts);
     ZL_Output* const matchSizes =
             ZL_Encoder_createTypedStream(eictx, 1, nbElts, sizeof(uint32_t));
-    ZL_RET_R_IF_NULL(
-            allocation,
+    ZL_ERR_IF_NULL(
             matchSizes,
+            allocation,
             "allocation error in prefix while trying to create an output stream of size %zu",
             nbElts);
 
@@ -52,7 +53,7 @@ ZL_Report EI_prefix(ZL_Encoder* eictx, const ZL_Input* ins[], size_t nbIns)
             nbElts,
             eltWidths,
             fieldSizesSum);
-    ZL_RET_R_IF_ERR(ZL_Output_commit(out, nbElts));
-    ZL_RET_R_IF_ERR(ZL_Output_commit(matchSizes, nbElts));
+    ZL_ERR_IF_ERR(ZL_Output_commit(out, nbElts));
+    ZL_ERR_IF_ERR(ZL_Output_commit(matchSizes, nbElts));
     return ZL_returnSuccess();
 }

--- a/src/openzl/codecs/quantize/decode_quantize_binding.c
+++ b/src/openzl/codecs/quantize/decode_quantize_binding.c
@@ -24,17 +24,18 @@ static ZL_Report DI_quantize(
         const ZL_Input* ins[],
         ZL_Quantize32Params const* params)
 {
+    ZL_RESULT_DECLARE_SCOPE_REPORT(dictx);
     ZL_Input const* const codes = ins[0];
     ZL_Input const* const bits  = ins[1];
 
-    ZL_RET_R_IF_NE(corruption, ZL_Input_eltWidth(codes), 1, "Unsupported");
+    ZL_ERR_IF_NE(ZL_Input_eltWidth(codes), 1, corruption, "Unsupported");
     ZL_ASSERT_EQ(ZL_Input_type(bits), ZL_Type_serial);
     ZL_ASSERT_EQ(ZL_Input_eltWidth(codes), 1);
 
     size_t const nbCodes = ZL_Input_numElts(codes);
 
     ZL_Output* const out = ZL_Decoder_create1OutStream(dictx, nbCodes, 4);
-    ZL_RET_R_IF_NULL(allocation, out);
+    ZL_ERR_IF_NULL(out, allocation);
 
     // TODO(terrelln): Get this information from the stream metadata
     // if it is available.
@@ -52,7 +53,7 @@ static ZL_Report DI_quantize(
         return ret;
     }
 
-    ZL_RET_R_IF_ERR(ZL_Output_commit(out, nbCodes));
+    ZL_ERR_IF_ERR(ZL_Output_commit(out, nbCodes));
 
     return ZL_returnValue(1);
 }

--- a/src/openzl/codecs/quantize/encode_quantize_binding.c
+++ b/src/openzl/codecs/quantize/encode_quantize_binding.c
@@ -12,8 +12,9 @@ static ZL_Report EI_quantize(
         const ZL_Input* in,
         ZL_Quantize32Params const* params)
 {
-    ZL_RET_R_IF_NE(GENERIC, ZL_Input_type(in), ZL_Type_numeric);
-    ZL_RET_R_IF_NE(GENERIC, ZL_Input_eltWidth(in), 4);
+    ZL_RESULT_DECLARE_SCOPE_REPORT(eictx);
+    ZL_ERR_IF_NE(ZL_Input_type(in), ZL_Type_numeric, GENERIC);
+    ZL_ERR_IF_NE(ZL_Input_eltWidth(in), 4, GENERIC);
 
     size_t const nbElts = ZL_Input_numElts(in);
 
@@ -22,8 +23,8 @@ static ZL_Report EI_quantize(
     size_t const bitsCapacity = 4 * nbElts + 9;
     ZL_Output* bits = ZL_Encoder_createTypedStream(eictx, 1, bitsCapacity, 1);
 
-    ZL_RET_R_IF_NULL(allocation, codes);
-    ZL_RET_R_IF_NULL(allocation, bits);
+    ZL_ERR_IF_NULL(codes, allocation);
+    ZL_ERR_IF_NULL(bits, allocation);
 
     ZL_Report const bitsSize = ZS2_quantize32Encode(
             (uint8_t*)ZL_Output_ptr(bits),
@@ -32,10 +33,10 @@ static ZL_Report EI_quantize(
             (uint32_t const*)ZL_Input_ptr(in),
             nbElts,
             params);
-    ZL_RET_R_IF_ERR(bitsSize);
+    ZL_ERR_IF_ERR(bitsSize);
 
-    ZL_RET_R_IF_ERR(ZL_Output_commit(codes, nbElts));
-    ZL_RET_R_IF_ERR(ZL_Output_commit(bits, ZL_validResult(bitsSize)));
+    ZL_ERR_IF_ERR(ZL_Output_commit(codes, nbElts));
+    ZL_ERR_IF_ERR(ZL_Output_commit(bits, ZL_validResult(bitsSize)));
 
     return ZL_returnValue(2);
 }

--- a/src/openzl/codecs/range_pack/decode_range_pack_binding.c
+++ b/src/openzl/codecs/range_pack/decode_range_pack_binding.c
@@ -12,6 +12,7 @@
 
 ZL_Report DI_rangePack(ZL_Decoder* dictx, const ZL_Input* streams[])
 {
+    ZL_RESULT_DECLARE_SCOPE_REPORT(dictx);
     ZL_ASSERT_NN(streams);
     const ZL_Input* in = streams[0];
     ZL_ASSERT(ZL_Input_type(in) == ZL_Type_numeric);
@@ -20,33 +21,31 @@ ZL_Report DI_rangePack(ZL_Decoder* dictx, const ZL_Input* streams[])
     const size_t nbElts   = ZL_Input_numElts(in);
 
     const ZL_RBuffer header = ZL_Decoder_getCodecHeader(dictx);
-    ZL_RET_R_IF_LT(
-            corruption, header.size, 1, "Range decoder expects a header");
+    ZL_ERR_IF_LT(header.size, 1, corruption, "Range decoder expects a header");
     uint8_t dstWidth = *(const uint8_t*)header.start;
-    ZL_RET_R_IF_LT(
-            corruption,
+    ZL_ERR_IF_LT(
             dstWidth,
             srcWidth,
-            "Range pack decoder expects dst to contain src");
-    ZL_RET_R_IF(
             corruption,
+            "Range pack decoder expects dst to contain src");
+    ZL_ERR_IF(
             !ZL_isLegalIntegerWidth(dstWidth),
+            corruption,
             "Range pack decoder got an illegal dstWidth (%zu)",
             dstWidth);
     uint64_t minValue = 0;
     if (header.size > 1) {
         if (header.size != (size_t)(dstWidth + 1)) {
-            ZL_RET_R_ERR(
-                    corruption,
-                    "Range pack decoder header should be either 1 or 1+dstWidth bytes");
+            ZL_ERR(corruption,
+                   "Range pack decoder header should be either 1 or 1+dstWidth bytes");
         }
         minValue = ZL_readLE64_N((const uint8_t*)header.start + 1, dstWidth);
     }
     ZL_Output* dstStream = ZL_Decoder_create1OutStream(dictx, nbElts, dstWidth);
-    ZL_RET_R_IF(allocation, !dstStream);
+    ZL_ERR_IF(!dstStream, allocation);
     void* dst = ZL_Output_ptr(dstStream);
     rangePackDecode(dst, dstWidth, src, srcWidth, nbElts, minValue);
 
-    ZL_RET_R_IF_ERR(ZL_Output_commit(dstStream, nbElts));
+    ZL_ERR_IF_ERR(ZL_Output_commit(dstStream, nbElts));
     return ZL_returnValue(1);
 }

--- a/src/openzl/codecs/range_pack/encode_range_pack_binding.c
+++ b/src/openzl/codecs/range_pack/encode_range_pack_binding.c
@@ -13,6 +13,7 @@
 
 ZL_Report EI_rangePack(ZL_Encoder* eictx, const ZL_Input* ins[], size_t nbIns)
 {
+    ZL_RESULT_DECLARE_SCOPE_REPORT(eictx);
     ZL_ASSERT_EQ(nbIns, 1);
     ZL_ASSERT_NN(ins);
     const ZL_Input* in    = ins[0];
@@ -25,10 +26,10 @@ ZL_Report EI_rangePack(ZL_Encoder* eictx, const ZL_Input* ins[], size_t nbIns)
 
     ZL_Output* const dstStream =
             ZL_Encoder_createTypedStream(eictx, 0, nbElts, dstWidth);
-    ZL_RET_R_IF(allocation, !dstStream);
+    ZL_ERR_IF(!dstStream, allocation);
     void* dst = ZL_Output_ptr(dstStream);
     rangePackEncode(dst, dstWidth, src, srcWidth, nbElts, range.min);
-    ZL_RET_R_IF_ERR(ZL_Output_commit(dstStream, nbElts));
+    ZL_ERR_IF_ERR(ZL_Output_commit(dstStream, nbElts));
 
     /* Header has the source size and the min value if needed */
     uint8_t header[9];

--- a/src/openzl/codecs/rolz/decode_rolz_binding.c
+++ b/src/openzl/codecs/rolz/decode_rolz_binding.c
@@ -8,6 +8,7 @@
 // ZL_TypedEncoderFn
 ZL_Report DI_rolz_typed(ZL_Decoder* dictx, const ZL_Input* ins[])
 {
+    ZL_RESULT_DECLARE_SCOPE_REPORT(dictx);
     ZL_ASSERT_NN(dictx);
     ZL_ASSERT_NN(ins);
     const ZL_Input* const in = ins[0];
@@ -16,28 +17,29 @@ ZL_Report DI_rolz_typed(ZL_Decoder* dictx, const ZL_Input* ins[])
     ZL_ASSERT_EQ(ZL_Input_eltWidth(in), 1);
     const void* const src = ZL_Input_ptr(in);
     size_t const srcSize  = ZL_Input_numElts(in);
-    ZL_RET_R_IF_LT(srcSize_tooSmall, srcSize, 4);
+    ZL_ERR_IF_LT(srcSize, 4, srcSize_tooSmall);
     size_t const dstCapacity = ZL_readLE32(src);
     ZL_Output* const out = ZL_Decoder_create1OutStream(dictx, dstCapacity, 1);
-    ZL_RET_R_IF_NULL(allocation, out);
+    ZL_ERR_IF_NULL(out, allocation);
     void* const dst = ZL_Output_ptr(out);
     // TODO(@Cyan): it seems rolz transform still uses the older (deprecated &
     // incompatible) ZL_Report interface. To be updated
     ZL_Report const r = ZL_rolzDecompress(
             dst, dstCapacity, (const char*)src + 4, srcSize - 4);
-    ZL_RET_R_IF(transform_executionFailure, ZL_isError(r));
-    ZL_RET_R_IF_NE(
-            GENERIC,
+    ZL_ERR_IF(ZL_isError(r), transform_executionFailure);
+    ZL_ERR_IF_NE(
             ZL_validResult(r),
             dstCapacity,
+            GENERIC,
             "corruption: wrong output size");
-    ZL_RET_R_IF_ERR(ZL_Output_commit(out, dstCapacity));
+    ZL_ERR_IF_ERR(ZL_Output_commit(out, dstCapacity));
     return ZL_returnValue(1);
 }
 
 // ZL_TypedEncoderFn
 ZL_Report DI_fastlz_typed(ZL_Decoder* dictx, const ZL_Input* ins[])
 {
+    ZL_RESULT_DECLARE_SCOPE_REPORT(dictx);
     ZL_ASSERT_NN(dictx);
     ZL_ASSERT_NN(ins);
     const ZL_Input* const in = ins[0];
@@ -46,22 +48,21 @@ ZL_Report DI_fastlz_typed(ZL_Decoder* dictx, const ZL_Input* ins[])
     ZL_ASSERT_EQ(ZL_Input_eltWidth(in), 1);
     const void* const src = ZL_Input_ptr(in);
     size_t const srcSize  = ZL_Input_numElts(in);
-    ZL_RET_R_IF_LT(srcSize_tooSmall, srcSize, 4);
+    ZL_ERR_IF_LT(srcSize, 4, srcSize_tooSmall);
     size_t const dstCapacity = ZL_readLE32(src);
     ZL_Output* const out = ZL_Decoder_create1OutStream(dictx, dstCapacity, 1);
-    ZL_RET_R_IF_NULL(allocation, out);
+    ZL_ERR_IF_NULL(out, allocation);
     void* const dst = ZL_Output_ptr(out);
     // TODO(@Cyan): it seems fastlz transform still uses the older (deprecated &
     // incompatible) ZL_Report interface. To be updated
     ZL_Report const r = ZS_fastLzDecompress(
             dst, dstCapacity, (const char*)src + 4, srcSize - 4);
-    ZL_RET_R_IF(
-            GENERIC, ZL_isError(r), "corruption: ZS_fastLzDecompress failed");
-    ZL_RET_R_IF_NE(
-            GENERIC,
+    ZL_ERR_IF(ZL_isError(r), GENERIC, "corruption: ZS_fastLzDecompress failed");
+    ZL_ERR_IF_NE(
             ZL_validResult(r),
             dstCapacity,
+            GENERIC,
             "corruption: wrong output size");
-    ZL_RET_R_IF_ERR(ZL_Output_commit(out, dstCapacity));
+    ZL_ERR_IF_ERR(ZL_Output_commit(out, dstCapacity));
     return ZL_returnValue(1);
 }

--- a/src/openzl/codecs/rolz/encode_rolz_binding.c
+++ b/src/openzl/codecs/rolz/encode_rolz_binding.c
@@ -10,6 +10,7 @@
 // ZL_TypedEncoderFn
 ZL_Report EI_rolz_typed(ZL_Encoder* eictx, const ZL_Input* ins[], size_t nbIns)
 {
+    ZL_RESULT_DECLARE_SCOPE_REPORT(eictx);
     ZL_ASSERT_EQ(nbIns, 1);
     ZL_ASSERT_NN(ins);
     const ZL_Input* in = ins[0];
@@ -23,7 +24,7 @@ ZL_Report EI_rolz_typed(ZL_Encoder* eictx, const ZL_Input* ins[], size_t nbIns)
     ZL_ASSERT_GE(dstCapacity, 4);
     ZL_Output* const out =
             ZL_Encoder_createTypedStream(eictx, 0, dstCapacity, 1);
-    ZL_RET_R_IF_NULL(allocation, out);
+    ZL_ERR_IF_NULL(out, allocation);
     void* const dst = ZL_Output_ptr(out);
     ZL_ASSERT_LT(srcSize, INT_MAX);
     ZL_writeLE32(dst, (uint32_t)srcSize);
@@ -32,9 +33,9 @@ ZL_Report EI_rolz_typed(ZL_Encoder* eictx, const ZL_Input* ins[], size_t nbIns)
     // deprecated) ZL_Report API To be updated
     ZL_Report const r =
             ZS_rolzCompress((char*)dst + 4, dstCapacity - 4, src, srcSize);
-    ZL_RET_R_IF(transform_executionFailure, ZL_isError(r));
+    ZL_ERR_IF(ZL_isError(r), transform_executionFailure);
 
-    ZL_RET_R_IF_ERR(ZL_Output_commit(out, ZL_validResult(r) + 4));
+    ZL_ERR_IF_ERR(ZL_Output_commit(out, ZL_validResult(r) + 4));
     return ZL_returnValue(1);
 }
 
@@ -42,6 +43,7 @@ ZL_Report EI_rolz_typed(ZL_Encoder* eictx, const ZL_Input* ins[], size_t nbIns)
 ZL_Report
 EI_fastlz_typed(ZL_Encoder* eictx, const ZL_Input* ins[], size_t nbIns)
 {
+    ZL_RESULT_DECLARE_SCOPE_REPORT(eictx);
     ZL_ASSERT_EQ(nbIns, 1);
     ZL_ASSERT_NN(ins);
     const ZL_Input* in = ins[0];
@@ -55,7 +57,7 @@ EI_fastlz_typed(ZL_Encoder* eictx, const ZL_Input* ins[], size_t nbIns)
     ZL_ASSERT_GE(dstCapacity, 4);
     ZL_Output* const out =
             ZL_Encoder_createTypedStream(eictx, 0, dstCapacity, 1);
-    ZL_RET_R_IF_NULL(allocation, out);
+    ZL_ERR_IF_NULL(out, allocation);
     void* const dst = ZL_Output_ptr(out);
     ZL_ASSERT_LT(srcSize, INT_MAX);
     ZL_writeLE32(dst, (uint32_t)srcSize);
@@ -64,9 +66,9 @@ EI_fastlz_typed(ZL_Encoder* eictx, const ZL_Input* ins[], size_t nbIns)
     // deprecated) ZL_Report API To be updated
     ZL_Report const r =
             ZS_fastLzCompress((char*)dst + 4, dstCapacity - 4, src, srcSize);
-    ZL_RET_R_IF(transform_executionFailure, ZL_isError(r));
+    ZL_ERR_IF(ZL_isError(r), transform_executionFailure);
 
-    ZL_RET_R_IF_ERR(ZL_Output_commit(out, ZL_validResult(r) + 4));
+    ZL_ERR_IF_ERR(ZL_Output_commit(out, ZL_validResult(r) + 4));
     return ZL_returnValue(1);
 }
 


### PR DESCRIPTION
Summary:
Migrate old-style `ZL_RET_R_*` error-handling macros to the new `ZL_ERR_*` macros in all 57 codec encode/decode binding files under `src/openzl/codecs/`.

The new `ZL_ERR_*` macros require an explicit `ZL_RESULT_DECLARE_SCOPE_REPORT(ctx)` declaration at the top of each function, which provides proper error context for rich error reporting. The old `ZL_RET_R_*` macros used "magic" auto-context detection via `_Generic`, which doesn't always work correctly.

**Migration pattern:**
- Add `ZL_RESULT_DECLARE_SCOPE_REPORT(ctx)` at the top of each migrated function
- Replace `ZL_RET_R_IF(errcode, expr, ...)` → `ZL_ERR_IF(expr, errcode, ...)`
- Replace `ZL_RET_R_IF_ERR(expr)` → `ZL_ERR_IF_ERR(expr)`
- Replace `ZL_RET_R_ERR(errcode)` → `ZL_ERR(errcode)`
- Similar replacements for IF_NULL, IF_NN, IF_EQ, IF_NE, IF_GT, IF_LT, IF_GE, IF_LE

**Codecs covered:** bitSplit, bitpack, bitunpack, concat, constant, conversion, dedup, delta, dispatchN_byTag, dispatch_string, divide_by, entropy, flatpack, float_deconstruct, interleave, lz, merge_sorted, parse_int, prefix, quantize, range_pack, rolz, splitByStruct, splitN, tokenize, transpose, zigzag, zstd

Only functions with real (non-NULL, non-const) error context are migrated.

Differential Revision: D94712942
