### PR TITLE
Migrate ZL_RET_R_* to ZL_ERR_* in src/openzl/codecs/ bindings (part 4/4: splitByStruct through zstd)

### DIFF
--- a/src/openzl/codecs/splitByStruct/decode_splitByStruct_binding.c
+++ b/src/openzl/codecs/splitByStruct/decode_splitByStruct_binding.c
@@ -14,14 +14,15 @@ ZL_Report DI_splitByStruct(
         const ZL_Input* inFields[],
         size_t nbInFields)
 {
+    ZL_RESULT_DECLARE_SCOPE_REPORT(dictx);
     ZL_DLOG(BLOCK, "DI_splitByStruct: combine %zu fs-fields", nbInFields);
     ZL_ASSERT_NN(dictx);
     ZL_ASSERT_EQ(nbInFixed, 0);
     (void)inFixed;
-    ZL_RET_R_IF_EQ(
-            corruption,
+    ZL_ERR_IF_EQ(
             nbInFields,
             0,
+            corruption,
             "Split by struct must have at least one field");
     ZL_ASSERT_NN(inFields);
     ZL_ASSERT_GT(nbInFields, 0);
@@ -30,21 +31,21 @@ ZL_Report DI_splitByStruct(
     size_t const nbElts = ZL_Input_numElts(inFields[0]);
     for (size_t n = 0; n < nbInFields; n++) {
         ZL_ASSERT_NN(inFields[n]);
-        ZL_RET_R_IF_NE(
-                corruption,
+        ZL_ERR_IF_NE(
                 ZL_Input_type(inFields[n]),
                 ZL_Type_struct,
-                "DI_splitByStruct decoder transform can only ingest ZL_Type_struct streams");
-        ZL_RET_R_IF_NE(
                 corruption,
+                "DI_splitByStruct decoder transform can only ingest ZL_Type_struct streams");
+        ZL_ERR_IF_NE(
                 ZL_Input_numElts(inFields[n]),
                 nbElts,
+                corruption,
                 "DI_splitByStruct decoder can only work if all input streams have same nb of elts");
         structSize += ZL_Input_eltWidth(inFields[n]);
     }
     size_t const dstSize = nbElts * structSize;
     ZL_Output* const out = ZL_Decoder_create1OutStream(dictx, dstSize, 1);
-    ZL_RET_R_IF_NULL(allocation, out);
+    ZL_ERR_IF_NULL(out, allocation);
 
     // Note : could employ a workspace instead, when available
     size_t* const fieldSizes =
@@ -52,9 +53,8 @@ ZL_Report DI_splitByStruct(
     const void** const fieldIns =
             ZL_Decoder_getScratchSpace(dictx, nbInFields * sizeof(*fieldIns));
     if (fieldSizes == NULL || fieldIns == NULL) {
-        ZL_RET_R_ERR(
-                allocation,
-                "DI_splitByStruct: unable to allocate for structure definitions");
+        ZL_ERR(allocation,
+               "DI_splitByStruct: unable to allocate for structure definitions");
     }
     for (size_t n = 0; n < nbInFields; n++) {
         fieldSizes[n] = ZL_Input_eltWidth(inFields[n]);
@@ -69,7 +69,7 @@ ZL_Report DI_splitByStruct(
             nbInFields,
             nbElts);
     ZL_ASSERT_EQ(r, dstSize);
-    ZL_RET_R_IF_ERR(ZL_Output_commit(out, dstSize));
+    ZL_ERR_IF_ERR(ZL_Output_commit(out, dstSize));
 
     return ZL_returnSuccess();
 }

--- a/src/openzl/codecs/splitByStruct/encode_splitByStruct_binding.c
+++ b/src/openzl/codecs/splitByStruct/encode_splitByStruct_binding.c
@@ -26,6 +26,7 @@ static size_t sum(const size_t array_st[], size_t arr_size)
 ZL_Report
 EI_splitByStruct(ZL_Encoder* eictx, const ZL_Input* ins[], size_t nbIns)
 {
+    ZL_RESULT_DECLARE_SCOPE_REPORT(eictx);
     ZL_ASSERT_EQ(nbIns, 1);
     ZL_ASSERT_NN(ins);
     const ZL_Input* in = ins[0];
@@ -42,10 +43,10 @@ EI_splitByStruct(ZL_Encoder* eictx, const ZL_Input* ins[], size_t nbIns)
     //        which ensures the presence of wanted parameter.
     //        However, our test fuzzer framework seems to be setup differently,
     //        and is nonetheless invoking this node directly, without parameter.
-    ZL_RET_R_IF_EQ(
-            nodeParameter_invalid,
+    ZL_ERR_IF_EQ(
             structure.paramId,
             ZL_LP_INVALID_PARAMID,
+            nodeParameter_invalid,
             "splitByStruct requires structure description (parameter ZL_SPLITBYSTRUCT_FIELDSIZES_PID)");
     const size_t* fieldSizes = structure.paramPtr;
     ZL_ASSERT_NN(fieldSizes);
@@ -60,43 +61,43 @@ EI_splitByStruct(ZL_Encoder* eictx, const ZL_Input* ins[], size_t nbIns)
      * at graph construction time,
      * so that there is no need to check it at run time.
      * This would require a proper way to invalidate a graph (NaG) */
-    ZL_RET_R_IF_EQ(
-            nodeParameter_invalidValue,
+    ZL_ERR_IF_EQ(
             structSize,
             0,
+            nodeParameter_invalidValue,
             "structure must have a size > 0");
-    ZL_RET_R_IF_NE(
-            node_invalid_input,
+    ZL_ERR_IF_NE(
             inSize % structSize,
             0,
+            node_invalid_input,
             "splitByStruct transform requires an input size which is a strict multiple of structure size");
     ZL_ASSERT_NE(nbFields, 0); // Guaranteed by structSize > 0
     size_t const nbStructs = inSize / structSize;
 
     void** const outArr =
             ZL_Encoder_getScratchSpace(eictx, nbFields * sizeof(size_t));
-    ZL_RET_R_IF_NULL(
-            allocation,
+    ZL_ERR_IF_NULL(
             outArr,
+            allocation,
             "allocation error in splitByStruct while trying to create array of %zu output pointers",
             nbFields);
 
     for (size_t n = 0; n < nbFields; n++) {
-        ZL_RET_R_IF_EQ(
-                nodeParameter_invalidValue,
+        ZL_ERR_IF_EQ(
                 fieldSizes[n],
                 0,
+                nodeParameter_invalidValue,
                 "Must not have a field size of zero!");
         ZL_Output* const out = ZL_Encoder_createTypedStream(
                 eictx, 0, nbStructs, fieldSizes[n]);
-        ZL_RET_R_IF_NULL(
-                allocation,
+        ZL_ERR_IF_NULL(
                 out,
+                allocation,
                 "allocation error in splitByStruct while trying to create output stream %zu of size %zu",
                 n,
                 nbStructs * fieldSizes[n]);
         outArr[n] = ZL_Output_ptr(out);
-        ZL_RET_R_IF_ERR(ZL_Output_commit(out, nbStructs));
+        ZL_ERR_IF_ERR(ZL_Output_commit(out, nbStructs));
     }
 
     ZS_dispatchArrayFixedSizeStruct(

--- a/src/openzl/codecs/splitN/decode_splitN_binding.c
+++ b/src/openzl/codecs/splitN/decode_splitN_binding.c
@@ -20,6 +20,7 @@ ZL_Report DI_splitN(
         const ZL_Input* ins[],
         size_t nbInVariable)
 {
+    ZL_RESULT_DECLARE_SCOPE_REPORT(dictx);
     ZL_DLOG(BLOCK, "DI_splitN (%zu inputs to join)", nbInVariable);
     ZL_ASSERT_NN(dictx);
     ZL_ASSERT_EQ(nbInFixed, 0);
@@ -50,21 +51,21 @@ ZL_Report DI_splitN(
     size_t totalElts = 0;
     for (size_t n = 0; n < nbInVariable; n++) {
         ZL_ASSERT_NN(ins[n]);
-        ZL_RET_R_IF_NE(
-                node_unexpected_input_type,
+        ZL_ERR_IF_NE(
                 ZL_Input_type(ins[n]),
                 type,
-                "SplitN types must be homogenous");
-        ZL_RET_R_IF_NE(
                 node_unexpected_input_type,
+                "SplitN types must be homogenous");
+        ZL_ERR_IF_NE(
                 ZL_Input_eltWidth(ins[n]),
                 eltWidth,
+                node_unexpected_input_type,
                 "SplitN widths must be homogenous");
         totalElts += ZL_Input_numElts(ins[n]);
     }
     ZL_Output* const out =
             ZL_Decoder_create1OutStream(dictx, totalElts, eltWidth);
-    ZL_RET_R_IF_NULL(allocation, out);
+    ZL_ERR_IF_NULL(out, allocation);
 
     size_t pos       = 0;
     char* const wptr = ZL_Output_ptr(out);
@@ -76,7 +77,7 @@ ZL_Report DI_splitN(
     }
     ZL_ASSERT_EQ(pos, totalElts * eltWidth);
 
-    ZL_RET_R_IF_ERR(ZL_Output_commit(out, totalElts));
+    ZL_ERR_IF_ERR(ZL_Output_commit(out, totalElts));
 
     return ZL_returnSuccess();
 }

--- a/src/openzl/codecs/splitN/encode_splitN_binding.c
+++ b/src/openzl/codecs/splitN/encode_splitN_binding.c
@@ -97,6 +97,7 @@ static ZL_RESULT_OF(ZL_SplitInstructions)
 // into output streams, as described in ZL_SPLITN_SEGMENTSIZES_PID parameter.
 ZL_Report EI_splitN(ZL_Encoder* eictx, const ZL_Input* ins[], size_t nbIns)
 {
+    ZL_RESULT_DECLARE_SCOPE_REPORT(eictx);
     ZL_ASSERT_EQ(nbIns, 1);
     ZL_ASSERT_NN(ins);
     const ZL_Input* in = ins[0];
@@ -132,22 +133,21 @@ ZL_Report EI_splitN(ZL_Encoder* eictx, const ZL_Input* ins[], size_t nbIns)
             segSize = inSize - pos;
         }
         ZL_DLOG(SEQ, "EI_splitN: segment %zu of size %zu", n, segSize);
-        ZL_RET_R_IF_GT(
-                nodeParameter_invalidValue,
+        ZL_ERR_IF_GT(
                 pos + segSize,
                 inSize,
+                nodeParameter_invalidValue,
                 "split instructions require more length than input");
         ZL_Output* const s = ENC_refTypedStream(
                 eictx, 0, eltWidth, segSize, in, pos * eltWidth);
-        ZL_RET_R_IF_NULL(allocation, s);
-        ZL_RET_R_IF_ERR(
-                ZL_Output_setIntMetadata(s, ZL_SPLIT_CHANNEL_ID, (int)n));
+        ZL_ERR_IF_NULL(s, allocation);
+        ZL_ERR_IF_ERR(ZL_Output_setIntMetadata(s, ZL_SPLIT_CHANNEL_ID, (int)n));
         pos += segSize;
     }
-    ZL_RET_R_IF_NE(
-            nodeParameter_invalidValue,
+    ZL_ERR_IF_NE(
             pos,
             inSize,
+            nodeParameter_invalidValue,
             "split instructions do not map exactly the entire input");
 
     return ZL_returnSuccess();

--- a/src/openzl/codecs/tokenize/decode_tokenize_binding.c
+++ b/src/openzl/codecs/tokenize/decode_tokenize_binding.c
@@ -11,6 +11,7 @@
 
 ZL_Report DI_tokenize(ZL_Decoder* dictx, const ZL_Input* in[])
 {
+    ZL_RESULT_DECLARE_SCOPE_REPORT(dictx);
     ZL_Input const* const alphabet = in[0];
     ZL_Input const* const indices  = in[1];
 
@@ -21,7 +22,7 @@ ZL_Report DI_tokenize(ZL_Decoder* dictx, const ZL_Input* in[])
     size_t const idxWidth = ZL_Input_eltWidth(indices);
 
     ZL_Output* out = ZL_Decoder_create1OutStream(dictx, nbElts, eltWidth);
-    ZL_RET_R_IF_NULL(allocation, out);
+    ZL_ERR_IF_NULL(out, allocation);
 
     bool const success = ZS_tokenizeDecode(
             ZL_Output_ptr(out),
@@ -31,15 +32,16 @@ ZL_Report DI_tokenize(ZL_Decoder* dictx, const ZL_Input* in[])
             nbElts,
             eltWidth,
             idxWidth);
-    ZL_RET_R_IF_NOT(corruption, success, "Tokenize detected corrupted input!");
+    ZL_ERR_IF_NOT(success, corruption, "Tokenize detected corrupted input!");
 
-    ZL_RET_R_IF_ERR(ZL_Output_commit(out, nbElts));
+    ZL_ERR_IF_ERR(ZL_Output_commit(out, nbElts));
 
     return ZL_returnValue(1);
 }
 
 ZL_Report DI_tokenizeVSF(ZL_Decoder* dictx, const ZL_Input* ins[])
 {
+    ZL_RESULT_DECLARE_SCOPE_REPORT(dictx);
     ZL_ASSERT_NN(dictx);
     ZL_ASSERT_NN(ins);
 
@@ -59,25 +61,25 @@ ZL_Report DI_tokenizeVSF(ZL_Decoder* dictx, const ZL_Input* ins[])
     size_t const dstNbElts             = ZL_Input_numElts(indices);
     size_t const idxWidth              = ZL_Input_eltWidth(indices);
 
-    ZL_RET_R_IF_NOT(
-            corruption,
+    ZL_ERR_IF_NOT(
             ZS_tokenizeValidateIndices(
-                    alphabetSize, indicesSrc, dstNbElts, idxWidth));
+                    alphabetSize, indicesSrc, dstNbElts, idxWidth),
+            corruption);
 
     size_t const dstNbBytes = ZS_tokenizeComputeVSFContentSize(
             indicesSrc, idxWidth, dstNbElts, alphabetFieldSizes, alphabetSize);
-    ZL_RET_R_IF_LT(corruption, dstNbElts, alphabetSize);
+    ZL_ERR_IF_LT(dstNbElts, alphabetSize, corruption);
 
     ZL_Output* const out = ZL_Decoder_create1OutStream(dictx, dstNbBytes, 1);
-    ZL_RET_R_IF_NULL(allocation, out);
+    ZL_ERR_IF_NULL(out, allocation);
     uint32_t* const dstFieldSizes = ZL_Output_reserveStringLens(out, dstNbElts);
-    ZL_RET_R_IF_NULL(allocation, dstFieldSizes);
+    ZL_ERR_IF_NULL(dstFieldSizes, allocation);
 
     void* workspace = ZL_Decoder_getScratchSpace(
             dictx,
             ZS_tokenizeVSFDecodeWorkspaceSize(
                     alphabetSize, alphabetFieldSizesSum));
-    ZL_RET_R_IF_NULL(allocation, workspace);
+    ZL_ERR_IF_NULL(workspace, allocation);
 
     ZS_tokenizeVSFDecode(
             ZL_Input_ptr(alphabet),
@@ -92,6 +94,6 @@ ZL_Report DI_tokenizeVSF(ZL_Decoder* dictx, const ZL_Input* ins[])
             idxWidth,
             workspace);
 
-    ZL_RET_R_IF_ERR(ZL_Output_commit(out, dstNbElts));
+    ZL_ERR_IF_ERR(ZL_Output_commit(out, dstNbElts));
     return ZL_returnSuccess();
 }

--- a/src/openzl/codecs/tokenize/encode_tokenize_binding.c
+++ b/src/openzl/codecs/tokenize/encode_tokenize_binding.c
@@ -107,11 +107,12 @@ ZL_FORCE_INLINE ZL_Report writeIndicesImpl(
         size_t eltWidth,
         size_t idxWidth)
 {
+    ZL_RESULT_DECLARE_SCOPE_REPORT(eictx);
     void const* const input = ZL_Input_ptr(in);
     size_t const nbElts     = ZL_Input_numElts(in);
 
     ZL_Output* out = ZL_Encoder_createTypedStream(eictx, 1, nbElts, idxWidth);
-    ZL_RET_R_IF_NULL(allocation, out);
+    ZL_ERR_IF_NULL(out, allocation);
     void* const indices = ZL_Output_ptr(out);
 
     for (size_t i = 0; i < nbElts; ++i) {
@@ -119,7 +120,7 @@ ZL_FORCE_INLINE ZL_Report writeIndicesImpl(
         size_t const index   = Map8_findVal(alphabet, token)->val;
         writeIndexAt(index, indices, i, idxWidth);
     }
-    ZL_RET_R_IF_ERR(ZL_Output_commit(out, nbElts));
+    ZL_ERR_IF_ERR(ZL_Output_commit(out, nbElts));
 
     return ZL_returnSuccess();
 }
@@ -131,6 +132,7 @@ ZL_FORCE_INLINE ZL_Report tokenizeImpl(
         bool sort,
         size_t eltWidth)
 {
+    ZL_RESULT_DECLARE_SCOPE_REPORT(eictx);
     ZL_ASSERT_EQ(eltWidth, ZL_Input_eltWidth(in));
 
     void const* const input = ZL_Input_ptr(in);
@@ -138,7 +140,7 @@ ZL_FORCE_INLINE ZL_Report tokenizeImpl(
 
     // Reserve up to 256 entries to skip past the small growth stage.
     if (!Map8_reserve(tokToIdx, ZL_MIN(256, (uint32_t)nbElts), false)) {
-        ZL_RET_R_ERR(allocation);
+        ZL_ERR(allocation);
     }
 
     // Build the alphabet map.
@@ -162,13 +164,13 @@ ZL_FORCE_INLINE ZL_Report tokenizeImpl(
         }
     }
 
-    ZL_RET_R_IF(allocation, badAlloc);
+    ZL_ERR_IF(badAlloc, allocation);
 
     size_t const alphabetSize = Map8_size(tokToIdx);
 
     ZL_Output* out =
             ZL_Encoder_createTypedStream(eictx, 0, alphabetSize, eltWidth);
-    ZL_RET_R_IF_NULL(allocation, out);
+    ZL_ERR_IF_NULL(out, allocation);
 
     // Write the alphabet
     // TODO(terrelln): Right now we have to write the alphabet out after the
@@ -193,12 +195,12 @@ ZL_FORCE_INLINE ZL_Report tokenizeImpl(
         }
     }
 
-    ZL_RET_R_IF_ERR(ZL_Output_commit(out, alphabetSize));
+    ZL_ERR_IF_ERR(ZL_Output_commit(out, alphabetSize));
 
-    ZL_RET_R_IF_GT(
-            temporaryLibraryLimitation,
+    ZL_ERR_IF_GT(
             alphabetSize,
             UINT32_MAX,
+            temporaryLibraryLimitation,
             "Only 4 byte indices supported... But why do you want this?");
 
     // Write the indices in the smallest output possible
@@ -212,7 +214,7 @@ ZL_FORCE_INLINE ZL_Report tokenizeImpl(
         return writeIndicesImpl(eictx, in, tokToIdx, eltWidth, 4);
     }
 
-    ZL_RET_R_ERR(logicError, "Impossible");
+    ZL_ERR(logicError, "Impossible");
 }
 
 #define GEN_TOKENIZE(eltWidth)                                                \
@@ -239,6 +241,7 @@ static ZL_Report tokenize2_shell(
         Map8* alphabet,
         bool sort)
 {
+    ZL_RESULT_DECLARE_SCOPE_REPORT(eictx);
     ZL_ASSERT_NN(in);
     ZL_ASSERT_EQ(ZL_Input_eltWidth(in), 2);
 
@@ -278,7 +281,7 @@ static ZL_Report tokenize2_shell(
 
     void* const workspace =
             ZL_Encoder_getScratchSpace(eictx, TOK2_CARDINALITY_MAX);
-    ZL_RET_R_IF_NULL(allocation, workspace);
+    ZL_ERR_IF_NULL(workspace, allocation);
 
     size_t const alphabetSize =
             TOK2_numSort_cardinality(workspace, srcPtr, nbSymbols);
@@ -292,11 +295,11 @@ static ZL_Report tokenize2_shell(
     ZL_DLOG(SEQ, "tokenize2_shell: alphabetSize: %zu", alphabetSize);
     ZL_Output* const alphabetStream =
             ZL_Encoder_createTypedStream(eictx, 0, alphabetSize, 2);
-    ZL_RET_R_IF_NULL(allocation, alphabetStream);
+    ZL_ERR_IF_NULL(alphabetStream, allocation);
 
     ZL_Output* const indexStream =
             ZL_Encoder_createTypedStream(eictx, 1, nbSymbols, 1);
-    ZL_RET_R_IF_NULL(allocation, indexStream);
+    ZL_ERR_IF_NULL(indexStream, allocation);
 
     TOK2_numSort_encode_into1(
             ZL_Output_ptr(indexStream),
@@ -307,8 +310,8 @@ static ZL_Report tokenize2_shell(
             nbSymbols,
             workspace);
 
-    ZL_RET_R_IF_ERR(ZL_Output_commit(alphabetStream, alphabetSize));
-    ZL_RET_R_IF_ERR(ZL_Output_commit(indexStream, nbSymbols));
+    ZL_ERR_IF_ERR(ZL_Output_commit(alphabetStream, alphabetSize));
+    ZL_ERR_IF_ERR(ZL_Output_commit(indexStream, nbSymbols));
 
     return ZL_returnSuccess();
 }
@@ -316,18 +319,19 @@ static ZL_Report tokenize2_shell(
 ZL_FORCE_INLINE ZL_Report
 tokenize1(ZL_Encoder* eictx, ZL_Input const* in, bool sort)
 {
+    ZL_RESULT_DECLARE_SCOPE_REPORT(eictx);
     ZL_ASSERT_EQ(1, ZL_Input_eltWidth(in));
     const uint8_t* input = (const uint8_t*)ZL_Input_ptr(in);
     const size_t nbElts  = ZL_Input_numElts(in);
 
     size_t alphabetSize;
     ZL_Output* alphabetStream = ZL_Encoder_createTypedStream(eictx, 0, 256, 1);
-    ZL_RET_R_IF_NULL(allocation, alphabetStream);
+    ZL_ERR_IF_NULL(alphabetStream, allocation);
     uint8_t* alphabet = (uint8_t*)ZL_Output_ptr(alphabetStream);
 
     ZL_Output* indicesStream =
             ZL_Encoder_createTypedStream(eictx, 1, nbElts, 1);
-    ZL_RET_R_IF_NULL(allocation, indicesStream);
+    ZL_ERR_IF_NULL(indicesStream, allocation);
     uint8_t* indices = (uint8_t*)ZL_Output_ptr(indicesStream);
 
     if (sort) {
@@ -363,14 +367,15 @@ tokenize1(ZL_Encoder* eictx, ZL_Input const* in, bool sort)
         }
     }
 
-    ZL_RET_R_IF_ERR(ZL_Output_commit(alphabetStream, alphabetSize));
-    ZL_RET_R_IF_ERR(ZL_Output_commit(indicesStream, nbElts));
+    ZL_ERR_IF_ERR(ZL_Output_commit(alphabetStream, alphabetSize));
+    ZL_ERR_IF_ERR(ZL_Output_commit(indicesStream, nbElts));
     return ZL_returnSuccess();
 }
 
 static ZL_Report
 tokenize(ZL_Encoder* eictx, Map8* alphabet, const ZL_Input* in, bool sort)
 {
+    ZL_RESULT_DECLARE_SCOPE_REPORT(eictx);
     ZL_ASSERT_NN(in);
     switch (ZL_Input_eltWidth(in)) {
         case 1:
@@ -382,11 +387,10 @@ tokenize(ZL_Encoder* eictx, Map8* alphabet, const ZL_Input* in, bool sort)
         case 8:
             return tokenize8(eictx, in, alphabet, sort);
         default:
-            ZL_RET_R_ERR(
-                    temporaryLibraryLimitation,
-                    "Elt width %u not supported yet! But decoder the decoder "
-                    "supports all width, so you only need to extend the encoder",
-                    (unsigned)ZL_Input_eltWidth(in));
+            ZL_ERR(temporaryLibraryLimitation,
+                   "Elt width %u not supported yet! But decoder the decoder "
+                   "supports all width, so you only need to extend the encoder",
+                   (unsigned)ZL_Input_eltWidth(in));
     }
 }
 
@@ -422,6 +426,7 @@ static bool EI_tokenizeShouldSort(const ZL_Encoder* encoder)
 
 ZL_Report EI_tokenize(ZL_Encoder* eictx, const ZL_Input* ins[], size_t nbIns)
 {
+    ZL_RESULT_DECLARE_SCOPE_REPORT(eictx);
     ZL_ASSERT_EQ(nbIns, 1);
     ZL_ASSERT_NN(ins);
     const ZL_Input* in = ins[0];
@@ -435,8 +440,8 @@ ZL_Report EI_tokenize(ZL_Encoder* eictx, const ZL_Input* ins[], size_t nbIns)
             .opaque = param.opaque,
             .input  = in,
         };
-        ZL_Report const report = (param.customTokenizeFn)(&ctx, in);
-        ZL_RET_R(report);
+        ZL_ERR_IF_ERR((param.customTokenizeFn)(&ctx, in));
+        return ZL_returnSuccess();
     }
     return EI_tokenizeImpl(eictx, in, EI_tokenizeShouldSort(eictx));
 }
@@ -458,6 +463,7 @@ static ZL_Report EI_tokenizeVSFImpl(
         const ZL_Input* in,
         bool sort)
 {
+    ZL_RESULT_DECLARE_SCOPE_REPORT(eictx);
     ZL_ASSERT_NN(eictx);
     ZL_ASSERT_NN(in);
     ZL_ASSERT_EQ(ZL_Input_type(in), ZL_Type_string);
@@ -468,31 +474,31 @@ static ZL_Report EI_tokenizeVSFImpl(
 
     // Build alphabet of input stream
     size_t alphabetFieldSizesSum;
-    ZL_RET_R_IF_ERR(ZS_buildTokenizeVsfAlphabet(
+    ZL_ERR_IF_ERR(ZS_buildTokenizeVsfAlphabet(
             tokToIdx, &alphabetFieldSizesSum, src, fieldSizes, nbElts));
     size_t const alphabetSize = MapVSF_size(tokToIdx);
 
     // Create alphabet stream
     ZL_Output* const alphabet =
             ZL_Encoder_createTypedStream(eictx, 0, alphabetFieldSizesSum, 1);
-    ZL_RET_R_IF_NULL(allocation, alphabet);
+    ZL_ERR_IF_NULL(alphabet, allocation);
 
     uint32_t* const alphabetFieldSizes =
             ZL_Output_reserveStringLens(alphabet, alphabetSize);
-    ZL_RET_R_IF_NULL(allocation, alphabetFieldSizes);
+    ZL_ERR_IF_NULL(alphabetFieldSizes, allocation);
 
     // Create indices stream
     size_t const idxWidth = getMinIdxSpace(alphabetSize);
     ZL_Output* const indices =
             ZL_Encoder_createTypedStream(eictx, 1, nbElts, idxWidth);
-    ZL_RET_R_IF_NULL(allocation, indices);
+    ZL_ERR_IF_NULL(indices, allocation);
 
     // Allocate buffer for key manipulation
     VSFKey* const keysBuffer =
             ZL_Encoder_getScratchSpace(eictx, alphabetSize * sizeof(VSFKey));
-    ZL_RET_R_IF_NULL(allocation, keysBuffer);
+    ZL_ERR_IF_NULL(keysBuffer, allocation);
 
-    ZL_RET_R_IF_ERR(ZS_tokenizeVSFEncode(
+    ZL_ERR_IF_ERR(ZS_tokenizeVSFEncode(
             ZL_Output_ptr(alphabet),
             alphabetFieldSizes,
             alphabetSize,
@@ -505,8 +511,8 @@ static ZL_Report EI_tokenizeVSFImpl(
             idxWidth,
             sort));
 
-    ZL_RET_R_IF_ERR(ZL_Output_commit(alphabet, alphabetSize));
-    ZL_RET_R_IF_ERR(ZL_Output_commit(indices, nbElts));
+    ZL_ERR_IF_ERR(ZL_Output_commit(alphabet, alphabetSize));
+    ZL_ERR_IF_ERR(ZL_Output_commit(indices, nbElts));
 
     return ZL_returnSuccess();
 }

--- a/src/openzl/codecs/transpose/decode_transpose_binding.c
+++ b/src/openzl/codecs/transpose/decode_transpose_binding.c
@@ -13,6 +13,7 @@
 //
 ZL_Report DI_transpose(ZL_Decoder* dictx, const ZL_Input* ins[])
 {
+    ZL_RESULT_DECLARE_SCOPE_REPORT(dictx);
     ZL_ASSERT_NN(dictx);
     ZL_ASSERT_NN(ins);
     const ZL_Input* const in = ins[0];
@@ -25,12 +26,12 @@ ZL_Report DI_transpose(ZL_Decoder* dictx, const ZL_Input* ins[])
     size_t const newFieldWidth = nbFields ? nbFields : fieldWidth;
     ZL_Output* const out =
             ZL_Decoder_create1OutStream(dictx, newNbFields, newFieldWidth);
-    ZL_RET_R_IF_NULL(allocation, out);
+    ZL_ERR_IF_NULL(out, allocation);
     // TODO(@Cyan) : optimize with a reference when newFieldWidth==1, or
     // nbFields<=1
     ZS_transposeDecode(
             ZL_Output_ptr(out), ZL_Input_ptr(in), newNbFields, newFieldWidth);
-    ZL_RET_R_IF_ERR(ZL_Output_commit(out, newNbFields));
+    ZL_ERR_IF_ERR(ZL_Output_commit(out, newNbFields));
     return ZL_returnValue(1);
 }
 
@@ -41,10 +42,11 @@ ZL_Report DI_transpose_split(
         const ZL_Input* inVOs[],
         size_t nbInVOs)
 {
+    ZL_RESULT_DECLARE_SCOPE_REPORT(dictx);
     (void)inFixed;
     ZL_ASSERT_NN(dictx);
     ZL_ASSERT_EQ(nbInFixed, 0);
-    ZL_RET_R_IF_EQ(corruption, nbInVOs, 0);
+    ZL_ERR_IF_EQ(nbInVOs, 0, corruption);
     ZL_ASSERT_NN(inVOs);
 
     size_t const nbElts      = ZL_Input_numElts(inVOs[0]);
@@ -52,24 +54,24 @@ ZL_Report DI_transpose_split(
     size_t const dstEltWidth = nbInVOs;
 
     for (size_t i = 0; i < nbInVOs; ++i) {
-        ZL_RET_R_IF_NE(corruption, ZL_Type_serial, ZL_Input_type(inVOs[i]));
-        ZL_RET_R_IF_NE(corruption, nbElts, ZL_Input_numElts(inVOs[i]));
+        ZL_ERR_IF_NE(ZL_Type_serial, ZL_Input_type(inVOs[i]), corruption);
+        ZL_ERR_IF_NE(nbElts, ZL_Input_numElts(inVOs[i]), corruption);
     }
 
     ZL_Output* const out =
             ZL_Decoder_create1OutStream(dictx, dstNbElts, dstEltWidth);
-    ZL_RET_R_IF_NULL(allocation, out);
+    ZL_ERR_IF_NULL(out, allocation);
 
     const uint8_t** const inPtrs =
             ZL_Decoder_getScratchSpace(dictx, nbInVOs * sizeof(uint8_t*));
-    ZL_RET_R_IF_NULL(allocation, inPtrs);
+    ZL_ERR_IF_NULL(inPtrs, allocation);
 
     for (size_t i = 0; i < nbInVOs; i++) {
         inPtrs[i] = (const uint8_t*)ZL_Input_ptr(inVOs[i]);
     }
 
     ZS_splitTransposeDecode(ZL_Output_ptr(out), inPtrs, dstNbElts, dstEltWidth);
-    ZL_RET_R_IF_ERR(ZL_Output_commit(out, dstNbElts));
+    ZL_ERR_IF_ERR(ZL_Output_commit(out, dstNbElts));
     return ZL_returnSuccess();
 }
 
@@ -82,6 +84,7 @@ ZL_Report DI_transpose_split(
 static ZL_Report
 DI_transposeN_typed(ZL_Decoder* dictx, const ZL_Input* ins[], size_t fieldSize)
 {
+    ZL_RESULT_DECLARE_SCOPE_REPORT(dictx);
     ZL_ASSERT_NN(dictx);
     ZL_ASSERT_NN(ins);
     const ZL_Input* const in = ins[0];
@@ -89,16 +92,16 @@ DI_transposeN_typed(ZL_Decoder* dictx, const ZL_Input* ins[], size_t fieldSize)
     ZL_ASSERT_EQ(ZL_Input_type(in), ZL_Type_serial);
     ZL_ASSERT_EQ(ZL_Input_eltWidth(in), 1);
     size_t const srcSize = ZL_Input_numElts(in);
-    ZL_RET_R_IF_NE(GENERIC, srcSize % fieldSize, 0);
+    ZL_ERR_IF_NE(srcSize % fieldSize, 0, GENERIC);
     size_t const dstCapacity = srcSize;
     ZL_Output* const out = ZL_Decoder_create1OutStream(dictx, dstCapacity, 1);
-    ZL_RET_R_IF_NULL(allocation, out);
+    ZL_ERR_IF_NULL(out, allocation);
     ZS_transposeDecode(
             ZL_Output_ptr(out),
             ZL_Input_ptr(in),
             srcSize / fieldSize,
             fieldSize);
-    ZL_RET_R_IF_ERR(ZL_Output_commit(out, srcSize));
+    ZL_ERR_IF_ERR(ZL_Output_commit(out, srcSize));
     return ZL_returnValue(1);
 }
 
@@ -125,6 +128,7 @@ static ZL_Report DI_transpose_split_bytes(
         const ZL_Input* ins[],
         size_t eltWidth)
 {
+    ZL_RESULT_DECLARE_SCOPE_REPORT(dictx);
     ZL_ASSERT_NN(dictx);
     ZL_ASSERT_NN(ins);
     ZL_ASSERT_NN(ins[0]);
@@ -134,19 +138,19 @@ static ZL_Report DI_transpose_split_bytes(
     uint8_t const* src[8];
     for (size_t i = 0; i < eltWidth; ++i) {
         ZL_ASSERT_NN(ins[i]);
-        ZL_RET_R_IF_NE(
-                corruption,
+        ZL_ERR_IF_NE(
                 nbElts,
                 ZL_Input_numElts(ins[i]),
+                corruption,
                 "Not all streams the same size");
         src[i] = ZL_Input_ptr(ins[i]);
     }
     ZL_Output* const out = ZL_Decoder_create1OutStream(dictx, nbElts, eltWidth);
-    ZL_RET_R_IF_NULL(allocation, out);
+    ZL_ERR_IF_NULL(out, allocation);
     uint8_t* dst = (uint8_t*)ZL_Output_ptr(out);
     ZS_splitTransposeDecode(dst, src, nbElts, eltWidth);
 
-    ZL_RET_R_IF_ERR(ZL_Output_commit(out, nbElts));
+    ZL_ERR_IF_ERR(ZL_Output_commit(out, nbElts));
     return ZL_returnValue(1);
 }
 

--- a/src/openzl/codecs/transpose/encode_transpose_binding.c
+++ b/src/openzl/codecs/transpose/encode_transpose_binding.c
@@ -15,6 +15,7 @@
 // - An N x W input stream becomes a W x N output stream
 ZL_Report EI_transpose(ZL_Encoder* eictx, const ZL_Input* ins[], size_t nbIns)
 {
+    ZL_RESULT_DECLARE_SCOPE_REPORT(eictx);
     ZL_ASSERT_NN(eictx);
     ZL_ASSERT_EQ(nbIns, 1);
     ZL_ASSERT_NN(ins);
@@ -29,19 +30,20 @@ ZL_Report EI_transpose(ZL_Encoder* eictx, const ZL_Input* ins[], size_t nbIns)
     size_t const newNbFields = nbFields ? fieldWidth : 0;
     ZL_Output* const out =
             ZL_Encoder_createTypedStream(eictx, 0, newNbFields, newFieldWidth);
-    ZL_RET_R_IF_NULL(allocation, out);
+    ZL_ERR_IF_NULL(out, allocation);
     const void* const src = ZL_Input_ptr(in);
     void* const dst       = ZL_Output_ptr(out);
     // TODO(@Cyan) : optimize with a reference when newFieldWidth==1, or
     // nbFields<=1
     ZS_transposeEncode(dst, src, nbFields, fieldWidth);
-    ZL_RET_R_IF_ERR(ZL_Output_commit(out, newNbFields));
+    ZL_ERR_IF_ERR(ZL_Output_commit(out, newNbFields));
     return ZL_returnValue(1);
 }
 
 ZL_Report
 EI_transpose_split(ZL_Encoder* eictx, const ZL_Input* ins[], size_t nbIns)
 {
+    ZL_RESULT_DECLARE_SCOPE_REPORT(eictx);
     ZL_ASSERT_NN(eictx);
     ZL_ASSERT_EQ(nbIns, 1);
     ZL_ASSERT_NN(ins);
@@ -59,19 +61,19 @@ EI_transpose_split(ZL_Encoder* eictx, const ZL_Input* ins[], size_t nbIns)
 
     uint8_t** const outPtrs =
             ZL_Encoder_getScratchSpace(eictx, nbOutStreams * sizeof(uint8_t*));
-    ZL_RET_R_IF_NULL(allocation, outPtrs);
+    ZL_ERR_IF_NULL(outPtrs, allocation);
     for (size_t i = 0; i < nbOutStreams; i++) {
         ZL_Output* const out =
                 ZL_Encoder_createTypedStream(eictx, 0, dstNbElts, 1);
-        ZL_RET_R_IF_NULL(
-                allocation,
+        ZL_ERR_IF_NULL(
                 out,
+                allocation,
                 "allocation error in transposeVO while trying to create output stream %zu of size %zu",
                 i,
                 dstNbElts);
 
         outPtrs[i] = (uint8_t*)ZL_Output_ptr(out);
-        ZL_RET_R_IF_ERR(ZL_Output_commit(out, dstNbElts));
+        ZL_ERR_IF_ERR(ZL_Output_commit(out, dstNbElts));
     }
 
     ZS_splitTransposeEncode(outPtrs, src, nbElts, eltWidth);
@@ -90,26 +92,27 @@ static ZL_Report EI_transpose_serial_typed(
         const ZL_Input* in,
         size_t eltWidth)
 {
+    ZL_RESULT_DECLARE_SCOPE_REPORT(eictx);
     ZL_ASSERT_NN(eictx);
     ZL_ASSERT_NN(in);
     ZL_ASSERT_EQ(ZL_Input_type(in), ZL_Type_serial);
     ZL_ASSERT_EQ(ZL_Input_eltWidth(in), 1);
     size_t const srcSize = ZL_Input_numElts(in);
-    ZL_RET_R_IF_NE(
-            GENERIC,
+    ZL_ERR_IF_NE(
             srcSize % eltWidth,
             0,
+            GENERIC,
             "source size is not a multiple of transpose width");
     size_t const dstCapacity = srcSize;
     ZL_Output* const out =
             ZL_Encoder_createTypedStream(eictx, 0, dstCapacity, 1);
-    ZL_RET_R_IF_NULL(allocation, out);
+    ZL_ERR_IF_NULL(out, allocation);
     // Note : we should also check alignment here,
     // but since this interface will disappear in the near future,
     // this is a disappearing concern too
     ZS_transposeEncode(
             ZL_Output_ptr(out), ZL_Input_ptr(in), srcSize / eltWidth, eltWidth);
-    ZL_RET_R_IF_ERR(ZL_Output_commit(out, srcSize));
+    ZL_ERR_IF_ERR(ZL_Output_commit(out, srcSize));
     return ZL_returnValue(1);
 }
 
@@ -204,10 +207,11 @@ size_t EI_transpose_8bytes(
 static ZL_Report
 EI_transpose_split_bytes(ZL_Encoder* eictx, const ZL_Input* in, size_t eltWidth)
 {
+    ZL_RESULT_DECLARE_SCOPE_REPORT(eictx);
     ZL_ASSERT_NN(eictx);
     ZL_ASSERT_NN(in);
     ZL_ASSERT_EQ(ZL_Input_type(in), ZL_Type_struct);
-    ZL_RET_R_IF_NE(GENERIC, ZL_Input_eltWidth(in), eltWidth);
+    ZL_ERR_IF_NE(ZL_Input_eltWidth(in), eltWidth, GENERIC);
 
     // Create one output buffer per elt byte
     size_t const nbElts = ZL_Input_numElts(in);
@@ -215,7 +219,7 @@ EI_transpose_split_bytes(ZL_Encoder* eictx, const ZL_Input* in, size_t eltWidth)
     uint8_t* dst[8];
     for (size_t i = 0; i < eltWidth; ++i) {
         out[i] = ZL_Encoder_createTypedStream(eictx, (int)i, nbElts, 1);
-        ZL_RET_R_IF_NULL(allocation, out[i]);
+        ZL_ERR_IF_NULL(out[i], allocation);
         dst[i] = (uint8_t*)ZL_Output_ptr(out[i]);
     }
 
@@ -224,7 +228,7 @@ EI_transpose_split_bytes(ZL_Encoder* eictx, const ZL_Input* in, size_t eltWidth)
     ZS_splitTransposeEncode(dst, src, nbElts, eltWidth);
 
     for (size_t i = 0; i < eltWidth; ++i) {
-        ZL_RET_R_IF_ERR(ZL_Output_commit(out[i], nbElts));
+        ZL_ERR_IF_ERR(ZL_Output_commit(out[i], nbElts));
     }
     return ZL_returnValue(eltWidth);
 }

--- a/src/openzl/codecs/zigzag/decode_zigzag_binding.c
+++ b/src/openzl/codecs/zigzag/decode_zigzag_binding.c
@@ -7,6 +7,7 @@
 // ZL_TypedEncoderFn, NUMPIPE
 ZL_Report DI_zigzag_num(ZL_Decoder* dictx, const ZL_Input* ins[])
 {
+    ZL_RESULT_DECLARE_SCOPE_REPORT(dictx);
     ZL_ASSERT_NN(dictx);
     ZL_ASSERT_NN(ins);
     const ZL_Input* const in = ins[0];
@@ -15,7 +16,7 @@ ZL_Report DI_zigzag_num(ZL_Decoder* dictx, const ZL_Input* ins[])
     size_t const numWidth = ZL_Input_eltWidth(in);
     size_t const nbInts   = ZL_Input_numElts(in);
     ZL_Output* const out = ZL_Decoder_create1OutStream(dictx, nbInts, numWidth);
-    ZL_RET_R_IF_NULL(allocation, out);
+    ZL_ERR_IF_NULL(out, allocation);
     ZL_ASSERT(numWidth == 1 || numWidth == 2 || numWidth == 4 || numWidth == 8);
     switch (numWidth) {
         case 1:
@@ -33,6 +34,6 @@ ZL_Report DI_zigzag_num(ZL_Decoder* dictx, const ZL_Input* ins[])
         default:
             ZL_ASSERT_FAIL("Unreachable");
     }
-    ZL_RET_R_IF_ERR(ZL_Output_commit(out, nbInts));
+    ZL_ERR_IF_ERR(ZL_Output_commit(out, nbInts));
     return ZL_returnValue(1);
 }

--- a/src/openzl/codecs/zigzag/encode_zigzag_binding.c
+++ b/src/openzl/codecs/zigzag/encode_zigzag_binding.c
@@ -7,6 +7,7 @@
 // ZL_TypedEncoderFn
 ZL_Report EI_zigzag_num(ZL_Encoder* eictx, const ZL_Input* ins[], size_t nbIns)
 {
+    ZL_RESULT_DECLARE_SCOPE_REPORT(eictx);
     ZL_ASSERT_NN(eictx);
     ZL_ASSERT_EQ(nbIns, 1);
     ZL_ASSERT_NN(ins);
@@ -17,7 +18,7 @@ ZL_Report EI_zigzag_num(ZL_Encoder* eictx, const ZL_Input* ins[], size_t nbIns)
     size_t const nbInts   = ZL_Input_numElts(in);
     ZL_Output* const out =
             ZL_Encoder_createTypedStream(eictx, 0, nbInts, numWidth);
-    ZL_RET_R_IF_NULL(allocation, out);
+    ZL_ERR_IF_NULL(out, allocation);
     ZL_ASSERT(numWidth == 1 || numWidth == 2 || numWidth == 4 || numWidth == 8);
     switch (numWidth) {
         case 1:
@@ -35,6 +36,6 @@ ZL_Report EI_zigzag_num(ZL_Encoder* eictx, const ZL_Input* ins[], size_t nbIns)
         default:
             ZL_ASSERT_FAIL("Unreachable");
     }
-    ZL_RET_R_IF_ERR(ZL_Output_commit(out, nbInts));
+    ZL_ERR_IF_ERR(ZL_Output_commit(out, nbInts));
     return ZL_returnValue(1);
 }

--- a/src/openzl/codecs/zstd/decode_zstd_binding.c
+++ b/src/openzl/codecs/zstd/decode_zstd_binding.c
@@ -59,6 +59,7 @@ static ZL_RESULT_OF(uint64_t) getFrameContentSize(
 
 ZL_Report DI_zstd(ZL_Decoder* dictx, ZL_Input const* ins[])
 {
+    ZL_RESULT_DECLARE_SCOPE_REPORT(dictx);
     ZL_ASSERT_NN(dictx);
     ZL_ASSERT_NN(ins);
     ZL_Input const* const in = ins[0];
@@ -70,47 +71,47 @@ ZL_Report DI_zstd(ZL_Decoder* dictx, ZL_Input const* ins[])
     uint8_t const* const srcEnd = src + ZL_Input_numElts(in);
 
     ZL_TRY_LET_T(uint64_t, dstEltWidth, ZL_varintDecode(&src, srcEnd));
-    ZL_RET_R_IF_EQ(corruption, dstEltWidth, 0);
+    ZL_ERR_IF_EQ(dstEltWidth, 0, corruption);
 
     size_t const srcSize = (size_t)(srcEnd - src);
     ZL_TRY_LET_T(uint64_t, dstSize, getFrameContentSize(dictx, src, srcSize));
-    ZL_RET_R_IF_NE(
-            corruption,
+    ZL_ERR_IF_NE(
             dstSize % dstEltWidth,
             0,
+            corruption,
             "content size not multiple of element width");
     size_t const dstNbElts = dstSize / dstEltWidth;
 
     ZL_Output* const out =
             ZL_Decoder_create1OutStream(dictx, dstNbElts, dstEltWidth);
-    ZL_RET_R_IF_NULL(allocation, out);
+    ZL_ERR_IF_NULL(out, allocation);
 
     ZSTD_DCtx* const dctx = ZL_Decoder_getState(dictx);
-    ZL_RET_R_IF_NULL(
-            allocation,
+    ZL_ERR_IF_NULL(
             dctx,
+            allocation,
             "Zstandard decompression state allocation failed");
-    ZL_RET_R_IF(
-            logicError,
+    ZL_ERR_IF(
             ZSTD_isError(
-                    ZSTD_DCtx_reset(dctx, ZSTD_reset_session_and_parameters)));
+                    ZSTD_DCtx_reset(dctx, ZSTD_reset_session_and_parameters)),
+            logicError);
     if (DI_getFrameFormatVersion(dictx) >= 9) {
         // See encoder_zstd.c for details
         if (ZSTD_isError(ZSTD_DCtx_setParameter(
                     dctx, ZSTD_d_format, ZSTD_f_zstd1_magicless))) {
-            ZL_RET_R_ERR(logicError, "Zstd unable to set parameter!");
+            ZL_ERR(logicError, "Zstd unable to set parameter!");
         }
     }
     size_t const dSize = ZSTD_decompressDCtx(
             dctx, ZL_Output_ptr(out), dstSize, src, srcSize);
-    ZL_RET_R_IF(
-            corruption,
+    ZL_ERR_IF(
             ZSTD_isError(dSize),
+            corruption,
             "Zstd decompression failed: %s",
             ZSTD_getErrorName(dSize));
-    ZL_RET_R_IF_NE(corruption, dSize, dstSize, "bad destination size");
+    ZL_ERR_IF_NE(dSize, dstSize, corruption, "bad destination size");
 
-    ZL_RET_R_IF_ERR(ZL_Output_commit(out, dstNbElts));
+    ZL_ERR_IF_ERR(ZL_Output_commit(out, dstNbElts));
 
     return ZL_returnValue(1);
 }

--- a/src/openzl/codecs/zstd/encode_zstd_binding.c
+++ b/src/openzl/codecs/zstd/encode_zstd_binding.c
@@ -32,12 +32,12 @@ static bool EI_zstd_parameter_valid(ZSTD_cParameter param)
     return true;
 }
 
-#define ZL_RET_R_IF_ZSTD_ERR(zstdResult)         \
+#define ZL_ERR_IF_ZSTD_ERR(zstdResult)           \
     do {                                         \
         size_t const _zstdResult = (zstdResult); \
-        ZL_RET_R_IF(                             \
-                GENERIC,                         \
+        ZL_ERR_IF(                               \
                 ZSTD_isError(_zstdResult),       \
+                GENERIC,                         \
                 "Zstd Error: %s",                \
                 ZSTD_getErrorName(_zstdResult)); \
     } while (0)
@@ -45,6 +45,7 @@ static bool EI_zstd_parameter_valid(ZSTD_cParameter param)
 static ZL_Report
 EI_zstdWithCCtx(ZL_Encoder* eictx, ZSTD_CCtx* cctx, const ZL_Input* src)
 {
+    ZL_RESULT_DECLARE_SCOPE_REPORT(eictx);
     ZL_ASSERT_NN(eictx);
     ZL_ASSERT_NN(src);
     ZL_ASSERT(
@@ -65,24 +66,24 @@ EI_zstdWithCCtx(ZL_Encoder* eictx, ZSTD_CCtx* cctx, const ZL_Input* src)
             + (blockSplit ? nbElts * 3 : 0) + ZL_varintSize((uint64_t)eltWidth);
     ZL_Output* const dst =
             ZL_Encoder_createTypedStream(eictx, 0, outCapacity, 1);
-    ZL_RET_R_IF_NULL(allocation, dst);
+    ZL_ERR_IF_NULL(dst, allocation);
 
     uint8_t* const ostart   = (uint8_t*)ZL_Output_ptr(dst);
     size_t const headerSize = ZL_varintEncode((uint64_t)eltWidth, ostart);
 
     /* Global parameters influence compression parameters */
-    ZL_RET_R_IF_ZSTD_ERR(
+    ZL_ERR_IF_ZSTD_ERR(
             ZSTD_CCtx_reset(cctx, ZSTD_reset_session_and_parameters));
 
     if (ZL_Encoder_getCParam(eictx, ZL_CParam_formatVersion) >= 9) {
         // Skip the zstd magic number for two reasons:
         // 1. We don't need it, Zstrong tells us we are decompressing zstd.
         // 2. It makes fuzzing harder, because the fuzzer can't find the magic.
-        ZL_RET_R_IF_ZSTD_ERR(ZSTD_CCtx_setParameter(
+        ZL_ERR_IF_ZSTD_ERR(ZSTD_CCtx_setParameter(
                 cctx, ZSTD_c_format, ZSTD_f_zstd1_magicless));
     }
 
-    ZL_RET_R_IF_ZSTD_ERR(ZSTD_CCtx_setParameter(
+    ZL_ERR_IF_ZSTD_ERR(ZSTD_CCtx_setParameter(
             cctx,
             ZSTD_c_compressionLevel,
             ZL_Encoder_getCParam(eictx, ZL_CParam_compressionLevel)));
@@ -90,7 +91,7 @@ EI_zstdWithCCtx(ZL_Encoder* eictx, ZSTD_CCtx* cctx, const ZL_Input* src)
     int const decompressionLevel =
             ZL_Encoder_getCParam(eictx, ZL_CParam_decompressionLevel);
     if (decompressionLevel == 1) {
-        ZL_RET_R_IF_ZSTD_ERR(ZSTD_CCtx_setParameter(
+        ZL_ERR_IF_ZSTD_ERR(ZSTD_CCtx_setParameter(
                 cctx, ZSTD_c_literalCompressionMode, ZSTD_lcm_uncompressed));
     }
 
@@ -105,12 +106,11 @@ EI_zstdWithCCtx(ZL_Encoder* eictx, ZSTD_CCtx* cctx, const ZL_Input* src)
     for (size_t n = 0; n < lips.nbIntParams; n++) {
         ZL_IntParam const ip        = lips.intParams[n];
         ZSTD_cParameter const param = (ZSTD_cParameter)ip.paramId;
-        ZL_RET_R_IF_NOT(
-                nodeParameter_invalid,
+        ZL_ERR_IF_NOT(
                 EI_zstd_parameter_valid(param),
+                nodeParameter_invalid,
                 "zstd parameter %i cannot be modified");
-        ZL_RET_R_IF_ZSTD_ERR(
-                ZSTD_CCtx_setParameter(cctx, param, ip.paramValue));
+        ZL_ERR_IF_ZSTD_ERR(ZSTD_CCtx_setParameter(cctx, param, ip.paramValue));
     }
 
     if (blockSize == srcSize) {
@@ -120,8 +120,8 @@ EI_zstdWithCCtx(ZL_Encoder* eictx, ZSTD_CCtx* cctx, const ZL_Input* src)
                 outCapacity - headerSize,
                 ZL_Input_ptr(src),
                 srcSize);
-        ZL_RET_R_IF_ZSTD_ERR(cSize);
-        ZL_RET_R_IF_ERR(ZL_Output_commit(dst, headerSize + cSize));
+        ZL_ERR_IF_ZSTD_ERR(cSize);
+        ZL_ERR_IF_ERR(ZL_Output_commit(dst, headerSize + cSize));
     } else {
         ZSTD_CCtx_setPledgedSrcSize(cctx, srcSize);
 
@@ -134,11 +134,11 @@ EI_zstdWithCCtx(ZL_Encoder* eictx, ZSTD_CCtx* cctx, const ZL_Input* src)
                 ZSTD_EndDirective const flush =
                         in.size == srcSize ? ZSTD_e_end : ZSTD_e_flush;
                 size_t const ret = ZSTD_compressStream2(cctx, &out, &in, flush);
-                ZL_RET_R_IF_ZSTD_ERR(ret);
+                ZL_ERR_IF_ZSTD_ERR(ret);
             }
         }
         ZL_ASSERT_EQ(in.pos, srcSize);
-        ZL_RET_R_IF_ERR(ZL_Output_commit(dst, out.pos));
+        ZL_ERR_IF_ERR(ZL_Output_commit(dst, out.pos));
     }
 
     return ZL_returnValue(1);
@@ -155,11 +155,12 @@ void EIZSTD_freeCCtx(void* state)
 
 ZL_Report EI_zstd(ZL_Encoder* eictx, const ZL_Input* ins[], size_t nbIns)
 {
+    ZL_RESULT_DECLARE_SCOPE_REPORT(eictx);
     ZL_ASSERT_EQ(nbIns, 1);
     ZL_ASSERT_NN(ins);
     const ZL_Input* in    = ins[0];
     ZSTD_CCtx* const cctx = ZL_Encoder_getState(eictx);
-    ZL_RET_R_IF_NULL(allocation, cctx);
+    ZL_ERR_IF_NULL(cctx, allocation);
     return EI_zstdWithCCtx(eictx, cctx, in);
 }
 


### PR DESCRIPTION
Summary:
Migrate old-style `ZL_RET_R_*` error-handling macros to the new `ZL_ERR_*` macros in all 57 codec encode/decode binding files under `src/openzl/codecs/`.

The new `ZL_ERR_*` macros require an explicit `ZL_RESULT_DECLARE_SCOPE_REPORT(ctx)` declaration at the top of each function, which provides proper error context for rich error reporting. The old `ZL_RET_R_*` macros used "magic" auto-context detection via `_Generic`, which doesn't always work correctly.

**Migration pattern:**
- Add `ZL_RESULT_DECLARE_SCOPE_REPORT(ctx)` at the top of each migrated function
- Replace `ZL_RET_R_IF(errcode, expr, ...)` → `ZL_ERR_IF(expr, errcode, ...)`
- Replace `ZL_RET_R_IF_ERR(expr)` → `ZL_ERR_IF_ERR(expr)`
- Replace `ZL_RET_R_ERR(errcode)` → `ZL_ERR(errcode)`
- Similar replacements for IF_NULL, IF_NN, IF_EQ, IF_NE, IF_GT, IF_LT, IF_GE, IF_LE

**Codecs covered:** bitSplit, bitpack, bitunpack, concat, constant, conversion, dedup, delta, dispatchN_byTag, dispatch_string, divide_by, entropy, flatpack, float_deconstruct, interleave, lz, merge_sorted, parse_int, prefix, quantize, range_pack, rolz, splitByStruct, splitN, tokenize, transpose, zigzag, zstd

Only functions with real (non-NULL, non-const) error context are migrated.

Differential Revision: D94712956
