### PR TITLE
Migrate ZL_RET_R_* to ZL_ERR_* in custom_transforms/

### DIFF
--- a/custom_parsers/csv/csv_parser.c
+++ b/custom_parsers/csv/csv_parser.c
@@ -105,7 +105,7 @@ csvParserGraphFn(ZL_Graph* gctx, ZL_Edge* inputs[], size_t numInputs)
     // Delimiters - ZL_GRAPH_COMPRESS_GENERIC
     // Header - ZL_GRAPH_COMPRESS_GENERIC
     ZL_GraphIDList customGraphs = ZL_Graph_getCustomGraphs(gctx);
-    ZL_RET_R_IF_NE(node_invalid_input, customGraphs.nbGraphIDs, 3);
+    ZL_ERR_IF_NE(customGraphs.nbGraphIDs, 3, node_invalid_input);
 
     ZL_TRY_LET(
             ZL_RefParam,

--- a/custom_parsers/pytorch_model_parser.c
+++ b/custom_parsers/pytorch_model_parser.c
@@ -71,6 +71,7 @@ static bool isDataFile(const char* filename, size_t filenameSize)
 static ZL_Report
 pytorchModelDynGraph(ZL_Graph* gctx, ZL_Edge* sctxs[], size_t nbIns)
 {
+    ZL_RESULT_DECLARE_SCOPE_REPORT(gctx);
 #ifdef FUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION
     // Allow interesting fuzzing with smaller inputs
     const size_t kMultiplier = 4;
@@ -79,13 +80,13 @@ pytorchModelDynGraph(ZL_Graph* gctx, ZL_Edge* sctxs[], size_t nbIns)
 #endif
     const size_t kMaxSegmentSize = 1024 * kMultiplier;
 
-    ZL_RET_R_IF(graph_invalidNumInputs, nbIns != 1);
+    ZL_ERR_IF(nbIns != 1, graph_invalidNumInputs);
     ZL_Edge* sctx               = sctxs[0];
     ZL_Input const* const input = ZL_Edge_getData(sctx);
     const size_t inputSize      = ZL_Input_numElts(input);
 
     ZS2_ZipLexer lexer;
-    ZL_RET_R_IF_ERR(ZS2_ZipLexer_init(&lexer, ZL_Input_ptr(input), inputSize));
+    ZL_ERR_IF_ERR(ZS2_ZipLexer_init(&lexer, ZL_Input_ptr(input), inputSize));
 
     const size_t nbFiles = ZS2_ZipLexer_numFiles(&lexer);
     const size_t maxNbSegments =
@@ -95,8 +96,8 @@ pytorchModelDynGraph(ZL_Graph* gctx, ZL_Edge* sctxs[], size_t nbIns)
             ZL_Graph_getScratchSpace(gctx, maxNbSegments * sizeof(size_t));
     unsigned* const tags =
             ZL_Graph_getScratchSpace(gctx, maxNbSegments * sizeof(unsigned));
-    ZL_RET_R_IF_NULL(allocation, segmentSizes);
-    ZL_RET_R_IF_NULL(allocation, tags);
+    ZL_ERR_IF_NULL(segmentSizes, allocation);
+    ZL_ERR_IF_NULL(tags, allocation);
 
     // Iterate over all the tokens in the Zip file, and fill out segmentSizes
     // and tags.
@@ -105,7 +106,7 @@ pytorchModelDynGraph(ZL_Graph* gctx, ZL_Edge* sctxs[], size_t nbIns)
         ZS2_ZipToken tokens[32];
         ZL_TRY_LET_R(nbTokens, ZS2_ZipLexer_lex(&lexer, tokens, 32));
         for (size_t i = 0; i < nbTokens; ++i) {
-            ZL_RET_R_IF_GE(corruption, nbSegments, maxNbSegments);
+            ZL_ERR_IF_GE(nbSegments, maxNbSegments, corruption);
             const ZS2_ZipToken token = tokens[i];
 
             // Assign the appropriate tag to the token.
@@ -133,7 +134,7 @@ pytorchModelDynGraph(ZL_Graph* gctx, ZL_Edge* sctxs[], size_t nbIns)
             // Split large files into smaller segments to optimize
             // (de)compression speed by improving memory locality.
             while (segmentSizes[nbSegments - 1] > kMaxSegmentSize) {
-                ZL_RET_R_IF_GE(corruption, nbSegments, maxNbSegments);
+                ZL_ERR_IF_GE(nbSegments, maxNbSegments, corruption);
                 const size_t segmentSize     = segmentSizes[nbSegments - 1];
                 segmentSizes[nbSegments - 1] = kMaxSegmentSize;
                 segmentSizes[nbSegments]     = segmentSize - kMaxSegmentSize;
@@ -153,7 +154,7 @@ pytorchModelDynGraph(ZL_Graph* gctx, ZL_Edge* sctxs[], size_t nbIns)
 
     // Set the destination for every segment
     for (size_t i = 0; i < streams.nbStreams; ++i) {
-        ZL_RET_R_IF_ERR(ZL_Edge_setDestination(
+        ZL_ERR_IF_ERR(ZL_Edge_setDestination(
                 streams.streams[i], graphs.graphids[tags[i]]));
     }
 

--- a/custom_parsers/shared_components/string_graphs.cpp
+++ b/custom_parsers/shared_components/string_graphs.cpp
@@ -32,8 +32,9 @@ ZL_GraphID ZL_Compressor_registerStringTokenize(ZL_Compressor* compressor)
 static ZL_Report
 nullAwareDispatchGraphFn(ZL_Graph* gctx, ZL_Edge* inputs[], size_t) noexcept
 {
+    ZL_RESULT_DECLARE_SCOPE_REPORT(gctx);
     const auto successors = ZL_Graph_getCustomGraphs(gctx);
-    ZL_RET_R_IF_NE(node_invalid_input, successors.nbGraphIDs, 3);
+    ZL_ERR_IF_NE(successors.nbGraphIDs, 3, node_invalid_input);
 
     auto* input        = ZL_Edge_getData(inputs[0]);
     const auto numStrs = ZL_Input_numElts(input);
@@ -46,14 +47,14 @@ nullAwareDispatchGraphFn(ZL_Graph* gctx, ZL_Edge* inputs[], size_t) noexcept
     }
     auto result =
             ZL_Edge_runDispatchStringNode(inputs[0], 2, dispatchIdx.data());
-    ZL_RET_R_IF_ERR(result);
-    ZL_RET_R_IF_NE(node_invalid_input, ZL_RES_value(result).nbEdges, 3);
+    ZL_ERR_IF_ERR(result);
+    ZL_ERR_IF_NE(ZL_RES_value(result).nbEdges, 3, node_invalid_input);
     const auto edgeList = ZL_RES_value(result);
-    ZL_RET_R_IF_ERR(
+    ZL_ERR_IF_ERR(
             ZL_Edge_setDestination(edgeList.edges[0], successors.graphids[0]));
-    ZL_RET_R_IF_ERR(
+    ZL_ERR_IF_ERR(
             ZL_Edge_setDestination(edgeList.edges[1], successors.graphids[1]));
-    ZL_RET_R_IF_ERR(
+    ZL_ERR_IF_ERR(
             ZL_Edge_setDestination(edgeList.edges[2], successors.graphids[2]));
     return ZL_returnSuccess();
 }

--- a/custom_transforms/json_extract/decode_json_extract.cpp
+++ b/custom_transforms/json_extract/decode_json_extract.cpp
@@ -139,6 +139,7 @@ ZL_Report replaceTokens(
         InStream& floats,
         InStream& strs)
 {
+    ZL_RESULT_DECLARE_SCOPE_REPORT(dictx);
     size_t idx           = 0;
     uint64_t mask        = bitmask[idx];
     uint32_t skipped     = 0;
@@ -183,13 +184,13 @@ ZL_Report replaceTokens(
 
         // Replace the token
         if (token[0] == char(Token::INT)) {
-            ZL_RET_R_IF_EQ(corruption, ints.remaining(), 0);
+            ZL_ERR_IF_EQ(ints.remaining(), 0, corruption);
             out = ints.read(out);
         } else if (token[0] == char(Token::FLOAT)) {
-            ZL_RET_R_IF_EQ(corruption, floats.remaining(), 0);
+            ZL_ERR_IF_EQ(floats.remaining(), 0, corruption);
             out = floats.read(out);
         } else if (token[0] == char(Token::STR)) {
-            ZL_RET_R_IF_EQ(corruption, strs.remaining(), 0);
+            ZL_ERR_IF_EQ(strs.remaining(), 0, corruption);
             out = strs.read(out);
         } else if (token[0] == char(Token::TRUE)) {
             memcpy(out, "true", 4);
@@ -216,6 +217,7 @@ ZL_Report jsonExtractDecode(
         ZL_Decoder* dictx,
         ZL_Input const* inputs[]) noexcept
 {
+    ZL_RESULT_DECLARE_SCOPE_REPORT(dictx);
     ZL_Input const* jsonStream = inputs[0];
     InStream ints{ inputs[1] };
     InStream floats{ inputs[2] };
@@ -231,18 +233,18 @@ ZL_Report jsonExtractDecode(
             + ZL_Input_contentSize(inputs[1]) + ZL_Input_contentSize(inputs[2])
             + ZL_Input_contentSize(inputs[3]) + ZS_WILDCOPY_OVERLENGTH;
     ZL_Output* outStream = ZL_Decoder_create1OutStream(dictx, outBound, 1);
-    ZL_RET_R_IF_NULL(allocation, outStream);
+    ZL_ERR_IF_NULL(outStream, allocation);
 
     std::array<uint64_t, kBitmaskSize> bitmask;
     char* out = (char*)ZL_Output_ptr(outStream);
     while (!json.empty()) {
         auto const block = buildBitmask(bitmask.data(), json);
-        ZL_RET_R_IF_ERR(replaceTokens(
+        ZL_ERR_IF_ERR(replaceTokens(
                 dictx, out, bitmask.data(), block, ints, floats, strs));
     }
 
     size_t const size = size_t(out - (char*)ZL_Output_ptr(outStream));
-    ZL_RET_R_IF_ERR(ZL_Output_commit(outStream, size));
+    ZL_ERR_IF_ERR(ZL_Output_commit(outStream, size));
 
     return ZL_returnSuccess();
 }

--- a/custom_transforms/json_extract/encode_json_extract.cpp
+++ b/custom_transforms/json_extract/encode_json_extract.cpp
@@ -468,6 +468,7 @@ void validateExtraction(Extracted const& extracted)
 
 ZL_Report jsonExtractEncode(ZL_Encoder* eictx, const ZL_Input* input) noexcept
 {
+    ZL_RESULT_DECLARE_SCOPE_REPORT(eictx);
     std::string_view src{ (char const*)ZL_Input_ptr(input),
                           ZL_Input_numElts(input) };
 
@@ -480,7 +481,7 @@ ZL_Report jsonExtractEncode(ZL_Encoder* eictx, const ZL_Input* input) noexcept
     }
     validateExtraction(extracted);
 
-    ZL_RET_R_IF_ERR(extracted.commit());
+    ZL_ERR_IF_ERR(extracted.commit());
 
     return ZL_returnSuccess();
 }

--- a/custom_transforms/parse/decode_parse_float.cpp
+++ b/custom_transforms/parse/decode_parse_float.cpp
@@ -59,21 +59,22 @@ namespace {
 template <typename T>
 ZL_Report parseDecode(ZL_Decoder* dictx, ZL_Input const* inputs[]) noexcept
 {
+    ZL_RESULT_DECLARE_SCOPE_REPORT(dictx);
     ZL_Input const* numbers          = inputs[0];
     ZL_Input const* exceptionIndices = inputs[1];
     ZL_Input const* exceptions       = inputs[2];
 
-    ZL_RET_R_IF_NE(
-            corruption,
+    ZL_ERR_IF_NE(
             ZL_Input_numElts(exceptionIndices),
-            ZL_Input_numElts(exceptions));
-    ZL_RET_R_IF_NE(corruption, ZL_Input_eltWidth(exceptionIndices), 4);
-    ZL_RET_R_IF_NE(corruption, ZL_Input_eltWidth(numbers), sizeof(T));
+            ZL_Input_numElts(exceptions),
+            corruption);
+    ZL_ERR_IF_NE(ZL_Input_eltWidth(exceptionIndices), 4, corruption);
+    ZL_ERR_IF_NE(ZL_Input_eltWidth(numbers), sizeof(T), corruption);
 
     size_t const outBound = ZL_Input_contentSize(exceptions)
             + ZL_Input_numElts(numbers) * maxStrLen(T{});
     ZL_Output* outStream = ZL_Decoder_create1OutStream(dictx, outBound, 1);
-    ZL_RET_R_IF_NULL(allocation, outStream);
+    ZL_ERR_IF_NULL(outStream, allocation);
 
     StreamAppender outAppender{ outStream };
 
@@ -81,7 +82,7 @@ ZL_Report parseDecode(ZL_Decoder* dictx, ZL_Input const* inputs[]) noexcept
             ZL_Input_numElts(numbers) + ZL_Input_numElts(exceptions);
 
     uint32_t* fieldSizes = ZL_Output_reserveStringLens(outStream, nbElts);
-    ZL_RET_R_IF_NULL(allocation, fieldSizes);
+    ZL_ERR_IF_NULL(fieldSizes, allocation);
 
     auto nums          = (T const*)ZL_Input_ptr(numbers);
     auto const numsEnd = nums + ZL_Input_numElts(numbers);
@@ -99,16 +100,16 @@ ZL_Report parseDecode(ZL_Decoder* dictx, ZL_Input const* inputs[]) noexcept
             outAppender.append(exData, exSize);
             exData += exSize;
         } else {
-            ZL_RET_R_IF_EQ(srcSize_tooSmall, nums, numsEnd);
+            ZL_ERR_IF_EQ(nums, numsEnd, srcSize_tooSmall);
             folly::toAppend(*nums++, &outAppender);
         }
         fieldSizes[i] = outAppender.commitField();
     }
 
-    ZL_RET_R_IF_NE(corruption, nums, numsEnd);
-    ZL_RET_R_IF_NE(corruption, exIdxs, exIdxsEnd);
+    ZL_ERR_IF_NE(nums, numsEnd, corruption);
+    ZL_ERR_IF_NE(exIdxs, exIdxsEnd, corruption);
 
-    ZL_RET_R_IF_ERR(ZL_Output_commit(outStream, nbElts));
+    ZL_ERR_IF_ERR(ZL_Output_commit(outStream, nbElts));
 
     return ZL_returnSuccess();
 }

--- a/custom_transforms/parse/decode_parse_int.cpp
+++ b/custom_transforms/parse/decode_parse_int.cpp
@@ -314,16 +314,17 @@ namespace {
 template <typename T>
 ZL_Report parseDecodeInt(ZL_Decoder* dictx, ZL_Input const* inputs[]) noexcept
 {
+    ZL_RESULT_DECLARE_SCOPE_REPORT(dictx);
     ZL_Input const* numbers          = inputs[0];
     ZL_Input const* exceptionIndices = inputs[1];
     ZL_Input const* exceptions       = inputs[2];
 
-    ZL_RET_R_IF_NE(
-            corruption,
+    ZL_ERR_IF_NE(
             ZL_Input_numElts(exceptionIndices),
-            ZL_Input_numElts(exceptions));
-    ZL_RET_R_IF_NE(corruption, ZL_Input_eltWidth(exceptionIndices), 4);
-    ZL_RET_R_IF_NE(corruption, ZL_Input_eltWidth(numbers), sizeof(T));
+            ZL_Input_numElts(exceptions),
+            corruption);
+    ZL_ERR_IF_NE(ZL_Input_eltWidth(exceptionIndices), 4, corruption);
+    ZL_ERR_IF_NE(ZL_Input_eltWidth(numbers), sizeof(T), corruption);
 
     // Note: we calculate the maximal outbound and allocate a matching outstream
     // this is inefficient as before we need the actual out stream we calculate
@@ -334,13 +335,13 @@ ZL_Report parseDecodeInt(ZL_Decoder* dictx, ZL_Input const* inputs[]) noexcept
     size_t const outBound = ZL_Input_contentSize(exceptions)
             + ZL_Input_numElts(numbers) * maxStrLen(T{});
     ZL_Output* outStream = ZL_Decoder_create1OutStream(dictx, outBound, 1);
-    ZL_RET_R_IF_NULL(allocation, outStream);
+    ZL_ERR_IF_NULL(outStream, allocation);
 
     size_t const nbElts =
             ZL_Input_numElts(numbers) + ZL_Input_numElts(exceptions);
 
     uint32_t* fieldSizes = ZL_Output_reserveStringLens(outStream, nbElts);
-    ZL_RET_R_IF_NULL(allocation, fieldSizes);
+    ZL_ERR_IF_NULL(fieldSizes, allocation);
 
     auto nums   = (T const*)ZL_Input_ptr(numbers);
     auto nbNums = ZL_Input_numElts(numbers);
@@ -366,7 +367,7 @@ ZL_Report parseDecodeInt(ZL_Decoder* dictx, ZL_Input const* inputs[]) noexcept
             fieldSizes,
             outSize,
             (uint8_t*)ZL_Output_ptr(outStream));
-    ZL_RET_R_IF_ERR(ZL_Output_commit(outStream, nbElts));
+    ZL_ERR_IF_ERR(ZL_Output_commit(outStream, nbElts));
 
     return ZL_returnSuccess();
 }

--- a/custom_transforms/parse/encode_parse.cpp
+++ b/custom_transforms/parse/encode_parse.cpp
@@ -29,6 +29,7 @@ ZL_Report fillVSFStream(
         size_t idx,
         std::vector<std::string_view> const& elts)
 {
+    ZL_RESULT_DECLARE_SCOPE_REPORT(eictx);
     size_t totalSize = 0;
     for (auto const& elt : elts) {
         totalSize += elt.size();
@@ -36,10 +37,10 @@ ZL_Report fillVSFStream(
 
     ZL_Output* const stream =
             ZL_Encoder_createTypedStream(eictx, idx, totalSize, 1);
-    ZL_RET_R_IF_NULL(allocation, stream);
+    ZL_ERR_IF_NULL(stream, allocation);
 
     auto* const sizes = ZL_Output_reserveStringLens(stream, elts.size());
-    ZL_RET_R_IF_NULL(allocation, sizes);
+    ZL_ERR_IF_NULL(sizes, allocation);
 
     auto content = (char*)ZL_Output_ptr(stream);
 
@@ -49,7 +50,7 @@ ZL_Report fillVSFStream(
         sizes[i] = elts[i].size();
     }
 
-    ZL_RET_R_IF_ERR(ZL_Output_commit(stream, elts.size()));
+    ZL_ERR_IF_ERR(ZL_Output_commit(stream, elts.size()));
 
     return ZL_returnSuccess();
 }
@@ -315,6 +316,7 @@ size_t parseEncodeKernel(
 template <typename T>
 ZL_Report parseEncode(ZL_Encoder* eictx, ZL_Input const* input) noexcept
 {
+    ZL_RESULT_DECLARE_SCOPE_REPORT(eictx);
     std::vector<std::string_view> exceptions;
     std::vector<uint32_t> exceptionIndices;
 
@@ -324,28 +326,28 @@ ZL_Report parseEncode(ZL_Encoder* eictx, ZL_Input const* input) noexcept
 
     ZL_Output* numbers =
             ZL_Encoder_createTypedStream(eictx, 0, nbElts, sizeof(T));
-    ZL_RET_R_IF_NULL(allocation, numbers);
+    ZL_ERR_IF_NULL(numbers, allocation);
 
     T* const nums = (T*)ZL_Output_ptr(numbers);
 
     size_t const numNums = parseEncodeKernel<T>(
             nums, exceptions, exceptionIndices, data, sizes, nbElts);
 
-    ZL_RET_R_IF_ERR(ZL_Output_commit(numbers, numNums));
+    ZL_ERR_IF_ERR(ZL_Output_commit(numbers, numNums));
 
     ZL_Output* exceptionIndicesStream =
             ZL_Encoder_createTypedStream(eictx, 1, exceptionIndices.size(), 4);
-    ZL_RET_R_IF_NULL(allocation, exceptionIndicesStream);
+    ZL_ERR_IF_NULL(exceptionIndicesStream, allocation);
 
     if (exceptionIndices.size() > 0)
         memcpy(ZL_Output_ptr(exceptionIndicesStream),
                exceptionIndices.data(),
                exceptionIndices.size() * 4);
 
-    ZL_RET_R_IF_ERR(
+    ZL_ERR_IF_ERR(
             ZL_Output_commit(exceptionIndicesStream, exceptionIndices.size()));
 
-    ZL_RET_R_IF_ERR(fillVSFStream(eictx, 2, exceptions));
+    ZL_ERR_IF_ERR(fillVSFStream(eictx, 2, exceptions));
 
     return ZL_returnSuccess();
 }

--- a/custom_transforms/thrift/kernels/decode_thrift_binding.cpp
+++ b/custom_transforms/thrift/kernels/decode_thrift_binding.cpp
@@ -50,10 +50,11 @@ template <typename Kernel>
 ZL_Report typedTransform(ZL_Decoder* dictx, ZL_Input const* src[]) noexcept
 {
     using InputStreams = typename Kernel::InputStreams;
-    ZL_RET_R_IF_LT(
-            formatVersion_unsupported,
+    ZL_RESULT_DECLARE_SCOPE_REPORT(dictx);
+    ZL_ERR_IF_LT(
             DI_getFrameFormatVersion(dictx),
             9,
+            formatVersion_unsupported,
             "Support first added in format version 9");
     try {
         InputStreams inputs;
@@ -65,36 +66,35 @@ ZL_Report typedTransform(ZL_Decoder* dictx, ZL_Input const* src[]) noexcept
             uint8_t const* ip   = (uint8_t const*)header.start;
             uint8_t const* iend = ip + header.size;
             dstCapacity         = unwrap(ZL_varintDecode(&ip, iend));
-            ZL_RET_R_IF_NE(corruption, ip, iend);
+            ZL_ERR_IF_NE(ip, iend, corruption);
         }
 
         ZL_Output* stream = ZL_Decoder_create1OutStream(dictx, dstCapacity, 1);
-        ZL_RET_R_IF_NULL(allocation, stream);
+        ZL_ERR_IF_NULL(stream, allocation);
         std::span<uint8_t> out = { (uint8_t*)ZL_Output_ptr(stream),
                                    dstCapacity };
 
-        ZL_RET_R_IF_NE(corruption, ZL_Input_eltWidth(src[0]), 8);
+        ZL_ERR_IF_NE(ZL_Input_eltWidth(src[0]), 8, corruption);
         std::span<uint64_t const> sizes = {
             (uint64_t const*)ZL_Input_ptr(src[0]), ZL_Input_numElts(src[0])
         };
 
         for (auto const& size : sizes) {
             auto const written = Kernel{}(dictx, out, inputs, size);
-            ZL_RET_R_IF_ERR(written);
+            ZL_ERR_IF_ERR(written);
             assert(ZL_validResult(written) <= out.size());
             out = out.subspan(ZL_validResult(written));
         }
 
-        ZL_RET_R_IF(corruption, !out.empty());
+        ZL_ERR_IF(!out.empty(), corruption);
 
-        ZL_RET_R_IF_ERR(ZL_Output_commit(stream, dstCapacity));
+        ZL_ERR_IF_ERR(ZL_Output_commit(stream, dstCapacity));
 
         return ZL_returnSuccess();
     } catch (std::exception const& e) {
-        ZL_RET_R_ERR(
-                transform_executionFailure,
-                "Thrift kernel failure: %s",
-                e.what());
+        ZL_ERR(transform_executionFailure,
+               "Thrift kernel failure: %s",
+               e.what());
     }
 }
 
@@ -133,9 +133,10 @@ ZL_Report ZS2_ThriftKernel_registerDTransformMapI32Float(
                 InputStreams& in,
                 size_t mapSize)
         {
+            ZL_RESULT_DECLARE_SCOPE_REPORT(dictx);
             auto& [keys, values] = in;
-            ZL_RET_R_IF_NE(corruption, keys.size(), values.size());
-            ZL_RET_R_IF_LT(corruption, keys.size(), mapSize);
+            ZL_ERR_IF_NE(keys.size(), values.size(), corruption);
+            ZL_ERR_IF_LT(keys.size(), mapSize, corruption);
             auto ret = ZS2_ThriftKernel_serializeMapI32Float(
                     out.data(),
                     out.size(),
@@ -167,9 +168,10 @@ ZL_Report ZS2_ThriftKernel_registerDTransformMapI32ArrayFloat(
                 InputStreams& in,
                 size_t mapSize)
         {
+            ZL_RESULT_DECLARE_SCOPE_REPORT(dictx);
             auto& [keys, lengths, innerValues] = in;
-            ZL_RET_R_IF_NE(corruption, keys.size(), lengths.size());
-            ZL_RET_R_IF_LT(corruption, keys.size(), mapSize);
+            ZL_ERR_IF_NE(keys.size(), lengths.size(), corruption);
+            ZL_ERR_IF_LT(keys.size(), mapSize, corruption);
             auto* innerValuesPtr = innerValues.data();
             auto* innerValuesEnd = innerValues.data() + innerValues.size();
             auto ret             = ZS2_ThriftKernel_serializeMapI32ArrayFloat(
@@ -207,9 +209,10 @@ ZL_Report ZS2_ThriftKernel_registerDTransformMapI32ArrayI64(
                 InputStreams& in,
                 size_t mapSize)
         {
+            ZL_RESULT_DECLARE_SCOPE_REPORT(dictx);
             auto& [keys, lengths, innerValues] = in;
-            ZL_RET_R_IF_NE(corruption, keys.size(), lengths.size());
-            ZL_RET_R_IF_LT(corruption, keys.size(), mapSize);
+            ZL_ERR_IF_NE(keys.size(), lengths.size(), corruption);
+            ZL_ERR_IF_LT(keys.size(), mapSize, corruption);
             auto* innerValuesPtr = innerValues.data();
             auto* innerValuesEnd = innerValues.data() + innerValues.size();
             auto ret             = ZS2_ThriftKernel_serializeMapI32ArrayI64(
@@ -248,9 +251,10 @@ ZL_Report ZS2_ThriftKernel_registerDTransformMapI32ArrayArrayI64(
                 InputStreams& in,
                 size_t mapSize)
         {
+            ZL_RESULT_DECLARE_SCOPE_REPORT(dictx);
             auto& [keys, lengths, innerLengths, innerInnerValues] = in;
-            ZL_RET_R_IF_NE(corruption, keys.size(), lengths.size());
-            ZL_RET_R_IF_LT(corruption, keys.size(), mapSize);
+            ZL_ERR_IF_NE(keys.size(), lengths.size(), corruption);
+            ZL_ERR_IF_LT(keys.size(), mapSize, corruption);
             auto* innerLengthsPtr = innerLengths.data();
             auto* innerLengthsEnd = innerLengths.data() + innerLengths.size();
             auto* innerInnerValuesPtr = innerInnerValues.data();
@@ -296,9 +300,10 @@ ZL_Report ZS2_ThriftKernel_registerDTransformMapI32MapI64Float(
                 InputStreams& in,
                 size_t mapSize)
         {
+            ZL_RESULT_DECLARE_SCOPE_REPORT(dictx);
             auto& [keys, lengths, innerKeys, innerValues] = in;
-            ZL_RET_R_IF_NE(corruption, keys.size(), lengths.size());
-            ZL_RET_R_IF_LT(corruption, keys.size(), mapSize);
+            ZL_ERR_IF_NE(keys.size(), lengths.size(), corruption);
+            ZL_ERR_IF_LT(keys.size(), mapSize, corruption);
             auto* innerKeysPtr   = innerKeys.data();
             auto* innerKeysEnd   = innerKeys.data() + innerKeys.size();
             auto* innerValuesPtr = innerValues.data();
@@ -339,8 +344,9 @@ ZL_Report ZS2_ThriftKernel_registerDTransformArrayI64(
                 InputStreams& in,
                 size_t arraySize)
         {
+            ZL_RESULT_DECLARE_SCOPE_REPORT(dictx);
             auto& [values] = in;
-            ZL_RET_R_IF_LT(corruption, values.size(), arraySize);
+            ZL_ERR_IF_LT(values.size(), arraySize, corruption);
             auto ret = ZS2_ThriftKernel_serializeArrayI64(
                     out.data(), out.size(), values.data(), arraySize);
             values = values.subspan(arraySize);
@@ -364,8 +370,9 @@ ZL_Report ZS2_ThriftKernel_registerDTransformArrayI32(
                 InputStreams& in,
                 size_t arraySize)
         {
+            ZL_RESULT_DECLARE_SCOPE_REPORT(dictx);
             auto& [values] = in;
-            ZL_RET_R_IF_LT(corruption, values.size(), arraySize);
+            ZL_ERR_IF_LT(values.size(), arraySize, corruption);
             auto ret = ZS2_ThriftKernel_serializeArrayI32(
                     out.data(), out.size(), values.data(), arraySize);
             values = values.subspan(arraySize);
@@ -389,8 +396,9 @@ ZL_Report ZS2_ThriftKernel_registerDTransformArrayFloat(
                 InputStreams& in,
                 size_t arraySize)
         {
+            ZL_RESULT_DECLARE_SCOPE_REPORT(dictx);
             auto& [values] = in;
-            ZL_RET_R_IF_LT(corruption, values.size(), arraySize);
+            ZL_ERR_IF_LT(values.size(), arraySize, corruption);
             auto ret = ZS2_ThriftKernel_serializeArrayFloat(
                     out.data(), out.size(), values.data(), arraySize);
             values = values.subspan(arraySize);

--- a/custom_transforms/thrift/kernels/encode_thrift_binding.cpp
+++ b/custom_transforms/thrift/kernels/encode_thrift_binding.cpp
@@ -18,6 +18,7 @@ ZL_Report commitOutputStream(
         size_t idx,
         std::vector<std::vector<T> const*> const& vectors)
 {
+    ZL_RESULT_DECLARE_SCOPE_REPORT(eictx);
     size_t size = 0;
     for (auto const* vector : vectors) {
         size += vector->size();
@@ -25,7 +26,7 @@ ZL_Report commitOutputStream(
 
     ZL_Output* stream =
             ZL_Encoder_createTypedStream(eictx, idx, size, sizeof(T));
-    ZL_RET_R_IF_NULL(allocation, stream);
+    ZL_ERR_IF_NULL(stream, allocation);
     uint8_t* op = (uint8_t*)ZL_Output_ptr(stream);
     for (auto const* vector : vectors) {
         if (vector->size() > 0)
@@ -33,7 +34,7 @@ ZL_Report commitOutputStream(
         op += vector->size() * sizeof(T);
     }
     assert((op - (uint8_t*)ZL_Output_ptr(stream)) == size * sizeof(T));
-    ZL_RET_R_IF_ERR(ZL_Output_commit(stream, size));
+    ZL_ERR_IF_ERR(ZL_Output_commit(stream, size));
     return ZL_returnSuccess();
 }
 
@@ -43,20 +44,21 @@ ZL_Report commitOutputStream(
         size_t idx,
         std::vector<ZeroCopyDynamicOutput<T> const*> const& outs)
 {
+    ZL_RESULT_DECLARE_SCOPE_REPORT(eictx);
     size_t size = 0;
     for (auto const* out : outs) {
         size += out->size();
     }
     ZL_Output* stream =
             ZL_Encoder_createTypedStream(eictx, idx, size, sizeof(T));
-    ZL_RET_R_IF_NULL(allocation, stream);
+    ZL_ERR_IF_NULL(stream, allocation);
     uint8_t* op = (uint8_t*)ZL_Output_ptr(stream);
     for (auto const* out : outs) {
         out->copyToBuffer(op, out->nbytes());
         op += out->nbytes();
     }
     assert((op - (uint8_t*)ZL_Output_ptr(stream)) == size * sizeof(T));
-    ZL_RET_R_IF_ERR(ZL_Output_commit(stream, size));
+    ZL_ERR_IF_ERR(ZL_Output_commit(stream, size));
     return ZL_returnSuccess();
 }
 
@@ -65,13 +67,14 @@ ZL_Report commitOutputStreams(
         ZL_Encoder* eictx,
         std::vector<std::tuple<Ts...>> const& outputs)
 {
+    ZL_RESULT_DECLARE_SCOPE_REPORT(eictx);
     if constexpr (idx < sizeof...(Ts)) {
         std::vector<std::tuple_element_t<idx, std::tuple<Ts...>> const*> output;
         output.reserve(outputs.size());
         for (auto&& tuple : outputs) {
             output.push_back(&std::get<idx>(tuple));
         }
-        ZL_RET_R_IF_ERR(commitOutputStream(eictx, idx + 1, output));
+        ZL_ERR_IF_ERR(commitOutputStream(eictx, idx + 1, output));
         return commitOutputStreams<idx + 1>(eictx, outputs);
     } else {
         return ZL_returnSuccess();
@@ -84,10 +87,11 @@ template <typename Kernel>
 ZL_Report typedTransform(ZL_Encoder* eictx, ZL_Input const* input) noexcept
 {
     // These transforms were added in version 9
-    ZL_RET_R_IF_LT(
-            formatVersion_unsupported,
+    ZL_RESULT_DECLARE_SCOPE_REPORT(eictx);
+    ZL_ERR_IF_LT(
             ZL_Encoder_getCParam(eictx, ZL_CParam_formatVersion),
-            9);
+            9,
+            formatVersion_unsupported);
 
     assert(ZL_Input_type(input) == ZL_Type_serial);
     try {
@@ -114,17 +118,16 @@ ZL_Report typedTransform(ZL_Encoder* eictx, ZL_Input const* input) noexcept
         // Add the lengths stream
         {
             std::vector<std::vector<uint64_t> const*> outs_2 = { &lengths };
-            ZL_RET_R_IF_ERR(commitOutputStream(eictx, 0, outs_2));
+            ZL_ERR_IF_ERR(commitOutputStream(eictx, 0, outs_2));
         }
 
-        ZL_RET_R_IF_ERR(commitOutputStreams(eictx, outs));
+        ZL_ERR_IF_ERR(commitOutputStreams(eictx, outs));
 
         return ZL_returnSuccess();
     } catch (std::exception const& e) {
-        ZL_RET_R_ERR(
-                transform_executionFailure,
-                "Thrift kernel failure: %s",
-                e.what());
+        ZL_ERR(transform_executionFailure,
+               "Thrift kernel failure: %s",
+               e.what());
     }
 }
 

--- a/custom_transforms/thrift/probabilistic_selector.c
+++ b/custom_transforms/thrift/probabilistic_selector.c
@@ -10,9 +10,10 @@
 static ZL_Report
 probabilisticSelectorImpl(ZL_Graph* gctx, ZL_Edge* inputs[], size_t nbInputs)
 {
+    ZL_RESULT_DECLARE_SCOPE_REPORT(gctx);
     ZL_GraphIDList customGraphs = ZL_Graph_getCustomGraphs(gctx);
     size_t nbCustomGraphs       = customGraphs.nbGraphIDs;
-    ZL_RET_R_IF_EQ(node_invalid_input, customGraphs.nbGraphIDs, 0);
+    ZL_ERR_IF_EQ(customGraphs.nbGraphIDs, 0, node_invalid_input);
 
     const size_t* probWeights =
             (const size_t*)ZL_Graph_getLocalRefParam(
@@ -21,8 +22,8 @@ probabilisticSelectorImpl(ZL_Graph* gctx, ZL_Edge* inputs[], size_t nbInputs)
     size_t totalWeight = 0;
     for (size_t i = 0; i < nbCustomGraphs; ++i) {
         // Weight overflow
-        ZL_RET_R_IF_GT(
-                node_invalid_input, totalWeight, SIZE_MAX - probWeights[i]);
+        ZL_ERR_IF_GT(
+                totalWeight, SIZE_MAX - probWeights[i], node_invalid_input);
         totalWeight += probWeights[i];
     }
     XXH32_hash_t hash = 0;

--- a/custom_transforms/thrift/thrift_parsers.cpp
+++ b/custom_transforms/thrift/thrift_parsers.cpp
@@ -319,10 +319,11 @@ ZL_Output* copyStringLogicalClusterToEICtx(
 template <typename Parser>
 ZL_Report configurableEncode(ZL_Encoder* eictx, const ZL_Input* in)
 {
+    ZL_RESULT_DECLARE_SCOPE_REPORT(eictx);
     unsigned int const formatVersion =
             ZL_Encoder_getCParam(eictx, ZL_CParam_formatVersion);
-    ZL_RET_R_IF_LT(
-            formatVersion_unsupported, formatVersion, kMinFormatVersionEncode);
+    ZL_ERR_IF_LT(
+            formatVersion, kMinFormatVersionEncode, formatVersion_unsupported);
 
     try {
         ZL_ASSERT(ZL_Input_type(in) == ZL_Type_serial);
@@ -331,26 +332,26 @@ ZL_Report configurableEncode(ZL_Encoder* eictx, const ZL_Input* in)
 
         // Read config
         ZL_CopyParam gp = ZL_Encoder_getLocalCopyParam(eictx, 0);
-        ZL_RET_R_IF_EQ(corruption, gp.paramId, ZL_LP_INVALID_PARAMID);
+        ZL_ERR_IF_EQ(gp.paramId, ZL_LP_INVALID_PARAMID, corruption);
         std::string_view const encoderConfigStr(
                 (const char*)gp.paramPtr, gp.paramSize);
         EncoderConfig config = EncoderConfig(encoderConfigStr);
 
         // Fail compression if config uses unsupported features
-        ZL_RET_R_IF_LT(
-                formatVersion_unsupported,
+        ZL_ERR_IF_LT(
                 formatVersion,
-                config.getMinFormatVersion());
+                config.getMinFormatVersion(),
+                formatVersion_unsupported);
 
         // Temporary requirement: ensure contiguous LogicalIds
         // (starting from 0)
         for (const auto& streamId : config.getLogicalIds()) {
             static_assert(std::is_unsigned_v<std::underlying_type_t<
                                   std::decay_t<decltype(streamId)>>>);
-            ZL_RET_R_IF_GE(
-                    temporaryLibraryLimitation,
+            ZL_ERR_IF_GE(
                     static_cast<size_t>(streamId),
-                    config.getLogicalIds().size());
+                    config.getLogicalIds().size(),
+                    temporaryLibraryLimitation);
         }
 
         // Encode the input stream!
@@ -360,10 +361,9 @@ ZL_Report configurableEncode(ZL_Encoder* eictx, const ZL_Input* in)
         try {
             parser.parse();
         } catch (const std::exception& ex) {
-            ZL_RET_R_ERR(
-                    GENERIC,
-                    "Thrift kernel failed inside core parser: %s",
-                    ex.what());
+            ZL_ERR(GENERIC,
+                   "Thrift kernel failed inside core parser: %s",
+                   ex.what());
         }
         debug("Encoder side:");
         debug(srcStream.repr());
@@ -472,10 +472,9 @@ ZL_Report configurableEncode(ZL_Encoder* eictx, const ZL_Input* in)
 
         return ZL_returnSuccess();
     } catch (const std::exception& ex) {
-        ZL_RET_R_ERR(
-                GENERIC,
-                "Thrift kernel failed outside of core parsing: %s",
-                ex.what());
+        ZL_ERR(GENERIC,
+               "Thrift kernel failed outside of core parsing: %s",
+               ex.what());
     }
 }
 
@@ -487,9 +486,10 @@ ZL_Report configurableDecode(
         const ZL_Input* variableSrcs[],
         size_t nbVariableSrcs)
 {
+    ZL_RESULT_DECLARE_SCOPE_REPORT(dictx);
     const unsigned int formatVersion = DI_getFrameFormatVersion(dictx);
-    ZL_RET_R_IF_LT(
-            formatVersion_unsupported, formatVersion, kMinFormatVersionDecode);
+    ZL_ERR_IF_LT(
+            formatVersion, kMinFormatVersionDecode, formatVersion_unsupported);
 
     assert(nbCompulsorySrcs == (size_t)SingletonId::kNumSingletonIds);
     try {
@@ -516,23 +516,21 @@ ZL_Report configurableDecode(
         try {
             parser.unparse();
         } catch (const std::exception& ex) {
-            ZL_RET_R_ERR(
-                    GENERIC,
-                    "Thrift kernel failed inside core parser: %s",
-                    ex.what());
+            ZL_ERR(GENERIC,
+                   "Thrift kernel failed inside core parser: %s",
+                   ex.what());
         }
         debug("Decoder side:");
         debug(srcStreams.repr());
         debug(dstStream.writeStream().repr());
 
-        ZL_RET_R_IF_ERR(dstStream.commit());
+        ZL_ERR_IF_ERR(dstStream.commit());
 
         return ZL_returnValue(1);
     } catch (const std::exception& ex) {
-        ZL_RET_R_ERR(
-                GENERIC,
-                "Thrift kernel failed outside of core parsing: %s",
-                ex.what());
+        ZL_ERR(GENERIC,
+               "Thrift kernel failed outside of core parsing: %s",
+               ex.what());
     }
 }
 
@@ -650,9 +648,10 @@ ZL_VODecoderDesc const thriftBinaryConfigurableUnSplitter = {
 
 ZL_Report registerCustomTransforms(ZL_DCtx* dctx)
 {
-    ZL_RET_R_IF_ERR(ZL_DCtx_registerVODecoder(
+    ZL_RESULT_DECLARE_SCOPE_REPORT(dctx);
+    ZL_ERR_IF_ERR(ZL_DCtx_registerVODecoder(
             dctx, &thriftCompactConfigurableUnSplitter));
-    ZL_RET_R_IF_ERR(ZL_DCtx_registerVODecoder(
+    ZL_ERR_IF_ERR(ZL_DCtx_registerVODecoder(
             dctx, &thriftBinaryConfigurableUnSplitter));
     return ZL_returnSuccess();
 }

--- a/custom_transforms/tulip_v2/decode_tulip_v2.cpp
+++ b/custom_transforms/tulip_v2/decode_tulip_v2.cpp
@@ -13,22 +13,24 @@ ZL_Report registerCustomTransforms(
         unsigned idRangeBegin,
         unsigned idRangeEnd)
 {
+    ZL_RESULT_DECLARE_SCOPE_REPORT(dctx);
+
     if (idRangeEnd - idRangeBegin < kNumCustomTransforms) {
         throw std::runtime_error("Not enough IDs");
     }
 
     // NOTE: These IDs must remain stable & in-sync with the compressor!
-    ZL_RET_R_IF_ERR(ZS2_ThriftKernel_registerDTransformMapI32Float(
+    ZL_ERR_IF_ERR(ZS2_ThriftKernel_registerDTransformMapI32Float(
             dctx, idRangeBegin + static_cast<unsigned>(Tag::FloatFeatures)));
-    ZL_RET_R_IF_ERR(ZS2_ThriftKernel_registerDTransformMapI32ArrayFloat(
+    ZL_ERR_IF_ERR(ZS2_ThriftKernel_registerDTransformMapI32ArrayFloat(
             dctx,
             idRangeBegin + static_cast<unsigned>(Tag::FloatListFeatures)));
-    ZL_RET_R_IF_ERR(ZS2_ThriftKernel_registerDTransformMapI32ArrayI64(
+    ZL_ERR_IF_ERR(ZS2_ThriftKernel_registerDTransformMapI32ArrayI64(
             dctx, idRangeBegin + static_cast<unsigned>(Tag::IdListFeatures)));
-    ZL_RET_R_IF_ERR(ZS2_ThriftKernel_registerDTransformMapI32ArrayArrayI64(
+    ZL_ERR_IF_ERR(ZS2_ThriftKernel_registerDTransformMapI32ArrayArrayI64(
             dctx,
             idRangeBegin + static_cast<unsigned>(Tag::IdListListFeatures)));
-    ZL_RET_R_IF_ERR(ZS2_ThriftKernel_registerDTransformMapI32MapI64Float(
+    ZL_ERR_IF_ERR(ZS2_ThriftKernel_registerDTransformMapI32MapI64Float(
             dctx,
             idRangeBegin + static_cast<unsigned>(Tag::IdScoreListFeatures)));
 

--- a/src/openzl/decompress/decompress2.c
+++ b/src/openzl/decompress/decompress2.c
@@ -130,6 +130,7 @@ ZL_DCtx* ZL_DCtx_create(void)
 
 ZL_Report ZL_DCtx_setStreamArena(ZL_DCtx* dctx, ZL_DataArenaType sat)
 {
+    ZL_RESULT_DECLARE_SCOPE_REPORT(dctx);
     ZL_ASSERT_NN(dctx);
     Arena* newArena = NULL;
     switch (sat) {
@@ -140,9 +141,9 @@ ZL_Report ZL_DCtx_setStreamArena(ZL_DCtx* dctx, ZL_DataArenaType sat)
             newArena = ALLOC_StackArena_create();
             break;
         default:
-            ZL_RET_R_IF(parameter_invalid, 1, "Stream Arena type is invalid");
+            ZL_ERR_IF(1, parameter_invalid, "Stream Arena type is invalid");
     }
-    ZL_RET_R_IF_NULL(allocation, newArena);
+    ZL_ERR_IF_NULL(newArena, allocation);
     ALLOC_Arena_freeArena(dctx->streamArena);
     dctx->streamArena = newArena;
     return ZL_returnSuccess();
@@ -243,9 +244,10 @@ ZL_Report ZL_DCtx_registerPipeDecoder(
         ZL_DCtx* dctx,
         const ZL_PipeDecoderDesc* ctd)
 {
+    ZL_RESULT_DECLARE_SCOPE_REPORT(dctx);
     ZL_ASSERT_NN(dctx);
     ZL_ASSERT_NN(ctd);
-    ZL_RET_R_IF_ERR(DTM_registerDPipeTransform(&dctx->dtm, ctd));
+    ZL_ERR_IF_ERR(DTM_registerDPipeTransform(&dctx->dtm, ctd));
     return ZL_returnSuccess();
 }
 
@@ -253,9 +255,10 @@ ZL_Report ZL_DCtx_registerSplitDecoder(
         ZL_DCtx* dctx,
         const ZL_SplitDecoderDesc* ctd)
 {
+    ZL_RESULT_DECLARE_SCOPE_REPORT(dctx);
     ZL_ASSERT_NN(dctx);
     ZL_ASSERT_NN(ctd);
-    ZL_RET_R_IF_ERR(DTM_registerDSplitTransform(&dctx->dtm, ctd));
+    ZL_ERR_IF_ERR(DTM_registerDSplitTransform(&dctx->dtm, ctd));
     return ZL_returnSuccess();
 }
 
@@ -263,10 +266,11 @@ ZL_Report ZL_DCtx_registerTypedDecoder(
         ZL_DCtx* dctx,
         const ZL_TypedDecoderDesc* dttd)
 {
+    ZL_RESULT_DECLARE_SCOPE_REPORT(dctx);
     ZL_ASSERT_NN(dctx);
     ZL_ASSERT_NN(dttd);
     // WARNING: Must not fail before this line otherwise opaque will be leaked
-    ZL_RET_R_IF_ERR(DTM_registerDTypedTransform(&dctx->dtm, dttd));
+    ZL_ERR_IF_ERR(DTM_registerDTypedTransform(&dctx->dtm, dttd));
     return ZL_returnSuccess();
 }
 
@@ -274,13 +278,14 @@ ZL_Report ZL_DCtx_registerVODecoder(
         ZL_DCtx* dctx,
         const ZL_VODecoderDesc* dvotd)
 {
+    ZL_RESULT_DECLARE_SCOPE_REPORT(dctx);
     ZL_DLOG(BLOCK,
             "ZL_DCtx_registerVODecoder '%s'",
             STR_REPLACE_NULL(dvotd->name));
     ZL_ASSERT_NN(dctx);
     ZL_ASSERT_NN(dvotd);
     // WARNING: Must not fail before this line otherwise opaque will be leaked
-    ZL_RET_R_IF_ERR(DTM_registerDVOTransform(&dctx->dtm, dvotd));
+    ZL_ERR_IF_ERR(DTM_registerDVOTransform(&dctx->dtm, dvotd));
     return ZL_returnSuccess();
 }
 
@@ -288,10 +293,11 @@ ZL_Report ZL_DCtx_registerMIDecoder(
         ZL_DCtx* dctx,
         const ZL_MIDecoderDesc* dmitd)
 {
+    ZL_RESULT_DECLARE_SCOPE_REPORT(dctx);
     ZL_ASSERT_NN(dctx);
     ZL_ASSERT_NN(dmitd);
     // WARNING: Must not fail before this line otherwise opaque will be leaked
-    ZL_RET_R_IF_ERR(DTM_registerDMITransform(&dctx->dtm, dmitd));
+    ZL_ERR_IF_ERR(DTM_registerDMITransform(&dctx->dtm, dmitd));
     return ZL_returnSuccess();
 }
 
@@ -320,6 +326,7 @@ static ZL_Report ZL_AppendToOutputOptimization_register(
         ZL_DataInfo* outputInfo,
         ZL_Data* outputData)
 {
+    ZL_RESULT_DECLARE_SCOPE_REPORT(dctx);
     if (dctx->preserveStreams) {
         // Does not work with stream preservation, so disable the optimization.
         return ZL_returnValue(0);
@@ -359,7 +366,7 @@ static ZL_Report ZL_AppendToOutputOptimization_register(
     }
     ZL_AppendToOutputOptimization* append = ALLOC_Arena_calloc(
             dctx->decompressArena, sizeof(ZL_AppendToOutputOptimization));
-    ZL_RET_R_IF_NULL(allocation, append);
+    ZL_ERR_IF_NULL(append, allocation);
     append->inputInfos   = inputInfos;
     append->nbInputs     = nbInputs;
     append->headInputIdx = 0;
@@ -369,7 +376,7 @@ static ZL_Report ZL_AppendToOutputOptimization_register(
     append->outputHeadPtr = outputPtr;
     append->outputTailPtr = outputPtr + outputCapacity;
 
-    ZL_RET_R_IF_ERR(STREAM_typeAttachedBuffer(
+    ZL_ERR_IF_ERR(STREAM_typeAttachedBuffer(
             outputData, ZL_Type_serial, 1, outputCapacity));
 
     // Everything succeeded, make stateful changes to infos
@@ -838,11 +845,12 @@ static ZL_Report decodeFrameHeader(
         size_t srcSize,
         size_t nbOutputs)
 {
+    ZL_RESULT_DECLARE_SCOPE_REPORT(dctx);
     ZL_DLOG(FRAME, "decodeFrameHeader (srcSize = %zu)", srcSize);
     ZL_TRY_LET_R(hSize, DFH_decodeFrameHeader(&dctx->dfh, src, srcSize));
 
     ZL_TRY_LET_R(nbOuts, ZL_FrameInfo_getNumOutputs(dctx->dfh.frameinfo));
-    ZL_RET_R_IF_NE(userBuffers_invalidNum, nbOuts, nbOutputs);
+    ZL_ERR_IF_NE(nbOuts, nbOutputs, userBuffers_invalidNum);
     dctx->nbOutputs = nbOutputs;
     return ZL_returnValue(hSize);
 }
@@ -1049,6 +1057,7 @@ static ZL_Report processStream(
         const DTransform* dt,
         const DFH_NodeInfo* nodeInfo)
 {
+    ZL_RESULT_DECLARE_SCOPE_REPORT(dctx);
     ZL_ASSERT_NN(dctx);
     const char* const trName = DT_getTransformName(dt);
     ZL_SCOPE_GRAPH_CONTEXT(
@@ -1061,20 +1070,20 @@ static ZL_Report processStream(
             trName,
             nodeInfo->trpid.trid);
     if (dctx->dfh.formatVersion < 9) {
-        ZL_RET_R_IF_EQ(
-                formatVersion_unsupported,
+        ZL_ERR_IF_EQ(
                 nbInStreams,
                 0,
+                formatVersion_unsupported,
                 "0 output streams not supported until format version 9");
     }
-    ZL_RET_R_IF_GT(
-            formatVersion_unsupported,
+    ZL_ERR_IF_GT(
             nbInStreams,
-            ZL_transformOutStreamsLimit(dctx->dfh.formatVersion));
+            ZL_transformOutStreamsLimit(dctx->dfh.formatVersion),
+            formatVersion_unsupported);
     // Validate that nb of regen streams is compatible
-    ZL_RET_R_IF_NOT(
-            nodeRegen_countIncorrect,
+    ZL_ERR_IF_NOT(
             DT_isNbRegensCompatible(dt, nodeInfo->nbRegens),
+            nodeRegen_countIncorrect,
             "Transform '%s'(%u) is assigned %u streams to regenerate, but its signature specifies %u streams",
             DT_getTransformName(dt),
             nodeInfo->trpid.trid,
@@ -1086,10 +1095,10 @@ static ZL_Report processStream(
     // to ensure that all non-variable transforms get the right number
     // of streams.
     if (dt->miGraphDesc.nbVOs == 0) {
-        ZL_RET_R_IF_NE(
-                corruption,
+        ZL_ERR_IF_NE(
                 nodeInfo->nbVOs,
                 0,
+                corruption,
                 "Transform id=%u isn't accepting VO streams, "
                 "but %zu VO streams are nonetheless assigned to it in this graph.",
                 dt->miGraphDesc.CTid,
@@ -1105,10 +1114,10 @@ static ZL_Report processStream(
     // Though they may not all be filled, so we have to check that.
     ZL_ASSERT_LE(streamID + nbInStreams, VECTOR_SIZE(dctx->dataInfos));
     // Check that output streams are not used as input streams
-    ZL_RET_R_IF_GT(
-            graph_invalid,
+    ZL_ERR_IF_GT(
             streamID + nbInStreams,
-            VECTOR_SIZE(dctx->dataInfos) - dctx->nbOutputs);
+            VECTOR_SIZE(dctx->dataInfos) - dctx->nbOutputs,
+            graph_invalid);
 
     if (nodeInfo->nbRegens == 1) {
         const size_t regenIdx =
@@ -1139,41 +1148,40 @@ static ZL_Report processStream(
     }
 
     // Collect inputs and validate types
-    ZL_RET_R_IF_NE(
-            allocation,
+    ZL_ERR_IF_NE(
             nbInStreams,
             VECTOR_RESIZE_UNINITIALIZED(
-                    dctx->transformInputStreams, nbInStreams));
+                    dctx->transformInputStreams, nbInStreams),
+            allocation);
     const ZL_Data** inputs = VECTOR_DATA(dctx->transformInputStreams);
     for (ZL_IDType n = 0; n < nbInStreams; n++) {
         ZL_IDType const snb = streamID + n;
         size_t const inb    = nbInStreams - 1 - n; // reverse order
         inputs[inb]         = VECTOR_AT(dctx->dataInfos, snb).data;
 
-        ZL_RET_R_IF_NULL(
-                graph_invalid, inputs[inb], "Input stream %u not filled!", inb);
+        ZL_ERR_IF_NULL(
+                inputs[inb], graph_invalid, "Input stream %u not filled!", inb);
 
         // Validate the input type is correct
         // (only for the compulsory output streams)
         if (inb < dt->miGraphDesc.nbSOs) {
             // Compulsory range
             if (ZL_Data_type(inputs[inb]) != dt->miGraphDesc.soTypes[inb]) {
-                ZL_RET_R_ERR(
-                        graph_invalid,
-                        "Error processing stream %u, transform %u: input stream %u has type %d, but we expected type %d",
-                        streamID,
-                        dt->miGraphDesc.CTid,
-                        (unsigned)inb,
-                        ZL_Data_type(inputs[inb]),
-                        dt->miGraphDesc.soTypes[inb]);
+                ZL_ERR(graph_invalid,
+                       "Error processing stream %u, transform %u: input stream %u has type %d, but we expected type %d",
+                       streamID,
+                       dt->miGraphDesc.CTid,
+                       (unsigned)inb,
+                       ZL_Data_type(inputs[inb]),
+                       dt->miGraphDesc.soTypes[inb]);
             }
         } else {
             // Validate that variable streams match one of the allowed types
             // in the graph description. We can't validate more than that,
             // the transform is responsible for everything else.
-            ZL_RET_R_IF_NOT(
-                    graph_invalid,
+            ZL_ERR_IF_NOT(
                     ZL_Data_type(inputs[inb]) & allowedVOTypes,
+                    graph_invalid,
                     "Error processing stream %u, transform %u: Variable input stream %u has type 0x%x, but we expected a type that matches the mask 0x%x",
                     streamID,
                     dt->miGraphDesc.CTid,
@@ -1193,7 +1201,7 @@ static ZL_Report processStream(
     // Determine regenerated streams slots (regensID)
     ZL_IDType* const regensID = ALLOC_Arena_malloc(
             dctx->workspaceArena, sizeof(ZL_IDType) * nodeInfo->nbRegens);
-    ZL_RET_R_IF_NULL(allocation, regensID);
+    ZL_ERR_IF_NULL(regensID, allocation);
     for (size_t n = 0; n < nodeInfo->nbRegens; n++) {
         regensID[n] = (ZL_IDType)(streamID + nbInStreams
                                   + nodeInfo->regenDistances[n]);
@@ -1201,9 +1209,9 @@ static ZL_Report processStream(
     // Check that regenerated streams slots are not already filled
     for (size_t n = 0; n < nodeInfo->nbRegens; n++) {
         ZL_Data* outStream = VECTOR_AT(dctx->dataInfos, regensID[n]).data;
-        ZL_RET_R_IF_NN(
-                graph_invalid,
+        ZL_ERR_IF_NN(
                 outStream,
+                graph_invalid,
                 "Regenerated stream slot already filled!");
     }
 
@@ -1222,9 +1230,9 @@ static ZL_Report processStream(
         .nbRegens       = nodeInfo->nbRegens,
         .thContent      = thContent,
     };
-    ZL_RET_R_IF_NULL(
-            logicError,
+    ZL_ERR_IF_NULL(
             diState.statePtr,
+            logicError,
             "Could not find state for transform %u",
             nodeInfo->trpid.trid);
 
@@ -1234,9 +1242,9 @@ static ZL_Report processStream(
     // Check transform's outcome
     for (size_t n = 0; n < nodeInfo->nbRegens; n++) {
         ZL_Data* outStream = VECTOR_AT(dctx->dataInfos, regensID[n]).data;
-        ZL_RET_R_IF_NULL(
-                transform_executionFailure,
+        ZL_ERR_IF_NULL(
                 outStream,
+                transform_executionFailure,
                 "Node didn't create expected regenerated stream!");
         ZL_ASSERT(
                 STREAM_isCommitted(outStream),
@@ -1265,6 +1273,7 @@ static ZL_Report processStream(
 
 static ZL_Report runDecoders(ZL_DCtx* dctx)
 {
+    ZL_RESULT_DECLARE_SCOPE_REPORT(dctx);
     ZL_DLOG(FRAME, "runDecoders (%zu stages)", dctx->dfh.nbDTransforms);
     ZL_ASSERT_NN(dctx);
     for (size_t stage = 0, startingStream = 0; stage < dctx->dfh.nbDTransforms;
@@ -1280,7 +1289,7 @@ static ZL_Report runDecoders(ZL_DCtx* dctx)
         ZL_RESULT_OF(DTrPtr)
         const transform =
                 DTM_getTransform(&dctx->dtm, trid, dctx->dfh.formatVersion);
-        ZL_RET_R_IF_ERR(transform);
+        ZL_ERR_IF_ERR(transform);
         DTrPtr const dt = ZL_RES_value(transform);
         ZL_TRY_LET_R(
                 nbps,
@@ -1294,6 +1303,7 @@ static ZL_Report runDecoders(ZL_DCtx* dctx)
 /* Only used for specific benchmark scenarios */
 ZL_Report DCTX_runTransformID(ZL_DCtx* dctx, ZL_IDType transformID)
 {
+    ZL_RESULT_DECLARE_SCOPE_REPORT(dctx);
     ZL_ASSERT(dctx->preserveStreams);
     size_t totalOutputBytes = 0;
     for (size_t stage = 0, startingStream = 0; stage < dctx->dfh.nbDTransforms;
@@ -1309,15 +1319,15 @@ ZL_Report DCTX_runTransformID(ZL_DCtx* dctx, ZL_IDType transformID)
         ZL_RESULT_OF(DTrPtr)
         const transform =
                 DTM_getTransform(&dctx->dtm, trid, dctx->dfh.formatVersion);
-        ZL_RET_R_IF_ERR(transform);
+        ZL_ERR_IF_ERR(transform);
         DTrPtr const dt = ZL_RES_value(transform);
         ZL_TRY_LET_R(
                 nbps, processStream(dctx, (ZL_IDType)startingStream, dt, node));
         startingStream += nbps;
-        ZL_RET_R_IF_NE(
-                node_versionMismatch,
+        ZL_ERR_IF_NE(
                 node->nbRegens,
                 1,
+                node_versionMismatch,
                 "This method only supports Transforms regenerating a single stream");
         ZL_IDType const outStreamID =
                 (ZL_IDType)(startingStream + node->regenDistances[0]);
@@ -1453,6 +1463,7 @@ static ZL_Report ZL_DCtx_decompressChunk(
         size_t frameSize,
         size_t alreadyConsumed)
 {
+    ZL_RESULT_DECLARE_SCOPE_REPORT(dctx);
     size_t consumedSize = alreadyConsumed;
     ZL_DLOG(BLOCK,
             "ZL_DCtx_decompressChunk (frameSize=%zu, consumedSize=%zu)",
@@ -1481,7 +1492,7 @@ static ZL_Report ZL_DCtx_decompressChunk(
     ZL_Report const chunkStreamsSize = fillStoredStreams(
             dctx, framePtr, frameSize, consumedSize, &isRegeneratedStream);
     VECTOR_DESTROY(isRegeneratedStream);
-    ZL_RET_R_IF_ERR(chunkStreamsSize);
+    ZL_ERR_IF_ERR(chunkStreamsSize);
     consumedSize += ZL_validResult(chunkStreamsSize);
 
     // If present, verify the compressed checksum before running decoders.
@@ -1490,14 +1501,14 @@ static ZL_Report ZL_DCtx_decompressChunk(
     uint32_t expectedContentHash = 0;
 
     if (FrameInfo_hasContentChecksum(dctx->dfh.frameinfo)) {
-        ZL_RET_R_IF_LT(srcSize_tooSmall, frameSize, consumedSize + 4);
+        ZL_ERR_IF_LT(frameSize, consumedSize + 4, srcSize_tooSmall);
         expectedContentHash = ZL_readCE32((const char*)framePtr + consumedSize);
         ZL_DLOG(SEQ, "stored contentHash: %08X", expectedContentHash);
         consumedSize += 4;
     }
 
     if (FrameInfo_hasCompressedChecksum(dctx->dfh.frameinfo)) {
-        ZL_RET_R_IF_LT(srcSize_tooSmall, frameSize, consumedSize + 4);
+        ZL_ERR_IF_LT(frameSize, consumedSize + 4, srcSize_tooSmall);
 #ifndef FUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION
         if (DCtx_getAppliedGParam(dctx, ZL_DParam_checkCompressedChecksum)
             == ZL_TernaryParam_enable) {
@@ -1521,10 +1532,10 @@ static ZL_Report ZL_DCtx_decompressChunk(
                     "actualCompressedHash:%08X vs %08X:expectedCompressedHash",
                     actualHash,
                     expectedHash);
-            ZL_RET_R_IF_NE(
-                    compressedChecksumWrong,
+            ZL_ERR_IF_NE(
                     actualHash,
                     expectedHash,
+                    compressedChecksumWrong,
                     "Compressed checksum mismatch! This indicates data corruption after compression!");
         }
 #endif
@@ -1532,12 +1543,12 @@ static ZL_Report ZL_DCtx_decompressChunk(
     }
 
     // start the decompression process.
-    ZL_RET_R_IF_ERR(runDecoders(dctx));
+    ZL_ERR_IF_ERR(runDecoders(dctx));
 
     // write result into user's buffer
     {
         ZL_TRY_LET_R(nbOuts, addChunksIntoFinalStreams(dctx));
-        ZL_RET_R_IF_NE(corruption, nbOuts, nbOutputs);
+        ZL_ERR_IF_NE(nbOuts, nbOutputs, corruption);
     }
 
     // verify block content checksum
@@ -1548,9 +1559,9 @@ static ZL_Report ZL_DCtx_decompressChunk(
         // Generate checksum based on actual output
         for (size_t n = 0; n < nbOutputs; n++) {
             if (ZL_Data_type(outputs[n]) == ZL_Type_numeric) {
-                ZL_RET_R_IF_NOT(
-                        temporaryLibraryLimitation,
+                ZL_ERR_IF_NOT(
                         ZL_isLittleEndian(),
+                        temporaryLibraryLimitation,
                         "Cannot calculate hash of numeric output on non little-endian platforms");
             }
         }
@@ -1569,10 +1580,10 @@ static ZL_Report ZL_DCtx_decompressChunk(
                 FrameInfo_hasCompressedChecksum(dctx->dfh.frameinfo)
                 ? "Content checksum mismatch! This indicates that the data was corrupted during compression or decompression, because the compressed checksum matched! This can be caused by a Zstrong bug, other ASAN bugs in the process, or faulty hardware."
                 : "Content checksum mismatch! This indicates that either data corruption after compression or that data was corrupted during compression or decompression!";
-        ZL_RET_R_IF_NE(
-                contentChecksumWrong,
+        ZL_ERR_IF_NE(
                 actualContentHash,
                 expectedContentHash,
+                contentChecksumWrong,
                 "%s",
                 errMsg);
 #else
@@ -1785,11 +1796,12 @@ ZL_Report ZL_DCtx_decompressTBuffer(
         const void* compressed,
         size_t cSize)
 {
+    ZL_RESULT_DECLARE_SCOPE_REPORT(dctx);
     ZL_DLOG(FRAME,
             "ZL_DCtx_decompressTBuffer: decompressing a Typed Buffer of capacity %zu",
             STREAM_byteCapacity(ZL_codemodOutputAsData(tbuffer)));
 
-    ZL_RET_R_IF_ERR(ZL_DCtx_decompressMultiTBuffer(
+    ZL_ERR_IF_ERR(ZL_DCtx_decompressMultiTBuffer(
             dctx, &tbuffer, 1, compressed, cSize));
 
     return ZL_returnValue(ZL_TypedBuffer_byteSize(tbuffer));
@@ -1803,9 +1815,10 @@ ZL_Report ZL_DCtx_decompressTyped(
         const void* compressed,
         size_t cSize)
 {
+    ZL_RESULT_DECLARE_SCOPE_REPORT(dctx);
     ZL_DLOG(FRAME, "ZL_DCtx_decompressTyped");
     ZL_TypedBuffer* const tbuffer = ZL_TypedBuffer_create();
-    ZL_RET_R_IF_NULL(allocation, tbuffer);
+    ZL_ERR_IF_NULL(tbuffer, allocation);
 
     ZL_Report const tbir = STREAM_attachRawBuffer(
             ZL_codemodOutputAsData(tbuffer), dst, dstByteCapacity);
@@ -1845,6 +1858,7 @@ ZL_Report ZL_DCtx_decompress(
         const void* const cSrc,
         const size_t cSize)
 {
+    ZL_RESULT_DECLARE_SCOPE_REPORT(dctx);
     ZL_DLOG(FRAME,
             "ZL_DCtx_decompress (cSrc=%zu, dstCapacity=%zu)",
             cSize,
@@ -1855,10 +1869,10 @@ ZL_Report ZL_DCtx_decompress(
     ZL_Report const r     = ZL_DCtx_decompressTyped(
             dctx, &outInfo, dst, dstCapacity, cSrc, cSize);
     if (!ZL_isError(r)) {
-        ZL_RET_R_IF_NE(
-                GENERIC,
+        ZL_ERR_IF_NE(
                 outInfo.type,
                 ZL_Type_serial,
+                GENERIC,
                 "ZL_DCtx_decompress is only compatible with serialized output");
     }
     return r;

--- a/src/openzl/decompress/dtransforms.c
+++ b/src/openzl/decompress/dtransforms.c
@@ -197,6 +197,7 @@ static ZL_Report pipeTransformWrapper(
         const ZL_Data* ins[],
         size_t nbIns)
 {
+    ZL_RESULT_DECLARE_SCOPE_REPORT(dictx);
     ZL_ASSERT_NN(ins);
     ZL_ASSERT_EQ(nbIns, 1);
     (void)nbIns;
@@ -210,20 +211,20 @@ static ZL_Report pipeTransformWrapper(
     }
 
     ZL_Output* const out = ZL_Decoder_create1OutStream(dictx, dstCapacity, 1);
-    ZL_RET_R_IF_NULL(allocation, out);
+    ZL_ERR_IF_NULL(out, allocation);
 
     void* const dst = ZL_Output_ptr(out);
     size_t const dstSize =
             transform->implDesc.dpt.transform_f(dst, dstCapacity, src, srcSize);
 
-    ZL_RET_R_IF_GT(
-            transform_executionFailure,
+    ZL_ERR_IF_GT(
             dstSize,
             dstCapacity,
+            transform_executionFailure,
             "transform %s failed",
             DT_getTransformName(transform));
 
-    ZL_RET_R_IF_ERR(ZL_Output_commit(out, dstSize));
+    ZL_ERR_IF_ERR(ZL_Output_commit(out, dstSize));
 
     return ZL_returnValue(1);
 }
@@ -264,6 +265,7 @@ static ZL_Report splitTransformWrapper(
         ZL_Data const* ins[],
         size_t nbIns)
 {
+    ZL_RESULT_DECLARE_SCOPE_REPORT(dictx);
     size_t const nbInputStreams = transform->miGraphDesc.nbSOs;
     ZL_ASSERT_EQ(nbIns, nbInputStreams);
     (void)nbIns;
@@ -271,10 +273,10 @@ static ZL_Report splitTransformWrapper(
     VECTOR(ZL_RBuffer)
     srcs = VECTOR_EMPTY(
             ZL_transformOutStreamsLimit(DI_getFrameFormatVersion(dictx)));
-    ZL_RET_R_IF_LT(
-            allocation,
+    ZL_ERR_IF_LT(
             VECTOR_RESERVE(srcs, nbInputStreams),
             nbInputStreams,
+            allocation,
             "splitTransformWrapper: Failed reserving vector");
     for (size_t i = 0; i < nbInputStreams; ++i) {
         ZL_ASSERT_EQ(ZL_Data_type(ins[i]), ZL_Type_serial);
@@ -291,7 +293,7 @@ static ZL_Report splitTransformWrapper(
     ZL_Output* const out = ZL_Decoder_create1OutStream(dictx, dstCapacity, 1);
     if (out == NULL) {
         VECTOR_DESTROY(srcs);
-        ZL_RET_R_ERR(allocation);
+        ZL_ERR(allocation);
     }
     ZL_WBuffer dst = { .start = ZL_Output_ptr(out), .capacity = dstCapacity };
     size_t const dstSize =
@@ -299,14 +301,14 @@ static ZL_Report splitTransformWrapper(
 
     VECTOR_DESTROY(srcs);
 
-    ZL_RET_R_IF_GT(
-            transform_executionFailure,
+    ZL_ERR_IF_GT(
             dstSize,
             dstCapacity,
+            transform_executionFailure,
             "transform %s failed",
             DT_getTransformName(transform));
 
-    ZL_RET_R_IF_ERR(ZL_Output_commit(out, dstSize));
+    ZL_ERR_IF_ERR(ZL_Output_commit(out, dstSize));
 
     return ZL_returnValue(1);
 }


### PR DESCRIPTION
Summary:
Migrate old-style `ZL_RET_R_*` error-handling macros to the new `ZL_ERR_*` macros in 10 custom transform files: json_extract (encode/decode), parse (decode_float, decode_int, encode), thrift (kernels encode/decode, probabilistic_selector, thrift_parsers), and tulip_v2 (decode).

The new `ZL_ERR_*` macros require an explicit `ZL_RESULT_DECLARE_SCOPE_REPORT(ctx)` declaration at the top of each function, which provides proper error context for rich error reporting. The old `ZL_RET_R_*` macros used "magic" auto-context detection via `_Generic`, which doesn't always work correctly.

**Migration pattern:**
- Add `ZL_RESULT_DECLARE_SCOPE_REPORT(ctx)` at the top of each migrated function
- Replace `ZL_RET_R_IF(errcode, expr, ...)` → `ZL_ERR_IF(expr, errcode, ...)`
- Replace `ZL_RET_R_IF_ERR(expr)` → `ZL_ERR_IF_ERR(expr)`
- Replace `ZL_RET_R_ERR(errcode)` → `ZL_ERR(errcode)`

Only functions with real (non-NULL, non-const) error context (eictx, dictx, sctx, etc.) are migrated.

Differential Revision: D94903775
