### PR TITLE
Migrate ZL_RET_R_* to ZL_ERR_* in src/openzl/compress/

### DIFF
--- a/custom_parsers/csv/csv_parser.c
+++ b/custom_parsers/csv/csv_parser.c
@@ -105,7 +105,7 @@ csvParserGraphFn(ZL_Graph* gctx, ZL_Edge* inputs[], size_t numInputs)
     // Delimiters - ZL_GRAPH_COMPRESS_GENERIC
     // Header - ZL_GRAPH_COMPRESS_GENERIC
     ZL_GraphIDList customGraphs = ZL_Graph_getCustomGraphs(gctx);
-    ZL_RET_R_IF_NE(node_invalid_input, customGraphs.nbGraphIDs, 3);
+    ZL_ERR_IF_NE(customGraphs.nbGraphIDs, 3, node_invalid_input);
 
     ZL_TRY_LET(
             ZL_RefParam,

--- a/custom_parsers/pytorch_model_parser.c
+++ b/custom_parsers/pytorch_model_parser.c
@@ -71,6 +71,7 @@ static bool isDataFile(const char* filename, size_t filenameSize)
 static ZL_Report
 pytorchModelDynGraph(ZL_Graph* gctx, ZL_Edge* sctxs[], size_t nbIns)
 {
+    ZL_RESULT_DECLARE_SCOPE_REPORT(gctx);
 #ifdef FUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION
     // Allow interesting fuzzing with smaller inputs
     const size_t kMultiplier = 4;
@@ -79,13 +80,13 @@ pytorchModelDynGraph(ZL_Graph* gctx, ZL_Edge* sctxs[], size_t nbIns)
 #endif
     const size_t kMaxSegmentSize = 1024 * kMultiplier;
 
-    ZL_RET_R_IF(graph_invalidNumInputs, nbIns != 1);
+    ZL_ERR_IF(nbIns != 1, graph_invalidNumInputs);
     ZL_Edge* sctx               = sctxs[0];
     ZL_Input const* const input = ZL_Edge_getData(sctx);
     const size_t inputSize      = ZL_Input_numElts(input);
 
     ZS2_ZipLexer lexer;
-    ZL_RET_R_IF_ERR(ZS2_ZipLexer_init(&lexer, ZL_Input_ptr(input), inputSize));
+    ZL_ERR_IF_ERR(ZS2_ZipLexer_init(&lexer, ZL_Input_ptr(input), inputSize));
 
     const size_t nbFiles = ZS2_ZipLexer_numFiles(&lexer);
     const size_t maxNbSegments =
@@ -95,8 +96,8 @@ pytorchModelDynGraph(ZL_Graph* gctx, ZL_Edge* sctxs[], size_t nbIns)
             ZL_Graph_getScratchSpace(gctx, maxNbSegments * sizeof(size_t));
     unsigned* const tags =
             ZL_Graph_getScratchSpace(gctx, maxNbSegments * sizeof(unsigned));
-    ZL_RET_R_IF_NULL(allocation, segmentSizes);
-    ZL_RET_R_IF_NULL(allocation, tags);
+    ZL_ERR_IF_NULL(segmentSizes, allocation);
+    ZL_ERR_IF_NULL(tags, allocation);
 
     // Iterate over all the tokens in the Zip file, and fill out segmentSizes
     // and tags.
@@ -105,7 +106,7 @@ pytorchModelDynGraph(ZL_Graph* gctx, ZL_Edge* sctxs[], size_t nbIns)
         ZS2_ZipToken tokens[32];
         ZL_TRY_LET_R(nbTokens, ZS2_ZipLexer_lex(&lexer, tokens, 32));
         for (size_t i = 0; i < nbTokens; ++i) {
-            ZL_RET_R_IF_GE(corruption, nbSegments, maxNbSegments);
+            ZL_ERR_IF_GE(nbSegments, maxNbSegments, corruption);
             const ZS2_ZipToken token = tokens[i];
 
             // Assign the appropriate tag to the token.
@@ -133,7 +134,7 @@ pytorchModelDynGraph(ZL_Graph* gctx, ZL_Edge* sctxs[], size_t nbIns)
             // Split large files into smaller segments to optimize
             // (de)compression speed by improving memory locality.
             while (segmentSizes[nbSegments - 1] > kMaxSegmentSize) {
-                ZL_RET_R_IF_GE(corruption, nbSegments, maxNbSegments);
+                ZL_ERR_IF_GE(nbSegments, maxNbSegments, corruption);
                 const size_t segmentSize     = segmentSizes[nbSegments - 1];
                 segmentSizes[nbSegments - 1] = kMaxSegmentSize;
                 segmentSizes[nbSegments]     = segmentSize - kMaxSegmentSize;
@@ -153,7 +154,7 @@ pytorchModelDynGraph(ZL_Graph* gctx, ZL_Edge* sctxs[], size_t nbIns)
 
     // Set the destination for every segment
     for (size_t i = 0; i < streams.nbStreams; ++i) {
-        ZL_RET_R_IF_ERR(ZL_Edge_setDestination(
+        ZL_ERR_IF_ERR(ZL_Edge_setDestination(
                 streams.streams[i], graphs.graphids[tags[i]]));
     }
 

--- a/custom_parsers/shared_components/string_graphs.cpp
+++ b/custom_parsers/shared_components/string_graphs.cpp
@@ -32,8 +32,9 @@ ZL_GraphID ZL_Compressor_registerStringTokenize(ZL_Compressor* compressor)
 static ZL_Report
 nullAwareDispatchGraphFn(ZL_Graph* gctx, ZL_Edge* inputs[], size_t) noexcept
 {
+    ZL_RESULT_DECLARE_SCOPE_REPORT(gctx);
     const auto successors = ZL_Graph_getCustomGraphs(gctx);
-    ZL_RET_R_IF_NE(node_invalid_input, successors.nbGraphIDs, 3);
+    ZL_ERR_IF_NE(successors.nbGraphIDs, 3, node_invalid_input);
 
     auto* input        = ZL_Edge_getData(inputs[0]);
     const auto numStrs = ZL_Input_numElts(input);
@@ -46,14 +47,14 @@ nullAwareDispatchGraphFn(ZL_Graph* gctx, ZL_Edge* inputs[], size_t) noexcept
     }
     auto result =
             ZL_Edge_runDispatchStringNode(inputs[0], 2, dispatchIdx.data());
-    ZL_RET_R_IF_ERR(result);
-    ZL_RET_R_IF_NE(node_invalid_input, ZL_RES_value(result).nbEdges, 3);
+    ZL_ERR_IF_ERR(result);
+    ZL_ERR_IF_NE(ZL_RES_value(result).nbEdges, 3, node_invalid_input);
     const auto edgeList = ZL_RES_value(result);
-    ZL_RET_R_IF_ERR(
+    ZL_ERR_IF_ERR(
             ZL_Edge_setDestination(edgeList.edges[0], successors.graphids[0]));
-    ZL_RET_R_IF_ERR(
+    ZL_ERR_IF_ERR(
             ZL_Edge_setDestination(edgeList.edges[1], successors.graphids[1]));
-    ZL_RET_R_IF_ERR(
+    ZL_ERR_IF_ERR(
             ZL_Edge_setDestination(edgeList.edges[2], successors.graphids[2]));
     return ZL_returnSuccess();
 }

--- a/custom_transforms/json_extract/decode_json_extract.cpp
+++ b/custom_transforms/json_extract/decode_json_extract.cpp
@@ -139,6 +139,7 @@ ZL_Report replaceTokens(
         InStream& floats,
         InStream& strs)
 {
+    ZL_RESULT_DECLARE_SCOPE_REPORT(dictx);
     size_t idx           = 0;
     uint64_t mask        = bitmask[idx];
     uint32_t skipped     = 0;
@@ -183,13 +184,13 @@ ZL_Report replaceTokens(
 
         // Replace the token
         if (token[0] == char(Token::INT)) {
-            ZL_RET_R_IF_EQ(corruption, ints.remaining(), 0);
+            ZL_ERR_IF_EQ(ints.remaining(), 0, corruption);
             out = ints.read(out);
         } else if (token[0] == char(Token::FLOAT)) {
-            ZL_RET_R_IF_EQ(corruption, floats.remaining(), 0);
+            ZL_ERR_IF_EQ(floats.remaining(), 0, corruption);
             out = floats.read(out);
         } else if (token[0] == char(Token::STR)) {
-            ZL_RET_R_IF_EQ(corruption, strs.remaining(), 0);
+            ZL_ERR_IF_EQ(strs.remaining(), 0, corruption);
             out = strs.read(out);
         } else if (token[0] == char(Token::TRUE)) {
             memcpy(out, "true", 4);
@@ -216,6 +217,7 @@ ZL_Report jsonExtractDecode(
         ZL_Decoder* dictx,
         ZL_Input const* inputs[]) noexcept
 {
+    ZL_RESULT_DECLARE_SCOPE_REPORT(dictx);
     ZL_Input const* jsonStream = inputs[0];
     InStream ints{ inputs[1] };
     InStream floats{ inputs[2] };
@@ -231,18 +233,18 @@ ZL_Report jsonExtractDecode(
             + ZL_Input_contentSize(inputs[1]) + ZL_Input_contentSize(inputs[2])
             + ZL_Input_contentSize(inputs[3]) + ZS_WILDCOPY_OVERLENGTH;
     ZL_Output* outStream = ZL_Decoder_create1OutStream(dictx, outBound, 1);
-    ZL_RET_R_IF_NULL(allocation, outStream);
+    ZL_ERR_IF_NULL(outStream, allocation);
 
     std::array<uint64_t, kBitmaskSize> bitmask;
     char* out = (char*)ZL_Output_ptr(outStream);
     while (!json.empty()) {
         auto const block = buildBitmask(bitmask.data(), json);
-        ZL_RET_R_IF_ERR(replaceTokens(
+        ZL_ERR_IF_ERR(replaceTokens(
                 dictx, out, bitmask.data(), block, ints, floats, strs));
     }
 
     size_t const size = size_t(out - (char*)ZL_Output_ptr(outStream));
-    ZL_RET_R_IF_ERR(ZL_Output_commit(outStream, size));
+    ZL_ERR_IF_ERR(ZL_Output_commit(outStream, size));
 
     return ZL_returnSuccess();
 }

--- a/custom_transforms/json_extract/encode_json_extract.cpp
+++ b/custom_transforms/json_extract/encode_json_extract.cpp
@@ -468,6 +468,7 @@ void validateExtraction(Extracted const& extracted)
 
 ZL_Report jsonExtractEncode(ZL_Encoder* eictx, const ZL_Input* input) noexcept
 {
+    ZL_RESULT_DECLARE_SCOPE_REPORT(eictx);
     std::string_view src{ (char const*)ZL_Input_ptr(input),
                           ZL_Input_numElts(input) };
 
@@ -480,7 +481,7 @@ ZL_Report jsonExtractEncode(ZL_Encoder* eictx, const ZL_Input* input) noexcept
     }
     validateExtraction(extracted);
 
-    ZL_RET_R_IF_ERR(extracted.commit());
+    ZL_ERR_IF_ERR(extracted.commit());
 
     return ZL_returnSuccess();
 }

--- a/custom_transforms/parse/decode_parse_float.cpp
+++ b/custom_transforms/parse/decode_parse_float.cpp
@@ -59,21 +59,22 @@ namespace {
 template <typename T>
 ZL_Report parseDecode(ZL_Decoder* dictx, ZL_Input const* inputs[]) noexcept
 {
+    ZL_RESULT_DECLARE_SCOPE_REPORT(dictx);
     ZL_Input const* numbers          = inputs[0];
     ZL_Input const* exceptionIndices = inputs[1];
     ZL_Input const* exceptions       = inputs[2];
 
-    ZL_RET_R_IF_NE(
-            corruption,
+    ZL_ERR_IF_NE(
             ZL_Input_numElts(exceptionIndices),
-            ZL_Input_numElts(exceptions));
-    ZL_RET_R_IF_NE(corruption, ZL_Input_eltWidth(exceptionIndices), 4);
-    ZL_RET_R_IF_NE(corruption, ZL_Input_eltWidth(numbers), sizeof(T));
+            ZL_Input_numElts(exceptions),
+            corruption);
+    ZL_ERR_IF_NE(ZL_Input_eltWidth(exceptionIndices), 4, corruption);
+    ZL_ERR_IF_NE(ZL_Input_eltWidth(numbers), sizeof(T), corruption);
 
     size_t const outBound = ZL_Input_contentSize(exceptions)
             + ZL_Input_numElts(numbers) * maxStrLen(T{});
     ZL_Output* outStream = ZL_Decoder_create1OutStream(dictx, outBound, 1);
-    ZL_RET_R_IF_NULL(allocation, outStream);
+    ZL_ERR_IF_NULL(outStream, allocation);
 
     StreamAppender outAppender{ outStream };
 
@@ -81,7 +82,7 @@ ZL_Report parseDecode(ZL_Decoder* dictx, ZL_Input const* inputs[]) noexcept
             ZL_Input_numElts(numbers) + ZL_Input_numElts(exceptions);
 
     uint32_t* fieldSizes = ZL_Output_reserveStringLens(outStream, nbElts);
-    ZL_RET_R_IF_NULL(allocation, fieldSizes);
+    ZL_ERR_IF_NULL(fieldSizes, allocation);
 
     auto nums          = (T const*)ZL_Input_ptr(numbers);
     auto const numsEnd = nums + ZL_Input_numElts(numbers);
@@ -99,16 +100,16 @@ ZL_Report parseDecode(ZL_Decoder* dictx, ZL_Input const* inputs[]) noexcept
             outAppender.append(exData, exSize);
             exData += exSize;
         } else {
-            ZL_RET_R_IF_EQ(srcSize_tooSmall, nums, numsEnd);
+            ZL_ERR_IF_EQ(nums, numsEnd, srcSize_tooSmall);
             folly::toAppend(*nums++, &outAppender);
         }
         fieldSizes[i] = outAppender.commitField();
     }
 
-    ZL_RET_R_IF_NE(corruption, nums, numsEnd);
-    ZL_RET_R_IF_NE(corruption, exIdxs, exIdxsEnd);
+    ZL_ERR_IF_NE(nums, numsEnd, corruption);
+    ZL_ERR_IF_NE(exIdxs, exIdxsEnd, corruption);
 
-    ZL_RET_R_IF_ERR(ZL_Output_commit(outStream, nbElts));
+    ZL_ERR_IF_ERR(ZL_Output_commit(outStream, nbElts));
 
     return ZL_returnSuccess();
 }

--- a/custom_transforms/parse/decode_parse_int.cpp
+++ b/custom_transforms/parse/decode_parse_int.cpp
@@ -314,16 +314,17 @@ namespace {
 template <typename T>
 ZL_Report parseDecodeInt(ZL_Decoder* dictx, ZL_Input const* inputs[]) noexcept
 {
+    ZL_RESULT_DECLARE_SCOPE_REPORT(dictx);
     ZL_Input const* numbers          = inputs[0];
     ZL_Input const* exceptionIndices = inputs[1];
     ZL_Input const* exceptions       = inputs[2];
 
-    ZL_RET_R_IF_NE(
-            corruption,
+    ZL_ERR_IF_NE(
             ZL_Input_numElts(exceptionIndices),
-            ZL_Input_numElts(exceptions));
-    ZL_RET_R_IF_NE(corruption, ZL_Input_eltWidth(exceptionIndices), 4);
-    ZL_RET_R_IF_NE(corruption, ZL_Input_eltWidth(numbers), sizeof(T));
+            ZL_Input_numElts(exceptions),
+            corruption);
+    ZL_ERR_IF_NE(ZL_Input_eltWidth(exceptionIndices), 4, corruption);
+    ZL_ERR_IF_NE(ZL_Input_eltWidth(numbers), sizeof(T), corruption);
 
     // Note: we calculate the maximal outbound and allocate a matching outstream
     // this is inefficient as before we need the actual out stream we calculate
@@ -334,13 +335,13 @@ ZL_Report parseDecodeInt(ZL_Decoder* dictx, ZL_Input const* inputs[]) noexcept
     size_t const outBound = ZL_Input_contentSize(exceptions)
             + ZL_Input_numElts(numbers) * maxStrLen(T{});
     ZL_Output* outStream = ZL_Decoder_create1OutStream(dictx, outBound, 1);
-    ZL_RET_R_IF_NULL(allocation, outStream);
+    ZL_ERR_IF_NULL(outStream, allocation);
 
     size_t const nbElts =
             ZL_Input_numElts(numbers) + ZL_Input_numElts(exceptions);
 
     uint32_t* fieldSizes = ZL_Output_reserveStringLens(outStream, nbElts);
-    ZL_RET_R_IF_NULL(allocation, fieldSizes);
+    ZL_ERR_IF_NULL(fieldSizes, allocation);
 
     auto nums   = (T const*)ZL_Input_ptr(numbers);
     auto nbNums = ZL_Input_numElts(numbers);
@@ -366,7 +367,7 @@ ZL_Report parseDecodeInt(ZL_Decoder* dictx, ZL_Input const* inputs[]) noexcept
             fieldSizes,
             outSize,
             (uint8_t*)ZL_Output_ptr(outStream));
-    ZL_RET_R_IF_ERR(ZL_Output_commit(outStream, nbElts));
+    ZL_ERR_IF_ERR(ZL_Output_commit(outStream, nbElts));
 
     return ZL_returnSuccess();
 }

--- a/custom_transforms/parse/encode_parse.cpp
+++ b/custom_transforms/parse/encode_parse.cpp
@@ -29,6 +29,7 @@ ZL_Report fillVSFStream(
         size_t idx,
         std::vector<std::string_view> const& elts)
 {
+    ZL_RESULT_DECLARE_SCOPE_REPORT(eictx);
     size_t totalSize = 0;
     for (auto const& elt : elts) {
         totalSize += elt.size();
@@ -36,10 +37,10 @@ ZL_Report fillVSFStream(
 
     ZL_Output* const stream =
             ZL_Encoder_createTypedStream(eictx, idx, totalSize, 1);
-    ZL_RET_R_IF_NULL(allocation, stream);
+    ZL_ERR_IF_NULL(stream, allocation);
 
     auto* const sizes = ZL_Output_reserveStringLens(stream, elts.size());
-    ZL_RET_R_IF_NULL(allocation, sizes);
+    ZL_ERR_IF_NULL(sizes, allocation);
 
     auto content = (char*)ZL_Output_ptr(stream);
 
@@ -49,7 +50,7 @@ ZL_Report fillVSFStream(
         sizes[i] = elts[i].size();
     }
 
-    ZL_RET_R_IF_ERR(ZL_Output_commit(stream, elts.size()));
+    ZL_ERR_IF_ERR(ZL_Output_commit(stream, elts.size()));
 
     return ZL_returnSuccess();
 }
@@ -315,6 +316,7 @@ size_t parseEncodeKernel(
 template <typename T>
 ZL_Report parseEncode(ZL_Encoder* eictx, ZL_Input const* input) noexcept
 {
+    ZL_RESULT_DECLARE_SCOPE_REPORT(eictx);
     std::vector<std::string_view> exceptions;
     std::vector<uint32_t> exceptionIndices;
 
@@ -324,28 +326,28 @@ ZL_Report parseEncode(ZL_Encoder* eictx, ZL_Input const* input) noexcept
 
     ZL_Output* numbers =
             ZL_Encoder_createTypedStream(eictx, 0, nbElts, sizeof(T));
-    ZL_RET_R_IF_NULL(allocation, numbers);
+    ZL_ERR_IF_NULL(numbers, allocation);
 
     T* const nums = (T*)ZL_Output_ptr(numbers);
 
     size_t const numNums = parseEncodeKernel<T>(
             nums, exceptions, exceptionIndices, data, sizes, nbElts);
 
-    ZL_RET_R_IF_ERR(ZL_Output_commit(numbers, numNums));
+    ZL_ERR_IF_ERR(ZL_Output_commit(numbers, numNums));
 
     ZL_Output* exceptionIndicesStream =
             ZL_Encoder_createTypedStream(eictx, 1, exceptionIndices.size(), 4);
-    ZL_RET_R_IF_NULL(allocation, exceptionIndicesStream);
+    ZL_ERR_IF_NULL(exceptionIndicesStream, allocation);
 
     if (exceptionIndices.size() > 0)
         memcpy(ZL_Output_ptr(exceptionIndicesStream),
                exceptionIndices.data(),
                exceptionIndices.size() * 4);
 
-    ZL_RET_R_IF_ERR(
+    ZL_ERR_IF_ERR(
             ZL_Output_commit(exceptionIndicesStream, exceptionIndices.size()));
 
-    ZL_RET_R_IF_ERR(fillVSFStream(eictx, 2, exceptions));
+    ZL_ERR_IF_ERR(fillVSFStream(eictx, 2, exceptions));
 
     return ZL_returnSuccess();
 }

--- a/custom_transforms/thrift/kernels/decode_thrift_binding.cpp
+++ b/custom_transforms/thrift/kernels/decode_thrift_binding.cpp
@@ -50,10 +50,11 @@ template <typename Kernel>
 ZL_Report typedTransform(ZL_Decoder* dictx, ZL_Input const* src[]) noexcept
 {
     using InputStreams = typename Kernel::InputStreams;
-    ZL_RET_R_IF_LT(
-            formatVersion_unsupported,
+    ZL_RESULT_DECLARE_SCOPE_REPORT(dictx);
+    ZL_ERR_IF_LT(
             DI_getFrameFormatVersion(dictx),
             9,
+            formatVersion_unsupported,
             "Support first added in format version 9");
     try {
         InputStreams inputs;
@@ -65,36 +66,35 @@ ZL_Report typedTransform(ZL_Decoder* dictx, ZL_Input const* src[]) noexcept
             uint8_t const* ip   = (uint8_t const*)header.start;
             uint8_t const* iend = ip + header.size;
             dstCapacity         = unwrap(ZL_varintDecode(&ip, iend));
-            ZL_RET_R_IF_NE(corruption, ip, iend);
+            ZL_ERR_IF_NE(ip, iend, corruption);
         }
 
         ZL_Output* stream = ZL_Decoder_create1OutStream(dictx, dstCapacity, 1);
-        ZL_RET_R_IF_NULL(allocation, stream);
+        ZL_ERR_IF_NULL(stream, allocation);
         std::span<uint8_t> out = { (uint8_t*)ZL_Output_ptr(stream),
                                    dstCapacity };
 
-        ZL_RET_R_IF_NE(corruption, ZL_Input_eltWidth(src[0]), 8);
+        ZL_ERR_IF_NE(ZL_Input_eltWidth(src[0]), 8, corruption);
         std::span<uint64_t const> sizes = {
             (uint64_t const*)ZL_Input_ptr(src[0]), ZL_Input_numElts(src[0])
         };
 
         for (auto const& size : sizes) {
             auto const written = Kernel{}(dictx, out, inputs, size);
-            ZL_RET_R_IF_ERR(written);
+            ZL_ERR_IF_ERR(written);
             assert(ZL_validResult(written) <= out.size());
             out = out.subspan(ZL_validResult(written));
         }
 
-        ZL_RET_R_IF(corruption, !out.empty());
+        ZL_ERR_IF(!out.empty(), corruption);
 
-        ZL_RET_R_IF_ERR(ZL_Output_commit(stream, dstCapacity));
+        ZL_ERR_IF_ERR(ZL_Output_commit(stream, dstCapacity));
 
         return ZL_returnSuccess();
     } catch (std::exception const& e) {
-        ZL_RET_R_ERR(
-                transform_executionFailure,
-                "Thrift kernel failure: %s",
-                e.what());
+        ZL_ERR(transform_executionFailure,
+               "Thrift kernel failure: %s",
+               e.what());
     }
 }
 
@@ -133,9 +133,10 @@ ZL_Report ZS2_ThriftKernel_registerDTransformMapI32Float(
                 InputStreams& in,
                 size_t mapSize)
         {
+            ZL_RESULT_DECLARE_SCOPE_REPORT(dictx);
             auto& [keys, values] = in;
-            ZL_RET_R_IF_NE(corruption, keys.size(), values.size());
-            ZL_RET_R_IF_LT(corruption, keys.size(), mapSize);
+            ZL_ERR_IF_NE(keys.size(), values.size(), corruption);
+            ZL_ERR_IF_LT(keys.size(), mapSize, corruption);
             auto ret = ZS2_ThriftKernel_serializeMapI32Float(
                     out.data(),
                     out.size(),
@@ -167,9 +168,10 @@ ZL_Report ZS2_ThriftKernel_registerDTransformMapI32ArrayFloat(
                 InputStreams& in,
                 size_t mapSize)
         {
+            ZL_RESULT_DECLARE_SCOPE_REPORT(dictx);
             auto& [keys, lengths, innerValues] = in;
-            ZL_RET_R_IF_NE(corruption, keys.size(), lengths.size());
-            ZL_RET_R_IF_LT(corruption, keys.size(), mapSize);
+            ZL_ERR_IF_NE(keys.size(), lengths.size(), corruption);
+            ZL_ERR_IF_LT(keys.size(), mapSize, corruption);
             auto* innerValuesPtr = innerValues.data();
             auto* innerValuesEnd = innerValues.data() + innerValues.size();
             auto ret             = ZS2_ThriftKernel_serializeMapI32ArrayFloat(
@@ -207,9 +209,10 @@ ZL_Report ZS2_ThriftKernel_registerDTransformMapI32ArrayI64(
                 InputStreams& in,
                 size_t mapSize)
         {
+            ZL_RESULT_DECLARE_SCOPE_REPORT(dictx);
             auto& [keys, lengths, innerValues] = in;
-            ZL_RET_R_IF_NE(corruption, keys.size(), lengths.size());
-            ZL_RET_R_IF_LT(corruption, keys.size(), mapSize);
+            ZL_ERR_IF_NE(keys.size(), lengths.size(), corruption);
+            ZL_ERR_IF_LT(keys.size(), mapSize, corruption);
             auto* innerValuesPtr = innerValues.data();
             auto* innerValuesEnd = innerValues.data() + innerValues.size();
             auto ret             = ZS2_ThriftKernel_serializeMapI32ArrayI64(
@@ -248,9 +251,10 @@ ZL_Report ZS2_ThriftKernel_registerDTransformMapI32ArrayArrayI64(
                 InputStreams& in,
                 size_t mapSize)
         {
+            ZL_RESULT_DECLARE_SCOPE_REPORT(dictx);
             auto& [keys, lengths, innerLengths, innerInnerValues] = in;
-            ZL_RET_R_IF_NE(corruption, keys.size(), lengths.size());
-            ZL_RET_R_IF_LT(corruption, keys.size(), mapSize);
+            ZL_ERR_IF_NE(keys.size(), lengths.size(), corruption);
+            ZL_ERR_IF_LT(keys.size(), mapSize, corruption);
             auto* innerLengthsPtr = innerLengths.data();
             auto* innerLengthsEnd = innerLengths.data() + innerLengths.size();
             auto* innerInnerValuesPtr = innerInnerValues.data();
@@ -296,9 +300,10 @@ ZL_Report ZS2_ThriftKernel_registerDTransformMapI32MapI64Float(
                 InputStreams& in,
                 size_t mapSize)
         {
+            ZL_RESULT_DECLARE_SCOPE_REPORT(dictx);
             auto& [keys, lengths, innerKeys, innerValues] = in;
-            ZL_RET_R_IF_NE(corruption, keys.size(), lengths.size());
-            ZL_RET_R_IF_LT(corruption, keys.size(), mapSize);
+            ZL_ERR_IF_NE(keys.size(), lengths.size(), corruption);
+            ZL_ERR_IF_LT(keys.size(), mapSize, corruption);
             auto* innerKeysPtr   = innerKeys.data();
             auto* innerKeysEnd   = innerKeys.data() + innerKeys.size();
             auto* innerValuesPtr = innerValues.data();
@@ -339,8 +344,9 @@ ZL_Report ZS2_ThriftKernel_registerDTransformArrayI64(
                 InputStreams& in,
                 size_t arraySize)
         {
+            ZL_RESULT_DECLARE_SCOPE_REPORT(dictx);
             auto& [values] = in;
-            ZL_RET_R_IF_LT(corruption, values.size(), arraySize);
+            ZL_ERR_IF_LT(values.size(), arraySize, corruption);
             auto ret = ZS2_ThriftKernel_serializeArrayI64(
                     out.data(), out.size(), values.data(), arraySize);
             values = values.subspan(arraySize);
@@ -364,8 +370,9 @@ ZL_Report ZS2_ThriftKernel_registerDTransformArrayI32(
                 InputStreams& in,
                 size_t arraySize)
         {
+            ZL_RESULT_DECLARE_SCOPE_REPORT(dictx);
             auto& [values] = in;
-            ZL_RET_R_IF_LT(corruption, values.size(), arraySize);
+            ZL_ERR_IF_LT(values.size(), arraySize, corruption);
             auto ret = ZS2_ThriftKernel_serializeArrayI32(
                     out.data(), out.size(), values.data(), arraySize);
             values = values.subspan(arraySize);
@@ -389,8 +396,9 @@ ZL_Report ZS2_ThriftKernel_registerDTransformArrayFloat(
                 InputStreams& in,
                 size_t arraySize)
         {
+            ZL_RESULT_DECLARE_SCOPE_REPORT(dictx);
             auto& [values] = in;
-            ZL_RET_R_IF_LT(corruption, values.size(), arraySize);
+            ZL_ERR_IF_LT(values.size(), arraySize, corruption);
             auto ret = ZS2_ThriftKernel_serializeArrayFloat(
                     out.data(), out.size(), values.data(), arraySize);
             values = values.subspan(arraySize);

--- a/custom_transforms/thrift/kernels/encode_thrift_binding.cpp
+++ b/custom_transforms/thrift/kernels/encode_thrift_binding.cpp
@@ -18,6 +18,7 @@ ZL_Report commitOutputStream(
         size_t idx,
         std::vector<std::vector<T> const*> const& vectors)
 {
+    ZL_RESULT_DECLARE_SCOPE_REPORT(eictx);
     size_t size = 0;
     for (auto const* vector : vectors) {
         size += vector->size();
@@ -25,7 +26,7 @@ ZL_Report commitOutputStream(
 
     ZL_Output* stream =
             ZL_Encoder_createTypedStream(eictx, idx, size, sizeof(T));
-    ZL_RET_R_IF_NULL(allocation, stream);
+    ZL_ERR_IF_NULL(stream, allocation);
     uint8_t* op = (uint8_t*)ZL_Output_ptr(stream);
     for (auto const* vector : vectors) {
         if (vector->size() > 0)
@@ -33,7 +34,7 @@ ZL_Report commitOutputStream(
         op += vector->size() * sizeof(T);
     }
     assert((op - (uint8_t*)ZL_Output_ptr(stream)) == size * sizeof(T));
-    ZL_RET_R_IF_ERR(ZL_Output_commit(stream, size));
+    ZL_ERR_IF_ERR(ZL_Output_commit(stream, size));
     return ZL_returnSuccess();
 }
 
@@ -43,20 +44,21 @@ ZL_Report commitOutputStream(
         size_t idx,
         std::vector<ZeroCopyDynamicOutput<T> const*> const& outs)
 {
+    ZL_RESULT_DECLARE_SCOPE_REPORT(eictx);
     size_t size = 0;
     for (auto const* out : outs) {
         size += out->size();
     }
     ZL_Output* stream =
             ZL_Encoder_createTypedStream(eictx, idx, size, sizeof(T));
-    ZL_RET_R_IF_NULL(allocation, stream);
+    ZL_ERR_IF_NULL(stream, allocation);
     uint8_t* op = (uint8_t*)ZL_Output_ptr(stream);
     for (auto const* out : outs) {
         out->copyToBuffer(op, out->nbytes());
         op += out->nbytes();
     }
     assert((op - (uint8_t*)ZL_Output_ptr(stream)) == size * sizeof(T));
-    ZL_RET_R_IF_ERR(ZL_Output_commit(stream, size));
+    ZL_ERR_IF_ERR(ZL_Output_commit(stream, size));
     return ZL_returnSuccess();
 }
 
@@ -65,13 +67,14 @@ ZL_Report commitOutputStreams(
         ZL_Encoder* eictx,
         std::vector<std::tuple<Ts...>> const& outputs)
 {
+    ZL_RESULT_DECLARE_SCOPE_REPORT(eictx);
     if constexpr (idx < sizeof...(Ts)) {
         std::vector<std::tuple_element_t<idx, std::tuple<Ts...>> const*> output;
         output.reserve(outputs.size());
         for (auto&& tuple : outputs) {
             output.push_back(&std::get<idx>(tuple));
         }
-        ZL_RET_R_IF_ERR(commitOutputStream(eictx, idx + 1, output));
+        ZL_ERR_IF_ERR(commitOutputStream(eictx, idx + 1, output));
         return commitOutputStreams<idx + 1>(eictx, outputs);
     } else {
         return ZL_returnSuccess();
@@ -84,10 +87,11 @@ template <typename Kernel>
 ZL_Report typedTransform(ZL_Encoder* eictx, ZL_Input const* input) noexcept
 {
     // These transforms were added in version 9
-    ZL_RET_R_IF_LT(
-            formatVersion_unsupported,
+    ZL_RESULT_DECLARE_SCOPE_REPORT(eictx);
+    ZL_ERR_IF_LT(
             ZL_Encoder_getCParam(eictx, ZL_CParam_formatVersion),
-            9);
+            9,
+            formatVersion_unsupported);
 
     assert(ZL_Input_type(input) == ZL_Type_serial);
     try {
@@ -114,17 +118,16 @@ ZL_Report typedTransform(ZL_Encoder* eictx, ZL_Input const* input) noexcept
         // Add the lengths stream
         {
             std::vector<std::vector<uint64_t> const*> outs_2 = { &lengths };
-            ZL_RET_R_IF_ERR(commitOutputStream(eictx, 0, outs_2));
+            ZL_ERR_IF_ERR(commitOutputStream(eictx, 0, outs_2));
         }
 
-        ZL_RET_R_IF_ERR(commitOutputStreams(eictx, outs));
+        ZL_ERR_IF_ERR(commitOutputStreams(eictx, outs));
 
         return ZL_returnSuccess();
     } catch (std::exception const& e) {
-        ZL_RET_R_ERR(
-                transform_executionFailure,
-                "Thrift kernel failure: %s",
-                e.what());
+        ZL_ERR(transform_executionFailure,
+               "Thrift kernel failure: %s",
+               e.what());
     }
 }
 

--- a/custom_transforms/thrift/probabilistic_selector.c
+++ b/custom_transforms/thrift/probabilistic_selector.c
@@ -10,9 +10,10 @@
 static ZL_Report
 probabilisticSelectorImpl(ZL_Graph* gctx, ZL_Edge* inputs[], size_t nbInputs)
 {
+    ZL_RESULT_DECLARE_SCOPE_REPORT(gctx);
     ZL_GraphIDList customGraphs = ZL_Graph_getCustomGraphs(gctx);
     size_t nbCustomGraphs       = customGraphs.nbGraphIDs;
-    ZL_RET_R_IF_EQ(node_invalid_input, customGraphs.nbGraphIDs, 0);
+    ZL_ERR_IF_EQ(customGraphs.nbGraphIDs, 0, node_invalid_input);
 
     const size_t* probWeights =
             (const size_t*)ZL_Graph_getLocalRefParam(
@@ -21,8 +22,8 @@ probabilisticSelectorImpl(ZL_Graph* gctx, ZL_Edge* inputs[], size_t nbInputs)
     size_t totalWeight = 0;
     for (size_t i = 0; i < nbCustomGraphs; ++i) {
         // Weight overflow
-        ZL_RET_R_IF_GT(
-                node_invalid_input, totalWeight, SIZE_MAX - probWeights[i]);
+        ZL_ERR_IF_GT(
+                totalWeight, SIZE_MAX - probWeights[i], node_invalid_input);
         totalWeight += probWeights[i];
     }
     XXH32_hash_t hash = 0;

--- a/custom_transforms/thrift/thrift_parsers.cpp
+++ b/custom_transforms/thrift/thrift_parsers.cpp
@@ -319,10 +319,11 @@ ZL_Output* copyStringLogicalClusterToEICtx(
 template <typename Parser>
 ZL_Report configurableEncode(ZL_Encoder* eictx, const ZL_Input* in)
 {
+    ZL_RESULT_DECLARE_SCOPE_REPORT(eictx);
     unsigned int const formatVersion =
             ZL_Encoder_getCParam(eictx, ZL_CParam_formatVersion);
-    ZL_RET_R_IF_LT(
-            formatVersion_unsupported, formatVersion, kMinFormatVersionEncode);
+    ZL_ERR_IF_LT(
+            formatVersion, kMinFormatVersionEncode, formatVersion_unsupported);
 
     try {
         ZL_ASSERT(ZL_Input_type(in) == ZL_Type_serial);
@@ -331,26 +332,26 @@ ZL_Report configurableEncode(ZL_Encoder* eictx, const ZL_Input* in)
 
         // Read config
         ZL_CopyParam gp = ZL_Encoder_getLocalCopyParam(eictx, 0);
-        ZL_RET_R_IF_EQ(corruption, gp.paramId, ZL_LP_INVALID_PARAMID);
+        ZL_ERR_IF_EQ(gp.paramId, ZL_LP_INVALID_PARAMID, corruption);
         std::string_view const encoderConfigStr(
                 (const char*)gp.paramPtr, gp.paramSize);
         EncoderConfig config = EncoderConfig(encoderConfigStr);
 
         // Fail compression if config uses unsupported features
-        ZL_RET_R_IF_LT(
-                formatVersion_unsupported,
+        ZL_ERR_IF_LT(
                 formatVersion,
-                config.getMinFormatVersion());
+                config.getMinFormatVersion(),
+                formatVersion_unsupported);
 
         // Temporary requirement: ensure contiguous LogicalIds
         // (starting from 0)
         for (const auto& streamId : config.getLogicalIds()) {
             static_assert(std::is_unsigned_v<std::underlying_type_t<
                                   std::decay_t<decltype(streamId)>>>);
-            ZL_RET_R_IF_GE(
-                    temporaryLibraryLimitation,
+            ZL_ERR_IF_GE(
                     static_cast<size_t>(streamId),
-                    config.getLogicalIds().size());
+                    config.getLogicalIds().size(),
+                    temporaryLibraryLimitation);
         }
 
         // Encode the input stream!
@@ -360,10 +361,9 @@ ZL_Report configurableEncode(ZL_Encoder* eictx, const ZL_Input* in)
         try {
             parser.parse();
         } catch (const std::exception& ex) {
-            ZL_RET_R_ERR(
-                    GENERIC,
-                    "Thrift kernel failed inside core parser: %s",
-                    ex.what());
+            ZL_ERR(GENERIC,
+                   "Thrift kernel failed inside core parser: %s",
+                   ex.what());
         }
         debug("Encoder side:");
         debug(srcStream.repr());
@@ -472,10 +472,9 @@ ZL_Report configurableEncode(ZL_Encoder* eictx, const ZL_Input* in)
 
         return ZL_returnSuccess();
     } catch (const std::exception& ex) {
-        ZL_RET_R_ERR(
-                GENERIC,
-                "Thrift kernel failed outside of core parsing: %s",
-                ex.what());
+        ZL_ERR(GENERIC,
+               "Thrift kernel failed outside of core parsing: %s",
+               ex.what());
     }
 }
 
@@ -487,9 +486,10 @@ ZL_Report configurableDecode(
         const ZL_Input* variableSrcs[],
         size_t nbVariableSrcs)
 {
+    ZL_RESULT_DECLARE_SCOPE_REPORT(dictx);
     const unsigned int formatVersion = DI_getFrameFormatVersion(dictx);
-    ZL_RET_R_IF_LT(
-            formatVersion_unsupported, formatVersion, kMinFormatVersionDecode);
+    ZL_ERR_IF_LT(
+            formatVersion, kMinFormatVersionDecode, formatVersion_unsupported);
 
     assert(nbCompulsorySrcs == (size_t)SingletonId::kNumSingletonIds);
     try {
@@ -516,23 +516,21 @@ ZL_Report configurableDecode(
         try {
             parser.unparse();
         } catch (const std::exception& ex) {
-            ZL_RET_R_ERR(
-                    GENERIC,
-                    "Thrift kernel failed inside core parser: %s",
-                    ex.what());
+            ZL_ERR(GENERIC,
+                   "Thrift kernel failed inside core parser: %s",
+                   ex.what());
         }
         debug("Decoder side:");
         debug(srcStreams.repr());
         debug(dstStream.writeStream().repr());
 
-        ZL_RET_R_IF_ERR(dstStream.commit());
+        ZL_ERR_IF_ERR(dstStream.commit());
 
         return ZL_returnValue(1);
     } catch (const std::exception& ex) {
-        ZL_RET_R_ERR(
-                GENERIC,
-                "Thrift kernel failed outside of core parsing: %s",
-                ex.what());
+        ZL_ERR(GENERIC,
+               "Thrift kernel failed outside of core parsing: %s",
+               ex.what());
     }
 }
 
@@ -650,9 +648,10 @@ ZL_VODecoderDesc const thriftBinaryConfigurableUnSplitter = {
 
 ZL_Report registerCustomTransforms(ZL_DCtx* dctx)
 {
-    ZL_RET_R_IF_ERR(ZL_DCtx_registerVODecoder(
+    ZL_RESULT_DECLARE_SCOPE_REPORT(dctx);
+    ZL_ERR_IF_ERR(ZL_DCtx_registerVODecoder(
             dctx, &thriftCompactConfigurableUnSplitter));
-    ZL_RET_R_IF_ERR(ZL_DCtx_registerVODecoder(
+    ZL_ERR_IF_ERR(ZL_DCtx_registerVODecoder(
             dctx, &thriftBinaryConfigurableUnSplitter));
     return ZL_returnSuccess();
 }

--- a/custom_transforms/tulip_v2/decode_tulip_v2.cpp
+++ b/custom_transforms/tulip_v2/decode_tulip_v2.cpp
@@ -13,22 +13,24 @@ ZL_Report registerCustomTransforms(
         unsigned idRangeBegin,
         unsigned idRangeEnd)
 {
+    ZL_RESULT_DECLARE_SCOPE_REPORT(dctx);
+
     if (idRangeEnd - idRangeBegin < kNumCustomTransforms) {
         throw std::runtime_error("Not enough IDs");
     }
 
     // NOTE: These IDs must remain stable & in-sync with the compressor!
-    ZL_RET_R_IF_ERR(ZS2_ThriftKernel_registerDTransformMapI32Float(
+    ZL_ERR_IF_ERR(ZS2_ThriftKernel_registerDTransformMapI32Float(
             dctx, idRangeBegin + static_cast<unsigned>(Tag::FloatFeatures)));
-    ZL_RET_R_IF_ERR(ZS2_ThriftKernel_registerDTransformMapI32ArrayFloat(
+    ZL_ERR_IF_ERR(ZS2_ThriftKernel_registerDTransformMapI32ArrayFloat(
             dctx,
             idRangeBegin + static_cast<unsigned>(Tag::FloatListFeatures)));
-    ZL_RET_R_IF_ERR(ZS2_ThriftKernel_registerDTransformMapI32ArrayI64(
+    ZL_ERR_IF_ERR(ZS2_ThriftKernel_registerDTransformMapI32ArrayI64(
             dctx, idRangeBegin + static_cast<unsigned>(Tag::IdListFeatures)));
-    ZL_RET_R_IF_ERR(ZS2_ThriftKernel_registerDTransformMapI32ArrayArrayI64(
+    ZL_ERR_IF_ERR(ZS2_ThriftKernel_registerDTransformMapI32ArrayArrayI64(
             dctx,
             idRangeBegin + static_cast<unsigned>(Tag::IdListListFeatures)));
-    ZL_RET_R_IF_ERR(ZS2_ThriftKernel_registerDTransformMapI32MapI64Float(
+    ZL_ERR_IF_ERR(ZS2_ThriftKernel_registerDTransformMapI32MapI64Float(
             dctx,
             idRangeBegin + static_cast<unsigned>(Tag::IdScoreListFeatures)));
 

--- a/src/openzl/compress/cctx.c
+++ b/src/openzl/compress/cctx.c
@@ -154,8 +154,8 @@ struct ZL_CCtx_s {
 
 static ZL_Report CCTX_init(ZL_CCtx* cctx)
 {
-    ZL_ASSERT_NN(cctx);
     ZL_RESULT_DECLARE_SCOPE_REPORT(cctx);
+    ZL_ASSERT_NN(cctx);
 
     ZL_OC_init(&cctx->opCtx);
 
@@ -237,8 +237,9 @@ ZL_Report ZL_CCtx_attachIntrospectionHooks(
         ZL_CCtx* cctx,
         const ZL_CompressIntrospectionHooks* hooks)
 {
+    ZL_RESULT_DECLARE_SCOPE_REPORT(cctx);
     ZL_ASSERT_NN(cctx);
-    ZL_RET_R_IF_NULL(allocation, hooks);
+    ZL_ERR_IF_NULL(hooks, allocation);
     ZL_OperationContext* oc = ZL_CCtx_getOperationContext(cctx);
     ZL_ASSERT_NN(oc);
     oc->introspectionHooks    = *hooks;
@@ -274,9 +275,10 @@ ZL_Report ZL_CCtx_selectStartingGraphID(
         ZL_GraphID graphID,
         const ZL_RuntimeGraphParameters* rgp)
 {
+    ZL_RESULT_DECLARE_SCOPE_REPORT(cctx);
     ZL_ASSERT_NN(cctx);
     if (compressor)
-        ZL_RET_R_IF_ERR(ZL_CCtx_refCompressor(cctx, compressor));
+        ZL_ERR_IF_ERR(ZL_CCtx_refCompressor(cctx, compressor));
     return GCParams_setStartingGraphID(
             &cctx->requestedGCParams, graphID, rgp, cctx->sessionArena);
 }
@@ -318,11 +320,12 @@ ZL_Report ZL_CCtx_resetParameters(ZL_CCtx* cctx)
 //        when using only standard Graphs.
 ZL_Report ZL_CCtx_refCompressor(ZL_CCtx* cctx, const ZL_Compressor* compressor)
 {
+    ZL_RESULT_DECLARE_SCOPE_REPORT(cctx);
     ZL_ASSERT_NN(cctx);
-    ZL_RET_R_IF_EQ(
-            graph_invalid,
+    ZL_ERR_IF_EQ(
             CGRAPH_getStartingGraphID(compressor).gid,
             0,
+            graph_invalid,
             "The cgraph's starting graph ID is not set, it must be set via "
             "ZL_Compressor_selectStartingGraphID() before it can be used.");
     cctx->cgraph = compressor;
@@ -334,14 +337,15 @@ ZL_Report CCTX_setLocalCGraph_usingGraph2Desc(
         ZL_CCtx* cctx,
         ZL_Graph2Desc graphDesc)
 {
+    ZL_RESULT_DECLARE_SCOPE_REPORT(cctx);
     ZL_LOG(FRAME, "CCTX_setLocalCGraph_usingGraph2Desc");
     ZL_ASSERT_NN(cctx);
     ZL_Compressor_free(cctx->internal_cgraph); // compatible with NULL
     cctx->internal_cgraph = ZL_Compressor_create();
-    ZL_RET_R_IF_NULL(allocation, cctx->internal_cgraph);
+    ZL_ERR_IF_NULL(cctx->internal_cgraph, allocation);
     ZL_GraphID const startingNode =
             graphDesc.f(cctx->internal_cgraph, graphDesc.customParams);
-    ZL_RET_R_IF_ERR(ZL_Compressor_selectStartingGraphID(
+    ZL_ERR_IF_ERR(ZL_Compressor_selectStartingGraphID(
             cctx->internal_cgraph, startingNode));
     // Creation is all fine, let's finalize the reference
     return ZL_CCtx_refCompressor(cctx, cctx->internal_cgraph);
@@ -417,6 +421,8 @@ static ZL_Report CCTX_runCNode_wParams(
         const CNode* cnode,
         const ZL_LocalParams* lparams)
 {
+    ZL_RESULT_DECLARE_SCOPE_REPORT(cctx);
+
     ZL_DLOG(TRANSFORM,
             "CCTX_runCNode_wParams (nbInputs=%u, lparams=%p)",
             nbInputs,
@@ -426,31 +432,31 @@ static ZL_Report CCTX_runCNode_wParams(
     ZL_ASSERT_EQ(cnode->nodetype, node_internalTransform);
 
     // Check inputs
-    ZL_RET_R_IF_NOT(
-            node_invalid_input, CNODE_isNbInputsCompatible(cnode, nbInputs));
+    ZL_ERR_IF_NOT(
+            CNODE_isNbInputsCompatible(cnode, nbInputs), node_invalid_input);
     // This check also takes care of versions<=15, which only support 1 input.
-    ZL_RET_R_IF_GT(
-            node_versionMismatch,
+    ZL_ERR_IF_GT(
             nbInputs,
             ZL_runtimeNodeInputLimit(cctx->appliedGCParams.formatVersion),
+            node_versionMismatch,
             "Too many inputs (%u) for format version %u (max=%u)",
             nbInputs,
             cctx->appliedGCParams.formatVersion,
             ZL_runtimeNodeInputLimit(cctx->appliedGCParams.formatVersion));
     ZL_ASSERT_NN(inputs);
     for (ZL_IDType n = 0; n < nbInputs; n++) {
-        ZL_RET_R_IF_NE(
-                node_unexpected_input_type,
+        ZL_ERR_IF_NE(
                 ZL_Data_type(inputs[n]),
-                CNODE_getInputType(cnode, n));
+                CNODE_getInputType(cnode, n),
+                node_unexpected_input_type);
     }
 
     CNODE_FormatInfo const cnfi = CNODE_getFormatInfo(cnode);
     int const reqFormat = CCTX_getAppliedGParam(cctx, ZL_CParam_formatVersion);
-    ZL_RET_R_IF(
-            node_versionMismatch,
+    ZL_ERR_IF(
             reqFormat < (int)cnfi.minFormatVersion
                     || (int)cnfi.maxFormatVersion < reqFormat,
+            node_versionMismatch,
             "Node %s (versions[%u-%u]) is incompatible with requested format version (%i)",
             CNODE_getName(cnode),
             cnfi.minFormatVersion,
@@ -481,10 +487,10 @@ static ZL_Report CCTX_runCNode_wParams(
             ZL_RefParam existingParam = LP_getLocalRefParam(
                     lparams,
                     cnode->transformDesc.publicDesc.materializer.paramId);
-            ZL_RET_R_IF_NE(
-                    node_invalid_input,
+            ZL_ERR_IF_NE(
                     existingParam.paramId,
                     ZL_LP_INVALID_PARAMID,
+                    node_invalid_input,
                     "Node runtime params cannot use the materialized param ID");
 
             // Param doesn't exist, perform on-the-fly materialization
@@ -494,7 +500,7 @@ static ZL_Report CCTX_runCNode_wParams(
                     ZL_CCtx_getOperationContext(cctx),
                     lparams,
                     &cnode->transformDesc.publicDesc.materializer);
-            ZL_RET_R_IF_ERR(res);
+            ZL_ERR_IF_ERR(res);
             matRes  = ZL_RES_value(res);
             lparams = &matRes.modifiedParams;
         }
@@ -517,13 +523,13 @@ static ZL_Report CCTX_runCNode_wParams(
     // check)
     MPM_dematerializeOneshot(cctx->sessionArena, &matRes);
 
-    ZL_RET_R_IF_ERR(
+    ZL_ERR_IF_ERR(
             nbOuts,
             "Node '%s' failed: %s(%u)",
             CNODE_getName(cnode),
             ZL_ErrorCode_toString(ZL_errorCode(nbOuts)),
             ZL_errorCode(nbOuts));
-    ZL_RET_R_IF_ERR(CCTX_checkOutputCommitted(cctx, *rtnid));
+    ZL_ERR_IF_ERR(CCTX_checkOutputCommitted(cctx, *rtnid));
 
     // Free input streams _if allowed_, since they have been processed.
     // This is typically possible for internal outputs of internal Transforms
@@ -550,13 +556,14 @@ ZL_Report CCTX_runNodeID_wParams(
         ZL_NodeID nodeid,
         const ZL_LocalParams* lparams)
 {
+    ZL_RESULT_DECLARE_SCOPE_REPORT(cctx);
+
     ZL_DLOG(BLOCK, "CCTX_runNodeID_wParams (nbInputs=%u)", nbInputs);
-    ZL_RET_R_IF_EQ(
-            node_invalid, ZL_NODE_ILLEGAL.nid, nodeid.nid, "Node is illegal");
+    ZL_ERR_IF_EQ(
+            ZL_NODE_ILLEGAL.nid, nodeid.nid, node_invalid, "Node is illegal");
     ZL_ASSERT_NN(cctx);
     const CNode* const cnode = CGRAPH_getCNode(cctx->cgraph, nodeid);
-    ZL_RET_R_IF_NULL(
-            node_invalid, cnode, "NodeID %u does not exist", nodeid.nid);
+    ZL_ERR_IF_NULL(cnode, node_invalid, "NodeID %u does not exist", nodeid.nid);
     ZL_ASSERT_EQ(cnode->nodetype, node_internalTransform);
     return CCTX_runCNode_wParams(
             cctx, nodeid, rtnid, inputs, irtsids, nbInputs, cnode, lparams);
@@ -579,16 +586,17 @@ static ZL_Report CCTX_convertInputs_internal(
         ZL_Type const inType,
         ZL_Type const portTypeMask)
 {
+    ZL_RESULT_DECLARE_SCOPE_REPORT(cctx);
     ZL_NodeID conversion = ICONV_implicitConversionNodeID(inType, portTypeMask);
-    ZL_RET_R_IF_NOT(
-            inputType_unsupported,
+    ZL_ERR_IF_NOT(
             ZL_NodeID_isValid(conversion),
+            inputType_unsupported,
             "cannot find an implicit conversion (%x => %x)",
             inType,
             portTypeMask);
 
     RTNodeID rtnodeid;
-    ZL_RET_R_IF_ERR(CCTX_runNodeID_wParams(
+    ZL_ERR_IF_ERR(CCTX_runNodeID_wParams(
             cctx, &rtnodeid, &input, rtsid, 1, conversion, NULL));
     // Implicit conversions are currently single-output only
     ZL_ASSERT_EQ(RTGM_getNbOutStreams(&cctx->rtgraph, rtnodeid), 1);
@@ -608,6 +616,7 @@ static ZL_Report CCTX_convertInputs(
         const ZL_Type* dstPortMasks,
         size_t nbPorts)
 {
+    ZL_RESULT_DECLARE_SCOPE_REPORT(cctx);
     ZL_ASSERT_GE(nbInputs, 1);
     for (size_t n = 0; n < nbInputs; n++) {
         const ZL_Data* input = CCTX_getRStream(cctx, orig_rtsids[n]);
@@ -638,7 +647,7 @@ static ZL_Report CCTX_convertInputs(
                 inType,
                 portTypeMask,
                 res);
-        ZL_RET_R_IF_ERR(res);
+        ZL_ERR_IF_ERR(res);
     }
     return ZL_returnSuccess();
 }
@@ -654,7 +663,7 @@ static ZL_Report GCTX_checkSuccessors(ZL_Graph* gctx)
                     (ZL_TernaryParam)CCTX_getAppliedGParam(
                             gctx->cctx, ZL_CParam_permissiveCompression);
             if (backupMode != ZL_TernaryParam_enable) {
-                ZL_RET_R_ERR(successor_invalid);
+                ZL_ERR(successor_invalid);
             }
         }
     }
@@ -746,10 +755,11 @@ static ZL_Report CCTX_runSuccessors(
         size_t nbSuccessors,
         unsigned depth)
 {
+    ZL_RESULT_DECLARE_SCOPE_REPORT(cctx);
     ZL_DLOG(SEQ, "CCTX_runSuccessors on %zu successors", nbSuccessors);
     for (size_t n = 0; n < nbSuccessors; n++) {
         const SuccessorInfo* const si = successorArray + n;
-        ZL_RET_R_IF_ERR(CCTX_runSuccessor(
+        ZL_ERR_IF_ERR(CCTX_runSuccessor(
                 cctx,
                 si->graphID,
                 si->rgp,
@@ -773,6 +783,8 @@ static ZL_Report CCTX_runGraph_internal(
         size_t nbInputs,
         unsigned depth)
 {
+    ZL_RESULT_DECLARE_SCOPE_REPORT(cctx);
+
     (void)graphid; // required only for waypoints
     // All streams created after this index will be created by the dynamic
     // graph
@@ -797,9 +809,9 @@ static ZL_Report CCTX_runGraph_internal(
             for (size_t i = 0; i < nbSuccs; i++) {
                 bool pushbackSuccess = VECTOR_PUSHBACK(
                         succGids, VECTOR_AT(gctx->dstGraphDescs, i).destGid);
-                ZL_RET_R_IF_NOT(
-                        allocation,
+                ZL_ERR_IF_NOT(
                         pushbackSuccess,
+                        allocation,
                         "Unable to append to the waypoint succGids vector");
             }
             WAYPOINT(
@@ -812,16 +824,16 @@ static ZL_Report CCTX_runGraph_internal(
         }
     }
     ALLOC_Arena_freeAll(cctx->graphArena);
-    ZL_RET_R_IF_ERR(graphExecutionReport);
+    ZL_ERR_IF_ERR(graphExecutionReport);
 
     // If an error happened during Dynamic Graph, but was not checked and
     // then not reported by the Dynamic Graph function, it's caught here.
     ZL_ASSERT_NN(gctx);
-    ZL_RET_R_IF_ERR(gctx->status);
+    ZL_ERR_IF_ERR(gctx->status);
 
     // Check if some streams have no Successors
     // Error out, or set them to default backup if permissive mode
-    ZL_RET_R_IF_ERR(GCTX_checkSuccessors(gctx));
+    ZL_ERR_IF_ERR(GCTX_checkSuccessors(gctx));
     // After that point, if there are unassigned Streams but the check was
     // successful, it means that permissive mode is enabled. Consequently,
     // permissive mode is considered active for the rest of the function.
@@ -836,7 +848,7 @@ static ZL_Report CCTX_runGraph_internal(
     // used is low.
     SuccessorInfo* const successors =
             ZL_malloc(nbSuccessors * sizeof(successors[0]));
-    ZL_RET_R_IF_NULL(allocation, successors);
+    ZL_ERR_IF_NULL(successors, allocation);
     GCTX_getSuccessors(gctx, successors, nbSuccessors);
 
     // Run successors
@@ -887,6 +899,8 @@ static ZL_Report CCTX_runSegmenter(
         const RTStreamID* rtsids,
         size_t nbInputs)
 {
+    ZL_RESULT_DECLARE_SCOPE_REPORT(cctx);
+
     ZL_ASSERT_NN(cctx);
     ZL_ASSERT_NN(cctx->cgraph);
     ZL_ASSERT_EQ(CGRAPH_graphType(cctx->cgraph, graphid), gt_segmenter);
@@ -900,17 +914,17 @@ static ZL_Report CCTX_runSegmenter(
     }
 
     // Check version
-    ZL_RET_R_IF_LT(
-            formatVersion_unsupported,
+    ZL_ERR_IF_LT(
             cctx->appliedGCParams.formatVersion,
             ZL_CHUNK_VERSION_MIN,
+            formatVersion_unsupported,
             "Segmenter is supported starting wire format version %u > %u (requested)",
             ZL_CHUNK_VERSION_MIN,
             cctx->appliedGCParams.formatVersion);
 
     // Check Input Types
     ALLOC_ARENA_MALLOC_CHECKED(ZL_Type, inTypes, nbInputs, cctx->sessionArena);
-    ZL_RET_R_IF_NULL(allocation, inTypes);
+    ZL_ERR_IF_NULL(inTypes, allocation);
     const ZL_SegmenterDesc* segDesc =
             CGRAPH_getSegmenterDesc(cctx->cgraph, graphid);
     size_t const nbPorts = segDesc->numInputs;
@@ -923,9 +937,9 @@ static ZL_Report CCTX_runSegmenter(
         needConversion |= !(inTypes[n] & outTypeMask);
     }
 
-    ZL_RET_R_IF(
-            temporaryLibraryLimitation,
+    ZL_ERR_IF(
             needConversion,
+            temporaryLibraryLimitation,
             "Conversion of Input types not supported by Segmenters");
     // @note not strictly impossible, but requires some attention:
     // we don't want to create Nodes in front of the Segmenter.
@@ -944,10 +958,10 @@ static ZL_Report CCTX_runSegmenter(
                 // Check if the materialized param already exists
                 ZL_RefParam existingParam = LP_getLocalRefParam(
                         rgp->localParams, segDesc->materializer.paramId);
-                ZL_RET_R_IF_NE(
-                        node_invalid_input,
+                ZL_ERR_IF_NE(
                         existingParam.paramId,
                         ZL_LP_INVALID_PARAMID,
+                        node_invalid_input,
                         "Segmenter runtime params cannot use the materialized param ID");
 
                 // Param doesn't exist, perform on-the-fly materialization
@@ -957,7 +971,7 @@ static ZL_Report CCTX_runSegmenter(
                         ZL_CCtx_getOperationContext(cctx),
                         rgp->localParams,
                         &segDesc->materializer);
-                ZL_RET_R_IF_ERR(res);
+                ZL_ERR_IF_ERR(res);
                 segMatRes         = ZL_RES_value(res);
                 migd->localParams = segMatRes.modifiedParams;
             } else {
@@ -1001,6 +1015,7 @@ static ZL_Report CCTX_runGraphDesc(
         size_t nbInputs,
         unsigned depth)
 {
+    ZL_RESULT_DECLARE_SCOPE_REPORT(cctx);
     ZL_ASSERT_NN(cctx);
     ZL_DLOG(BLOCK,
             "CCTX_runGraphDesc on graph '%s(%zu)' with %zu inputs",
@@ -1026,7 +1041,7 @@ static ZL_Report CCTX_runGraphDesc(
         if (ZL_isError(ret)) {
             ZL_free(inputsArray);
             GCTX_destroy(&graphCtx);
-            ZL_RET_R(ret);
+            return ret;
         }
         inputsPtrs[n] = inputsArray + n;
     }
@@ -1058,11 +1073,13 @@ static ZL_Report CCTX_runSupervisedGraphID_internal(
         size_t nbInputs,
         unsigned depth)
 {
+    ZL_RESULT_DECLARE_SCOPE_REPORT(cctx);
+
     // Ensure the graph exists
     ZL_ASSERT_NN(cctx);
-    ZL_RET_R_IF_NOT(
-            graph_invalid,
+    ZL_ERR_IF_NOT(
             CGRAPH_checkGraphIDExists(cctx->cgraph, graphid),
+            graph_invalid,
             "GraphID %u doesn't exist",
             graphid.gid);
     ZL_DLOG(BLOCK,
@@ -1076,7 +1093,7 @@ static ZL_Report CCTX_runSupervisedGraphID_internal(
 
     // Check Input Types
     ALLOC_ARENA_MALLOC_CHECKED(ZL_Type, inTypes, nbInputs, cctx->graphArena);
-    ZL_RET_R_IF_NULL(allocation, inTypes);
+    ZL_ERR_IF_NULL(inTypes, allocation);
     const ZL_FunctionGraphDesc* dstGd =
             CGRAPH_getMultiInputGraphDesc(cctx->cgraph, graphid);
     size_t const nbPorts = dstGd->nbInputs;
@@ -1095,7 +1112,7 @@ static ZL_Report CCTX_runSupervisedGraphID_internal(
                         ZL_Compressor_Graph_getName(cctx->cgraph, graphid)));
         ALLOC_ARENA_MALLOC_CHECKED(
                 RTStreamID, newrtsids, nbInputs, cctx->graphArena);
-        ZL_RET_R_IF_ERR(CCTX_convertInputs(
+        ZL_ERR_IF_ERR(CCTX_convertInputs(
                 cctx,
                 newrtsids,
                 rtsids,
@@ -1125,10 +1142,10 @@ static ZL_Report CCTX_runSupervisedGraphID_internal(
                 // Check if the materialized param already exists
                 ZL_RefParam existingParam = LP_getLocalRefParam(
                         rgp->localParams, dstGd->materializer.paramId);
-                ZL_RET_R_IF_NE(
-                        node_invalid_input,
+                ZL_ERR_IF_NE(
                         existingParam.paramId,
                         ZL_LP_INVALID_PARAMID,
+                        node_invalid_input,
                         "Graph runtime params cannot use the materialized param ID");
 
                 // Param doesn't exist, perform on-the-fly materialization
@@ -1138,7 +1155,7 @@ static ZL_Report CCTX_runSupervisedGraphID_internal(
                         ZL_CCtx_getOperationContext(cctx),
                         rgp->localParams,
                         &dstGd->materializer);
-                ZL_RET_R_IF_ERR(res);
+                ZL_ERR_IF_ERR(res);
                 graphMatRes       = ZL_RES_value(res);
                 migd->localParams = graphMatRes.modifiedParams;
             } else {
@@ -1195,12 +1212,14 @@ static ZL_Report CCTX_triggerBackupMode(
         size_t nbInputs,
         unsigned depth)
 {
+    ZL_RESULT_DECLARE_SCOPE_REPORT(cctx);
+
     ZL_DLOG(BLOCK, "CCTX_triggerBackupMode (nbInputs==%u)", nbInputs);
     ZL_ASSERT_EQ(cctx->inBackupMode, 0, "Recursive backup shouldn't happen");
-    ZL_RET_R_IF_NE(
-            logicError,
+    ZL_ERR_IF_NE(
             cctx->inBackupMode,
             0,
+            logicError,
             "Recursive backup shouldn't happen");
     cctx->inBackupMode = 1;
     ZL_Report outcome  = CCTX_runSupervisedGraphID(
@@ -1225,6 +1244,8 @@ static ZL_Report CCTX_runSuccessor_internal(
         size_t nbInputs,
         unsigned depth)
 {
+    ZL_RESULT_DECLARE_SCOPE_REPORT(cctx);
+
     ZL_ASSERT_NN(cctx);
     ZL_SCOPE_GRAPH_CONTEXT(cctx, { .graphID = graphid });
 
@@ -1258,7 +1279,7 @@ static ZL_Report CCTX_runSuccessor_internal(
             cctx, ZL_CParam_permissiveCompression);
     ZL_DLOG(BLOCK, "node just failed : permissiveMode = %u", backupMode);
     if (backupMode != ZL_TernaryParam_enable || cctx->inBackupMode) {
-        ZL_RET_R(outcome);
+        return outcome;
     }
 
     ZL_E_log(ZL_RES_error(outcome), ZL_LOG_LVL_V);
@@ -1344,13 +1365,13 @@ ZL_Report CCTX_runSuccessor(
 ZL_Report
 CCTX_startCompression(ZL_CCtx* cctx, const ZL_Data* inputs[], size_t nbInputs)
 {
+    ZL_RESULT_DECLARE_SCOPE_REPORT(cctx);
     ZL_DLOG(FRAME,
             "CCTX_startCompression (%zu inputs; input[0].size = %zu)",
             nbInputs,
             ZL_Data_contentSize(inputs[0]));
     ZL_ASSERT_NN(cctx);
     ZL_ASSERT_NN(inputs);
-    ZL_RESULT_DECLARE_SCOPE_REPORT(cctx);
 
     /* Current library limitation :
      * Compression requires attaching a Compressor.
@@ -1517,6 +1538,7 @@ ZL_Report CCTX_setOutBufferSizes(
         const size_t writtenSizes[],
         size_t nbOutStreams)
 {
+    ZL_RESULT_DECLARE_SCOPE_REPORT(cctx);
     ZL_DLOG(BLOCK,
             "CCTX_setOutBufferSizes (node id %u => %zu buffs)",
             rtnodeid.rtnid,
@@ -1527,7 +1549,7 @@ ZL_Report CCTX_setOutBufferSizes(
     for (int n = 0; n < (int)nbOutStreams; n++) {
         RTStreamID const rtstreamid =
                 RTGM_getOutStreamID(&cctx->rtgraph, rtnodeid, n);
-        ZL_RET_R_IF_ERR(ZL_Data_commit(
+        ZL_ERR_IF_ERR(ZL_Data_commit(
                 RTGM_getWStream(&cctx->rtgraph, rtstreamid), writtenSizes[n]));
     }
     return ZL_returnSuccess();
@@ -1610,8 +1632,8 @@ static ZL_Report CCTX_writeChunkHeader(
 ZL_Report
 CCTX_flushChunk(ZL_CCtx* cctx, const ZL_Data* inputs[], size_t nbInputs)
 {
-    ZL_DLOG(BLOCK, "CCTX_flushChunk (%zu inputs)", nbInputs);
     ZL_RESULT_DECLARE_SCOPE_REPORT(cctx);
+    ZL_DLOG(BLOCK, "CCTX_flushChunk (%zu inputs)", nbInputs);
 
     GraphInfo gi;
     ZL_ERR_IF_ERR(CCTX_getFinalGraph(cctx, &gi));
@@ -1661,7 +1683,7 @@ CCTX_flushChunk(ZL_CCtx* cctx, const ZL_Data* inputs[], size_t nbInputs)
         ZL_ASSERT_EQ(
                 CCTX_getAppliedGParam(cctx, ZL_CParam_contentChecksum),
                 ZL_TernaryParam_enable);
-        ZL_RET_R_IF_LT(dstCapacity_tooSmall, capacity - frameSize, 4);
+        ZL_ERR_IF_LT(capacity - frameSize, 4, dstCapacity_tooSmall);
         uint32_t const formatVersion =
                 (uint32_t)CCTX_getAppliedGParam(cctx, ZL_CParam_formatVersion);
         ZL_TRY_LET(
@@ -1680,7 +1702,7 @@ CCTX_flushChunk(ZL_CCtx* cctx, const ZL_Data* inputs[], size_t nbInputs)
         ZL_ASSERT_EQ(
                 CCTX_getAppliedGParam(cctx, ZL_CParam_compressedChecksum),
                 ZL_TernaryParam_enable);
-        ZL_RET_R_IF_LT(dstCapacity_tooSmall, capacity - frameSize, 4);
+        ZL_ERR_IF_LT(capacity - frameSize, 4, dstCapacity_tooSmall);
         size_t startHashPosition = startFrameSize;
         if (CCTX_getAppliedGParam(cctx, ZL_CParam_formatVersion)
             < ZL_CHUNK_VERSION_MIN) {
@@ -1708,6 +1730,8 @@ CCTX_flushChunk(ZL_CCtx* cctx, const ZL_Data* inputs[], size_t nbInputs)
 
 ZL_Report CCTX_getFinalGraph(ZL_CCtx* cctx, GraphInfo* gip)
 {
+    ZL_RESULT_DECLARE_SCOPE_REPORT(cctx);
+
     ZL_ASSERT_NN(cctx);
     unsigned const formatVersion =
             (unsigned)CCTX_getAppliedGParam(cctx, ZL_CParam_formatVersion);
@@ -1722,18 +1746,18 @@ ZL_Report CCTX_getFinalGraph(ZL_CCtx* cctx, GraphInfo* gip)
     ZL_ASSERT_NN(gip);
 
     // Check format limitations
-    ZL_RET_R_IF_GE(
-            formatVersion_unsupported,
+    ZL_ERR_IF_GE(
             nbTransforms,
-            ZL_runtimeNodeLimit(formatVersion));
-    ZL_RET_R_IF_GE(
-            formatVersion_unsupported,
+            ZL_runtimeNodeLimit(formatVersion),
+            formatVersion_unsupported);
+    ZL_ERR_IF_GE(
             nbStreamsMax,
-            ZL_runtimeStreamLimit(formatVersion));
-    ZL_RET_R_IF_GT(
-            formatVersion_unsupported,
+            ZL_runtimeStreamLimit(formatVersion),
+            formatVersion_unsupported);
+    ZL_ERR_IF_GT(
             nbInputs,
-            ZL_runtimeInputLimit(formatVersion));
+            ZL_runtimeInputLimit(formatVersion),
+            formatVersion_unsupported);
 
     // Allocation
     ALLOC_ARENA_MALLOC_CHECKED(
@@ -1774,10 +1798,10 @@ ZL_Report CCTX_getFinalGraph(ZL_CCtx* cctx, GraphInfo* gip)
         const NodeHeaderSegment nhs =
                 RTGM_nodeHeaderSegment(&cctx->rtgraph, rtnid);
         trHSizes[n] = nhs.len;
-        ZL_RET_R_IF_LT(
-                corruption,
+        ZL_ERR_IF_LT(
                 RTGM_getNbOutStreams(&cctx->rtgraph, rtnid),
-                CNODE_getNbOut1s(cnode));
+                CNODE_getNbOut1s(cnode),
+                corruption);
         nbVOs[n] = RTGM_getNbOutStreams(&cctx->rtgraph, rtnid)
                 - CNODE_getNbOut1s(cnode);
         nbTrInputs[n] = RTGM_getNbInStreams(&cctx->rtgraph, rtnid);
@@ -1796,7 +1820,7 @@ ZL_Report CCTX_getFinalGraph(ZL_CCtx* cctx, GraphInfo* gip)
                                 &cctx->trHeaders.stagingHeaderStream),
                         nhs.startPos,
                         nhs.len));
-        ZL_RET_R_IF_ERR(
+        ZL_ERR_IF_ERR(
                 CCTX_TransformHeaders_send(&cctx->trHeaders, buffer_slice));
     }
     ZL_ASSERT_GE(nbDistances, nbTransforms);

--- a/src/openzl/compress/cgraph.c
+++ b/src/openzl/compress/cgraph.c
@@ -105,6 +105,7 @@ ZL_Report ZL_Compressor_selectStartingGraphID(
         ZL_Compressor* cgraph,
         ZL_GraphID gid)
 {
+    ZL_RESULT_DECLARE_SCOPE_REPORT(cgraph);
     ZL_ASSERT_NN(cgraph);
     if (CGRAPH_checkGraphIDExists(cgraph, gid)) {
         ZL_DLOG(FRAME,
@@ -112,7 +113,7 @@ ZL_Report ZL_Compressor_selectStartingGraphID(
                 ZL_Compressor_Graph_getName(cgraph, gid),
                 gid.gid);
     }
-    ZL_RET_R_IF_ERR(ZL_Compressor_validate(cgraph, gid));
+    ZL_ERR_IF_ERR(ZL_Compressor_validate(cgraph, gid));
     cgraph->starting_graph = gid;
     return ZL_returnSuccess();
 }
@@ -129,6 +130,7 @@ int ZL_NodeID_isValid(ZL_NodeID nodeid)
 static ZL_Report
 CGraph_pipeAdaptor(ZL_Encoder* eictx, const ZL_Input* ins[], size_t nbInputs)
 {
+    ZL_RESULT_DECLARE_SCOPE_REPORT(eictx);
     ZL_DLOG(BLOCK, "CGraph_pipeAdaptor");
     ZL_ASSERT_NN(ins);
     ZL_ASSERT_EQ(nbInputs, 1);
@@ -147,14 +149,14 @@ CGraph_pipeAdaptor(ZL_Encoder* eictx, const ZL_Input* ins[], size_t nbInputs)
     ZL_ASSERT_NN(eictx);
     ZL_Output* const out =
             ZL_Encoder_createTypedStream(eictx, 0, outCapacity, 1);
-    ZL_RET_R_IF_NULL(allocation, out);
+    ZL_ERR_IF_NULL(out, allocation);
 
-    ZL_RET_R_IF_NULL(customNode_definitionInvalid, pipeDesc->transform_f);
+    ZL_ERR_IF_NULL(pipeDesc->transform_f, customNode_definitionInvalid);
     size_t const dstSize = pipeDesc->transform_f(
             ZL_Output_ptr(out), outCapacity, src, srcSize);
 
-    ZL_RET_R_IF_GT(transform_executionFailure, dstSize, outCapacity);
-    ZL_RET_R_IF_ERR(ZL_Output_commit(out, dstSize));
+    ZL_ERR_IF_GT(dstSize, outCapacity, transform_executionFailure);
+    ZL_ERR_IF_ERR(ZL_Output_commit(out, dstSize));
 
     return ZL_returnValue(1);
 }
@@ -199,6 +201,7 @@ typedef struct {
 static ZL_Report
 CGraph_splitAdaptor(ZL_Encoder* eictx, const ZL_Input* ins[], size_t nbInputs)
 {
+    ZL_RESULT_DECLARE_SCOPE_REPORT(eictx);
     ZL_DLOG(BLOCK, "CGraph_splitAdaptor");
     ZL_ASSERT_NN(ins);
     ZL_ASSERT_EQ(nbInputs, 1);
@@ -214,14 +217,14 @@ CGraph_splitAdaptor(ZL_Encoder* eictx, const ZL_Input* ins[], size_t nbInputs)
     size_t const nbDsts = splitDesc->nbOuts;
     size_t* const dstSizes =
             ZL_Encoder_getScratchSpace(eictx, nbDsts * sizeof(*dstSizes));
-    ZL_RET_R_IF_NULL(allocation, dstSizes);
+    ZL_ERR_IF_NULL(dstSizes, allocation);
     ZL_Report const r = splitDesc->transform_f(eictx, dstSizes, src, srcSize);
-    ZL_RET_R_IF_ERR(r);
+    ZL_ERR_IF_ERR(r);
     ZL_ASSERT_EQ(
             nbDsts, ZL_validResult(r)); // create as many outputs as pledged
 
     ZL_ASSERT_NN(eictx);
-    ZL_RET_R_IF_ERR(CCTX_setOutBufferSizes(
+    ZL_ERR_IF_ERR(CCTX_setOutBufferSizes(
             eictx->cctx, eictx->rtnodeid, dstSizes, nbDsts));
 
     return r;

--- a/src/openzl/compress/cgraph_validation.c
+++ b/src/openzl/compress/cgraph_validation.c
@@ -9,9 +9,10 @@ static ZL_Report CGraph_validateGraphAtGid(
         ZL_Compressor* cgraph,
         ZL_GraphID gid)
 {
+    ZL_RESULT_DECLARE_SCOPE_REPORT(cgraph);
     ZL_DLOG(BLOCK, "CGraph_validateGraphAtGid (%u)", gid.gid);
 
-    ZL_RET_R_IF_NOT(graph_invalid, ZL_GraphID_isValid(gid));
+    ZL_ERR_IF_NOT(ZL_GraphID_isValid(gid), graph_invalid);
 
     return ZL_returnSuccess();
 }
@@ -20,9 +21,10 @@ ZL_Report ZL_Compressor_validate(
         ZL_Compressor* cgraph,
         const ZL_GraphID starting_graph)
 {
+    ZL_RESULT_DECLARE_SCOPE_REPORT(cgraph);
     ZL_DLOG(BLOCK, "ZL_Compressor_validate");
     // Check that we start with a valid gid
-    ZL_RET_R_IF_ERR(CGraph_validateGraphAtGid(cgraph, starting_graph));
+    ZL_ERR_IF_ERR(CGraph_validateGraphAtGid(cgraph, starting_graph));
     // Note (@Cyan): since zstrong supports Typed Inputs, there is no longer a
     // requirement for Starting Graph to support Serial Input.
     return ZL_returnSuccess();

--- a/src/openzl/compress/compress2.c
+++ b/src/openzl/compress/compress2.c
@@ -38,6 +38,7 @@ static ZL_Report writeFrameHeader(
         const ZL_Data* inputs[],
         size_t numInputs)
 {
+    ZL_RESULT_DECLARE_SCOPE_REPORT(cctx);
     ZL_DLOG(BLOCK, "writeFrameHeader");
 
     // Check format limitations
@@ -47,10 +48,10 @@ static ZL_Report writeFrameHeader(
     ZL_ASSERT(
             ZL_isFormatVersionSupported(formatVersion),
             "Format should already have been validated.");
-    ZL_RET_R_IF_GT(
-            formatVersion_unsupported,
+    ZL_ERR_IF_GT(
             numInputs,
-            ZL_runtimeInputLimit(formatVersion));
+            ZL_runtimeInputLimit(formatVersion),
+            formatVersion_unsupported);
 
     // Allocate array for description of inputs
     ALLOC_MALLOC_CHECKED(InputDesc, inputDescs, numInputs);
@@ -131,6 +132,7 @@ ZL_Report CCTX_compressInputs_withGraphSet(
         size_t nbInputs)
 {
     // @note all compression entry points converge here.
+    ZL_RESULT_DECLARE_SCOPE_REPORT(cctx);
     ZL_DLOG(FRAME, "CCTX_compressInputs_withGraphSet");
 
     ZL_Report const r = CCTX_compressInputs_withGraphSet_stage2(
@@ -141,7 +143,7 @@ ZL_Report CCTX_compressInputs_withGraphSet(
     CCTX_clean(cctx);
     if (!CCTX_getAppliedGParam(cctx, ZL_CParam_stickyParameters)) {
         // If cctx parameters are not explicitly sticky, reset them
-        ZL_RET_R_IF_ERR(ZL_CCtx_resetParameters(cctx));
+        ZL_ERR_IF_ERR(ZL_CCtx_resetParameters(cctx));
     }
 
     return r;
@@ -175,7 +177,8 @@ static ZL_Report ZL_CCtx_compress_usingCGraph(
         size_t srcSize,
         const ZL_Compressor* cgraph)
 {
-    ZL_RET_R_IF_ERR(ZL_CCtx_refCompressor(cctx, cgraph));
+    ZL_RESULT_DECLARE_SCOPE_REPORT(cctx);
+    ZL_ERR_IF_ERR(ZL_CCtx_refCompressor(cctx, cgraph));
     return CCTX_compressSerial_withGraphSet(
             cctx, dst, dstCapacity, src, srcSize);
 }
@@ -188,9 +191,10 @@ static ZL_Report ZL_CCtx_compress_usingGraph2Desc(
         size_t srcSize,
         ZL_Graph2Desc gfDesc)
 {
+    ZL_RESULT_DECLARE_SCOPE_REPORT(cctx);
     ZL_LOG(FRAME, "ZL_CCtx_compress_usingGraph2Desc (srcSize=%zu)", srcSize);
     ZL_ASSERT_NN(cctx);
-    ZL_RET_R_IF_ERR(CCTX_setLocalCGraph_usingGraph2Desc(cctx, gfDesc));
+    ZL_ERR_IF_ERR(CCTX_setLocalCGraph_usingGraph2Desc(cctx, gfDesc));
     return CCTX_compressSerial_withGraphSet(
             cctx, dst, dstCapacity, src, srcSize);
 }
@@ -335,6 +339,7 @@ ZL_Report ZL_CCtx_compressMultiTypedRef(
         const ZL_TypedRef* inputs[],
         size_t nbInputs)
 {
+    ZL_RESULT_DECLARE_SCOPE_REPORT(cctx);
     WAYPOINT(
             on_ZL_CCtx_compressMultiTypedRef_start,
             cctx,
@@ -342,11 +347,11 @@ ZL_Report ZL_CCtx_compressMultiTypedRef(
             dstCapacity,
             inputs,
             nbInputs);
-    ZL_RET_R_IF_NULL(compressionParameter_invalid, inputs);
+    ZL_ERR_IF_NULL(inputs, compressionParameter_invalid);
     // this works directly because ZL_TypedRef == ZL_Data
     // In the future, if these types diverge, a conversion operation will be
     // required
-    ZL_RET_R_IF_NOT(compressionParameter_invalid, CCTX_isGraphSet(cctx));
+    ZL_ERR_IF_NOT(CCTX_isGraphSet(cctx), compressionParameter_invalid);
     const ZL_Report rep = CCTX_compressInputs_withGraphSet(
             cctx, dst, dstCapacity, ZL_codemodInputsAsDatas(inputs), nbInputs);
     WAYPOINT(on_ZL_CCtx_compressMultiTypedRef_end, cctx, rep);

--- a/src/openzl/compress/enc_interface.c
+++ b/src/openzl/compress/enc_interface.c
@@ -126,6 +126,8 @@ ZL_Report ZL_Encoder_createAllOutBuffers(
         const size_t buffSizes[],
         size_t nbBuffs)
 {
+    ZL_RESULT_DECLARE_SCOPE_REPORT(eic);
+
     /* General idea :
      *
      * 1) Access the definition of the node in the immutable cgraph,
@@ -164,10 +166,10 @@ ZL_Report ZL_Encoder_createAllOutBuffers(
     for (int n = 0; n < (int)nbBuffs; n++) {
         ZL_Output* const data =
                 ZL_Encoder_createTypedStream(eic, n, buffSizes[n], 1);
-        ZL_RET_R_IF_NULL(allocation, data);
+        ZL_ERR_IF_NULL(data, allocation);
         buffStarts[n] = ZL_Output_ptr(data);
         if (buffSizes[n] > 0 && buffStarts[n] == NULL)
-            ZL_RET_R_ERR(allocation);
+            ZL_ERR(allocation);
     }
     return ZL_returnSuccess();
 }
@@ -240,6 +242,7 @@ static ZL_Report ENC_runTransform_internal(
         const ZL_Data* inStreams[],
         size_t nbInStreams)
 {
+    ZL_RESULT_DECLARE_SCOPE_REPORT(eictx);
     ZL_DLOG(BLOCK,
             "ENC_runTransform_internal (%s, nodeid=%zu, nbInputs=%zu)",
             CT_getTrName(trDesc),
@@ -285,9 +288,9 @@ static ZL_Report ENC_runTransform_internal(
                     RTGM_getOutStreamID(rtgm, eictx->rtnodeid, (int)i);
             const ZL_Data* d     = RTGM_getRStream(rtgm, rtsid);
             bool pushbackSuccess = VECTOR_PUSHBACK(odata, d);
-            ZL_RET_R_IF_NOT(
-                    allocation,
+            ZL_ERR_IF_NOT(
                     pushbackSuccess,
+                    allocation,
                     "Unable to append to the waypoint odata vector");
         }
         WAYPOINT(
@@ -300,7 +303,7 @@ static ZL_Report ENC_runTransform_internal(
     }
 
     // Check that we didn't encounter an error sending the transform header.
-    ZL_RET_R_IF_ERR(eictx->sendTransformHeaderError);
+    ZL_ERR_IF_ERR(eictx->sendTransformHeaderError);
 
     // Check that the transform has generated
     // at least as many output streams as compulsory singleton outputs.
@@ -309,23 +312,23 @@ static ZL_Report ENC_runTransform_internal(
     //        This can't be done with a simple counter though,
     //        and would require contribution from the RTGraph Manager.
     size_t const nbOut1 = trDesc->publicDesc.gd.nbSOs;
-    ZL_RET_R_IF_LT(transform_executionFailure, nbOutStreams, nbOut1);
+    ZL_ERR_IF_LT(nbOutStreams, nbOut1, transform_executionFailure);
 
     unsigned const formatVersion =
             (unsigned)ZL_Encoder_getCParam(eictx, ZL_CParam_formatVersion);
     if (formatVersion < 9) {
         // Format versions less than 9 don't support 0 output streams.
-        ZL_RET_R_IF_EQ(
-                formatVersion_unsupported,
+        ZL_ERR_IF_EQ(
                 nbOutStreams,
                 0,
+                formatVersion_unsupported,
                 "Not supported until format version 9");
     }
 
-    ZL_RET_R_IF_GT(
-            formatVersion_unsupported,
+    ZL_ERR_IF_GT(
             nbOutStreams,
-            ZL_transformOutStreamsLimit(formatVersion));
+            ZL_transformOutStreamsLimit(formatVersion),
+            formatVersion_unsupported);
 
     return ZL_returnValue(nbOutStreams);
 }
@@ -342,6 +345,7 @@ ZL_Report ENC_runTransform(
         Arena* wkspArena,
         CachedStates* trstates)
 {
+    ZL_RESULT_DECLARE_SCOPE_REPORT(cctx);
     ZL_ASSERT_NN(trDesc);
     ZL_DLOG(BLOCK,
             "ENC_runTransform on Transform '%s' (%u) (lparams=%p)",
@@ -351,7 +355,7 @@ ZL_Report ENC_runTransform(
     if (lparams == NULL)
         lparams = CNODE_getLocalParams(cnode);
     ZL_Encoder eiState;
-    ZL_RET_R_IF_ERR(ENC_initEICtx(
+    ZL_ERR_IF_ERR(ENC_initEICtx(
             &eiState, cctx, wkspArena, &rtnodeid, cnode, lparams, trstates));
     ZL_Report const transformRes = ENC_runTransform_internal(
             &eiState, nodeid, trDesc, inputs, nbInputs);

--- a/src/openzl/compress/graph_registry.c
+++ b/src/openzl/compress/graph_registry.c
@@ -287,6 +287,7 @@ void GR_validate(void)
 ZL_Report
 GR_staticGraphWrapper(ZL_Graph* gctx, ZL_Edge* inputs[], size_t nbInputs)
 {
+    ZL_RESULT_DECLARE_SCOPE_REPORT(gctx);
     ZL_ASSERT_NN(gctx);
     ZL_ASSERT_NN(inputs);
     ZL_NodeIDList const headNode_l = ZL_Graph_getCustomNodes(gctx);
@@ -309,7 +310,7 @@ GR_staticGraphWrapper(ZL_Graph* gctx, ZL_Edge* inputs[], size_t nbInputs)
     // Note: this version only supports TypedTransform as HeadNode
     ZL_ASSERT_EQ(gidl.nbGraphIDs, nbOutputs);
     for (size_t n = 0; n < nbOutputs; n++) {
-        ZL_RET_R_IF_ERR(
+        ZL_ERR_IF_ERR(
                 ZL_Edge_setDestination(outputList.edges[n], gidl.graphids[n]));
     }
     return ZL_returnSuccess();
@@ -321,6 +322,7 @@ GR_staticGraphWrapper(ZL_Graph* gctx, ZL_Edge* inputs[], size_t nbInputs)
 //       it might be more readable to keep them separated.
 ZL_Report GR_VOGraphWrapper(ZL_Graph* gctx, ZL_Edge* inputs[], size_t nbInputs)
 {
+    ZL_RESULT_DECLARE_SCOPE_REPORT(gctx);
     ZL_ASSERT_NN(gctx);
     ZL_ASSERT_EQ(nbInputs, 1);
     ZL_ASSERT_NN(inputs);
@@ -345,10 +347,10 @@ ZL_Report GR_VOGraphWrapper(ZL_Graph* gctx, ZL_Edge* inputs[], size_t nbInputs)
     const void* const pp = GCTX_getPrivateParam(gctx);
     ZL_ASSERT_NN(pp);
     unsigned const nbSingletons = ((const unsigned*)pp)[0];
-    ZL_RET_R_IF_LT(
-            nodeExecution_invalidOutputs,
+    ZL_ERR_IF_LT(
             nbOutputs,
             (size_t)nbSingletons,
+            nodeExecution_invalidOutputs,
             "the head VO Node has not generated enough outputs according to its definition ");
 
     // Register and check that all singular outputs receive one successor.
@@ -359,27 +361,27 @@ ZL_Report GR_VOGraphWrapper(ZL_Graph* gctx, ZL_Edge* inputs[], size_t nbInputs)
         ZL_IDType const outcomeID = StreamCtx_getOutcomeID(sctx);
         if (n < nbSingletons) {
             /* Singular output */
-            ZL_RET_R_IF_NE(
-                    nodeExecution_invalidOutputs,
+            ZL_ERR_IF_NE(
                     outcomeID,
                     n,
+                    nodeExecution_invalidOutputs,
                     "a Singular output has not received a Successor");
         } else {
             /* Variable outputs */
-            ZL_RET_R_IF_LT(
-                    nodeExecution_invalidOutputs,
+            ZL_ERR_IF_LT(
                     outcomeID,
                     nbSingletons,
-                    "overloading Singular output");
-            ZL_RET_R_IF_GE(
                     nodeExecution_invalidOutputs,
+                    "overloading Singular output");
+            ZL_ERR_IF_GE(
                     outcomeID,
                     outcomeList.nbGraphIDs,
+                    nodeExecution_invalidOutputs,
                     "Variable Output ID is out of range");
         }
         // assign successor
         ZL_GraphID const next_gid = outcomeList.graphids[outcomeID];
-        ZL_RET_R_IF_ERR(ZL_Edge_setDestination(sctx, next_gid));
+        ZL_ERR_IF_ERR(ZL_Edge_setDestination(sctx, next_gid));
     }
 
     return ZL_returnSuccess();
@@ -388,6 +390,7 @@ ZL_Report GR_VOGraphWrapper(ZL_Graph* gctx, ZL_Edge* inputs[], size_t nbInputs)
 ZL_Report
 GR_selectorWrapper(ZL_Graph* gctx, ZL_Edge* inputCtxs[], size_t nbInputs)
 {
+    ZL_RESULT_DECLARE_SCOPE_REPORT(gctx);
     ZL_ASSERT_NN(gctx);
     ZL_ASSERT_EQ(nbInputs, 1);
     ZL_Edge* const inputCtx             = inputCtxs[0];
@@ -406,7 +409,7 @@ GR_selectorWrapper(ZL_Graph* gctx, ZL_Edge* inputCtxs[], size_t nbInputs)
             SelectorSuccessorParams, successorParams, 1, gctx->graphArena);
     successorParams->params = NULL; // init to NULL, will be set by selector if
                                     // there are params to be sent
-    ZL_RET_R_IF_ERR(SelCtx_initSelectorCtx(
+    ZL_ERR_IF_ERR(SelCtx_initSelectorCtx(
             &siState,
             gctx->cctx,
             gctx->graphArena,
@@ -423,7 +426,7 @@ GR_selectorWrapper(ZL_Graph* gctx, ZL_Edge* inputCtxs[], size_t nbInputs)
 
     ZL_RuntimeGraphParameters const rgp = { .localParams =
                                                     successorParams->params };
-    ZL_RET_R_IF_ERR(ZL_Edge_setParameterizedDestination(
+    ZL_ERR_IF_ERR(ZL_Edge_setParameterizedDestination(
             inputCtxs, nbInputs, selectedSuccessor, &rgp));
     SelCtx_destroySelectorCtx(&siState);
 

--- a/src/openzl/compress/graphs/generic_clustering_graph.c
+++ b/src/openzl/compress/graphs/generic_clustering_graph.c
@@ -181,21 +181,21 @@ ZL_Report ZL_Clustering_serializeClusteringConfig(
 {
     ZL_RESULT_DECLARE_SCOPE_REPORT(errCtx);
     A1C_Item* root = A1C_Item_root(arena);
-    ZL_RET_R_IF_NULL(allocation, root);
+    ZL_ERR_IF_NULL(root, allocation);
     A1C_MapBuilder rootMapBuilder = A1C_Item_map_builder(root, 2, arena);
     {
         A1C_MAP_TRY_ADD_R(pair, rootMapBuilder);
         A1C_Item_string_refCStr(&pair->key, "clusters");
         A1C_Item* clusters =
                 A1C_Item_array(&pair->val, config->nbClusters, arena);
-        ZL_RET_R_IF_NULL(allocation, clusters);
+        ZL_ERR_IF_NULL(clusters, allocation);
         for (size_t i = 0; i < config->nbClusters; i++) {
             A1C_MapBuilder clustersMapBuilder =
                     A1C_Item_map_builder(&clusters[i], 2, arena);
             {
                 A1C_MAP_TRY_ADD_R(p, clustersMapBuilder);
                 A1C_Item_string_refCStr(&p->key, "typeSuccessor");
-                ZL_RET_R_IF_ERR(cbor_serializeTypeSuccessor(
+                ZL_ERR_IF_ERR(cbor_serializeTypeSuccessor(
                         errCtx,
                         &p->val,
                         arena,
@@ -206,7 +206,7 @@ ZL_Report ZL_Clustering_serializeClusteringConfig(
                 A1C_Item_string_refCStr(&p->key, "memberTags");
                 A1C_Item* memberTags = A1C_Item_array(
                         &p->val, config->clusters[i].nbMemberTags, arena);
-                ZL_RET_R_IF_NULL(allocation, memberTags);
+                ZL_ERR_IF_NULL(memberTags, allocation);
                 for (size_t j = 0; j < config->clusters[i].nbMemberTags; j++) {
                     A1C_Item_int64(
                             &memberTags[j],
@@ -220,21 +220,21 @@ ZL_Report ZL_Clustering_serializeClusteringConfig(
         A1C_Item_string_refCStr(&pair->key, "typeDefaults");
         A1C_Item* typeDefaults =
                 A1C_Item_array(&pair->val, config->nbTypeDefaults, arena);
-        ZL_RET_R_IF_NULL(allocation, typeDefaults);
+        ZL_ERR_IF_NULL(typeDefaults, allocation);
         for (size_t i = 0; i < config->nbTypeDefaults; i++) {
-            ZL_RET_R_IF_ERR(cbor_serializeTypeSuccessor(
+            ZL_ERR_IF_ERR(cbor_serializeTypeSuccessor(
                     errCtx, &typeDefaults[i], arena, &config->typeDefaults[i]));
         }
     }
     *dstSize = A1C_Item_encodedSize(root);
     *dst     = arena->calloc(arena->opaque, *dstSize);
-    ZL_RET_R_IF_NULL(allocation, *dst);
+    ZL_ERR_IF_NULL(*dst, allocation);
     A1C_Error error;
     size_t res = A1C_Item_encode(root, *dst, *dstSize, &error);
     if (res == 0) {
-        ZL_RET_R_WRAP_ERR(A1C_Error_convert(NULL, error));
+        return ZL_WRAP_ERROR(A1C_Error_convert(NULL, error));
     }
-    ZL_RET_R_IF_NE(allocation, res, *dstSize);
+    ZL_ERR_IF_NE(res, *dstSize, allocation);
     return ZL_returnSuccess();
 }
 
@@ -439,17 +439,17 @@ static ZL_Report validateClusteredConfig(
     ZL_RESULT_DECLARE_SCOPE_REPORT(graph);
     /* Check successor index is not out of range for clusters */
     for (size_t i = 0; i < config->nbClusters; i++) {
-        ZL_RET_R_IF_GE(
-                graphParameter_invalid,
+        ZL_ERR_IF_GE(
                 config->clusters[i].typeSuccessor.successorIdx,
-                succList->nbGraphIDs);
+                succList->nbGraphIDs,
+                graphParameter_invalid);
     }
     /* Check successor index is not out of range for defaultSuccessors */
     for (size_t i = 0; i < config->nbTypeDefaults; i++) {
-        ZL_RET_R_IF_GE(
-                graphParameter_invalid,
+        ZL_ERR_IF_GE(
                 config->typeDefaults[i].successorIdx,
-                succList->nbGraphIDs);
+                succList->nbGraphIDs,
+                graphParameter_invalid);
     }
     return ZL_returnSuccess();
 }
@@ -481,7 +481,7 @@ static ZL_Report sendClustersToSuccessors(
         if (nbEdges == 1) {
             // Directly send edge to successor if there is only a single edge in
             // the cluster.
-            ZL_RET_R_IF_ERR(ZL_Edge_setDestination(cluster[0], successor));
+            ZL_ERR_IF_ERR(ZL_Edge_setDestination(cluster[0], successor));
             continue;
         }
 
@@ -498,13 +498,13 @@ static ZL_Report sendClustersToSuccessors(
             // TODO: These numeric streams can be concat together across all
             // clusters. It is worth checking if this is worthwhile at the stage
             // of benchmarking the testing corpus
-            ZL_RET_R_IF_ERR(ZL_Edge_setDestination(
+            ZL_ERR_IF_ERR(ZL_Edge_setDestination(
                     clustered.edges[0], ZL_GRAPH_FIELD_LZ));
             clusteredOutIdx = 1;
         }
 
         // The second edge goes to the custom successor
-        ZL_RET_R_IF_ERR(ZL_Edge_setDestination(
+        ZL_ERR_IF_ERR(ZL_Edge_setDestination(
                 clustered.edges[clusteredOutIdx], successor));
     }
     return ZL_returnSuccess();
@@ -548,7 +548,7 @@ static ZL_Report setClusterInfosUnconfigured_byTag(
         ZL_TRY_LET_T(Tag, tag, getTagForEdge(inputs[i]));
         TagToClusterMap_Insert status = TagToClusterMap_insertVal(
                 tagToClusterMap, (TagToClusterMap_Entry){ tag, nbClusters });
-        ZL_RET_R_IF(allocation, status.badAlloc);
+        ZL_ERR_IF(status.badAlloc, allocation);
 
         size_t idx = status.ptr->val;
         // Skip if configured cluster
@@ -602,10 +602,10 @@ static ZL_Report setClusterInfosConfigured(
             Tag tag = { .tag = cluster.memberTags[j], .typeWidth = typeWidth };
             TagToClusterMap_Insert status = TagToClusterMap_insertVal(
                     tagToCluster, (TagToClusterMap_Entry){ tag, i });
-            ZL_RET_R_IF(allocation, status.badAlloc);
+            ZL_ERR_IF(status.badAlloc, allocation);
             // Checks that for clusters of the same type, a tag does not appear
             // twice
-            ZL_RET_R_IF(node_invalid_input, !status.inserted);
+            ZL_ERR_IF(!status.inserted, node_invalid_input);
         }
         clusterInfos[i].nbEdges = 0;
         ZL_ERR_IF_GE(
@@ -661,7 +661,7 @@ static ZL_Report graph_compressClusteredImpl(
     ZL_RESULT_DECLARE_SCOPE_REPORT(graph);
     ZL_GraphIDList succList            = ZL_Graph_getCustomGraphs(graph);
     ZL_NodeIDList clusteringCodecsList = ZL_Graph_getCustomNodes(graph);
-    ZL_RET_R_IF_ERR(validateClusteredConfig(graph, config, &succList));
+    ZL_ERR_IF_ERR(validateClusteredConfig(graph, config, &succList));
 
     // Initialize cluster infos
     size_t maxNbClusters      = nbInputs + config->nbClusters;
@@ -689,9 +689,9 @@ static ZL_Report graph_compressClusteredImpl(
         TypeToSuccessorMap_Insert status = TypeToSuccessorMap_insertVal(
                 defaultSuccessors,
                 (TypeToSuccessorMap_Entry){ typeWidth, *typeSuccesor });
-        ZL_RET_R_IF(allocation, status.badAlloc);
+        ZL_ERR_IF(status.badAlloc, allocation);
         // Checks that there are no duplicates among type defualts
-        ZL_RET_R_IF(node_invalid_input, !status.inserted);
+        ZL_ERR_IF(!status.inserted, node_invalid_input);
     }
 
     // Cluster unconfigured inputs and update nbClusters
@@ -711,7 +711,7 @@ static ZL_Report graph_compressClusteredImpl(
     // Group edges present by cluster
     ZL_Edge*** clusteredEdges =
             ZL_Graph_getScratchSpace(graph, nbClusters * sizeof(ZL_Edge**));
-    ZL_RET_R_IF_NULL(allocation, clusteredEdges);
+    ZL_ERR_IF_NULL(clusteredEdges, allocation);
     size_t* clusterSizes =
             ZL_Graph_getScratchSpace(graph, nbClusters * sizeof(size_t));
     memset(clusterSizes, 0, nbClusters * sizeof(size_t));
@@ -719,7 +719,7 @@ static ZL_Report graph_compressClusteredImpl(
     for (size_t i = 0; i < nbClusters; i++) {
         clusteredEdges[i] = ZL_Graph_getScratchSpace(
                 graph, clusterInfos[i].nbEdges * sizeof(ZL_Edge*));
-        ZL_RET_R_IF_NULL(allocation, clusteredEdges[i]);
+        ZL_ERR_IF_NULL(clusteredEdges[i], allocation);
     }
 
     // Group edges by cluster
@@ -727,14 +727,14 @@ static ZL_Report graph_compressClusteredImpl(
         ZL_TRY_LET_T(Tag, tag, getTagForEdge(inputs[i]));
         const TagToClusterMap_Entry* entry =
                 TagToClusterMap_findVal(tagToClusterIdxMap, tag);
-        ZL_RET_R_IF_NULL(GENERIC, entry);
+        ZL_ERR_IF_NULL(entry, GENERIC);
         size_t idx = entry->val;
-        ZL_RET_R_IF_GT(GENERIC, clusterSizes[idx], clusterInfos[idx].nbEdges);
+        ZL_ERR_IF_GT(clusterSizes[idx], clusterInfos[idx].nbEdges, GENERIC);
         clusteredEdges[idx][clusterSizes[idx]++] = inputs[i];
     }
 
     // Send clustered edges to their successors
-    ZL_RET_R_IF_ERR(sendClustersToSuccessors(
+    ZL_ERR_IF_ERR(sendClustersToSuccessors(
             ZL_ERR_CTX_PTR, clusteredEdges, clusterInfos, nbClusters));
     return ZL_returnSuccess();
 }

--- a/src/openzl/compress/selectors/ml/ml_selector_graph.c
+++ b/src/openzl/compress/selectors/ml/ml_selector_graph.c
@@ -143,9 +143,9 @@ static ZL_Report GBTModel_serializeTree(
         A1C_MAP_TRY_ADD_R(pair, treeMapBuilder);
         A1C_Item_string_refCStr(&pair->key, "nodes");
         A1C_Item* nodes = A1C_Item_array(&pair->val, tree->numNodes, a1cArena);
-        ZL_RET_R_IF_NULL(allocation, nodes);
+        ZL_ERR_IF_NULL(nodes, allocation);
         for (size_t i = 0; i < tree->numNodes; i++) {
-            ZL_RET_R_IF_ERR(GBTModel_serializeNode(
+            ZL_ERR_IF_ERR(GBTModel_serializeNode(
                     errCtx, &nodes[i], a1cArena, &tree->nodes[i]));
         }
     }
@@ -170,9 +170,9 @@ static ZL_Report GBTModel_serializeForest(
         A1C_Item_string_refCStr(&pair->key, "trees");
         A1C_Item* trees =
                 A1C_Item_array(&pair->val, forest->numTrees, a1cArena);
-        ZL_RET_R_IF_NULL(allocation, trees);
+        ZL_ERR_IF_NULL(trees, allocation);
         for (size_t i = 0; i < forest->numTrees; i++) {
-            ZL_RET_R_IF_ERR(GBTModel_serializeTree(
+            ZL_ERR_IF_ERR(GBTModel_serializeTree(
                     errCtx, &trees[i], a1cArena, &forest->trees[i]));
         }
     }
@@ -198,9 +198,9 @@ static ZL_Report GBTModel_serializePredictor(
         A1C_Item_string_refCStr(&pair->key, "forests");
         A1C_Item* forests =
                 A1C_Item_array(&pair->val, predictor->numForests, a1cArena);
-        ZL_RET_R_IF_NULL(allocation, forests);
+        ZL_ERR_IF_NULL(forests, allocation);
         for (size_t i = 0; i < predictor->numForests; i++) {
-            ZL_RET_R_IF_ERR(GBTModel_serializeForest(
+            ZL_ERR_IF_ERR(GBTModel_serializeForest(
                     errCtx, &forests[i], a1cArena, &predictor->forests[i]));
         }
     }
@@ -227,19 +227,20 @@ static ZL_Report GBTModel_serialize(
         A1C_Item* parent,
         A1C_Arena* a1cArena)
 {
+    ZL_RESULT_DECLARE_SCOPE_REPORT(errCtx);
     A1C_MapBuilder rootMapBuilder = A1C_Item_map_builder(parent, 6, a1cArena);
 
     // Serialize predictor
     {
         A1C_MAP_TRY_ADD_R(pair, rootMapBuilder);
         A1C_Item_string_refCStr(&pair->key, "predictor");
-        ZL_RET_R_IF_ERR(GBTModel_serializePredictor(
+        ZL_ERR_IF_ERR(GBTModel_serializePredictor(
                 errCtx, &pair->val, a1cArena, model->predictor));
     }
     // Serialize featureGenerator using enum
     {
         FeatureGenId fg = FeatureGen_getId(model->featureGenerator);
-        ZL_RET_R_IF_EQ(invalidName, fg, FeatureGenId_Invalid);
+        ZL_ERR_IF_EQ(fg, FeatureGenId_Invalid, invalidName);
 
         A1C_MAP_TRY_ADD_R(pair, rootMapBuilder);
         A1C_Item_string_refCStr(&pair->key, "featureGenerator");
@@ -266,7 +267,7 @@ static ZL_Report GBTModel_serialize(
         A1C_Item_string_refCStr(&pair->key, "featureLabels");
         A1C_Item* labels =
                 A1C_Item_array(&pair->val, model->nbFeatures, a1cArena);
-        ZL_RET_R_IF_NULL(allocation, labels);
+        ZL_ERR_IF_NULL(labels, allocation);
         for (size_t i = 0; i < model->nbFeatures; i++) {
             A1C_Item_string_refCStr(&labels[i], model->featureLabels[i]);
         }

--- a/src/openzl/compress/selectors/selector_compress.c
+++ b/src/openzl/compress/selectors/selector_compress.c
@@ -12,9 +12,9 @@ ZL_Report
 MultiInputGraph_compress(ZL_Graph* gctx, ZL_Edge* inputs[], size_t nbInputs)
 {
     ZL_DLOG(SEQ, "MultiInputGraph_compress: %zu inputs", nbInputs);
-    (void)gctx;
+    ZL_RESULT_DECLARE_SCOPE_REPORT(gctx);
     for (size_t n = 0; n < nbInputs; n++) {
-        ZL_RET_R_IF_ERR(ZL_Edge_setDestination(inputs[n], ZL_GRAPH_COMPRESS1));
+        ZL_ERR_IF_ERR(ZL_Edge_setDestination(inputs[n], ZL_GRAPH_COMPRESS1));
     }
     return ZL_returnSuccess();
 }

--- a/src/openzl/compress/selectors/selector_store.c
+++ b/src/openzl/compress/selectors/selector_store.c
@@ -8,9 +8,9 @@
 ZL_Report
 MultiInputGraph_store(ZL_Graph* gctx, ZL_Edge* inputs[], size_t nbInputs)
 {
-    (void)gctx;
+    ZL_RESULT_DECLARE_SCOPE_REPORT(gctx);
     for (size_t n = 0; n < nbInputs; n++) {
-        ZL_RET_R_IF_ERR(ZL_Edge_setDestination(inputs[n], ZL_GRAPH_STORE1));
+        ZL_ERR_IF_ERR(ZL_Edge_setDestination(inputs[n], ZL_GRAPH_STORE1));
     }
     return ZL_returnSuccess();
 }

--- a/src/openzl/decompress/decompress2.c
+++ b/src/openzl/decompress/decompress2.c
@@ -130,6 +130,7 @@ ZL_DCtx* ZL_DCtx_create(void)
 
 ZL_Report ZL_DCtx_setStreamArena(ZL_DCtx* dctx, ZL_DataArenaType sat)
 {
+    ZL_RESULT_DECLARE_SCOPE_REPORT(dctx);
     ZL_ASSERT_NN(dctx);
     Arena* newArena = NULL;
     switch (sat) {
@@ -140,9 +141,9 @@ ZL_Report ZL_DCtx_setStreamArena(ZL_DCtx* dctx, ZL_DataArenaType sat)
             newArena = ALLOC_StackArena_create();
             break;
         default:
-            ZL_RET_R_IF(parameter_invalid, 1, "Stream Arena type is invalid");
+            ZL_ERR_IF(1, parameter_invalid, "Stream Arena type is invalid");
     }
-    ZL_RET_R_IF_NULL(allocation, newArena);
+    ZL_ERR_IF_NULL(newArena, allocation);
     ALLOC_Arena_freeArena(dctx->streamArena);
     dctx->streamArena = newArena;
     return ZL_returnSuccess();
@@ -243,9 +244,10 @@ ZL_Report ZL_DCtx_registerPipeDecoder(
         ZL_DCtx* dctx,
         const ZL_PipeDecoderDesc* ctd)
 {
+    ZL_RESULT_DECLARE_SCOPE_REPORT(dctx);
     ZL_ASSERT_NN(dctx);
     ZL_ASSERT_NN(ctd);
-    ZL_RET_R_IF_ERR(DTM_registerDPipeTransform(&dctx->dtm, ctd));
+    ZL_ERR_IF_ERR(DTM_registerDPipeTransform(&dctx->dtm, ctd));
     return ZL_returnSuccess();
 }
 
@@ -253,9 +255,10 @@ ZL_Report ZL_DCtx_registerSplitDecoder(
         ZL_DCtx* dctx,
         const ZL_SplitDecoderDesc* ctd)
 {
+    ZL_RESULT_DECLARE_SCOPE_REPORT(dctx);
     ZL_ASSERT_NN(dctx);
     ZL_ASSERT_NN(ctd);
-    ZL_RET_R_IF_ERR(DTM_registerDSplitTransform(&dctx->dtm, ctd));
+    ZL_ERR_IF_ERR(DTM_registerDSplitTransform(&dctx->dtm, ctd));
     return ZL_returnSuccess();
 }
 
@@ -263,10 +266,11 @@ ZL_Report ZL_DCtx_registerTypedDecoder(
         ZL_DCtx* dctx,
         const ZL_TypedDecoderDesc* dttd)
 {
+    ZL_RESULT_DECLARE_SCOPE_REPORT(dctx);
     ZL_ASSERT_NN(dctx);
     ZL_ASSERT_NN(dttd);
     // WARNING: Must not fail before this line otherwise opaque will be leaked
-    ZL_RET_R_IF_ERR(DTM_registerDTypedTransform(&dctx->dtm, dttd));
+    ZL_ERR_IF_ERR(DTM_registerDTypedTransform(&dctx->dtm, dttd));
     return ZL_returnSuccess();
 }
 
@@ -274,13 +278,14 @@ ZL_Report ZL_DCtx_registerVODecoder(
         ZL_DCtx* dctx,
         const ZL_VODecoderDesc* dvotd)
 {
+    ZL_RESULT_DECLARE_SCOPE_REPORT(dctx);
     ZL_DLOG(BLOCK,
             "ZL_DCtx_registerVODecoder '%s'",
             STR_REPLACE_NULL(dvotd->name));
     ZL_ASSERT_NN(dctx);
     ZL_ASSERT_NN(dvotd);
     // WARNING: Must not fail before this line otherwise opaque will be leaked
-    ZL_RET_R_IF_ERR(DTM_registerDVOTransform(&dctx->dtm, dvotd));
+    ZL_ERR_IF_ERR(DTM_registerDVOTransform(&dctx->dtm, dvotd));
     return ZL_returnSuccess();
 }
 
@@ -288,10 +293,11 @@ ZL_Report ZL_DCtx_registerMIDecoder(
         ZL_DCtx* dctx,
         const ZL_MIDecoderDesc* dmitd)
 {
+    ZL_RESULT_DECLARE_SCOPE_REPORT(dctx);
     ZL_ASSERT_NN(dctx);
     ZL_ASSERT_NN(dmitd);
     // WARNING: Must not fail before this line otherwise opaque will be leaked
-    ZL_RET_R_IF_ERR(DTM_registerDMITransform(&dctx->dtm, dmitd));
+    ZL_ERR_IF_ERR(DTM_registerDMITransform(&dctx->dtm, dmitd));
     return ZL_returnSuccess();
 }
 
@@ -320,6 +326,7 @@ static ZL_Report ZL_AppendToOutputOptimization_register(
         ZL_DataInfo* outputInfo,
         ZL_Data* outputData)
 {
+    ZL_RESULT_DECLARE_SCOPE_REPORT(dctx);
     if (dctx->preserveStreams) {
         // Does not work with stream preservation, so disable the optimization.
         return ZL_returnValue(0);
@@ -359,7 +366,7 @@ static ZL_Report ZL_AppendToOutputOptimization_register(
     }
     ZL_AppendToOutputOptimization* append = ALLOC_Arena_calloc(
             dctx->decompressArena, sizeof(ZL_AppendToOutputOptimization));
-    ZL_RET_R_IF_NULL(allocation, append);
+    ZL_ERR_IF_NULL(append, allocation);
     append->inputInfos   = inputInfos;
     append->nbInputs     = nbInputs;
     append->headInputIdx = 0;
@@ -369,7 +376,7 @@ static ZL_Report ZL_AppendToOutputOptimization_register(
     append->outputHeadPtr = outputPtr;
     append->outputTailPtr = outputPtr + outputCapacity;
 
-    ZL_RET_R_IF_ERR(STREAM_typeAttachedBuffer(
+    ZL_ERR_IF_ERR(STREAM_typeAttachedBuffer(
             outputData, ZL_Type_serial, 1, outputCapacity));
 
     // Everything succeeded, make stateful changes to infos
@@ -838,11 +845,12 @@ static ZL_Report decodeFrameHeader(
         size_t srcSize,
         size_t nbOutputs)
 {
+    ZL_RESULT_DECLARE_SCOPE_REPORT(dctx);
     ZL_DLOG(FRAME, "decodeFrameHeader (srcSize = %zu)", srcSize);
     ZL_TRY_LET_R(hSize, DFH_decodeFrameHeader(&dctx->dfh, src, srcSize));
 
     ZL_TRY_LET_R(nbOuts, ZL_FrameInfo_getNumOutputs(dctx->dfh.frameinfo));
-    ZL_RET_R_IF_NE(userBuffers_invalidNum, nbOuts, nbOutputs);
+    ZL_ERR_IF_NE(nbOuts, nbOutputs, userBuffers_invalidNum);
     dctx->nbOutputs = nbOutputs;
     return ZL_returnValue(hSize);
 }
@@ -1049,6 +1057,7 @@ static ZL_Report processStream(
         const DTransform* dt,
         const DFH_NodeInfo* nodeInfo)
 {
+    ZL_RESULT_DECLARE_SCOPE_REPORT(dctx);
     ZL_ASSERT_NN(dctx);
     const char* const trName = DT_getTransformName(dt);
     ZL_SCOPE_GRAPH_CONTEXT(
@@ -1061,20 +1070,20 @@ static ZL_Report processStream(
             trName,
             nodeInfo->trpid.trid);
     if (dctx->dfh.formatVersion < 9) {
-        ZL_RET_R_IF_EQ(
-                formatVersion_unsupported,
+        ZL_ERR_IF_EQ(
                 nbInStreams,
                 0,
+                formatVersion_unsupported,
                 "0 output streams not supported until format version 9");
     }
-    ZL_RET_R_IF_GT(
-            formatVersion_unsupported,
+    ZL_ERR_IF_GT(
             nbInStreams,
-            ZL_transformOutStreamsLimit(dctx->dfh.formatVersion));
+            ZL_transformOutStreamsLimit(dctx->dfh.formatVersion),
+            formatVersion_unsupported);
     // Validate that nb of regen streams is compatible
-    ZL_RET_R_IF_NOT(
-            nodeRegen_countIncorrect,
+    ZL_ERR_IF_NOT(
             DT_isNbRegensCompatible(dt, nodeInfo->nbRegens),
+            nodeRegen_countIncorrect,
             "Transform '%s'(%u) is assigned %u streams to regenerate, but its signature specifies %u streams",
             DT_getTransformName(dt),
             nodeInfo->trpid.trid,
@@ -1086,10 +1095,10 @@ static ZL_Report processStream(
     // to ensure that all non-variable transforms get the right number
     // of streams.
     if (dt->miGraphDesc.nbVOs == 0) {
-        ZL_RET_R_IF_NE(
-                corruption,
+        ZL_ERR_IF_NE(
                 nodeInfo->nbVOs,
                 0,
+                corruption,
                 "Transform id=%u isn't accepting VO streams, "
                 "but %zu VO streams are nonetheless assigned to it in this graph.",
                 dt->miGraphDesc.CTid,
@@ -1105,10 +1114,10 @@ static ZL_Report processStream(
     // Though they may not all be filled, so we have to check that.
     ZL_ASSERT_LE(streamID + nbInStreams, VECTOR_SIZE(dctx->dataInfos));
     // Check that output streams are not used as input streams
-    ZL_RET_R_IF_GT(
-            graph_invalid,
+    ZL_ERR_IF_GT(
             streamID + nbInStreams,
-            VECTOR_SIZE(dctx->dataInfos) - dctx->nbOutputs);
+            VECTOR_SIZE(dctx->dataInfos) - dctx->nbOutputs,
+            graph_invalid);
 
     if (nodeInfo->nbRegens == 1) {
         const size_t regenIdx =
@@ -1139,41 +1148,40 @@ static ZL_Report processStream(
     }
 
     // Collect inputs and validate types
-    ZL_RET_R_IF_NE(
-            allocation,
+    ZL_ERR_IF_NE(
             nbInStreams,
             VECTOR_RESIZE_UNINITIALIZED(
-                    dctx->transformInputStreams, nbInStreams));
+                    dctx->transformInputStreams, nbInStreams),
+            allocation);
     const ZL_Data** inputs = VECTOR_DATA(dctx->transformInputStreams);
     for (ZL_IDType n = 0; n < nbInStreams; n++) {
         ZL_IDType const snb = streamID + n;
         size_t const inb    = nbInStreams - 1 - n; // reverse order
         inputs[inb]         = VECTOR_AT(dctx->dataInfos, snb).data;
 
-        ZL_RET_R_IF_NULL(
-                graph_invalid, inputs[inb], "Input stream %u not filled!", inb);
+        ZL_ERR_IF_NULL(
+                inputs[inb], graph_invalid, "Input stream %u not filled!", inb);
 
         // Validate the input type is correct
         // (only for the compulsory output streams)
         if (inb < dt->miGraphDesc.nbSOs) {
             // Compulsory range
             if (ZL_Data_type(inputs[inb]) != dt->miGraphDesc.soTypes[inb]) {
-                ZL_RET_R_ERR(
-                        graph_invalid,
-                        "Error processing stream %u, transform %u: input stream %u has type %d, but we expected type %d",
-                        streamID,
-                        dt->miGraphDesc.CTid,
-                        (unsigned)inb,
-                        ZL_Data_type(inputs[inb]),
-                        dt->miGraphDesc.soTypes[inb]);
+                ZL_ERR(graph_invalid,
+                       "Error processing stream %u, transform %u: input stream %u has type %d, but we expected type %d",
+                       streamID,
+                       dt->miGraphDesc.CTid,
+                       (unsigned)inb,
+                       ZL_Data_type(inputs[inb]),
+                       dt->miGraphDesc.soTypes[inb]);
             }
         } else {
             // Validate that variable streams match one of the allowed types
             // in the graph description. We can't validate more than that,
             // the transform is responsible for everything else.
-            ZL_RET_R_IF_NOT(
-                    graph_invalid,
+            ZL_ERR_IF_NOT(
                     ZL_Data_type(inputs[inb]) & allowedVOTypes,
+                    graph_invalid,
                     "Error processing stream %u, transform %u: Variable input stream %u has type 0x%x, but we expected a type that matches the mask 0x%x",
                     streamID,
                     dt->miGraphDesc.CTid,
@@ -1193,7 +1201,7 @@ static ZL_Report processStream(
     // Determine regenerated streams slots (regensID)
     ZL_IDType* const regensID = ALLOC_Arena_malloc(
             dctx->workspaceArena, sizeof(ZL_IDType) * nodeInfo->nbRegens);
-    ZL_RET_R_IF_NULL(allocation, regensID);
+    ZL_ERR_IF_NULL(regensID, allocation);
     for (size_t n = 0; n < nodeInfo->nbRegens; n++) {
         regensID[n] = (ZL_IDType)(streamID + nbInStreams
                                   + nodeInfo->regenDistances[n]);
@@ -1201,9 +1209,9 @@ static ZL_Report processStream(
     // Check that regenerated streams slots are not already filled
     for (size_t n = 0; n < nodeInfo->nbRegens; n++) {
         ZL_Data* outStream = VECTOR_AT(dctx->dataInfos, regensID[n]).data;
-        ZL_RET_R_IF_NN(
-                graph_invalid,
+        ZL_ERR_IF_NN(
                 outStream,
+                graph_invalid,
                 "Regenerated stream slot already filled!");
     }
 
@@ -1222,9 +1230,9 @@ static ZL_Report processStream(
         .nbRegens       = nodeInfo->nbRegens,
         .thContent      = thContent,
     };
-    ZL_RET_R_IF_NULL(
-            logicError,
+    ZL_ERR_IF_NULL(
             diState.statePtr,
+            logicError,
             "Could not find state for transform %u",
             nodeInfo->trpid.trid);
 
@@ -1234,9 +1242,9 @@ static ZL_Report processStream(
     // Check transform's outcome
     for (size_t n = 0; n < nodeInfo->nbRegens; n++) {
         ZL_Data* outStream = VECTOR_AT(dctx->dataInfos, regensID[n]).data;
-        ZL_RET_R_IF_NULL(
-                transform_executionFailure,
+        ZL_ERR_IF_NULL(
                 outStream,
+                transform_executionFailure,
                 "Node didn't create expected regenerated stream!");
         ZL_ASSERT(
                 STREAM_isCommitted(outStream),
@@ -1265,6 +1273,7 @@ static ZL_Report processStream(
 
 static ZL_Report runDecoders(ZL_DCtx* dctx)
 {
+    ZL_RESULT_DECLARE_SCOPE_REPORT(dctx);
     ZL_DLOG(FRAME, "runDecoders (%zu stages)", dctx->dfh.nbDTransforms);
     ZL_ASSERT_NN(dctx);
     for (size_t stage = 0, startingStream = 0; stage < dctx->dfh.nbDTransforms;
@@ -1280,7 +1289,7 @@ static ZL_Report runDecoders(ZL_DCtx* dctx)
         ZL_RESULT_OF(DTrPtr)
         const transform =
                 DTM_getTransform(&dctx->dtm, trid, dctx->dfh.formatVersion);
-        ZL_RET_R_IF_ERR(transform);
+        ZL_ERR_IF_ERR(transform);
         DTrPtr const dt = ZL_RES_value(transform);
         ZL_TRY_LET_R(
                 nbps,
@@ -1294,6 +1303,7 @@ static ZL_Report runDecoders(ZL_DCtx* dctx)
 /* Only used for specific benchmark scenarios */
 ZL_Report DCTX_runTransformID(ZL_DCtx* dctx, ZL_IDType transformID)
 {
+    ZL_RESULT_DECLARE_SCOPE_REPORT(dctx);
     ZL_ASSERT(dctx->preserveStreams);
     size_t totalOutputBytes = 0;
     for (size_t stage = 0, startingStream = 0; stage < dctx->dfh.nbDTransforms;
@@ -1309,15 +1319,15 @@ ZL_Report DCTX_runTransformID(ZL_DCtx* dctx, ZL_IDType transformID)
         ZL_RESULT_OF(DTrPtr)
         const transform =
                 DTM_getTransform(&dctx->dtm, trid, dctx->dfh.formatVersion);
-        ZL_RET_R_IF_ERR(transform);
+        ZL_ERR_IF_ERR(transform);
         DTrPtr const dt = ZL_RES_value(transform);
         ZL_TRY_LET_R(
                 nbps, processStream(dctx, (ZL_IDType)startingStream, dt, node));
         startingStream += nbps;
-        ZL_RET_R_IF_NE(
-                node_versionMismatch,
+        ZL_ERR_IF_NE(
                 node->nbRegens,
                 1,
+                node_versionMismatch,
                 "This method only supports Transforms regenerating a single stream");
         ZL_IDType const outStreamID =
                 (ZL_IDType)(startingStream + node->regenDistances[0]);
@@ -1453,6 +1463,7 @@ static ZL_Report ZL_DCtx_decompressChunk(
         size_t frameSize,
         size_t alreadyConsumed)
 {
+    ZL_RESULT_DECLARE_SCOPE_REPORT(dctx);
     size_t consumedSize = alreadyConsumed;
     ZL_DLOG(BLOCK,
             "ZL_DCtx_decompressChunk (frameSize=%zu, consumedSize=%zu)",
@@ -1481,7 +1492,7 @@ static ZL_Report ZL_DCtx_decompressChunk(
     ZL_Report const chunkStreamsSize = fillStoredStreams(
             dctx, framePtr, frameSize, consumedSize, &isRegeneratedStream);
     VECTOR_DESTROY(isRegeneratedStream);
-    ZL_RET_R_IF_ERR(chunkStreamsSize);
+    ZL_ERR_IF_ERR(chunkStreamsSize);
     consumedSize += ZL_validResult(chunkStreamsSize);
 
     // If present, verify the compressed checksum before running decoders.
@@ -1490,14 +1501,14 @@ static ZL_Report ZL_DCtx_decompressChunk(
     uint32_t expectedContentHash = 0;
 
     if (FrameInfo_hasContentChecksum(dctx->dfh.frameinfo)) {
-        ZL_RET_R_IF_LT(srcSize_tooSmall, frameSize, consumedSize + 4);
+        ZL_ERR_IF_LT(frameSize, consumedSize + 4, srcSize_tooSmall);
         expectedContentHash = ZL_readCE32((const char*)framePtr + consumedSize);
         ZL_DLOG(SEQ, "stored contentHash: %08X", expectedContentHash);
         consumedSize += 4;
     }
 
     if (FrameInfo_hasCompressedChecksum(dctx->dfh.frameinfo)) {
-        ZL_RET_R_IF_LT(srcSize_tooSmall, frameSize, consumedSize + 4);
+        ZL_ERR_IF_LT(frameSize, consumedSize + 4, srcSize_tooSmall);
 #ifndef FUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION
         if (DCtx_getAppliedGParam(dctx, ZL_DParam_checkCompressedChecksum)
             == ZL_TernaryParam_enable) {
@@ -1521,10 +1532,10 @@ static ZL_Report ZL_DCtx_decompressChunk(
                     "actualCompressedHash:%08X vs %08X:expectedCompressedHash",
                     actualHash,
                     expectedHash);
-            ZL_RET_R_IF_NE(
-                    compressedChecksumWrong,
+            ZL_ERR_IF_NE(
                     actualHash,
                     expectedHash,
+                    compressedChecksumWrong,
                     "Compressed checksum mismatch! This indicates data corruption after compression!");
         }
 #endif
@@ -1532,12 +1543,12 @@ static ZL_Report ZL_DCtx_decompressChunk(
     }
 
     // start the decompression process.
-    ZL_RET_R_IF_ERR(runDecoders(dctx));
+    ZL_ERR_IF_ERR(runDecoders(dctx));
 
     // write result into user's buffer
     {
         ZL_TRY_LET_R(nbOuts, addChunksIntoFinalStreams(dctx));
-        ZL_RET_R_IF_NE(corruption, nbOuts, nbOutputs);
+        ZL_ERR_IF_NE(nbOuts, nbOutputs, corruption);
     }
 
     // verify block content checksum
@@ -1548,9 +1559,9 @@ static ZL_Report ZL_DCtx_decompressChunk(
         // Generate checksum based on actual output
         for (size_t n = 0; n < nbOutputs; n++) {
             if (ZL_Data_type(outputs[n]) == ZL_Type_numeric) {
-                ZL_RET_R_IF_NOT(
-                        temporaryLibraryLimitation,
+                ZL_ERR_IF_NOT(
                         ZL_isLittleEndian(),
+                        temporaryLibraryLimitation,
                         "Cannot calculate hash of numeric output on non little-endian platforms");
             }
         }
@@ -1569,10 +1580,10 @@ static ZL_Report ZL_DCtx_decompressChunk(
                 FrameInfo_hasCompressedChecksum(dctx->dfh.frameinfo)
                 ? "Content checksum mismatch! This indicates that the data was corrupted during compression or decompression, because the compressed checksum matched! This can be caused by a Zstrong bug, other ASAN bugs in the process, or faulty hardware."
                 : "Content checksum mismatch! This indicates that either data corruption after compression or that data was corrupted during compression or decompression!";
-        ZL_RET_R_IF_NE(
-                contentChecksumWrong,
+        ZL_ERR_IF_NE(
                 actualContentHash,
                 expectedContentHash,
+                contentChecksumWrong,
                 "%s",
                 errMsg);
 #else
@@ -1785,11 +1796,12 @@ ZL_Report ZL_DCtx_decompressTBuffer(
         const void* compressed,
         size_t cSize)
 {
+    ZL_RESULT_DECLARE_SCOPE_REPORT(dctx);
     ZL_DLOG(FRAME,
             "ZL_DCtx_decompressTBuffer: decompressing a Typed Buffer of capacity %zu",
             STREAM_byteCapacity(ZL_codemodOutputAsData(tbuffer)));
 
-    ZL_RET_R_IF_ERR(ZL_DCtx_decompressMultiTBuffer(
+    ZL_ERR_IF_ERR(ZL_DCtx_decompressMultiTBuffer(
             dctx, &tbuffer, 1, compressed, cSize));
 
     return ZL_returnValue(ZL_TypedBuffer_byteSize(tbuffer));
@@ -1803,9 +1815,10 @@ ZL_Report ZL_DCtx_decompressTyped(
         const void* compressed,
         size_t cSize)
 {
+    ZL_RESULT_DECLARE_SCOPE_REPORT(dctx);
     ZL_DLOG(FRAME, "ZL_DCtx_decompressTyped");
     ZL_TypedBuffer* const tbuffer = ZL_TypedBuffer_create();
-    ZL_RET_R_IF_NULL(allocation, tbuffer);
+    ZL_ERR_IF_NULL(tbuffer, allocation);
 
     ZL_Report const tbir = STREAM_attachRawBuffer(
             ZL_codemodOutputAsData(tbuffer), dst, dstByteCapacity);
@@ -1845,6 +1858,7 @@ ZL_Report ZL_DCtx_decompress(
         const void* const cSrc,
         const size_t cSize)
 {
+    ZL_RESULT_DECLARE_SCOPE_REPORT(dctx);
     ZL_DLOG(FRAME,
             "ZL_DCtx_decompress (cSrc=%zu, dstCapacity=%zu)",
             cSize,
@@ -1855,10 +1869,10 @@ ZL_Report ZL_DCtx_decompress(
     ZL_Report const r     = ZL_DCtx_decompressTyped(
             dctx, &outInfo, dst, dstCapacity, cSrc, cSize);
     if (!ZL_isError(r)) {
-        ZL_RET_R_IF_NE(
-                GENERIC,
+        ZL_ERR_IF_NE(
                 outInfo.type,
                 ZL_Type_serial,
+                GENERIC,
                 "ZL_DCtx_decompress is only compatible with serialized output");
     }
     return r;

--- a/src/openzl/decompress/dtransforms.c
+++ b/src/openzl/decompress/dtransforms.c
@@ -197,6 +197,7 @@ static ZL_Report pipeTransformWrapper(
         const ZL_Data* ins[],
         size_t nbIns)
 {
+    ZL_RESULT_DECLARE_SCOPE_REPORT(dictx);
     ZL_ASSERT_NN(ins);
     ZL_ASSERT_EQ(nbIns, 1);
     (void)nbIns;
@@ -210,20 +211,20 @@ static ZL_Report pipeTransformWrapper(
     }
 
     ZL_Output* const out = ZL_Decoder_create1OutStream(dictx, dstCapacity, 1);
-    ZL_RET_R_IF_NULL(allocation, out);
+    ZL_ERR_IF_NULL(out, allocation);
 
     void* const dst = ZL_Output_ptr(out);
     size_t const dstSize =
             transform->implDesc.dpt.transform_f(dst, dstCapacity, src, srcSize);
 
-    ZL_RET_R_IF_GT(
-            transform_executionFailure,
+    ZL_ERR_IF_GT(
             dstSize,
             dstCapacity,
+            transform_executionFailure,
             "transform %s failed",
             DT_getTransformName(transform));
 
-    ZL_RET_R_IF_ERR(ZL_Output_commit(out, dstSize));
+    ZL_ERR_IF_ERR(ZL_Output_commit(out, dstSize));
 
     return ZL_returnValue(1);
 }
@@ -264,6 +265,7 @@ static ZL_Report splitTransformWrapper(
         ZL_Data const* ins[],
         size_t nbIns)
 {
+    ZL_RESULT_DECLARE_SCOPE_REPORT(dictx);
     size_t const nbInputStreams = transform->miGraphDesc.nbSOs;
     ZL_ASSERT_EQ(nbIns, nbInputStreams);
     (void)nbIns;
@@ -271,10 +273,10 @@ static ZL_Report splitTransformWrapper(
     VECTOR(ZL_RBuffer)
     srcs = VECTOR_EMPTY(
             ZL_transformOutStreamsLimit(DI_getFrameFormatVersion(dictx)));
-    ZL_RET_R_IF_LT(
-            allocation,
+    ZL_ERR_IF_LT(
             VECTOR_RESERVE(srcs, nbInputStreams),
             nbInputStreams,
+            allocation,
             "splitTransformWrapper: Failed reserving vector");
     for (size_t i = 0; i < nbInputStreams; ++i) {
         ZL_ASSERT_EQ(ZL_Data_type(ins[i]), ZL_Type_serial);
@@ -291,7 +293,7 @@ static ZL_Report splitTransformWrapper(
     ZL_Output* const out = ZL_Decoder_create1OutStream(dictx, dstCapacity, 1);
     if (out == NULL) {
         VECTOR_DESTROY(srcs);
-        ZL_RET_R_ERR(allocation);
+        ZL_ERR(allocation);
     }
     ZL_WBuffer dst = { .start = ZL_Output_ptr(out), .capacity = dstCapacity };
     size_t const dstSize =
@@ -299,14 +301,14 @@ static ZL_Report splitTransformWrapper(
 
     VECTOR_DESTROY(srcs);
 
-    ZL_RET_R_IF_GT(
-            transform_executionFailure,
+    ZL_ERR_IF_GT(
             dstSize,
             dstCapacity,
+            transform_executionFailure,
             "transform %s failed",
             DT_getTransformName(transform));
 
-    ZL_RET_R_IF_ERR(ZL_Output_commit(out, dstSize));
+    ZL_ERR_IF_ERR(ZL_Output_commit(out, dstSize));
 
     return ZL_returnValue(1);
 }


### PR DESCRIPTION
Summary:
Migrate old-style `ZL_RET_R_*` error-handling macros to the new `ZL_ERR_*` macros across 15 files in the compress subsystem: cctx.c, cgraph.c, cgraph_validation.c, compress2.c, compressor_serialization.c, dyngraph_interface.c, enc_interface.c, graph_registry.c, graphmgr.c, graphs/generic_clustering_graph.c, graphs/sddl/simple_data_description_language.c, selectors/ml/gbt.c, selectors/ml/ml_selector_graph.c, selectors/selector_compress.c, and selectors/selector_store.c.

The new `ZL_ERR_*` macros require an explicit `ZL_RESULT_DECLARE_SCOPE_REPORT(ctx)` declaration at the top of each function, which provides proper error context for rich error reporting. The old `ZL_RET_R_*` macros used "magic" auto-context detection via `_Generic`, which doesn't always work correctly.

**Migration pattern:**
- Add `ZL_RESULT_DECLARE_SCOPE_REPORT(ctx)` at the top of each migrated function
- Replace `ZL_RET_R_IF(errcode, expr, ...)` → `ZL_ERR_IF(expr, errcode, ...)`
- Replace `ZL_RET_R_IF_ERR(expr)` → `ZL_ERR_IF_ERR(expr)`
- Replace `ZL_RET_R_ERR(errcode)` → `ZL_ERR(errcode)`

Only functions with real (non-NULL, non-const) error context (cctx, gctx, compressor, etc.) are migrated.

Differential Revision: D94903778
