### PR TITLE
Migrate ZL_RET_R_* to ZL_ERR_* in test files

### DIFF
--- a/cpp/tests/TestDCtx.cpp
+++ b/cpp/tests/TestDCtx.cpp
@@ -155,9 +155,10 @@ TEST_F(TestDCtx, decoderFailureHasCodecName)
                 .nbSOs = 1,
             },
             .transform_f = [](ZL_Encoder* encoder, const ZL_Input** inputs, size_t numInputs) noexcept -> ZL_Report {
+                ZL_RESULT_DECLARE_SCOPE_REPORT(encoder);
                 auto input = inputs[0];
                 auto output = ZL_Encoder_createTypedStream(encoder, 0, ZL_Input_numElts(input), ZL_Input_eltWidth(input));
-                ZL_RET_R_IF_NULL(allocation, output);
+                ZL_ERR_IF_NULL(output, allocation);
                 memcpy(ZL_Output_ptr(output), ZL_Input_ptr(input), ZL_Input_contentSize(input));
                 return ZL_Output_commit(output, ZL_Input_numElts(input));
             },

--- a/custom_transforms/thrift/tests/test_prob_selector_fixture.cpp
+++ b/custom_transforms/thrift/tests/test_prob_selector_fixture.cpp
@@ -18,12 +18,13 @@ ZL_Report ProbSelectorTest::compress(
         size_t srcSize,
         ZL_GraphID graphid)
 {
+    ZL_RESULT_DECLARE_SCOPE_REPORT(cgraph);
     ZL_CCtx* const cctx = ZL_CCtx_create();
 
-    ZL_RET_R_IF_ERR(ZL_Compressor_setParameter(
+    ZL_ERR_IF_ERR(ZL_Compressor_setParameter(
             cgraph, ZL_CParam_formatVersion, ZL_MAX_FORMAT_VERSION));
-    ZL_RET_R_IF_ERR(ZL_Compressor_selectStartingGraphID(cgraph, graphid));
-    ZL_RET_R_IF_ERR(ZL_CCtx_refCompressor(cctx, cgraph));
+    ZL_ERR_IF_ERR(ZL_Compressor_selectStartingGraphID(cgraph, graphid));
+    ZL_ERR_IF_ERR(ZL_CCtx_refCompressor(cctx, cgraph));
 
     ZL_Report result =
             ZL_CCtx_compress(cctx, dstBuff, dstCapacity, src, srcSize);

--- a/tools/py/zstrong_json_pybind.cpp
+++ b/tools/py/zstrong_json_pybind.cpp
@@ -63,6 +63,7 @@ ZL_Report fillFromObject(
         ZL_Type streamType,
         py::handle const& handle)
 {
+    ZL_RESULT_DECLARE_SCOPE_REPORT(nullptr);
     try {
         if (streamType == ZL_Type_string) {
             auto const list   = handle.cast<py::list>();
@@ -70,7 +71,7 @@ ZL_Report fillFromObject(
                     list, streamType, [idx, createStream](size_t contentSize) {
                         return createStream(idx, contentSize, 1);
                     });
-            ZL_RET_R_IF_NULL(allocation, stream);
+            ZL_ERR_IF_NULL(stream, allocation);
         } else {
             auto const buffer = handle.cast<py::buffer>();
             auto const info   = buffer.request();
@@ -80,21 +81,19 @@ ZL_Report fillFromObject(
                     [idx, createStream](size_t nbElts, size_t eltWidth) {
                         return createStream(idx, nbElts, eltWidth);
                     });
-            ZL_RET_R_IF_NULL(allocation, stream);
+            ZL_ERR_IF_NULL(stream, allocation);
         }
         return ZL_returnSuccess();
     } catch (py::cast_error const& e) {
-        ZL_RET_R_ERR(
-                transform_executionFailure,
-                "Stream returned by python fn %d is not the right type: %s!",
-                idx,
-                e.what());
+        ZL_ERR(transform_executionFailure,
+               "Stream returned by python fn %d is not the right type: %s!",
+               idx,
+               e.what());
     } catch (std::exception const& e) {
-        ZL_RET_R_ERR(
-                transform_executionFailure,
-                "Unexpected error reading stream %d: %s",
-                idx,
-                e.what());
+        ZL_ERR(transform_executionFailure,
+               "Unexpected error reading stream %d: %s",
+               idx,
+               e.what());
     }
 }
 
@@ -547,17 +546,17 @@ class PyCustomTransformAdaptor : public CustomTransform {
             ZL_Input const* inputs[],
             size_t nbInputs) const override
     {
+        ZL_RESULT_DECLARE_SCOPE_REPORT(eictx);
         try {
             ZL_Report report;
             PyEncoderCtx ctx{ eictx, this, inputs, nbInputs, &report };
             transform().encode(ctx);
-            ZL_RET_R_IF_ERR(report);
+            ZL_ERR_IF_ERR(report);
             return ZL_returnValue(nbSuccessors());
         } catch (std::runtime_error const& err) {
-            ZL_RET_R_ERR(
-                    transform_executionFailure,
-                    "Exception thrown: %s",
-                    err.what());
+            ZL_ERR(transform_executionFailure,
+                   "Exception thrown: %s",
+                   err.what());
         }
     }
 
@@ -568,18 +567,18 @@ class PyCustomTransformAdaptor : public CustomTransform {
             ZL_Input const* voInputs[],
             size_t nbVoInputs) const override
     {
+        ZL_RESULT_DECLARE_SCOPE_REPORT(dictx);
         try {
             ZL_Report report;
             PyDecoderCtx ctx{ dictx,    this,       fixedInputs, nbFixedInputs,
                               voInputs, nbVoInputs, &report };
             transform().decode(ctx);
-            ZL_RET_R_IF_ERR(report);
+            ZL_ERR_IF_ERR(report);
             return ZL_returnValue(nbSuccessors());
         } catch (std::runtime_error const& err) {
-            ZL_RET_R_ERR(
-                    transform_executionFailure,
-                    "Exception thrown: %s",
-                    err.what());
+            ZL_ERR(transform_executionFailure,
+                   "Exception thrown: %s",
+                   err.what());
         }
     }
 

--- a/tools/tests/test_zstrong_json.cpp
+++ b/tools/tests/test_zstrong_json.cpp
@@ -117,8 +117,9 @@ class EveryOtherTransform : public CustomTransform {
             ZL_Input const* inputs[],
             size_t nbInputs) const override
     {
-        ZL_RET_R_IF_NE(node_invalid_input, nbInputs, 1);
-        ZL_RET_R_IF_NULL(node_invalid_input, inputs);
+        ZL_RESULT_DECLARE_SCOPE_REPORT(eictx);
+        ZL_ERR_IF_NE(nbInputs, 1, node_invalid_input);
+        ZL_ERR_IF_NULL(inputs, node_invalid_input);
         const auto* input   = inputs[0];
         size_t const nbElts = ZL_Input_numElts(input);
         ZL_Output* output0 =
@@ -137,14 +138,15 @@ class EveryOtherTransform : public CustomTransform {
             *out[i % 2]++ = in[i];
         }
 
-        ZL_RET_R_IF_ERR(ZL_Output_commit(output0, (nbElts + 1) / 2));
-        ZL_RET_R_IF_ERR(ZL_Output_commit(output1, nbElts / 2));
+        ZL_ERR_IF_ERR(ZL_Output_commit(output0, (nbElts + 1) / 2));
+        ZL_ERR_IF_ERR(ZL_Output_commit(output1, nbElts / 2));
 
         return ZL_returnValue(2);
     }
 
     ZL_Report decode(ZL_Decoder* dictx, ZL_Input const* inputs[]) const override
     {
+        ZL_RESULT_DECLARE_SCOPE_REPORT(dictx);
         size_t const nbElts0 = ZL_Input_numElts(inputs[0]);
         size_t const nbElts1 = ZL_Input_numElts(inputs[1]);
         uint8_t const* in0   = (uint8_t const*)ZL_Input_ptr(inputs[0]);
@@ -166,7 +168,7 @@ class EveryOtherTransform : public CustomTransform {
             out[i] = *ins[i % 2]++;
         }
 
-        ZL_RET_R_IF_ERR(ZL_Output_commit(output, nbElts));
+        ZL_ERR_IF_ERR(ZL_Output_commit(output, nbElts));
 
         return ZL_returnValue(1);
     }
@@ -208,8 +210,9 @@ class DelayedDecodeTransfom : public CustomTransform {
             ZL_Input const* inputs[],
             size_t nbInputs) const override
     {
-        ZL_RET_R_IF_NE(node_invalid_input, nbInputs, 1);
-        ZL_RET_R_IF_NULL(node_invalid_input, inputs);
+        ZL_RESULT_DECLARE_SCOPE_REPORT(eictx);
+        ZL_ERR_IF_NE(nbInputs, 1, node_invalid_input);
+        ZL_ERR_IF_NULL(inputs, node_invalid_input);
         const auto* input   = inputs[0];
         size_t const nbElts = ZL_Input_numElts(input);
         ZL_Output* output   = ZL_Encoder_createTypedStream(eictx, 0, nbElts, 1);
@@ -222,13 +225,14 @@ class DelayedDecodeTransfom : public CustomTransform {
         uint8_t* out      = (uint8_t*)ZL_Output_ptr(output);
         memcpy(out, in, nbElts);
 
-        ZL_RET_R_IF_ERR(ZL_Output_commit(output, nbElts));
+        ZL_ERR_IF_ERR(ZL_Output_commit(output, nbElts));
 
         return ZL_returnValue(1);
     }
 
     ZL_Report decode(ZL_Decoder* dictx, ZL_Input const* inputs[]) const override
     {
+        ZL_RESULT_DECLARE_SCOPE_REPORT(dictx);
         size_t const nbElts = ZL_Input_numElts(inputs[0]);
         uint8_t const* in   = (uint8_t const*)ZL_Input_ptr(inputs[0]);
 
@@ -240,7 +244,7 @@ class DelayedDecodeTransfom : public CustomTransform {
         uint8_t* out = (uint8_t*)ZL_Output_ptr(output);
         memcpy(out, in, nbElts);
 
-        ZL_RET_R_IF_ERR(ZL_Output_commit(output, nbElts));
+        ZL_ERR_IF_ERR(ZL_Output_commit(output, nbElts));
 
         std::this_thread::sleep_for(std::chrono::milliseconds(milliseconds_));
 

--- a/tools/zstrong_cpp.cpp
+++ b/tools/zstrong_cpp.cpp
@@ -1015,13 +1015,14 @@ ZL_Report CustomTransform::decode(
         ZL_Input const*[],
         size_t nbVO) const
 {
+    ZL_RESULT_DECLARE_SCOPE_REPORT(dictx);
     assert(nbFixed == nbFixedSuccessors());
     (void)nbFixed;
     if (nbVariableSuccessors() == 0) {
-        ZL_RET_R_IF_NE(node_invalid_input, nbVO, 0);
+        ZL_ERR_IF_NE(nbVO, 0, node_invalid_input);
         return this->decode(dictx, fixedInputs);
     }
-    ZL_RET_R_ERR(logicError);
+    ZL_ERR(logicError);
 }
 
 ZL_GraphID CustomSelector::registerSelector(


### PR DESCRIPTION
Summary:
Migrate old-style `ZL_RET_R_*` error-handling macros to the new `ZL_ERR_*` macros

The new `ZL_ERR_*` macros require an explicit `ZL_RESULT_DECLARE_SCOPE_REPORT(ctx)` declaration at the top of each function, which provides proper error context for rich error reporting. The old `ZL_RET_R_*` macros used "magic" auto-context detection via `_Generic`, which doesn't always work correctly.

**Migration pattern:**
- Add `ZL_RESULT_DECLARE_SCOPE_REPORT(ctx)` at the top of each migrated function
- Replace `ZL_RET_R_IF(errcode, expr, ...)` → `ZL_ERR_IF(expr, errcode, ...)`
- Replace `ZL_RET_R_IF_ERR(expr)` → `ZL_ERR_IF_ERR(expr)`
- Replace `ZL_RET_R_ERR(errcode)` → `ZL_ERR(errcode)`

Only functions with real (non-NULL, non-const) error context are migrated.

Differential Revision: D94903780
