### PR TITLE
Migrate ZL_RET_R_* to ZL_ERR_* in src/openzl/common/

### DIFF
--- a/src/openzl/common/allocation.h
+++ b/src/openzl/common/allocation.h
@@ -106,7 +106,7 @@ Arena* ALLOC_HeapArena_create(void);
  * When there is not enough room in the Primary Buffer,
  * StackArena employs a HeapArena as backup,
  * and since it's not possible to safely increase Primary Buffer's size without
- * modifying pointer adresses.
+ * modifying pointer addresses.
  * Then, at next session (a session ends with an invocation to
  * ALLOC_Arena_freeAll()), the Primary Buffer is speculatively resized based on
  * previous session's needs.
@@ -143,40 +143,40 @@ size_t ALLOC_Arena_memUsed(const Arena* arena);
 /* =============================== */
 
 // Note: these macros require including the error header.
-// They only work if the host function returns a ZL_Report.
-#define ALLOC_CHECKED(_type, _var, _mallocf, _count)                     \
-    _type* _var;                                                         \
-    {                                                                    \
-        size_t _allocSize;                                               \
-        ZL_RET_R_IF(                                                     \
-                allocation,                                              \
-                ZL_overflowMulST(sizeof(_type), (_count), &_allocSize)); \
-        _var = (_mallocf)(_allocSize);                                   \
-    }                                                                    \
-    ZL_RET_R_IF_NULL(                                                    \
-            allocation,                                                  \
-            _var,                                                        \
-            "cannot allocate buffer of %zu bytes using %s",              \
-            (_count) * sizeof(_type),                                    \
+// They only work if the host function has declared ZL_RESULT_DECLARE_SCOPE.
+#define ALLOC_CHECKED(_type, _var, _mallocf, _count)                    \
+    _type* _var;                                                        \
+    {                                                                   \
+        size_t _allocSize;                                              \
+        ZL_ERR_IF(                                                      \
+                ZL_overflowMulST(sizeof(_type), (_count), &_allocSize), \
+                allocation);                                            \
+        _var = (_mallocf)(_allocSize);                                  \
+    }                                                                   \
+    ZL_ERR_IF_NULL(                                                     \
+            _var,                                                       \
+            allocation,                                                 \
+            "cannot allocate buffer of %zu bytes using %s",             \
+            (_count) * sizeof(_type),                                   \
             #_mallocf)
 
 #define ALLOC_MALLOC_CHECKED(_type, _var, _count) \
     ALLOC_CHECKED(_type, _var, ZL_malloc, _count)
 
-#define ALLOC_ARENA_CHECKED(_type, _var, _mallocf, _count, _arena)       \
-    _type* _var;                                                         \
-    {                                                                    \
-        size_t _allocSize;                                               \
-        ZL_RET_R_IF(                                                     \
-                allocation,                                              \
-                ZL_overflowMulST(sizeof(_type), (_count), &_allocSize)); \
-        _var = (_mallocf)(_arena, _allocSize);                           \
-    }                                                                    \
-    ZL_RET_R_IF_NULL(                                                    \
-            allocation,                                                  \
-            _var,                                                        \
-            "cannot allocate buffer of %zu bytes using %s",              \
-            (_count) * sizeof(_type),                                    \
+#define ALLOC_ARENA_CHECKED(_type, _var, _mallocf, _count, _arena)      \
+    _type* _var;                                                        \
+    {                                                                   \
+        size_t _allocSize;                                              \
+        ZL_ERR_IF(                                                      \
+                ZL_overflowMulST(sizeof(_type), (_count), &_allocSize), \
+                allocation);                                            \
+        _var = (_mallocf)(_arena, _allocSize);                          \
+    }                                                                   \
+    ZL_ERR_IF_NULL(                                                     \
+            _var,                                                       \
+            allocation,                                                 \
+            "cannot allocate buffer of %zu bytes using %s",             \
+            (_count) * sizeof(_type),                                   \
             #_arena)
 
 #define ALLOC_ARENA_MALLOC_CHECKED(_type, _var, _count, _arena) \
@@ -184,29 +184,6 @@ size_t ALLOC_Arena_memUsed(const Arena* arena);
 
 #define ALLOC_ARENA_CALLOC_CHECKED(_type, _var, _count, _arena) \
     ALLOC_ARENA_CHECKED(_type, _var, ALLOC_Arena_calloc, _count, _arena)
-
-#define ALLOC_ARENA_CHECKED_T(                                           \
-        _type, _var, _mallocf, _count, _arena, _errorType)               \
-    _type* _var;                                                         \
-    {                                                                    \
-        size_t _allocSize;                                               \
-        ZL_RET_T_IF(                                                     \
-                _errorType,                                              \
-                allocation,                                              \
-                ZL_overflowMulST(sizeof(_type), (_count), &_allocSize)); \
-        _var = (_mallocf)(_arena, _allocSize);                           \
-    }                                                                    \
-    ZL_RET_T_IF_NULL(                                                    \
-            _errorType,                                                  \
-            allocation,                                                  \
-            _var,                                                        \
-            "cannot allocate buffer of %zu bytes using %s",              \
-            (_count) * sizeof(_type),                                    \
-            #_arena)
-
-#define ALLOC_ARENA_MALLOC_CHECKED_T(_type, _var, _count, _arena, _errorType) \
-    ALLOC_ARENA_CHECKED_T(                                                    \
-            _type, _var, ALLOC_Arena_malloc, _count, _arena, _errorType)
 
 ZL_END_C_DECLS
 

--- a/src/openzl/compress/dyngraph_interface.c
+++ b/src/openzl/compress/dyngraph_interface.c
@@ -155,13 +155,14 @@ ZL_Edge_runMultiInputNode_withParams(
     ZL_ASSERT_GE(nbInputs, 1);
     ZL_ASSERT_NN(inputCtxs);
     ZL_ASSERT_NN(inputCtxs[0]);
+    ZL_RESULT_DECLARE_SCOPE(ZL_EdgeList, inputCtxs[0]);
     ZL_Graph* const gctx = inputCtxs[0]->gctx;
     ZL_ASSERT_NN(gctx);
     Arena* const allocator = gctx->graphArena;
     ZL_ASSERT_NN(allocator);
 
 #define ALLOC_ARRAY(type, name, nb) \
-    ALLOC_ARENA_MALLOC_CHECKED_T(type, name, nb, allocator, ZL_EdgeList)
+    ALLOC_ARENA_MALLOC_CHECKED(type, name, nb, allocator)
 
     // Check input doesn't already have a set successor
     ALLOC_ARRAY(DG_StreamCtx*, inDGSCtxs, nbInputs);
@@ -274,6 +275,7 @@ static ZL_Report ZL_transferRuntimeGraphParams_stage2(
         Arena* arena,
         ZL_RuntimeGraphParameters* rgp)
 {
+    ZL_RESULT_DECLARE_SCOPE_REPORT(NULL); // T258630070
     ZL_ASSERT_NN(arena);
     ZL_ASSERT_NN(rgp);
     if (rgp->localParams) {

--- a/src/openzl/compress/rtgraphs.c
+++ b/src/openzl/compress/rtgraphs.c
@@ -91,18 +91,15 @@ RTGM_createNode(
         const RTStreamID* inRtsids,
         size_t nbInRtsids)
 {
+    ZL_RESULT_DECLARE_SCOPE(RTNodeID, NULL); // T258630070
     ZL_DLOG(SEQ, "RTGM_createNode (cnode: %s)", CNODE_getName(cnode));
     ZL_ASSERT_NN(rtgraph);
     size_t const nbOutSingletons = CNODE_getNbOut1s(cnode);
 
     // Assign new RTnode
     size_t const rtsids_byteSize = sizeof(RTStreamID) * nbInRtsids;
-    ALLOC_ARENA_MALLOC_CHECKED_T(
-            RTStreamID,
-            rtsids_stored,
-            nbInRtsids,
-            rtgraph->rtsidsArena,
-            RTNodeID);
+    ALLOC_ARENA_MALLOC_CHECKED(
+            RTStreamID, rtsids_stored, nbInRtsids, rtgraph->rtsidsArena);
     ZL_memcpy(rtsids_stored, inRtsids, rtsids_byteSize);
     RTNode node = {
         .cnode          = cnode,

--- a/src/openzl/compress/selector.c
+++ b/src/openzl/compress/selector.c
@@ -66,6 +66,7 @@ ZL_Report ZL_Selector_setSuccessorParams(
         const ZL_Selector* selCtx,
         const ZL_LocalParams* lparams)
 {
+    ZL_RESULT_DECLARE_SCOPE_REPORT(selCtx->cctx);
     if (lparams) {
         ALLOC_ARENA_MALLOC_CHECKED(
                 ZL_LocalParams, lparamsCopy, 1, selCtx->wkspArena);

--- a/src/openzl/decompress/decode_frameheader.c
+++ b/src/openzl/decompress/decode_frameheader.c
@@ -269,6 +269,7 @@ static ZL_Report DFH_FrameInfo_decodeFrameHeader(
         const void* cSrc,
         size_t cSize)
 {
+    ZL_RESULT_DECLARE_SCOPE_REPORT(NULL); // T258630070
     ZL_DLOG(BLOCK, "*****   DFH_FrameInfo_decodeFrameHeader   ***** \n");
     memset(zfi, 0, sizeof(*zfi));
     ZL_TRY_LET_R(formatVersion, ZL_getFormatVersionFromFrame(cSrc, cSize));

--- a/src/openzl/decompress/dtransforms.c
+++ b/src/openzl/decompress/dtransforms.c
@@ -60,6 +60,7 @@ static ZL_Report DTM_storeTransformName(
         DTransforms_manager* dtm,
         const char** namePtr)
 {
+    ZL_RESULT_DECLARE_SCOPE_REPORT(NULL); // T258630070
     const char* name = *namePtr;
     if (name != NULL) {
         const size_t len = strlen(name) + 1;

--- a/src/openzl/decompress/reflection.c
+++ b/src/openzl/decompress/reflection.c
@@ -129,6 +129,7 @@ static ZL_Report fillStreamAndTransformInfo(
         ZL_ReflectionCtx* rctx,
         const char* src)
 {
+    ZL_RESULT_DECLARE_SCOPE_REPORT(rctx->dctx);
     DFH_Struct const* dfh = DCtx_getFrameHeader(rctx->dctx);
     ZL_RET_R_IF_NULL(GENERIC, dfh);
     const size_t nbStreams    = ZL_DCtx_getNumStreams(rctx->dctx);
@@ -216,6 +217,7 @@ static ZL_Report fillExtraStreamInfo(
         ZL_ReflectionCtx* rctx,
         size_t nbInputStreams)
 {
+    ZL_RESULT_DECLARE_SCOPE_REPORT(rctx->dctx);
     const DFH_Struct* dfh        = DCtx_getFrameHeader(rctx->dctx);
     const size_t nbStoredStreams = dfh->nbStoredStreams;
 
@@ -277,6 +279,7 @@ static ZL_Report ZL_ReflectionCtx_setCompressedFrame_impl(
         const void* src,
         size_t srcSize)
 {
+    ZL_RESULT_DECLARE_SCOPE_REPORT(rctx->dctx);
     // Create the output stream storage in our arena.
     // We reference these streams, so they must live for the lifetime of the
     // ZL_ReflectionCtx.


### PR DESCRIPTION
Summary:
Migrate old-style `ZL_RET_R_*` error-handling macros to the new `ZL_ERR_*` macros in `src/openzl/common/allocation.h`.

This file also includes a typo fix and an error message improvement in the allocation helpers.

**Migration pattern:**
- Add `ZL_RESULT_DECLARE_SCOPE_REPORT(ctx)` at the top of each migrated function
- Replace `ZL_RET_R_IF(errcode, expr, ...)` → `ZL_ERR_IF(expr, errcode, ...)`
- Replace `ZL_RET_R_IF_ERR(expr)` → `ZL_ERR_IF_ERR(expr)`
- Replace `ZL_RET_R_ERR(errcode)` → `ZL_ERR(errcode)`

Only functions with real (non-NULL, non-const) error context are migrated.

Differential Revision: D94903771
