### PR TITLE
Add dead-var pass to optimizer

### DIFF
--- a/tools/sddl2/compiler/optimizer/DeadVarPass.cpp
+++ b/tools/sddl2/compiler/optimizer/DeadVarPass.cpp
@@ -1,0 +1,166 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#include <unordered_map>
+
+#include "tools/sddl2/compiler/optimizer/DeadVarPass.h"
+#include "tools/sddl2/compiler/parser/AST.h"
+
+namespace openzl::sddl2 {
+namespace {
+
+class DeadVarImpl {
+   public:
+    ASTVec optimize(const ASTVec& ast)
+    {
+        // Phase 1: collect all variable reads and record the last reference to
+        // a variable
+        for (const auto& node : ast) {
+            recordLastRefs(node);
+        }
+
+        // Phase 2: optimize the AST
+        ASTVec result;
+        result.reserve(ast.size());
+        for (const auto& node : ast) {
+            // It's possible that the node is optimized away.
+            auto optimized = optimizeNode(node);
+            if (optimized) {
+                result.push_back(optimized);
+            }
+        }
+        return result;
+    }
+
+   private:
+    void recordLastRefs(const ASTPtr& node)
+    {
+        switch (node->converted_node_type()) {
+            case ConvertedNodeType::NUM:
+            case ConvertedNodeType::BUILTIN_FIELD:
+                return;
+            case ConvertedNodeType::VAR: {
+                auto var               = node->as_var();
+                last_ref_[var->name()] = var;
+                return;
+            }
+            case ConvertedNodeType::BYTES: {
+                recordLastRefs(node->as_bytes()->len());
+                return;
+            }
+            case ConvertedNodeType::ARRAY: {
+                recordLastRefs(node->as_array()->field());
+                if (node->as_array()->len()) {
+                    recordLastRefs(node->as_array()->len());
+                }
+                return;
+            }
+            case ConvertedNodeType::RECORD: {
+                for (const auto& field : node->as_record()->fields()) {
+                    recordLastRefs(field);
+                }
+                return;
+            }
+            case ConvertedNodeType::OP: {
+                const auto& op = *node->as_op();
+                for (size_t i = 0; i < op.args().size(); ++i) {
+                    if ((op.op() == Op::ASSIGN || op.op() == Op::ASSUME)
+                        && i == 0) {
+                        continue;
+                    }
+                    recordLastRefs(op.args()[i]);
+                }
+                return;
+            }
+        }
+    }
+
+    ASTPtr optimizeNode(const ASTPtr& node)
+    {
+        switch (node->converted_node_type()) {
+            case ConvertedNodeType::NUM:
+            case ConvertedNodeType::BUILTIN_FIELD:
+            case ConvertedNodeType::RECORD:
+                return node;
+            case ConvertedNodeType::VAR:
+                return optimize(node->as_var());
+            case ConvertedNodeType::BYTES:
+                return optimize(node->as_bytes());
+            case ConvertedNodeType::ARRAY:
+                return optimize(node->as_array());
+            case ConvertedNodeType::OP:
+                return optimize(node->as_op());
+            default:
+                throw InvariantViolation("Unsupported AST node type.");
+        }
+    }
+
+    ASTPtr optimize(const ASTVar* var)
+    {
+        const auto& last_ref_it = last_ref_.find(var->name());
+        if (last_ref_it == last_ref_.end()) {
+            throw InvariantViolation("Variable not found: " + var->name());
+        }
+        const auto& last_ref = last_ref_it->second;
+        if (last_ref == var) {
+            return Codegen(var->loc()).var(var->name(), true /* is_last */);
+        }
+        return Codegen(var->loc()).var(var->name());
+    }
+
+    ASTPtr optimize(const ASTBytes* bytes)
+    {
+        return Codegen(bytes->loc()).bytes(optimizeNode(bytes->len()));
+    }
+
+    ASTPtr optimize(const ASTArray* arr)
+    {
+        if (!arr->len()) {
+            return Codegen(arr->loc()).array(optimizeNode(arr->field()));
+        }
+        return Codegen(arr->loc())
+                .array(optimizeNode(arr->field()), optimizeNode(arr->len()));
+    }
+
+    ASTPtr optimize(const ASTOp* op)
+    {
+        // If the variable is not referenced, we can remove the assignment
+        if (op->op() == Op::ASSIGN) {
+            if (!last_ref_.count(op->args()[0]->as_var()->name())) {
+                return nullptr;
+            }
+            return Codegen(op->loc()).op(
+                    Op::ASSIGN, op->args()[0], optimizeNode(op->args()[1]));
+        }
+
+        if (op->op() == Op::ASSUME) {
+            if (!last_ref_.count(op->args()[0]->as_var()->name())) {
+                return Codegen(op->loc()).consume(op->args()[1]);
+            }
+            return Codegen(op->loc()).op(
+                    Op::ASSUME, op->args()[0], optimizeNode(op->args()[1]));
+        }
+
+        // Other ops
+        ASTVec args;
+        for (size_t i = 0; i < op->args().size(); ++i) {
+            args.push_back(optimizeNode(op->args()[i]));
+        }
+        return Codegen(op->loc()).op(op->op(), std::move(args));
+    }
+
+    // Maps variable name → the last time it is referenced. Variables not in
+    // this map are never referenced.
+    std::unordered_map<std::string, const ASTVar*> last_ref_;
+};
+
+} // namespace
+
+DeadVarPass::DeadVarPass(const detail::Logger& logger) : log_(logger) {}
+
+ASTVec DeadVarPass::optimize(const ASTVec& ast) const
+{
+    log_(1) << "Running DeadVar Optimization Pass ..." << std::endl;
+    return DeadVarImpl{}.optimize(ast);
+}
+
+} // namespace openzl::sddl2

--- a/tools/sddl2/compiler/optimizer/DeadVarPass.h
+++ b/tools/sddl2/compiler/optimizer/DeadVarPass.h
@@ -1,0 +1,20 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#pragma once
+
+#include "tools/sddl2/compiler/Logger.h"
+#include "tools/sddl2/compiler/optimizer/OptimizationPass.h"
+
+namespace openzl::sddl2 {
+
+class DeadVarPass : public OptimizationPass {
+   public:
+    explicit DeadVarPass(const detail::Logger& logger);
+
+    ASTVec optimize(const ASTVec& ast) const override;
+
+   private:
+    const detail::Logger& log_;
+};
+
+} // namespace openzl::sddl2

--- a/tools/sddl2/compiler/optimizer/Optimizer.cpp
+++ b/tools/sddl2/compiler/optimizer/Optimizer.cpp
@@ -2,12 +2,14 @@
 
 #include "tools/sddl2/compiler/optimizer/Optimizer.h"
 #include "tools/sddl2/compiler/optimizer/ConstFoldPass.h"
+#include "tools/sddl2/compiler/optimizer/DeadVarPass.h"
 
 namespace openzl::sddl2 {
 
 Optimizer::Optimizer(const detail::Logger& logger)
 {
     passes_.push_back(std::make_unique<ConstFoldPass>(logger));
+    passes_.push_back(std::make_unique<DeadVarPass>(logger));
 }
 
 ASTVec Optimizer::optimize(const ASTVec& ast) const

--- a/tools/sddl2/compiler/parser/AST.cpp
+++ b/tools/sddl2/compiler/parser/AST.cpp
@@ -207,8 +207,10 @@ int64_t ASTNum::val() const
     return val_;
 }
 
-ASTVar::ASTVar(const Token& token)
-        : ASTConverted(token.loc()), name_(token.word())
+ASTVar::ASTVar(const Token& token, bool is_last_reference)
+        : ASTConverted(token.loc()),
+          name_(token.word()),
+          is_last_reference_(is_last_reference)
 {
 }
 
@@ -219,12 +221,21 @@ const ASTVar* ASTVar::as_var() const
 
 void ASTVar::print(std::ostream& os, size_t indent) const
 {
-    os << std::string(indent, ' ') << "Var: " << name_ << std::endl;
+    os << std::string(indent, ' ') << "Var: " << name_;
+    if (is_last_reference_) {
+        os << " (last ref)";
+    }
+    os << std::endl;
 }
 
 const std::string& ASTVar::name() const
 {
     return name_;
+}
+
+bool ASTVar::is_last_reference() const
+{
+    return is_last_reference_;
 }
 
 ASTBuiltinField::ASTBuiltinField(const SourceLocation& loc, const Symbol& sym)

--- a/tools/sddl2/compiler/parser/AST.h
+++ b/tools/sddl2/compiler/parser/AST.h
@@ -171,7 +171,7 @@ class ASTNum : public ASTConverted {
 
 class ASTVar : public ASTConverted {
    public:
-    explicit ASTVar(const Token& token);
+    explicit ASTVar(const Token& token, bool is_last_reference = false);
 
     const ASTVar* as_var() const override;
 
@@ -183,9 +183,11 @@ class ASTVar : public ASTConverted {
     }
 
     const std::string& name() const;
+    bool is_last_reference() const;
 
    private:
     const std::string name_;
+    bool is_last_reference_ = false;
 };
 
 class ASTField : public ASTConverted {
@@ -427,6 +429,11 @@ class Codegen {
     ASTPtr var(poly::string_view name) const
     {
         return std::make_shared<ASTVar>(Token{ loc_, name });
+    }
+
+    ASTPtr var(poly::string_view name, bool is_last_reference) const
+    {
+        return std::make_shared<ASTVar>(Token{ loc_, name }, is_last_reference);
     }
 
     ASTPtr list(Symbol open_sym, ASTVec elts) const

--- a/tools/sddl2/compiler/tests/CompilerTest.cpp
+++ b/tools/sddl2/compiler/tests/CompilerTest.cpp
@@ -219,12 +219,11 @@ TEST_F(CompilerTest, UnaryNegationAST)
 {
     const auto prog = R"(
         tmp = 10 - - 11
+        expect tmp == 21
     )";
 
     const auto cg       = Codegen(SourceLocation::null());
-    const auto expected = std::vector<ASTPtr>({
-            cg.assign(cg.var("tmp"), cg.num(21)),
-    });
+    const auto expected = std::vector<ASTPtr>({ cg.expect(cg.num(1)) });
     expect_ast(prog, expected);
 }
 
@@ -251,8 +250,7 @@ TEST_F(CompilerTest, ArrayAST)
 
     const auto cg       = Codegen(SourceLocation::null());
     const auto expected = std::vector<ASTPtr>(
-            { cg.assign(cg.var("len"), cg.num(3)),
-              cg.consume(cg.array(cg.builtin_field(Symbol::BYTE), cg.num(3))),
+            { cg.consume(cg.array(cg.builtin_field(Symbol::BYTE), cg.num(3))),
               cg.consume(cg.array(cg.builtin_field(Symbol::BYTE))) });
 
     expect_ast(prog, expected);
@@ -264,16 +262,19 @@ TEST_F(CompilerTest, RecordAST)
         Record Entry() = {
             id: Int32LE,
         }
+        : Entry
     )";
 
     const auto cg       = Codegen(SourceLocation::null());
-    const auto expected = std::vector<ASTPtr>({ cg.assign(
-            cg.var("Entry"),
-            cg.record(
-                    ArgVec{},
-                    ArgVec{ cg.assume(
-                            cg.var("id"),
-                            cg.builtin_field(Symbol::I32LE)) })) });
+    const auto expected = std::vector<ASTPtr>(
+            { cg.assign(
+                      cg.var("Entry"),
+                      cg.record(
+                              ArgVec{},
+                              ArgVec{ cg.assume(
+                                      cg.var("id"),
+                                      cg.builtin_field(Symbol::I32LE)) })),
+              cg.consume(cg.var("Entry", true)) });
     expect_ast(prog, expected);
 }
 
@@ -297,11 +298,12 @@ TEST_F(CompilerTest, ParenthesesOverridePrecedenceAST)
 {
     const auto prog = R"(
         tmp = (1 - 2) * 3
+        expect tmp == -3
     )";
 
     const auto cg       = Codegen(SourceLocation::null());
     const auto expected = std::vector<ASTPtr>({
-            cg.assign(cg.var("tmp"), cg.num(-3)),
+            cg.expect(cg.num(1)),
     });
     expect_ast(prog, expected);
 }
@@ -310,11 +312,12 @@ TEST_F(CompilerTest, NestedParenthesesAST)
 {
     const auto prog = R"(
         tmp = ((1 + 2) * (3 + 4))
+        expect tmp == 21
     )";
 
     const auto cg       = Codegen(SourceLocation::null());
     const auto expected = std::vector<ASTPtr>({
-            cg.assign(cg.var("tmp"), cg.num(21)),
+            cg.expect(cg.num(1)),
     });
     expect_ast(prog, expected);
 }
@@ -323,11 +326,12 @@ TEST_F(CompilerTest, ComplexArithmeticExpressionAST)
 {
     const auto prog = R"(
         tmp = 1 + 2 * 3 - 4 / 2
+        expect tmp == 5
     )";
 
     const auto cg       = Codegen(SourceLocation::null());
     const auto expected = std::vector<ASTPtr>({
-            cg.assign(cg.var("tmp"), cg.num(5)),
+            cg.expect(cg.num(1)),
     });
     expect_ast(prog, expected);
 }
@@ -376,9 +380,8 @@ TEST_F(CompilerTest, SimpleSaoAST)
                                             cg.var("XDPM"),
                                             cg.builtin_field(Symbol::F32LE)),
                             })),
-            cg.assume(cg.var("header"), cg.bytes(cg.num(28))),
-            cg.assume(
-                    cg.var("stars"), cg.array(cg.var("StarEntry"), cg.num(10))),
+            cg.consume(cg.bytes(cg.num(28))),
+            cg.consume(cg.array(cg.var("StarEntry"), cg.num(10))),
     });
     expect_ast(prog, expected);
 }
@@ -486,15 +489,12 @@ TEST_F(CompilerTest, ArithmeticConstFold)
 {
     const auto prog     = R"(
         tmp = 1 + 2
-        tmp = -(3 + 2)
-        tmp = 2 * 3 + 4
-        expect tmp == 10
+        tmp = -(tmp + 2)
+        tmp = 2 * 3 + tmp
+        expect tmp == 1
     )";
     const auto cg       = Codegen(SourceLocation::null());
     const auto expected = std::vector<ASTPtr>({
-            cg.assign(cg.var("tmp"), cg.num(3)),
-            cg.assign(cg.var("tmp"), cg.num(-5)),
-            cg.assign(cg.var("tmp"), cg.num(10)),
             cg.expect(cg.num(1)),
     });
     expect_ast(prog, expected);
@@ -536,7 +536,6 @@ TEST_F(CompilerTest, ConstPropagation)
     )";
     const auto cg       = Codegen(SourceLocation::null());
     const auto expected = std::vector<ASTPtr>({
-            cg.assign(cg.var("x"), cg.num(5)),
             cg.expect(cg.num(1)),
     });
     expect_ast(prog, expected);
@@ -552,9 +551,6 @@ TEST_F(CompilerTest, ChainedConstPropagation)
     )";
     const auto cg       = Codegen(SourceLocation::null());
     const auto expected = std::vector<ASTPtr>({
-            cg.assign(cg.var("a"), cg.num(1)),
-            cg.assign(cg.var("b"), cg.num(2)),
-            cg.assign(cg.var("b"), cg.num(4)),
             cg.expect(cg.num(1)),
     });
     expect_ast(prog, expected);


### PR DESCRIPTION
Summary:
Extend the optimizer to mark ASTVar nodes when they are the final
value-reference to their variable. This metadata allows (1) the optimizer to remove variable assignments if they are never referenced (2) codegen to release
variable storage after its last use.

Differential Revision: D94932644


