### PR TITLE
Easy: Modify generator to use a random seed

### DIFF
--- a/custom_transforms/tulip_v2/tests/fuzz_tulip_v2_generator.cpp
+++ b/custom_transforms/tulip_v2/tests/fuzz_tulip_v2_generator.cpp
@@ -19,8 +19,10 @@ namespace fs = std::filesystem;
 
 std::vector<std::string> generateFuzzCompressCorpus()
 {
+    std::random_device rd;
     std::vector<std::string> examples;
-    std::mt19937 gen(0xdeadbeef);
+    std::mt19937 gen(rd());
+    examples.reserve(100);
     for (size_t n = 0; n < 100; ++n) {
         examples.push_back(generateTulipV2(n % 5, gen));
     }


### PR DESCRIPTION
Summary: Modifies the generator for fuzz_tulip_v2 to use a random seed instead of a deterministic one. This generates a different corpus each time improving fuzzing.

Reviewed By: terrelln

Differential Revision: D94708076


