### PR TITLE
Modify zs_fuzzers macro naming

### DIFF
--- a/defs.bzl
+++ b/defs.bzl
@@ -330,16 +330,7 @@ def zs_fuzzers(ftest_names, generator = None, **kwargs):
 
     for ftest_name in ftest_names:
         name = prefix + "_".join(ftest_name)
-        cpp_lionhead_harness(
-            name = name,
-            metadata = ZS_FUZZ_METADATA,
-            ftest_name = ftest_name,
-            harness_configs = {mode: {} for mode in ZS_HARNESS_MODES},
-            **kwargs
-        )
-
         if generator:
-            generator_name = name + "_Generator"
             generator_config = {
                 "seed_generator_command": [
                     "./generator",
@@ -349,7 +340,7 @@ def zs_fuzzers(ftest_names, generator = None, **kwargs):
                 ],
             }
             generic_lionhead_harness(
-                name = generator_name,
+                name = name,
                 bundle_spec_version = 1,
                 environment_constraints = {
                     "remote_execution.linux": {},
@@ -365,10 +356,18 @@ def zs_fuzzers(ftest_names, generator = None, **kwargs):
                     "fuzz": "fbsource//xplat/security/lionhead/utils/runners/libfuzzer:fuzz",
                     "fuzz_utils.py": "fbsource//xplat/security/lionhead/utils/runners:fuzz_utils",
                     "generator": generator,
-                    generator_name: ":" + name + "_bin",
+                    name: ":" + name + "_NoGenerator_bin",
                 },
                 metadata = ZS_FUZZ_METADATA,
             )
+
+        cpp_lionhead_harness(
+            name = name if not generator else name + "_NoGenerator",
+            metadata = ZS_FUZZ_METADATA,
+            ftest_name = ftest_name,
+            harness_configs = {mode: {} for mode in ZS_HARNESS_MODES},
+            **kwargs
+        )
 
 def zs_raw_fuzzer(name, **kwargs):
     if _is_release():

--- a/tests/serialization/fuzz_compressor_serialization_generator.cpp
+++ b/tests/serialization/fuzz_compressor_serialization_generator.cpp
@@ -22,7 +22,8 @@ namespace fs = std::filesystem;
 
 std::vector<std::string> generateFuzzDeserializationCorpus()
 {
-    auto gen                = std::make_shared<std::mt19937>(0xdeadbeef);
+    std::random_device rd;
+    auto gen                = std::make_shared<std::mt19937>(rd());
     auto rw                 = std::make_shared<datagen::PRNGWrapper>(gen);
     auto compressorProducer = datagen::CompressorProducer{ rw };
 
@@ -40,6 +41,8 @@ std::optional<std::vector<std::string>> generateCorpus(std::string_view harness)
 {
     if (harness == "FuzzDeserialization") {
         return generateFuzzDeserializationCorpus();
+    } else if (harness == "FuzzRandomCompressorDeserializesSuccessfully") {
+        return std::vector<std::string>{};
     } else {
         return std::nullopt;
     }


### PR DESCRIPTION
Summary:
Modifies `zs_fuzzers` macro to change harness naming with/without generators.

1. `zs_fuzzers` has generator - `name_Generator` is with generated corpus -> `name` is with generated corpus
2. `zs_fuzzers` has generator - `name` is without generated corpus -> `name_NoGenerator` is without generated corpus
3. `zs_fuzzers` has no generator - There are no changes in naming.

Reviewed By: terrelln

Differential Revision: D94710058


