### PR TITLE
Add option to opt-out of optimization pass

### DIFF
--- a/src/openzl/compress/graphs/sddl2/sddl2_disasm_generated.h
+++ b/src/openzl/compress/graphs/sddl2/sddl2_disasm_generated.h
@@ -3,7 +3,7 @@
 // AUTO-GENERATED FILE - DO NOT EDIT MANUALLY
 //
 // Generated from: src/openzl/compress/graphs/sddl2/sddl2_opcodes.def
-// Generated at: 2025-11-21 17:16:01 UTC
+// Generated at: 2026-02-25 19:35:29 UTC
 // Generator: generate_c_headers.py
 //
 // To regenerate: python3 src/openzl/compress/graphs/sddl2/generate_c_headers.py
@@ -226,7 +226,16 @@ static inline const char* SDDL2_instruction_name_impl(
             }
 
         case SDDL2_FAMILY_VAR:
-            return "var.?";
+            switch (opcode) {
+                case SDDL2_OP_VAR_STORE:
+                    return "var.store";
+                case SDDL2_OP_VAR_LOAD:
+                    return "var.load";
+                case SDDL2_OP_VAR_CLEAR:
+                    return "var.clear";
+                default:
+                    return "var.?";
+            }
 
         case SDDL2_FAMILY_CALL:
             return "call.?";

--- a/src/openzl/compress/graphs/sddl2/sddl2_interpreter.c
+++ b/src/openzl/compress/graphs/sddl2/sddl2_interpreter.c
@@ -88,6 +88,12 @@
     _func(SDDL2_OP_PUSH_TYPE_F32BE, SDDL2_TYPE_F32BE)        \
     _func(SDDL2_OP_PUSH_TYPE_F64LE, SDDL2_TYPE_F64LE)        \
     _func(SDDL2_OP_PUSH_TYPE_F64BE, SDDL2_TYPE_F64BE)
+
+#define FOR_EACH_VAR_OP(_func)              \
+    _func(SDDL2_OP_VAR_STORE, SDDL2_op_var_store) \
+    _func(SDDL2_OP_VAR_LOAD, SDDL2_op_var_load)   \
+    _func(SDDL2_OP_VAR_CLEAR, SDDL2_op_var_clear)
+
 // clang-format on
 
 /* ============================================================================
@@ -331,6 +337,9 @@ SDDL2_Error SDDL2_execute_bytecode(
     SDDL2_Input_cursor buffer;
     SDDL2_Input_cursor_init(&buffer, input_data, input_size);
 
+    SDDL2_Var_registers var_regs;
+    SDDL2_Var_registers_init(&var_regs);
+
     SDDL2_Tag_registry registry;
     // Use same allocator as output_segments (arena in production, NULL in
     // tests)
@@ -443,11 +452,25 @@ SDDL2_Error SDDL2_execute_bytecode(
                 DISPATCH_OP_FAMILY(FOR_EACH_LOAD_OP, EMIT_LOAD_OP_CASE);
                 break;
 
-            // Note: expect_true is part of CONTROL family (ID 0x000A not
-            // generated for empty EXPECT family)
+                // Note: expect_true is part of CONTROL family (ID 0x000A not
+                // generated for empty EXPECT family)
+
+            case SDDL2_FAMILY_VAR:
+                if (opcode == SDDL2_OP_VAR_STORE) {
+                    err = SDDL2_op_var_store(
+                            &stack, &trace, pc_before, &var_regs);
+                } else if (opcode == SDDL2_OP_VAR_LOAD) {
+                    err = SDDL2_op_var_load(
+                            &stack, &trace, pc_before, &var_regs);
+                } else if (opcode == SDDL2_OP_VAR_CLEAR) {
+                    err = SDDL2_op_var_clear(
+                            &stack, &trace, pc_before, &var_regs);
+                } else {
+                    CLEANUP_AND_RETURN(SDDL2_INVALID_BYTECODE);
+                }
+                break;
 
             // Unimplemented families
-            case SDDL2_FAMILY_VAR:
             case SDDL2_FAMILY_CALL:
                 CLEANUP_AND_RETURN(SDDL2_INVALID_BYTECODE);
         }

--- a/src/openzl/compress/graphs/sddl2/sddl2_opcodes.def
+++ b/src/openzl/compress/graphs/sddl2/sddl2_opcodes.def
@@ -127,6 +127,9 @@
   type.sizeof       0x0010  "Pop Type, push its total size in bytes as I64"
 
 @family VAR 0x0009 "Variable operations"
+  var.store 0x0001  "Pop Value, pop I64 (register), store Value in register"
+  var.load  0x0002  "Pop I64 (register), push Value stored in register"
+  var.clear 0x0003  "Pop I64 (register), mark register as unoccupied"
 
 @family CALL 0x000B "Function call operations"
 

--- a/src/openzl/compress/graphs/sddl2/sddl2_opcodes.h
+++ b/src/openzl/compress/graphs/sddl2/sddl2_opcodes.h
@@ -3,7 +3,7 @@
 // AUTO-GENERATED FILE - DO NOT EDIT MANUALLY
 //
 // Generated from: src/openzl/compress/graphs/sddl2/sddl2_opcodes.def
-// Generated at: 2025-11-21 17:16:01 UTC
+// Generated at: 2026-02-25 19:35:29 UTC
 // Generator: generate_c_headers.py
 //
 // To regenerate: python3 src/openzl/compress/graphs/sddl2/generate_c_headers.py
@@ -148,6 +148,13 @@ enum sddl2_opcode_type {
     SDDL2_OP_TYPE_FIXED_ARRAY = 0x0001,
     SDDL2_OP_TYPE_STRUCTURE   = 0x0002,
     SDDL2_OP_TYPE_SIZEOF      = 0x0010,
+};
+
+/* VAR family (0x0009) - Variable operations */
+enum sddl2_opcode_var {
+    SDDL2_OP_VAR_STORE = 0x0001,
+    SDDL2_OP_VAR_LOAD  = 0x0002,
+    SDDL2_OP_VAR_CLEAR = 0x0003,
 };
 
 /* SEGMENT family (0x000C) - Segment creation operations */

--- a/src/openzl/compress/graphs/sddl2/sddl2_vm.c
+++ b/src/openzl/compress/graphs/sddl2/sddl2_vm.c
@@ -816,6 +816,93 @@ SDDL2_op_swap(SDDL2_Stack* stack, SDDL2_Trace_buffer* trace, size_t pc)
 }
 
 /* ============================================================================
+ * Variable Operations (VAR Family)
+ *
+ * Provides register-based variable storage:
+ * - var.store: Pop value + register index, store value in register
+ * - var.load: Pop register index, push value from register
+ * - var.clear: Pop register index, clear register
+ * These enable saving and restoring intermediate values across stack
+ * operations without complex stack manipulation.
+ * ========================================================================= */
+
+void SDDL2_Var_registers_init(SDDL2_Var_registers* regs)
+{
+    for (size_t i = 0; i < SDDL2_VAR_REGISTER_COUNT; i++) {
+        regs->occupied[i] = 0;
+    }
+}
+
+SDDL2_Error SDDL2_op_var_store(
+        SDDL2_Stack* stack,
+        SDDL2_Trace_buffer* trace,
+        size_t pc,
+        SDDL2_Var_registers* regs)
+{
+    (void)trace;
+    (void)pc;
+
+    int64_t reg_index;
+    SDDL2_TRY(pop_i64(stack, &reg_index));
+
+    if (reg_index < 0 || reg_index >= SDDL2_VAR_REGISTER_COUNT) {
+        return SDDL2_LOAD_BOUNDS;
+    }
+
+    SDDL2_Value val;
+    SDDL2_TRY(SDDL2_Stack_pop(stack, &val));
+
+    regs->values[reg_index]   = val;
+    regs->occupied[reg_index] = 1;
+
+    return SDDL2_OK;
+}
+
+SDDL2_Error SDDL2_op_var_load(
+        SDDL2_Stack* stack,
+        SDDL2_Trace_buffer* trace,
+        size_t pc,
+        SDDL2_Var_registers* regs)
+{
+    (void)trace;
+    (void)pc;
+
+    int64_t reg_index;
+    SDDL2_TRY(pop_i64(stack, &reg_index));
+
+    if (reg_index < 0 || reg_index >= SDDL2_VAR_REGISTER_COUNT) {
+        return SDDL2_LOAD_BOUNDS;
+    }
+
+    if (!regs->occupied[reg_index]) {
+        return SDDL2_LOAD_BOUNDS;
+    }
+
+    return SDDL2_Stack_push(stack, regs->values[reg_index]);
+}
+
+SDDL2_Error SDDL2_op_var_clear(
+        SDDL2_Stack* stack,
+        SDDL2_Trace_buffer* trace,
+        size_t pc,
+        SDDL2_Var_registers* regs)
+{
+    (void)trace;
+    (void)pc;
+
+    int64_t reg_index;
+    SDDL2_TRY(pop_i64(stack, &reg_index));
+
+    if (reg_index < 0 || reg_index >= SDDL2_VAR_REGISTER_COUNT) {
+        return SDDL2_LOAD_BOUNDS;
+    }
+
+    regs->occupied[reg_index] = 0;
+
+    return SDDL2_OK;
+}
+
+/* ============================================================================
  * Validation Operations (EXPECT Family)
  *
  * Provides runtime validation and assertion operations:

--- a/src/openzl/compress/graphs/sddl2/sddl2_vm.h
+++ b/src/openzl/compress/graphs/sddl2/sddl2_vm.h
@@ -165,6 +165,38 @@ typedef struct {
 } SDDL2_Stack;
 
 /* ============================================================================
+ * Variable Register File
+ * ========================================================================= */
+
+/**
+ * Number of variable registers available to VM programs.
+ * Can be overridden at compile time with -DSDDL2_VAR_REGISTER_COUNT=value.
+ */
+#ifndef SDDL2_VAR_REGISTER_COUNT
+#    define SDDL2_VAR_REGISTER_COUNT 256
+#endif
+
+/**
+ * Variable register file for the SDDL2 VM.
+ *
+ * Provides a fixed set of named registers that can store any Value type.
+ * Programs use var.store/var.load to save and restore intermediate values
+ * across sequences of stack operations.
+ *
+ * Each register tracks whether it has been written to (occupied), so that
+ * loading from an uninitialized register produces a clear error.
+ */
+typedef struct {
+    SDDL2_Value values[SDDL2_VAR_REGISTER_COUNT];
+    uint8_t occupied[SDDL2_VAR_REGISTER_COUNT];
+} SDDL2_Var_registers;
+
+/**
+ * Initialize a variable register file (all registers unoccupied).
+ */
+void SDDL2_Var_registers_init(SDDL2_Var_registers* regs);
+
+/* ============================================================================
  * Memory Allocation Strategy
  * ========================================================================= */
 
@@ -658,6 +690,67 @@ SDDL2_op_dup(SDDL2_Stack* stack, SDDL2_Trace_buffer* trace, size_t pc);
  */
 SDDL2_Error
 SDDL2_op_swap(SDDL2_Stack* stack, SDDL2_Trace_buffer* trace, size_t pc);
+
+/* ============================================================================
+ * Variable Operations (VAR Family)
+ * ========================================================================= */
+
+/**
+ * Store a value into a variable register.
+ * Stack: value:Value register:I64 -> (empty)
+ *
+ * Pops an I64 register index, then pops a generic Value, and stores the
+ * Value into the given register. The register index must be in range
+ * [0, SDDL2_VAR_REGISTER_COUNT).
+ *
+ * Errors:
+ *   - SDDL2_STACK_UNDERFLOW: stack has fewer than 2 values
+ *   - SDDL2_TYPE_MISMATCH: top value is not I64 (register index)
+ *   - SDDL2_LOAD_BOUNDS: register index out of range
+ */
+SDDL2_Error SDDL2_op_var_store(
+        SDDL2_Stack* stack,
+        SDDL2_Trace_buffer* trace,
+        size_t pc,
+        SDDL2_Var_registers* regs);
+
+/**
+ * Load a value from a variable register.
+ * Stack: register:I64 -> value:Value
+ *
+ * Pops an I64 register index and pushes the Value stored in that register
+ * onto the stack. The register must have been previously written to with
+ * var.store.
+ *
+ * Errors:
+ *   - SDDL2_STACK_UNDERFLOW: stack is empty
+ *   - SDDL2_TYPE_MISMATCH: top value is not I64 (register index)
+ *   - SDDL2_LOAD_BOUNDS: register index out of range or register uninitialized
+ */
+SDDL2_Error SDDL2_op_var_load(
+        SDDL2_Stack* stack,
+        SDDL2_Trace_buffer* trace,
+        size_t pc,
+        SDDL2_Var_registers* regs);
+
+/**
+ * Clear (unoccupy) a variable register.
+ * Stack: register:I64 -> (empty)
+ *
+ * Pops an I64 register index and marks the corresponding register as
+ * unoccupied. If the register was already unoccupied, this is a no-op.
+ * A subsequent var.load from this register will fail with SDDL2_LOAD_BOUNDS.
+ *
+ * Errors:
+ *   - SDDL2_STACK_UNDERFLOW: stack is empty
+ *   - SDDL2_TYPE_MISMATCH: top value is not I64 (register index)
+ *   - SDDL2_LOAD_BOUNDS: register index out of range
+ */
+SDDL2_Error SDDL2_op_var_clear(
+        SDDL2_Stack* stack,
+        SDDL2_Trace_buffer* trace,
+        size_t pc,
+        SDDL2_Var_registers* regs);
 
 /* ============================================================================
  * Validation Operations (EXPECT Family)

--- a/tests/compress/graphs/sddl2/test_sddl2_assembly_execution.cpp
+++ b/tests/compress/graphs/sddl2/test_sddl2_assembly_execution.cpp
@@ -1236,6 +1236,101 @@ TEST_F(SDDL2AssemblyExecutionTest, SegmentZero)
     EXPECT_EQ(segments_.items[0].size_bytes, 0u);
 }
 
+// ============================================================================
+// Variable Operation Tests
+// ============================================================================
+
+TEST_F(SDDL2AssemblyExecutionTest, VarStoreLoadExecution)
+{
+    const std::string input = "Test";
+    ASSERT_EQ(
+            run(R"(
+                push.i32 42
+                push.i32 0
+                var.store
+                push.i32 0
+                var.load
+                push.i32 42
+                cmp.eq
+                expect_true
+                halt
+            )",
+                input),
+            SDDL2_OK);
+}
+
+TEST_F(SDDL2AssemblyExecutionTest, VarClearExecution)
+{
+    const std::string input = "Test";
+    ASSERT_EQ(
+            run(R"(
+                push.i32 42
+                push.i32 0
+                var.store
+                push.i32 0
+                var.clear
+                halt
+            )",
+                input),
+            SDDL2_OK);
+}
+
+TEST_F(SDDL2AssemblyExecutionTest, VarClearThenLoadFails)
+{
+    const std::string input = "Test";
+    EXPECT_EQ(
+            run(R"(
+                push.i32 42
+                push.i32 0
+                var.store
+                push.i32 0
+                var.clear
+                push.i32 0
+                var.load
+                halt
+            )",
+                input),
+            SDDL2_LOAD_BOUNDS);
+}
+
+TEST_F(SDDL2AssemblyExecutionTest, VarMultipleRegistersExecution)
+{
+    const std::string input = "Test";
+    ASSERT_EQ(
+            run(R"(
+                push.i32 10
+                push.i32 0
+                var.store
+                push.i32 20
+                push.i32 1
+                var.store
+                push.i32 30
+                push.i32 2
+                var.store
+
+                push.i32 0
+                var.load
+                push.i32 10
+                cmp.eq
+                expect_true
+
+                push.i32 1
+                var.load
+                push.i32 20
+                cmp.eq
+                expect_true
+
+                push.i32 2
+                var.load
+                push.i32 30
+                cmp.eq
+                expect_true
+                halt
+            )",
+                input),
+            SDDL2_OK);
+}
+
 } // namespace testing
 } // namespace sddl2
 } // namespace openzl

--- a/tests/compress/graphs/sddl2/test_sddl2_var.cpp
+++ b/tests/compress/graphs/sddl2/test_sddl2_var.cpp
@@ -1,0 +1,276 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#include "tests/compress/graphs/sddl2/utils.h"
+
+using namespace openzl::sddl2::testing;
+
+namespace {
+
+class SDDL2VarTest : public SDDL2StackTest {
+   protected:
+    void SetUp() override
+    {
+        SDDL2StackTest::SetUp();
+        SDDL2_Var_registers_init(&regs_);
+    }
+
+    SDDL2_Var_registers regs_{};
+};
+
+} // namespace
+
+// ============================================================================
+// var.store Tests
+// ============================================================================
+
+TEST_F(SDDL2VarTest, StoreI64)
+{
+    ASSERT_EQ(SDDL2_Stack_push(stack_, SDDL2_Value_i64(42)), SDDL2_OK);
+    ASSERT_EQ(SDDL2_Stack_push(stack_, SDDL2_Value_i64(0)), SDDL2_OK);
+    ASSERT_EQ(SDDL2_op_var_store(stack_, NULL, 0, &regs_), SDDL2_OK);
+    EXPECT_EQ(regs_.occupied[0], 1);
+    EXPECT_EQ(SDDL2_Stack_depth(stack_), 0u);
+}
+
+TEST_F(SDDL2VarTest, StoreTag)
+{
+    ASSERT_EQ(SDDL2_Stack_push(stack_, SDDL2_Value_tag(100)), SDDL2_OK);
+    ASSERT_EQ(SDDL2_Stack_push(stack_, SDDL2_Value_i64(5)), SDDL2_OK);
+    ASSERT_EQ(SDDL2_op_var_store(stack_, NULL, 0, &regs_), SDDL2_OK);
+    EXPECT_EQ(regs_.occupied[5], 1);
+}
+
+TEST_F(SDDL2VarTest, StoreType)
+{
+    SDDL2_Type t = { .kind = SDDL2_TYPE_I32LE, .width = 1 };
+    ASSERT_EQ(SDDL2_Stack_push(stack_, SDDL2_Value_type(t)), SDDL2_OK);
+    ASSERT_EQ(SDDL2_Stack_push(stack_, SDDL2_Value_i64(10)), SDDL2_OK);
+    ASSERT_EQ(SDDL2_op_var_store(stack_, NULL, 0, &regs_), SDDL2_OK);
+    EXPECT_EQ(regs_.occupied[10], 1);
+}
+
+TEST_F(SDDL2VarTest, StoreOverwrite)
+{
+    ASSERT_EQ(SDDL2_Stack_push(stack_, SDDL2_Value_i64(42)), SDDL2_OK);
+    ASSERT_EQ(SDDL2_Stack_push(stack_, SDDL2_Value_i64(0)), SDDL2_OK);
+    ASSERT_EQ(SDDL2_op_var_store(stack_, NULL, 0, &regs_), SDDL2_OK);
+
+    ASSERT_EQ(SDDL2_Stack_push(stack_, SDDL2_Value_i64(99)), SDDL2_OK);
+    ASSERT_EQ(SDDL2_Stack_push(stack_, SDDL2_Value_i64(0)), SDDL2_OK);
+    ASSERT_EQ(SDDL2_op_var_store(stack_, NULL, 0, &regs_), SDDL2_OK);
+
+    ASSERT_EQ(SDDL2_Stack_push(stack_, SDDL2_Value_i64(0)), SDDL2_OK);
+    ASSERT_EQ(SDDL2_op_var_load(stack_, NULL, 0, &regs_), SDDL2_OK);
+    popAndVerifyI64(stack_, 99);
+}
+
+TEST_F(SDDL2VarTest, StoreBoundsNegative)
+{
+    ASSERT_EQ(SDDL2_Stack_push(stack_, SDDL2_Value_i64(42)), SDDL2_OK);
+    ASSERT_EQ(SDDL2_Stack_push(stack_, SDDL2_Value_i64(-1)), SDDL2_OK);
+    EXPECT_EQ(SDDL2_op_var_store(stack_, NULL, 0, &regs_), SDDL2_LOAD_BOUNDS);
+}
+
+TEST_F(SDDL2VarTest, StoreBoundsOverflow)
+{
+    ASSERT_EQ(SDDL2_Stack_push(stack_, SDDL2_Value_i64(42)), SDDL2_OK);
+    ASSERT_EQ(SDDL2_Stack_push(stack_, SDDL2_Value_i64(256)), SDDL2_OK);
+    EXPECT_EQ(SDDL2_op_var_store(stack_, NULL, 0, &regs_), SDDL2_LOAD_BOUNDS);
+}
+
+TEST_F(SDDL2VarTest, StoreTypeMismatch)
+{
+    ASSERT_EQ(SDDL2_Stack_push(stack_, SDDL2_Value_i64(42)), SDDL2_OK);
+    ASSERT_EQ(SDDL2_Stack_push(stack_, SDDL2_Value_tag(0)), SDDL2_OK);
+    EXPECT_EQ(SDDL2_op_var_store(stack_, NULL, 0, &regs_), SDDL2_TYPE_MISMATCH);
+}
+
+TEST_F(SDDL2VarTest, StoreUnderflowEmpty)
+{
+    EXPECT_EQ(
+            SDDL2_op_var_store(stack_, NULL, 0, &regs_), SDDL2_STACK_UNDERFLOW);
+}
+
+TEST_F(SDDL2VarTest, StoreUnderflowOneValue)
+{
+    ASSERT_EQ(SDDL2_Stack_push(stack_, SDDL2_Value_i64(0)), SDDL2_OK);
+    EXPECT_EQ(
+            SDDL2_op_var_store(stack_, NULL, 0, &regs_), SDDL2_STACK_UNDERFLOW);
+}
+
+// ============================================================================
+// var.load Tests
+// ============================================================================
+
+TEST_F(SDDL2VarTest, LoadI64)
+{
+    ASSERT_EQ(SDDL2_Stack_push(stack_, SDDL2_Value_i64(42)), SDDL2_OK);
+    ASSERT_EQ(SDDL2_Stack_push(stack_, SDDL2_Value_i64(0)), SDDL2_OK);
+    ASSERT_EQ(SDDL2_op_var_store(stack_, NULL, 0, &regs_), SDDL2_OK);
+
+    ASSERT_EQ(SDDL2_Stack_push(stack_, SDDL2_Value_i64(0)), SDDL2_OK);
+    ASSERT_EQ(SDDL2_op_var_load(stack_, NULL, 0, &regs_), SDDL2_OK);
+    popAndVerifyI64(stack_, 42);
+}
+
+TEST_F(SDDL2VarTest, LoadTag)
+{
+    ASSERT_EQ(SDDL2_Stack_push(stack_, SDDL2_Value_tag(100)), SDDL2_OK);
+    ASSERT_EQ(SDDL2_Stack_push(stack_, SDDL2_Value_i64(5)), SDDL2_OK);
+    ASSERT_EQ(SDDL2_op_var_store(stack_, NULL, 0, &regs_), SDDL2_OK);
+
+    ASSERT_EQ(SDDL2_Stack_push(stack_, SDDL2_Value_i64(5)), SDDL2_OK);
+    ASSERT_EQ(SDDL2_op_var_load(stack_, NULL, 0, &regs_), SDDL2_OK);
+    SDDL2_Value result;
+    ASSERT_EQ(SDDL2_Stack_pop(stack_, &result), SDDL2_OK);
+    EXPECT_EQ(result.kind, SDDL2_VALUE_TAG);
+    EXPECT_EQ(result.value.as_tag, 100u);
+}
+
+TEST_F(SDDL2VarTest, LoadType)
+{
+    SDDL2_Type t = { .kind = SDDL2_TYPE_I32LE, .width = 1 };
+    ASSERT_EQ(SDDL2_Stack_push(stack_, SDDL2_Value_type(t)), SDDL2_OK);
+    ASSERT_EQ(SDDL2_Stack_push(stack_, SDDL2_Value_i64(10)), SDDL2_OK);
+    ASSERT_EQ(SDDL2_op_var_store(stack_, NULL, 0, &regs_), SDDL2_OK);
+
+    ASSERT_EQ(SDDL2_Stack_push(stack_, SDDL2_Value_i64(10)), SDDL2_OK);
+    ASSERT_EQ(SDDL2_op_var_load(stack_, NULL, 0, &regs_), SDDL2_OK);
+    SDDL2_Value result;
+    ASSERT_EQ(SDDL2_Stack_pop(stack_, &result), SDDL2_OK);
+    EXPECT_EQ(result.kind, SDDL2_VALUE_TYPE);
+    EXPECT_EQ(result.value.as_type.kind, SDDL2_TYPE_I32LE);
+    EXPECT_EQ(result.value.as_type.width, 1u);
+}
+
+TEST_F(SDDL2VarTest, LoadUninitialized)
+{
+    ASSERT_EQ(SDDL2_Stack_push(stack_, SDDL2_Value_i64(0)), SDDL2_OK);
+    EXPECT_EQ(SDDL2_op_var_load(stack_, NULL, 0, &regs_), SDDL2_LOAD_BOUNDS);
+}
+
+TEST_F(SDDL2VarTest, LoadBoundsNegative)
+{
+    ASSERT_EQ(SDDL2_Stack_push(stack_, SDDL2_Value_i64(-1)), SDDL2_OK);
+    EXPECT_EQ(SDDL2_op_var_load(stack_, NULL, 0, &regs_), SDDL2_LOAD_BOUNDS);
+}
+
+TEST_F(SDDL2VarTest, LoadBoundsOverflow)
+{
+    ASSERT_EQ(SDDL2_Stack_push(stack_, SDDL2_Value_i64(256)), SDDL2_OK);
+    EXPECT_EQ(SDDL2_op_var_load(stack_, NULL, 0, &regs_), SDDL2_LOAD_BOUNDS);
+}
+
+TEST_F(SDDL2VarTest, LoadTypeMismatch)
+{
+    ASSERT_EQ(SDDL2_Stack_push(stack_, SDDL2_Value_tag(0)), SDDL2_OK);
+    EXPECT_EQ(SDDL2_op_var_load(stack_, NULL, 0, &regs_), SDDL2_TYPE_MISMATCH);
+}
+
+TEST_F(SDDL2VarTest, LoadUnderflow)
+{
+    EXPECT_EQ(
+            SDDL2_op_var_load(stack_, NULL, 0, &regs_), SDDL2_STACK_UNDERFLOW);
+}
+
+// ============================================================================
+// var.clear Tests
+// ============================================================================
+
+TEST_F(SDDL2VarTest, ClearOccupied)
+{
+    ASSERT_EQ(SDDL2_Stack_push(stack_, SDDL2_Value_i64(42)), SDDL2_OK);
+    ASSERT_EQ(SDDL2_Stack_push(stack_, SDDL2_Value_i64(0)), SDDL2_OK);
+    ASSERT_EQ(SDDL2_op_var_store(stack_, NULL, 0, &regs_), SDDL2_OK);
+    EXPECT_EQ(regs_.occupied[0], 1);
+
+    ASSERT_EQ(SDDL2_Stack_push(stack_, SDDL2_Value_i64(0)), SDDL2_OK);
+    ASSERT_EQ(SDDL2_op_var_clear(stack_, NULL, 0, &regs_), SDDL2_OK);
+    EXPECT_EQ(regs_.occupied[0], 0);
+
+    ASSERT_EQ(SDDL2_Stack_push(stack_, SDDL2_Value_i64(0)), SDDL2_OK);
+    EXPECT_EQ(SDDL2_op_var_load(stack_, NULL, 0, &regs_), SDDL2_LOAD_BOUNDS);
+}
+
+TEST_F(SDDL2VarTest, ClearUnoccupied)
+{
+    ASSERT_EQ(SDDL2_Stack_push(stack_, SDDL2_Value_i64(0)), SDDL2_OK);
+    EXPECT_EQ(SDDL2_op_var_clear(stack_, NULL, 0, &regs_), SDDL2_OK);
+    EXPECT_EQ(regs_.occupied[0], 0);
+}
+
+TEST_F(SDDL2VarTest, ClearBoundsNegative)
+{
+    ASSERT_EQ(SDDL2_Stack_push(stack_, SDDL2_Value_i64(-1)), SDDL2_OK);
+    EXPECT_EQ(SDDL2_op_var_clear(stack_, NULL, 0, &regs_), SDDL2_LOAD_BOUNDS);
+}
+
+TEST_F(SDDL2VarTest, ClearBoundsOverflow)
+{
+    ASSERT_EQ(SDDL2_Stack_push(stack_, SDDL2_Value_i64(256)), SDDL2_OK);
+    EXPECT_EQ(SDDL2_op_var_clear(stack_, NULL, 0, &regs_), SDDL2_LOAD_BOUNDS);
+}
+
+TEST_F(SDDL2VarTest, ClearTypeMismatch)
+{
+    ASSERT_EQ(SDDL2_Stack_push(stack_, SDDL2_Value_tag(0)), SDDL2_OK);
+    EXPECT_EQ(SDDL2_op_var_clear(stack_, NULL, 0, &regs_), SDDL2_TYPE_MISMATCH);
+}
+
+TEST_F(SDDL2VarTest, ClearUnderflow)
+{
+    EXPECT_EQ(
+            SDDL2_op_var_clear(stack_, NULL, 0, &regs_), SDDL2_STACK_UNDERFLOW);
+}
+
+// ============================================================================
+// Combined / Integration Tests
+// ============================================================================
+
+TEST_F(SDDL2VarTest, StoreLoadRoundTrip)
+{
+    ASSERT_EQ(SDDL2_Stack_push(stack_, SDDL2_Value_i64(12345)), SDDL2_OK);
+    ASSERT_EQ(SDDL2_Stack_push(stack_, SDDL2_Value_i64(0)), SDDL2_OK);
+    ASSERT_EQ(SDDL2_op_var_store(stack_, NULL, 0, &regs_), SDDL2_OK);
+
+    ASSERT_EQ(SDDL2_Stack_push(stack_, SDDL2_Value_i64(0)), SDDL2_OK);
+    ASSERT_EQ(SDDL2_op_var_load(stack_, NULL, 0, &regs_), SDDL2_OK);
+    popAndVerifyI64(stack_, 12345);
+}
+
+TEST_F(SDDL2VarTest, MultipleRegisters)
+{
+    for (int i = 0; i < 3; i++) {
+        ASSERT_EQ(SDDL2_Stack_push(stack_, SDDL2_Value_i64(100 + i)), SDDL2_OK);
+        ASSERT_EQ(SDDL2_Stack_push(stack_, SDDL2_Value_i64(i)), SDDL2_OK);
+        ASSERT_EQ(SDDL2_op_var_store(stack_, NULL, 0, &regs_), SDDL2_OK);
+    }
+
+    for (int i = 2; i >= 0; i--) {
+        ASSERT_EQ(SDDL2_Stack_push(stack_, SDDL2_Value_i64(i)), SDDL2_OK);
+        ASSERT_EQ(SDDL2_op_var_load(stack_, NULL, 0, &regs_), SDDL2_OK);
+        popAndVerifyI64(stack_, 100 + i);
+    }
+}
+
+TEST_F(SDDL2VarTest, ClearAndRestore)
+{
+    // Store 42 in register 0
+    ASSERT_EQ(SDDL2_Stack_push(stack_, SDDL2_Value_i64(42)), SDDL2_OK);
+    ASSERT_EQ(SDDL2_Stack_push(stack_, SDDL2_Value_i64(0)), SDDL2_OK);
+    ASSERT_EQ(SDDL2_op_var_store(stack_, NULL, 0, &regs_), SDDL2_OK);
+
+    // Clear register 0
+    ASSERT_EQ(SDDL2_Stack_push(stack_, SDDL2_Value_i64(0)), SDDL2_OK);
+    ASSERT_EQ(SDDL2_op_var_clear(stack_, NULL, 0, &regs_), SDDL2_OK);
+
+    // Re-store 99 in register 0
+    ASSERT_EQ(SDDL2_Stack_push(stack_, SDDL2_Value_i64(99)), SDDL2_OK);
+    ASSERT_EQ(SDDL2_Stack_push(stack_, SDDL2_Value_i64(0)), SDDL2_OK);
+    ASSERT_EQ(SDDL2_op_var_store(stack_, NULL, 0, &regs_), SDDL2_OK);
+
+    // Load and verify new value
+    ASSERT_EQ(SDDL2_Stack_push(stack_, SDDL2_Value_i64(0)), SDDL2_OK);
+    ASSERT_EQ(SDDL2_op_var_load(stack_, NULL, 0, &regs_), SDDL2_OK);
+    popAndVerifyI64(stack_, 99);
+}

--- a/tools/sddl2/assembler/Assembly_opcodes.md
+++ b/tools/sddl2/assembler/Assembly_opcodes.md
@@ -135,7 +135,11 @@ Type operations
 ### VAR (0x0009)
 Variable operations
 
-_No instructions defined._
+| Mnemonic    | Opcode   | Params | Description                                            |
+| ----------- | -------- | ------ | ------------------------------------------------------ |
+| `var.store` | `0x0001` | `-`    | Pop Value, pop I64 (register), store Value in register |
+| `var.load`  | `0x0002` | `-`    | Pop I64 (register), push Value stored in register      |
+| `var.clear` | `0x0003` | `-`    | Pop I64 (register), mark register as unoccupied        |
 
 ### CALL (0x000B)
 Function call operations

--- a/tools/sddl2/assembler/OpcodesGenerated.cpp
+++ b/tools/sddl2/assembler/OpcodesGenerated.cpp
@@ -3,7 +3,7 @@
 // AUTO-GENERATED FILE - DO NOT EDIT MANUALLY
 //
 // Generated from: src/openzl/compress/graphs/sddl2/sddl2_opcodes.def
-// Generated at: 2026-02-13 16:24:43 UTC
+// Generated at: 2026-02-25 19:35:34 UTC
 // Generator: generate_opcodes.py
 //
 // To regenerate: python3 generate_opcodes.py
@@ -181,6 +181,12 @@ const std::unordered_map<std::string, Instruction> INSTRUCTIONS = {
       Instruction{ Family::TYPE, 0x0010, std::vector<ParamType>{} } },
 
     // VAR family (0x0009)
+    { "var.store",
+      Instruction{ Family::VAR, 0x0001, std::vector<ParamType>{} } },
+    { "var.load",
+      Instruction{ Family::VAR, 0x0002, std::vector<ParamType>{} } },
+    { "var.clear",
+      Instruction{ Family::VAR, 0x0003, std::vector<ParamType>{} } },
 
     // CALL family (0x000B)
 

--- a/tools/sddl2/assembler/OpcodesGenerated.h
+++ b/tools/sddl2/assembler/OpcodesGenerated.h
@@ -3,7 +3,7 @@
 // AUTO-GENERATED FILE - DO NOT EDIT MANUALLY
 //
 // Generated from: src/openzl/compress/graphs/sddl2/sddl2_opcodes.def
-// Generated at: 2026-02-13 16:24:43 UTC
+// Generated at: 2026-02-25 19:35:34 UTC
 // Generator: generate_opcodes.py
 //
 // To regenerate: python3 generate_opcodes.py

--- a/tools/sddl2/compiler/Compiler.cpp
+++ b/tools/sddl2/compiler/Compiler.cpp
@@ -114,10 +114,12 @@ std::string Compiler::compile(
     const Source src{ source, filename };
     const auto tokens = tokenizer_.tokenize(src);
     const auto groups = grouper_.group(tokens);
-    const auto tree   = parser_.parse(groups);
+    auto tree         = parser_.parse(groups);
     semantic_analyzer_.analyze(tree);
-    const auto optimized = optimizer_.optimize(tree);
-    return codegen_.generate(optimized);
+    if (options_.optimize) {
+        tree = optimizer_.optimize(tree);
+    }
+    return codegen_.generate(tree);
 }
 
 Compiler::Options::Options() {}
@@ -180,5 +182,27 @@ Compiler::Options& Compiler::Options::with_no_debug_info() &
 Compiler::Options&& Compiler::Options::with_no_debug_info() &&
 {
     return std::move(with_no_debug_info());
+}
+
+Compiler::Options& Compiler::Options::with_optimization(bool o) &
+{
+    optimize = o;
+    return *this;
+}
+
+Compiler::Options&& Compiler::Options::with_optimization(bool o) &&
+{
+    return std::move(with_optimization(o));
+}
+
+Compiler::Options& Compiler::Options::with_no_optimization() &
+{
+    optimize = false;
+    return *this;
+}
+
+Compiler::Options&& Compiler::Options::with_no_optimization() &&
+{
+    return std::move(with_no_optimization());
 }
 } // namespace openzl::sddl2

--- a/tools/sddl2/compiler/Compiler.h
+++ b/tools/sddl2/compiler/Compiler.h
@@ -111,9 +111,22 @@ class Compiler {
         Options& with_no_debug_info() &;
         Options&& with_no_debug_info() &&;
 
+        /**
+         * Whether to perform the optimization pass.
+         */
+        Options& with_optimization(bool o = true) &;
+        Options&& with_optimization(bool o = true) &&;
+
+        /**
+         * Don't perform the optimization pass.
+         */
+        Options& with_no_optimization() &;
+        Options&& with_no_optimization() &&;
+
         std::ostream* log_os{ &std::cerr };
         int verbosity{ 0 };
         bool include_debug_info{ true };
+        bool optimize{ true };
     };
 
    protected:

--- a/tools/sddl2/compiler/optimizer/DeadVarPass.cpp
+++ b/tools/sddl2/compiler/optimizer/DeadVarPass.cpp
@@ -1,0 +1,167 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#include <unordered_map>
+
+#include "tools/sddl2/compiler/optimizer/DeadVarPass.h"
+#include "tools/sddl2/compiler/parser/AST.h"
+
+namespace openzl::sddl2 {
+namespace {
+
+bool isAssignment(Op op)
+{
+    return op == Op::ASSIGN || op == Op::ASSUME;
+}
+
+class DeadVarImpl {
+   public:
+    ASTVec optimize(const ASTVec& ast)
+    {
+        // Phase 1: collect all variable reads and record the last read index
+        // for each variable name.
+        for (const auto& node : ast) {
+            recordLastRefs(node);
+        }
+
+        // Phase 2: optimize the AST
+        ASTVec result;
+        result.reserve(ast.size());
+        for (const auto& node : ast) {
+            // It's possible that the node is optimized away.
+            auto optimized = optimizeNode(node);
+            if (optimized) {
+                result.push_back(optimized);
+            }
+        }
+        return result;
+    }
+
+   private:
+    void recordLastRefs(const ASTPtr& node)
+    {
+        switch (node->converted_node_type()) {
+            case ConvertedNodeType::NUM:
+            case ConvertedNodeType::BUILTIN_FIELD:
+                return;
+            case ConvertedNodeType::VAR: {
+                auto var               = node->as_var();
+                last_ref_[var->name()] = var;
+                return;
+            }
+            case ConvertedNodeType::BYTES: {
+                recordLastRefs(node->as_bytes()->len());
+                return;
+            }
+            case ConvertedNodeType::ARRAY: {
+                recordLastRefs(node->as_array()->field());
+                if (node->as_array()->len()) {
+                    recordLastRefs(node->as_array()->len());
+                }
+                return;
+            }
+            case ConvertedNodeType::RECORD: {
+                for (const auto& field : node->as_record()->fields()) {
+                    recordLastRefs(field);
+                }
+                return;
+            }
+            case ConvertedNodeType::OP: {
+                const auto& op = *node->as_op();
+                for (size_t i = 0; i < op.args().size(); ++i) {
+                    if (isAssignment(op.op()) && i == 0) {
+                        continue;
+                    }
+                    recordLastRefs(op.args()[i]);
+                }
+                return;
+            }
+        }
+    }
+
+    ASTPtr optimizeNode(const ASTPtr& node)
+    {
+        switch (node->converted_node_type()) {
+            case ConvertedNodeType::NUM:
+            case ConvertedNodeType::BUILTIN_FIELD:
+            case ConvertedNodeType::RECORD:
+                return node;
+            case ConvertedNodeType::VAR:
+                return optimize(node->as_var());
+            case ConvertedNodeType::BYTES:
+                return optimize(node->as_bytes());
+            case ConvertedNodeType::ARRAY:
+                return optimize(node->as_array());
+            case ConvertedNodeType::OP:
+                return optimize(node->as_op());
+            default:
+                throw InvariantViolation("Unsupported AST node type.");
+        }
+    }
+
+    ASTPtr optimize(const ASTVar* var)
+    {
+        const auto& last_ref_it = last_ref_.find(var->name());
+        if (last_ref_it == last_ref_.end()) {
+            throw InvariantViolation("Variable not found: " + var->name());
+        }
+        const auto& last_ref = last_ref_it->second;
+        if (last_ref == var) {
+            return Codegen(var->loc()).var(var->name(), true /* is_last */);
+        }
+        return Codegen(var->loc()).var(var->name());
+    }
+
+    ASTPtr optimize(const ASTBytes* bytes)
+    {
+        return Codegen(bytes->loc()).bytes(optimizeNode(bytes->len()));
+    }
+
+    ASTPtr optimize(const ASTArray* arr)
+    {
+        if (!arr->len()) {
+            return Codegen(arr->loc()).array(optimizeNode(arr->field()));
+        }
+        return Codegen(arr->loc())
+                .array(optimizeNode(arr->field()), optimizeNode(arr->len()));
+    }
+
+    ASTPtr optimize(const ASTOp* op)
+    {
+        // If the variable is not referenced, we can remove the assignment
+        if (isAssignment(op->op())
+            && !last_ref_.count(op->args()[0]->as_var()->name())) {
+            if (op->op() == Op::ASSIGN) {
+                return nullptr;
+            }
+            if (op->op() == Op::ASSUME) {
+                return Codegen(op->loc()).consume(op->args()[1]);
+            }
+        }
+
+        ASTVec args;
+        for (size_t i = 0; i < op->args().size(); ++i) {
+            if (isAssignment(op->op()) && i == 0) {
+                args.push_back(op->args()[i]);
+                continue;
+            }
+            args.push_back(optimizeNode(op->args()[i]));
+        }
+        return Codegen(op->loc()).op(op->op(), std::move(args));
+    }
+
+    // Maps variable name → the list time it is referenced. Variables not in
+    // this map are never referenced.
+    std::unordered_map<std::string, const ASTVar*> last_ref_;
+};
+
+} // namespace
+
+DeadVarPass::DeadVarPass(const detail::Logger& logger) : log_(logger) {}
+
+ASTVec DeadVarPass::optimize(const ASTVec& ast) const
+{
+    log_(1) << "Running DeadVar Optimization Pass ..." << std::endl;
+    return DeadVarImpl{}.optimize(ast);
+}
+
+} // namespace openzl::sddl2

--- a/tools/sddl2/compiler/optimizer/DeadVarPass.h
+++ b/tools/sddl2/compiler/optimizer/DeadVarPass.h
@@ -1,0 +1,20 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#pragma once
+
+#include "tools/sddl2/compiler/Logger.h"
+#include "tools/sddl2/compiler/optimizer/OptimizationPass.h"
+
+namespace openzl::sddl2 {
+
+class DeadVarPass : public OptimizationPass {
+   public:
+    explicit DeadVarPass(const detail::Logger& logger);
+
+    ASTVec optimize(const ASTVec& ast) const override;
+
+   private:
+    const detail::Logger& log_;
+};
+
+} // namespace openzl::sddl2

--- a/tools/sddl2/compiler/optimizer/Optimizer.cpp
+++ b/tools/sddl2/compiler/optimizer/Optimizer.cpp
@@ -2,12 +2,14 @@
 
 #include "tools/sddl2/compiler/optimizer/Optimizer.h"
 #include "tools/sddl2/compiler/optimizer/ConstFoldPass.h"
+#include "tools/sddl2/compiler/optimizer/DeadVarPass.h"
 
 namespace openzl::sddl2 {
 
 Optimizer::Optimizer(const detail::Logger& logger)
 {
     passes_.push_back(std::make_unique<ConstFoldPass>(logger));
+    passes_.push_back(std::make_unique<DeadVarPass>(logger));
 }
 
 ASTVec Optimizer::optimize(const ASTVec& ast) const

--- a/tools/sddl2/compiler/parser/AST.cpp
+++ b/tools/sddl2/compiler/parser/AST.cpp
@@ -207,8 +207,10 @@ int64_t ASTNum::val() const
     return val_;
 }
 
-ASTVar::ASTVar(const Token& token)
-        : ASTConverted(token.loc()), name_(token.word())
+ASTVar::ASTVar(const Token& token, bool is_last_reference)
+        : ASTConverted(token.loc()),
+          name_(token.word()),
+          is_last_reference_(is_last_reference)
 {
 }
 
@@ -219,12 +221,21 @@ const ASTVar* ASTVar::as_var() const
 
 void ASTVar::print(std::ostream& os, size_t indent) const
 {
-    os << std::string(indent, ' ') << "Var: " << name_ << std::endl;
+    os << std::string(indent, ' ') << "Var: " << name_;
+    if (is_last_reference_) {
+        os << " (last ref)";
+    }
+    os << std::endl;
 }
 
 const std::string& ASTVar::name() const
 {
     return name_;
+}
+
+bool ASTVar::is_last_reference() const
+{
+    return is_last_reference_;
 }
 
 ASTBuiltinField::ASTBuiltinField(const SourceLocation& loc, const Symbol& sym)

--- a/tools/sddl2/compiler/parser/AST.h
+++ b/tools/sddl2/compiler/parser/AST.h
@@ -171,7 +171,7 @@ class ASTNum : public ASTConverted {
 
 class ASTVar : public ASTConverted {
    public:
-    explicit ASTVar(const Token& token);
+    explicit ASTVar(const Token& token, bool is_last_reference = false);
 
     const ASTVar* as_var() const override;
 
@@ -183,9 +183,11 @@ class ASTVar : public ASTConverted {
     }
 
     const std::string& name() const;
+    bool is_last_reference() const;
 
    private:
     const std::string name_;
+    bool is_last_reference_ = false;
 };
 
 class ASTField : public ASTConverted {
@@ -427,6 +429,11 @@ class Codegen {
     ASTPtr var(poly::string_view name) const
     {
         return std::make_shared<ASTVar>(Token{ loc_, name });
+    }
+
+    ASTPtr var(poly::string_view name, bool is_last_reference) const
+    {
+        return std::make_shared<ASTVar>(Token{ loc_, name }, is_last_reference);
     }
 
     ASTPtr list(Symbol open_sym, ASTVec elts) const

--- a/tools/sddl2/compiler/tests/CompilerTest.cpp
+++ b/tools/sddl2/compiler/tests/CompilerTest.cpp
@@ -219,12 +219,11 @@ TEST_F(CompilerTest, UnaryNegationAST)
 {
     const auto prog = R"(
         tmp = 10 - - 11
+        expect tmp == 21
     )";
 
     const auto cg       = Codegen(SourceLocation::null());
-    const auto expected = std::vector<ASTPtr>({
-            cg.assign(cg.var("tmp"), cg.num(21)),
-    });
+    const auto expected = std::vector<ASTPtr>({ cg.expect(cg.num(1)) });
     expect_ast(prog, expected);
 }
 
@@ -251,8 +250,7 @@ TEST_F(CompilerTest, ArrayAST)
 
     const auto cg       = Codegen(SourceLocation::null());
     const auto expected = std::vector<ASTPtr>(
-            { cg.assign(cg.var("len"), cg.num(3)),
-              cg.consume(cg.array(cg.builtin_field(Symbol::BYTE), cg.num(3))),
+            { cg.consume(cg.array(cg.builtin_field(Symbol::BYTE), cg.num(3))),
               cg.consume(cg.array(cg.builtin_field(Symbol::BYTE))) });
 
     expect_ast(prog, expected);
@@ -264,16 +262,19 @@ TEST_F(CompilerTest, RecordAST)
         Record Entry() = {
             id: Int32LE,
         }
+        : Entry
     )";
 
     const auto cg       = Codegen(SourceLocation::null());
-    const auto expected = std::vector<ASTPtr>({ cg.assign(
-            cg.var("Entry"),
-            cg.record(
-                    ArgVec{},
-                    ArgVec{ cg.assume(
-                            cg.var("id"),
-                            cg.builtin_field(Symbol::I32LE)) })) });
+    const auto expected = std::vector<ASTPtr>(
+            { cg.assign(
+                      cg.var("Entry"),
+                      cg.record(
+                              ArgVec{},
+                              ArgVec{ cg.assume(
+                                      cg.var("id"),
+                                      cg.builtin_field(Symbol::I32LE)) })),
+              cg.consume(cg.var("Entry", true)) });
     expect_ast(prog, expected);
 }
 
@@ -297,11 +298,12 @@ TEST_F(CompilerTest, ParenthesesOverridePrecedenceAST)
 {
     const auto prog = R"(
         tmp = (1 - 2) * 3
+        expect tmp == -3
     )";
 
     const auto cg       = Codegen(SourceLocation::null());
     const auto expected = std::vector<ASTPtr>({
-            cg.assign(cg.var("tmp"), cg.num(-3)),
+            cg.expect(cg.num(1)),
     });
     expect_ast(prog, expected);
 }
@@ -310,11 +312,12 @@ TEST_F(CompilerTest, NestedParenthesesAST)
 {
     const auto prog = R"(
         tmp = ((1 + 2) * (3 + 4))
+        expect tmp == 21
     )";
 
     const auto cg       = Codegen(SourceLocation::null());
     const auto expected = std::vector<ASTPtr>({
-            cg.assign(cg.var("tmp"), cg.num(21)),
+            cg.expect(cg.num(1)),
     });
     expect_ast(prog, expected);
 }
@@ -323,11 +326,12 @@ TEST_F(CompilerTest, ComplexArithmeticExpressionAST)
 {
     const auto prog = R"(
         tmp = 1 + 2 * 3 - 4 / 2
+        expect tmp == 5
     )";
 
     const auto cg       = Codegen(SourceLocation::null());
     const auto expected = std::vector<ASTPtr>({
-            cg.assign(cg.var("tmp"), cg.num(5)),
+            cg.expect(cg.num(1)),
     });
     expect_ast(prog, expected);
 }
@@ -376,9 +380,8 @@ TEST_F(CompilerTest, SimpleSaoAST)
                                             cg.var("XDPM"),
                                             cg.builtin_field(Symbol::F32LE)),
                             })),
-            cg.assume(cg.var("header"), cg.bytes(cg.num(28))),
-            cg.assume(
-                    cg.var("stars"), cg.array(cg.var("StarEntry"), cg.num(10))),
+            cg.consume(cg.bytes(cg.num(28))),
+            cg.consume(cg.array(cg.var("StarEntry"), cg.num(10))),
     });
     expect_ast(prog, expected);
 }
@@ -486,15 +489,12 @@ TEST_F(CompilerTest, ArithmeticConstFold)
 {
     const auto prog     = R"(
         tmp = 1 + 2
-        tmp = -(3 + 2)
-        tmp = 2 * 3 + 4
-        expect tmp == 10
+        tmp = -(tmp + 2)
+        tmp = 2 * 3 + tmp
+        expect tmp == 1
     )";
     const auto cg       = Codegen(SourceLocation::null());
     const auto expected = std::vector<ASTPtr>({
-            cg.assign(cg.var("tmp"), cg.num(3)),
-            cg.assign(cg.var("tmp"), cg.num(-5)),
-            cg.assign(cg.var("tmp"), cg.num(10)),
             cg.expect(cg.num(1)),
     });
     expect_ast(prog, expected);
@@ -536,7 +536,6 @@ TEST_F(CompilerTest, ConstPropagation)
     )";
     const auto cg       = Codegen(SourceLocation::null());
     const auto expected = std::vector<ASTPtr>({
-            cg.assign(cg.var("x"), cg.num(5)),
             cg.expect(cg.num(1)),
     });
     expect_ast(prog, expected);
@@ -552,9 +551,6 @@ TEST_F(CompilerTest, ChainedConstPropagation)
     )";
     const auto cg       = Codegen(SourceLocation::null());
     const auto expected = std::vector<ASTPtr>({
-            cg.assign(cg.var("a"), cg.num(1)),
-            cg.assign(cg.var("b"), cg.num(2)),
-            cg.assign(cg.var("b"), cg.num(4)),
             cg.expect(cg.num(1)),
     });
     expect_ast(prog, expected);


### PR DESCRIPTION
Summary:
# Stack
The purpose of this stack is to enhance the sddl2 compiler so it can produce code compatible with the sddl2 virtual machine.

# Diff
This diff adds a `with_optimization()` / `with_no_optimization()` option to `Compiler::Options`, allowing callers to skip the optimizer pass entirely.

- Added `bool optimize` field to `Compiler::Options` (defaults to `true` so existing behavior is unchanged).
- Added `with_optimization(bool)` and `with_no_optimization()` builder methods following the existing Options pattern.
- Made the optimization pass in `Compiler::compile()` conditional on this flag, passing the unoptimized AST directly to codegen when disabled.

Differential Revision: D95084139


