### PR TITLE
Migrate fbcode/openzl from legacy Thrift reflection to modern always-on reflection

### DIFF
--- a/custom_transforms/thrift/kernels/tests/BUCK
+++ b/custom_transforms/thrift/kernels/tests/BUCK
@@ -25,7 +25,6 @@ cpp_library(
     exported_deps = [
         "../../../..:zstronglib",
         "../../../../tests/datagen:datagen",
-        ":fuzz_data-cpp2-reflection",
         ":fuzz_data-cpp2-types",
         ":fuzz_data-cpp2-visitation",
         "//folly:overload",

--- a/custom_transforms/thrift/kernels/tests/thrift_kernel_test_utils.h
+++ b/custom_transforms/thrift/kernels/tests/thrift_kernel_test_utils.h
@@ -20,11 +20,9 @@
 
 // TODO: Not sure if there is a better way to do this
 #if ZL_FBCODE_IS_RELEASE
-#    include "openzl/prod/custom_transforms/thrift/kernels/tests/gen-cpp2/fuzz_data_fatal_types.h"
 #    include "openzl/prod/custom_transforms/thrift/kernels/tests/gen-cpp2/fuzz_data_types.h"
 #    include "openzl/prod/custom_transforms/thrift/kernels/tests/gen-cpp2/fuzz_data_visitation.h"
 #else
-#    include "openzl/dev/custom_transforms/thrift/kernels/tests/gen-cpp2/fuzz_data_fatal_types.h"
 #    include "openzl/dev/custom_transforms/thrift/kernels/tests/gen-cpp2/fuzz_data_types.h"
 #    include "openzl/dev/custom_transforms/thrift/kernels/tests/gen-cpp2/fuzz_data_visitation.h"
 #endif


### PR DESCRIPTION
Summary: Replace _fatal_types.h includes with _types.h and update BUCK dependencies from -cpp2-reflection to -cpp2-types.

Differential Revision: D95270677


