### PR TITLE
Add Partition codec (#464)

### DIFF
--- a/BUCK
+++ b/BUCK
@@ -103,8 +103,6 @@ zs_library(
     ],
     deps = [
         "fbsource//third-party/lz4:lz4",
-        "fbsource//third-party/zstd:zstd",
-        ":common",
     ],
     exported_deps = [
         ":common",
@@ -136,7 +134,6 @@ zs_library(
     header_namespace = "",
     deps = [
         "fbsource//third-party/lz4:lz4",
-        "fbsource//third-party/zstd:zstd",
     ],
     exported_deps = [
         ":common",

--- a/cpp/include/openzl/cpp/Codecs.hpp
+++ b/cpp/include/openzl/cpp/Codecs.hpp
@@ -23,6 +23,7 @@
 #include "openzl/cpp/codecs/Lz4.hpp"              // IWYU pragma: export
 #include "openzl/cpp/codecs/MergeSorted.hpp"      // IWYU pragma: export
 #include "openzl/cpp/codecs/ParseInt.hpp"         // IWYU pragma: export
+#include "openzl/cpp/codecs/Partition.hpp"        // IWYU pragma: export
 #include "openzl/cpp/codecs/Prefix.hpp"           // IWYU pragma: export
 #include "openzl/cpp/codecs/Quantize.hpp"         // IWYU pragma: export
 #include "openzl/cpp/codecs/RangePack.hpp"        // IWYU pragma: export

--- a/cpp/include/openzl/cpp/codecs/Partition.hpp
+++ b/cpp/include/openzl/cpp/codecs/Partition.hpp
@@ -1,0 +1,80 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#pragma once
+
+#include "openzl/codecs/zl_partition.h"
+#include "openzl/codecs/zl_store.h"
+#include "openzl/cpp/Compressor.hpp"
+#include "openzl/cpp/codecs/Metadata.hpp"
+#include "openzl/cpp/codecs/Node.hpp"
+
+#include <vector>
+
+namespace openzl {
+namespace nodes {
+
+class Partition : public Node {
+   public:
+    static constexpr NodeID node = ZL_NODE_PARTITION;
+
+    static constexpr NodeMetadata<1, 2> metadata = {
+        .inputs           = { InputMetadata{ .type = Type::Numeric } },
+        .singletonOutputs = { OutputMetadata{ .type = Type::Numeric,
+                                              .name = "partitions" },
+                              OutputMetadata{ .type = Type::Serial,
+                                              .name = "offsets" } },
+        .description =
+                "Partition unsigned integer values into buckets and extra bits using configurable partition boundaries",
+    };
+
+    /// Construct with a preset ID (1-4).
+    explicit Partition(ZL_PartitionParamsPreset preset) : preset_(preset) {}
+
+    explicit Partition(
+            uint64_t startValue,
+            std::vector<uint64_t> partitionSizes)
+            : preset_(ZL_PartitionParamsPreset_custom)
+    {
+        copyParam_.push_back(startValue);
+        copyParam_.insert(
+                copyParam_.end(), partitionSizes.begin(), partitionSizes.end());
+    }
+
+    NodeID baseNode() const override
+    {
+        return node;
+    }
+
+    poly::optional<NodeParameters> parameters() const override
+    {
+        LocalParams params;
+        if (preset_ == ZL_PartitionParamsPreset_custom) {
+            params.addCopyParam(
+                    ZL_PARTITION_CUSTOM_PID,
+                    copyParam_.data(),
+                    copyParam_.size() * sizeof(uint64_t));
+        } else {
+            params.addIntParam(ZL_PARTITION_PRESET_PID, preset_);
+        }
+        return NodeParameters{ .localParams = std::move(params) };
+    }
+
+    GraphID operator()(
+            Compressor& compressor,
+            GraphID partitions,
+            GraphID offsets = ZL_GRAPH_STORE) const
+    {
+        return buildGraph(
+                compressor,
+                std::initializer_list<GraphID>{ partitions, offsets });
+    }
+
+    ~Partition() override = default;
+
+   private:
+    ZL_PartitionParamsPreset preset_;
+    std::vector<uint64_t> copyParam_;
+};
+
+} // namespace nodes
+} // namespace openzl

--- a/include/openzl/codecs/zl_partition.h
+++ b/include/openzl/codecs/zl_partition.h
@@ -1,0 +1,81 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#ifndef OPENZL_CODECS_ZL_PARTITION_H
+#define OPENZL_CODECS_ZL_PARTITION_H
+
+#include <stdint.h>
+
+#include "openzl/zl_errors.h"
+#include "openzl/zl_nodes.h"
+
+#if defined(__cplusplus)
+extern "C" {
+#endif
+
+/**
+ * Partitions unsigned integers into buckets and extra bits.
+ *
+ * Each value is assigned a bucket based on a configurable list of partition
+ * boundaries. The extra bits encode the offset within the bucket using
+ * ceil(log2(bucket_size)) bits per value.
+ *
+ * Presets are available for common partitioning schemes.
+ * Custom partition lists can be provided via ZL_PARTITION_CUSTOM_PID.
+ *
+ * Input: Numeric unsigned integers (1, 2, 4, or 8 bytes)
+ * Output 0: Numeric 8-bit unsigned bucket IDs
+ * Output 1: Serial extra-bits
+ */
+#define ZL_NODE_PARTITION ZL_MAKE_NODE_ID(ZL_StandardNodeID_partition)
+
+/// Maximum number of buckets supported by the partition codec.
+#define ZL_PARTITION_MAX_PARTITIONS 256
+
+/// Int param key selecting a ZL_PartitionPreset value.
+#define ZL_PARTITION_PRESET_PID 120
+
+/**
+ * Copy param key for custom partition settings
+ *
+ * The format is:
+ *   [uint64_t] starting value for the first partition
+ *   N * [uint64_t] partition size
+ *
+ * Requirements:
+ * - At least one partition
+ * - If there is only one partition, then the starting value must not be zero
+ * - Each partition size must be > 0
+ * - The sum of the partition sizes must be <= 2^64
+ * - If the partitioning does not cover the entire range of inputs,
+ *   the input MUST NOT contain values outside of the range, otherwise
+ *   compression will fail.
+ */
+#define ZL_PARTITION_CUSTOM_PID 121
+
+/// Preset partition IDs for the codec header.
+typedef enum {
+    ZL_PartitionParamsPreset_quantizeOffsets = 0,
+    ZL_PartitionParamsPreset_quantizeLengths = 1,
+    ZL_PartitionParamsPreset_varbyte16       = 2,
+    ZL_PartitionParamsPreset_custom,
+} ZL_PartitionParamsPreset;
+
+/// Build a partition node using a preset partitioning scheme.
+ZL_RESULT_OF(ZL_NodeID)
+ZL_Compressor_buildPartitionNodeFromPreset(
+        ZL_Compressor* compressor,
+        ZL_PartitionParamsPreset preset);
+
+/// Build a partition node with a custom partition list.
+ZL_RESULT_OF(ZL_NodeID)
+ZL_Compressor_buildPartitionNode(
+        ZL_Compressor* compressor,
+        uint64_t startValue,
+        const uint64_t* partitionSizes,
+        size_t numPartitions);
+
+#if defined(__cplusplus)
+}
+#endif
+
+#endif

--- a/include/openzl/zl_nodes.h
+++ b/include/openzl/zl_nodes.h
@@ -83,6 +83,8 @@ typedef enum {
     ZL_StandardNodeID_bitsplit_top8,
     ZL_StandardNodeID_bitsplit_fp,
 
+    ZL_StandardNodeID_partition,
+
     ZL_StandardNodeID_public_end // last id, used to detect end of public range
 } ZL_StandardNodeID;
 

--- a/src/openzl/codecs/decoder_registry.c
+++ b/src/openzl/codecs/decoder_registry.c
@@ -23,6 +23,7 @@
 #include "openzl/codecs/merge_sorted/decode_merge_sorted_binding.h"
 #include "openzl/codecs/parse_int/decode_parse_int_binding.h"
 #include "openzl/codecs/parse_int/graph_parse_int.h"
+#include "openzl/codecs/partition/decode_partition_binding.h"
 #include "openzl/codecs/prefix/decode_prefix_binding.h"
 #include "openzl/codecs/quantize/decode_quantize_binding.h"
 #include "openzl/codecs/range_pack/decode_range_pack_binding.h"
@@ -127,6 +128,7 @@ const StandardDTransform SDecoders_array[ZL_StandardTransformID_end] = {
     REGISTER_TTRANSFORM_G(ZL_StandardTransformID_divide_by, 16, DI_DIVIDE_BY_INT, NUMPIPE_GRAPH),
     REGISTER_TTRANSFORM(ZL_StandardTransformID_parse_int, 19, PARSE_INT),
     REGISTER_TTRANSFORM_G(ZL_StandardTransformID_lz4, 23, DI_LZ4, PIPE_GRAPH),
+    REGISTER_TTRANSFORM_G(ZL_StandardTransformID_partition, 24, DI_PARTITION, PARTITION_GRAPH),
 
     REGISTER_VOTRANSFORM_G(ZL_StandardTransformID_splitn, 9, DI_SPLITN, GRAPH_VO_SERIAL),
     REGISTER_VOTRANSFORM_G(ZL_StandardTransformID_splitn_struct, 14, DI_SPLITN_STRUCT, GRAPH_VO_STRUCT),

--- a/src/openzl/codecs/encoder_registry.c
+++ b/src/openzl/codecs/encoder_registry.c
@@ -23,6 +23,7 @@
 #include "openzl/codecs/lz4/encode_lz4_binding.h"
 #include "openzl/codecs/merge_sorted/encode_merge_sorted_binding.h"
 #include "openzl/codecs/parse_int/encode_parse_int_binding.h"
+#include "openzl/codecs/partition/encode_partition_binding.h"
 #include "openzl/codecs/prefix/encode_prefix_binding.h"
 #include "openzl/codecs/quantize/encode_quantize_binding.h"
 #include "openzl/codecs/range_pack/encode_range_pack_binding.h"
@@ -110,6 +111,7 @@ const CNode ER_standardNodes[STANDARD_ENCODERS_NB] = {
     REGISTER_TRANSFORM(ZL_StandardNodeID_quantize_lengths, ZL_StandardTransformID_quantize_lengths, 3, EI_QUANTIZE_LENGTHS),
     REGISTER_TRANSFORM(ZL_StandardNodeID_bitsplit_top8, ZL_StandardTransformID_bitSplit, 24, EI_BITSPLIT_TOP8),
     REGISTER_TRANSFORM(ZL_StandardNodeID_bitsplit_fp, ZL_StandardTransformID_bitSplit, 24, EI_BITSPLIT_FP),
+    REGISTER_TRANSFORM(ZL_StandardNodeID_partition, ZL_StandardTransformID_partition, 24, EI_PARTITION),
 
     // Private Nodes
     REGISTER_TRANSFORM(ZL_PrivateStandardNodeID_set_string_lens,           ZL_StandardTransformID_convert_serial_string, 10, EI_SETSTRINGLENS),

--- a/src/openzl/codecs/partition/common_partition.c
+++ b/src/openzl/codecs/partition/common_partition.c
@@ -1,0 +1,158 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#include "openzl/codecs/partition/common_partition.h"
+
+#include "openzl/codecs/zl_partition.h"
+#include "openzl/shared/bits.h"
+#include "openzl/shared/overflow.h"
+#include "openzl/shared/utils.h"
+
+bool ZL_PartitionParams_validate(const ZL_PartitionParams* params)
+{
+    if (params->numPartitions == 0) {
+        // Invalid: Can only work on empty data => store
+        return false;
+    }
+    if (params->numPartitions > 256) {
+        // Invalid: Too many partitions
+        return false;
+    }
+    if (params->numPartitions == 1 && params->startValue == 0) {
+        // Invalid: No-op
+        return false;
+    }
+    uint64_t sum = params->startValue;
+    for (size_t i = 0; i < params->numPartitions; ++i) {
+        if (params->partitionSizes[i] == 0) {
+            // Invalid: Partitions cannot be empty
+            return false;
+        }
+        if (ZL_overflowAddU64(sum, params->partitionSizes[i], &sum)) {
+            if (!(i + 1 == params->numPartitions && sum == 0)) {
+                // Invalid: Either non-final partition overflows, or final
+                // partition does not exactly sum to 2^64.
+                return false;
+            }
+        }
+    }
+    return true;
+}
+
+bool ZL_PartitionParams_areAllSizesPow2(const ZL_PartitionParams* params)
+{
+    for (size_t i = 0; i < params->numPartitions; ++i) {
+        if (!ZL_isPow2(params->partitionSizes[i])) {
+            return false;
+        }
+    }
+    return true;
+}
+
+// ---------------------------------------------------------------------------
+// Preset: Quantize Offsets (preset 0)
+// Pure power-of-2 scheme: [1, 2), [2, 4), [4, 8), ..., [2^31, 2^32)
+// Value 0 cannot be encoded.
+// ---------------------------------------------------------------------------
+static uint64_t const quantizeOffsetsPartitionSizes[32] = {
+    0x1,        0x2,        0x4,       0x8,       0x10,       0x20,
+    0x40,       0x80,       0x100,     0x200,     0x400,      0x800,
+    0x1000,     0x2000,     0x4000,    0x8000,    0x10000,    0x20000,
+    0x40000,    0x80000,    0x100000,  0x200000,  0x400000,   0x800000,
+    0x1000000,  0x2000000,  0x4000000, 0x8000000, 0x10000000, 0x20000000,
+    0x40000000, 0x80000000,
+};
+
+static ZL_PartitionParams const quantizeOffsetsParams = {
+    .startValue     = 1,
+    .numPartitions  = 32,
+    .partitionSizes = quantizeOffsetsPartitionSizes,
+};
+
+// ---------------------------------------------------------------------------
+// Preset: Quantize Lengths (preset 1)
+// Values 0-15 each get their own bucket (0 extra bits).
+// Then power-of-2 scheme: [16, 32), [32, 64), ..., [2^31, 2^32)
+// ---------------------------------------------------------------------------
+static uint64_t const quantizeLengthsPartitionSizess[44] = {
+    0x1,        0x1,        0x1,       0x1,       0x1,        0x1,
+    0x1,        0x1,        0x1,       0x1,       0x1,        0x1,
+    0x1,        0x1,        0x1,       0x1,       0x10,       0x20,
+    0x40,       0x80,       0x100,     0x200,     0x400,      0x800,
+    0x1000,     0x2000,     0x4000,    0x8000,    0x10000,    0x20000,
+    0x40000,    0x80000,    0x100000,  0x200000,  0x400000,   0x800000,
+    0x1000000,  0x2000000,  0x4000000, 0x8000000, 0x10000000, 0x20000000,
+    0x40000000, 0x80000000,
+};
+
+static ZL_PartitionParams const quantizeLengthsParams = {
+    .startValue     = 0,
+    .numPartitions  = 44,
+    .partitionSizes = quantizeLengthsPartitionSizess,
+};
+
+// ---------------------------------------------------------------------------
+// Preset: Varbyte16 (preset 2)
+// [0, 2), [2, 4), [4, 8), [8, 16), ..., [0x8000, 0x10000)
+// ---------------------------------------------------------------------------
+static uint64_t const varbyte16PartitionSizes[16] = {
+    0x2,   0x2,   0x4,   0x8,   0x10,   0x20,   0x40,   0x80,
+    0x100, 0x200, 0x400, 0x800, 0x1000, 0x2000, 0x4000, 0x8000,
+};
+
+static ZL_PartitionParams const varbyte16Params = {
+    .startValue     = 0,
+    .numPartitions  = 16,
+    .partitionSizes = varbyte16PartitionSizes,
+};
+
+#if 0
+// ---------------------------------------------------------------------------
+// Preset: Varbyte32 (disabled)
+// Can only encode values < 0x1558000
+// ---------------------------------------------------------------------------
+static uint64_t const varbyte32PartitionSizes[16] = {
+    0x20,   0x20,   0x40,   0x80,    0x100,   0x200,    0x400,    0x800,
+    0x1000, 0x2000, 0x4000, 0x10000, 0x40000, 0x100000, 0x400000, 0x1000000,
+};
+
+static ZL_PartitionParams const varbyte32Params = {
+    .startValue     = 0,
+    .numPartitions  = 16,
+    .partitionSizes = varbyte32PartitionSizes,
+};
+#endif
+
+static ZL_PartitionParams const* const
+        presetTable[ZL_PartitionParamsPreset_custom] = {
+            &quantizeOffsetsParams,
+            &quantizeLengthsParams,
+            &varbyte16Params,
+        };
+
+const ZL_PartitionParams* ZL_PartitionParams_getPreset(
+        ZL_PartitionParamsPreset preset)
+{
+    if ((int)preset < 0 || (int)preset >= ZL_PartitionParamsPreset_custom) {
+        return NULL;
+    }
+    return presetTable[preset];
+}
+
+void ZL_PartitionParams_computeBits(
+        const ZL_PartitionParams* params,
+        uint8_t* bits)
+{
+    for (size_t i = 0; i < params->numPartitions; ++i) {
+        bits[i] = (uint8_t)ZL_nextPow2(params->partitionSizes[i]);
+    }
+}
+
+void ZL_PartitionParams_computeBasesU64(
+        const ZL_PartitionParams* params,
+        uint64_t* bases)
+{
+    bases[0] = params->startValue;
+    for (size_t i = 1; i < params->numPartitions; ++i) {
+        bases[i] = bases[i - 1] + params->partitionSizes[i - 1];
+    }
+}

--- a/src/openzl/codecs/partition/common_partition.h
+++ b/src/openzl/codecs/partition/common_partition.h
@@ -1,0 +1,60 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+#ifndef OPENZL_CODECS_PARTITION_COMMON_PARTITION_H
+#define OPENZL_CODECS_PARTITION_COMMON_PARTITION_H
+
+#include "openzl/codecs/zl_partition.h"
+#include "openzl/shared/portability.h"
+#include "openzl/zl_errors.h"
+#include "openzl/zl_localParams.h"
+
+ZL_BEGIN_C_DECLS
+
+/**
+ * Runtime parameters for the partition codec.
+ * @param startValue The start value for the first partition.
+ * @param numPartitions The number of partitions.
+ * @param partitionSizes The size of each partition.
+ */
+typedef struct {
+    uint64_t startValue;
+    size_t numPartitions;
+    const uint64_t* partitionSizes;
+} ZL_PartitionParams;
+
+bool ZL_PartitionParams_validate(const ZL_PartitionParams* params);
+
+/// Check if all partition sizes are powers of 2.
+bool ZL_PartitionParams_areAllSizesPow2(const ZL_PartitionParams* params);
+
+/// Get a preset's partition parameters.
+/// @returns A pointer to the preset's static params, or NULL if invalid.
+const ZL_PartitionParams* ZL_PartitionParams_getPreset(
+        ZL_PartitionParamsPreset preset);
+
+/// Compute the number of extra bits needed per partition.
+/// bits[i] = ceil(log2(partitionSizes[i]))
+void ZL_PartitionParams_computeBits(
+        const ZL_PartitionParams* params,
+        uint8_t* bits);
+
+/// Compute the base value for each partition.
+/// bases[i] = startValue + sum(partitionSizes[0..i-1])
+void ZL_PartitionParams_computeBasesU64(
+        const ZL_PartitionParams* params,
+        uint64_t* bases);
+
+/// Header flag bits for the partition codec header byte.
+/// Bits [1:0]: log2(element width in bytes).
+
+/// Bit 2: params are a preset (remaining bits encode preset ID).
+#define ZL_PARTITION_HEADER_IS_PRESET_BIT 0x4
+/// Bit 3: startValue is 0 (omitted from header).
+#define ZL_PARTITION_HEADER_IS_FIRST_VALUE_ZERO_BIT 0x8
+/// Bit 4: unused.
+#define ZL_PARTITION_HEADER_UNUSED_BIT 0x10
+/// Bit 5: all partition sizes are powers of 2.
+#define ZL_PARTITION_HEADER_IS_POW2_BIT 0x20
+
+ZL_END_C_DECLS
+
+#endif

--- a/src/openzl/codecs/partition/decode_partition_binding.c
+++ b/src/openzl/codecs/partition/decode_partition_binding.c
@@ -1,0 +1,132 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+#include "openzl/codecs/partition/decode_partition_binding.h"
+
+#include "openzl/codecs/common/bitstream/ff_bitstream.h"
+#include "openzl/codecs/partition/common_partition.h"
+#include "openzl/codecs/partition/decode_partition_kernel.h"
+#include "openzl/shared/varint.h"
+#include "openzl/zl_dtransform.h"
+
+/// Parse partition parameters from the codec header.
+static ZL_Report ZL_PartitionParams_readHeader(
+        ZL_PartitionParams* params,
+        size_t* width,
+        ZL_Decoder* decoder)
+{
+    ZL_RESULT_DECLARE_SCOPE_REPORT(decoder);
+
+    ZL_RBuffer const header = ZL_Decoder_getCodecHeader(decoder);
+    ZL_ERR_IF_LT(header.size, 1, corruption, "Empty header");
+    const uint8_t* hdr       = (uint8_t const*)header.start;
+    const uint8_t* const end = hdr + header.size;
+    const uint8_t flags      = *hdr++;
+
+    *width = 1u << (flags & 0x3);
+
+    if (flags & ZL_PARTITION_HEADER_IS_PRESET_BIT) {
+        const ZL_PartitionParamsPreset preset =
+                (ZL_PartitionParamsPreset)(flags >> 3);
+        ZL_PartitionParams const* const presetParams =
+                ZL_PartitionParams_getPreset(preset);
+        ZL_ERR_IF_NULL(presetParams, corruption);
+        *params = *presetParams;
+        return ZL_returnSuccess();
+    }
+
+    if (flags & ZL_PARTITION_HEADER_IS_FIRST_VALUE_ZERO_BIT) {
+        params->startValue = 0;
+    } else {
+        ZL_TRY_SET(uint64_t, params->startValue, ZL_varintDecode(&hdr, end));
+    }
+
+    if (flags & ZL_PARTITION_HEADER_IS_POW2_BIT) {
+        const size_t numBits = (size_t)(flags >> 6) + 3;
+        ZL_ERR_IF_EQ(numBits, 0, corruption, "Invalid numBits");
+        ZL_ERR_IF_EQ(hdr, end, corruption, "Missing partition sizes");
+        ZL_ERR_IF_EQ(
+                end[-1], 0, corruption, "Corrupted partition sizes bitstream");
+        // The bitstream ends with a 1 bit, so we know when to stop.
+        const size_t unusedBits = 8 - (size_t)ZL_highbit32(end[-1]);
+        const size_t totalBits  = 8 * (size_t)(end - hdr) - unusedBits;
+        ZL_ERR_IF_NE(
+                totalBits % numBits,
+                0,
+                corruption,
+                "bitstream size not multiple of numBits");
+        params->numPartitions = totalBits / numBits;
+
+        ZL_ERR_IF_GT(
+                params->numPartitions, ZL_PARTITION_MAX_PARTITIONS, corruption);
+        uint64_t* partitionSizes = ZL_Decoder_getScratchSpace(
+                decoder,
+                sizeof(params->partitionSizes[0]) * params->numPartitions);
+        ZL_ERR_IF_NULL(partitionSizes, allocation);
+
+        ZS_BitDStreamFF bitstream =
+                ZS_BitDStreamFF_init(hdr, (size_t)(end - hdr));
+        for (size_t i = 0; i < params->numPartitions; ++i) {
+            uint64_t const log2Size = ZS_BitDStreamFF_read(&bitstream, numBits);
+            partitionSizes[i]       = 1ULL << log2Size;
+            ZS_BitDStreamFF_reload(&bitstream);
+        }
+
+        ZL_ERR_IF_ERR(ZS_BitDStreamFF_finish(&bitstream));
+        params->partitionSizes = partitionSizes;
+    } else {
+        const size_t partitionBound =
+                ZL_MIN((size_t)(end - hdr), ZL_PARTITION_MAX_PARTITIONS);
+        uint64_t* partitionSizes = ZL_Decoder_getScratchSpace(
+                decoder, sizeof(params->partitionSizes[0]) * partitionBound);
+        ZL_ERR_IF_NULL(partitionSizes, allocation);
+        params->numPartitions = 0;
+        while (hdr < end) {
+            ZL_ERR_IF_GE(
+                    params->numPartitions,
+                    ZL_PARTITION_MAX_PARTITIONS,
+                    corruption);
+            ZL_TRY_SET(
+                    uint64_t,
+                    partitionSizes[params->numPartitions++],
+                    ZL_varintDecode(&hdr, end));
+        }
+        params->partitionSizes = partitionSizes;
+    }
+    ZL_ERR_IF_NOT(ZL_PartitionParams_validate(params), corruption);
+    return ZL_returnSuccess();
+}
+
+ZL_Report DI_partition(ZL_Decoder* dictx, const ZL_Input* ins[])
+{
+    ZL_RESULT_DECLARE_SCOPE_REPORT(dictx);
+    ZL_Input const* const bucketsIn = ins[0];
+    ZL_Input const* const bitsIn    = ins[1];
+
+    ZL_ERR_IF_NE(ZL_Input_eltWidth(bucketsIn), 1, corruption, "Unsupported");
+    ZL_ASSERT_EQ(ZL_Input_type(bitsIn), ZL_Type_serial);
+
+    size_t const numElts = ZL_Input_numElts(bucketsIn);
+
+    ZL_PartitionParams params = { 0 };
+    size_t eltWidth           = 0;
+    ZL_ERR_IF_ERR(ZL_PartitionParams_readHeader(&params, &eltWidth, dictx));
+
+    ZL_Output* const out =
+            ZL_Decoder_create1OutStream(dictx, numElts, eltWidth);
+    ZL_ERR_IF_NULL(out, allocation);
+
+    ZL_Report const ret = ZL_partitionDecode(
+            ZL_Output_ptr(out),
+            eltWidth,
+            (uint8_t const*)ZL_Input_ptr(bucketsIn),
+            numElts,
+            (uint8_t const*)ZL_Input_ptr(bitsIn),
+            ZL_Input_numElts(bitsIn),
+            &params);
+    if (ZL_isError(ret)) {
+        return ret;
+    }
+
+    ZL_ERR_IF_ERR(ZL_Output_commit(out, numElts));
+
+    return ZL_returnValue(1);
+}

--- a/src/openzl/codecs/partition/decode_partition_binding.h
+++ b/src/openzl/codecs/partition/decode_partition_binding.h
@@ -1,0 +1,22 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+#ifndef OPENZL_CODECS_PARTITION_DECODE_PARTITION_BINDING_H
+#define OPENZL_CODECS_PARTITION_DECODE_PARTITION_BINDING_H
+
+#include "openzl/codecs/partition/graph_partition.h"
+#include "openzl/shared/portability.h"
+#include "openzl/zl_dtransform.h"
+
+ZL_BEGIN_C_DECLS
+
+/// Decoder binding for the partition transform.
+/// Reads the codec header, then decodes bucket IDs + extra bits back into
+/// the original values.
+ZL_Report DI_partition(ZL_Decoder* dictx, const ZL_Input* ins[]);
+
+/// Macro to register the partition decoder transform.
+#define DI_PARTITION(id) \
+    { .transform_f = DI_partition, .name = "!zl.partition" }
+
+ZL_END_C_DECLS
+
+#endif

--- a/src/openzl/codecs/partition/decode_partition_kernel.c
+++ b/src/openzl/codecs/partition/decode_partition_kernel.c
@@ -1,0 +1,88 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#include "openzl/codecs/partition/decode_partition_kernel.h"
+
+#include "openzl/codecs/common/bitstream/ff_bitstream.h"
+#include "openzl/zl_errors.h"
+
+/// The bitstream accumulator holds 63 bits, and after a reload up to 7 bits
+/// may be consumed. A single read must satisfy: residual + nbBits <= 64, so the
+/// maximum safe read after reload is 57 bits. Use 56 to match the encoder.
+#define ZL_PARTITION_BITS_SPLIT 56
+
+/// Read an offset value from the bitstream, splitting into two reads if the
+/// number of bits exceeds ZL_PARTITION_BITS_SPLIT.
+static uint64_t ZL_partitionReadBits(ZS_BitDStreamFF* bitstream, size_t nbBits)
+{
+    if (nbBits <= ZL_PARTITION_BITS_SPLIT) {
+        return (uint64_t)ZS_BitDStreamFF_read(bitstream, nbBits);
+    } else {
+        uint64_t const lo = (uint64_t)ZS_BitDStreamFF_read(bitstream, 32);
+        ZS_BitDStreamFF_reload(bitstream);
+        uint64_t const hi =
+                (uint64_t)ZS_BitDStreamFF_read(bitstream, nbBits - 32);
+        return lo | (hi << 32);
+    }
+}
+
+static uint64_t ZL_partitionDecode1(
+        uint8_t bucket,
+        ZS_BitDStreamFF* bitstream,
+        uint64_t const* partitions,
+        uint8_t const* bits)
+{
+    uint64_t const offset = ZL_partitionReadBits(bitstream, bits[bucket]);
+    return partitions[bucket] + offset;
+}
+
+/// Write a decoded value to the output buffer at the given index.
+static void
+ZL_writeValue(void* dst, size_t index, uint64_t value, size_t eltWidth)
+{
+    switch (eltWidth) {
+        case 1:
+            ((uint8_t*)dst)[index] = (uint8_t)value;
+            break;
+        case 2:
+            ((uint16_t*)dst)[index] = (uint16_t)value;
+            break;
+        case 4:
+            ((uint32_t*)dst)[index] = (uint32_t)value;
+            break;
+        case 8:
+            ((uint64_t*)dst)[index] = value;
+            break;
+    }
+}
+
+ZL_Report ZL_partitionDecode(
+        void* dst,
+        size_t eltWidth,
+        uint8_t const* buckets,
+        size_t nbValues,
+        uint8_t const* offsets,
+        size_t offsetsSize,
+        ZL_PartitionParams const* params)
+{
+    ZL_RESULT_DECLARE_SCOPE_REPORT(NULL);
+    ZL_ASSERT(ZL_PartitionParams_validate(params));
+
+    uint64_t bases[ZL_PARTITION_MAX_PARTITIONS];
+    uint8_t bits[ZL_PARTITION_MAX_PARTITIONS];
+    ZL_PartitionParams_computeBasesU64(params, bases);
+    ZL_PartitionParams_computeBits(params, bits);
+
+    ZS_BitDStreamFF bitstream = ZS_BitDStreamFF_init(offsets, offsetsSize);
+
+    for (size_t i = 0; i < nbValues; ++i) {
+        uint64_t const val =
+                ZL_partitionDecode1(buckets[i], &bitstream, bases, bits);
+        ZL_writeValue(dst, i, val, eltWidth);
+        ZS_BitDStreamFF_reload(&bitstream);
+    }
+
+    ZL_Report const ret = ZS_BitDStreamFF_finish(&bitstream);
+    ZL_ERR_IF(ZL_isError(ret), srcSize_tooSmall);
+
+    return ZL_returnSuccess();
+}

--- a/src/openzl/codecs/partition/decode_partition_kernel.h
+++ b/src/openzl/codecs/partition/decode_partition_kernel.h
@@ -1,0 +1,38 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+#ifndef OPENZL_CODECS_PARTITION_DECODE_PARTITION_KERNEL_H
+#define OPENZL_CODECS_PARTITION_DECODE_PARTITION_KERNEL_H
+
+#include "openzl/codecs/partition/common_partition.h"
+#include "openzl/shared/portability.h"
+#include "openzl/zl_errors.h"
+
+ZL_BEGIN_C_DECLS
+
+/**
+ * Decodes partition-encoded data.
+ *
+ * For each bucket ID, reads the corresponding number of extra bits from
+ * the bitstream and reconstructs the original value as:
+ *   value = partitions[bucket_id] + offset
+ *
+ * @param dst Output buffer for decoded values.
+ * @param eltWidth Element width in bytes (1, 2, 4, or 8).
+ * @param buckets Input bucket IDs (one per value).
+ * @param nbValues Number of values to decode.
+ * @param bits Input bitstream containing the extra bits.
+ * @param bitsSize Size of the bitstream in bytes.
+ * @param params Partition parameters.
+ * @returns Success or an error code.
+ */
+ZL_Report ZL_partitionDecode(
+        void* dst,
+        size_t eltWidth,
+        uint8_t const* buckets,
+        size_t nbValues,
+        uint8_t const* bits,
+        size_t bitsSize,
+        ZL_PartitionParams const* params);
+
+ZL_END_C_DECLS
+
+#endif

--- a/src/openzl/codecs/partition/encode_partition_binding.c
+++ b/src/openzl/codecs/partition/encode_partition_binding.c
@@ -1,0 +1,235 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+#include "openzl/codecs/partition/encode_partition_binding.h"
+
+#include "openzl/codecs/common/bitstream/ff_bitstream.h"
+#include "openzl/codecs/partition/common_partition.h"
+#include "openzl/codecs/partition/encode_partition_kernel.h"
+#include "openzl/codecs/zl_partition.h"
+#include "openzl/shared/bits.h"
+#include "openzl/shared/numeric_operations.h"
+#include "openzl/shared/varint.h"
+#include "openzl/zl_ctransform.h"
+
+ZL_Report ZL_PartitionParams_fromLocalParams(
+        ZL_PartitionParams* params,
+        const ZL_LocalParams* localParams)
+{
+    ZL_RESULT_DECLARE_SCOPE_REPORT(NULL);
+
+    for (size_t i = 0; i < localParams->intParams.nbIntParams; ++i) {
+        if (localParams->intParams.intParams[i].paramId
+            == ZL_PARTITION_PRESET_PID) {
+            const ZL_PartitionParamsPreset preset =
+                    (ZL_PartitionParamsPreset)localParams->intParams
+                            .intParams[i]
+                            .paramValue;
+            const ZL_PartitionParams* presetParams =
+                    ZL_PartitionParams_getPreset(preset);
+            if (presetParams != NULL) {
+                *params = *presetParams;
+                ZL_ASSERT(ZL_PartitionParams_validate(params));
+                return ZL_returnValue(preset);
+            }
+            break;
+        }
+    }
+
+    for (size_t i = 0; i < localParams->copyParams.nbCopyParams; ++i) {
+        if (localParams->copyParams.copyParams[i].paramId
+            == ZL_PARTITION_CUSTOM_PID) {
+            const ZL_CopyParam param = localParams->copyParams.copyParams[i];
+            ZL_ERR_IF_NE(
+                    param.paramSize % sizeof(uint64_t),
+                    0,
+                    nodeParameter_invalid);
+            ZL_ERR_IF_LT(
+                    param.paramSize,
+                    2 * sizeof(uint64_t),
+                    nodeParameter_invalid);
+            const uint64_t* partitionsPtr = (const uint64_t*)param.paramPtr;
+            params->startValue            = *partitionsPtr;
+            params->partitionSizes        = partitionsPtr + 1;
+            params->numPartitions = param.paramSize / sizeof(uint64_t) - 1;
+            ZL_ERR_IF_NOT(
+                    ZL_PartitionParams_validate(params), nodeParameter_invalid);
+            return ZL_returnValue(ZL_PartitionParamsPreset_custom);
+        }
+    }
+    ZL_ERR(nodeParameter_invalid, "Neither preset nor custom partition found");
+}
+
+/// Write partition parameters into the codec header.
+static ZL_Report ZL_PartitionParams_sendHeader(
+        const ZL_PartitionParams* params,
+        const uint8_t* bits,
+        ZL_PartitionParamsPreset preset,
+        size_t eltWidth,
+        ZL_Encoder* encoder)
+{
+    ZL_RESULT_DECLARE_SCOPE_REPORT(encoder);
+    uint8_t flags = (uint8_t)ZL_nextPow2(eltWidth);
+    if (preset != ZL_PartitionParamsPreset_custom) {
+        ZL_STATIC_ASSERT(
+                ZL_PartitionParamsPreset_custom <= 32, "must fit in 5 bits");
+        flags |= ZL_PARTITION_HEADER_IS_PRESET_BIT;
+        flags |= (uint8_t)(preset << 3);
+        ZL_Encoder_sendCodecHeader(encoder, &flags, 1);
+        return ZL_returnSuccess();
+    }
+
+    if (params->startValue == 0) {
+        flags |= ZL_PARTITION_HEADER_IS_FIRST_VALUE_ZERO_BIT;
+    }
+
+    // TODO: Consider a RLE-like scheme. E.g. if the value shows up twice in a
+    // row, the next value is a repeat count rather than a new value.
+    if (ZL_PartitionParams_areAllSizesPow2(params)) {
+        flags |= ZL_PARTITION_HEADER_IS_POW2_BIT;
+
+        size_t numBits = (size_t)ZL_nextPow2(
+                NUMOP_findMaxU8(bits, params->numPartitions));
+        numBits = ZL_MAX(numBits, 3);
+        ZL_ASSERT_LE(numBits, 6, "Impossible for valid params");
+
+        flags |= (uint8_t)((numBits - 3) << 6);
+
+        const size_t headerSizeBound = 1 + ZL_VARINT_LENGTH_64
+                + (numBits * params->numPartitions + 1 + 7) / 8;
+        uint8_t* header = ZL_Encoder_getScratchSpace(encoder, headerSizeBound);
+        ZL_ERR_IF_NULL(header, allocation);
+        size_t size    = 0;
+        header[size++] = flags;
+        if (params->startValue != 0) {
+            size += ZL_varintEncode(params->startValue, header + size);
+        }
+        ZS_BitCStreamFF bitstream =
+                ZS_BitCStreamFF_init(header + size, headerSizeBound - size);
+
+        for (size_t i = 0; i < params->numPartitions; ++i) {
+            ZS_BitCStreamFF_write(&bitstream, bits[i], numBits);
+            ZS_BitCStreamFF_flush(&bitstream);
+        }
+        ZS_BitCStreamFF_write(&bitstream, 1, 1);
+        ZL_TRY_LET(size_t, bitSize, ZS_BitCStreamFF_finish(&bitstream));
+        size += bitSize;
+
+        ZL_Encoder_sendCodecHeader(encoder, header, size);
+        return ZL_returnSuccess();
+    } else {
+        const size_t headerSizeBound =
+                1 + ZL_VARINT_LENGTH_64 * (params->numPartitions + 1);
+        uint8_t* header = ZL_Encoder_getScratchSpace(encoder, headerSizeBound);
+        ZL_ERR_IF_NULL(header, allocation);
+        size_t size    = 0;
+        header[size++] = flags;
+        if (params->startValue != 0) {
+            size += ZL_varintEncode(params->startValue, header + size);
+        }
+        for (size_t i = 0; i < params->numPartitions; ++i) {
+            size += ZL_varintEncode(params->partitionSizes[i], header + size);
+        }
+        ZL_Encoder_sendCodecHeader(encoder, header, size);
+        return ZL_returnSuccess();
+    }
+}
+
+ZL_Report EI_partitionWithParams(
+        ZL_Encoder* eictx,
+        const ZL_Input* ins[],
+        size_t nbIns,
+        const ZL_PartitionParams* params,
+        ZL_PartitionParamsPreset preset)
+{
+    ZL_RESULT_DECLARE_SCOPE_REPORT(eictx);
+    ZL_ASSERT_EQ(nbIns, 1);
+    ZL_ASSERT_NN(ins);
+    const ZL_Input* in = ins[0];
+    ZL_ASSERT_EQ(ZL_Input_type(in), ZL_Type_numeric);
+    size_t const eltWidth = ZL_Input_eltWidth(in);
+    size_t const numElts  = ZL_Input_numElts(in);
+
+    uint8_t* bits = ZL_Encoder_getScratchSpace(eictx, params->numPartitions);
+    ZL_ERR_IF_NULL(bits, allocation);
+    ZL_PartitionParams_computeBits(params, bits);
+    const size_t maxNumBits = NUMOP_findMaxU8(bits, params->numPartitions);
+
+    ZL_Output* bucketOut = ZL_Encoder_createTypedStream(eictx, 0, numElts, 1);
+    ZL_ERR_IF_NULL(bucketOut, allocation);
+
+    size_t const bitsCapacity = (maxNumBits * numElts + 7) / 8;
+    ZL_Output* bitsOut =
+            ZL_Encoder_createTypedStream(eictx, 1, bitsCapacity, 1);
+    ZL_ERR_IF_NULL(bitsOut, allocation);
+
+    ZL_TRY_LET(
+            size_t,
+            bitsSize,
+            ZL_partitionEncode(
+                    (uint8_t*)ZL_Output_ptr(bitsOut),
+                    bitsCapacity,
+                    (uint8_t*)ZL_Output_ptr(bucketOut),
+                    ZL_Input_ptr(in),
+                    numElts,
+                    eltWidth,
+                    params));
+    ZL_ASSERT_LE(bitsSize, bitsCapacity);
+
+    ZL_ERR_IF_ERR(ZL_PartitionParams_sendHeader(
+            params, bits, preset, eltWidth, eictx));
+    ZL_ERR_IF_ERR(ZL_Output_commit(bucketOut, numElts));
+    ZL_ERR_IF_ERR(ZL_Output_commit(bitsOut, bitsSize));
+
+    return ZL_returnSuccess();
+}
+
+ZL_Report EI_partition(ZL_Encoder* eictx, const ZL_Input* ins[], size_t nbIns)
+{
+    ZL_RESULT_DECLARE_SCOPE_REPORT(eictx);
+    ZL_PartitionParams params;
+    ZL_TRY_LET(
+            size_t,
+            preset,
+            ZL_PartitionParams_fromLocalParams(
+                    &params, ZL_Encoder_getLocalParams(eictx)));
+    return EI_partitionWithParams(
+            eictx, ins, nbIns, &params, (ZL_PartitionParamsPreset)preset);
+}
+
+ZL_RESULT_OF(ZL_NodeID)
+ZL_Compressor_buildPartitionNodeFromPreset(
+        ZL_Compressor* compressor,
+        ZL_PartitionParamsPreset preset)
+{
+    ZL_IntParam param        = { ZL_PARTITION_PRESET_PID, (int)preset };
+    ZL_LocalParams lp        = { .intParams = { &param, 1 } };
+    ZL_NodeParameters params = { .localParams = &lp };
+    return ZL_Compressor_parameterizeNode(
+            compressor, ZL_NODE_PARTITION, &params);
+}
+
+ZL_RESULT_OF(ZL_NodeID)
+ZL_Compressor_buildPartitionNode(
+        ZL_Compressor* compressor,
+        uint64_t startValue,
+        const uint64_t* partitionSizes,
+        size_t numPartitions)
+{
+    ZL_RESULT_DECLARE_SCOPE(ZL_NodeID, compressor);
+
+    ZL_ERR_IF_GT(
+            numPartitions,
+            ZL_PARTITION_MAX_PARTITIONS,
+            nodeParameter_invalid,
+            "Partition codec only supports up to 256 partitions");
+
+    uint64_t array[ZL_PARTITION_MAX_PARTITIONS + 1];
+    array[0] = startValue;
+    memcpy(&array[1], partitionSizes, sizeof(uint64_t) * numPartitions);
+    ZL_CopyParam param       = { ZL_PARTITION_CUSTOM_PID,
+                                 array,
+                                 sizeof(uint64_t) * (numPartitions + 1) };
+    ZL_LocalParams lp        = { .copyParams = { &param, 1 } };
+    ZL_NodeParameters params = { .localParams = &lp };
+    return ZL_Compressor_parameterizeNode(
+            compressor, ZL_NODE_PARTITION, &params);
+}

--- a/src/openzl/codecs/partition/encode_partition_binding.h
+++ b/src/openzl/codecs/partition/encode_partition_binding.h
@@ -1,0 +1,40 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#ifndef OPENZL_CODECS_PARTITION_ENCODE_PARTITION_BINDING_H
+#define OPENZL_CODECS_PARTITION_ENCODE_PARTITION_BINDING_H
+
+#include "openzl/codecs/partition/common_partition.h"
+#include "openzl/codecs/partition/graph_partition.h"
+#include "openzl/shared/portability.h"
+#include "openzl/zl_ctransform.h"
+
+ZL_BEGIN_C_DECLS
+
+/// Encoder binding for the partition transform.
+/// Reads partition parameters from local params, then encodes.
+ZL_Report EI_partition(ZL_Encoder* eictx, const ZL_Input* ins[], size_t nbIns);
+
+/// Encoder binding with explicit partition parameters and preset ID.
+ZL_Report EI_partitionWithParams(
+        ZL_Encoder* eictx,
+        const ZL_Input* ins[],
+        size_t nbIns,
+        const ZL_PartitionParams* params,
+        ZL_PartitionParamsPreset preset);
+
+/// Parse partition parameters from a node's local params.
+/// @returns The preset ID, or ZL_PartitionParamsPreset_custom for custom
+/// params.
+ZL_Report ZL_PartitionParams_fromLocalParams(
+        ZL_PartitionParams* params,
+        const ZL_LocalParams* localParams);
+
+/// Macro to register the partition encoder transform.
+#define EI_PARTITION(id)                  \
+    { .gd          = PARTITION_GRAPH(id), \
+      .transform_f = EI_partition,        \
+      .name        = "!zl.partition" }
+
+ZL_END_C_DECLS
+
+#endif

--- a/src/openzl/codecs/partition/encode_partition_kernel.c
+++ b/src/openzl/codecs/partition/encode_partition_kernel.c
@@ -1,0 +1,114 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#include "openzl/codecs/partition/encode_partition_kernel.h"
+
+#include "openzl/codecs/common/bitstream/ff_bitstream.h"
+#include "openzl/zl_errors.h"
+
+/// Find the bucket for @p value using binary search.
+/// Returns the index i such that partitions[i] <= value, and either
+/// i+1 == numBuckets or value < partitions[i+1].
+/// Returns numBuckets if the value is out of range.
+static size_t ZL_findBucket(
+        uint64_t value,
+        uint64_t const* partitions,
+        size_t numBuckets,
+        uint64_t maxValue)
+{
+    // Check that the value is within the partition range
+    if (value < partitions[0] || value > maxValue) {
+        return numBuckets; // out of range
+    }
+    size_t lo = 0;
+    size_t hi = numBuckets;
+    while (lo < hi) {
+        size_t const mid = lo + (hi - lo) / 2;
+        if (mid + 1 < numBuckets && partitions[mid + 1] <= value) {
+            lo = mid + 1;
+        } else {
+            hi = mid;
+        }
+    }
+    return lo;
+}
+
+/// Read a value from a buffer at the given index with the given element width.
+static uint64_t ZL_readValue(void const* src, size_t index, size_t eltWidth)
+{
+    switch (eltWidth) {
+        case 1:
+            return ((uint8_t const*)src)[index];
+        case 2:
+            return ((uint16_t const*)src)[index];
+        case 4:
+            return ((uint32_t const*)src)[index];
+        case 8:
+            return ((uint64_t const*)src)[index];
+        default:
+            return 0;
+    }
+}
+
+/// The bitstream accumulator holds 63 bits, and after a flush up to 7 bits
+/// may remain. A single write must satisfy: residual + nbBits <= 63, so the
+/// maximum safe write after flush is 56 bits.
+#define ZL_PARTITION_BITS_SPLIT 56
+
+/// Write an offset value into the bitstream, splitting into two writes if the
+/// number of bits exceeds ZL_PARTITION_BITS_SPLIT.
+static void ZL_partitionWriteBits(
+        ZS_BitCStreamFF* bitstream,
+        uint64_t offset,
+        size_t nbBits)
+{
+    if (nbBits <= ZL_PARTITION_BITS_SPLIT) {
+        ZS_BitCStreamFF_write(bitstream, (size_t)offset, nbBits);
+    } else {
+        ZS_BitCStreamFF_write(bitstream, (size_t)offset, 32);
+        ZS_BitCStreamFF_flush(bitstream);
+        ZS_BitCStreamFF_write(bitstream, (size_t)(offset >> 32), nbBits - 32);
+    }
+}
+
+ZL_Report ZL_partitionEncode(
+        uint8_t* bitsDst,
+        size_t bitsCapacity,
+        uint8_t* buckets,
+        void const* src,
+        size_t srcSize,
+        size_t eltWidth,
+        ZL_PartitionParams const* params)
+{
+    ZL_RESULT_DECLARE_SCOPE_REPORT(NULL);
+    ZL_ASSERT(ZL_PartitionParams_validate(params));
+
+    uint64_t bases[ZL_PARTITION_MAX_PARTITIONS];
+    uint8_t bits[ZL_PARTITION_MAX_PARTITIONS];
+    ZL_PartitionParams_computeBasesU64(params, bases);
+    ZL_PartitionParams_computeBits(params, bits);
+
+    size_t const numPartitions = params->numPartitions;
+    const uint64_t maxValue    = bases[numPartitions - 1]
+            + (params->partitionSizes[numPartitions - 1] - 1);
+
+    ZS_BitCStreamFF bitstream = ZS_BitCStreamFF_init(bitsDst, bitsCapacity);
+    for (size_t i = 0; i < srcSize; ++i) {
+        uint64_t const value = ZL_readValue(src, i, eltWidth);
+        size_t const partition =
+                ZL_findBucket(value, bases, numPartitions, maxValue);
+
+        ZL_ERR_IF_GE(partition, numPartitions, GENERIC);
+
+        ZL_ASSERT_GE(value, bases[partition]);
+        ZL_ASSERT_LE(value, maxValue);
+
+        buckets[i] = (uint8_t)partition;
+
+        uint64_t const offset = value - bases[partition];
+        ZL_partitionWriteBits(&bitstream, offset, bits[partition]);
+        ZS_BitCStreamFF_flush(&bitstream);
+    }
+    ZL_Report const ret = ZS_BitCStreamFF_finish(&bitstream);
+    ZL_ERR_IF(ZL_isError(ret), internalBuffer_tooSmall);
+    return ret;
+}

--- a/src/openzl/codecs/partition/encode_partition_kernel.h
+++ b/src/openzl/codecs/partition/encode_partition_kernel.h
@@ -1,0 +1,38 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+#ifndef OPENZL_CODECS_PARTITION_ENCODE_PARTITION_KERNEL_H
+#define OPENZL_CODECS_PARTITION_ENCODE_PARTITION_KERNEL_H
+
+#include "openzl/codecs/partition/common_partition.h"
+#include "openzl/shared/portability.h"
+#include "openzl/zl_errors.h"
+
+ZL_BEGIN_C_DECLS
+
+/**
+ * Encodes values using the partition scheme.
+ *
+ * Each value is split into a bucket ID (written to @p buckets) and an offset
+ * within the bucket (written to the bitstream at @p bitsDst). The number of
+ * bits per offset is determined by the bucket size (params->bits[bucket]).
+ *
+ * @param bitsDst Output buffer for the extra-bits bitstream.
+ * @param bitsCapacity Capacity of the bits buffer in bytes.
+ * @param buckets Output buffer for bucket IDs, must hold @p srcSize bytes.
+ * @param src Input values to encode.
+ * @param srcSize Number of input values.
+ * @param eltWidth Element width in bytes (1, 2, 4, or 8).
+ * @param params Partition parameters (start value and partition sizes).
+ * @returns The size of the bits stream in bytes, or an error.
+ */
+ZL_Report ZL_partitionEncode(
+        uint8_t* bitsDst,
+        size_t bitsCapacity,
+        uint8_t* buckets,
+        void const* src,
+        size_t srcSize,
+        size_t eltWidth,
+        ZL_PartitionParams const* params);
+
+ZL_END_C_DECLS
+
+#endif

--- a/src/openzl/codecs/partition/graph_partition.h
+++ b/src/openzl/codecs/partition/graph_partition.h
@@ -1,0 +1,19 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+#ifndef OPENZL_CODECS_PARTITION_GRAPH_PARTITION_H
+#define OPENZL_CODECS_PARTITION_GRAPH_PARTITION_H
+
+/// Graph definition for the partition transform
+/// used by both the encoder and decoder side.
+///
+/// Input: 1 numeric stream of unsigned integers (1, 2, 4, or 8 bytes)
+/// Output 0: numeric stream of 8-bit bucket IDs
+/// Output 1: serial stream of extra bits (bitstream)
+
+#define PARTITION_GRAPH(id)                                               \
+    {                                                                     \
+        .CTid       = id,                                                 \
+        .inputTypes = ZL_STREAMTYPELIST(ZL_Type_numeric),                 \
+        .soTypes    = ZL_STREAMTYPELIST(ZL_Type_numeric, ZL_Type_serial), \
+    }
+
+#endif

--- a/src/openzl/codecs/partition/spec.md
+++ b/src/openzl/codecs/partition/spec.md
@@ -1,0 +1,68 @@
+## Partition Decoder Specification
+### Inputs
+The decoder for the 'partition' transform takes two streams as input:
+- a numeric stream of 8-bit unsigned bucket IDs (one per element).
+- a serial stream containing a packed bitstream of intra-bucket offsets.
+
+### Codec Header
+The 'partition' codec header encodes the partition parameters: the element width of the decoded stream, a start value, and the size of each partition. The partitions define contiguous, non-overlapping ranges of unsigned integers. The maximum number of partitions is 256.
+
+#### Flags Byte
+The first byte of the header is always present and encodes flags that determine the header format.
+
+| Bits | Meaning |
+|------|---------|
+| `[1:0]` | `log2(elementWidth)`: 0 = 1 byte, 1 = 2 bytes, 2 = 4 bytes, 3 = 8 bytes |
+| `[2]` | IS_PRESET: parameters are a built-in preset; remaining bits encode the preset ID |
+| `[3]` | IS_FIRST_VALUE_ZERO: `startValue` is 0 and omitted from the header |
+| `[4]` | Unused |
+| `[5]` | IS_POW2: all partition sizes are powers of 2 (compact encoding) |
+| `[7:6]` | When IS_POW2 is set: `numBits - 3`, where `numBits` is the bit-width used to encode each log2(partitionSize) value |
+
+#### Preset Mode (bit 2 set)
+When the IS_PRESET bit is set, the header is exactly 1 byte. The preset ID is `flags >> 3`. The following presets are defined:
+
+| Preset ID | Name | Partitions | Start Value | Description |
+|-----------|------|------------|-------------|-------------|
+| 0 | Quantize Offsets | 32 | 1 | Power-of-2 sizes: 1, 2, 4, ..., 2^31. Covers [1, 2^32). |
+| 1 | Quantize Lengths | 44 | 0 | First 16 partitions each have size 1 (values 0-15). Then power-of-2 sizes: 16, 32, ..., 2^31. Covers [0, 2^32). |
+| 2 | Varbyte16 | 16 | 0 | Sizes: 2, 2, 4, 8, 16, ..., 2^15. Covers [0, 2^16). |
+
+#### Power-of-2 Mode (bit 5 set, bit 2 clear)
+When IS_POW2 is set but IS_PRESET is not, the partition sizes are all powers of 2 and are encoded compactly as their log2 values in a bitstream.
+
+The header layout is: `[flags] [varint startValue?] [bitstream of log2(sizes)]`.
+
+The `startValue` is present as a varint unless IS_FIRST_VALUE_ZERO is set. The varint format is described here: https://protobuf.dev/programming-guides/encoding/#varints.
+
+The bitstream encodes each `log2(partitionSize)` value using `numBits` bits, where `numBits = ((flags >> 6) & 3) + 3`. A sentinel `1` bit follows the last value. The number of partitions is determined by dividing the total number of payload bits (excluding the sentinel) by `numBits`.
+
+#### General Mode (bits 2 and 5 clear)
+When neither IS_PRESET nor IS_POW2 is set, partition sizes are stored as consecutive varints.
+
+The header layout is: `[flags] [varint startValue?] [varint size_0] [varint size_1] ... [varint size_{N-1}]`.
+
+The `startValue` is present as a varint unless IS_FIRST_VALUE_ZERO is set. The number of partitions is determined by the number of varints that fit in the remaining header bytes.
+
+### Decoding
+The partition parameters define `N` contiguous ranges of unsigned integers. The base value for each partition is computed as:
+- `bases[0] = startValue`
+- `bases[i] = bases[i-1] + partitionSizes[i-1]`
+
+The number of extra bits for each partition is computed as:
+- `bits[i] = ceil(log2(partitionSizes[i]))`
+
+For each element, the decoder reads the bucket ID from the first input stream and `bits[bucket]` bits from the second input stream (the offset bitstream). The decoded value is `bases[bucket] + offset`.
+
+Consider the partition parameters `startValue = 10`, `partitionSizes = {4, 8, 4}`. This defines three partitions covering [10, 14), [14, 22), and [22, 26). The computed base values are `{10, 14, 22}` and the extra bits per partition are `{2, 3, 2}`.
+
+Given the bucket stream {0, 1, 2, 1} and extra bits bitstream containing the offsets {2, 3, 1, 0} encoded using {2, 3, 2, 3} bits respectively, the decoder produces:
+- Element 0: `bases[0] + 2 = 10 + 2 = 12`
+- Element 1: `bases[1] + 3 = 14 + 3 = 17`
+- Element 2: `bases[2] + 1 = 22 + 1 = 23`
+- Element 3: `bases[1] + 0 = 14 + 0 = 14`
+
+The decoded stream is {12, 17, 23, 14}.
+
+### Outputs
+The output of the decoder is a single numeric stream. The element width is encoded in the codec header flags byte and must be 1, 2, 4, or 8 bytes. The number of elements is equal to the number of elements in the bucket ID input stream.

--- a/src/openzl/common/wire_format.c
+++ b/src/openzl/common/wire_format.c
@@ -56,3 +56,13 @@ unsigned ZL_getDefaultEncodingVersion(void)
 {
     return ZL_MAX_FORMAT_VERSION;
 }
+
+int ZL_StandardTransformID_numBits(unsigned formatVersion)
+{
+    if (formatVersion < 24) {
+        return ZL_nextPow2(64);
+    } else {
+        ZL_ASSERT_EQ(ZL_StandardTransformID_end, 128);
+        return ZL_nextPow2(ZL_StandardTransformID_end);
+    }
+}

--- a/src/openzl/common/wire_format.h
+++ b/src/openzl/common/wire_format.h
@@ -302,11 +302,19 @@ typedef enum {
 
     ZL_StandardTransformID_bitSplit = 63,
 
+    ZL_StandardTransformID_partition = 64,
+
     ZL_StandardTransformID_end =
-            64 // last id, used to detect end of ID range (impacts
-               // header encoding) give some room to be able to add new
-               // transforms without breaking encoder / decoder
+            128 // last id, used to detect end of ID range (impacts
+                // header encoding) give some room to be able to add new
+                // transforms without breaking encoder / decoder
 } ZL_StandardTransformID;
+
+/**
+ * @returns The number of bits required to encode standard transform IDs
+ * in the given format version.
+ */
+int ZL_StandardTransformID_numBits(unsigned formatVersion);
 
 // Min version of standard transforms is published
 // for standard transforms which can be dynamically defined at runtime.

--- a/src/openzl/compress/encode_frameheader.c
+++ b/src/openzl/compress/encode_frameheader.c
@@ -161,7 +161,8 @@ static void compressTrID(
         size_t nbTransforms,
         const uint8_t ctrFlags[],
         uint32_t* snodeidsScratch,
-        uint32_t* cnodeidsScratch)
+        uint32_t* cnodeidsScratch,
+        unsigned formatVersion)
 {
     if (!nbTransforms)
         return;
@@ -179,7 +180,7 @@ static void compressTrID(
     size_t const nbCNodeIds =
             MEM_ptrDistance(cnodeids, niPtr[1]) / sizeof(uint32_t);
     // use bitPacking for standard nodes
-    int const nbBits = ZL_nextPow2(ZL_StandardTransformID_end);
+    int const nbBits = ZL_StandardTransformID_numBits(formatVersion);
     ZL_ASSERT_GE(ZL_WC_avail(out), ((nbTransforms * (size_t)nbBits) + 7) / 8);
 
     ZL_WC_bitpackEncode32(out, snodeids, nbSNodeIds, nbBits);
@@ -747,7 +748,13 @@ static ZL_Report writeChunkHeaderV8_internal(
             array32[u] = (uint32_t)gip->trInfo[u].trid;
         }
         compressTrID(
-                &out, array32, nbCodecs, trt, wksp->scratch1, wksp->scratch2);
+                &out,
+                array32,
+                nbCodecs,
+                trt,
+                wksp->scratch1,
+                wksp->scratch2,
+                encoder->formatVersion);
     }
 
     /* Encode Transform's private header's sizes */

--- a/src/openzl/decompress/decode_frameheader.c
+++ b/src/openzl/decompress/decode_frameheader.c
@@ -12,7 +12,7 @@
 #include "openzl/common/assertion.h"  // ZS_ASSERT_*
 #include "openzl/common/cursor.h"     // ZL_RC
 #include "openzl/common/limits.h"
-#include "openzl/common/wire_format.h" // ZL_StandardTransformID_end
+#include "openzl/common/wire_format.h" // ZL_StandardTransformID_numBits
 #include "openzl/fse/fse.h"            // FSE_getErrorName
 #include "openzl/fse/hist.h"           // HIST_count_simple
 #include "openzl/shared/bits.h"
@@ -683,7 +683,8 @@ static ZL_Report decompressTrID(
         size_t nbTransforms,
         ZL_RC* src,
         const uint8_t trt8[],
-        uint32_t scratch[])
+        uint32_t scratch[],
+        unsigned formatVersion)
 {
     if (!nbTransforms)
         return ZL_returnSuccess();
@@ -708,7 +709,7 @@ static ZL_Report decompressTrID(
 
     // start decoding standard nodes
     uint32_t* snodeids = scratch;
-    int const nbBits   = ZL_nextPow2(ZL_StandardTransformID_end);
+    int const nbBits   = ZL_StandardTransformID_numBits(formatVersion);
     ZL_RET_R_IF_ERR(checkedBitpackDecode32(snodeids, nbTrs[0], src, nbBits));
 
     // then decode custom nodes
@@ -1023,8 +1024,13 @@ static ZL_Report decodeChunkHeader_internal(
         }
 
         uint32_t* trIDs = wksp.scratch0;
-        ZL_RET_R_IF_ERR(
-                decompressTrID(trIDs, nbDecoders, &in, trt8, wksp.scratch1));
+        ZL_RET_R_IF_ERR(decompressTrID(
+                trIDs,
+                nbDecoders,
+                &in,
+                trt8,
+                wksp.scratch1,
+                decoder->formatVersion));
         for (unsigned u = 0; u < nbDecoders; u++) {
             if (nodes[u].trpid.trt == trt_standard
                 && trIDs[u] >= ZL_StandardTransformID_end) {

--- a/src/openzl/shared/numeric_operations.c
+++ b/src/openzl/shared/numeric_operations.c
@@ -47,6 +47,18 @@ size_t NUMOP_findMaxST(const size_t array[], size_t arraySize)
     return max;
 }
 
+uint8_t NUMOP_findMaxU8(const uint8_t array[], size_t arraySize)
+{
+    if (arraySize)
+        ZL_ASSERT_NN(array);
+    uint8_t max = 0;
+    for (size_t n = 0; n < arraySize; n++) {
+        if (max < array[n])
+            max = array[n];
+    }
+    return max;
+}
+
 uint32_t NUMOP_findMaxArr32(const uint32_t array32[], size_t arraySize)
 {
     if (arraySize)

--- a/src/openzl/shared/numeric_operations.h
+++ b/src/openzl/shared/numeric_operations.h
@@ -13,6 +13,7 @@ size_t NUMOP_sumArrayST(const size_t array[], size_t arraySize);
 uint64_t NUMOP_sumArray32(const uint32_t array[], size_t arraySize);
 
 size_t NUMOP_findMaxST(const size_t array[], size_t arraySize);
+uint8_t NUMOP_findMaxU8(const uint8_t array[], size_t arraySize);
 uint32_t NUMOP_findMaxArr32(const uint32_t array32[], size_t arraySize);
 
 int NUMOP_underLimit(const unsigned array[], size_t arraySize, unsigned limit);

--- a/tests/registry/OpenZLComponents.h
+++ b/tests/registry/OpenZLComponents.h
@@ -59,6 +59,7 @@ enum class OpenZLComponentID {
     TokenizeString,
     QuantizeOffsets,
     QuantizeLengths,
+    Partition,
     Store,
     StoreString,
     Fse,
@@ -121,6 +122,7 @@ std::unique_ptr<OpenZLComponent> makeTokenizeNumericComponent();
 std::unique_ptr<OpenZLComponent> makeTokenizeStringComponent();
 std::unique_ptr<OpenZLComponent> makeQuantizeOffsetsComponent();
 std::unique_ptr<OpenZLComponent> makeQuantizeLengthsComponent();
+std::unique_ptr<OpenZLComponent> makePartitionComponent();
 std::unique_ptr<OpenZLComponent> makeStoreComponent();
 std::unique_ptr<OpenZLComponent> makeStoreStringComponent();
 std::unique_ptr<OpenZLComponent> makeFseComponent();
@@ -213,6 +215,8 @@ inline std::unique_ptr<OpenZLComponent> makeOpenZLComponent(
             return components::makeQuantizeOffsetsComponent();
         case OpenZLComponentID::QuantizeLengths:
             return components::makeQuantizeLengthsComponent();
+        case OpenZLComponentID::Partition:
+            return components::makePartitionComponent();
         case OpenZLComponentID::Store:
             return components::makeStoreComponent();
         case OpenZLComponentID::StoreString:

--- a/tests/registry/components/Partition.cpp
+++ b/tests/registry/components/Partition.cpp
@@ -1,0 +1,299 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#include <limits.h>
+#include <algorithm>
+
+#include "openzl/codecs/partition/encode_partition_binding.h"
+#include "openzl/codecs/zl_store.h"
+#include "openzl/cpp/codecs/Partition.hpp"
+#include "openzl/shared/bits.h"
+#include "openzl/zl_reflection.h"
+#include "tests/registry/OpenZLComponents.h"
+#include "tests/registry/OpenZLInput.h"
+
+namespace openzl::tests::components {
+namespace {
+
+uint64_t getMaxValue(const ZL_PartitionParams& params)
+{
+    uint64_t maxValue = params.startValue;
+    for (size_t i = 0; i < params.numPartitions; ++i) {
+        maxValue += params.partitionSizes[i];
+    }
+    return maxValue - 1;
+}
+
+size_t getSmallestWidthForValue(uint64_t value)
+{
+    if (value <= UCHAR_MAX) {
+        return 1;
+    }
+    if (value <= USHRT_MAX) {
+        return 2;
+    }
+    if (value <= UINT_MAX) {
+        return 4;
+    }
+    return 8;
+}
+
+/// Inclusive maximum value for partition values given an element width.
+uint64_t maxValueForWidth(size_t width)
+{
+    if (width >= 8) {
+        return UINT64_MAX;
+    }
+    return (uint64_t(1) << (width * 8)) - 1;
+}
+
+/// Generate a random custom partition node for values in [0, maxValue].
+/// When pow2Only is true, all partition sizes are powers of 2, which exercises
+/// the compact pow2 header encoding path. Otherwise, arbitrary sizes are used,
+/// which exercises the varint header encoding path.
+nodes::Partition generateCustomPartition(
+        datagen::DataGen& gen,
+        uint64_t maxValue)
+{
+    const uint64_t startValue  = gen.boolean("start_at_zero")
+             ? 0
+             : gen.u64_range("start_value", 0, maxValue - 1);
+    const bool endAtMaxValue   = gen.boolean("end_at_max_value");
+    const bool powerOfTwoSizes = gen.boolean("power_of_two_sizes");
+
+    std::vector<uint64_t> partitionSizes;
+    uint64_t currentValue = startValue;
+    while (currentValue < maxValue
+           && partitionSizes.size() < ZL_PARTITION_MAX_PARTITIONS) {
+        size_t size =
+                gen.u64_range("partition_size", 1, maxValue - currentValue);
+        if (powerOfTwoSizes) {
+            size = 1ull << ZL_highbit64(size);
+        }
+        partitionSizes.push_back(size);
+        currentValue += size;
+    }
+    if (endAtMaxValue && currentValue < maxValue) {
+        if (partitionSizes.size() == ZL_PARTITION_MAX_PARTITIONS) {
+            partitionSizes.back() += maxValue - currentValue;
+        } else {
+            partitionSizes.push_back(maxValue - currentValue);
+        }
+    }
+
+    return nodes::Partition{ startValue, std::move(partitionSizes) };
+}
+
+class PartitionComponent : public OpenZLComponent {
+   public:
+    std::string name() const override
+    {
+        return "Partition";
+    }
+
+    int minFormatVersion() const override
+    {
+        return 24;
+    }
+
+    // Partition produces buckets + extra_bits, roughly 2-3x expansion.
+    size_t compressBound(poly::span<const Input> inputs) const override
+    {
+        return 4 * this->OpenZLComponent::compressBound(inputs);
+    }
+
+    std::vector<GraphID> predefinedGraphs(Compressor& compressor) const override
+    {
+        return {
+            // All 4 presets
+            nodes::Partition{ ZL_PartitionParamsPreset_quantizeOffsets }(
+                    compressor, ZL_GRAPH_STORE, ZL_GRAPH_STORE),
+            nodes::Partition{ ZL_PartitionParamsPreset_quantizeLengths }(
+                    compressor, ZL_GRAPH_STORE, ZL_GRAPH_STORE),
+            nodes::Partition{ ZL_PartitionParamsPreset_varbyte16 }(
+                    compressor, ZL_GRAPH_STORE, ZL_GRAPH_STORE),
+            // Custom: 8-bit range [0, 255]
+            nodes::Partition{ 0, { 16, 112, 128 } }(
+                    compressor, ZL_GRAPH_STORE, ZL_GRAPH_STORE),
+            // Custom: 16-bit range with many small buckets
+            nodes::Partition{ 0,
+                              { 1,
+                                1,
+                                2,
+                                4,
+                                8,
+                                16,
+                                32,
+                                64,
+                                128,
+                                256,
+                                512,
+                                1024,
+                                2048,
+                                61440 } }(
+                    compressor, ZL_GRAPH_STORE, ZL_GRAPH_STORE),
+            // Custom: 32-bit range
+            nodes::Partition{ 0, { 256, 65280, 4294901760 } }(
+                    compressor, ZL_GRAPH_STORE, ZL_GRAPH_STORE),
+        };
+    }
+
+    std::vector<NodeID> generateNodes(
+            Compressor& compressor,
+            datagen::DataGen& gen,
+            size_t num) const override
+    {
+        std::vector<NodeID> result;
+        result.reserve(num);
+        for (size_t i = 0; i < num; ++i) {
+            auto useCustom = gen.boolean("useCustom");
+            if (useCustom) {
+                auto widthChoice = gen.usize_range("width", 0, 3);
+                size_t width     = widthChoice == 0 ? 1
+                            : widthChoice == 1      ? 2
+                            : widthChoice == 2      ? 4
+                                                    : 8;
+                auto maxValue    = maxValueForWidth(width);
+                auto partition   = generateCustomPartition(gen, maxValue);
+                result.push_back(partition.parameterize(compressor));
+            } else {
+                auto presetId = (ZL_PartitionParamsPreset)gen.i32_range(
+                        "preset", 0, ZL_PartitionParamsPreset_custom - 1);
+                result.push_back(
+                        nodes::Partition{ presetId }.parameterize(compressor));
+            }
+        }
+        return result;
+    }
+
+    std::vector<GraphID> generateGraphs(
+            Compressor& compressor,
+            datagen::DataGen& gen,
+            size_t num) const override
+    {
+        std::vector<GraphID> result;
+        result.reserve(num);
+        for (size_t i = 0; i < num; ++i) {
+            auto useCustom = gen.boolean("useCustom");
+            if (useCustom) {
+                auto widthChoice = gen.usize_range("width", 0, 3);
+                size_t width     = widthChoice == 0 ? 1
+                            : widthChoice == 1      ? 2
+                            : widthChoice == 2      ? 4
+                                                    : 8;
+                auto maxValue    = maxValueForWidth(width);
+                auto partition   = generateCustomPartition(gen, maxValue);
+                result.push_back(
+                        partition(compressor, ZL_GRAPH_STORE, ZL_GRAPH_STORE));
+            } else {
+                auto presetId = (ZL_PartitionParamsPreset)gen.i32_range(
+                        "preset", 0, ZL_PartitionParamsPreset_custom - 1);
+                result.push_back(
+                        nodes::Partition{ presetId }(
+                                compressor, ZL_GRAPH_STORE, ZL_GRAPH_STORE));
+            }
+        }
+        return result;
+    }
+
+    std::vector<std::unique_ptr<OpenZLInput>> predefinedInputs() const override
+    {
+        // Empty inputs are valid for any partition configuration.
+        std::vector<std::unique_ptr<OpenZLInput>> inputs;
+        inputs.push_back(U8OpenZLInput::make(std::vector<uint8_t>{}));
+        inputs.push_back(U16OpenZLInput::make(std::vector<uint16_t>{}));
+        inputs.push_back(U32OpenZLInput::make(std::vector<uint32_t>{}));
+        inputs.push_back(U64OpenZLInput::make(std::vector<uint64_t>{}));
+        return inputs;
+    }
+
+    /// Extract partition parameters from a graph via the reflection API.
+    ZL_PartitionParams getPartitionParams(
+            const Compressor& compressor,
+            GraphID graphID) const
+    {
+        auto node = ZL_Compressor_Graph_getHeadNode(compressor.get(), graphID);
+        auto localParams =
+                ZL_Compressor_Node_getLocalParams(compressor.get(), node);
+        ZL_PartitionParams params;
+        compressor.unwrap(
+                ZL_PartitionParams_fromLocalParams(&params, &localParams));
+        return params;
+    }
+
+    template <typename T>
+    std::unique_ptr<OpenZLInput> generateInput(
+            datagen::DataGen& gen,
+            size_t maxInputSize,
+            uint64_t lo,
+            uint64_t hi) const
+    {
+        auto maxElts   = maxInputSize / sizeof(T);
+        auto clampedLo = static_cast<T>(lo);
+        auto clampedHi = static_cast<T>(
+                std::min(hi, (uint64_t)std::numeric_limits<T>::max()));
+        auto vec = gen.randVector<T>("values", clampedLo, clampedHi, maxElts);
+        if (vec.empty()) {
+            vec.push_back(clampedLo);
+        }
+        return NumericOpenZLInput<T>::make(std::move(vec));
+    }
+
+    std::vector<std::unique_ptr<OpenZLInput>> generateInputs(
+            datagen::DataGen& gen,
+            size_t num,
+            size_t maxInputSize,
+            const Compressor& compressor,
+            GraphID graphID) const override
+    {
+        auto params         = getPartitionParams(compressor, graphID);
+        uint64_t lo         = params.startValue;
+        uint64_t hi         = getMaxValue(params);
+        size_t naturalWidth = getSmallestWidthForValue(hi);
+
+        std::vector<std::unique_ptr<OpenZLInput>> inputs;
+        inputs.reserve(num);
+        for (size_t i = 0; i < num; ++i) {
+            // Pick a width >= naturalWidth (fallthrough finds the first valid)
+            auto widthChoice = gen.usize_range("width", 0, 3);
+            switch (widthChoice) {
+                case 0:
+                    if (naturalWidth <= 1) {
+                        inputs.push_back(
+                                generateInput<uint8_t>(
+                                        gen, maxInputSize, lo, hi));
+                        break;
+                    }
+                    ZL_FALLTHROUGH;
+                case 1:
+                    if (naturalWidth <= 2) {
+                        inputs.push_back(
+                                generateInput<uint16_t>(
+                                        gen, maxInputSize, lo, hi));
+                        break;
+                    }
+                    ZL_FALLTHROUGH;
+                case 2:
+                    if (naturalWidth <= 4) {
+                        inputs.push_back(
+                                generateInput<uint32_t>(
+                                        gen, maxInputSize, lo, hi));
+                        break;
+                    }
+                    ZL_FALLTHROUGH;
+                case 3:
+                    inputs.push_back(
+                            generateInput<uint64_t>(gen, maxInputSize, lo, hi));
+                    break;
+            }
+        }
+        return inputs;
+    }
+};
+
+} // namespace
+
+std::unique_ptr<OpenZLComponent> makePartitionComponent()
+{
+    return std::make_unique<PartitionComponent>();
+}
+} // namespace openzl::tests::components


### PR DESCRIPTION
Summary:

Add a partition codec that:
* Can replace `ZL_NODE_QUANTIZE_OFFSETS` (preset present, but implementation not optimized for this yet)
* Can replace `ZL_NODE_QUANTIZE_LENGTHS` (preset present, but implementation not optimized for this yet)
* Can implement the `VarByte16` and `Bucket16` codecs from `contrib/lz-research`

See the [design doc](https://docs.google.com/document/d/15ojKVhaCa1wwecbt3mRCgiy59pveJVQBASKbC2zuzEI/edit?tab=t.6ggqt4jnzgcj#heading=h.wvrp8vwdxgp8) for details.

Reviewed By: Cyan4973

Differential Revision: D95218214


