### PR TITLE
Add member op to grammar

### DIFF
--- a/tests/compress/graphs/sddl2/test_sddl2_code_execution.cpp
+++ b/tests/compress/graphs/sddl2/test_sddl2_code_execution.cpp
@@ -178,7 +178,7 @@ TEST_F(SDDL2CodeExecutionTest, ConsumeArrayOfArrays)
             expected_sizes);
 }
 
-TEST_F(SDDL2CodeExecutionTest, ConsumeSimpleSAO)
+TEST_F(SDDL2CodeExecutionTest, ConsumeSimpleAnonymous)
 {
     const size_t star_entry_size = 2 * sizeof(double) + 2 * sizeof(uint8_t)
             + sizeof(int16_t) + 2 * sizeof(float);
@@ -196,6 +196,67 @@ TEST_F(SDDL2CodeExecutionTest, ConsumeSimpleSAO)
                     XRPM : Float32LE, # R.A. proper motion
                     XDPM : Float32LE # Dec. proper motion
                 }[]
+            )",
+            input,
+            expected_sizes);
+}
+
+TEST_F(SDDL2CodeExecutionTest, ConsumeSimpleSAO)
+{
+    const size_t star_entry_size = 2 * sizeof(double) + 2 * sizeof(uint8_t)
+            + sizeof(int16_t) + 2 * sizeof(float);
+    const std::vector<size_t> expected_sizes = { 28, 4 * star_entry_size };
+    const auto input = gen<uint8_t>(sum(expected_sizes));
+
+    expect_success(
+            R"(
+                # Star catalog entry (28 bytes)
+                Record StarEntry() = {
+                    SRA0:  Float64LE,    # Right Ascension (radians)
+                    SDEC0: Float64LE,    # Declination (radians)
+                    ISP:   Bytes(2),     # Spectral type
+                    MAG:   Int16LE,      # Magnitude
+                    XRPM:  Float32LE,    # R.A. proper motion
+                    XDPM:  Float32LE     # Dec. proper motion
+                }
+
+                # File structure
+                header: Bytes(28)
+                stars: StarEntry[]
+            )",
+            input,
+            expected_sizes);
+}
+
+TEST_F(SDDL2CodeExecutionTest, ConsumeArrayTypeVars)
+{
+    const std::vector<size_t> expected_sizes = { 16, 16 * 10, 12, 12 * 10 };
+    const auto input = gen<uint8_t>(sum(expected_sizes));
+
+    expect_success(
+            R"(
+                Foo = Int32LE[4]
+                Bar = Int32LE[3]
+                : Foo
+                : Foo[10]
+                : Bar
+                : Bar[10]
+            )",
+            input,
+            expected_sizes);
+}
+
+TEST_F(SDDL2CodeExecutionTest, VarRecordType)
+{
+    const size_t record_size = sizeof(int32_t) + sizeof(int16_t);
+    const std::vector<size_t> expected_sizes = { record_size, 3 * record_size };
+    const auto input = gen<uint8_t>(sum(expected_sizes));
+
+    expect_success(
+            R"(
+                Entry = Record() { x: Int32LE, y: Int16LE }
+                : Entry
+                : Entry[3]
             )",
             input,
             expected_sizes);

--- a/tools/sddl2/compiler/codegen/CodeGenerator.cpp
+++ b/tools/sddl2/compiler/codegen/CodeGenerator.cpp
@@ -1,6 +1,9 @@
 // Copyright (c) Meta Platforms, Inc. and affiliates.
 
 #include <sstream>
+#include <unordered_set>
+
+#include "src/openzl/compress/graphs/sddl2/sddl2_vm.h"
 
 #include "tools/sddl2/compiler/Exception.h"
 #include "tools/sddl2/compiler/codegen/CodeGenerator.h"
@@ -141,9 +144,17 @@ class CodeGeneratorImpl {
      */
     void generate(const ASTVar& var, AssemblyOutput& output)
     {
-        (void)output;
-        throw CodegenError(
-                "Variable references are not yet supported: " + var.name());
+        auto it = var_registry_.find(var.name());
+        if (it == var_registry_.end()) {
+            throw CodegenError(var.loc(), "Undefined variable: " + var.name());
+        }
+        output.emplace_back("push.i64 " + std::to_string(it->second));
+        output.emplace_back("var.load");
+        // If this is the last reference to the variable, free the register
+        if (var.is_last_reference()) {
+            free_registers_.insert(it->second);
+            var_registry_.erase(it);
+        }
     }
 
     /**
@@ -247,7 +258,11 @@ class CodeGeneratorImpl {
             }
             case Op::ASSIGN: {
                 // Sema guarantees LHS is a variable
-                // TODO: actually handle variable assignment
+                auto var = op.args()[0]->as_var();
+                generateNode(op.args()[1], output);
+                auto reg = assignRegister(var->name());
+                output.emplace_back("push.i64 " + std::to_string(reg));
+                output.emplace_back("var.store");
                 break;
             }
             case Op::ASSUME: // TODO: treat assume differently from consume
@@ -270,8 +285,40 @@ class CodeGeneratorImpl {
         };
     }
 
+    size_t assignRegister(const std::string& name)
+    {
+        // If the variable is already in the registry, return its register
+        auto it = var_registry_.find(name);
+        if (it != var_registry_.end()) {
+            return it->second;
+        }
+
+        // Otherwise, allocate a new register
+        size_t reg;
+        if (!free_registers_.empty()) {
+            auto free_it = free_registers_.begin();
+            reg          = *free_it;
+            free_registers_.erase(free_it);
+        } else {
+            reg = next_register_++;
+            if (reg >= SDDL2_VAR_REGISTER_COUNT) {
+                throw CodegenError(
+                        "Too many variables! Maximum number of variables is "
+                        + std::to_string(SDDL2_VAR_REGISTER_COUNT));
+            }
+        }
+
+        var_registry_[name] = reg;
+        return reg;
+    }
+
     const detail::Logger& log_;
     size_t tag_ = 1;
+
+    // Register allocation
+    std::map<std::string, size_t> var_registry_;
+    std::unordered_set<size_t> free_registers_;
+    size_t next_register_ = 0;
 };
 
 } // namespace

--- a/tools/sddl2/compiler/codegen/CodeGenerator.cpp
+++ b/tools/sddl2/compiler/codegen/CodeGenerator.cpp
@@ -279,6 +279,10 @@ class CodeGeneratorImpl {
                 output.emplace_back("segment.create_tagged");
                 break;
             }
+            case Op::MEMBER: {
+                throw CodegenError(
+                        op.loc(), "Member access not yet supported.");
+            }
             case Op::SEND:
             default:
                 throw InvariantViolation(op.loc(), "Unsupported operation.");

--- a/tools/sddl2/compiler/optimizer/ConstFoldPass.cpp
+++ b/tools/sddl2/compiler/optimizer/ConstFoldPass.cpp
@@ -167,6 +167,7 @@ class ConstFoldImpl {
             case Op::CONSUME:
             case Op::ASSUME:
             case Op::SIZEOF:
+            case Op::MEMBER:
             case Op::SEND:
             default:
                 return std::make_shared<ASTOp>(

--- a/tools/sddl2/compiler/parser/AST.h
+++ b/tools/sddl2/compiler/parser/AST.h
@@ -358,6 +358,11 @@ class Codegen {
         return op(Op::ASSUME, std::move(lhs), std::move(rhs));
     }
 
+    ASTPtr member(ASTPtr lhs, ASTPtr rhs) const
+    {
+        return op(Op::MEMBER, std::move(lhs), std::move(rhs));
+    }
+
     ASTPtr eq(ASTPtr lhs, ASTPtr rhs) const
     {
         return op(Op::EQ, std::move(lhs), std::move(rhs));

--- a/tools/sddl2/compiler/parser/Grammar.cpp
+++ b/tools/sddl2/compiler/parser/Grammar.cpp
@@ -122,6 +122,7 @@ const std::vector<Symbol> builtin_field_syms{
 const std::map<Symbol, Op> syms_to_ops{
     { Symbol::EXPECT, Op::EXPECT },   { Symbol::ASSIGN, Op::ASSIGN },
     { Symbol::SIZEOF, Op::SIZEOF },   { Symbol::ASSUME, Op::ASSUME },
+    { Symbol::MEMBER, Op::MEMBER },
 
     { Symbol::EQ, Op::EQ },           { Symbol::NE, Op::NE },
 

--- a/tools/sddl2/compiler/parser/Ops.cpp
+++ b/tools/sddl2/compiler/parser/Ops.cpp
@@ -13,6 +13,7 @@ static const std::map<Op, poly::string_view> ops_to_debug_strs{
     { Op::CONSUME, "CONSUME" },
     { Op::ASSUME, "ASSUME" },
     { Op::SEND, "SEND" },
+    { Op::MEMBER, "MEMBER" },
     { Op::SIZEOF, "SIZEOF" },
 
     // Arithmetic Operators

--- a/tools/sddl2/compiler/parser/Ops.h
+++ b/tools/sddl2/compiler/parser/Ops.h
@@ -13,6 +13,7 @@ enum class Op {
     CONSUME,
     ASSUME,
     SEND,
+    MEMBER,
 
     // Arithmetic Operators
     NEG,

--- a/tools/sddl2/compiler/semantic_analyzer/SemanticAnalyzer.cpp
+++ b/tools/sddl2/compiler/semantic_analyzer/SemanticAnalyzer.cpp
@@ -142,6 +142,10 @@ class SemanticAnalyzerImpl {
                 var_types_[op.args()[0]->as_var()->name()] = ValueType::NUMERIC;
                 break;
             }
+            case Op::MEMBER: {
+                // TODO: implement
+                return ValueType::NUMERIC;
+            }
             case Op::CONSUME: {
                 expectFieldType(analyzeNode(op.args()[0]));
                 return ValueType::NONE;

--- a/tools/sddl2/compiler/tests/SemanticAnalyzerTest.cpp
+++ b/tools/sddl2/compiler/tests/SemanticAnalyzerTest.cpp
@@ -43,9 +43,9 @@ TEST_F(SemanticAnalyzerTest, AssumeDefinesVar)
         : Byte[count]
     )";
 
-    // TODO: Update this once once variable references are supported in codegen.
+    // TODO: Update this once once assume is supported in codegen.
     // This still shows us that the semantic analysis passes.
-    expect_error(prog, "not yet supported");
+    expect_error(prog, "Undefined variable");
 }
 
 TEST_F(SemanticAnalyzerTest, AssignLHSNotVar)


### PR DESCRIPTION
Summary:
# Stack
The goal of this stack is to add support for variable assignments and assume operations to SDDL2.

# Diff
This diff adds a `MEMBER` op to the SDDL grammar, which can be used to access fields of consumed recrds. This operator (`.`) was already supported in the syntax.

Differential Revision: D95396139


