### PR TITLE
Support multi-stream output verification in codec tests

### DIFF
--- a/cpp/include/openzl/cpp/Codecs.hpp
+++ b/cpp/include/openzl/cpp/Codecs.hpp
@@ -4,7 +4,7 @@
 
 #include "openzl/cpp/codecs/ACE.hpp"              // IWYU pragma: export
 #include "openzl/cpp/codecs/Bitpack.hpp"          // IWYU pragma: export
-#include "openzl/cpp/codecs/BitsplitTop8.hpp"     // IWYU pragma: export
+#include "openzl/cpp/codecs/Bitsplit.hpp"         // IWYU pragma: export
 #include "openzl/cpp/codecs/Bitunpack.hpp"        // IWYU pragma: export
 #include "openzl/cpp/codecs/BruteForce.hpp"       // IWYU pragma: export
 #include "openzl/cpp/codecs/Compress.hpp"         // IWYU pragma: export

--- a/cpp/include/openzl/cpp/codecs/Bitsplit.hpp
+++ b/cpp/include/openzl/cpp/codecs/Bitsplit.hpp
@@ -20,5 +20,17 @@ struct BitsplitTop8 : public SimplePipeNode<BitsplitTop8> {
         .description = "Split numeric into top 8 significant bits and remainder"
     };
 };
+
+struct BitsplitFP : public SimplePipeNode<BitsplitFP> {
+   public:
+    static constexpr NodeID node = ZL_NODE_BITSPLIT_FP;
+
+    static constexpr NodeMetadata<1, 0, 1> metadata = {
+        .inputs          = { InputMetadata{ .type = Type::Numeric } },
+        .variableOutputs = { OutputMetadata{ .type = Type::Numeric,
+                                             .name = "bit_ranges" } },
+        .description = "Split IEEE 754 floats into sign, exponent, and mantissa"
+    };
+};
 } // namespace nodes
 } // namespace openzl

--- a/include/openzl/codecs/zl_bitsplit.h
+++ b/include/openzl/codecs/zl_bitsplit.h
@@ -10,11 +10,18 @@ extern "C" {
 #endif
 
 // bitsplit transforms
+
 // Input : 1 numeric stream (all widths supported: 1, 2, 4, 8 bytes)
 // Output : 1 or 2 numeric streams (lower remainder bits, upper bits)
 // Note : All variants share the same wire format (bitSplit).
 //        Each variant bundles a different policy for choosing bit widths.
 #define ZL_NODE_BITSPLIT_TOP8 ZL_MAKE_NODE_ID(ZL_StandardNodeID_bitsplit_top8)
+
+// input  : 1 numeric stream (IEEE 754 widths: 2, 4, or 8 bytes)
+// output : 1 variable output stream of 3 outputs
+//          (sign, exponent, mantissa)
+// Supports IEEE 754 fp16, fp32, fp64.
+#define ZL_NODE_BITSPLIT_FP ZL_MAKE_NODE_ID(ZL_StandardNodeID_bitsplit_fp)
 
 #if defined(__cplusplus)
 }

--- a/include/openzl/zl_nodes.h
+++ b/include/openzl/zl_nodes.h
@@ -81,6 +81,7 @@ typedef enum {
     ZL_StandardNodeID_quantize_lengths,
 
     ZL_StandardNodeID_bitsplit_top8,
+    ZL_StandardNodeID_bitsplit_fp,
 
     ZL_StandardNodeID_public_end // last id, used to detect end of public range
 } ZL_StandardNodeID;

--- a/src/openzl/codecs/bitSplit/encode_bitsplit_fp_binding.c
+++ b/src/openzl/codecs/bitSplit/encode_bitsplit_fp_binding.c
@@ -1,0 +1,51 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#include "openzl/codecs/bitSplit/encode_bitsplit_fp_binding.h"
+#include "openzl/codecs/bitSplit/encode_bitSplit_binding.h" /* EI_bitSplit_withWidths */
+#include "openzl/common/assertion.h"                        /* ZL_ASSERT */
+#include "openzl/zl_data.h"                                 /* ZL_Input_type */
+#include "openzl/zl_errors.h"                               /* ZL_ERR_IF_NOT */
+#include "openzl/zl_input.h" /* ZL_Input_ptr, ZL_Input_eltWidth, ZL_Input_numElts */
+
+ZL_Report EI_bitsplit_fp(ZL_Encoder* eictx, const ZL_Input* ins[], size_t nbIns)
+{
+    ZL_RESULT_DECLARE_SCOPE_REPORT(eictx);
+
+    ZL_ASSERT_NN(eictx);
+    ZL_ASSERT_EQ(nbIns, 1);
+    ZL_ASSERT_NN(ins);
+    const ZL_Input* in = ins[0];
+    ZL_ASSERT_NN(in);
+    ZL_ASSERT_EQ(ZL_Input_type(in), ZL_Type_numeric);
+    size_t const eltWidth = ZL_Input_eltWidth(in);
+    ZL_ERR_IF_NOT(
+            eltWidth == 2 || eltWidth == 4 || eltWidth == 8,
+            node_invalid_input,
+            "bitsplit_fp requires IEEE 754 floats (2, 4, or 8-byte elements)");
+
+    uint8_t bitWidths[3];
+
+    switch (eltWidth) {
+        case 2:                // IEEE 754 binary16 (fp16)
+            bitWidths[0] = 10; // mantissa bits (LSB)
+            bitWidths[1] = 5;  // exponent bits
+            bitWidths[2] = 1;  // sign bit     (MSB)
+            break;
+        case 4:                // IEEE 754 binary32 (fp32)
+            bitWidths[0] = 23; // mantissa bits (LSB)
+            bitWidths[1] = 8;  // exponent bits
+            bitWidths[2] = 1;  // sign bit     (MSB)
+            break;
+        case 8:                // IEEE 754 binary64 (fp64)
+            bitWidths[0] = 52; // mantissa bits (LSB)
+            bitWidths[1] = 11; // exponent bits
+            bitWidths[2] = 1;  // sign bit     (MSB)
+            break;
+        default:
+            ZL_ERR(node_invalid_input,
+                   "Unsupported element width for floating point");
+            break;
+    }
+
+    return EI_bitSplit_withWidths(eictx, in, bitWidths, 3);
+}

--- a/src/openzl/codecs/bitSplit/encode_bitsplit_fp_binding.h
+++ b/src/openzl/codecs/bitSplit/encode_bitsplit_fp_binding.h
@@ -1,0 +1,43 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#ifndef OPENZL_CODECS_BITSPLIT_ENCODE_BITSPLIT_FP_BINDING_H
+#define OPENZL_CODECS_BITSPLIT_ENCODE_BITSPLIT_FP_BINDING_H
+
+#include "openzl/codecs/common/graph_vo.h" /* GRAPH_VO_NUM */
+#include "openzl/shared/portability.h"
+#include "openzl/zl_ctransform.h" /* ZL_Encoder */
+#include "openzl/zl_errors.h"     /* ZL_Report */
+#include "openzl/zl_opaque_types.h"
+
+ZL_BEGIN_C_DECLS
+
+/**
+ * bitsplit_fp encoder
+ *
+ * Decomposes IEEE 754 floats into 3 separate streams:
+ * sign (1 bit), exponent, and mantissa.
+ *
+ * Supported IEEE 754 widths:
+ * - 2-byte (16-bit): sign (1 bit), exponent (5 bits), mantissa (10 bits)
+ * - 4-byte (32-bit): sign (1 bit), exponent (8 bits), mantissa (23 bits)
+ * - 8-byte (64-bit): sign (1 bit), exponent (11 bits), mantissa (52 bits)
+ *
+ * Input: 1 numeric stream (2, 4, or 8-byte elements)
+ * Output: 1 variable output stream of 3 outputs
+ *         (sign, exponent, mantissa)
+ *
+ * Parameters: none (parameter-free node)
+ *
+ * Wire format: reuses bitSplit transform ID and codec header.
+ */
+ZL_Report
+EI_bitsplit_fp(ZL_Encoder* eictx, const ZL_Input* ins[], size_t nbIns);
+
+#define EI_BITSPLIT_FP(id)             \
+    { .gd          = GRAPH_VO_NUM(id), \
+      .transform_f = EI_bitsplit_fp,   \
+      .name        = "!zl.bitsplit_fp" }
+
+ZL_END_C_DECLS
+
+#endif // OPENZL_CODECS_BITSPLIT_ENCODE_BITSPLIT_FP_BINDING_H

--- a/src/openzl/codecs/encoder_registry.c
+++ b/src/openzl/codecs/encoder_registry.c
@@ -3,6 +3,7 @@
 #include "openzl/codecs/encoder_registry.h"
 
 #include "openzl/codecs/bitSplit/encode_bitSplit_binding.h"
+#include "openzl/codecs/bitSplit/encode_bitsplit_fp_binding.h"
 #include "openzl/codecs/bitSplit/encode_bitsplit_top8_binding.h"
 #include "openzl/codecs/bitpack/encode_bitpack_binding.h"
 #include "openzl/codecs/bitunpack/encode_bitunpack_binding.h"
@@ -108,6 +109,7 @@ const CNode ER_standardNodes[STANDARD_ENCODERS_NB] = {
     REGISTER_TRANSFORM(ZL_StandardNodeID_quantize_offsets, ZL_StandardTransformID_quantize_offsets, 3, EI_QUANTIZE_OFFSETS),
     REGISTER_TRANSFORM(ZL_StandardNodeID_quantize_lengths, ZL_StandardTransformID_quantize_lengths, 3, EI_QUANTIZE_LENGTHS),
     REGISTER_TRANSFORM(ZL_StandardNodeID_bitsplit_top8, ZL_StandardTransformID_bitSplit, 24, EI_BITSPLIT_TOP8),
+    REGISTER_TRANSFORM(ZL_StandardNodeID_bitsplit_fp, ZL_StandardTransformID_bitSplit, 24, EI_BITSPLIT_FP),
 
     // Private Nodes
     REGISTER_TRANSFORM(ZL_PrivateStandardNodeID_set_string_lens,           ZL_StandardTransformID_convert_serial_string, 10, EI_SETSTRINGLENS),

--- a/tests/codecs/test_bitsplit_fp.cpp
+++ b/tests/codecs/test_bitsplit_fp.cpp
@@ -1,0 +1,272 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#include <cmath>
+#include <cstdint>
+#include <limits>
+#include <vector>
+
+#include <gtest/gtest.h>
+
+#include "openzl/openzl.hpp"
+#include "tests/codecs/test_codec.h"
+
+namespace openzl {
+namespace tests {
+
+class BitsplitFPTest : public CodecTest {
+   public:
+    /**
+     * Tests round-trip compression/decompression using bitsplit_fp.
+     *
+     * @param input Numeric input data (2, 4, or 8-byte IEEE 754 elements)
+     */
+    template <typename T>
+    void testBitsplitFPRoundTrip(const std::vector<T>& input)
+    {
+        compressor_.setParameter(CParam::FormatVersion, ZL_MAX_FORMAT_VERSION);
+
+        auto graph = compressor_.buildStaticGraph(
+                ZL_NODE_BITSPLIT_FP, { graphs::Compress{}() });
+        compressor_.selectStartingGraph(graph);
+
+        Input numericInput = Input::refNumeric(poly::span<const T>{ input });
+        testRoundTrip(numericInput);
+    }
+};
+
+// =============================================================================
+// FP32 Round-Trip Tests
+// =============================================================================
+
+TEST_F(BitsplitFPTest, FP32_RoundTrip)
+{
+    std::vector<float> input(1000);
+    for (size_t i = 0; i < input.size(); i++) {
+        input[i] = static_cast<float>(i) * 0.1f;
+    }
+    testBitsplitFPRoundTrip(input);
+}
+
+TEST_F(BitsplitFPTest, FP32_AllZero)
+{
+    std::vector<float> input(1000, 0.0f);
+    testBitsplitFPRoundTrip(input);
+}
+
+// =============================================================================
+// FP32 Edge Cases
+// =============================================================================
+
+TEST_F(BitsplitFPTest, FP32_EmptyInput)
+{
+    std::vector<float> input;
+    testBitsplitFPRoundTrip(input);
+}
+
+TEST_F(BitsplitFPTest, FP32_SingleElement)
+{
+    std::vector<float> input{ 999.999f };
+    testBitsplitFPRoundTrip(input);
+}
+
+TEST_F(BitsplitFPTest, FP32_NaN)
+{
+    std::vector<float> input{ std::numeric_limits<float>::quiet_NaN() };
+    testBitsplitFPRoundTrip(input);
+}
+
+TEST_F(BitsplitFPTest, FP32_Infinity)
+{
+    std::vector<float> input{
+        std::numeric_limits<float>::infinity(),
+        -std::numeric_limits<float>::infinity(),
+    };
+    testBitsplitFPRoundTrip(input);
+}
+
+TEST_F(BitsplitFPTest, FP32_NegativeZero)
+{
+    std::vector<float> input{ -0.0f };
+    testBitsplitFPRoundTrip(input);
+}
+
+TEST_F(BitsplitFPTest, FP32_MinMax)
+{
+    std::vector<float> input{
+        std::numeric_limits<float>::lowest(),
+        std::numeric_limits<float>::max(),
+    };
+    testBitsplitFPRoundTrip(input);
+}
+
+TEST_F(BitsplitFPTest, FP32_Subnormals)
+{
+    std::vector<float> input(1000);
+    const float subnormal = std::numeric_limits<float>::denorm_min();
+    for (size_t i = 0; i < input.size(); i++) {
+        input[i] = subnormal * static_cast<float>(i + 1);
+    }
+    testBitsplitFPRoundTrip(input);
+}
+
+// =============================================================================
+// FP64 Round-Trip Tests
+// =============================================================================
+
+TEST_F(BitsplitFPTest, FP64_RoundTrip)
+{
+    std::vector<double> input(1000);
+    for (size_t i = 0; i < input.size(); i++) {
+        input[i] = static_cast<double>(i) * 0.1;
+    }
+    testBitsplitFPRoundTrip(input);
+}
+
+TEST_F(BitsplitFPTest, FP64_AllZero)
+{
+    std::vector<double> input(1000, 0.0);
+    testBitsplitFPRoundTrip(input);
+}
+
+// =============================================================================
+// FP64 Edge Cases
+// =============================================================================
+
+TEST_F(BitsplitFPTest, FP64_EmptyInput)
+{
+    std::vector<double> input;
+    testBitsplitFPRoundTrip(input);
+}
+
+TEST_F(BitsplitFPTest, FP64_SingleElement)
+{
+    std::vector<double> input{ 123456.789012 };
+    testBitsplitFPRoundTrip(input);
+}
+
+TEST_F(BitsplitFPTest, FP64_NaN)
+{
+    std::vector<double> input{ std::numeric_limits<double>::quiet_NaN() };
+    testBitsplitFPRoundTrip(input);
+}
+
+TEST_F(BitsplitFPTest, FP64_Infinity)
+{
+    std::vector<double> input{
+        std::numeric_limits<double>::infinity(),
+        -std::numeric_limits<double>::infinity(),
+    };
+    testBitsplitFPRoundTrip(input);
+}
+
+TEST_F(BitsplitFPTest, FP64_NegativeZero)
+{
+    std::vector<double> input{ -0.0 };
+    testBitsplitFPRoundTrip(input);
+}
+
+TEST_F(BitsplitFPTest, FP64_MinMax)
+{
+    std::vector<double> input{
+        std::numeric_limits<double>::lowest(),
+        std::numeric_limits<double>::max(),
+    };
+    testBitsplitFPRoundTrip(input);
+}
+
+TEST_F(BitsplitFPTest, FP64_Subnormals)
+{
+    std::vector<double> input(1000);
+    const double subnormal = std::numeric_limits<double>::denorm_min();
+    for (size_t i = 0; i < input.size(); i++) {
+        input[i] = subnormal * static_cast<double>(i + 1);
+    }
+    testBitsplitFPRoundTrip(input);
+}
+
+// =============================================================================
+// FP16 Round-Trip Tests
+// =============================================================================
+// IEEE 754 half-precision: 1 sign + 5 exponent + 10 mantissa
+// No native C++ type, so we use uint16_t with manually constructed bit
+// patterns.
+
+TEST_F(BitsplitFPTest, FP16_RoundTrip)
+{
+    // Sweep through a range of normal fp16 values
+    std::vector<uint16_t> input(1000);
+    for (size_t i = 0; i < input.size(); i++) {
+        // Range from small positive normals to larger ones
+        // Exponent field [0x0400..0x7BFF] covers all normal fp16 values
+        input[i] = static_cast<uint16_t>(0x0400 + (i % 0x7800));
+    }
+    testBitsplitFPRoundTrip(input);
+}
+
+TEST_F(BitsplitFPTest, FP16_AllZero)
+{
+    std::vector<uint16_t> input(1000, 0x0000);
+    testBitsplitFPRoundTrip(input);
+}
+
+// =============================================================================
+// FP16 Edge Cases
+// =============================================================================
+
+TEST_F(BitsplitFPTest, FP16_EmptyInput)
+{
+    std::vector<uint16_t> input;
+    testBitsplitFPRoundTrip(input);
+}
+
+TEST_F(BitsplitFPTest, FP16_SingleElement)
+{
+    // 0x3C00 = 1.0 in fp16
+    std::vector<uint16_t> input{ 0x3C00 };
+    testBitsplitFPRoundTrip(input);
+}
+
+TEST_F(BitsplitFPTest, FP16_NaN)
+{
+    // fp16 quiet NaN: exponent all 1s, mantissa nonzero
+    std::vector<uint16_t> input{ 0x7E00 };
+    testBitsplitFPRoundTrip(input);
+}
+
+TEST_F(BitsplitFPTest, FP16_Infinity)
+{
+    std::vector<uint16_t> input{
+        0x7C00, // +Inf
+        0xFC00, // -Inf
+    };
+    testBitsplitFPRoundTrip(input);
+}
+
+TEST_F(BitsplitFPTest, FP16_NegativeZero)
+{
+    std::vector<uint16_t> input{ 0x8000 };
+    testBitsplitFPRoundTrip(input);
+}
+
+TEST_F(BitsplitFPTest, FP16_MinMax)
+{
+    std::vector<uint16_t> input{
+        0x0400, // smallest normal (2^-14)
+        0x7BFF, // largest finite (65504.0)
+    };
+    testBitsplitFPRoundTrip(input);
+}
+
+TEST_F(BitsplitFPTest, FP16_Subnormals)
+{
+    // fp16 subnormals: exponent = 0, mantissa nonzero
+    std::vector<uint16_t> input(1000);
+    for (size_t i = 0; i < input.size(); i++) {
+        // Subnormal mantissa range: 0x0001..0x03FF
+        input[i] = static_cast<uint16_t>((i % 0x03FF) + 1);
+    }
+    testBitsplitFPRoundTrip(input);
+}
+
+} // namespace tests
+} // namespace openzl

--- a/tests/codecs/test_bitsplit_fp.cpp
+++ b/tests/codecs/test_bitsplit_fp.cpp
@@ -2,6 +2,7 @@
 
 #include <cmath>
 #include <cstdint>
+#include <cstring>
 #include <limits>
 #include <vector>
 
@@ -268,5 +269,95 @@ TEST_F(BitsplitFPTest, FP16_Subnormals)
     testBitsplitFPRoundTrip(input);
 }
 
+// =============================================================================
+// Split Order Cases
+// =============================================================================
+
+TEST_F(BitsplitFPTest, FP32_OutputOrder)
+{
+    std::vector<float> input{ -3.14f };
+
+    uint32_t rawBits;
+    // write the float to 4 bytes of raw bits
+
+    std::memcpy(&rawBits, input.data(), sizeof(rawBits));
+    uint32_t mantissaVal = rawBits & 0x7FFFFF;     // bottom 23 bits
+    uint8_t exponentVal  = (rawBits >> 23) & 0xFF; // next 8 bits
+    uint8_t signVal      = (rawBits >> 31) & 0x1;  // top 1 bit
+
+    std::vector<uint32_t> expectedMantissa{ mantissaVal };
+    std::vector<uint8_t> expectedExponent{ exponentVal };
+    std::vector<uint8_t> expectedSign{ signVal };
+
+    Input inMantissa =
+            Input::refNumeric(poly::span<const uint32_t>{ expectedMantissa });
+    Input inExponent =
+            Input::refNumeric(poly::span<const uint8_t>{ expectedExponent });
+    Input inSign = Input::refNumeric(poly::span<const uint8_t>{ expectedSign });
+
+    Input numericInput = Input::refNumeric(poly::span<const float>{ input });
+    testCodecVO(
+            ZL_NODE_BITSPLIT_FP,
+            numericInput,
+            { &inMantissa, &inExponent, &inSign },
+            24); // 24 is version where we added this codec
+}
+
+TEST_F(BitsplitFPTest, FP64_OutputOrder)
+{
+    std::vector<double> input{ -3.14 };
+
+    uint64_t rawBits;
+    std::memcpy(&rawBits, input.data(), sizeof(rawBits));
+    uint64_t mantissaVal = rawBits & 0xFFFFFFFFFFFFF; // bottom 52 bits
+    uint16_t exponentVal = (rawBits >> 52) & 0x7FF;   // next 11 bits
+    uint8_t signVal      = (rawBits >> 63) & 0x1;     // top 1 bit
+
+    std::vector<uint64_t> expectedMantissa{ mantissaVal };
+    std::vector<uint16_t> expectedExponent{ exponentVal };
+    std::vector<uint8_t> expectedSign{ signVal };
+
+    Input inMantissa =
+            Input::refNumeric(poly::span<const uint64_t>{ expectedMantissa });
+    Input inExponent =
+            Input::refNumeric(poly::span<const uint16_t>{ expectedExponent });
+    Input inSign = Input::refNumeric(poly::span<const uint8_t>{ expectedSign });
+
+    Input numericInput = Input::refNumeric(poly::span<const double>{ input });
+    testCodecVO(
+            ZL_NODE_BITSPLIT_FP,
+            numericInput,
+            { &inMantissa, &inExponent, &inSign },
+            24); // 24 is version where we added this codec
+}
+
+TEST_F(BitsplitFPTest, FP16_OutputOrder)
+{
+    // -3.14 in fp16 = 0xC248
+    std::vector<uint16_t> input{ 0xC248 };
+
+    uint16_t rawBits;
+    std::memcpy(&rawBits, input.data(), sizeof(rawBits));
+    uint16_t mantissaVal = rawBits & 0x3FF;        // bottom 10 bits
+    uint8_t exponentVal  = (rawBits >> 10) & 0x1F; // next 5 bits
+    uint8_t signVal      = (rawBits >> 15) & 0x1;  // top 1 bit
+
+    std::vector<uint16_t> expectedMantissa{ mantissaVal };
+    std::vector<uint8_t> expectedExponent{ exponentVal };
+    std::vector<uint8_t> expectedSign{ signVal };
+
+    Input inMantissa =
+            Input::refNumeric(poly::span<const uint16_t>{ expectedMantissa });
+    Input inExponent =
+            Input::refNumeric(poly::span<const uint8_t>{ expectedExponent });
+    Input inSign = Input::refNumeric(poly::span<const uint8_t>{ expectedSign });
+
+    Input numericInput = Input::refNumeric(poly::span<const uint16_t>{ input });
+    testCodecVO(
+            ZL_NODE_BITSPLIT_FP,
+            numericInput,
+            { &inMantissa, &inExponent, &inSign },
+            24); // 24 is version where we added this codec
+}
 } // namespace tests
 } // namespace openzl

--- a/tests/codecs/test_codec.h
+++ b/tests/codecs/test_codec.h
@@ -44,6 +44,41 @@ class AssertEqFunctionGraph : public FunctionGraph {
     const Input& expected_;
 };
 
+class AssertEqVOFunctionGraph : public FunctionGraph {
+   public:
+    explicit AssertEqVOFunctionGraph(const std::vector<const Input*>& expected)
+            : expected_(expected), callIndex_(0)
+    {
+    }
+
+    FunctionGraphDescription functionGraphDescription() const override
+    {
+        return FunctionGraphDescription{
+            .name           = "AssertEqVO",
+            .inputTypeMasks = { TypeMask::Any },
+        };
+    }
+
+    void graph(GraphState& state) const override
+    {
+        auto& edge        = state.edges()[0];
+        const auto& input = edge.getInput();
+        if (callIndex_ >= expected_.size()) {
+            throw AssertEqException("More streams than expected");
+        }
+        if (input != *expected_[callIndex_]) {
+            throw AssertEqException(
+                    "Stream " + std::to_string(callIndex_) + " does not match");
+        }
+        ++callIndex_;
+        edge.setDestination(graphs::Compress{}());
+    }
+
+   private:
+    const std::vector<const Input*>& expected_;
+    mutable int callIndex_;
+};
+
 class CodecTest : public testing::Test {
     void testCodecImpl(
             NodeID node,
@@ -64,6 +99,21 @@ class CodecTest : public testing::Test {
             }
         }
         auto graph = compressor_.buildStaticGraph(node, successors);
+        compressor_.selectStartingGraph(graph);
+
+        testRoundTrip(input);
+    }
+
+    void testCodecVOImpl(
+            NodeID node,
+            poly::span<const Input> input,
+            const std::vector<const Input*>& expectedOutputs,
+            int formatVersion)
+    {
+        compressor_.setParameter(CParam::FormatVersion, formatVersion);
+        auto successor = compressor_.registerFunctionGraph(
+                std::make_shared<AssertEqVOFunctionGraph>(expectedOutputs));
+        auto graph = compressor_.buildStaticGraph(node, { successor });
         compressor_.selectStartingGraph(graph);
 
         testRoundTrip(input);
@@ -116,6 +166,46 @@ class CodecTest : public testing::Test {
              formatVersion <= maxFormatVersion;
              ++formatVersion) {
             testCodecImpl(node, input, expectedOutputs, formatVersion);
+        }
+    }
+
+    /**
+     * Tests @p node on @p input, expecting @p expectedOutputs streams on a
+     * single output for each format version between @p minFormatVersion and
+     * @p maxFormatVersion.
+     */
+    void testCodecVO(
+            NodeID node,
+            const Input& input,
+            const std::vector<const Input*>& expectedOutputs,
+            int minFormatVersion,
+            int maxFormatVersion = ZL_MAX_FORMAT_VERSION)
+    {
+        testCodecVO(
+                node,
+                { &input, 1 },
+                expectedOutputs,
+                minFormatVersion,
+                maxFormatVersion);
+    }
+
+    /**
+     * Tests @p node on @p input, expecting @p expectedOutputs streams on a
+     * single output for each format version between @p minFormatVersion and
+     * @p maxFormatVersion.
+     */
+    void testCodecVO(
+            NodeID node,
+            poly::span<const Input> input,
+            const std::vector<const Input*>& expectedOutputs,
+            int minFormatVersion,
+            int maxFormatVersion = ZL_MAX_FORMAT_VERSION)
+    {
+        for (int formatVersion =
+                     std::max<int>(minFormatVersion, ZL_MIN_FORMAT_VERSION);
+             formatVersion <= maxFormatVersion;
+             ++formatVersion) {
+            testCodecVOImpl(node, input, expectedOutputs, formatVersion);
         }
     }
 

--- a/tests/registry/OpenZLComponents.h
+++ b/tests/registry/OpenZLComponents.h
@@ -75,6 +75,7 @@ enum class OpenZLComponentID {
     SplitByParam,
     SplitStructByParam,
     SplitNumericByParam,
+    BitSplitFP,
     // Must be last enum value
     NumComponents,
 };
@@ -136,6 +137,8 @@ std::unique_ptr<OpenZLComponent> makeTryParseIntComponent();
 std::unique_ptr<OpenZLComponent> makeSplitByParamComponent();
 std::unique_ptr<OpenZLComponent> makeSplitStructByParamComponent();
 std::unique_ptr<OpenZLComponent> makeSplitNumericByParamComponent();
+std::unique_ptr<OpenZLComponent> makeBitSplitFPComponent();
+
 } // namespace components
 
 inline std::unique_ptr<OpenZLComponent> makeOpenZLComponent(
@@ -242,6 +245,8 @@ inline std::unique_ptr<OpenZLComponent> makeOpenZLComponent(
             return components::makeSplitStructByParamComponent();
         case OpenZLComponentID::SplitNumericByParam:
             return components::makeSplitNumericByParamComponent();
+        case OpenZLComponentID::BitSplitFP:
+            return components::makeBitSplitFPComponent();
         case OpenZLComponentID::NumComponents:
         default:
             throw std::runtime_error("Invalid component");

--- a/tests/registry/OpenZLInput.h
+++ b/tests/registry/OpenZLInput.h
@@ -104,6 +104,8 @@ using U8OpenZLInput  = NumericOpenZLInput<uint8_t>;
 using U16OpenZLInput = NumericOpenZLInput<uint16_t>;
 using U32OpenZLInput = NumericOpenZLInput<uint32_t>;
 using U64OpenZLInput = NumericOpenZLInput<uint64_t>;
+using F32OpenZLInput = NumericOpenZLInput<float>;
+using F64OpenZLInput = NumericOpenZLInput<double>;
 
 inline std::unique_ptr<OpenZLInput> makeNumericInput(
         std::string str,

--- a/tests/registry/components/BitSplit.cpp
+++ b/tests/registry/components/BitSplit.cpp
@@ -3,7 +3,7 @@
 #include <limits>
 
 #include "openzl/codecs/bitSplit/encode_bitSplit_binding.h"
-#include "openzl/cpp/codecs/BitsplitTop8.hpp"
+#include "openzl/cpp/codecs/Bitsplit.hpp"
 #include "openzl/zl_reflection.h"
 #include "tests/registry/OpenZLComponents.h"
 #include "tests/registry/OpenZLInput.h"
@@ -277,6 +277,111 @@ class BitSplitTop8Component : public OpenZLComponent {
     }
 };
 
+class BitSplitFPComponent : public OpenZLComponent {
+   public:
+    std::string name() const override
+    {
+        return "BitSplitFP";
+    }
+
+    int minFormatVersion() const override
+    {
+        return 24;
+    }
+
+    std::vector<NodeID> predefinedNodes(Compressor& compressor) const override
+    {
+        return { nodes::BitsplitFP{}.parameterize(compressor) };
+    }
+
+    std::vector<std::unique_ptr<OpenZLInput>> predefinedInputs() const override
+    {
+        std::vector<std::unique_ptr<OpenZLInput>> inputs;
+        // fp32 (IEEE 754)
+        inputs.push_back(F32OpenZLInput::make(std::vector<float>{}));
+        inputs.push_back(F32OpenZLInput::make(std::vector<float>{ 0.0f }));
+        inputs.push_back(
+                F32OpenZLInput::make(
+                        std::vector<float>{
+                                std::numeric_limits<float>::quiet_NaN() }));
+        inputs.push_back(
+                F32OpenZLInput::make(
+                        std::vector<float>{
+                                std::numeric_limits<float>::infinity(),
+                                -std::numeric_limits<float>::infinity() }));
+        inputs.push_back(F32OpenZLInput::make(std::vector<float>{ -0.0f }));
+        inputs.push_back(
+                F32OpenZLInput::make(
+                        std::vector<float>{
+                                std::numeric_limits<float>::lowest(),
+                                std::numeric_limits<float>::max() }));
+        inputs.push_back(
+                F32OpenZLInput::make(
+                        std::vector<float>{
+                                std::numeric_limits<float>::denorm_min() }));
+        // fp64 (IEEE 754)
+        inputs.push_back(F64OpenZLInput::make(std::vector<double>{}));
+        inputs.push_back(F64OpenZLInput::make(std::vector<double>{ 0.0 }));
+        inputs.push_back(
+                F64OpenZLInput::make(
+                        std::vector<double>{
+                                std::numeric_limits<double>::quiet_NaN() }));
+        inputs.push_back(
+                F64OpenZLInput::make(
+                        std::vector<double>{
+                                std::numeric_limits<double>::infinity(),
+                                -std::numeric_limits<double>::infinity() }));
+        inputs.push_back(F64OpenZLInput::make(std::vector<double>{ -0.0 }));
+        inputs.push_back(
+                F64OpenZLInput::make(
+                        std::vector<double>{
+                                std::numeric_limits<double>::lowest(),
+                                std::numeric_limits<double>::max() }));
+        inputs.push_back(
+                F64OpenZLInput::make(
+                        std::vector<double>{
+                                std::numeric_limits<double>::denorm_min() }));
+        // fp16 (IEEE 754)
+        inputs.push_back(U16OpenZLInput::make(std::vector<uint16_t>{}));
+        inputs.push_back(U16OpenZLInput::make(std::vector<uint16_t>{ 0x0000 }));
+        inputs.push_back(
+                U16OpenZLInput::make(
+                        std::vector<uint16_t>{ 0x7E00 })); // quiet NaN
+        inputs.push_back(
+                U16OpenZLInput::make(
+                        std::vector<uint16_t>{ 0x7C00, 0xFC00 })); // +-Inf
+        inputs.push_back(
+                U16OpenZLInput::make(std::vector<uint16_t>{ 0x8000 })); // -0
+        inputs.push_back(
+                U16OpenZLInput::make(
+                        std::vector<uint16_t>{
+                                0x0400, 0x7BFF })); // min normal, max finite
+        inputs.push_back(
+                U16OpenZLInput::make(
+                        std::vector<uint16_t>{ 0x0001 })); // smallest subnormal
+
+        return inputs;
+    }
+
+    std::vector<std::unique_ptr<OpenZLInput>> generateInputs(
+            datagen::DataGen& gen,
+            size_t num,
+            size_t maxInputSize,
+            const Compressor&,
+            GraphID) const override
+    {
+        std::vector<std::unique_ptr<OpenZLInput>> inputs;
+        inputs.reserve(num);
+        for (size_t i = 0; i < num; ++i) {
+            auto width = gen.choices("width", std::vector<size_t>{ 2, 4, 8 });
+            auto data  = gen.randStringWithQuantizedLength(
+                    "data", maxInputSize, width);
+            inputs.push_back(makeNumericInput(data, width));
+        }
+        return inputs;
+    }
+};
+
 } // namespace
 
 std::unique_ptr<OpenZLComponent> makeBitSplitComponent()
@@ -287,6 +392,11 @@ std::unique_ptr<OpenZLComponent> makeBitSplitComponent()
 std::unique_ptr<OpenZLComponent> makeBitSplitTop8Component()
 {
     return std::make_unique<BitSplitTop8Component>();
+}
+
+std::unique_ptr<OpenZLComponent> makeBitSplitFPComponent()
+{
+    return std::make_unique<BitSplitFPComponent>();
 }
 
 } // namespace openzl::tests::components

--- a/tools/training/ace/ace_compressors.cpp
+++ b/tools/training/ace/ace_compressors.cpp
@@ -6,7 +6,7 @@
 #include "openzl/zl_reflection.h"
 #include "tools/training/ace/ace_sampling.h"
 
-#include "openzl/cpp/codecs/BitsplitTop8.hpp"
+#include "openzl/cpp/codecs/Bitsplit.hpp"
 
 namespace openzl {
 namespace training {
@@ -90,6 +90,7 @@ std::vector<ACENode> makeAllNodes()
     n.push_back(buildNode(nodes::QuantizeOffsets{}));
     n.push_back(buildNode(nodes::QuantizeLengths{}));
     n.push_back(buildNode(nodes::TransposeSplit{}));
+    n.push_back(buildNode(nodes::BitsplitFP{}));
     n.push_back(buildNode(nodes::BitsplitTop8{}));
     n.push_back(buildNode(nodes::Zigzag{}));
     n.push_back(buildNode(nodes::ConvertSerialToNum8{}));
@@ -155,6 +156,7 @@ std::vector<ACECompressor> makePrebuiltNumericCompressors()
     ACECompressor entropy(buildGraph(graphs::Entropy{}));
     ACECompressor top8bitsEntropy(
             buildNode(nodes::BitsplitTop8{}), { entropy });
+    ACECompressor fpBitsEntropy(buildNode(nodes::BitsplitFP{}), { entropy });
     ACECompressor fse(buildGraph(graphs::Fse{}));
     ACECompressor store(buildGraph(graphs::Store{}));
     ACECompressor quantizeOffsets(
@@ -174,6 +176,7 @@ std::vector<ACECompressor> makePrebuiltNumericCompressors()
         rangePackFieldLz,
         rangePackDeltaFieldLz,
         top8bitsEntropy,
+        fpBitsEntropy,
         quantizeOffsets,
         quantizeLengths,
     };


### PR DESCRIPTION
Summary:
- Adds `testCodecMultiStream` and `AssertEqMultiStreamFunctionGraph` to the codec
  test framework, enabling tests to verify that a codec produces the expected output
  streams from a single input
- Adds `FP32_OutputOrder`, `FP64_OutputOrder`, and `FP16_OutputOrder` tests that verify
  bitsplit_fp splits IEEE 754 floats into the correct mantissa, exponent, and sign streams

Differential Revision: D95400978
