### PR TITLE
Split register allocation logic into utility class

### DIFF
--- a/tests/compress/graphs/sddl2/test_sddl2_code_execution.cpp
+++ b/tests/compress/graphs/sddl2/test_sddl2_code_execution.cpp
@@ -178,7 +178,7 @@ TEST_F(SDDL2CodeExecutionTest, ConsumeArrayOfArrays)
             expected_sizes);
 }
 
-TEST_F(SDDL2CodeExecutionTest, ConsumeSimpleSAO)
+TEST_F(SDDL2CodeExecutionTest, ConsumeSimpleAnonymous)
 {
     const size_t star_entry_size = 2 * sizeof(double) + 2 * sizeof(uint8_t)
             + sizeof(int16_t) + 2 * sizeof(float);
@@ -196,6 +196,67 @@ TEST_F(SDDL2CodeExecutionTest, ConsumeSimpleSAO)
                     XRPM : Float32LE, # R.A. proper motion
                     XDPM : Float32LE # Dec. proper motion
                 }[]
+            )",
+            input,
+            expected_sizes);
+}
+
+TEST_F(SDDL2CodeExecutionTest, ConsumeSimpleSAO)
+{
+    const size_t star_entry_size = 2 * sizeof(double) + 2 * sizeof(uint8_t)
+            + sizeof(int16_t) + 2 * sizeof(float);
+    const std::vector<size_t> expected_sizes = { 28, 4 * star_entry_size };
+    const auto input = gen<uint8_t>(sum(expected_sizes));
+
+    expect_success(
+            R"(
+                # Star catalog entry (28 bytes)
+                Record StarEntry() = {
+                    SRA0:  Float64LE,    # Right Ascension (radians)
+                    SDEC0: Float64LE,    # Declination (radians)
+                    ISP:   Bytes(2),     # Spectral type
+                    MAG:   Int16LE,      # Magnitude
+                    XRPM:  Float32LE,    # R.A. proper motion
+                    XDPM:  Float32LE     # Dec. proper motion
+                }
+
+                # File structure
+                header: Bytes(28)
+                stars: StarEntry[]
+            )",
+            input,
+            expected_sizes);
+}
+
+TEST_F(SDDL2CodeExecutionTest, ConsumeArrayTypeVars)
+{
+    const std::vector<size_t> expected_sizes = { 16, 16 * 10, 12, 12 * 10 };
+    const auto input = gen<uint8_t>(sum(expected_sizes));
+
+    expect_success(
+            R"(
+                Foo = Int32LE[4]
+                Bar = Int32LE[3]
+                : Foo
+                : Foo[10]
+                : Bar
+                : Bar[10]
+            )",
+            input,
+            expected_sizes);
+}
+
+TEST_F(SDDL2CodeExecutionTest, VarRecordType)
+{
+    const size_t record_size = sizeof(int32_t) + sizeof(int16_t);
+    const std::vector<size_t> expected_sizes = { record_size, 3 * record_size };
+    const auto input = gen<uint8_t>(sum(expected_sizes));
+
+    expect_success(
+            R"(
+                Entry = Record() { x: Int32LE, y: Int16LE }
+                : Entry
+                : Entry[3]
             )",
             input,
             expected_sizes);

--- a/tools/sddl2/compiler/Exception.cpp
+++ b/tools/sddl2/compiler/Exception.cpp
@@ -14,7 +14,9 @@ std::string make_msg(
         const poly::string_view& msg)
 {
     if (loc.empty()) {
-        return std::string{ msg } + '\n';
+        std::stringstream ss;
+        ss << error_type << ": " << msg << "\n";
+        return std::move(ss).str();
     }
     std::stringstream ss;
     ss << loc.pos_str() << ": " << error_type << ": " << msg << "\n";

--- a/tools/sddl2/compiler/codegen/CodeGenerator.cpp
+++ b/tools/sddl2/compiler/codegen/CodeGenerator.cpp
@@ -1,6 +1,9 @@
 // Copyright (c) Meta Platforms, Inc. and affiliates.
 
 #include <sstream>
+#include <unordered_set>
+
+#include "src/openzl/compress/graphs/sddl2/sddl2_vm.h"
 
 #include "tools/sddl2/compiler/Exception.h"
 #include "tools/sddl2/compiler/codegen/CodeGenerator.h"
@@ -141,9 +144,17 @@ class CodeGeneratorImpl {
      */
     void generate(const ASTVar& var, AssemblyOutput& output)
     {
-        (void)output;
-        throw CodegenError(
-                "Variable references are not yet supported: " + var.name());
+        auto it = var_registry_.find(var.name());
+        if (it == var_registry_.end()) {
+            throw CodegenError(var.loc(), "Undefined variable: " + var.name());
+        }
+        output.emplace_back("push.i64 " + std::to_string(it->second));
+        output.emplace_back("var.load");
+        // If this is the last reference to the variable, free the register
+        if (var.is_last_reference()) {
+            free_registers_.insert(it->second);
+            var_registry_.erase(it);
+        }
     }
 
     /**
@@ -247,7 +258,11 @@ class CodeGeneratorImpl {
             }
             case Op::ASSIGN: {
                 // Sema guarantees LHS is a variable
-                // TODO: actually handle variable assignment
+                auto var = op.args()[0]->as_var();
+                generateNode(op.args()[1], output);
+                auto reg = assignRegister(var->name());
+                output.emplace_back("push.i64 " + std::to_string(reg));
+                output.emplace_back("var.store");
                 break;
             }
             case Op::ASSUME: // TODO: treat assume differently from consume
@@ -270,8 +285,40 @@ class CodeGeneratorImpl {
         };
     }
 
+    size_t assignRegister(const std::string& name)
+    {
+        // If the variable is already in the registry, return its register
+        auto it = var_registry_.find(name);
+        if (it != var_registry_.end()) {
+            return it->second;
+        }
+
+        // Otherwise, allocate a new register
+        size_t reg;
+        if (!free_registers_.empty()) {
+            auto free_it = free_registers_.begin();
+            reg          = *free_it;
+            free_registers_.erase(free_it);
+        } else {
+            reg = next_register_++;
+            if (reg >= SDDL2_VAR_REGISTER_COUNT) {
+                throw CodegenError(
+                        "Too many variables! Maximum number of variables is "
+                        + std::to_string(SDDL2_VAR_REGISTER_COUNT));
+            }
+        }
+
+        var_registry_[name] = reg;
+        return reg;
+    }
+
     const detail::Logger& log_;
     size_t tag_ = 1;
+
+    // Register allocation
+    std::map<std::string, size_t> var_registry_;
+    std::unordered_set<size_t> free_registers_;
+    size_t next_register_ = 0;
 };
 
 } // namespace

--- a/tools/sddl2/compiler/codegen/CodeGenerator.cpp
+++ b/tools/sddl2/compiler/codegen/CodeGenerator.cpp
@@ -7,6 +7,7 @@
 
 #include "tools/sddl2/compiler/Exception.h"
 #include "tools/sddl2/compiler/codegen/CodeGenerator.h"
+#include "tools/sddl2/compiler/codegen/RegisterAllocator.h"
 #include "tools/sddl2/compiler/parser/AST.h"
 
 namespace openzl::sddl2 {
@@ -144,16 +145,11 @@ class CodeGeneratorImpl {
      */
     void generate(const ASTVar& var, AssemblyOutput& output)
     {
-        auto it = var_registry_.find(var.name());
-        if (it == var_registry_.end()) {
-            throw CodegenError(var.loc(), "Undefined variable: " + var.name());
-        }
-        output.emplace_back("push.i64 " + std::to_string(it->second));
+        output.emplace_back(
+                "push.i64 " + std::to_string(registers_.get(var.name())));
         output.emplace_back("var.load");
-        // If this is the last reference to the variable, free the register
         if (var.is_last_reference()) {
-            free_registers_.insert(it->second);
-            var_registry_.erase(it);
+            registers_.unassign(var.name());
         }
     }
 
@@ -260,8 +256,9 @@ class CodeGeneratorImpl {
                 // Sema guarantees LHS is a variable
                 auto var = op.args()[0]->as_var();
                 generateNode(op.args()[1], output);
-                auto reg = assignRegister(var->name());
-                output.emplace_back("push.i64 " + std::to_string(reg));
+                output.emplace_back(
+                        "push.i64 "
+                        + std::to_string(registers_.assign(var->name())));
                 output.emplace_back("var.store");
                 break;
             }
@@ -289,40 +286,11 @@ class CodeGeneratorImpl {
         };
     }
 
-    size_t assignRegister(const std::string& name)
-    {
-        // If the variable is already in the registry, return its register
-        auto it = var_registry_.find(name);
-        if (it != var_registry_.end()) {
-            return it->second;
-        }
-
-        // Otherwise, allocate a new register
-        size_t reg;
-        if (!free_registers_.empty()) {
-            auto free_it = free_registers_.begin();
-            reg          = *free_it;
-            free_registers_.erase(free_it);
-        } else {
-            reg = next_register_++;
-            if (reg >= SDDL2_VAR_REGISTER_COUNT) {
-                throw CodegenError(
-                        "Too many variables! Maximum number of variables is "
-                        + std::to_string(SDDL2_VAR_REGISTER_COUNT));
-            }
-        }
-
-        var_registry_[name] = reg;
-        return reg;
-    }
-
     const detail::Logger& log_;
     size_t tag_ = 1;
 
     // Register allocation
-    std::map<std::string, size_t> var_registry_;
-    std::unordered_set<size_t> free_registers_;
-    size_t next_register_ = 0;
+    RegisterAllocator registers_;
 };
 
 } // namespace

--- a/tools/sddl2/compiler/codegen/CodeGenerator.cpp
+++ b/tools/sddl2/compiler/codegen/CodeGenerator.cpp
@@ -279,6 +279,10 @@ class CodeGeneratorImpl {
                 output.emplace_back("segment.create_tagged");
                 break;
             }
+            case Op::MEMBER: {
+                throw CodegenError(
+                        op.loc(), "Member access not yet supported.");
+            }
             case Op::SEND:
             default:
                 throw InvariantViolation(op.loc(), "Unsupported operation.");

--- a/tools/sddl2/compiler/codegen/RegisterAllocator.cpp
+++ b/tools/sddl2/compiler/codegen/RegisterAllocator.cpp
@@ -1,0 +1,63 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#include "src/openzl/compress/graphs/sddl2/sddl2_vm.h"
+
+#include "tools/sddl2/compiler/Exception.h"
+#include "tools/sddl2/compiler/codegen/RegisterAllocator.h"
+
+namespace openzl::sddl2 {
+
+size_t RegisterAllocator::allocate()
+{
+    size_t reg;
+    if (!free_registers_.empty()) {
+        auto free_it = free_registers_.begin();
+        reg          = *free_it;
+        free_registers_.erase(free_it);
+    } else {
+        reg = next_register_++;
+        if (reg >= SDDL2_VAR_REGISTER_COUNT) {
+            throw CodegenError(
+                    "Too many registers! Maximum number of registers is "
+                    + std::to_string(SDDL2_VAR_REGISTER_COUNT));
+        }
+    }
+    return reg;
+}
+
+void RegisterAllocator::free(size_t reg)
+{
+    free_registers_.insert(reg);
+}
+
+size_t RegisterAllocator::assign(const std::string& name)
+{
+    auto it = var_registry_.find(name);
+    if (it != var_registry_.end()) {
+        return it->second;
+    }
+
+    size_t reg          = allocate();
+    var_registry_[name] = reg;
+    return reg;
+}
+
+void RegisterAllocator::unassign(const std::string& name)
+{
+    auto it = var_registry_.find(name);
+    if (it != var_registry_.end()) {
+        free(it->second);
+        var_registry_.erase(it);
+    }
+}
+
+size_t RegisterAllocator::get(const std::string& name)
+{
+    auto it = var_registry_.find(name);
+    if (it == var_registry_.end()) {
+        throw CodegenError("Undefined variable! '" + name + "'");
+    }
+    return it->second;
+}
+
+} // namespace openzl::sddl2

--- a/tools/sddl2/compiler/codegen/RegisterAllocator.h
+++ b/tools/sddl2/compiler/codegen/RegisterAllocator.h
@@ -1,0 +1,64 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#pragma once
+
+#include <map>
+#include <string>
+#include <unordered_set>
+
+#include "tools/sddl2/compiler/parser/AST.h"
+
+namespace openzl::sddl2 {
+
+/**
+ * Manages register allocation for the SDDL2 code generator.
+ */
+class RegisterAllocator {
+   public:
+    /**
+     * Allocates an anonymous register (not associated with a variable name).
+     *
+     * @returns The allocated register number.
+     * @throws CodegenError if the maximum number of registers is exceeded.
+     */
+    size_t allocate();
+
+    /**
+     * Frees a register so it can be reused.
+     *
+     * @param reg The register number to free.
+     */
+    void free(size_t reg);
+
+    /**
+     * Assigns a register to a named variable.
+     *
+     * @param name The variable name.
+     * @returns The assigned register number.
+     * @throws CodegenError if the maximum number of registers is exceeded.
+     */
+    size_t assign(const std::string& name);
+
+    /**
+     * Unassigns a named variable's register, freeing it for reuse.
+     *
+     * @param name The variable name to unassign.
+     */
+    void unassign(const std::string& name);
+
+    /**
+     * Gets the register for a variable.
+     *
+     * @param name The variable name.
+     * @returns The register number.
+     * @throws CodegenError if the variable is undefined.
+     */
+    size_t get(const std::string& name);
+
+   private:
+    std::map<std::string, size_t> var_registry_;
+    std::unordered_set<size_t> free_registers_;
+    size_t next_register_ = 0;
+};
+
+} // namespace openzl::sddl2

--- a/tools/sddl2/compiler/optimizer/ConstFoldPass.cpp
+++ b/tools/sddl2/compiler/optimizer/ConstFoldPass.cpp
@@ -167,6 +167,7 @@ class ConstFoldImpl {
             case Op::CONSUME:
             case Op::ASSUME:
             case Op::SIZEOF:
+            case Op::MEMBER:
             case Op::SEND:
             default:
                 return std::make_shared<ASTOp>(

--- a/tools/sddl2/compiler/optimizer/DeadVarPass.cpp
+++ b/tools/sddl2/compiler/optimizer/DeadVarPass.cpp
@@ -62,11 +62,15 @@ class DeadVarImpl {
             }
             case ConvertedNodeType::OP: {
                 const auto& op = *node->as_op();
+                if (op.op() == Op::ASSIGN || op.op() == Op::ASSUME) {
+                    recordLastRefs(op.args()[1]);
+                    return;
+                }
+                if (op.op() == Op::MEMBER) {
+                    recordLastRefs(op.args()[0]);
+                    return;
+                }
                 for (size_t i = 0; i < op.args().size(); ++i) {
-                    if ((op.op() == Op::ASSIGN || op.op() == Op::ASSUME)
-                        && i == 0) {
-                        continue;
-                    }
                     recordLastRefs(op.args()[i]);
                 }
                 return;
@@ -138,6 +142,11 @@ class DeadVarImpl {
             }
             return Codegen(op->loc()).op(
                     Op::ASSUME, op->args()[0], optimizeNode(op->args()[1]));
+        }
+
+        if (op->op() == Op::MEMBER) {
+            return Codegen(op->loc()).member(
+                    optimizeNode(op->args()[0]), op->args()[1]);
         }
 
         // Other ops

--- a/tools/sddl2/compiler/parser/AST.h
+++ b/tools/sddl2/compiler/parser/AST.h
@@ -358,6 +358,11 @@ class Codegen {
         return op(Op::ASSUME, std::move(lhs), std::move(rhs));
     }
 
+    ASTPtr member(ASTPtr lhs, ASTPtr rhs) const
+    {
+        return op(Op::MEMBER, std::move(lhs), std::move(rhs));
+    }
+
     ASTPtr eq(ASTPtr lhs, ASTPtr rhs) const
     {
         return op(Op::EQ, std::move(lhs), std::move(rhs));

--- a/tools/sddl2/compiler/parser/Grammar.cpp
+++ b/tools/sddl2/compiler/parser/Grammar.cpp
@@ -122,6 +122,7 @@ const std::vector<Symbol> builtin_field_syms{
 const std::map<Symbol, Op> syms_to_ops{
     { Symbol::EXPECT, Op::EXPECT },   { Symbol::ASSIGN, Op::ASSIGN },
     { Symbol::SIZEOF, Op::SIZEOF },   { Symbol::ASSUME, Op::ASSUME },
+    { Symbol::MEMBER, Op::MEMBER },
 
     { Symbol::EQ, Op::EQ },           { Symbol::NE, Op::NE },
 

--- a/tools/sddl2/compiler/parser/Ops.cpp
+++ b/tools/sddl2/compiler/parser/Ops.cpp
@@ -13,6 +13,7 @@ static const std::map<Op, poly::string_view> ops_to_debug_strs{
     { Op::CONSUME, "CONSUME" },
     { Op::ASSUME, "ASSUME" },
     { Op::SEND, "SEND" },
+    { Op::MEMBER, "MEMBER" },
     { Op::SIZEOF, "SIZEOF" },
 
     // Arithmetic Operators

--- a/tools/sddl2/compiler/parser/Ops.h
+++ b/tools/sddl2/compiler/parser/Ops.h
@@ -13,6 +13,7 @@ enum class Op {
     CONSUME,
     ASSUME,
     SEND,
+    MEMBER,
 
     // Arithmetic Operators
     NEG,

--- a/tools/sddl2/compiler/semantic_analyzer/SemanticAnalyzer.cpp
+++ b/tools/sddl2/compiler/semantic_analyzer/SemanticAnalyzer.cpp
@@ -1,6 +1,7 @@
 // Copyright (c) Meta Platforms, Inc. and affiliates.
 
 #include <unordered_map>
+#include <unordered_set>
 
 #include "tools/sddl2/compiler/Exception.h"
 #include "tools/sddl2/compiler/parser/AST.h"
@@ -9,7 +10,74 @@
 namespace openzl::sddl2 {
 namespace {
 
-enum class ValueType { NUMERIC, ARRAY, RECORD, BYTES, BUILTIN_FIELD, NONE };
+enum class TypeKind {
+    NUMERIC,
+    CONSUMED_RECORD,
+    NONE,
+    ARRAY,
+    RECORD,
+    BYTES,
+    BUILTIN_FIELD,
+};
+
+struct Type {
+    TypeKind kind           = TypeKind::NONE;
+    const ASTNode* type_def = nullptr;
+};
+
+void expectNumeric(const Type& t)
+{
+    if (t.kind != TypeKind::NUMERIC) {
+        throw SemanticError("Expected a numeric expression.");
+    }
+}
+
+void expectFieldType(const Type& t)
+{
+    if (!(t.kind == TypeKind::ARRAY || t.kind == TypeKind::RECORD
+          || t.kind == TypeKind::BYTES || t.kind == TypeKind::BUILTIN_FIELD)) {
+        throw SemanticError("Expected a field type expression.");
+    }
+}
+
+const ASTVar* someVar(const ASTPtr& node)
+{
+    if (auto var = node->as_var()) {
+        return var;
+    }
+    throw SemanticError("Expected a variable name.");
+}
+
+bool hasLoadInstruction(Symbol sym)
+{
+    static const std::unordered_set<Symbol> loadable{
+        Symbol::BYTE,  Symbol::U8,    Symbol::I8,    Symbol::U16LE,
+        Symbol::U16BE, Symbol::I16LE, Symbol::I16BE, Symbol::U32LE,
+        Symbol::U32BE, Symbol::I32LE, Symbol::I32BE, Symbol::U64LE,
+        Symbol::U64BE, Symbol::I64LE, Symbol::I64BE,
+    };
+    return loadable.count(sym) > 0;
+}
+
+/**
+ * Returns the type of the resulting variable after assuming a field of the
+ * given field_type.
+ */
+Type assumedType(const Type& field_type)
+{
+    if (field_type.kind == TypeKind::RECORD) {
+        return Type{ TypeKind::CONSUMED_RECORD, field_type.type_def };
+    }
+    if (field_type.kind == TypeKind::BUILTIN_FIELD) {
+        const auto* builtin = field_type.type_def->as_builtin_field();
+        if (builtin && hasLoadInstruction(builtin->kw())) {
+            return Type{ TypeKind::NUMERIC };
+        }
+    }
+    // Assume not defined for other types. Trying to use the result in an
+    // operation will fail.
+    return Type{ TypeKind::NONE };
+}
 
 class SemanticAnalyzerImpl {
    public:
@@ -26,29 +94,19 @@ class SemanticAnalyzerImpl {
     }
 
    private:
-    void expectNumeric(ValueType type)
-    {
-        if (type != ValueType::NUMERIC) {
-            throw SemanticError("Expected a numeric expression.");
-        }
-    }
+    // Data members
+    const detail::Logger& log_;
+    std::unordered_map<std::string, Type> var_types_;
 
-    void expectFieldType(ValueType type)
+    // Analysis methods
+    Type analyzeNode(const ASTPtr& node)
     {
-        if (type != ValueType::BUILTIN_FIELD && type != ValueType::ARRAY
-            && type != ValueType::RECORD && type != ValueType::BYTES) {
-            throw SemanticError("Expected a field type expression.");
-        }
-    }
-
-    ValueType analyzeNode(const ASTPtr& node)
-    {
-        const auto type = node->converted_node_type();
-        switch (type) {
+        switch (node->converted_node_type()) {
             case ConvertedNodeType::NUM:
-                return ValueType::NUMERIC;
+                return Type{ TypeKind::NUMERIC };
             case ConvertedNodeType::BUILTIN_FIELD:
-                return ValueType::BUILTIN_FIELD;
+                return Type{ TypeKind::BUILTIN_FIELD,
+                             node->as_builtin_field() };
             case ConvertedNodeType::VAR:
                 return analyze(*node->as_var());
             case ConvertedNodeType::BYTES:
@@ -64,31 +122,32 @@ class SemanticAnalyzerImpl {
         }
     }
 
-    ValueType analyze(const ASTVar& var)
+    Type analyze(const ASTVar& var)
     {
-        if (var_types_.find(var.name()) == var_types_.end()) {
+        auto it = var_types_.find(var.name());
+        if (it == var_types_.end()) {
             throw SemanticError(
                     var.loc(), "Undefined variable: '" + var.name() + "'");
         }
-        return var_types_[var.name()];
+        return it->second;
     }
 
-    ValueType analyze(const ASTBytes& bytes)
+    Type analyze(const ASTBytes& bytes)
     {
         expectNumeric(analyzeNode(bytes.len()));
-        return ValueType::BYTES;
+        return Type{ TypeKind::BYTES, &bytes };
     }
 
-    ValueType analyze(const ASTArray& array)
+    Type analyze(const ASTArray& array)
     {
         expectFieldType(analyzeNode(array.field()));
         if (array.len()) {
             expectNumeric(analyzeNode(array.len()));
         }
-        return ValueType::ARRAY;
+        return Type{ TypeKind::ARRAY, &array };
     }
 
-    ValueType analyze(const ASTRecord& record)
+    Type analyze(const ASTRecord& record)
     {
         // Validate all fields are ASSUME ops
         auto saved_vars = var_types_;
@@ -99,7 +158,7 @@ class SemanticAnalyzerImpl {
                         field->loc(),
                         "Record field must be an assume operation!");
             }
-            analyzeNode(field);
+            analyzeAssume(*assume);
         }
         var_types_ = std::move(saved_vars);
 
@@ -109,61 +168,34 @@ class SemanticAnalyzerImpl {
                     record.loc(), "Record params not yet supported!");
         }
 
-        return ValueType::RECORD;
+        return Type{ TypeKind::RECORD, &record };
     }
 
-    ValueType analyze(const ASTOp& op)
+    Type analyze(const ASTOp& op)
     {
         switch (op.op()) {
-            case Op::ASSIGN: {
-                // LHS must be a variable
-                if (!op.args()[0]->as_var()) {
-                    throw SemanticError(
-                            op.args()[0]->loc(),
-                            "Left-hand side of assignment must be a variable "
-                            "name!");
-                }
-                // Analyze RHS first (so `x = x + 1` errors if x undefined)
-                auto type = analyzeNode(op.args()[1]);
-                var_types_[op.args()[0]->as_var()->name()] = type;
-                break;
-            }
-            case Op::ASSUME: {
-                // LHS must be a variable
-                if (!op.args()[0]->as_var()) {
-                    throw SemanticError(
-                            op.args()[0]->loc(),
-                            "Left-hand side of assume must be a variable "
-                            "name!");
-                }
-                // Value must be a field type
-                auto type = analyzeNode(op.args()[1]);
-                expectFieldType(type);
-                var_types_[op.args()[0]->as_var()->name()] = ValueType::NUMERIC;
-                break;
-            }
-            case Op::MEMBER: {
-                // TODO: implement
-                return ValueType::NUMERIC;
-            }
-            case Op::CONSUME: {
+            case Op::ASSIGN:
+                var_types_[someVar(op.args()[0])->name()] =
+                        analyzeNode(op.args()[1]);
+                return Type{ TypeKind::NONE };
+            case Op::ASSUME:
+                return analyzeAssume(op);
+            case Op::MEMBER:
+                return analyzeMember(op);
+            case Op::CONSUME:
                 expectFieldType(analyzeNode(op.args()[0]));
-                return ValueType::NONE;
-            }
-            case Op::SIZEOF: {
+                return Type{ TypeKind::NONE };
+            case Op::SIZEOF:
                 expectFieldType(analyzeNode(op.args()[0]));
-                return ValueType::NUMERIC;
-            }
-            case Op::EXPECT: {
+                return Type{ TypeKind::NUMERIC };
+            case Op::EXPECT:
                 expectNumeric(analyzeNode(op.args()[0]));
-                return ValueType::NONE;
-            }
+                return Type{ TypeKind::NONE };
             case Op::NEG:
             case Op::LOG_NOT:
-            case Op::BIT_NOT: {
+            case Op::BIT_NOT:
                 expectNumeric(analyzeNode(op.args()[0]));
-                return ValueType::NUMERIC;
-            }
+                return Type{ TypeKind::NUMERIC };
             case Op::ADD:
             case Op::SUB:
             case Op::MUL:
@@ -179,20 +211,52 @@ class SemanticAnalyzerImpl {
             case Op::BIT_OR:
             case Op::BIT_XOR:
             case Op::LOG_AND:
-            case Op::LOG_OR: {
+            case Op::LOG_OR:
                 expectNumeric(analyzeNode(op.args()[0]));
                 expectNumeric(analyzeNode(op.args()[1]));
-                return ValueType::NUMERIC;
-            }
+                return Type{ TypeKind::NUMERIC };
             case Op::SEND:
             default:
                 throw InvariantViolation(op.loc(), "Unsupported operation.");
         }
-        return ValueType::NONE;
     }
 
-    const detail::Logger& log_;
-    std::unordered_map<std::string, ValueType> var_types_;
+    Type analyzeAssume(const ASTOp& op)
+    {
+        // Check that the RHS is a valid field type
+        auto field_type = analyzeNode(op.args()[1]);
+        expectFieldType(field_type);
+
+        // Assign the var to the assumed type
+        var_types_[someVar(op.args()[0])->name()] = assumedType(field_type);
+
+        return Type{ TypeKind::NONE };
+    }
+
+    Type analyzeMember(const ASTOp& op)
+    {
+        // Check that the LHS is a consumed record
+        auto lhs_type = analyzeNode(op.args()[0]);
+        if (lhs_type.kind != TypeKind::CONSUMED_RECORD) {
+            throw SemanticError(
+                    op.args()[0]->loc(),
+                    "LHS of member access is not a record.");
+        }
+
+        // Check that the RHS is a valid field name return the consumed type
+        const auto* record     = lhs_type.type_def->as_record();
+        const auto& field_name = someVar(op.args()[1])->name();
+        for (const auto& field : record->fields()) {
+            auto assume = field->as_op();
+            auto& name  = assume->args()[0]->as_var()->name();
+            if (name == field_name) {
+                return assumedType(analyzeNode(assume->args()[1]));
+            }
+        }
+        throw SemanticError(
+                op.args()[1]->loc(),
+                "Field '" + field_name + "' not a valid record field.");
+    }
 };
 
 } // namespace

--- a/tools/sddl2/compiler/semantic_analyzer/SemanticAnalyzer.cpp
+++ b/tools/sddl2/compiler/semantic_analyzer/SemanticAnalyzer.cpp
@@ -142,6 +142,10 @@ class SemanticAnalyzerImpl {
                 var_types_[op.args()[0]->as_var()->name()] = ValueType::NUMERIC;
                 break;
             }
+            case Op::MEMBER: {
+                // TODO: implement
+                return ValueType::NUMERIC;
+            }
             case Op::CONSUME: {
                 expectFieldType(analyzeNode(op.args()[0]));
                 return ValueType::NONE;

--- a/tools/sddl2/compiler/tests/OptimizerTest.cpp
+++ b/tools/sddl2/compiler/tests/OptimizerTest.cpp
@@ -167,4 +167,50 @@ TEST_F(OptimizerTest, ModuloByZeroError)
     expect_error(prog, "Modulo by zero");
 }
 
+TEST_F(OptimizerTest, DeadRecordVarElimination)
+{
+    const auto prog = R"(
+        entry: Record() { id: Int32LE }
+    )";
+
+    const auto cg       = Codegen(SourceLocation::null());
+    const auto expected = std::vector<ASTPtr>({
+            cg.consume(cg.record(
+                    ArgVec{},
+                    ArgVec{ cg.assume(
+                            cg.var("id"), cg.builtin_field(Symbol::I32LE)) })),
+    });
+    expect_ast(prog, expected);
+}
+
+TEST_F(OptimizerTest, RecordMemberLastReference)
+{
+    const auto prog = R"(
+        entry: Record() { id: Int32LE, val: Int32LE }
+        expect entry.id == 0
+        expect entry.val == 0
+    )";
+
+    const auto cg       = Codegen(SourceLocation::null());
+    const auto expected = std::vector<ASTPtr>({
+            cg.assume(
+                    cg.var("entry"),
+                    cg.record(
+                            ArgVec{},
+                            ArgVec{ cg.assume(
+                                            cg.var("id"),
+                                            cg.builtin_field(Symbol::I32LE)),
+                                    cg.assume(
+                                            cg.var("val"),
+                                            cg.builtin_field(
+                                                    Symbol::I32LE)) })),
+            cg.expect(
+                    cg.eq(cg.member(cg.var("entry"), cg.var("id")), cg.num(0))),
+            cg.expect(
+                    cg.eq(cg.member(cg.var("entry", true), cg.var("val")),
+                          cg.num(0))),
+    });
+    expect_ast(prog, expected);
+}
+
 } // namespace openzl::sddl2::tests

--- a/tools/sddl2/compiler/tests/SemanticAnalyzerTest.cpp
+++ b/tools/sddl2/compiler/tests/SemanticAnalyzerTest.cpp
@@ -43,9 +43,9 @@ TEST_F(SemanticAnalyzerTest, AssumeDefinesVar)
         : Byte[count]
     )";
 
-    // TODO: Update this once once assume is supported in codegen.
-    // This still shows us that the semantic analysis passes.
-    expect_error(prog, "Undefined variable");
+    // TODO: This will succees when codegen is implemented. For now we know it
+    // passes semantic analysis.
+    expect_error(prog, "code generation error");
 }
 
 TEST_F(SemanticAnalyzerTest, AssignLHSNotVar)
@@ -53,7 +53,7 @@ TEST_F(SemanticAnalyzerTest, AssignLHSNotVar)
     const auto prog = R"(
         1 = 2
     )";
-    expect_error(prog, "must be a variable");
+    expect_error(prog, "variable name");
 }
 
 TEST_F(SemanticAnalyzerTest, ConsumeNonFieldType)
@@ -86,6 +86,136 @@ TEST_F(SemanticAnalyzerTest, ExpectFieldType)
         expect Int32LE
     )";
     expect_error(prog, "numeric");
+}
+
+TEST_F(SemanticAnalyzerTest, AssumeRecordAndMemberAccess)
+{
+    const auto prog = R"(
+        entry: Record() { id: Int32LE }
+        expect entry.id == 0
+    )";
+
+    // TODO: This will succees when codegen is implemented. For now we know it
+    // passes semantic analysis.
+    expect_error(prog, "code generation error");
+}
+
+TEST_F(SemanticAnalyzerTest, MemberAccessOnNonRecord)
+{
+    const auto prog = R"(
+        x: Int32LE
+        expect x.id == 0
+    )";
+    expect_error(prog, "not a record");
+}
+
+TEST_F(SemanticAnalyzerTest, MemberAccessUndefinedField)
+{
+    const auto prog = R"(
+        entry: Record() { id: Int32LE }
+        expect entry.nonexistent == 0
+    )";
+    expect_error(prog, "not a valid record field");
+}
+
+TEST_F(SemanticAnalyzerTest, MemberAccessUndefinedVar)
+{
+    const auto prog = R"(
+        expect entry.id == 0
+    )";
+    expect_error(prog, "Undefined variable");
+}
+
+TEST_F(SemanticAnalyzerTest, AssumeRecordTypeAlias)
+{
+    const auto prog = R"(
+        Record Entry() = {
+            id: Int32LE,
+            val: Int32LE,
+            bytes: Byte[4]
+        }
+        entry: Entry
+        expect entry.id == 0
+        expect entry.val == 0
+    )";
+    // TODO: This will succees when codegen is implemented. For now we know it
+    // passes semantic analysis.
+    expect_error(prog, "code generation error");
+}
+
+TEST_F(SemanticAnalyzerTest, AssumeBuiltinTypeAlias)
+{
+    const auto prog = R"(
+        MyType = Int32LE
+        x: MyType
+        expect x == 0
+    )";
+    // TODO: This will succees when codegen is implemented. For now we know it
+    // passes semantic analysis.
+    expect_error(prog, "code generation error");
+}
+
+TEST_F(SemanticAnalyzerTest, AssumeFloatType)
+{
+    const auto prog = R"(
+        x: Float32LE
+        expect x == 0
+    )";
+    expect_error(prog, "numeric expression");
+}
+
+TEST_F(SemanticAnalyzerTest, AssumeFloatTypeAlias)
+{
+    const auto prog = R"(
+        MyFloat = Float32LE
+        x: MyFloat
+        expect x == 0
+    )";
+    expect_error(prog, "numeric expression");
+}
+
+TEST_F(SemanticAnalyzerTest, AssumeChainedTypeAlias)
+{
+    const auto prog = R"(
+        MyInt = Int32LE
+        MyType = MyInt
+        x: MyType
+        expect x == 0
+    )";
+    // TODO: This will succees when codegen is implemented. For now we know it
+    // passes semantic analysis.
+    expect_error(prog, "code generation error");
+}
+
+TEST_F(SemanticAnalyzerTest, NestedMemberAccess)
+{
+    const auto prog = R"(
+        Record Foo() = {
+            x: Int32LE
+        }
+        Record Bar() = {
+            foo: Foo,
+            y: Int16LE
+        }
+        bar: Bar
+        expect bar.foo.x == 1
+    )";
+
+    // TODO: This will succees when codegen is implemented. For now we know it
+    // passes semantic analysis.
+    expect_error(prog, "code generation error");
+}
+
+TEST_F(SemanticAnalyzerTest, NestedMemberAccessOnNonRecordField)
+{
+    const auto prog = R"(
+        Record Bar() = {
+            y: Int16LE
+        }
+        bar: Bar
+        expect bar.y.z == 0
+    )";
+    expect_error(prog, "not a record");
 }
 
 } // namespace openzl::sddl2::tests

--- a/tools/sddl2/compiler/tests/SemanticAnalyzerTest.cpp
+++ b/tools/sddl2/compiler/tests/SemanticAnalyzerTest.cpp
@@ -43,9 +43,9 @@ TEST_F(SemanticAnalyzerTest, AssumeDefinesVar)
         : Byte[count]
     )";
 
-    // TODO: Update this once once variable references are supported in codegen.
+    // TODO: Update this once once assume is supported in codegen.
     // This still shows us that the semantic analysis passes.
-    expect_error(prog, "not yet supported");
+    expect_error(prog, "Undefined variable");
 }
 
 TEST_F(SemanticAnalyzerTest, AssignLHSNotVar)


### PR DESCRIPTION
Summary:
# Stack
The goal of this stack is to add support for variable assignments and assume operations to SDDL2.

# Diff
This diff extracts register allocation logic from `CodeGenerator` into a dedicated `RegisterAllocator` utility class. This improves code organization.

Differential Revision: D95582393


