### PR TITLE
Fix issues found by component fuzzer

### DIFF
--- a/src/openzl/codecs/conversion/decode_conversion_binding.c
+++ b/src/openzl/codecs/conversion/decode_conversion_binding.c
@@ -84,11 +84,9 @@ ZL_Report DI_revert_num_to_serial_le(ZL_Decoder* di, const ZL_Input* ins[])
 
     ZL_RBuffer const header = ZL_Decoder_getCodecHeader(di);
     ZL_ERR_IF_NE(header.size, 1, header_unknown, "Invalid transform header!");
+    size_t const intLog = ((const uint8_t*)header.start)[0];
+    ZL_ERR_IF_GT(intLog, 3, header_unknown, "Invalid intLog");
     size_t const intSize = (size_t)1 << (((const uint8_t*)header.start)[0]);
-    ZL_ERR_IF(
-            !(intSize == 1 || intSize == 2 || intSize == 4 || intSize == 8),
-            header_unknown,
-            "header contains bad integer width");
     size_t const nbBytes = ZL_Input_contentSize(in);
     ZL_ERR_IF_NE(
             nbBytes % intSize,

--- a/src/openzl/common/stream.c
+++ b/src/openzl/common/stream.c
@@ -474,7 +474,8 @@ static ZL_Report STREAM_refStreamStringSlice(
     ZL_ASSERT_NN(dst);
     ZL_ASSERT_EQ(STREAM_type(dst), ZL_Type_string);
     ZL_ASSERT(dst->buffer._ptr == src->buffer._ptr);
-    dst->buffer._ptr = (char*)dst->buffer._ptr + skipped;
+    dst->buffer._ptr     = (char*)dst->buffer._ptr + skipped;
+    dst->stringLens._ptr = (uint32_t*)dst->stringLens._ptr + startingEltNum;
     ZL_ASSERT_GE(dst->eltCount, eltCount);
     dst->eltCount      = eltCount;
     dst->lastCommmited = eltCount;
@@ -780,14 +781,15 @@ static ZL_Report STREAM_commitStrings(Stream* s, size_t numStrings)
     ZL_DLOG(SEQ, "STREAM_commitStrings (numStrings=%zu)", numStrings);
     ZL_ASSERT_NN(s);
     ZL_ASSERT_EQ(s->type, ZL_Type_string);
+    const uint32_t* const stringLens = ZL_Refcount_get(&s->stringLens);
 
     ZL_RET_R_IF_GT(
             streamCapacity_tooSmall,
             numStrings,
             s->eltsCapacity,
             "Number of strings committed is greater than capacity");
-    uint64_t const totalStringsSize =
-            NUMOP_sumArray32(ZL_Refcount_get(&s->stringLens), numStrings);
+    uint64_t const totalStringsSize = NUMOP_sumArray32(
+            s->eltCount ? stringLens + s->eltCount : stringLens, numStrings);
     ZL_RET_R_IF_GT(
             streamCapacity_tooSmall,
             totalStringsSize,
@@ -798,6 +800,7 @@ static ZL_Report STREAM_commitStrings(Stream* s, size_t numStrings)
     s->eltCount += numStrings;
     s->lastCommmited = numStrings;
     s->bufferUsed += totalStringsSize;
+    ZL_ASSERT_LE(s->bufferUsed, s->bufferCapacity);
     s->writeCommitted = 1;
     return ZL_returnSuccess();
 }
@@ -822,6 +825,7 @@ ZL_Report STREAM_commit(Stream* s, size_t eltCount)
     s->eltCount += eltCount;
     s->lastCommmited = eltCount;
     s->bufferUsed += eltCount * s->eltWidth;
+    ZL_ASSERT_LE(s->bufferUsed, s->bufferCapacity);
     s->writeCommitted = 1;
     ZL_DLOG(SEQ, "STREAM_commit: new total eltCount=%zu", s->eltCount);
     return ZL_returnSuccess();

--- a/tests/fuzz/OpenZLComponentFuzzer.cpp
+++ b/tests/fuzz/OpenZLComponentFuzzer.cpp
@@ -145,8 +145,7 @@ std::unique_ptr<OpenZLInput> generateInput(
     for (size_t i = 0; i < numInputs; ++i) {
         if (i + 1 == numInputs && isVariableInput) {
             while (gen.has_more_data() && gen.boolean("more_variable_inputs")
-                   && inputs.size() < ZL_runtimeInputLimit(
-                              std::max(formatVersion, 15))) {
+                   && inputs.size() < ZL_runtimeInputLimit(formatVersion)) {
                 inputs.push_back(generateInput(
                         gen,
                         TypeMask(ZL_Compressor_Graph_getInputMask(
@@ -243,7 +242,13 @@ FUZZ(OpenZLComponentFuzzer, FuzzCompress)
 
     while (gen.has_more_data()) {
         auto input = generateInput(gen, compressor, graph, formatVersion);
-        fuzzRoundTrip(*component, compressor, *input, graph, formatVersion);
+        try {
+            // TODO: Permissive mode doesn't guarantee success when hitting
+            // runtime limits on the number of nodes or streams.
+            fuzzRoundTrip(*component, compressor, *input, graph, formatVersion);
+        } catch (...) {
+            // Raising exceptions is okay, just can't crash
+        }
     }
 }
 

--- a/tests/round_trip/test_segmenter.cpp
+++ b/tests/round_trip/test_segmenter.cpp
@@ -736,4 +736,115 @@ TEST(Segmenter, parameterizedSegmenterIsSerializable)
     deserialized.deserialize(serialized);
 }
 
+/* =======   Segmenter on string input with variable-length chunks   ======== */
+
+// Custom segmenter: splits input into two halves by element count
+ZL_Report halfSplitStringSegmenterFn(ZL_Segmenter* sctx)
+{
+    assert(ZL_Segmenter_numInputs(sctx) == 1);
+    const ZL_Input* input = ZL_Segmenter_getInput(sctx, 0);
+    assert(ZL_Input_type(input) == ZL_Type_string);
+
+    size_t const totalElts = ZL_Input_numElts(input);
+    size_t firstHalf       = totalElts / 2;
+
+    // Chunk 1: first half
+    ZL_Report r = ZL_Segmenter_processChunk(
+            sctx, &firstHalf, 1, ZL_GRAPH_COMPRESS_GENERIC, NULL);
+    EXPECT_FALSE(ZL_isError(r));
+    if (ZL_isError(r))
+        return r;
+
+    // Chunk 2: remaining
+    input             = ZL_Segmenter_getInput(sctx, 0);
+    size_t secondHalf = ZL_Input_numElts(input);
+    r                 = ZL_Segmenter_processChunk(
+            sctx, &secondHalf, 1, ZL_GRAPH_COMPRESS_GENERIC, NULL);
+    EXPECT_FALSE(ZL_isError(r));
+    if (ZL_isError(r))
+        return r;
+
+    return ZL_returnSuccess();
+}
+
+static ZL_SegmenterDesc const halfSplitStringSegmenter = {
+    .name           = "Half-Split String Segmenter",
+    .segmenterFn    = halfSplitStringSegmenterFn,
+    .inputTypeMasks = (const ZL_Type[]){ ZL_Type_string },
+    .numInputs      = 1,
+};
+
+TEST(Segmenter, stringVariableLengthChunks)
+{
+    if (g_testVersion < ZL_CHUNK_VERSION_MIN)
+        return;
+
+    // Create variable-length strings:
+    // First 50 strings are 2 bytes each (100 bytes total)
+    // Last 50 strings are 6 bytes each (300 bytes total)
+    size_t const numStrings       = 100;
+    size_t const firstHalf        = 50;
+    size_t const shortLen         = 2;
+    size_t const longLen          = 6;
+    size_t const totalContentSize = firstHalf * shortLen + firstHalf * longLen;
+
+    uint32_t* stringLengths = (uint32_t*)malloc(numStrings * sizeof(uint32_t));
+    assert(stringLengths);
+    for (size_t i = 0; i < firstHalf; i++)
+        stringLengths[i] = shortLen;
+    for (size_t i = firstHalf; i < numStrings; i++)
+        stringLengths[i] = longLen;
+
+    // Fill content with recognizable pattern
+    unsigned char* content = (unsigned char*)malloc(totalContentSize);
+    assert(content);
+    for (size_t i = 0; i < totalContentSize; i++)
+        content[i] = (unsigned char)(i & 0xFF);
+
+    ZL_TypedRef* input = ZL_TypedRef_createString(
+            content, totalContentSize, stringLengths, numStrings);
+    assert(input);
+
+    // Compress
+    size_t const compressedBound = ZL_compressBound(totalContentSize);
+    void* const compressed       = malloc(compressedBound);
+    assert(compressed);
+
+    g_segmenterDescPtr = &halfSplitStringSegmenter;
+
+    ZL_CCtx* const cctx = ZL_CCtx_create();
+    assert(cctx);
+    ZL_Compressor* const compressor = ZL_Compressor_create();
+    assert(compressor);
+    ZL_Report gssr =
+            ZL_Compressor_initUsingGraphFn(compressor, registerSegmenter);
+    EXPECT_FALSE(ZL_isError(gssr)) << "cgraph initialization failed";
+    ZL_Report rcgr = ZL_CCtx_refCompressor(cctx, compressor);
+    EXPECT_FALSE(ZL_isError(rcgr)) << "CGraph reference failed";
+    ZL_Report r =
+            ZL_CCtx_compressTypedRef(cctx, compressed, compressedBound, input);
+    EXPECT_FALSE(ZL_isError(r)) << "compression failed";
+    size_t const compressedSize = ZL_validResult(r);
+
+    ZL_Compressor_free(compressor);
+    ZL_CCtx_free(cctx);
+
+    // Decompress
+    void* const decompressed = malloc(totalContentSize);
+    assert(decompressed);
+    size_t const decompressedSize = decompress(
+            decompressed, totalContentSize, compressed, compressedSize);
+
+    // Verify
+    EXPECT_EQ(decompressedSize, totalContentSize);
+    EXPECT_EQ(memcmp(content, decompressed, totalContentSize), 0)
+            << "Decompressed content differs from original";
+
+    free(decompressed);
+    free(compressed);
+    ZL_TypedRef_free(input);
+    free(content);
+    free(stringLengths);
+}
+
 } // namespace


### PR DESCRIPTION
Summary:
1. Fix invalid shift in conversion decoder
2. Fix segmenter with `ZL_Type_string` input. It was broken in 2 places in `stream.c` & add a unit test
3. Catch exceptions in the `FuzzCompress` fuzzer. Initially, I was hoping that permissive mode would be enough. But when we run into limits like too many streams or too many nodes, permissive mode also fails.

Differential Revision: D95604467


