### PR TITLE
minor optimization: skip one useless conversion operation

### DIFF
--- a/src/openzl/compress/graph_registry.c
+++ b/src/openzl/compress/graph_registry.c
@@ -132,7 +132,7 @@ const InternalGraphDesc GR_standardGraphs[ZL_PrivateStandardGraphID_end] = {
     REGISTER_DYNAMIC_GRAPH(ZL_StandardGraphID_fse, "!zl.fse", ZL_Type_serial, EI_fseDynamicGraph),
     REGISTER_DYNAMIC_GRAPH(ZL_StandardGraphID_huffman, "!zl.huffman", ZL_Type_serial | ZL_Type_struct | ZL_Type_numeric, EI_huffmanDynamicGraph),
     REGISTER_DYNAMIC_GRAPH(ZL_StandardGraphID_entropy, "!zl.entropy", ZL_Type_serial | ZL_Type_struct | ZL_Type_numeric, EI_entropyDynamicGraph),
-    REGISTER_SELECTOR(ZL_StandardGraphID_constant, "!zl.constant", SI_selector_constant, ZL_Type_serial | ZL_Type_struct),
+    REGISTER_SELECTOR(ZL_StandardGraphID_constant, "!zl.constant", SI_selector_constant, ZL_Type_serial | ZL_Type_struct | ZL_Type_numeric),
     REGISTER_STATIC_GRAPH(ZL_StandardGraphID_zstd, "!zl.zstd", ZL_Type_serial, ZL_PrivateStandardNodeID_zstd, _1_SUCCESSOR(ZL_PrivateStandardGraphID_serial_store) ),
     REGISTER_SELECTOR(ZL_StandardGraphID_bitpack, "!zl.bitpack", SI_selector_bitpack, ZL_Type_serial | ZL_Type_numeric),
     REGISTER_STATIC_GRAPH(ZL_StandardGraphID_flatpack, "!zl.flatpack", ZL_Type_serial, ZL_PrivateStandardNodeID_flatpack, _2_SUCCESSORS(ZL_PrivateStandardGraphID_serial_store, ZL_PrivateStandardGraphID_serial_store) ),

--- a/src/openzl/compress/selectors/selector_constant.c
+++ b/src/openzl/compress/selectors/selector_constant.c
@@ -43,7 +43,7 @@ ZL_GraphID SI_selector_constant(
     (void)nbCustomGraphs;
 
     ZL_Type const inType = ZL_Input_type(inputStream);
-    ZL_ASSERT(inType == ZL_Type_serial || inType == ZL_Type_struct);
+    ZL_ASSERT(inType == ZL_Type_serial || inType == ZL_Type_struct || inType == ZL_Type_numeric);
 
     /* If all bytes are identical, Serial path is more efficient */
     if (ZL_Input_eltWidth(inputStream) > 1
@@ -55,9 +55,9 @@ ZL_GraphID SI_selector_constant(
         case ZL_Type_serial:
             return ZL_GRAPH_CONSTANT_SERIAL;
         case ZL_Type_struct:
+        case ZL_Type_numeric:
             return ZL_GRAPH_CONSTANT_FIXED;
         /* fallthrough - not supported */
-        case ZL_Type_numeric:
         case ZL_Type_string:
         default:
             ZL_REQUIRE(0, "Unsupported input type for constant selector");

--- a/src/openzl/compress/selectors/selector_constant.c
+++ b/src/openzl/compress/selectors/selector_constant.c
@@ -30,6 +30,10 @@ static int isSingleBytePattern(const ZL_Input* inputStream)
  *
  * Single-byte patterns (0x00, 0xFF, 0x55, etc.) are routed
  * to CONSTANT_SERIAL (more efficient).
+ *
+ * Note: data arriving at this selector should be verified constant.
+ * No verification is done here, but if the data is not constant,
+ * operation will later fail, on reaching the constant node.
  */
 
 ZL_GraphID SI_selector_constant(
@@ -48,8 +52,7 @@ ZL_GraphID SI_selector_constant(
             || inType == ZL_Type_numeric);
 
     /* If all bytes are identical, Serial path is more efficient */
-    if (ZL_Input_eltWidth(inputStream) > 1
-        && isSingleBytePattern(inputStream)) {
+    if (isSingleBytePattern(inputStream)) {
         return ZL_GRAPH_CONSTANT_SERIAL;
     }
 

--- a/src/openzl/compress/selectors/selector_constant.c
+++ b/src/openzl/compress/selectors/selector_constant.c
@@ -43,7 +43,9 @@ ZL_GraphID SI_selector_constant(
     (void)nbCustomGraphs;
 
     ZL_Type const inType = ZL_Input_type(inputStream);
-    ZL_ASSERT(inType == ZL_Type_serial || inType == ZL_Type_struct || inType == ZL_Type_numeric);
+    ZL_ASSERT(
+            inType == ZL_Type_serial || inType == ZL_Type_struct
+            || inType == ZL_Type_numeric);
 
     /* If all bytes are identical, Serial path is more efficient */
     if (ZL_Input_eltWidth(inputStream) > 1

--- a/src/openzl/compress/selectors/selector_constant.h
+++ b/src/openzl/compress/selectors/selector_constant.h
@@ -9,7 +9,7 @@
 ZL_BEGIN_C_DECLS
 
 // .selector_f   = SI_selector_constant,
-// .inStreamType = ZL_Type_serial | ZL_Type_struct,
+// .inStreamType = ZL_Type_serial | ZL_Type_struct | ZL_Type_numeric,
 ZL_GraphID SI_selector_constant(
         const ZL_Selector* selCtx,
         const ZL_Input* inputStream,


### PR DESCRIPTION
to compress single-byte repeated patterns within numeric streams.

This saves 1-2 bytes per generated numeric stream feature single-byte repeat pattern.