### PR TITLE
Add support for parameterized records (parsing) (#486)

### DIFF
--- a/tools/sddl2/compiler/codegen/CodeGenerator.cpp
+++ b/tools/sddl2/compiler/codegen/CodeGenerator.cpp
@@ -177,6 +177,7 @@ class CodeGeneratorImpl {
             case ConvertedNodeType::BYTES:
             case ConvertedNodeType::ARRAY:
             case ConvertedNodeType::RECORD:
+            case ConvertedNodeType::CALL:
             default:
                 throw InvariantViolation(
                         node->loc(), "Expected a value, got a type.");
@@ -242,6 +243,8 @@ class CodeGeneratorImpl {
                 output += "type.fixed_array";
                 return { std::move(output), type };
             }
+            case ConvertedNodeType::CALL:
+                throw CodegenError(type->loc(), "Call not yet implemented.");
             case ConvertedNodeType::NUM:
             case ConvertedNodeType::OP:
             default:

--- a/tools/sddl2/compiler/optimizer/ConstFoldPass.cpp
+++ b/tools/sddl2/compiler/optimizer/ConstFoldPass.cpp
@@ -43,6 +43,8 @@ class ConstFoldImpl {
                 return optimize(*node->as_array());
             case ConvertedNodeType::RECORD:
                 return optimize(*node->as_record());
+            case ConvertedNodeType::CALL:
+                return optimize(*node->as_call());
             case ConvertedNodeType::OP:
                 return optimize(*node->as_op());
             default:
@@ -71,6 +73,17 @@ class ConstFoldImpl {
         }
         return Codegen(array.loc())
                 .array(optimizeNode(array.field()), optimizeNode(array.len()));
+    }
+
+    ASTPtr optimize(const ASTCall& call)
+    {
+        ASTVec new_args;
+        new_args.reserve(call.args().size());
+        for (const auto& arg : call.args()) {
+            new_args.push_back(optimizeNode(arg));
+        }
+        return Codegen(call.loc())
+                .call(optimizeNode(call.target()), std::move(new_args));
     }
 
     ASTPtr optimize(const ASTRecord& record)

--- a/tools/sddl2/compiler/optimizer/DeadVarPass.cpp
+++ b/tools/sddl2/compiler/optimizer/DeadVarPass.cpp
@@ -54,6 +54,14 @@ class DeadVarImpl {
                 }
                 return;
             }
+            case ConvertedNodeType::CALL: {
+                auto call = node->as_call();
+                recordLastRefs(call->target());
+                for (const auto& arg : call->args()) {
+                    recordLastRefs(arg);
+                }
+                return;
+            }
             case ConvertedNodeType::RECORD: {
                 for (const auto& field : node->as_record()->fields()) {
                     recordLastRefs(field);
@@ -91,6 +99,8 @@ class DeadVarImpl {
                 return optimize(node->as_bytes());
             case ConvertedNodeType::ARRAY:
                 return optimize(node->as_array());
+            case ConvertedNodeType::CALL:
+                return optimize(node->as_call());
             case ConvertedNodeType::OP:
                 return optimize(node->as_op());
             default:
@@ -123,6 +133,17 @@ class DeadVarImpl {
         }
         return Codegen(arr->loc())
                 .array(optimizeNode(arr->field()), optimizeNode(arr->len()));
+    }
+
+    ASTPtr optimize(const ASTCall* call)
+    {
+        ASTVec new_args;
+        new_args.reserve(call->args().size());
+        for (const auto& arg : call->args()) {
+            new_args.push_back(optimizeNode(arg));
+        }
+        return Codegen(call->loc())
+                .call(optimizeNode(call->target()), std::move(new_args));
     }
 
     ASTPtr optimize(const ASTOp* op)

--- a/tools/sddl2/compiler/parser/AST.cpp
+++ b/tools/sddl2/compiler/parser/AST.cpp
@@ -57,6 +57,11 @@ const ASTRecord* ASTNode::as_record() const
     return nullptr;
 }
 
+const ASTCall* ASTNode::as_call() const
+{
+    return nullptr;
+}
+
 const ASTOp* ASTNode::as_op() const
 {
     return nullptr;
@@ -368,6 +373,39 @@ ASTVec ASTRecord::extract_params(
                 loc, "Record declaration params list must be parens.");
     }
     return unwrap_parens(list->nodes());
+}
+
+ASTCall::ASTCall(ASTPtr target, ASTVec args)
+        : ASTField(some(target).loc() + join_locs(args)),
+          target_(std::move(target)),
+          args_(std::move(args))
+{
+}
+
+const ASTCall* ASTCall::as_call() const
+{
+    return this;
+}
+
+void ASTCall::print(std::ostream& os, size_t indent) const
+{
+    os << std::string(indent, ' ') << "Field: CALL:" << std::endl;
+    os << std::string(indent + 2, ' ') << "Target: " << std::endl;
+    target_->print(os, indent + 4);
+    os << std::string(indent + 2, ' ') << "Args: " << std::endl;
+    for (const auto& arg : args_) {
+        arg->print(os, indent + 4);
+    }
+}
+
+const ASTPtr& ASTCall::target() const
+{
+    return target_;
+}
+
+const ASTVec& ASTCall::args() const
+{
+    return args_;
 }
 
 ASTArray::ASTArray(const ASTPtr& field, const ASTPtr& len)

--- a/tools/sddl2/compiler/parser/AST.h
+++ b/tools/sddl2/compiler/parser/AST.h
@@ -27,6 +27,7 @@ class ASTBuiltinField;
 class ASTBytes;
 class ASTArray;
 class ASTRecord;
+class ASTCall;
 class ASTOp;
 
 enum class ConvertedNodeType {
@@ -36,6 +37,7 @@ enum class ConvertedNodeType {
     BYTES,
     ARRAY,
     RECORD,
+    CALL,
     OP
 };
 
@@ -57,6 +59,7 @@ class ASTNode {
     virtual const ASTBytes* as_bytes() const;
     virtual const ASTArray* as_array() const;
     virtual const ASTRecord* as_record() const;
+    virtual const ASTCall* as_call() const;
     virtual const ASTOp* as_op() const;
 
     bool operator==(const Symbol& symbol) const;
@@ -264,6 +267,27 @@ class ASTRecord : public ASTField {
     const ASTVec fields_;
 };
 
+class ASTCall : public ASTField {
+   public:
+    explicit ASTCall(ASTPtr target, ASTVec args);
+
+    const ASTCall* as_call() const override;
+
+    void print(std::ostream& os, size_t indent) const override;
+
+    ConvertedNodeType converted_node_type() const override final
+    {
+        return ConvertedNodeType::CALL;
+    }
+
+    const ASTPtr& target() const;
+    const ASTVec& args() const;
+
+   private:
+    const ASTPtr target_;
+    const ASTVec args_;
+};
+
 class ASTArray : public ASTField {
    public:
     explicit ASTArray(const ASTPtr& field, const ASTPtr& len);
@@ -434,6 +458,11 @@ class Codegen {
     {
         return std::make_shared<ASTRecord>(
                 paren_list(std::move(params)), curly_list(std::move(fields)));
+    }
+
+    ASTPtr call(ASTPtr target, ASTVec args) const
+    {
+        return std::make_shared<ASTCall>(std::move(target), std::move(args));
     }
 
     ASTPtr var(poly::string_view name) const

--- a/tools/sddl2/compiler/parser/Grammar.cpp
+++ b/tools/sddl2/compiler/parser/Grammar.cpp
@@ -497,6 +497,31 @@ class AnonymousRecordRule : public GrammarRule {
     }
 };
 
+class CallRule : public GrammarRule {
+   public:
+    explicit CallRule()
+            : GrammarRule(
+                      Symbol::PAREN_OPEN, /* bit weird */
+                      Precedence::ACCESS,
+                      std::vector<ArgType>({ ArgType::EXPR }),
+                      true)
+    {
+    }
+
+   private:
+    ASTPtr do_gen(ASTPtr op, ArgsVec args) const override
+    {
+        auto& target     = args.at(0);
+        const auto* list = some(op).as_list();
+        if (list == nullptr || list->list_type() != ListType::PAREN) {
+            throw InvariantViolation(
+                    some(op).loc(), "Expected paren list in call.");
+        }
+        return std::make_shared<ASTCall>(
+                std::move(target), unwrap_parens(list->nodes()));
+    }
+};
+
 class BytesRule : public GrammarRule {
    public:
     explicit BytesRule()
@@ -588,7 +613,9 @@ const std::map<Symbol, GrammarRuleRefs> syms_to_rules{ []() {
 const std::map<ListType, GrammarRuleRefs> list_types_to_rules{ []() {
     std::map<ListType, GrammarRuleRefs> m;
 
-    m[ListType::PAREN] = {};
+    static const std::unique_ptr<const GrammarRule> call_rule =
+            std::make_unique<CallRule>();
+    m[ListType::PAREN] = { *call_rule };
 
     static const std::unique_ptr<const GrammarRule> array_rule =
             std::make_unique<ArrayRule>();

--- a/tools/sddl2/compiler/semantic_analyzer/SemanticAnalyzer.cpp
+++ b/tools/sddl2/compiler/semantic_analyzer/SemanticAnalyzer.cpp
@@ -1,5 +1,6 @@
 // Copyright (c) Meta Platforms, Inc. and affiliates.
 
+#include <optional>
 #include <unordered_map>
 #include <unordered_set>
 
@@ -115,6 +116,8 @@ class SemanticAnalyzerImpl {
                 return analyze(*node->as_array());
             case ConvertedNodeType::RECORD:
                 return analyze(*node->as_record());
+            case ConvertedNodeType::CALL:
+                return analyze(*node->as_call());
             case ConvertedNodeType::OP:
                 return analyze(*node->as_op());
             default:
@@ -149,8 +152,19 @@ class SemanticAnalyzerImpl {
 
     Type analyze(const ASTRecord& record)
     {
-        // Validate all fields are ASSUME ops
+        // Validate params are variable names and introduce them as NUMERIC
         auto saved_vars = var_types_;
+        for (const auto& param : record.params()) {
+            const auto* var = param->as_var();
+            if (!var) {
+                throw SemanticError(
+                        param->loc(),
+                        "Record parameter must be a variable name.");
+            }
+            var_types_[var->name()] = Type{ TypeKind::NUMERIC };
+        }
+
+        // Validate all fields are ASSUME ops
         for (const auto& field : record.fields()) {
             auto assume = field->as_op();
             if (!assume || assume->op() != Op::ASSUME) {
@@ -162,13 +176,39 @@ class SemanticAnalyzerImpl {
         }
         var_types_ = std::move(saved_vars);
 
-        // TODO: support params
-        if (!record.params().empty()) {
+        return Type{ TypeKind::RECORD, &record };
+    }
+
+    Type analyze(const ASTCall& call)
+    {
+        // Target must resolve to a record type
+        auto target_type = analyzeNode(call.target());
+        if (target_type.kind != TypeKind::RECORD) {
             throw SemanticError(
-                    record.loc(), "Record params not yet supported!");
+                    call.target()->loc(), "Call target must be a record type.");
         }
 
-        return Type{ TypeKind::RECORD, &record };
+        const auto* record = target_type.type_def->as_record();
+        if (!record) {
+            throw SemanticError(
+                    call.target()->loc(), "Call target must be a record type.");
+        }
+
+        // Validate argument count matches parameter count
+        if (call.args().size() != record->params().size()) {
+            throw SemanticError(
+                    call.loc(),
+                    "Expected " + std::to_string(record->params().size())
+                            + " arguments but got "
+                            + std::to_string(call.args().size()) + ".");
+        }
+
+        // Validate each argument is a numeric expression
+        for (const auto& arg : call.args()) {
+            expectNumeric(analyzeNode(arg));
+        }
+
+        return Type{ TypeKind::RECORD, target_type.type_def };
     }
 
     Type analyze(const ASTOp& op)
@@ -251,6 +291,7 @@ class SemanticAnalyzerImpl {
 
     Type analyzeMember(const ASTOp& op)
     {
+        auto saved_vars = var_types_;
         // Check that the LHS is a consumed record
         auto lhs_type = analyzeNode(op.args()[0]);
         if (lhs_type.kind != TypeKind::CONSUMED_RECORD) {
@@ -260,18 +301,30 @@ class SemanticAnalyzerImpl {
         }
 
         // Check that the RHS is a valid field name return the consumed type
-        const auto* record     = lhs_type.type_def->as_record();
+        auto* record           = lhs_type.type_def->as_record();
         const auto& field_name = someVar(op.args()[1])->name();
+
+        // Add the record params to scope
+        for (const auto& param : record->params()) {
+            var_types_[param->as_var()->name()] = Type{ TypeKind::NUMERIC };
+        }
+
+        // Find the field
+        std::optional<Type> found_type;
         for (const auto& field : record->fields()) {
             auto assume = field->as_op();
             auto& name  = assume->args()[0]->as_var()->name();
             if (name == field_name) {
-                return assumedType(analyzeNode(assume->args()[1]));
+                found_type = assumedType(analyzeNode(assume->args()[1]));
             }
         }
-        throw SemanticError(
-                op.args()[1]->loc(),
-                "Field '" + field_name + "' not a valid record field.");
+        if (!found_type) {
+            throw SemanticError(
+                    op.args()[1]->loc(),
+                    "Field '" + field_name + "' not a valid record field.");
+        }
+        var_types_ = std::move(saved_vars);
+        return *found_type;
     }
 };
 

--- a/tools/sddl2/compiler/tests/ParserTest.cpp
+++ b/tools/sddl2/compiler/tests/ParserTest.cpp
@@ -314,4 +314,39 @@ TEST_F(ParserTest, SimpleSaoAST)
     expect_ast(prog, expected);
 }
 
+TEST_F(ParserTest, CallAST)
+{
+    const auto prog = R"(
+        Record Foo(A, B) = {
+            x: Int32LE[A],
+            y: Int16LE[B]
+        }
+        : Foo(3, 5)
+    )";
+
+    const auto cg       = Codegen(SourceLocation::null());
+    const auto expected = std::vector<ASTPtr>({
+            cg.assign(
+                    cg.var("Foo"),
+                    cg.record(
+                            ArgVec{ cg.var("A"), cg.var("B") },
+                            ArgVec{
+                                    cg.assume(
+                                            cg.var("x"),
+                                            cg.array(
+                                                    cg.builtin_field(
+                                                            Symbol::I32LE),
+                                                    cg.var("A"))),
+                                    cg.assume(
+                                            cg.var("y"),
+                                            cg.array(
+                                                    cg.builtin_field(
+                                                            Symbol::I16LE),
+                                                    cg.var("B"))),
+                            })),
+            cg.consume(cg.call(cg.var("Foo"), ArgVec{ cg.num(3), cg.num(5) })),
+    });
+    expect_ast(prog, expected);
+}
+
 } // namespace openzl::sddl2::tests

--- a/tools/sddl2/compiler/tests/SemanticAnalyzerTest.cpp
+++ b/tools/sddl2/compiler/tests/SemanticAnalyzerTest.cpp
@@ -223,4 +223,35 @@ TEST_F(SemanticAnalyzerTest, NestedMemberAccessOnNonRecordField)
     expect_error(prog, "not a record");
 }
 
+TEST_F(SemanticAnalyzerTest, ParameterizedRecordWrongArgCount)
+{
+    const auto prog = R"(
+        Record Entry(N) = {
+            items: Int32LE[N]
+        }
+        : Entry(1, 2)
+    )";
+    expect_error(prog, "Expected 1 arguments but got 2");
+}
+
+TEST_F(SemanticAnalyzerTest, ParameterizedRecordNonNumericArg)
+{
+    const auto prog = R"(
+        Record Entry(N) = {
+            items: Int32LE[N]
+        }
+        : Entry(Int32LE)
+    )";
+    expect_error(prog, "numeric");
+}
+
+TEST_F(SemanticAnalyzerTest, ParameterizedRecordCallNonRecord)
+{
+    const auto prog = R"(
+        MyType = Int32LE
+        : MyType(10)
+    )";
+    expect_error(prog, "record type");
+}
+
 } // namespace openzl::sddl2::tests


### PR DESCRIPTION
Summary:

# Stack
The goal of this stack is to add support for Parameterized Records to sddl2.

# Diff
This diff adds parsing and semantic analysis support for parameterized records in sddl2. Parameterized records allow record types to accept parameters that can be used within field definitions, enabling more flexible type definitions.

## Key Changes
- **ASTCall node:** New AST node type representing a parameterized record instantiation (e.g., `Entry(N)`). Contains a target (the record type) and arguments.

- **CallRule grammar:** New grammar rule that parses parenthesized argument lists after identifiers as function calls, enabling syntax like `Foo(3, 5)`.

Differential Revision: D95827616
