### PR TITLE
fix os.getenv bool handling

### DIFF
--- a/cli/commands/cmd_compress.cpp
+++ b/cli/commands/cmd_compress.cpp
@@ -96,7 +96,7 @@ void writeTrace(CCtx& cctx, const CompressArgs& args)
             throw InvalidArgsException(msg);
         }
         for (const auto& [id, stream] : trace.second) {
-            std::filesystem::path path = dir / (std::to_string(id) + ".sdd");
+            std::filesystem::path path = dir / (id + ".sdd");
             std::ofstream file{ path, std::ios::binary };
             if (!file.is_open()) {
                 Logger::log(
@@ -107,8 +107,7 @@ void writeTrace(CCtx& cctx, const CompressArgs& args)
             }
             file.write(stream.first.data(), stream.first.size());
             if (stream.second != "") {
-                std::filesystem::path strLensPath =
-                        dir / (std::to_string(id) + ".sdlens");
+                std::filesystem::path strLensPath = dir / (id + ".sdlens");
                 std::ofstream strLensFile{ strLensPath, std::ios::binary };
                 if (!strLensFile.is_open()) {
                     Logger::log(

--- a/contrib/lz-research/Compressor.cpp
+++ b/contrib/lz-research/Compressor.cpp
@@ -746,17 +746,15 @@ size_t OpenZLCompressor::compress(
         }
         if (traceStreamsDir_.has_value()) {
             fs::create_directories(*traceStreamsDir_);
-            for (const auto& [index, data] : streams) {
+            for (const auto& [id, data] : streams) {
                 {
                     tools::io::OutputFile out(
-                            fs::path(*traceStreamsDir_)
-                            / (std::to_string(index) + ".sdd"));
+                            fs::path(*traceStreamsDir_) / (id + ".sdd"));
                     out.write(data.first);
                 }
                 if (!data.second.empty()) {
                     tools::io::OutputFile out(
-                            fs::path(*traceStreamsDir_)
-                            / (std::to_string(index) + ".sdlens"));
+                            fs::path(*traceStreamsDir_) / (id + ".sdlens"));
                     out.write(data.first);
                 }
             }

--- a/cpp/include/openzl/cpp/CCtx.hpp
+++ b/cpp/include/openzl/cpp/CCtx.hpp
@@ -105,7 +105,9 @@ class CCtx {
      */
     std::pair<
             poly::string_view,
-            std::map<size_t, std::pair<poly::string_view, poly::string_view>>>
+            std::map<
+                    std::string,
+                    std::pair<poly::string_view, poly::string_view>>>
     getLatestTrace();
 
    protected:

--- a/cpp/src/openzl/cpp/CCtx.cpp
+++ b/cpp/src/openzl/cpp/CCtx.cpp
@@ -166,7 +166,7 @@ void CCtx::writeTraces(bool enabled)
 
 std::pair<
         poly::string_view,
-        std::map<size_t, std::pair<poly::string_view, poly::string_view>>>
+        std::map<std::string, std::pair<poly::string_view, poly::string_view>>>
 CCtx::getLatestTrace()
 {
     if (!visHooks_) {

--- a/cpp/src/openzl/cpp/experimental/trace/CborHelpers.cpp
+++ b/cpp/src/openzl/cpp/experimental/trace/CborHelpers.cpp
@@ -41,6 +41,66 @@ ZL_Report addBooleanValue(A1C_MapBuilder& builder, const char* key, bool val)
     return ZL_returnSuccess();
 }
 
+ZL_Report addBytesArray(
+        A1C_Arena* a1c_arena,
+        A1C_MapBuilder& builder,
+        const char* key,
+        const std::vector<uint8_t>& bytes)
+{
+    A1C_MAP_TRY_ADD_R(pair, builder);
+    A1C_Item_string_refCStr(&pair->key, key);
+
+    if (!bytes.empty()) {
+        bool success = A1C_Item_bytes_copy(
+                &pair->val, bytes.data(), bytes.size(), a1c_arena);
+        ZL_RET_R_IF(allocation, !success, "Failed to copy bytes data.");
+    } else {
+        A1C_Item_bytes_ref(&pair->val, nullptr, 0);
+    }
+
+    return ZL_returnSuccess();
+}
+
+ZL_Report addNumArray(
+        A1C_Arena* a1c_arena,
+        A1C_MapBuilder& builder,
+        const char* key,
+        const std::vector<int64_t>& numbers)
+{
+    A1C_MAP_TRY_ADD_R(pair, builder);
+    A1C_Item_string_refCStr(&pair->key, key);
+
+    A1C_ArrayBuilder arrayBuilder =
+            A1C_Item_array_builder(&pair->val, numbers.size(), a1c_arena);
+    ZL_RET_R_IF_NULL(allocation, arrayBuilder.array);
+
+    for (const int64_t val : numbers) {
+        A1C_ARRAY_TRY_ADD_R(item, arrayBuilder);
+        A1C_Item_int64(item, val);
+    }
+    return ZL_returnSuccess();
+}
+
+ZL_Report addStrArray(
+        A1C_Arena* a1c_arena,
+        A1C_MapBuilder& builder,
+        const char* key,
+        const std::vector<std::string>& strs)
+{
+    A1C_MAP_TRY_ADD_R(pair, builder);
+    A1C_Item_string_refCStr(&pair->key, key);
+
+    A1C_ArrayBuilder arrayBuilder =
+            A1C_Item_array_builder(&pair->val, strs.size(), a1c_arena);
+    ZL_RET_R_IF_NULL(allocation, arrayBuilder.array);
+
+    for (const std::string& str : strs) {
+        A1C_ARRAY_TRY_ADD_R(item, arrayBuilder);
+        A1C_Item_string_refCStr(item, str.c_str());
+    }
+    return ZL_returnSuccess();
+}
+
 ZL_Report serializeLocalParams(
         A1C_Arena* a1c_arena,
         A1C_Item* a1c_localParamsParent,

--- a/cpp/src/openzl/cpp/experimental/trace/CborHelpers.hpp
+++ b/cpp/src/openzl/cpp/experimental/trace/CborHelpers.hpp
@@ -16,6 +16,24 @@ addStringValue(A1C_MapBuilder& builder, const char* key, const char* val);
 
 ZL_Report addBooleanValue(A1C_MapBuilder& builder, const char* key, bool val);
 
+ZL_Report addStrArray(
+        A1C_Arena* a1c_arena,
+        A1C_MapBuilder& builder,
+        const char* key,
+        const std::vector<std::string>& strs);
+
+ZL_Report addNumArray(
+        A1C_Arena* a1c_arena,
+        A1C_MapBuilder& builder,
+        const char* key,
+        const std::vector<int64_t>& numbers);
+
+ZL_Report addBytesArray(
+        A1C_Arena* a1c_arena,
+        A1C_MapBuilder& builder,
+        const char* key,
+        const std::vector<uint8_t>& bytes);
+
 ZL_Report serializeLocalParams(
         A1C_Arena* a1c_arena,
         A1C_Item* a1c_localParamsParent,

--- a/cpp/src/openzl/cpp/experimental/trace/ChunkTrace.cpp
+++ b/cpp/src/openzl/cpp/experimental/trace/ChunkTrace.cpp
@@ -579,6 +579,7 @@ void ChunkTrace::on_codecEncode_end(
         };
 
         codecInfo_[currCodecNum_].outEdges.push_back(streamID);
+        streamdump(outStreams[i]);
     }
 
     // connect stream successors for cSize calculation
@@ -761,4 +762,24 @@ void ChunkTrace::on_ZL_Segmenter_processChunk_end(
     finalizeTrace(r);
 }
 
+void ChunkTrace::streamdump(const ZL_Output* createdStream)
+{
+    auto content = std::string(
+            (const char*)ZL_Output_constPtr(createdStream),
+            ZL_validResult(ZL_Output_contentSize(createdStream)));
+    std::string strLens = "";
+    if (ZL_Output_type(createdStream) == ZL_Type_string) {
+        auto ptr = ZL_Output_constStringLens(createdStream);
+        strLens  = std::string(
+                (const char*)ptr,
+                ZL_validResult(ZL_Output_numElts(createdStream))
+                        * sizeof(ptr[0]));
+    }
+    streamdump_[ZL_Output_id(createdStream).sid] = { content, strLens };
+}
+std::map<size_t, std::pair<std::string, std::string>>&&
+ChunkTrace::getStreamdump()
+{
+    return std::move(streamdump_);
+}
 } // namespace openzl::visualizer

--- a/cpp/src/openzl/cpp/experimental/trace/ChunkTrace.cpp
+++ b/cpp/src/openzl/cpp/experimental/trace/ChunkTrace.cpp
@@ -15,8 +15,129 @@
 #include <iomanip>
 #include <iostream>
 #include <numeric>
+#include <variant>
 
 namespace openzl::visualizer {
+
+using StreamPreview = std::variant<
+        std::vector<std::string>,
+        std::vector<int64_t>,
+        std::vector<uint8_t>>;
+
+static std::vector<int64_t>
+getNumericData(const void* data, size_t eltWidth, size_t numElts)
+{
+    if (data == nullptr || numElts == 0) {
+        return {};
+    }
+
+    std::vector<int64_t> numericData;
+    numericData.reserve(numElts);
+
+    const auto* bytes = reinterpret_cast<const uint8_t*>(data);
+    for (size_t i = 0; i < numElts; ++i) {
+        int64_t val = 0;
+        switch (eltWidth) {
+            case 1:
+                val = reinterpret_cast<const int8_t*>(bytes)[i];
+                break;
+            case 2:
+                val = reinterpret_cast<const int16_t*>(bytes)[i];
+                break;
+            case 4:
+                val = reinterpret_cast<const int32_t*>(bytes)[i];
+                break;
+            case 8:
+                val = reinterpret_cast<const int64_t*>(bytes)[i];
+                break;
+            default:
+                throw std::runtime_error("Unexpected numeric eltWidth!");
+        }
+        numericData.push_back(val);
+    }
+
+    return numericData;
+}
+
+static std::vector<std::string>
+getStringData(const void* data, size_t numStrings, const uint32_t* stringLens)
+{
+    if (data == nullptr || stringLens == nullptr || numStrings == 0) {
+        return {};
+    }
+
+    std::vector<std::string> strings;
+    strings.reserve(numStrings);
+
+    const auto* bytes = reinterpret_cast<const char*>(data);
+    size_t offset     = 0;
+
+    for (size_t i = 0; i < numStrings; ++i) {
+        uint32_t len          = stringLens[i];
+        std::string rawStr    = std::string(bytes + offset, len);
+        std::string parsedStr = "";
+        if (rawStr.find('\n') != std::string::npos
+            || rawStr.find('\t') != std::string::npos
+            || rawStr.find('\r') != std::string::npos) {
+            for (char c : rawStr) {
+                switch (c) {
+                    case '\n':
+                        parsedStr += "\\n";
+                        break;
+                    case '\t':
+                        parsedStr += "\\t";
+                        break;
+                    case '\r':
+                        parsedStr += "\\r";
+                        break;
+                    default:
+                        parsedStr += c;
+                        break;
+                }
+            }
+        } else {
+            parsedStr = std::move(rawStr);
+        }
+
+        strings.push_back(parsedStr);
+        offset += len;
+    }
+
+    return strings;
+}
+
+static std::vector<uint8_t> getSerialData(const void* data, size_t numBytes)
+{
+    if (data == nullptr || numBytes == 0) {
+        return {};
+    }
+
+    std::vector<uint8_t> bytes;
+    const auto* rawBytes = reinterpret_cast<const uint8_t*>(data);
+    bytes.assign(rawBytes, rawBytes + numBytes);
+
+    return bytes;
+}
+
+static StreamPreview getStreamPreviewData(
+        const void* data,
+        ZL_Type type,
+        size_t eltWidth,
+        size_t numElts,
+        const uint32_t* stringLens = nullptr)
+{
+    switch (type) {
+        case ZL_Type_numeric:
+            return getNumericData(data, eltWidth, numElts);
+        case ZL_Type_string:
+            return getStringData(data, numElts, stringLens);
+        case ZL_Type_struct:
+        case ZL_Type_serial:
+            return getSerialData(data, numElts);
+        default:
+            throw std::runtime_error("Unsupported stream preview type!");
+    }
+}
 
 void ChunkTrace::initTrace()
 {
@@ -40,14 +161,27 @@ void ChunkTrace::recordStartStreams(
     for (size_t i = 0; i < numInStreams; ++i) {
         StreamID streamID = ZL_Input_id(inStreams[i]);
         if (streamInfo_.find(streamID) == streamInfo_.end()) {
+            ZL_Type type       = ZL_Input_type(inStreams[i]);
+            size_t eltWidth    = ZL_Input_eltWidth(inStreams[i]);
+            size_t numElts     = ZL_Input_numElts(inStreams[i]);
+            size_t contentSize = ZL_Input_contentSize(inStreams[i]);
+
+            StreamPreview preview = getStreamPreviewData(
+                    ZL_Input_ptr(inStreams[i]),
+                    type,
+                    eltWidth,
+                    numElts,
+                    ZL_Input_stringLens(inStreams[i]));
+
             streamInfo_[streamID] = Stream{
-                .id          = streamID,
-                .type        = ZL_Input_type(inStreams[i]),
-                .outputIdx   = i,
-                .eltWidth    = ZL_Input_eltWidth(inStreams[i]),
-                .numElts     = ZL_Input_numElts(inStreams[i]),
-                .contentSize = ZL_Input_contentSize(inStreams[i]),
-                .chunkId     = chunkId_,
+                .id            = streamID,
+                .type          = type,
+                .outputIdx     = i,
+                .eltWidth      = eltWidth,
+                .numElts       = numElts,
+                .contentSize   = contentSize,
+                .chunkId       = chunkId_,
+                .streamPreview = std::move(preview),
             };
             codecInfo_[0].outEdges.push_back(streamID);
         }
@@ -420,15 +554,29 @@ void ChunkTrace::on_codecEncode_end(
         // set stream ELT values
         const ZL_Output* createdStream = outStreams[i];
         StreamID streamID              = ZL_Output_id(createdStream);
-        streamInfo_[streamID]          = {
-                     .type        = ZL_Output_type(createdStream),
-                     .outputIdx   = i,
-                     .eltWidth    = openzl::unwrap(ZL_Output_eltWidth(createdStream)),
-                     .numElts     = openzl::unwrap(ZL_Output_numElts(createdStream)),
-                     .contentSize = openzl::unwrap(ZL_Output_contentSize(createdStream)),
-                     .chunkId     = chunkId_,
+        ZL_Type type                   = ZL_Output_type(createdStream);
+        size_t eltWidth = openzl::unwrap(ZL_Output_eltWidth(createdStream));
+        size_t numElts  = openzl::unwrap(ZL_Output_numElts(createdStream));
+        size_t contentSize =
+                openzl::unwrap(ZL_Output_contentSize(createdStream));
+
+        StreamPreview preview = getStreamPreviewData(
+                ZL_Output_constPtr(createdStream),
+                type,
+                eltWidth,
+                numElts,
+                ZL_Output_constStringLens(createdStream));
+
+        streamInfo_[streamID] = {
+            .id            = streamID,
+            .type          = type,
+            .outputIdx     = i,
+            .eltWidth      = eltWidth,
+            .numElts       = numElts,
+            .contentSize   = contentSize,
+            .chunkId       = chunkId_,
+            .streamPreview = std::move(preview),
         };
-        streamInfo_[streamID].id = streamID;
 
         codecInfo_[currCodecNum_].outEdges.push_back(streamID);
     }

--- a/cpp/src/openzl/cpp/experimental/trace/ChunkTrace.hpp
+++ b/cpp/src/openzl/cpp/experimental/trace/ChunkTrace.hpp
@@ -114,6 +114,8 @@ class ChunkTrace {
         ZL_Report failureReport;
     };
 
+    std::map<size_t, std::pair<std::string, std::string>>&& getStreamdump();
+
    private:
     void printStreamMetadata();
     void printCodecMetadata();
@@ -123,10 +125,12 @@ class ChunkTrace {
     size_t compressedSize_{}; // compressed size for this specific chunk
     size_t currCodecNum_ = 0;
     std::map<ZL_DataID, Stream, ZL_DataIDCustomComparator> streamInfo_;
+    std::map<size_t, std::pair<std::string, std::string>> streamdump_;
     std::vector<Codec> codecInfo_;
     std::vector<Graph> graphInfo_;
     bool currEncompassingGraph_ = false; // if codecs are running within a graph
     std::optional<ConversionError> maybeConversionError_ = std::nullopt;
+    void streamdump(const ZL_Output* createdStream);
 };
 
 } // namespace openzl::visualizer

--- a/cpp/src/openzl/cpp/experimental/trace/CompressionTraceHooks.cpp
+++ b/cpp/src/openzl/cpp/experimental/trace/CompressionTraceHooks.cpp
@@ -187,8 +187,7 @@ void CompressionTraceHooks::on_ZL_CCtx_compressMultiTypedRef_start(
     // Reset the output stream
     outStream_.str("");
     outStream_.clear();
-    latestStreamdumpCache_ =
-            std::map<size_t, std::pair<std::string, std::string>>();
+    latestStreamdumpCache_ = {};
 
     if (tracer_) {
         throw std::runtime_error(
@@ -213,15 +212,21 @@ void CompressionTraceHooks::on_ZL_CCtx_compressMultiTypedRef_end(
 
 std::pair<
         poly::string_view,
-        std::map<size_t, std::pair<poly::string_view, poly::string_view>>>
+        std::map<std::string, std::pair<poly::string_view, poly::string_view>>>
 CompressionTraceHooks::getLatestTrace()
 {
-    std::map<size_t, std::pair<poly::string_view, poly::string_view>>
+    std::map<std::string, std::pair<poly::string_view, poly::string_view>>
             streamdumps;
-    for (auto& [k, v] : latestStreamdumpCache_) {
-        streamdumps[k] = { poly::string_view(v.first),
-                           poly::string_view(v.second) };
+    for (size_t chunkId = 0; chunkId < latestStreamdumpCache_.size();
+         chunkId++) {
+        for (const auto& streamdump : latestStreamdumpCache_[chunkId]) {
+            std::string key = "chunk_" + std::to_string(chunkId) + "_stream_"
+                    + std::to_string(streamdump.streamId);
+            streamdumps[key] = { poly::string_view(streamdump.content),
+                                 poly::string_view(streamdump.strLens) };
+        }
     }
+
     return { latestTraceCache_, std::move(streamdumps) };
 }
 

--- a/cpp/src/openzl/cpp/experimental/trace/CompressionTraceHooks.hpp
+++ b/cpp/src/openzl/cpp/experimental/trace/CompressionTraceHooks.hpp
@@ -22,7 +22,9 @@ class CompressionTraceHooks : public openzl::CompressIntrospectionHooks {
 
     std::pair<
             poly::string_view,
-            std::map<size_t, std::pair<poly::string_view, poly::string_view>>>
+            std::map<
+                    std::string,
+                    std::pair<poly::string_view, poly::string_view>>>
     getLatestTrace();
 
     // ***************************************************
@@ -108,10 +110,11 @@ class CompressionTraceHooks : public openzl::CompressIntrospectionHooks {
 
    private:
     std::stringstream outStream_; // output stream to write to
-    std::map<size_t, std::pair<std::string, std::string>>
-            latestStreamdumpCache_; // cache for latest streamdumps. Key is the
-                                    // stream ID, value is a pair of strings
-                                    // (content, string lengths (or ""))
+    std::vector<std::vector<Tracer::StreamdumpEntry>>
+            latestStreamdumpCache_; // cache for latest streamdumps. Key
+                                    // is the stream ID, value is a pair
+                                    // of strings (content, string
+                                    // lengths (or ""))
     std::string latestTraceCache_;  // cache for latest trace
 
     std::unique_ptr<Tracer>

--- a/cpp/src/openzl/cpp/experimental/trace/StreamVisualizer.cpp
+++ b/cpp/src/openzl/cpp/experimental/trace/StreamVisualizer.cpp
@@ -11,7 +11,7 @@ const ZL_Report Stream::serializeStream(
         A1C_Arena* a1c_arena,
         A1C_Item* arrayItem)
 {
-    A1C_MapBuilder builder = A1C_Item_map_builder(arrayItem, 8, a1c_arena);
+    A1C_MapBuilder builder = A1C_Item_map_builder(arrayItem, 9, a1c_arena);
     ZL_RET_R_IF_NULL(allocation, builder.map);
 
     ZL_RET_R_IF_ERR(addIntValue(builder, "chunkId", this->chunkId));
@@ -22,6 +22,26 @@ const ZL_Report Stream::serializeStream(
     ZL_RET_R_IF_ERR(addIntValue(builder, "cSize", cSize));
     ZL_RET_R_IF_ERR(addFloatValue(builder, "share", share));
     ZL_RET_R_IF_ERR(addIntValue(builder, "contentSize", contentSize));
+
+    if (type == ZL_Type_string) {
+        ZL_RET_R_IF_ERR(addStrArray(
+                a1c_arena,
+                builder,
+                "streamPreview",
+                std::get<std::vector<std::string>>(streamPreview)));
+    } else if (type == ZL_Type_numeric) {
+        ZL_RET_R_IF_ERR(addNumArray(
+                a1c_arena,
+                builder,
+                "streamPreview",
+                std::get<std::vector<int64_t>>(streamPreview)));
+    } else {
+        ZL_RET_R_IF_ERR(addBytesArray(
+                a1c_arena,
+                builder,
+                "streamPreview",
+                std::get<std::vector<uint8_t>>(streamPreview)));
+    }
 
     return ZL_returnSuccess();
 }

--- a/cpp/src/openzl/cpp/experimental/trace/StreamVisualizer.hpp
+++ b/cpp/src/openzl/cpp/experimental/trace/StreamVisualizer.hpp
@@ -9,6 +9,8 @@
 
 #include <functional>
 #include <optional>
+#include <string>
+#include <variant>
 #include <vector>
 
 namespace openzl::visualizer {
@@ -25,6 +27,11 @@ struct Stream {
     size_t chunkId{};
     std::vector<StreamID> successors;
     std::optional<CodecID> consumerCodec;
+    std::variant<
+            std::vector<std::string>,
+            std::vector<int64_t>,
+            std::vector<uint8_t>>
+            streamPreview;
 
     const ZL_Report serializeStream(A1C_Arena* a1c_arena, A1C_Item* arrayItem);
 };

--- a/cpp/src/openzl/cpp/experimental/trace/Tracer.cpp
+++ b/cpp/src/openzl/cpp/experimental/trace/Tracer.cpp
@@ -31,6 +31,20 @@ static constexpr size_t MAIN_TRACE_IDX = 0;
 
 Tracer::TraceResult Tracer::extractTrace()
 {
+    // Aggregate streamdump from all chunks
+    trace.streamdump.reserve(graphRuns.size());
+    for (auto& chunk : graphRuns) {
+        auto streamdump                  = chunk.getStreamdump();
+        std::vector<StreamdumpEntry> tmp = {};
+        tmp.reserve(streamdump.size());
+        for (auto& [k, v] : streamdump) {
+            tmp.push_back(
+                    StreamdumpEntry{ std::move(k),
+                                     std::move(v.first),
+                                     std::move(v.second) });
+        }
+        trace.streamdump.push_back(tmp);
+    }
     return std::move(trace);
 }
 
@@ -88,10 +102,6 @@ void Tracer::on_codecEncode_end(
 {
     currChunk->on_codecEncode_end(
             encoder, outStreams, nbOutputs, codecExecResult);
-    // streamdump needs to remain in Tracer as it accesses trace member
-    for (size_t i = 0; i < nbOutputs; ++i) {
-        streamdump(outStreams[i]);
-    }
 }
 
 void Tracer::on_ZL_Encoder_getScratchSpace(ZL_Encoder* ei, size_t size)
@@ -283,22 +293,6 @@ ZL_Report Tracer::writeSerializedStreamdump(std::vector<uint8_t>& buffer)
     ZL_LOG(ALWAYS, "Successfully wrote streamdump CBOR");
 
     return ZL_returnSuccess();
-}
-
-void Tracer::streamdump(const ZL_Output* createdStream)
-{
-    auto content = std::string(
-            (const char*)ZL_Output_constPtr(createdStream),
-            ZL_validResult(ZL_Output_contentSize(createdStream)));
-    std::string strLens = "";
-    if (ZL_Output_type(createdStream) == ZL_Type_string) {
-        auto ptr = ZL_Output_constStringLens(createdStream);
-        strLens  = std::string(
-                (const char*)ptr,
-                ZL_validResult(ZL_Output_numElts(createdStream))
-                        * sizeof(ptr[0]));
-    }
-    trace.streamdump[ZL_Output_id(createdStream).sid] = { content, strLens };
 }
 
 } // namespace openzl::visualizer

--- a/cpp/src/openzl/cpp/experimental/trace/Tracer.hpp
+++ b/cpp/src/openzl/cpp/experimental/trace/Tracer.hpp
@@ -16,9 +16,15 @@ class Tracer {
    public:
     explicit Tracer(const ZL_CCtx* const cctx) : cctx_(cctx) {}
 
+    struct StreamdumpEntry {
+        size_t streamId;
+        std::string content;
+        std::string strLens;
+    };
+
     struct TraceResult {
         std::string trace;
-        std::map<size_t, std::pair<std::string, std::string>> streamdump;
+        std::vector<std::vector<StreamdumpEntry>> streamdump;
     };
 
     TraceResult extractTrace();
@@ -103,8 +109,6 @@ class Tracer {
    private:
     void printStreamMetadata();
     void printCodecMetadata();
-
-    void streamdump(const ZL_Output* stream);
 
     ZL_Report serializeStreamdumpToCbor(
             A1C_Arena* a1c_arena,

--- a/cpp/tests/BUCK
+++ b/cpp/tests/BUCK
@@ -18,5 +18,6 @@ cpp_unittest(
     labels = cross_platform_labels(),
     deps = [
         "..:openzl_cpp",
+        "../../tests/datagen:datagen",
     ],
 )

--- a/cpp/tests/CMakeLists.txt
+++ b/cpp/tests/CMakeLists.txt
@@ -10,6 +10,7 @@ if (OPENZL_BUILD_TESTS)
         test_openzl_cpp
         PRIVATE
             openzl_cpp
+            datagen
             GTest::gtest_main
     )
     apply_openzl_compile_options_to_target(test_openzl_cpp)

--- a/cpp/tests/TestCCtx.cpp
+++ b/cpp/tests/TestCCtx.cpp
@@ -164,7 +164,7 @@ TEST_F(TestCCtx, writeMultipleTraces)
     auto numeric = Input::refNumeric(poly::span<const int64_t>(data));
     std::vector<std::pair<
             std::string,
-            std::map<size_t, std::pair<std::string, std::string>>>>
+            std::map<std::string, std::pair<std::string, std::string>>>>
             traces;
     // convenience function to copy the trace internals, since we get returned
     // string_views
@@ -172,12 +172,14 @@ TEST_F(TestCCtx, writeMultipleTraces)
             [](const std::pair<
                     poly::string_view,
                     std::map<
-                            size_t,
+                            std::string,
                             std::pair<poly::string_view, poly::string_view>>>&
                        trace) {
                 std::pair<
                         std::string,
-                        std::map<size_t, std::pair<std::string, std::string>>>
+                        std::map<
+                                std::string,
+                                std::pair<std::string, std::string>>>
                         copy;
                 copy.first = trace.first;
                 for (const auto& [k, v] : trace.second) {

--- a/cpp/tests/experimental/trace/StreamdumpTest.cpp
+++ b/cpp/tests/experimental/trace/StreamdumpTest.cpp
@@ -1,0 +1,139 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#include <gtest/gtest.h>
+
+#include "openzl/cpp/CCtx.hpp"
+#include "openzl/cpp/Compressor.hpp"
+#include "openzl/zl_compressor.h"
+#include "openzl/zl_input.h"
+#include "openzl/zl_segmenter.h"
+#include "tests/datagen/DataGen.h"
+
+using namespace ::testing;
+
+namespace openzl {
+#ifdef ZL_ALLOW_INTROSPECTION
+#    define SMALL_CHUNK_SIZE 200
+
+// Segmenter function for numeric input
+static ZL_Report numericChunkSegmenterFn(ZL_Segmenter* sctx)
+{
+    assert(ZL_Segmenter_numInputs(sctx) == 1);
+    const ZL_Input* input = ZL_Segmenter_getInput(sctx, 0);
+    assert(ZL_Input_type(input) == ZL_Type_numeric);
+
+    size_t eltWidth = ZL_Input_eltWidth(input);
+
+    while (ZL_Input_numElts(input) > 0) {
+        size_t inElts       = ZL_Input_numElts(input);
+        size_t maxChunkElts = SMALL_CHUNK_SIZE / eltWidth;
+        size_t chunkNumElts = (inElts < maxChunkElts) ? inElts : maxChunkElts;
+
+        ZL_Report processR = ZL_Segmenter_processChunk(
+                sctx, &chunkNumElts, 1, ZL_GRAPH_FIELD_LZ, NULL);
+        if (ZL_isError(processR)) {
+            return processR;
+        }
+        // Update input pointer for next iteration
+        input = ZL_Segmenter_getInput(sctx, 0);
+    }
+
+    return ZL_returnSuccess();
+}
+
+// Segmenter descriptor for numeric input
+static ZL_SegmenterDesc const numericChunkSegmenter = {
+    .name           = "NumericChunkSegmenter",
+    .segmenterFn    = numericChunkSegmenterFn,
+    .inputTypeMasks = (const ZL_Type[]){ ZL_Type_numeric },
+    .numInputs      = 1,
+};
+
+// Helper to register the numeric chunk segmenter
+static ZL_GraphID registerNumericChunkSegmenter(
+        ZL_Compressor* compressor) noexcept
+{
+    ZL_Report const r = ZL_Compressor_setParameter(
+            compressor, ZL_CParam_formatVersion, ZL_MAX_FORMAT_VERSION);
+    if (ZL_isError(r)) {
+        abort();
+    }
+    return ZL_Compressor_registerSegmenter(compressor, &numericChunkSegmenter);
+}
+
+TEST(StreamdumpTest, VerifyStreamdump)
+{
+    Compressor compressor;
+    compressor.setParameter(CParam::FormatVersion, ZL_MAX_FORMAT_VERSION);
+    compressor.selectStartingGraph(ZL_GRAPH_COMPRESS_GENERIC);
+
+    auto dg         = openzl::tests::datagen::DataGen();
+    const auto data = dg.template randVector<int64_t>("randVec", 0, 100, 1000);
+
+    auto input = Input::refNumeric(data.data(), sizeof(int64_t), data.size());
+    CCtx cctx;
+    cctx.refCompressor(compressor);
+    cctx.writeTraces(true);
+
+    auto compressed = cctx.compressOne(input);
+
+    auto traceResult = cctx.getLatestTrace();
+    auto trace       = traceResult.first;
+    auto streamdump  = traceResult.second;
+
+    EXPECT_FALSE(trace.empty());
+    EXPECT_FALSE(streamdump.empty());
+
+    // Verify all streams are from chunk 0 (single chunk compression)
+    // All streams are unique since streamdump is a map
+    for (const auto& [key, value] : streamdump) {
+        EXPECT_TRUE(key.find("chunk_0_") == 0);
+    }
+}
+
+TEST(StreamdumpTest, VerifyMultiChunkStreamdump)
+{
+    Compressor compressor;
+    ZL_GraphID segmenterId = registerNumericChunkSegmenter(compressor.get());
+    compressor.selectStartingGraph(segmenterId);
+
+    auto dg   = openzl::tests::datagen::DataGen();
+    auto data = dg.template randVector<int64_t>("randVec", 0, 100, 1000);
+    data.resize(1000); // make sure we have 1000 elements to verify number
+                       // of chunks
+
+    auto input = Input::refNumeric(data.data(), sizeof(int64_t), data.size());
+    CCtx cctx;
+    cctx.refCompressor(compressor);
+    cctx.writeTraces(true);
+
+    auto compressed = cctx.compressOne(input);
+
+    auto traceResult = cctx.getLatestTrace();
+    auto trace       = traceResult.first;
+    auto streamdump  = traceResult.second;
+
+    EXPECT_FALSE(trace.empty());
+    EXPECT_FALSE(streamdump.empty());
+
+    int chunkSize = SMALL_CHUNK_SIZE / sizeof(int64_t);
+    int numDataChunks =
+            (data.size() + chunkSize - 1) / chunkSize; // ceiling division
+    int numChunks =
+            numDataChunks + 1; // +1 for the main/wrapper chunk at index 0
+
+    // Verify streams are from chunks between 0 and numChunks
+    for (const auto& [key, value] : streamdump) {
+        // Extract chunk ID from key format
+        // "chunk_{chunkId}_stream{streamId}"
+        size_t chunkStart = key.find("chunk_") + 6;
+        size_t chunkEnd   = key.find("_stream");
+        ASSERT_NE(chunkEnd, std::string::npos) << "Invalid key format: " << key;
+        int chunkId = std::stoi(key.substr(chunkStart, chunkEnd - chunkStart));
+        EXPECT_GE(chunkId, 0) << "Chunk ID should be >= 0, got: " << chunkId;
+        EXPECT_LT(chunkId, numChunks)
+                << "Chunk ID should be < " << numChunks << ", got: " << chunkId;
+    }
+}
+#endif // ZL_ALLOW_INTROSPECTION
+} // namespace openzl

--- a/doc/mkdocs/BUCK
+++ b/doc/mkdocs/BUCK
@@ -42,6 +42,12 @@ buck_genrule(
 # Test the internal website builds successfully
 buck_sh_test(
     name = "static_docs_test",
+    env = {
+        "DOXYGEN_PATH": "$(location fbsource//third-party/doxygen:doxygen)",
+        # Skip building the trace visualizer in tests since it requires external network access
+        # to fetch npm packages, which is not available in remote execution
+        "OPENZL_SKIP_VISUALIZER_BUILD": "1",
+    },
     test = ":static_docs",
     deps = [
         ":static_docs_build_script",
@@ -50,6 +56,8 @@ buck_sh_test(
         # Inject fake dependencies to ensure the test triggers on changes to the library and visualization app
         "../..:zstronglib",  # @manual
         "../../tools/visualization_app:app_srcs",  # @manual
+        # Doxygen binary must be explicitly declared as a dependency to be materialized in remote execution
+        "fbsource//third-party/doxygen:doxygen",  # @manual
     ],
 )
 

--- a/doc/mkdocs/mkdocs-openzl/src/mkdocs_openzl/plugin.py
+++ b/doc/mkdocs/mkdocs-openzl/src/mkdocs_openzl/plugin.py
@@ -79,7 +79,7 @@ class StreamdumpBuilder:
         self._src_dir = Path(config.docs_dir) / "../../../tools/visualization_app"
         assert self._src_dir.exists()
         self._build_dir = Path(build_directory) / "tools" / "trace"
-        self._skip_build = os.getenv("OPENZL_SKIP_VISUALIZER_BUILD", False)
+        self._skip_build = os.getenv("OPENZL_SKIP_VISUALIZER_BUILD", "") == "1"
         self._stamp = Stamp(
             self._build_dir / "stamp.txt",
             [self._src_dir],
@@ -124,8 +124,8 @@ class PythonBuilder:
         self._config = config
         self._src_dir = Path(config.docs_dir) / "../../../py"
         self._build_dir = Path(build_directory) / "py"
-        self._use_system_python_extension = os.getenv(
-            "OPENZL_USE_SYSTEM_PYTHON_EXTENSION", False
+        self._use_system_python_extension = (
+            os.getenv("OPENZL_USE_SYSTEM_PYTHON_EXTENSION", "") == "1"
         )
         self._stamp = Stamp(
             self._build_dir / "stamp.txt",

--- a/doc/mkdocs/mkdocs-openzl/src/mkdocs_openzl/plugin.py
+++ b/doc/mkdocs/mkdocs-openzl/src/mkdocs_openzl/plugin.py
@@ -79,6 +79,7 @@ class StreamdumpBuilder:
         self._src_dir = Path(config.docs_dir) / "../../../tools/visualization_app"
         assert self._src_dir.exists()
         self._build_dir = Path(build_directory) / "tools" / "trace"
+        self._skip_build = os.getenv("OPENZL_SKIP_VISUALIZER_BUILD", False)
         self._stamp = Stamp(
             self._build_dir / "stamp.txt",
             [self._src_dir],
@@ -92,6 +93,12 @@ class StreamdumpBuilder:
         """
         Build the visualization app
         """
+        if self._skip_build:
+            print(
+                "Skipping trace visualizer build (OPENZL_SKIP_VISUALIZER_BUILD is set)"
+            )
+            return
+
         stamp = self._stamp.compute_stamp()
 
         if self._stamp.needs_rebuild(stamp) or not (self._src_dir / "dist").exists():

--- a/doc/mkdocs/mkdocstrings-zstd/src/mkdocstrings_handlers/zstd/doxygen.py
+++ b/doc/mkdocs/mkdocstrings-zstd/src/mkdocstrings_handlers/zstd/doxygen.py
@@ -731,7 +731,8 @@ class Doxygen:
         shutil.rmtree(self._doxyxml_dir, ignore_errors=True)
         os.makedirs(self._doxyxml_dir, exist_ok=True)
         # Run doxygen.
-        cmd = ["doxygen", "-"]
+        doxygen_path = os.environ.get("DOXYGEN_PATH", "doxygen")
+        cmd = [doxygen_path, "-"]
         p = Popen(cmd, cwd=source_directory, stdin=PIPE, stdout=PIPE, stderr=PIPE)
         include_paths = [str(p) for p in include_paths] + ["."]
         out, err = p.communicate(

--- a/tools/visualization_app/src/graphVisualization/models/InteractiveChunkGraph.ts
+++ b/tools/visualization_app/src/graphVisualization/models/InteractiveChunkGraph.ts
@@ -271,6 +271,7 @@ export class InteractiveChunkGraph {
             totCSize,
             totShare,
             -1,
+            undefined, // streamPreview: empty for coalesced edges
             edges[0].source,
             edges[0].target,
           );

--- a/tools/visualization_app/src/graphVisualization/models/InternalEdge.ts
+++ b/tools/visualization_app/src/graphVisualization/models/InternalEdge.ts
@@ -4,6 +4,7 @@ import {ZL_Type, type StreamID} from '../../models/idTypes';
 import type {Stream} from '../../models/Stream';
 import type {InternalNode} from './InternalNode';
 import type {RF_edgeId} from './types';
+import type {StreamPreviewData} from '../../interfaces/SerializedStream';
 
 export class InternalEdge {
   readonly streamId: StreamID;
@@ -17,6 +18,7 @@ export class InternalEdge {
   readonly cSize: number;
   readonly share: number;
   readonly contentSize: number;
+  readonly streamPreview?: StreamPreviewData;
 
   // graph properties
   readonly source: InternalNode;
@@ -34,6 +36,7 @@ export class InternalEdge {
     cSize: number,
     share: number,
     contentSize: number,
+    streamPreview: StreamPreviewData | undefined,
     source: InternalNode,
     target: InternalNode,
   ) {
@@ -46,6 +49,7 @@ export class InternalEdge {
     this.cSize = cSize;
     this.share = share;
     this.contentSize = contentSize;
+    this.streamPreview = streamPreview;
 
     this.source = source;
     this.target = target;
@@ -67,6 +71,7 @@ export class InternalEdge {
       stream.cSize,
       stream.share,
       stream.contentSize,
+      stream.streamPreview,
       source,
       target,
     );
@@ -88,6 +93,7 @@ export class InternalEdge {
       edge.cSize,
       edge.share,
       edge.contentSize,
+      edge.streamPreview,
       source,
       target,
     );

--- a/tools/visualization_app/src/graphVisualization/views/EdgeView.tsx
+++ b/tools/visualization_app/src/graphVisualization/views/EdgeView.tsx
@@ -5,11 +5,215 @@ import type {InternalEdge} from '../models/InternalEdge';
 import {Box} from '@chakra-ui/react/box';
 import {Separator} from '@chakra-ui/react/separator';
 import {ZL_Type} from '../../models/idTypes';
+import {Float, Popover} from '@chakra-ui/react';
+import {MdInfoOutline} from 'react-icons/md';
+import type {ReactNode} from 'react';
 
 interface EdgeViewProps {
   data: {
     internalNode: InternalEdge;
   };
+}
+
+const MAX_LINES = 4;
+const BYTES_PER_LINE = 8;
+const MAX_STRING_LEN = 40;
+
+const HIGHLIGHT_COLOR = '#cfffafcb';
+
+// Format bytes as hex dump with highlighting for struct streams
+function formatSerialPreview(bytes: number[], eltWidth: number, isStruct: boolean): ReactNode {
+  if (!bytes || bytes.length === 0) {
+    return 'Stream Preview (0 bytes)';
+  }
+
+  const header = isStruct ? `Stream Preview (struct - eltWidth: ${eltWidth})` : 'Stream Preview (serial)';
+
+  const totalLines = Math.ceil(bytes.length / BYTES_PER_LINE);
+  const linesToShow = Math.min(MAX_LINES, totalLines);
+
+  const lines: ReactNode[] = [];
+
+  for (let line = 0; line < linesToShow; line++) {
+    const offset = line * BYTES_PER_LINE;
+    const lineBytes = Math.min(BYTES_PER_LINE, bytes.length - offset);
+
+    const lineElements: ReactNode[] = [];
+
+    // Offset column (no highlight)
+    lineElements.push(<span key={`offset-${line}`}>{offset.toString(16).padStart(8, '0')} </span>);
+
+    // Hex bytes - group consecutive bytes with same highlight state
+    let currentHexChunk = '';
+    let currentHexHighlight = false;
+
+    for (let i = 0; i <= lineBytes; i++) {
+      const byteIndex = offset + i;
+      const elementIndex = Math.floor(byteIndex / eltWidth);
+      const shouldHighlight = isStruct && elementIndex % 2 === 1;
+
+      // If we've hit the end or highlight state changed, save the current chunk
+      if (i === lineBytes || (i > 0 && shouldHighlight !== currentHexHighlight)) {
+        if (currentHexChunk) {
+          lineElements.push(
+            <span key={`hex-${line}-${i}`} style={currentHexHighlight ? {backgroundColor: HIGHLIGHT_COLOR} : undefined}>
+              {currentHexChunk}
+            </span>,
+          );
+        }
+        currentHexChunk = '';
+        currentHexHighlight = shouldHighlight;
+      }
+
+      if (i < lineBytes) {
+        currentHexChunk += bytes[byteIndex].toString(16).padStart(2, '0') + ' ';
+      }
+    }
+
+    // Pad remaining (no highlight)
+    if (lineBytes < BYTES_PER_LINE) {
+      lineElements.push(<span key={`pad-${line}`}>{'   '.repeat(BYTES_PER_LINE - lineBytes)}</span>);
+    }
+
+    // ASCII section separator
+    lineElements.push(<span key={`sep-${line}`}> |</span>);
+
+    // ASCII section - group consecutive chars with same highlight state
+    let currentAsciiChunk = '';
+    let currentAsciiHighlight = false;
+
+    for (let i = 0; i <= lineBytes; i++) {
+      const byteIndex = offset + i;
+      const elementIndex = Math.floor(byteIndex / eltWidth);
+      const shouldHighlight = isStruct && elementIndex % 2 === 1;
+
+      // If we've hit the end or highlight state changed, save the current chunk
+      if (i === lineBytes || (i > 0 && shouldHighlight !== currentAsciiHighlight)) {
+        if (currentAsciiChunk) {
+          lineElements.push(
+            <span
+              key={`ascii-${line}-${i}`}
+              style={currentAsciiHighlight ? {backgroundColor: HIGHLIGHT_COLOR} : undefined}>
+              {currentAsciiChunk}
+            </span>,
+          );
+        }
+        currentAsciiChunk = '';
+        currentAsciiHighlight = shouldHighlight;
+      }
+
+      if (i < lineBytes) {
+        const c = bytes[byteIndex];
+        currentAsciiChunk += c >= 0x20 && c <= 0x7e ? String.fromCharCode(c) : '.';
+      }
+    }
+
+    lineElements.push(<span key={`end-${line}`}>|</span>);
+
+    lines.push(
+      <div key={`line-${line}`} style={{display: 'flex'}}>
+        {lineElements}
+      </div>,
+    );
+  }
+
+  const footer =
+    totalLines > linesToShow ? <div key="footer">{`... (${totalLines - linesToShow} more lines)`}</div> : null;
+
+  return (
+    <div>
+      <div>{header}</div>
+      {lines}
+      {footer}
+    </div>
+  );
+}
+
+// Format numeric values (for numeric streams)
+function formatNumericPreview(values: number[], eltWidth: number): ReactNode {
+  if (!values || values.length === 0) {
+    return 'Stream Preview (numeric - 0 elements)';
+  }
+
+  let overflow = false;
+  const lines: string[] = [];
+  lines.push(`Stream Preview (numeric - eltWidth: ${eltWidth})`);
+
+  let currentLine = '';
+  let lineCount = 0;
+  // Store each line until max character length is reached, then start a new line
+  for (let i = 0; i < values.length; i++) {
+    currentLine += values[i] + ' ';
+    if (currentLine.length >= MAX_STRING_LEN) {
+      lines.push(currentLine);
+      currentLine = '';
+      lineCount++;
+    }
+
+    if (lineCount >= MAX_LINES) {
+      const remaining = values.length - i - 1;
+      if (remaining > 0) {
+        lines.push('...(' + remaining + ' more numbers)');
+        overflow = true;
+      }
+      break;
+    }
+  }
+
+  if (!overflow && currentLine.length !== 0) {
+    lines.push(currentLine);
+  }
+
+  return <>{lines.join('\n')}</>;
+}
+
+// Format string values (for string streams)
+function formatStringPreview(strings: string[]): ReactNode {
+  if (!strings || strings.length === 0) {
+    return 'Stream Preview (string - empty)';
+  }
+
+  const lines: string[] = [];
+  lines.push(`Stream Preview (string - ${strings.length} elements)`);
+
+  const stringsToShow = Math.min(MAX_LINES, strings.length);
+
+  for (let i = 0; i < stringsToShow; i++) {
+    let currentLine = strings[i];
+
+    if (currentLine.length > MAX_STRING_LEN) {
+      currentLine = strings[i].substring(0, MAX_STRING_LEN - 3) + '...';
+    }
+
+    lines.push(`[${i}]: "${currentLine}"`);
+  }
+
+  if (strings.length > stringsToShow) {
+    lines.push(`... (${strings.length - stringsToShow} more strings)`);
+  }
+
+  return <>{lines.join('\n')}</>;
+}
+
+// Format preview based on stream type
+function formatPreview(edge: InternalEdge): ReactNode | null {
+  const {type, eltWidth, streamPreview} = edge;
+
+  if (!streamPreview) {
+    return null;
+  }
+
+  switch (type) {
+    case ZL_Type.ZL_Type_string:
+      return formatStringPreview(streamPreview as string[]);
+    case ZL_Type.ZL_Type_numeric:
+      return formatNumericPreview(streamPreview as number[], eltWidth);
+    case ZL_Type.ZL_Type_struct:
+      return formatSerialPreview(streamPreview as number[], eltWidth, true);
+    case ZL_Type.ZL_Type_serial:
+    default:
+      return formatSerialPreview(streamPreview as number[], eltWidth, false);
+  }
 }
 
 export function EdgeView({data}: EdgeViewProps) {
@@ -18,6 +222,9 @@ export function EdgeView({data}: EdgeViewProps) {
   if (edge.type === ZL_Type.ZL_Type_numeric || edge.type === ZL_Type.ZL_Type_struct) {
     typeAndWidthInfo += `[${edge.eltWidth}]`;
   }
+
+  const formattedPreview = formatPreview(edge);
+
   return (
     <Box
       bg={edge.inLargestCompressionPath ? '#d9ffee' : '#ffffffb0'}
@@ -34,6 +241,36 @@ export function EdgeView({data}: EdgeViewProps) {
       <Separator />
       <p>{`${edge.cSize} [${edge.share.toFixed(2)}%]`}</p>
       <p>{`${edge.numElts} elts`}</p>
+
+      {formattedPreview && (
+        <>
+          <Float placement="top-end" offsetX={3} offsetY={3}>
+            <Popover.Root positioning={{placement: 'top', flip: false, slide: false, offset: {crossAxis: -90}}}>
+              <Popover.Trigger asChild>
+                <Box
+                  as="button"
+                  cursor="pointer"
+                  p="0px"
+                  borderRadius="full"
+                  _hover={{bg: 'gray.100'}}
+                  aria-label="Stream Preview">
+                  <MdInfoOutline size={20} />
+                </Box>
+              </Popover.Trigger>
+              <Popover.Positioner>
+                <Popover.Content width="auto">
+                  <Popover.Arrow />
+                  <Popover.Body>
+                    <Box fontFamily="monospace" fontSize="12px" textAlign="left" whiteSpace="pre">
+                      {formattedPreview}
+                    </Box>
+                  </Popover.Body>
+                </Popover.Content>
+              </Popover.Positioner>
+            </Popover.Root>
+          </Float>
+        </>
+      )}
     </Box>
   );
 }

--- a/tools/visualization_app/src/interfaces/SerializedStream.ts
+++ b/tools/visualization_app/src/interfaces/SerializedStream.ts
@@ -2,6 +2,8 @@
 
 import {ZL_Type} from '../models/idTypes';
 
+export type StreamPreviewData = string[] | number[];
+
 export interface SerializedStream {
   chunkId: number;
   type: ZL_Type;
@@ -11,4 +13,5 @@ export interface SerializedStream {
   cSize: number;
   share: number;
   contentSize: number;
+  streamPreview?: StreamPreviewData;
 }

--- a/tools/visualization_app/src/models/Stream.ts
+++ b/tools/visualization_app/src/models/Stream.ts
@@ -2,8 +2,9 @@
 
 import type {ChunkID, CodecID, StreamID} from './idTypes';
 import {ZL_Type} from './idTypes';
-import type {SerializedStream} from '../interfaces/SerializedStream';
+import type {SerializedStream, StreamPreviewData} from '../interfaces/SerializedStream';
 import type {RF_edgeId} from '../graphVisualization/models/types';
+
 export class Stream {
   static readonly NO_TARGET: CodecID = -1 as CodecID;
   static readonly NO_SOURCE: CodecID = -1 as CodecID;
@@ -19,6 +20,7 @@ export class Stream {
   readonly cSize: number;
   readonly share: number;
   readonly contentSize: number;
+  readonly streamPreview?: StreamPreviewData;
 
   // graph properties
   sourceCodec: CodecID = Stream.NO_SOURCE;
@@ -38,6 +40,7 @@ export class Stream {
     cSize: number,
     share: number,
     contentSize: number,
+    streamPreview: StreamPreviewData | undefined,
     rfId: RF_edgeId,
   ) {
     this.streamId = streamId;
@@ -50,6 +53,7 @@ export class Stream {
     this.cSize = cSize;
     this.share = share;
     this.contentSize = contentSize;
+    this.streamPreview = streamPreview;
 
     this.rfId = rfId;
   }
@@ -80,6 +84,7 @@ export class Stream {
       obj.cSize,
       obj.share,
       obj.contentSize,
+      obj.streamPreview,
       `C${obj.chunkId}-S${idx}` as RF_edgeId,
     );
   }

--- a/tools/visualization_app/yarn.lock
+++ b/tools/visualization_app/yarn.lock
@@ -521,31 +521,29 @@
   resolved "https://registry.yarnpkg.com/@esbuild/win32-x64/-/win32-x64-0.25.4.tgz#0b17ec8a70b2385827d52314c1253160a0b9bacc"
   integrity sha512-nOT2vZNw6hJ+z43oP1SPea/G/6AbN6X+bGNhNuq8NtRHy4wsMhw765IKLNmnjek7GvjWBYQ8Q5VBoYTFg9y1UQ==
 
-"@eslint-community/eslint-utils@^4.7.0":
-  version "4.7.0"
-  resolved "https://registry.yarnpkg.com/@eslint-community/eslint-utils/-/eslint-utils-4.7.0.tgz#607084630c6c033992a082de6e6fbc1a8b52175a"
-  integrity sha512-dyybb3AcajC7uha6CvhdVRJqaKyn7w2YKqKyAN37NKYgZT36w+iRb0Dymmc5qEJ549c/S31cMMSFd75bteCpCw==
+"@eslint-community/eslint-utils@^4.7.0", "@eslint-community/eslint-utils@^4.8.0":
+  version "4.9.1"
+  resolved "https://registry.yarnpkg.com/@eslint-community/eslint-utils/-/eslint-utils-4.9.1.tgz#4e90af67bc51ddee6cdef5284edf572ec376b595"
+  integrity sha512-phrYmNiYppR7znFEdqgfWHXR6NCkZEK7hwWDHZUjit/2/U0r6XvkDl0SYnoM51Hq7FhCGdLDT6zxCCOY1hexsQ==
   dependencies:
     eslint-visitor-keys "^3.4.3"
 
-"@eslint-community/eslint-utils@^4.8.0":
-  version "4.9.0"
-  resolved "https://registry.yarnpkg.com/@eslint-community/eslint-utils/-/eslint-utils-4.9.0.tgz#7308df158e064f0dd8b8fdb58aa14fa2a7f913b3"
-  integrity sha512-ayVFHdtZ+hsq1t2Dy24wCmGXGe4q9Gu3smhLYALJrr473ZH27MsnSL+LKUlimp4BWJqMDMLmPpx/Q9R3OAlL4g==
-  dependencies:
-    eslint-visitor-keys "^3.4.3"
-
-"@eslint-community/regexpp@^4.10.0", "@eslint-community/regexpp@^4.12.1":
+"@eslint-community/regexpp@^4.10.0":
   version "4.12.1"
   resolved "https://registry.yarnpkg.com/@eslint-community/regexpp/-/regexpp-4.12.1.tgz#cfc6cffe39df390a3841cde2abccf92eaa7ae0e0"
   integrity sha512-CCZCDJuduB9OUkFkY2IgppNZMi2lBQgD2qzwXkEia16cge2pijY/aXi96CJMquDMn3nJdlPV1A5KrJEXwfLNzQ==
 
+"@eslint-community/regexpp@^4.12.1":
+  version "4.12.2"
+  resolved "https://registry.yarnpkg.com/@eslint-community/regexpp/-/regexpp-4.12.2.tgz#bccdf615bcf7b6e8db830ec0b8d21c9a25de597b"
+  integrity sha512-EriSTlt5OC9/7SXkRSCAhfSxxoSUgBm33OH+IkwbdpgoqsSsUg7y3uh+IICI/Qg4BBWr3U2i39RpmycbxMq4ew==
+
 "@eslint/config-array@^0.21.0":
-  version "0.21.0"
-  resolved "https://registry.yarnpkg.com/@eslint/config-array/-/config-array-0.21.0.tgz#abdbcbd16b124c638081766392a4d6b509f72636"
-  integrity sha512-ENIdc4iLu0d93HeYirvKmrzshzofPw6VkZRKQGe9Nv46ZnWUzcF1xV01dcvEg/1wXUR61OmmlSfyeyO7EvjLxQ==
+  version "0.21.1"
+  resolved "https://registry.yarnpkg.com/@eslint/config-array/-/config-array-0.21.1.tgz#7d1b0060fea407f8301e932492ba8c18aff29713"
+  integrity sha512-aw1gNayWpdI/jSYVgzN5pL0cfzU02GT3NBpeT/DXbx1/1x7ZKxFPd9bwrzygx/qiwIQiJ1sw/zD8qY/kRvlGHA==
   dependencies:
-    "@eslint/object-schema" "^2.1.6"
+    "@eslint/object-schema" "^2.1.7"
     debug "^4.3.1"
     minimatch "^3.1.2"
 
@@ -562,9 +560,9 @@
     "@types/json-schema" "^7.0.15"
 
 "@eslint/css-tree@^3.6.5":
-  version "3.6.5"
-  resolved "https://registry.yarnpkg.com/@eslint/css-tree/-/css-tree-3.6.5.tgz#e51b69206117135557352982ba65d18f9d9b5a60"
-  integrity sha512-bJgnXu0D0K1BbfPfHTmCaJe2ucBOjeg/tG37H2CSqYCw51VMmBtPfWrH8LKPLAVCOp0h94e1n8PfR3v9iRbtyA==
+  version "3.6.8"
+  resolved "https://registry.yarnpkg.com/@eslint/css-tree/-/css-tree-3.6.8.tgz#8449d80a6e061bde514bd302a278a533d9716aba"
+  integrity sha512-s0f40zY7dlMp8i0Jf0u6l/aSswS0WRAgkhgETgiCJRcxIWb4S/Sp9uScKHWbkM3BnoFLbJbmOYk5AZUDFVxaLA==
   dependencies:
     mdn-data "2.23.0"
     source-map-js "^1.0.1"
@@ -579,9 +577,9 @@
     "@eslint/plugin-kit" "^0.3.5"
 
 "@eslint/eslintrc@^3.3.1":
-  version "3.3.1"
-  resolved "https://registry.yarnpkg.com/@eslint/eslintrc/-/eslintrc-3.3.1.tgz#e55f7f1dd400600dd066dbba349c4c0bac916964"
-  integrity sha512-gtF186CXhIl1p4pJNGZw8Yc6RlshoePRvE0X91oPGb3vZ8pM3qOS9W9NGPat9LziaBV7XrJWGylNQXkGcnM3IQ==
+  version "3.3.3"
+  resolved "https://registry.yarnpkg.com/@eslint/eslintrc/-/eslintrc-3.3.3.tgz#26393a0806501b5e2b6a43aa588a4d8df67880ac"
+  integrity sha512-Kr+LPIUVKz2qkx1HAMH8q1q6azbqBAsXJUxBl/ODDuVPX45Z9DfwB8tPjTi6nNZ8BuM3nbJxC5zCAg5elnBUTQ==
   dependencies:
     ajv "^6.12.4"
     debug "^4.3.2"
@@ -589,7 +587,7 @@
     globals "^14.0.0"
     ignore "^5.2.0"
     import-fresh "^3.2.1"
-    js-yaml "^4.1.0"
+    js-yaml "^4.1.1"
     minimatch "^3.1.2"
     strip-json-comments "^3.1.1"
 
@@ -608,10 +606,10 @@
     "@humanwhocodes/momoa" "^3.3.9"
     natural-compare "^1.4.0"
 
-"@eslint/object-schema@^2.1.6":
-  version "2.1.6"
-  resolved "https://registry.yarnpkg.com/@eslint/object-schema/-/object-schema-2.1.6.tgz#58369ab5b5b3ca117880c0f6c0b0f32f6950f24f"
-  integrity sha512-RBMg5FRL0I0gs51M/guSAj5/e14VQ4tpZnQNWwuDT66P14I43ItmPfIZRhO9fUVIPOAQXU47atlywZ/czoqFPA==
+"@eslint/object-schema@^2.1.7":
+  version "2.1.7"
+  resolved "https://registry.yarnpkg.com/@eslint/object-schema/-/object-schema-2.1.7.tgz#6e2126a1347e86a4dedf8706ec67ff8e107ebbad"
+  integrity sha512-VtAOaymWVfZcmZbp6E2mympDIHvyjXs/12LqWYjVw6qjrfF+VK+fyG33kChz3nnK+SU5/NeHOqrTEHS8sXO3OA==
 
 "@eslint/plugin-kit@0.3.5", "@eslint/plugin-kit@^0.3.5":
   version "0.3.5"
@@ -678,12 +676,12 @@
   integrity sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA==
 
 "@humanfs/node@^0.16.6":
-  version "0.16.6"
-  resolved "https://registry.yarnpkg.com/@humanfs/node/-/node-0.16.6.tgz#ee2a10eaabd1131987bf0488fd9b820174cd765e"
-  integrity sha512-YuI2ZHQL78Q5HbhDiBA1X4LmYdXCKCMQIfw0pw7piHJwyREFebJUvrQN4cMssyES6x+vfUbx1CIpaQUKYdQZOw==
+  version "0.16.7"
+  resolved "https://registry.yarnpkg.com/@humanfs/node/-/node-0.16.7.tgz#822cb7b3a12c5a240a24f621b5a2413e27a45f26"
+  integrity sha512-/zUx+yOsIrG4Y43Eh2peDeKCxlRt/gET6aHfaKpuq267qXdYDFViVHfMaLyygZOnl0kGWxFIgsBy8QFuTLUXEQ==
   dependencies:
     "@humanfs/core" "^0.19.1"
-    "@humanwhocodes/retry" "^0.3.0"
+    "@humanwhocodes/retry" "^0.4.0"
 
 "@humanwhocodes/module-importer@^1.0.1":
   version "1.0.1"
@@ -691,16 +689,11 @@
   integrity sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==
 
 "@humanwhocodes/momoa@^3.3.9":
-  version "3.3.9"
-  resolved "https://registry.yarnpkg.com/@humanwhocodes/momoa/-/momoa-3.3.9.tgz#513ff7fb5e3ce08fb5ddbd3a5730e195cab2dd36"
-  integrity sha512-LHw6Op4bJb3/3KZgOgwflJx5zY9XOy0NU1NuyUFKGdTwHYmP+PbnQGCYQJ8NVNlulLfQish34b0VuUlLYP3AXA==
+  version "3.3.10"
+  resolved "https://registry.yarnpkg.com/@humanwhocodes/momoa/-/momoa-3.3.10.tgz#8ffe034b31e1d43e480846695869c45a06539c73"
+  integrity sha512-KWiFQpSAqEIyrTXko3hFNLeQvSK8zXlJQzhhxsyVn58WFRYXST99b3Nqnu+ttOtjds2Pl2grUHGpe2NzhPynuQ==
 
-"@humanwhocodes/retry@^0.3.0":
-  version "0.3.1"
-  resolved "https://registry.yarnpkg.com/@humanwhocodes/retry/-/retry-0.3.1.tgz#c72a5c76a9fbaf3488e231b13dc52c0da7bab42a"
-  integrity sha512-JBxkERygn7Bv/GbN5Rv8Ul6LVknS+5Bp6RgDC/O8gEBU/yeH5Ui5C/OlWrTb6qct7LjjfT6Re2NxB0ln0yYybA==
-
-"@humanwhocodes/retry@^0.4.2":
+"@humanwhocodes/retry@^0.4.0", "@humanwhocodes/retry@^0.4.2":
   version "0.4.3"
   resolved "https://registry.yarnpkg.com/@humanwhocodes/retry/-/retry-0.4.3.tgz#c2b9d2e374ee62c586d3adbea87199b1d7a7a6ba"
   integrity sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==
@@ -1000,15 +993,10 @@
     "@types/d3-interpolate" "*"
     "@types/d3-selection" "*"
 
-"@types/estree@1.0.8":
+"@types/estree@1.0.8", "@types/estree@^1.0.6":
   version "1.0.8"
   resolved "https://registry.yarnpkg.com/@types/estree/-/estree-1.0.8.tgz#958b91c991b1867ced318bedea0e215ee050726e"
   integrity sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==
-
-"@types/estree@^1.0.6":
-  version "1.0.7"
-  resolved "https://registry.yarnpkg.com/@types/estree/-/estree-1.0.7.tgz#4158d3105276773d5b7695cd4834b1722e4f37a8"
-  integrity sha512-w28IoSUCJpidD/TGviZwwMJckNESJZXFu7NBZ5YJ4mEUnNraUn9Pm8HSZm/jDF1pDWYKspWE7oVphigUPRakIQ==
 
 "@types/json-schema@^7.0.15":
   version "7.0.15"
@@ -1075,10 +1063,15 @@
     "@typescript-eslint/types" "8.45.0"
     "@typescript-eslint/visitor-keys" "8.45.0"
 
-"@typescript-eslint/tsconfig-utils@8.45.0", "@typescript-eslint/tsconfig-utils@^8.45.0":
+"@typescript-eslint/tsconfig-utils@8.45.0":
   version "8.45.0"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.45.0.tgz#63d38282790a2566c571bad423e7c1cad1f3d64c"
   integrity sha512-aFdr+c37sc+jqNMGhH+ajxPXwjv9UtFZk79k8pLoJ6p4y0snmYpPA52GuWHgt2ZF4gRRW6odsEj41uZLojDt5w==
+
+"@typescript-eslint/tsconfig-utils@^8.45.0":
+  version "8.54.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.54.0.tgz#71dd7ba1674bd48b172fc4c85b2f734b0eae3dbc"
+  integrity sha512-dRgOyT2hPk/JwxNMZDsIXDgyl9axdJI3ogZ2XWhBPsnZUv+hPesa5iuhdYt2gzwA9t8RE5ytOJ6xB0moV0Ujvw==
 
 "@typescript-eslint/type-utils@8.45.0":
   version "8.45.0"
@@ -1091,10 +1084,15 @@
     debug "^4.3.4"
     ts-api-utils "^2.1.0"
 
-"@typescript-eslint/types@8.45.0", "@typescript-eslint/types@^8.45.0":
+"@typescript-eslint/types@8.45.0":
   version "8.45.0"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-8.45.0.tgz#fc01cd2a4690b9713b02f895e82fb43f7d960684"
   integrity sha512-WugXLuOIq67BMgQInIxxnsSyRLFxdkJEJu8r4ngLR56q/4Q5LrbfkFRH27vMTjxEK8Pyz7QfzuZe/G15qQnVRA==
+
+"@typescript-eslint/types@^8.45.0":
+  version "8.54.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-8.54.0.tgz#c12d41f67a2e15a8a96fbc5f2d07b17331130889"
+  integrity sha512-PDUI9R1BVjqu7AUDsRBbKMtwmjWcn4J3le+5LpcFgWULN3LvHC5rkc9gCVxbrsrGmO1jfPybN5s6h4Jy+OnkAA==
 
 "@typescript-eslint/typescript-estree@8.45.0":
   version "8.45.0"
@@ -1872,11 +1870,6 @@ acorn-jsx@^5.3.2:
   resolved "https://registry.yarnpkg.com/acorn-jsx/-/acorn-jsx-5.3.2.tgz#7ed5bb55908b3b2f1bc55c6af1653bada7f07937"
   integrity sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==
 
-acorn@^8.14.0:
-  version "8.14.1"
-  resolved "https://registry.yarnpkg.com/acorn/-/acorn-8.14.1.tgz#721d5dc10f7d5b5609a891773d47731796935dfb"
-  integrity sha512-OvQ/2pUDKmgfCg++xsTX1wGxfTaszcHVcTctW4UJB4hibJx2HXxxO5UmVgyjMa+ZDsiaf5wWLXYpRWMmBI0QHg==
-
 acorn@^8.15.0:
   version "8.15.0"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-8.15.0.tgz#a360898bc415edaac46c8241f6383975b930b816"
@@ -2508,11 +2501,6 @@ eslint-visitor-keys@^3.4.3:
   resolved "https://registry.yarnpkg.com/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz#0cd72fe8550e3c2eae156a96a4dddcd1c8ac5800"
   integrity sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==
 
-eslint-visitor-keys@^4.2.0:
-  version "4.2.0"
-  resolved "https://registry.yarnpkg.com/eslint-visitor-keys/-/eslint-visitor-keys-4.2.0.tgz#687bacb2af884fcdda8a6e7d65c606f46a14cd45"
-  integrity sha512-UyLnSehNt62FFhSwjZlHmeokpRK59rcz29j+F1/aDgbkbRTk7wIc9XzdoasMUbRNKDM0qQt/+BJ4BrpFeABemw==
-
 eslint-visitor-keys@^4.2.1:
   version "4.2.1"
   resolved "https://registry.yarnpkg.com/eslint-visitor-keys/-/eslint-visitor-keys-4.2.1.tgz#4cfea60fe7dd0ad8e816e1ed026c1d5251b512c1"
@@ -2559,16 +2547,7 @@ eslint@9.36.0:
     natural-compare "^1.4.0"
     optionator "^0.9.3"
 
-espree@^10.0.1:
-  version "10.3.0"
-  resolved "https://registry.yarnpkg.com/espree/-/espree-10.3.0.tgz#29267cf5b0cb98735b65e64ba07e0ed49d1eed8a"
-  integrity sha512-0QYC8b24HWY8zjRnDTL6RiHfDbAWn63qb4LMj1Z4b076A4une81+z03Kg7l7mn/48PUTqoLptSXez8oknU8Clg==
-  dependencies:
-    acorn "^8.14.0"
-    acorn-jsx "^5.3.2"
-    eslint-visitor-keys "^4.2.0"
-
-espree@^10.4.0:
+espree@^10.0.1, espree@^10.4.0:
   version "10.4.0"
   resolved "https://registry.yarnpkg.com/espree/-/espree-10.4.0.tgz#d54f4949d4629005a1fa168d937c3ff1f7e2a837"
   integrity sha512-j6PAQ2uUr79PZhBjP5C5fhl8e39FmRnOjsD5lGnWrFU8i2G776tBK7+nP8KuQUTTyAZUwfQqXAgrVH5MbH9CYQ==
@@ -2578,9 +2557,9 @@ espree@^10.4.0:
     eslint-visitor-keys "^4.2.1"
 
 esquery@^1.5.0:
-  version "1.6.0"
-  resolved "https://registry.yarnpkg.com/esquery/-/esquery-1.6.0.tgz#91419234f804d852a82dceec3e16cdc22cf9dae7"
-  integrity sha512-ca9pw9fomFcKPvFLXhBKUK90ZvGibiGOvRJNbjljY7s7uq/5YO4BOzcYtJqExdx99rF6aAcnRxHmcUHcz6sQsg==
+  version "1.7.0"
+  resolved "https://registry.yarnpkg.com/esquery/-/esquery-1.7.0.tgz#08d048f261f0ddedb5bae95f46809463d9c9496d"
+  integrity sha512-Ap6G0WQwcU/LHsvLwON1fAQX9Zp0A2Y6Y/cJBl9r/JbW90Zyg4/zbG6zzKa2OTALELarYHmKu0GhpM5EO+7T0g==
   dependencies:
     estraverse "^5.1.0"
 
@@ -2874,9 +2853,9 @@ ignore@^5.2.0:
   integrity sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==
 
 ignore@^7.0.0:
-  version "7.0.4"
-  resolved "https://registry.yarnpkg.com/ignore/-/ignore-7.0.4.tgz#a12c70d0f2607c5bf508fb65a40c75f037d7a078"
-  integrity sha512-gJzzk+PQNznz8ysRrC0aOkBNVRBDtE1n53IqyqEf3PXrYwomFs5q4pGMizBMJF+ykh03insJ27hB8gSrD2Hn8A==
+  version "7.0.5"
+  resolved "https://registry.yarnpkg.com/ignore/-/ignore-7.0.5.tgz#4cb5f6cd7d4c7ab0365738c7aea888baa6d7efd9"
+  integrity sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==
 
 import-fresh@^3.2.1:
   version "3.3.1"
@@ -3115,7 +3094,7 @@ iterator.prototype@^1.1.4:
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-4.0.0.tgz#19203fb59991df98e3a287050d4647cdeaf32499"
   integrity sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==
 
-js-yaml@4.1.1, js-yaml@^4.1.0:
+js-yaml@4.1.1, js-yaml@^4.1.1:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-4.1.1.tgz#854c292467705b699476e1a2decc0c8a3458806b"
   integrity sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==
@@ -3852,9 +3831,9 @@ to-regex-range@^5.0.1:
     is-number "^7.0.0"
 
 ts-api-utils@^2.1.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/ts-api-utils/-/ts-api-utils-2.1.0.tgz#595f7094e46eed364c13fd23e75f9513d29baf91"
-  integrity sha512-CUgTZL1irw8u29bzrOD/nH85jqyc74D6SshFgujOIA7osm2Rz7dYH77agkx7H4FBNxDq7Cjf+IjaX/8zwFW+ZQ==
+  version "2.4.0"
+  resolved "https://registry.yarnpkg.com/ts-api-utils/-/ts-api-utils-2.4.0.tgz#2690579f96d2790253bdcf1ca35d569ad78f9ad8"
+  integrity sha512-3TaVTaAv2gTiMB35i3FiGJaRfwb3Pyn/j3m/bfAvGe8FB7CF6u+LMYqYlDh7reQf7UNvoTvdfAqHGmPGOSsPmA==
 
 tsconfck@^3.0.3:
   version "3.1.6"


### PR DESCRIPTION
Summary:
Fix `os.getenv` boolean handling for `OPENZL_SKIP_VISUALIZER_BUILD` and `OPENZL_USE_SYSTEM_PYTHON_EXTENSION`.

Previously used `False` as the default, which returns a boolean when unset but a string when set.  [OPENZL_SKIP_VISUALIZER_BUILD](https://fburl.com/code/ffh2g9s7) and [OPENZL_USE_SYSTEM_PYTHON_EXTENSION](https://fburl.com/code/8y08ameq) are defined with "1", directly check if equal to string now.

Differential Revision: D96188097


