### PR TITLE
use explicit types in Cursor::write (assorted)

### DIFF
--- a/custom_transforms/thrift/split_helpers.h
+++ b/custom_transforms/thrift/split_helpers.h
@@ -244,7 +244,7 @@ class WriteStream : public detail::BaseWriteStream<WriteStream> {
     ZL_FORCE_INLINE_ATTR void writeValue(Value val)
     {
         static_assert(folly::kIsLittleEndian);
-        appender_.writeLE(val);
+        appender_.writeLE<Value>(val);
     }
 
     void copyTo(folly::MutableByteRange dst) const


### PR DESCRIPTION
Summary:
Addresses problems like this:

```
void* buf = /*...*/;
uint16_t word = /*...*/;
cursor.write(word & 0xffff); // oops, 32-bit store due to implicit integer promotion
```

Differential Revision: D96317691


