### PR TITLE
Add basic optimizer support for when blocks (#500)

### DIFF
--- a/tests/compress/graphs/sddl2/test_sddl2_code_execution.cpp
+++ b/tests/compress/graphs/sddl2/test_sddl2_code_execution.cpp
@@ -374,6 +374,119 @@ TEST_F(SDDL2CodeExecutionTest, AssumeRecordWithGlobalVariableReference)
     expect_success(prog, input, expected_sizes);
 }
 
+// ============================================================================
+// Parameterized Records
+// ============================================================================
+
+TEST_F(SDDL2CodeExecutionTest, ConsumeParameterizedRecord)
+{
+    const std::vector<size_t> expected_sizes = { 40 };
+    const auto input = gen<uint8_t>(sum(expected_sizes));
+
+    const auto prog = R"(
+        Record Entry(N) = {
+            items: Int32LE[N]
+        }
+        : Entry(10)
+    )";
+
+    expect_success(prog, input, expected_sizes);
+}
+
+TEST_F(SDDL2CodeExecutionTest, ConsumeParameterizedRecordMultipleParams)
+{
+    const std::vector<size_t> expected_sizes = { 22 };
+    const auto input = gen<uint8_t>(sum(expected_sizes));
+
+    const auto prog = R"(
+        Record Foo(A, B) = {
+            x: Int32LE[A],
+            y: Int16LE[B]
+        }
+        ParamFoo = Foo(3, 5)
+        : ParamFoo
+    )";
+
+    expect_success(prog, input, expected_sizes);
+}
+
+TEST_F(SDDL2CodeExecutionTest, ConsumeParameterizedRecordMultipleCalls)
+{
+    const std::vector<size_t> expected_sizes = { 8, 12 };
+    const auto input = gen<uint8_t>(sum(expected_sizes));
+
+    const auto prog = R"(
+        Record Entry(N) = {
+            items: Int32LE[N]
+        }
+        : Entry(2)
+        : Entry(3)
+    )";
+
+    expect_success(prog, input, expected_sizes);
+}
+
+TEST_F(SDDL2CodeExecutionTest, ConsumeArrayOfParameterizedRecord)
+{
+    const std::vector<size_t> expected_sizes = { 60 };
+    const auto input = gen<uint8_t>(sum(expected_sizes));
+
+    const auto prog = R"(
+        Record Entry(N) = {
+            items: Int32LE[N]
+        }
+        : Entry(5)[3]
+    )";
+
+    expect_success(prog, input, expected_sizes);
+}
+
+TEST_F(SDDL2CodeExecutionTest, AssumeParameterizedRecord)
+{
+    const std::vector<size_t> expected_sizes = { 1, 21 };
+    std::vector<uint8_t> input(22, 0);
+    input[0]  = 5; // n = 5
+    input[21] = 3; // tag = 3
+
+    const auto prog = R"(
+        Record Entry(N) = {
+            items: Int32LE[N],
+            tag: Byte
+        }
+        n: Byte
+        entry: Entry(n)
+        expect entry.tag == 3
+    )";
+
+    expect_success(prog, input, expected_sizes);
+}
+
+TEST_F(SDDL2CodeExecutionTest, AssumeNestedParameterizedRecord)
+{
+    const std::vector<size_t> expected_sizes = { 1, 10 };
+    std::vector<uint8_t> input(11, 0);
+    input[0]  = 2; // n = 2
+    input[9]  = 3; // foo.bar.tag = 3
+    input[10] = 5; // foo.tag = 5
+
+    const auto prog = R"(
+        Record Bar(N) = {
+            items: Int32LE[N],
+            tag: Byte
+        }
+        Record Foo(M) = {
+            bar: Bar(M),
+            tag: Byte
+        }
+        N: Byte
+        foo: Foo(N)
+        expect foo.bar.tag == 3
+        expect foo.tag == 5
+        expect N == 2
+    )";
+
+    expect_success(prog, input, expected_sizes);
+}
 } // namespace testing
 } // namespace sddl2
 } // namespace openzl

--- a/tools/sddl2/compiler/Syntax.cpp
+++ b/tools/sddl2/compiler/Syntax.cpp
@@ -115,6 +115,8 @@ static const std::map<Symbol, poly::string_view> syms_to_debug_strs{
 
     { Symbol::BYTES, "BYTES" },
     { Symbol::RECORD, "RECORD" },
+
+    { Symbol::WHEN, "WHEN" },
 };
 
 poly::string_view sym_to_debug_str(Symbol sym)
@@ -185,6 +187,7 @@ const std::vector<std::pair<poly::string_view, Symbol>> strs_to_syms{
     { "BFloat16BE", Symbol::BF16BE },
     { "Bytes", Symbol::BYTES },
     { "Record", Symbol::RECORD },
+    { "when", Symbol::WHEN },
 };
 
 /* These symbols can't actually be accessed via these names. */

--- a/tools/sddl2/compiler/Syntax.h
+++ b/tools/sddl2/compiler/Syntax.h
@@ -89,7 +89,10 @@ enum class Symbol {
 
     // Other Fields
     BYTES,
-    RECORD
+    RECORD,
+
+    // Control Flow
+    WHEN
 };
 
 /// @returns a name string for a symbol.

--- a/tools/sddl2/compiler/codegen/CodeGenerator.cpp
+++ b/tools/sddl2/compiler/codegen/CodeGenerator.cpp
@@ -184,6 +184,19 @@ class CodeGeneratorImpl {
         }
     }
 
+    AssemblyOutput bindParams(const ASTRecord* record, const ASTVec& args)
+    {
+        AssemblyOutput output;
+        for (size_t i = 0; i < record->params().size(); ++i) {
+            const auto& param_name = record->params()[i]->as_var()->name();
+            auto reg               = registers_.assign(param_name);
+            output += generateValue(args[i]);
+            output += "push.i64 " + std::to_string(reg);
+            output += "var.store";
+        }
+        return output;
+    }
+
     TypeResult generateType(const ASTPtr& type)
     {
         AssemblyOutput output;
@@ -243,8 +256,24 @@ class CodeGeneratorImpl {
                 output += "type.fixed_array";
                 return { std::move(output), type };
             }
-            case ConvertedNodeType::CALL:
-                throw CodegenError(type->loc(), "Call not yet implemented.");
+            case ConvertedNodeType::CALL: {
+                auto call               = type->as_call();
+                const auto& target_name = call->target()->as_var()->name();
+                auto target             = type_aliases_.at(target_name);
+
+                auto saved_regs = registers_;
+                // Bind params to registers
+                output += bindParams(target->as_record(), call->args());
+
+                // Generate the record body
+                auto [record_asm, _] = generateType(target);
+                output += std::move(record_asm);
+
+                // Restore the registers
+                registers_ = std::move(saved_regs);
+
+                return { std::move(output), type };
+            }
             case ConvertedNodeType::NUM:
             case ConvertedNodeType::OP:
             default:
@@ -278,23 +307,27 @@ class CodeGeneratorImpl {
         // Flatten the member chain
         const auto& [root, path] = flattenMember(op);
 
-        // Get the type info
-        auto type = assumed_types_[root.name()];
-
         // Load the base offset
         output += "push.i64 " + std::to_string(registers_.get(root.name()));
         output += "var.load";
 
+        auto type       = assumed_types_[root.name()];
+        auto saved_regs = registers_;
+
         // Walk through the path, accumulating offsets
         for (const auto& name : path) {
             auto curr_record = type->as_record();
+            if (const auto call = type->as_call()) {
+                auto const target_name = call->target()->as_var()->name();
+                curr_record = type_aliases_.at(target_name)->as_record();
+                output += bindParams(curr_record, call->args());
+            }
             for (const auto& field : curr_record->fields()) {
                 auto assume      = field->as_op();
                 auto& field_name = assume->args()[0]->as_var()->name();
                 auto [field_asm, field_type] = generateType(assume->args()[1]);
                 if (name == field_name) {
                     type = field_type;
-                    log_(0) << "  Found " << name << std::endl;
                     break;
                 }
                 output += std::move(field_asm);
@@ -302,6 +335,7 @@ class CodeGeneratorImpl {
                 output += "math.add";
             }
         }
+        registers_ = std::move(saved_regs);
 
         // Load the final value if it's a builtin type
         if (auto builtin = type->as_builtin_field()) {
@@ -315,9 +349,18 @@ class CodeGeneratorImpl {
 
     AssemblyOutput generateAssign(const ASTOp& op)
     {
-        auto& var             = *op.args()[0]->as_var();
-        auto [type_asm, type] = generateType(op.args()[1]);
+        auto& var = *op.args()[0]->as_var();
+        auto& rhs = op.args()[1];
 
+        // If the RHS is a parameterized record, do not generate the code
+        if (auto record = rhs->as_record()) {
+            if (!record->params().empty()) {
+                type_aliases_[var.name()] = rhs;
+                return AssemblyOutput{};
+            }
+        }
+
+        auto [type_asm, type]     = generateType(rhs);
         type_aliases_[var.name()] = type;
 
         AssemblyOutput output;
@@ -346,7 +389,7 @@ class CodeGeneratorImpl {
             output += builtin_field_to_load.at(builtin->kw());
             output +=
                     "push.i64 " + std::to_string(registers_.assign(var.name()));
-        } else if (type->as_record()) {
+        } else if (type->as_record() || type->as_call()) {
             // Otherwise, save the current position and type information
             output +=
                     "push.i64 " + std::to_string(registers_.assign(var.name()));

--- a/tools/sddl2/compiler/codegen/CodeGenerator.cpp
+++ b/tools/sddl2/compiler/codegen/CodeGenerator.cpp
@@ -88,7 +88,15 @@ class CodeGeneratorImpl {
         (void)log_;
         AssemblyOutput output;
         for (const auto& node : ast) {
-            output += generateOp(*node->as_op());
+            if (auto op = node->as_op()) {
+                output += generateOp(*op);
+            } else if (auto when = node->as_when()) {
+                (void)when;
+                throw CodegenError(node->loc(), "Not yet implemented!");
+            } else {
+                throw InvariantViolation(
+                        node->loc(), "Expected an operation or when.");
+            }
         }
         return output.str();
     }
@@ -178,6 +186,7 @@ class CodeGeneratorImpl {
             case ConvertedNodeType::ARRAY:
             case ConvertedNodeType::RECORD:
             case ConvertedNodeType::CALL:
+            case ConvertedNodeType::WHEN:
             default:
                 throw InvariantViolation(
                         node->loc(), "Expected a value, got a type.");
@@ -223,10 +232,16 @@ class CodeGeneratorImpl {
             case ConvertedNodeType::RECORD: {
                 auto record = type->as_record();
                 for (const auto& field : record->fields()) {
-                    auto assume            = field->as_op();
-                    const auto& field_type = assume->args()[1];
-                    auto [field_asm, _]    = generateType(field_type);
-                    output += std::move(field_asm);
+                    if (auto assume = field->as_op()) {
+                        const auto& field_type = assume->args()[1];
+                        auto [field_asm, _]    = generateType(field_type);
+                        output += std::move(field_asm);
+                    }
+                    if (auto when = field->as_when()) {
+                        (void)when;
+                        throw CodegenError(
+                                field->loc(), "Not yet implemented!");
+                    }
                 }
                 output += "push.i64 " + std::to_string(record->fields().size());
                 output += "type.structure";
@@ -276,6 +291,7 @@ class CodeGeneratorImpl {
             }
             case ConvertedNodeType::NUM:
             case ConvertedNodeType::OP:
+            case ConvertedNodeType::WHEN:
             default:
                 throw InvariantViolation(
                         type->loc(), "Expected a type, got a value.");

--- a/tools/sddl2/compiler/codegen/CodeGenerator.cpp
+++ b/tools/sddl2/compiler/codegen/CodeGenerator.cpp
@@ -177,6 +177,7 @@ class CodeGeneratorImpl {
             case ConvertedNodeType::BYTES:
             case ConvertedNodeType::ARRAY:
             case ConvertedNodeType::RECORD:
+            case ConvertedNodeType::CALL:
             default:
                 throw InvariantViolation(
                         node->loc(), "Expected a value, got a type.");
@@ -242,6 +243,8 @@ class CodeGeneratorImpl {
                 output += "type.fixed_array";
                 return { std::move(output), type };
             }
+            case ConvertedNodeType::CALL:
+                throw CodegenError(type->loc(), "Call not yet implemented.");
             case ConvertedNodeType::NUM:
             case ConvertedNodeType::OP:
             default:

--- a/tools/sddl2/compiler/optimizer/ConstFoldPass.cpp
+++ b/tools/sddl2/compiler/optimizer/ConstFoldPass.cpp
@@ -43,6 +43,8 @@ class ConstFoldImpl {
                 return optimize(*node->as_array());
             case ConvertedNodeType::RECORD:
                 return optimize(*node->as_record());
+            case ConvertedNodeType::CALL:
+                return optimize(*node->as_call());
             case ConvertedNodeType::OP:
                 return optimize(*node->as_op());
             default:
@@ -71,6 +73,17 @@ class ConstFoldImpl {
         }
         return Codegen(array.loc())
                 .array(optimizeNode(array.field()), optimizeNode(array.len()));
+    }
+
+    ASTPtr optimize(const ASTCall& call)
+    {
+        ASTVec new_args;
+        new_args.reserve(call.args().size());
+        for (const auto& arg : call.args()) {
+            new_args.push_back(optimizeNode(arg));
+        }
+        return Codegen(call.loc())
+                .call(optimizeNode(call.target()), std::move(new_args));
     }
 
     ASTPtr optimize(const ASTRecord& record)

--- a/tools/sddl2/compiler/optimizer/ConstFoldPass.cpp
+++ b/tools/sddl2/compiler/optimizer/ConstFoldPass.cpp
@@ -15,11 +15,14 @@ ASTPtr makeNum(const SourceLocation& loc, int64_t val)
 
 class ConstFoldImpl {
    public:
-    explicit ConstFoldImpl(const detail::Logger& logger) : log_(logger) {}
-
     ASTVec optimize(const ASTVec& ast)
     {
-        (void)log_;
+        return optimizeVec(ast);
+    }
+
+   private:
+    ASTVec optimizeVec(const ASTVec& ast)
+    {
         ASTVec result;
         result.reserve(ast.size());
         for (const auto& node : ast) {
@@ -28,7 +31,6 @@ class ConstFoldImpl {
         return result;
     }
 
-   private:
     ASTPtr optimizeNode(const ASTPtr& node)
     {
         switch (node->converted_node_type()) {
@@ -36,23 +38,23 @@ class ConstFoldImpl {
             case ConvertedNodeType::BUILTIN_FIELD:
                 return node;
             case ConvertedNodeType::VAR:
-                return optimize(*node->as_var());
+                return optimizeVar(*node->as_var());
             case ConvertedNodeType::BYTES:
-                return optimize(*node->as_bytes());
+                return optimizeBytes(*node->as_bytes());
             case ConvertedNodeType::ARRAY:
-                return optimize(*node->as_array());
+                return optimizeArray(*node->as_array());
             case ConvertedNodeType::RECORD:
-                return optimize(*node->as_record());
+                return optimizeRecord(*node->as_record());
             case ConvertedNodeType::CALL:
-                return optimize(*node->as_call());
+                return optimizeCall(*node->as_call());
             case ConvertedNodeType::OP:
-                return optimize(*node->as_op());
+                return optimizeOp(*node->as_op());
             default:
                 throw InvariantViolation("Unsupported AST node type.");
         }
     }
 
-    ASTPtr optimize(const ASTVar& var)
+    ASTPtr optimizeVar(const ASTVar& var)
     {
         auto it = const_vars_.find(var.name());
         if (it != const_vars_.end()) {
@@ -61,12 +63,12 @@ class ConstFoldImpl {
         return std::make_shared<ASTVar>(var);
     }
 
-    ASTPtr optimize(const ASTBytes& bytes)
+    ASTPtr optimizeBytes(const ASTBytes& bytes)
     {
         return Codegen(bytes.loc()).bytes(optimizeNode(bytes.len()));
     }
 
-    ASTPtr optimize(const ASTArray& array)
+    ASTPtr optimizeArray(const ASTArray& array)
     {
         if (!array.len()) {
             return Codegen(array.loc()).array(optimizeNode(array.field()));
@@ -75,31 +77,22 @@ class ConstFoldImpl {
                 .array(optimizeNode(array.field()), optimizeNode(array.len()));
     }
 
-    ASTPtr optimize(const ASTCall& call)
+    ASTPtr optimizeCall(const ASTCall& call)
     {
-        ASTVec new_args;
-        new_args.reserve(call.args().size());
-        for (const auto& arg : call.args()) {
-            new_args.push_back(optimizeNode(arg));
-        }
         return Codegen(call.loc())
-                .call(optimizeNode(call.target()), std::move(new_args));
+                .call(optimizeNode(call.target()), optimizeVec(call.args()));
     }
 
-    ASTPtr optimize(const ASTRecord& record)
+    ASTPtr optimizeRecord(const ASTRecord& record)
     {
-        auto saved_vars = const_vars_;
-        ASTVec new_fields;
-        new_fields.reserve(record.fields().size());
-        for (const auto& field : record.fields()) {
-            new_fields.push_back(optimizeNode(field));
-        }
-        const_vars_ = std::move(saved_vars);
+        auto saved_vars   = const_vars_;
+        ASTVec new_fields = optimizeVec(record.fields());
+        const_vars_       = std::move(saved_vars);
         return Codegen(record.loc())
                 .record(record.params(), std::move(new_fields));
     }
 
-    ASTPtr optimize(const ASTOp& op)
+    ASTPtr optimizeOp(const ASTOp& op)
     {
         ASTVec new_args;
 
@@ -188,7 +181,6 @@ class ConstFoldImpl {
         }
     }
 
-    const detail::Logger& log_;
     std::unordered_map<std::string, int64_t> const_vars_;
 };
 
@@ -198,7 +190,8 @@ ConstFoldPass::ConstFoldPass(const detail::Logger& logger) : log_(logger) {}
 
 ASTVec ConstFoldPass::optimize(const ASTVec& ast) const
 {
-    return ConstFoldImpl{ log_ }.optimize(ast);
+    log_(1) << "Running Constant Folding Pass ..." << std::endl;
+    return ConstFoldImpl{}.optimize(ast);
 }
 
 } // namespace openzl::sddl2

--- a/tools/sddl2/compiler/optimizer/ConstFoldPass.cpp
+++ b/tools/sddl2/compiler/optimizer/ConstFoldPass.cpp
@@ -26,7 +26,12 @@ class ConstFoldImpl {
         ASTVec result;
         result.reserve(ast.size());
         for (const auto& node : ast) {
-            result.push_back(optimizeNode(node));
+            if (auto when = node->as_when()) {
+                auto optimized = optimizeWhen(*when);
+                result.insert(result.end(), optimized.begin(), optimized.end());
+            } else {
+                result.push_back(optimizeNode(node));
+            }
         }
         return result;
     }
@@ -50,8 +55,6 @@ class ConstFoldImpl {
             case ConvertedNodeType::OP:
                 return optimizeOp(*node->as_op());
             case ConvertedNodeType::WHEN:
-                // TODO: implement
-                return node;
             default:
                 throw InvariantViolation("Unsupported AST node type.");
         }
@@ -93,6 +96,22 @@ class ConstFoldImpl {
         const_vars_       = std::move(saved_vars);
         return Codegen(record.loc())
                 .record(record.params(), std::move(new_fields));
+    }
+
+    ASTVec optimizeWhen(const ASTWhen& when)
+    {
+        auto optimized_cond = optimizeNode(when.condition());
+
+        if (auto* cond_num = optimized_cond->as_num()) {
+            if (cond_num->val() == 0) {
+                return ASTVec{};
+            }
+            return optimizeVec(when.body());
+        }
+
+        return { Codegen(when.loc())
+                         .when(std::move(optimized_cond),
+                               optimizeVec(when.body())) };
     }
 
     ASTPtr optimizeOp(const ASTOp& op)

--- a/tools/sddl2/compiler/optimizer/ConstFoldPass.cpp
+++ b/tools/sddl2/compiler/optimizer/ConstFoldPass.cpp
@@ -49,6 +49,9 @@ class ConstFoldImpl {
                 return optimizeCall(*node->as_call());
             case ConvertedNodeType::OP:
                 return optimizeOp(*node->as_op());
+            case ConvertedNodeType::WHEN:
+                // TODO: implement
+                return node;
             default:
                 throw InvariantViolation("Unsupported AST node type.");
         }

--- a/tools/sddl2/compiler/optimizer/DeadVarPass.cpp
+++ b/tools/sddl2/compiler/optimizer/DeadVarPass.cpp
@@ -14,24 +14,19 @@ class DeadVarImpl {
     {
         // Phase 1: collect all variable reads and record the last reference to
         // a variable
-        for (const auto& node : ast) {
-            recordLastRefs(node);
-        }
+        recordLastRefs(ast);
 
         // Phase 2: optimize the AST
-        ASTVec result;
-        result.reserve(ast.size());
-        for (const auto& node : ast) {
-            // It's possible that the node is optimized away.
-            auto optimized = optimizeNode(node);
-            if (optimized) {
-                result.push_back(optimized);
-            }
-        }
-        return result;
+        return optimizeVec(ast);
     }
 
    private:
+    void recordLastRefs(const ASTVec& vec)
+    {
+        for (const auto& node : vec) {
+            recordLastRefs(node);
+        }
+    }
     void recordLastRefs(const ASTPtr& node)
     {
         switch (node->converted_node_type()) {
@@ -57,15 +52,11 @@ class DeadVarImpl {
             case ConvertedNodeType::CALL: {
                 auto call = node->as_call();
                 recordLastRefs(call->target());
-                for (const auto& arg : call->args()) {
-                    recordLastRefs(arg);
-                }
+                recordLastRefs(call->args());
                 return;
             }
             case ConvertedNodeType::RECORD: {
-                for (const auto& field : node->as_record()->fields()) {
-                    recordLastRefs(field);
-                }
+                recordLastRefs(node->as_record()->fields());
                 return;
             }
             case ConvertedNodeType::OP: {
@@ -78,12 +69,24 @@ class DeadVarImpl {
                     recordLastRefs(op.args()[0]);
                     return;
                 }
-                for (size_t i = 0; i < op.args().size(); ++i) {
-                    recordLastRefs(op.args()[i]);
-                }
+                recordLastRefs(op.args());
                 return;
             }
         }
+    }
+
+    ASTVec optimizeVec(const ASTVec& vec)
+    {
+        ASTVec result;
+        result.reserve(vec.size());
+        for (const auto& node : vec) {
+            // It's possible that the node is optimized away.
+            auto optimized = optimizeNode(node);
+            if (optimized) {
+                result.push_back(optimized);
+            }
+        }
+        return result;
     }
 
     ASTPtr optimizeNode(const ASTPtr& node)
@@ -94,21 +97,21 @@ class DeadVarImpl {
             case ConvertedNodeType::RECORD:
                 return node;
             case ConvertedNodeType::VAR:
-                return optimize(node->as_var());
+                return optimizeVar(node->as_var());
             case ConvertedNodeType::BYTES:
-                return optimize(node->as_bytes());
+                return optimizeBytes(node->as_bytes());
             case ConvertedNodeType::ARRAY:
-                return optimize(node->as_array());
+                return optimizeArray(node->as_array());
             case ConvertedNodeType::CALL:
-                return optimize(node->as_call());
+                return optimizeCall(node->as_call());
             case ConvertedNodeType::OP:
-                return optimize(node->as_op());
+                return optimizeOp(node->as_op());
             default:
                 throw InvariantViolation("Unsupported AST node type.");
         }
     }
 
-    ASTPtr optimize(const ASTVar* var)
+    ASTPtr optimizeVar(const ASTVar* var)
     {
         const auto& last_ref_it = last_ref_.find(var->name());
         if (last_ref_it == last_ref_.end()) {
@@ -121,12 +124,12 @@ class DeadVarImpl {
         return Codegen(var->loc()).var(var->name());
     }
 
-    ASTPtr optimize(const ASTBytes* bytes)
+    ASTPtr optimizeBytes(const ASTBytes* bytes)
     {
         return Codegen(bytes->loc()).bytes(optimizeNode(bytes->len()));
     }
 
-    ASTPtr optimize(const ASTArray* arr)
+    ASTPtr optimizeArray(const ASTArray* arr)
     {
         if (!arr->len()) {
             return Codegen(arr->loc()).array(optimizeNode(arr->field()));
@@ -135,18 +138,13 @@ class DeadVarImpl {
                 .array(optimizeNode(arr->field()), optimizeNode(arr->len()));
     }
 
-    ASTPtr optimize(const ASTCall* call)
+    ASTPtr optimizeCall(const ASTCall* call)
     {
-        ASTVec new_args;
-        new_args.reserve(call->args().size());
-        for (const auto& arg : call->args()) {
-            new_args.push_back(optimizeNode(arg));
-        }
         return Codegen(call->loc())
-                .call(optimizeNode(call->target()), std::move(new_args));
+                .call(optimizeNode(call->target()), optimizeVec(call->args()));
     }
 
-    ASTPtr optimize(const ASTOp* op)
+    ASTPtr optimizeOp(const ASTOp* op)
     {
         // If the variable is not referenced, we can remove the assignment
         if (op->op() == Op::ASSIGN) {
@@ -171,11 +169,7 @@ class DeadVarImpl {
         }
 
         // Other ops
-        ASTVec args;
-        for (size_t i = 0; i < op->args().size(); ++i) {
-            args.push_back(optimizeNode(op->args()[i]));
-        }
-        return Codegen(op->loc()).op(op->op(), std::move(args));
+        return Codegen(op->loc()).op(op->op(), optimizeVec(op->args()));
     }
 
     // Maps variable name → the last time it is referenced. Variables not in

--- a/tools/sddl2/compiler/optimizer/DeadVarPass.cpp
+++ b/tools/sddl2/compiler/optimizer/DeadVarPass.cpp
@@ -73,7 +73,9 @@ class DeadVarImpl {
                 return;
             }
             case ConvertedNodeType::WHEN: {
-                // TODO: implement
+                auto when = node->as_when();
+                recordLastRefs(when->condition());
+                recordLastRefs(when->body());
                 return;
             }
         }
@@ -111,8 +113,7 @@ class DeadVarImpl {
             case ConvertedNodeType::OP:
                 return optimizeOp(node->as_op());
             case ConvertedNodeType::WHEN:
-                // TODO: implement
-                return node;
+                return optimizeWhen(node->as_when());
             default:
                 throw InvariantViolation("Unsupported AST node type.");
         }
@@ -177,6 +178,13 @@ class DeadVarImpl {
 
         // Other ops
         return Codegen(op->loc()).op(op->op(), optimizeVec(op->args()));
+    }
+
+    ASTPtr optimizeWhen(const ASTWhen* when)
+    {
+        return Codegen(when->loc())
+                .when(optimizeNode(when->condition()),
+                      optimizeVec(when->body()));
     }
 
     // Maps variable name → the last time it is referenced. Variables not in

--- a/tools/sddl2/compiler/optimizer/DeadVarPass.cpp
+++ b/tools/sddl2/compiler/optimizer/DeadVarPass.cpp
@@ -72,6 +72,10 @@ class DeadVarImpl {
                 recordLastRefs(op.args());
                 return;
             }
+            case ConvertedNodeType::WHEN: {
+                // TODO: implement
+                return;
+            }
         }
     }
 
@@ -106,6 +110,9 @@ class DeadVarImpl {
                 return optimizeCall(node->as_call());
             case ConvertedNodeType::OP:
                 return optimizeOp(node->as_op());
+            case ConvertedNodeType::WHEN:
+                // TODO: implement
+                return node;
             default:
                 throw InvariantViolation("Unsupported AST node type.");
         }

--- a/tools/sddl2/compiler/optimizer/DeadVarPass.cpp
+++ b/tools/sddl2/compiler/optimizer/DeadVarPass.cpp
@@ -54,6 +54,14 @@ class DeadVarImpl {
                 }
                 return;
             }
+            case ConvertedNodeType::CALL: {
+                auto call = node->as_call();
+                recordLastRefs(call->target());
+                for (const auto& arg : call->args()) {
+                    recordLastRefs(arg);
+                }
+                return;
+            }
             case ConvertedNodeType::RECORD: {
                 for (const auto& field : node->as_record()->fields()) {
                     recordLastRefs(field);
@@ -91,6 +99,8 @@ class DeadVarImpl {
                 return optimize(node->as_bytes());
             case ConvertedNodeType::ARRAY:
                 return optimize(node->as_array());
+            case ConvertedNodeType::CALL:
+                return optimize(node->as_call());
             case ConvertedNodeType::OP:
                 return optimize(node->as_op());
             default:
@@ -123,6 +133,17 @@ class DeadVarImpl {
         }
         return Codegen(arr->loc())
                 .array(optimizeNode(arr->field()), optimizeNode(arr->len()));
+    }
+
+    ASTPtr optimize(const ASTCall* call)
+    {
+        ASTVec new_args;
+        new_args.reserve(call->args().size());
+        for (const auto& arg : call->args()) {
+            new_args.push_back(optimizeNode(arg));
+        }
+        return Codegen(call->loc())
+                .call(optimizeNode(call->target()), std::move(new_args));
     }
 
     ASTPtr optimize(const ASTOp* op)

--- a/tools/sddl2/compiler/parser/AST.cpp
+++ b/tools/sddl2/compiler/parser/AST.cpp
@@ -57,6 +57,11 @@ const ASTRecord* ASTNode::as_record() const
     return nullptr;
 }
 
+const ASTCall* ASTNode::as_call() const
+{
+    return nullptr;
+}
+
 const ASTOp* ASTNode::as_op() const
 {
     return nullptr;
@@ -368,6 +373,39 @@ ASTVec ASTRecord::extract_params(
                 loc, "Record declaration params list must be parens.");
     }
     return unwrap_parens(list->nodes());
+}
+
+ASTCall::ASTCall(ASTPtr target, ASTVec args)
+        : ASTField(some(target).loc() + join_locs(args)),
+          target_(std::move(target)),
+          args_(std::move(args))
+{
+}
+
+const ASTCall* ASTCall::as_call() const
+{
+    return this;
+}
+
+void ASTCall::print(std::ostream& os, size_t indent) const
+{
+    os << std::string(indent, ' ') << "Field: CALL:" << std::endl;
+    os << std::string(indent + 2, ' ') << "Target: " << std::endl;
+    target_->print(os, indent + 4);
+    os << std::string(indent + 2, ' ') << "Args: " << std::endl;
+    for (const auto& arg : args_) {
+        arg->print(os, indent + 4);
+    }
+}
+
+const ASTPtr& ASTCall::target() const
+{
+    return target_;
+}
+
+const ASTVec& ASTCall::args() const
+{
+    return args_;
 }
 
 ASTArray::ASTArray(const ASTPtr& field, const ASTPtr& len)

--- a/tools/sddl2/compiler/parser/AST.cpp
+++ b/tools/sddl2/compiler/parser/AST.cpp
@@ -62,6 +62,11 @@ const ASTCall* ASTNode::as_call() const
     return nullptr;
 }
 
+const ASTWhen* ASTNode::as_when() const
+{
+    return nullptr;
+}
+
 const ASTOp* ASTNode::as_op() const
 {
     return nullptr;
@@ -406,6 +411,39 @@ const ASTPtr& ASTCall::target() const
 const ASTVec& ASTCall::args() const
 {
     return args_;
+}
+
+ASTWhen::ASTWhen(ASTPtr condition, ASTVec body)
+        : ASTConverted(some(condition).loc() + join_locs(body)),
+          condition_(std::move(condition)),
+          body_(std::move(body))
+{
+}
+
+const ASTWhen* ASTWhen::as_when() const
+{
+    return this;
+}
+
+void ASTWhen::print(std::ostream& os, size_t indent) const
+{
+    os << std::string(indent, ' ') << "When:" << std::endl;
+    os << std::string(indent + 2, ' ') << "Condition:" << std::endl;
+    condition_->print(os, indent + 4);
+    os << std::string(indent + 2, ' ') << "Body:" << std::endl;
+    for (const auto& stmt : body_) {
+        stmt->print(os, indent + 4);
+    }
+}
+
+const ASTPtr& ASTWhen::condition() const
+{
+    return condition_;
+}
+
+const ASTVec& ASTWhen::body() const
+{
+    return body_;
 }
 
 ASTArray::ASTArray(const ASTPtr& field, const ASTPtr& len)

--- a/tools/sddl2/compiler/parser/AST.h
+++ b/tools/sddl2/compiler/parser/AST.h
@@ -27,6 +27,7 @@ class ASTBuiltinField;
 class ASTBytes;
 class ASTArray;
 class ASTRecord;
+class ASTCall;
 class ASTOp;
 
 enum class ConvertedNodeType {
@@ -36,6 +37,7 @@ enum class ConvertedNodeType {
     BYTES,
     ARRAY,
     RECORD,
+    CALL,
     OP
 };
 
@@ -57,6 +59,7 @@ class ASTNode {
     virtual const ASTBytes* as_bytes() const;
     virtual const ASTArray* as_array() const;
     virtual const ASTRecord* as_record() const;
+    virtual const ASTCall* as_call() const;
     virtual const ASTOp* as_op() const;
 
     bool operator==(const Symbol& symbol) const;
@@ -264,6 +267,27 @@ class ASTRecord : public ASTField {
     const ASTVec fields_;
 };
 
+class ASTCall : public ASTField {
+   public:
+    explicit ASTCall(ASTPtr target, ASTVec args);
+
+    const ASTCall* as_call() const override;
+
+    void print(std::ostream& os, size_t indent) const override;
+
+    ConvertedNodeType converted_node_type() const override final
+    {
+        return ConvertedNodeType::CALL;
+    }
+
+    const ASTPtr& target() const;
+    const ASTVec& args() const;
+
+   private:
+    const ASTPtr target_;
+    const ASTVec args_;
+};
+
 class ASTArray : public ASTField {
    public:
     explicit ASTArray(const ASTPtr& field, const ASTPtr& len);
@@ -434,6 +458,11 @@ class Codegen {
     {
         return std::make_shared<ASTRecord>(
                 paren_list(std::move(params)), curly_list(std::move(fields)));
+    }
+
+    ASTPtr call(ASTPtr target, ASTVec args) const
+    {
+        return std::make_shared<ASTCall>(std::move(target), std::move(args));
     }
 
     ASTPtr var(poly::string_view name) const

--- a/tools/sddl2/compiler/parser/AST.h
+++ b/tools/sddl2/compiler/parser/AST.h
@@ -28,6 +28,7 @@ class ASTBytes;
 class ASTArray;
 class ASTRecord;
 class ASTCall;
+class ASTWhen;
 class ASTOp;
 
 enum class ConvertedNodeType {
@@ -38,6 +39,7 @@ enum class ConvertedNodeType {
     ARRAY,
     RECORD,
     CALL,
+    WHEN,
     OP
 };
 
@@ -60,6 +62,7 @@ class ASTNode {
     virtual const ASTArray* as_array() const;
     virtual const ASTRecord* as_record() const;
     virtual const ASTCall* as_call() const;
+    virtual const ASTWhen* as_when() const;
     virtual const ASTOp* as_op() const;
 
     bool operator==(const Symbol& symbol) const;
@@ -288,6 +291,27 @@ class ASTCall : public ASTField {
     const ASTVec args_;
 };
 
+class ASTWhen : public ASTConverted {
+   public:
+    explicit ASTWhen(ASTPtr condition, ASTVec body);
+
+    const ASTWhen* as_when() const override;
+
+    void print(std::ostream& os, size_t indent) const override;
+
+    ConvertedNodeType converted_node_type() const override final
+    {
+        return ConvertedNodeType::WHEN;
+    }
+
+    const ASTPtr& condition() const;
+    const ASTVec& body() const;
+
+   private:
+    const ASTPtr condition_;
+    const ASTVec body_;
+};
+
 class ASTArray : public ASTField {
    public:
     explicit ASTArray(const ASTPtr& field, const ASTPtr& len);
@@ -463,6 +487,11 @@ class Codegen {
     ASTPtr call(ASTPtr target, ASTVec args) const
     {
         return std::make_shared<ASTCall>(std::move(target), std::move(args));
+    }
+
+    ASTPtr when(ASTPtr condition, ASTVec body) const
+    {
+        return std::make_shared<ASTWhen>(std::move(condition), std::move(body));
     }
 
     ASTPtr var(poly::string_view name) const

--- a/tools/sddl2/compiler/parser/Grammar.cpp
+++ b/tools/sddl2/compiler/parser/Grammar.cpp
@@ -497,6 +497,31 @@ class AnonymousRecordRule : public GrammarRule {
     }
 };
 
+class CallRule : public GrammarRule {
+   public:
+    explicit CallRule()
+            : GrammarRule(
+                      Symbol::PAREN_OPEN, /* bit weird */
+                      Precedence::ACCESS,
+                      std::vector<ArgType>({ ArgType::EXPR }),
+                      true)
+    {
+    }
+
+   private:
+    ASTPtr do_gen(ASTPtr op, ArgsVec args) const override
+    {
+        auto& target     = args.at(0);
+        const auto* list = some(op).as_list();
+        if (list == nullptr || list->list_type() != ListType::PAREN) {
+            throw InvariantViolation(
+                    some(op).loc(), "Expected paren list in call.");
+        }
+        return std::make_shared<ASTCall>(
+                std::move(target), unwrap_parens(list->nodes()));
+    }
+};
+
 class BytesRule : public GrammarRule {
    public:
     explicit BytesRule()
@@ -588,7 +613,9 @@ const std::map<Symbol, GrammarRuleRefs> syms_to_rules{ []() {
 const std::map<ListType, GrammarRuleRefs> list_types_to_rules{ []() {
     std::map<ListType, GrammarRuleRefs> m;
 
-    m[ListType::PAREN] = {};
+    static const std::unique_ptr<const GrammarRule> call_rule =
+            std::make_unique<CallRule>();
+    m[ListType::PAREN] = { *call_rule };
 
     static const std::unique_ptr<const GrammarRule> array_rule =
             std::make_unique<ArrayRule>();

--- a/tools/sddl2/compiler/parser/Grammar.cpp
+++ b/tools/sddl2/compiler/parser/Grammar.cpp
@@ -539,6 +539,28 @@ class BytesRule : public GrammarRule {
     }
 };
 
+class WhenRule : public GrammarRule {
+   public:
+    explicit WhenRule()
+            : GrammarRule(
+                      Symbol::WHEN,
+                      Precedence::NULLARY,
+                      std::vector<ArgType>(
+                              { ArgType::EXPR, ArgType::LIST_CURLY }))
+    {
+    }
+
+   private:
+    ASTPtr do_gen(ASTPtr op, ArgsVec args) const override
+    {
+        auto& condition = args.at(0);
+        auto& body_list = args.at(1);
+
+        return std::make_shared<ASTWhen>(
+                std::move(condition), unwrap_curly(body_list));
+    }
+};
+
 template <typename RuleT, typename... Args>
 void add_rule(
         std::vector<std::unique_ptr<const GrammarRule>>& rules,
@@ -563,6 +585,7 @@ const std::vector<std::unique_ptr<const GrammarRule>> grammar_rules{ []() {
     // Ops
     add_rule<UnaryOpRule>(r, Symbol::EXPECT, Precedence::ASSIGNMENT);
     add_rule<UnaryOpRule>(r, Symbol::SIZEOF);
+    add_rule<WhenRule>(r);
 
     add_rule<BinaryOpRule>(r, Symbol::ASSIGN, Precedence::ASSIGNMENT);
     add_rule<BinaryOpRule>(r, Symbol::ASSUME, Precedence::ASSIGNMENT);

--- a/tools/sddl2/compiler/semantic_analyzer/SemanticAnalyzer.cpp
+++ b/tools/sddl2/compiler/semantic_analyzer/SemanticAnalyzer.cpp
@@ -1,5 +1,6 @@
 // Copyright (c) Meta Platforms, Inc. and affiliates.
 
+#include <optional>
 #include <unordered_map>
 #include <unordered_set>
 
@@ -115,6 +116,8 @@ class SemanticAnalyzerImpl {
                 return analyze(*node->as_array());
             case ConvertedNodeType::RECORD:
                 return analyze(*node->as_record());
+            case ConvertedNodeType::CALL:
+                return analyze(*node->as_call());
             case ConvertedNodeType::OP:
                 return analyze(*node->as_op());
             default:
@@ -149,8 +152,19 @@ class SemanticAnalyzerImpl {
 
     Type analyze(const ASTRecord& record)
     {
-        // Validate all fields are ASSUME ops
+        // Validate params are variable names and introduce them as NUMERIC
         auto saved_vars = var_types_;
+        for (const auto& param : record.params()) {
+            const auto* var = param->as_var();
+            if (!var) {
+                throw SemanticError(
+                        param->loc(),
+                        "Record parameter must be a variable name.");
+            }
+            var_types_[var->name()] = Type{ TypeKind::NUMERIC };
+        }
+
+        // Validate all fields are ASSUME ops
         for (const auto& field : record.fields()) {
             auto assume = field->as_op();
             if (!assume || assume->op() != Op::ASSUME) {
@@ -162,13 +176,39 @@ class SemanticAnalyzerImpl {
         }
         var_types_ = std::move(saved_vars);
 
-        // TODO: support params
-        if (!record.params().empty()) {
+        return Type{ TypeKind::RECORD, &record };
+    }
+
+    Type analyze(const ASTCall& call)
+    {
+        // Target must resolve to a record type
+        auto target_type = analyzeNode(call.target());
+        if (target_type.kind != TypeKind::RECORD) {
             throw SemanticError(
-                    record.loc(), "Record params not yet supported!");
+                    call.target()->loc(), "Call target must be a record type.");
         }
 
-        return Type{ TypeKind::RECORD, &record };
+        const auto* record = target_type.type_def->as_record();
+        if (!record) {
+            throw SemanticError(
+                    call.target()->loc(), "Call target must be a record type.");
+        }
+
+        // Validate argument count matches parameter count
+        if (call.args().size() != record->params().size()) {
+            throw SemanticError(
+                    call.loc(),
+                    "Expected " + std::to_string(record->params().size())
+                            + " arguments but got "
+                            + std::to_string(call.args().size()) + ".");
+        }
+
+        // Validate each argument is a numeric expression
+        for (const auto& arg : call.args()) {
+            expectNumeric(analyzeNode(arg));
+        }
+
+        return Type{ TypeKind::RECORD, target_type.type_def };
     }
 
     Type analyze(const ASTOp& op)
@@ -251,6 +291,7 @@ class SemanticAnalyzerImpl {
 
     Type analyzeMember(const ASTOp& op)
     {
+        auto saved_vars = var_types_;
         // Check that the LHS is a consumed record
         auto lhs_type = analyzeNode(op.args()[0]);
         if (lhs_type.kind != TypeKind::CONSUMED_RECORD) {
@@ -260,18 +301,30 @@ class SemanticAnalyzerImpl {
         }
 
         // Check that the RHS is a valid field name return the consumed type
-        const auto* record     = lhs_type.type_def->as_record();
+        auto* record           = lhs_type.type_def->as_record();
         const auto& field_name = someVar(op.args()[1])->name();
+
+        // Add the record params to scope
+        for (const auto& param : record->params()) {
+            var_types_[param->as_var()->name()] = Type{ TypeKind::NUMERIC };
+        }
+
+        // Find the field
+        std::optional<Type> found_type;
         for (const auto& field : record->fields()) {
             auto assume = field->as_op();
             auto& name  = assume->args()[0]->as_var()->name();
             if (name == field_name) {
-                return assumedType(analyzeNode(assume->args()[1]));
+                found_type = assumedType(analyzeNode(assume->args()[1]));
             }
         }
-        throw SemanticError(
-                op.args()[1]->loc(),
-                "Field '" + field_name + "' not a valid record field.");
+        if (!found_type) {
+            throw SemanticError(
+                    op.args()[1]->loc(),
+                    "Field '" + field_name + "' not a valid record field.");
+        }
+        var_types_ = std::move(saved_vars);
+        return *found_type;
     }
 };
 

--- a/tools/sddl2/compiler/semantic_analyzer/SemanticAnalyzer.cpp
+++ b/tools/sddl2/compiler/semantic_analyzer/SemanticAnalyzer.cpp
@@ -118,6 +118,8 @@ class SemanticAnalyzerImpl {
                 return analyze(*node->as_record());
             case ConvertedNodeType::CALL:
                 return analyze(*node->as_call());
+            case ConvertedNodeType::WHEN:
+                return analyze(*node->as_when());
             case ConvertedNodeType::OP:
                 return analyze(*node->as_op());
             default:
@@ -150,6 +152,23 @@ class SemanticAnalyzerImpl {
         return Type{ TypeKind::ARRAY, &array };
     }
 
+    void analyzeRecordFields(const ASTVec& fields)
+    {
+        for (const auto& field : fields) {
+            if (auto op = field->as_op()) {
+                if (op->op() != Op::ASSUME) {
+                    throw SemanticError(op->loc(), "Invalid record field!");
+                }
+                analyzeAssume(*op);
+            } else if (auto when = field->as_when()) {
+                expectNumeric(analyzeNode(when->condition()));
+                analyzeRecordFields(when->body());
+            } else {
+                throw SemanticError(field->loc(), "Invalid record field!");
+            }
+        }
+    }
+
     Type analyze(const ASTRecord& record)
     {
         // Validate params are variable names and introduce them as NUMERIC
@@ -164,16 +183,8 @@ class SemanticAnalyzerImpl {
             var_types_[var->name()] = Type{ TypeKind::NUMERIC };
         }
 
-        // Validate all fields are ASSUME ops
-        for (const auto& field : record.fields()) {
-            auto assume = field->as_op();
-            if (!assume || assume->op() != Op::ASSUME) {
-                throw SemanticError(
-                        field->loc(),
-                        "Record field must be an assume operation!");
-            }
-            analyzeAssume(*assume);
-        }
+        // Validate all fields
+        analyzeRecordFields(record.fields());
         var_types_ = std::move(saved_vars);
 
         return Type{ TypeKind::RECORD, &record };
@@ -325,6 +336,15 @@ class SemanticAnalyzerImpl {
         }
         var_types_ = std::move(saved_vars);
         return *found_type;
+    }
+
+    Type analyze(const ASTWhen& when)
+    {
+        expectNumeric(analyzeNode(when.condition()));
+        for (const auto& stmt : when.body()) {
+            analyzeNode(stmt);
+        }
+        return Type{ TypeKind::NONE };
     }
 };
 

--- a/tools/sddl2/compiler/tests/OptimizerTest.cpp
+++ b/tools/sddl2/compiler/tests/OptimizerTest.cpp
@@ -216,4 +216,20 @@ TEST_F(OptimizerTest, RecordMemberLastReference)
     expect_ast(prog, expected);
 }
 
+TEST_F(OptimizerTest, WhenConstant)
+{
+    const auto prog     = R"(
+        when 1 {
+            : Int32LE
+        }
+        when 0 {
+            : Int16LE
+        }
+    )";
+    const auto cg       = Codegen(SourceLocation::null());
+    const auto expected = std::vector<ASTPtr>(
+            { cg.consume(cg.builtin_field(Symbol::I32LE)) });
+    expect_ast(prog, expected);
+}
+
 } // namespace openzl::sddl2::tests

--- a/tools/sddl2/compiler/tests/ParserTest.cpp
+++ b/tools/sddl2/compiler/tests/ParserTest.cpp
@@ -314,4 +314,39 @@ TEST_F(ParserTest, SimpleSaoAST)
     expect_ast(prog, expected);
 }
 
+TEST_F(ParserTest, CallAST)
+{
+    const auto prog = R"(
+        Record Foo(A, B) = {
+            x: Int32LE[A],
+            y: Int16LE[B]
+        }
+        : Foo(3, 5)
+    )";
+
+    const auto cg       = Codegen(SourceLocation::null());
+    const auto expected = std::vector<ASTPtr>({
+            cg.assign(
+                    cg.var("Foo"),
+                    cg.record(
+                            ArgVec{ cg.var("A"), cg.var("B") },
+                            ArgVec{
+                                    cg.assume(
+                                            cg.var("x"),
+                                            cg.array(
+                                                    cg.builtin_field(
+                                                            Symbol::I32LE),
+                                                    cg.var("A"))),
+                                    cg.assume(
+                                            cg.var("y"),
+                                            cg.array(
+                                                    cg.builtin_field(
+                                                            Symbol::I16LE),
+                                                    cg.var("B"))),
+                            })),
+            cg.consume(cg.call(cg.var("Foo"), ArgVec{ cg.num(3), cg.num(5) })),
+    });
+    expect_ast(prog, expected);
+}
+
 } // namespace openzl::sddl2::tests

--- a/tools/sddl2/compiler/tests/ParserTest.cpp
+++ b/tools/sddl2/compiler/tests/ParserTest.cpp
@@ -349,4 +349,56 @@ TEST_F(ParserTest, CallAST)
     expect_ast(prog, expected);
 }
 
+TEST_F(ParserTest, WhenBlockAST)
+{
+    const auto prog = R"(
+        flag: UInt8
+        when flag == 1 {
+            x: Int32LE
+        }
+    )";
+
+    const auto cg       = Codegen(SourceLocation::null());
+    const auto expected = std::vector<ASTPtr>({
+            cg.assume(cg.var("flag"), cg.builtin_field(Symbol::U8)),
+            cg.when(cg.eq(cg.var("flag"), cg.num(1)),
+                    ArgVec{ cg.assume(
+                            cg.var("x"), cg.builtin_field(Symbol::I32LE)) }),
+    });
+    expect_ast(prog, expected);
+}
+
+TEST_F(ParserTest, WhenBlockInRecordAST)
+{
+    const auto prog = R"(
+        Record Data(flag) = {
+            base: UInt32LE,
+            when flag {
+                optional: UInt16LE
+            }
+        }
+        : Data(1)
+    )";
+
+    const auto cg       = Codegen(SourceLocation::null());
+    const auto expected = std::vector<ASTPtr>({
+            cg.assign(
+                    cg.var("Data"),
+                    cg.record(
+                            ArgVec{ cg.var("flag") },
+                            ArgVec{
+                                    cg.assume(
+                                            cg.var("base"),
+                                            cg.builtin_field(Symbol::U32LE)),
+                                    cg.when(cg.var("flag"),
+                                            ArgVec{ cg.assume(
+                                                    cg.var("optional"),
+                                                    cg.builtin_field(
+                                                            Symbol::U16LE)) }),
+                            })),
+            cg.consume(cg.call(cg.var("Data"), ArgVec{ cg.num(1) })),
+    });
+    expect_ast(prog, expected);
+}
+
 } // namespace openzl::sddl2::tests

--- a/tools/sddl2/compiler/tests/SemanticAnalyzerTest.cpp
+++ b/tools/sddl2/compiler/tests/SemanticAnalyzerTest.cpp
@@ -254,4 +254,86 @@ TEST_F(SemanticAnalyzerTest, ParameterizedRecordCallNonRecord)
     expect_error(prog, "record type");
 }
 
+TEST_F(SemanticAnalyzerTest, WhenBlockWithNonNumericCondition)
+{
+    const auto prog = R"(
+        when Int32LE {
+            : Int32LE
+        }
+    )";
+    expect_error(prog, "numeric");
+}
+
+TEST_F(SemanticAnalyzerTest, WhenBlockWithUndefinedVarInCondition)
+{
+    const auto prog = R"(
+        when undefined_var == 1 {
+            : Int32LE
+        }
+    )";
+    expect_error(prog, "Undefined variable");
+}
+
+TEST_F(SemanticAnalyzerTest, NestedWhenBlocks)
+{
+    const auto prog = R"(
+        a: UInt8
+        b: UInt8
+        when a == 1 {
+            when b == 2 {
+                : Int32LE
+            }
+        }
+    )";
+
+    // TODO: this will pass once codegen is implemented
+    expect_error(prog, "code generation error");
+}
+
+TEST_F(SemanticAnalyzerTest, WhenBlockInRecord)
+{
+    const auto prog = R"(
+        Record Data(flags) = {
+            base: UInt32LE,
+            when flags == 1 {
+                optional: UInt16LE
+            }
+        }
+        : Data(1)
+    )";
+
+    // TODO: this will pass once codegen is implemented
+    expect_error(prog, "code generation error");
+}
+
+TEST_F(SemanticAnalyzerTest, WhenBlockInRecordWithUndefinedParam)
+{
+    const auto prog = R"(
+        Record Data(flags) = {
+            base: UInt32LE,
+            when undefined_param == 1 {
+                optional: UInt16LE
+            }
+        }
+        : Data(1)
+    )";
+    expect_error(prog, "Undefined variable");
+}
+
+TEST_F(SemanticAnalyzerTest, WhenBlockInRecordWithFieldReference)
+{
+    const auto prog = R"(
+        Record Data() = {
+            flags: UInt8,
+            when flags == 1 {
+                optional: UInt16LE
+            }
+        }
+        : Data
+    )";
+
+    // TODO: this will pass once codegen is implemented
+    expect_error(prog, "code generation error");
+}
+
 } // namespace openzl::sddl2::tests

--- a/tools/sddl2/compiler/tests/SemanticAnalyzerTest.cpp
+++ b/tools/sddl2/compiler/tests/SemanticAnalyzerTest.cpp
@@ -223,4 +223,35 @@ TEST_F(SemanticAnalyzerTest, NestedMemberAccessOnNonRecordField)
     expect_error(prog, "not a record");
 }
 
+TEST_F(SemanticAnalyzerTest, ParameterizedRecordWrongArgCount)
+{
+    const auto prog = R"(
+        Record Entry(N) = {
+            items: Int32LE[N]
+        }
+        : Entry(1, 2)
+    )";
+    expect_error(prog, "Expected 1 arguments but got 2");
+}
+
+TEST_F(SemanticAnalyzerTest, ParameterizedRecordNonNumericArg)
+{
+    const auto prog = R"(
+        Record Entry(N) = {
+            items: Int32LE[N]
+        }
+        : Entry(Int32LE)
+    )";
+    expect_error(prog, "numeric");
+}
+
+TEST_F(SemanticAnalyzerTest, ParameterizedRecordCallNonRecord)
+{
+    const auto prog = R"(
+        MyType = Int32LE
+        : MyType(10)
+    )";
+    expect_error(prog, "record type");
+}
+
 } // namespace openzl::sddl2::tests


### PR DESCRIPTION
Summary:

## Stack
The goal of this stack is to add support for conditional `when` blocks to sddl.

## Diff
This diff implements optimizer passes for `when` blocks in sddl., enabling constant folding and dead variable elimination for conditional constructs.

### Changes

- **ConstFoldPass:** Implemented `optimizeWhen()` that folds constant conditions—eliminates `when 0 { ... }` blocks entirely (dead code removal) and inlines the body for `when <non-zero> { ... }`.

- **DeadVarPass:** Implemented `optimizeWhen()` that tracks variable references in condition and body, applies dead variable elimination to when body.

Differential Revision: D96342234
