### PR TITLE
Implement codegen for when blocks (#501)

### DIFF
--- a/tests/compress/graphs/sddl2/test_sddl2_code_execution.cpp
+++ b/tests/compress/graphs/sddl2/test_sddl2_code_execution.cpp
@@ -487,6 +487,165 @@ TEST_F(SDDL2CodeExecutionTest, AssumeNestedParameterizedRecord)
 
     expect_success(prog, input, expected_sizes);
 }
+
+// ============================================================================
+// When Blocks
+// ============================================================================
+
+TEST_F(SDDL2CodeExecutionTest, WhenBlockTrueCondition)
+{
+    const std::vector<size_t> expected_sizes = { 1, 4 };
+    std::vector<uint8_t> input               = {
+        0x01,                   // flag = 1 (true)
+        0x0A, 0x00, 0x00, 0x00, // optional = 10
+    };
+
+    const auto prog = R"(
+        flag: UInt8
+        when flag {
+            optional: Int32LE
+        }
+        expect flag == 1
+    )";
+
+    expect_success(prog, input, expected_sizes);
+}
+
+TEST_F(SDDL2CodeExecutionTest, WhenBlockFalseCondition)
+{
+    const std::vector<size_t> expected_sizes = { 1 };
+    std::vector<uint8_t> input               = {
+        0x00, // flag = 0 (false)
+    };
+
+    const auto prog = R"(
+        flag: UInt8
+        when flag {
+            optional: Int32LE
+        }
+        expect flag == 0
+    )";
+
+    expect_success(prog, input, expected_sizes);
+}
+
+TEST_F(SDDL2CodeExecutionTest, NestedWhenBlocks)
+{
+    const std::vector<size_t> expected_sizes = { 1, 1, 4 };
+    std::vector<uint8_t> input               = {
+        0x01,                   // a = 1
+        0x02,                   // b = 2
+        0x0A, 0x00, 0x00, 0x00, // optional = 10
+    };
+
+    const auto prog = R"(
+        a: UInt8
+        b: UInt8
+        when a == 1 {
+            when b == 2 {
+                optional: Int32LE
+            }
+        }
+        expect a == 1
+        expect b == 2
+    )";
+
+    expect_success(prog, input, expected_sizes);
+}
+
+TEST_F(SDDL2CodeExecutionTest, NestedWhenBlocksOuterFalse)
+{
+    const std::vector<size_t> expected_sizes = { 1, 1 };
+    std::vector<uint8_t> input               = {
+        0x00, // a = 0 (outer false)
+        0x02, // b = 2
+    };
+
+    const auto prog = R"(
+        a: UInt8
+        b: UInt8
+        when a == 1 {
+            when b == 2 {
+                optional: Int32LE
+            }
+        }
+        expect a == 0
+        expect b == 2
+    )";
+
+    expect_success(prog, input, expected_sizes);
+}
+
+TEST_F(SDDL2CodeExecutionTest, NestedWhenBlocksInnerFalse)
+{
+    const std::vector<size_t> expected_sizes = { 1, 1 };
+    std::vector<uint8_t> input               = {
+        0x01, // a = 1 (outer true)
+        0x05, // b = 5 (inner false, not 2)
+    };
+
+    const auto prog = R"(
+        a: UInt8
+        b: UInt8
+        when a == 1 {
+            when b == 2 {
+                optional: Int32LE
+            }
+        }
+        expect a == 1
+        expect b == 5
+    )";
+
+    expect_success(prog, input, expected_sizes);
+}
+
+TEST_F(SDDL2CodeExecutionTest, WhenBlockInParameterizedRecord)
+{
+    const std::vector<size_t> expected_sizes = { 10 };
+    std::vector<uint8_t> input               = {
+        0x01, 0x00, 0x00, 0x00, // a = 1
+        0x02, 0x00,             // optional = 2
+        0x03, 0x00, 0x00, 0x00, // b = 3
+    };
+
+    const auto prog = R"(
+        Record Data(flag) = {
+            a: Int32LE,
+            when flag {
+                optional: Int16LE
+            },
+            b: Int32LE
+        }
+        data: Data(1)
+        expect data.a == 1
+        expect data.b == 3
+    )";
+    expect_success(prog, input, expected_sizes);
+}
+
+TEST_F(SDDL2CodeExecutionTest, WhenBlockInParameterizedRecordFalse)
+{
+    const std::vector<size_t> expected_sizes = { 8 };
+    std::vector<uint8_t> input               = {
+        0x01, 0x00, 0x00, 0x00, // a = 1
+        0x02, 0x00, 0x00, 0x00, // b = 2
+    };
+
+    const auto prog = R"(
+        Record Data(flag) = {
+            a: Int32LE,
+            when flag {
+                optional: Int16LE
+            },
+            b: Int32LE
+        }
+        data: Data(0)
+        expect data.a == 1
+        expect data.b == 2
+    )";
+
+    expect_success(prog, input, expected_sizes);
+}
 } // namespace testing
 } // namespace sddl2
 } // namespace openzl

--- a/tools/sddl2/compiler/codegen/AssemblyOutput.h
+++ b/tools/sddl2/compiler/codegen/AssemblyOutput.h
@@ -39,6 +39,11 @@ class AssemblyOutput {
         return std::move(oss).str();
     }
 
+    size_t size() const
+    {
+        return insts_.size();
+    }
+
    private:
     std::list<Instruction> insts_;
 };

--- a/tools/sddl2/compiler/codegen/CodeGenerator.cpp
+++ b/tools/sddl2/compiler/codegen/CodeGenerator.cpp
@@ -86,22 +86,28 @@ class CodeGeneratorImpl {
     std::string generate(const ASTVec& ast)
     {
         (void)log_;
+        AssemblyOutput output = generateBlock(ast);
+        auto result           = output.str();
+        return result;
+    }
+
+   private:
+    AssemblyOutput generateBlock(const ASTVec& ast)
+    {
         AssemblyOutput output;
         for (const auto& node : ast) {
             if (auto op = node->as_op()) {
                 output += generateOp(*op);
             } else if (auto when = node->as_when()) {
-                (void)when;
-                throw CodegenError(node->loc(), "Not yet implemented!");
+                output += generateWhen(*when);
             } else {
-                throw InvariantViolation(
-                        node->loc(), "Expected an operation or when.");
+                auto [type_asm, _] = generateType(node);
+                output += std::move(type_asm);
             }
         }
-        return output.str();
+        return output;
     }
 
-   private:
     /**
      * Generates code for an operation node. This is the central dispatch
      * for the code generator. Each op knows whether its arguments are
@@ -158,6 +164,32 @@ class CodeGeneratorImpl {
             default:
                 throw InvariantViolation(op.loc(), "Unsupported operation.");
         };
+    }
+
+    /**
+     * Generates code for a when block.
+     */
+    AssemblyOutput generateWhen(const ASTWhen& when)
+    {
+        AssemblyOutput output;
+
+        // Get code for body
+        auto body_asm = generateBlock(when.body());
+
+        // Push N (number of instructions in body)
+        output += "push.i64 " + std::to_string(body_asm.size());
+
+        // Evaluate condition
+        output += generateValue(when.condition());
+
+        // Negate condition (cmp.eq with 0) so we skip the body when false
+        output += "push.zero";
+        output += "cmp.eq";
+        output += "jump_if";
+
+        output += std::move(body_asm);
+
+        return output;
     }
 
     /**
@@ -232,17 +264,24 @@ class CodeGeneratorImpl {
             }
             case ConvertedNodeType::RECORD: {
                 auto record = type->as_record();
-                for (const auto& field : record->fields()) {
-                    if (auto when = field->as_when()) {
-                        (void)when;
-                        throw CodegenError(
-                                field->loc(), "Not yet implemented!");
-                    }
-                    auto [field_asm, _] = generateType(field);
-                    output += std::move(field_asm);
-                }
-                output += "push.i64 " + std::to_string(record->fields().size());
+                // Save the current stack depth
+                auto reg = registers_.allocate();
+                output += "push.stack_depth";
+                output += "push.i64 " + std::to_string(reg);
+                output += "var.store";
+
+                // Generate the record body
+                output += generateBlock(record->fields());
+
+                // Restore the stack depth and get the size of the record based
+                // on the number of types that were generated
+                output += "push.stack_depth";
+                output += "push.i64 " + std::to_string(reg);
+                output += "var.load";
+                output += "math.sub";
                 output += "type.structure";
+                registers_.free(reg);
+
                 return { std::move(output), type };
             }
             case ConvertedNodeType::RECORD_FIELD: {
@@ -343,15 +382,22 @@ class CodeGeneratorImpl {
                 output += bindParams(curr_record, call->args());
             }
             for (const auto& field : curr_record->fields()) {
-                auto record_field = field->as_record_field();
-                auto& field_name  = record_field->name()->as_var()->name();
-                auto [field_asm, field_type] =
-                        generateType(record_field->type());
-                if (name == field_name) {
-                    type = field_type;
-                    break;
+                if (auto record_field = field->as_record_field()) {
+                    auto [field_asm, field_type] = generateType(field);
+                    auto& field_name = record_field->name()->as_var()->name();
+                    if (name == field_name) {
+                        type = field_type;
+                        break;
+                    }
+                    output += std::move(field_asm);
                 }
-                output += std::move(field_asm);
+                if (field->as_when()) {
+                    // Hack: we generate a dummy type for the when block so that
+                    // we can get its size
+                    auto dummy = Codegen().record(ASTVec{}, ASTVec{ field });
+                    auto [when_asm, _] = generateType(dummy);
+                    output += std::move(when_asm);
+                }
                 output += "type.sizeof";
                 output += "math.add";
             }

--- a/tools/sddl2/compiler/parser/AST.h
+++ b/tools/sddl2/compiler/parser/AST.h
@@ -384,6 +384,7 @@ class ASTRecordField : public ASTConverted {
  */
 class Codegen {
    public:
+    explicit Codegen() : loc_(SourceLocation::null()) {}
     explicit Codegen(SourceLocation loc) : loc_(std::move(loc)) {}
 
     Token token(Symbol sym) const

--- a/tools/sddl2/compiler/semantic_analyzer/SemanticAnalyzer.cpp
+++ b/tools/sddl2/compiler/semantic_analyzer/SemanticAnalyzer.cpp
@@ -298,6 +298,27 @@ class SemanticAnalyzerImpl {
         return Type{ TypeKind::NONE };
     }
 
+    std::optional<Type> findField(const ASTVec& fields, const std::string& name)
+    {
+        for (const auto& field : fields) {
+            if (auto record_field = field->as_record_field()) {
+                auto& field_name = record_field->name()->as_var()->name();
+                if (field_name == name) {
+                    return assumedType(analyzeNode(record_field->type()));
+                }
+            }
+            if (auto when = field->as_when()) {
+                auto found_type = findField(when->body(), name);
+                if (found_type) {
+                    throw SemanticError(
+                            field->loc(),
+                            "Member access not supported on optional fields.");
+                }
+            }
+        }
+        return std::nullopt;
+    }
+
     Type analyzeMember(const ASTOp& op)
     {
         auto saved_vars = var_types_;
@@ -319,14 +340,7 @@ class SemanticAnalyzerImpl {
         }
 
         // Find the field
-        std::optional<Type> found_type;
-        for (const auto& field : record->fields()) {
-            auto record_field = field->as_record_field();
-            auto& name        = record_field->name()->as_var()->name();
-            if (name == field_name) {
-                found_type = assumedType(analyzeNode(record_field->type()));
-            }
-        }
+        auto found_type = findField(record->fields(), field_name);
         if (!found_type) {
             throw SemanticError(
                     op.args()[1]->loc(),

--- a/tools/sddl2/compiler/tests/CompilerTest.h
+++ b/tools/sddl2/compiler/tests/CompilerTest.h
@@ -32,8 +32,9 @@ class TestCompiler : public Compiler {
 
     ASTVec compile_ast(std::string_view source, std::string_view filename)
     {
-        const Source src{ source, filename };
-        const auto tokens = tokenizer_.tokenize(src);
+        // Store Source as member so it outlives the returned AST
+        src_              = std::make_unique<Source>(source, filename);
+        const auto tokens = tokenizer_.tokenize(*src_);
         const auto groups = grouper_.group(tokens);
         auto tree         = parser_.parse(groups);
         semantic_analyzer_.analyze(tree);
@@ -45,6 +46,7 @@ class TestCompiler : public Compiler {
 
    private:
     bool optimize_;
+    std::unique_ptr<Source> src_;
 };
 
 void expect_node_eq(const ASTNode& lhs, const ASTNode& rhs)

--- a/tools/sddl2/compiler/tests/SemanticAnalyzerTest.cpp
+++ b/tools/sddl2/compiler/tests/SemanticAnalyzerTest.cpp
@@ -335,4 +335,35 @@ TEST_F(SemanticAnalyzerTest, WhenBlockInRecordWithFieldReference)
     expect_error(prog, "Undefined variable");
 }
 
+TEST_F(SemanticAnalyzerTest, MemberAccessOnConditionalField)
+{
+    const auto prog = R"(
+        Record Data(flags) = {
+            when flags {
+                optional: Int32LE
+            }
+        }
+        data: Data(1)
+        expect data.optional == 0
+    )";
+    expect_error(prog, "access not supported");
+}
+
+TEST_F(SemanticAnalyzerTest, MemberAccessOnNonConditionalField)
+{
+    const auto prog = R"(
+        Record Data(flags) = {
+            when flags {
+                optional: Int32LE
+            },
+            present: Int32LE
+        }
+        data: Data(1)
+        expect data.present == 0
+    )";
+
+    // TODO: this will pass once codegen is implemented
+    expect_error(prog, "code generation error");
+}
+
 } // namespace openzl::sddl2::tests

--- a/tools/sddl2/compiler/tests/SemanticAnalyzerTest.cpp
+++ b/tools/sddl2/compiler/tests/SemanticAnalyzerTest.cpp
@@ -286,8 +286,7 @@ TEST_F(SemanticAnalyzerTest, NestedWhenBlocks)
         }
     )";
 
-    // TODO: this will pass once codegen is implemented
-    expect_error(prog, "code generation error");
+    expect_success(prog);
 }
 
 TEST_F(SemanticAnalyzerTest, WhenBlockInRecord)
@@ -302,8 +301,7 @@ TEST_F(SemanticAnalyzerTest, WhenBlockInRecord)
         : Data(1)
     )";
 
-    // TODO: this will pass once codegen is implemented
-    expect_error(prog, "code generation error");
+    expect_success(prog);
 }
 
 TEST_F(SemanticAnalyzerTest, WhenBlockInRecordWithUndefinedParam)
@@ -362,8 +360,7 @@ TEST_F(SemanticAnalyzerTest, MemberAccessOnNonConditionalField)
         expect data.present == 0
     )";
 
-    // TODO: this will pass once codegen is implemented
-    expect_error(prog, "code generation error");
+    expect_success(prog);
 }
 
 } // namespace openzl::sddl2::tests


### PR DESCRIPTION
Summary:

## Stack
The goal of this stack is to add support for conditional `when` blocks to sddl.

## Diff
Implement code generation for `when` blocks, enabling conditional field consumption based on runtime expressions.

This diff completes the `when` block feature by adding the code generation phase. Previous diffs in the stack added parsing, semantic analysis, optimizer support, and the `jump_if` VM opcode—this ties them all together.

### Changes

- **generateWhen():** New method that generates code for `when` blocks using the `jump_if` opcode. Emits the body instruction count, evaluates the condition, negates it, and conditionally skips the body.

- **generateBlock():** Extracted block generation logic from `generate()` to enable reuse for `when` block bodies and record fields.

Reviewed By: Cyan4973

Differential Revision: D96342427


