### PR TITLE
Add specialized bitSplit decode fast paths for fp16/fp32/fp64 with unitBench benchmarks (#506)

### DIFF
--- a/.claude/skills/unitbench-scenarios/SKILL.md
+++ b/.claude/skills/unitbench-scenarios/SKILL.md
@@ -33,7 +33,7 @@ Before creating scenarios, ask the user:
 | BUCK file | `benchmark/unitBench/BUCK` |
 | Test data | `/tmp/` (use `dd if=/dev/urandom`) |
 
-All paths relative to `fbcode/openzl/dev/`.
+All paths relative to the openzl dev root.
 
 ## Kernel Benchmark
 
@@ -165,23 +165,23 @@ Kernel `.c`/`.h` files are auto-included by the unitBench binary's `glob(["**/*.
 dd if=/dev/urandom of=/tmp/openzl_bench/test_1MB.bin bs=1M count=1
 dd if=/dev/urandom of=/tmp/openzl_bench/test_10MB.bin bs=1M count=10
 
-# Build with make (optimized -O3, no ASAN - use this for benchmarking) (located in fbcode/openzl/dev/)
-make unitBench
+# Build with BUCK in opt mode (best practice - optimized, no ASAN)
+buck build @//mode/opt //openzl/dev/benchmark/unitBench:unitBench
 
-# Run benchmark
-./unitBench <scenarioName> /tmp/openzl_bench/test_10MB.bin
+# Run benchmark via buck run
+buck run @//mode/opt //openzl/dev/benchmark/unitBench:unitBench -- <scenarioName> /tmp/openzl_bench/test_10MB.bin
 
-# Useful options
+# Useful options (after the -- separator)
 #   -i <seconds>    benchmark duration (default ~2s)
 #   -B <bytes>      split input into blocks
 #   --csv           CSV output for parsing
 #   -z              compression only (skip decompression round-trip)
 
 # List all scenarios
-./unitBench --list
+buck run @//mode/opt //openzl/dev/benchmark/unitBench:unitBench -- --list
 ```
 
-**Do NOT use buck for benchmarking** - buck builds include ASAN and debug flags that make results 10-50x slower than production. Use `make unitBench` for representative numbers.
+**Always use `buck build/run @//mode/opt`** for benchmarking. If buck is not available, fall back to `make unitBench` (from the openzl dev root).
 
 ## Common Mistakes
 

--- a/benchmark/unitBench/benchList.h
+++ b/benchmark/unitBench/benchList.h
@@ -428,7 +428,9 @@ static size_t varintEncode32_wrapper(
 Bench_Entry const scenarioList[] = {
     { "bitSplitDecode_bf16", bitSplitDecode_bf16_wrapper, .prep = bitSplitDecode_bf16_prep, .outSize = bitSplitDecode_bf16_outSize },
     { "bitSplitDecode_bounded32", bitSplitDecode_bounded32_wrapper, .prep = bitSplitDecode_bounded32_prep, .outSize = bitSplitDecode_bounded32_outSize },
+    { "bitSplitDecode_fp16", bitSplitDecode_fp16_wrapper, .prep = bitSplitDecode_fp16_prep, .outSize = bitSplitDecode_fp16_outSize },
     { "bitSplitDecode_fp32", bitSplitDecode_fp32_wrapper, .prep = bitSplitDecode_fp32_prep, .outSize = bitSplitDecode_fp32_outSize },
+    { "bitSplitDecode_fp64", bitSplitDecode_fp64_wrapper, .prep = bitSplitDecode_fp64_prep, .outSize = bitSplitDecode_fp64_outSize },
     { "bitSplitEncode_bf16", bitSplitEncode_bf16_wrapper, .prep = bitSplitEncode_bf16_prep, .outSize = bitSplitEncode_bf16_outSize },
     { "bitSplitEncode_bounded32", bitSplitEncode_bounded32_wrapper, .prep = bitSplitEncode_bounded32_prep, .outSize = bitSplitEncode_bounded32_outSize },
     { "bitSplitEncode_fp16", bitSplitEncode_fp16_wrapper, .prep = bitSplitEncode_fp16_prep, .outSize = bitSplitEncode_fp16_outSize },

--- a/benchmark/unitBench/scenarios/codecs/bitSplit.c
+++ b/benchmark/unitBench/scenarios/codecs/bitSplit.c
@@ -282,6 +282,152 @@ size_t bitSplitDecode_bounded32_wrapper(
     return nbElts * dstEltWidth;
 }
 
+/* ===   fp16 decode scenario   ===
+ * bitWidths {10, 5, 1}, srcEltWidths {2, 1, 1}, dstEltWidth=2
+ * sum(srcEltWidths) = 4
+ */
+
+size_t
+bitSplitDecode_fp16_prep(void* src, size_t srcSize, const BenchPayload* bp)
+{
+    (void)bp;
+
+    static const size_t srcEltWidths[3] = { 2, 1, 1 };
+    static const unsigned bitWidths[3]  = { 10, 5, 1 };
+    static const size_t sumSrcElt       = 2 + 1 + 1; /* 4 */
+
+    size_t const nbElts = srcSize / sumSrcElt;
+    if (nbElts == 0)
+        return 0;
+
+    uint8_t* p    = (uint8_t*)src;
+    size_t offset = 0;
+    for (int i = 0; i < 3; i++) {
+        fillRandomMasked(p + offset, nbElts, srcEltWidths[i], bitWidths[i]);
+        offset += nbElts * srcEltWidths[i];
+    }
+
+    return nbElts * sumSrcElt;
+}
+
+size_t bitSplitDecode_fp16_outSize(const void* src, size_t srcSize)
+{
+    (void)src;
+    /* nbElts = srcSize / 4, output = nbElts * 2 */
+    return (srcSize / 4) * 2;
+}
+
+size_t bitSplitDecode_fp16_wrapper(
+        const void* src,
+        size_t srcSize,
+        void* dst,
+        size_t dstCapacity,
+        void* customPayload)
+{
+    (void)dstCapacity;
+    (void)customPayload;
+
+    static const size_t dstEltWidth     = 2;
+    static const size_t srcEltWidths[3] = { 2, 1, 1 };
+    static const uint8_t bitWidths[3]   = { 10, 5, 1 };
+    static const size_t nbWidths        = 3;
+    static const size_t sumSrcElt       = 2 + 1 + 1; /* 4 */
+
+    size_t const nbElts = srcSize / sumSrcElt;
+    const uint8_t* p    = (const uint8_t*)src;
+
+    size_t offset = 0;
+    const void* srcPtrs[3];
+    for (int i = 0; i < 3; i++) {
+        srcPtrs[i] = p + offset;
+        offset += nbElts * srcEltWidths[i];
+    }
+
+    ZL_bitSplitDecode(
+            dst,
+            dstEltWidth,
+            nbElts,
+            srcPtrs,
+            srcEltWidths,
+            bitWidths,
+            nbWidths);
+
+    return nbElts * dstEltWidth;
+}
+
+/* ===   fp64 decode scenario   ===
+ * bitWidths {52, 11, 1}, srcEltWidths {8, 2, 1}, dstEltWidth=8
+ * sum(srcEltWidths) = 11
+ */
+
+size_t
+bitSplitDecode_fp64_prep(void* src, size_t srcSize, const BenchPayload* bp)
+{
+    (void)bp;
+
+    static const size_t srcEltWidths[3] = { 8, 2, 1 };
+    static const unsigned bitWidths[3]  = { 52, 11, 1 };
+    static const size_t sumSrcElt       = 8 + 2 + 1; /* 11 */
+
+    size_t const nbElts = srcSize / sumSrcElt;
+    if (nbElts == 0)
+        return 0;
+
+    uint8_t* p    = (uint8_t*)src;
+    size_t offset = 0;
+    for (int i = 0; i < 3; i++) {
+        fillRandomMasked(p + offset, nbElts, srcEltWidths[i], bitWidths[i]);
+        offset += nbElts * srcEltWidths[i];
+    }
+
+    return nbElts * sumSrcElt;
+}
+
+size_t bitSplitDecode_fp64_outSize(const void* src, size_t srcSize)
+{
+    (void)src;
+    /* nbElts = srcSize / 11, output = nbElts * 8 */
+    return (srcSize / 11) * 8;
+}
+
+size_t bitSplitDecode_fp64_wrapper(
+        const void* src,
+        size_t srcSize,
+        void* dst,
+        size_t dstCapacity,
+        void* customPayload)
+{
+    (void)dstCapacity;
+    (void)customPayload;
+
+    static const size_t dstEltWidth     = 8;
+    static const size_t srcEltWidths[3] = { 8, 2, 1 };
+    static const uint8_t bitWidths[3]   = { 52, 11, 1 };
+    static const size_t nbWidths        = 3;
+    static const size_t sumSrcElt       = 8 + 2 + 1; /* 11 */
+
+    size_t const nbElts = srcSize / sumSrcElt;
+    const uint8_t* p    = (const uint8_t*)src;
+
+    size_t offset = 0;
+    const void* srcPtrs[3];
+    for (int i = 0; i < 3; i++) {
+        srcPtrs[i] = p + offset;
+        offset += nbElts * srcEltWidths[i];
+    }
+
+    ZL_bitSplitDecode(
+            dst,
+            dstEltWidth,
+            nbElts,
+            srcPtrs,
+            srcEltWidths,
+            bitWidths,
+            nbWidths);
+
+    return nbElts * dstEltWidth;
+}
+
 /* =========================================================================
  *                          ENCODE SCENARIOS
  * =========================================================================

--- a/benchmark/unitBench/scenarios/codecs/bitSplit.h
+++ b/benchmark/unitBench/scenarios/codecs/bitSplit.h
@@ -83,6 +83,52 @@ size_t bitSplitDecode_bounded32_wrapper(
         size_t dstCapacity,
         void* customPayload);
 
+/**
+ * Preparation function for fp16 decomposition benchmark.
+ * Packs 3 source streams with bitWidths {10, 5, 1} contiguously into src.
+ */
+size_t
+bitSplitDecode_fp16_prep(void* src, size_t srcSize, const BenchPayload* bp);
+
+/**
+ * Output size for fp16 decode: nbElts * 2, where nbElts = srcSize / 4.
+ */
+size_t bitSplitDecode_fp16_outSize(const void* src, size_t srcSize);
+
+/**
+ * Wrapper function for fp16 decomposition decode benchmark.
+ * Decodes 3 streams from src into 16-bit elements in dst.
+ */
+size_t bitSplitDecode_fp16_wrapper(
+        const void* src,
+        size_t srcSize,
+        void* dst,
+        size_t dstCapacity,
+        void* customPayload);
+
+/**
+ * Preparation function for fp64 decomposition benchmark.
+ * Packs 3 source streams with bitWidths {52, 11, 1} contiguously into src.
+ */
+size_t
+bitSplitDecode_fp64_prep(void* src, size_t srcSize, const BenchPayload* bp);
+
+/**
+ * Output size for fp64 decode: nbElts * 8, where nbElts = srcSize / 11.
+ */
+size_t bitSplitDecode_fp64_outSize(const void* src, size_t srcSize);
+
+/**
+ * Wrapper function for fp64 decomposition decode benchmark.
+ * Decodes 3 streams from src into 64-bit elements in dst.
+ */
+size_t bitSplitDecode_fp64_wrapper(
+        const void* src,
+        size_t srcSize,
+        void* dst,
+        size_t dstCapacity,
+        void* customPayload);
+
 /* ===   Encode scenarios   === */
 
 /**

--- a/src/openzl/codecs/bitSplit/decode_bitSplit_kernel.c
+++ b/src/openzl/codecs/bitSplit/decode_bitSplit_kernel.c
@@ -24,8 +24,80 @@ decodeBf16(void* dst, size_t nbElts, const void* const srcPtrs[])
     for (size_t e = 0; e < nbElts; e++) {
         uint16_t value = (uint16_t)mantissa[e]; /* bits 0-6 */
         value |= (uint16_t)exponent[e] << 7;    /* bits 7-14 */
-        value |= (uint16_t)(sign[e] & 1) << 15; /* bit 15 */
+        value |= (uint16_t)sign[e] << 15;       /* bit 15 */
         dst16[e] = value;
+    }
+}
+
+/*
+ * Specialized decoder for fp16 pattern:
+ * - 3 streams with bitWidths {10, 5, 1}
+ * - srcEltWidths are {2, 1, 1} (uint16_t, uint8_t, uint8_t)
+ * - dstEltWidth is 2 (uint16_t)
+ *
+ * Layout: [mantissa:10][exponent:5][sign:1] = 16 bits
+ */
+static inline void
+decodeFp16(void* dst, size_t nbElts, const void* const srcPtrs[])
+{
+    uint16_t* const dst16          = (uint16_t*)dst;
+    const uint16_t* const mantissa = (const uint16_t*)srcPtrs[0];
+    const uint8_t* const exponent  = (const uint8_t*)srcPtrs[1];
+    const uint8_t* const sign      = (const uint8_t*)srcPtrs[2];
+
+    for (size_t e = 0; e < nbElts; e++) {
+        uint16_t value = mantissa[e];         /* bits 0-9 */
+        value |= (uint16_t)exponent[e] << 10; /* bits 10-14 */
+        value |= (uint16_t)sign[e] << 15;     /* bit 15 */
+        dst16[e] = value;
+    }
+}
+
+/*
+ * Specialized decoder for fp32 pattern:
+ * - 3 streams with bitWidths {23, 8, 1}
+ * - srcEltWidths are {4, 1, 1} (uint32_t, uint8_t, uint8_t)
+ * - dstEltWidth is 4 (uint32_t)
+ *
+ * Layout: [mantissa:23][exponent:8][sign:1] = 32 bits
+ */
+static inline void
+decodeFp32(void* dst, size_t nbElts, const void* const srcPtrs[])
+{
+    uint32_t* const dst32          = (uint32_t*)dst;
+    const uint32_t* const mantissa = (const uint32_t*)srcPtrs[0];
+    const uint8_t* const exponent  = (const uint8_t*)srcPtrs[1];
+    const uint8_t* const sign      = (const uint8_t*)srcPtrs[2];
+
+    for (size_t e = 0; e < nbElts; e++) {
+        uint32_t value = mantissa[e];         /* bits 0-22 */
+        value |= (uint32_t)exponent[e] << 23; /* bits 23-30 */
+        value |= (uint32_t)sign[e] << 31;     /* bit 31 */
+        dst32[e] = value;
+    }
+}
+
+/*
+ * Specialized decoder for fp64 pattern:
+ * - 3 streams with bitWidths {52, 11, 1}
+ * - srcEltWidths are {8, 2, 1} (uint64_t, uint16_t, uint8_t)
+ * - dstEltWidth is 8 (uint64_t)
+ *
+ * Layout: [mantissa:52][exponent:11][sign:1] = 64 bits
+ */
+static inline void
+decodeFp64(void* dst, size_t nbElts, const void* const srcPtrs[])
+{
+    uint64_t* const dst64          = (uint64_t*)dst;
+    const uint64_t* const mantissa = (const uint64_t*)srcPtrs[0];
+    const uint16_t* const exponent = (const uint16_t*)srcPtrs[1];
+    const uint8_t* const sign      = (const uint8_t*)srcPtrs[2];
+
+    for (size_t e = 0; e < nbElts; e++) {
+        uint64_t value = mantissa[e];         /* bits 0-51 */
+        value |= (uint64_t)exponent[e] << 52; /* bits 52-62 */
+        value |= (uint64_t)sign[e] << 63;     /* bit 63 */
+        dst64[e] = value;
     }
 }
 
@@ -45,6 +117,66 @@ static inline bool isBf16Pattern(
     if (bitWidths[0] != 7 || bitWidths[1] != 8 || bitWidths[2] != 1)
         return false;
     if (srcEltWidths[0] != 1 || srcEltWidths[1] != 1 || srcEltWidths[2] != 1)
+        return false;
+    return true;
+}
+
+/*
+ * Check if parameters match the fp16 pattern.
+ */
+static inline bool isFp16Pattern(
+        size_t dstEltWidth,
+        const size_t* srcEltWidths,
+        const uint8_t* bitWidths,
+        size_t nbWidths)
+{
+    if (dstEltWidth != 2)
+        return false;
+    if (nbWidths != 3)
+        return false;
+    if (bitWidths[0] != 10 || bitWidths[1] != 5 || bitWidths[2] != 1)
+        return false;
+    if (srcEltWidths[0] != 2 || srcEltWidths[1] != 1 || srcEltWidths[2] != 1)
+        return false;
+    return true;
+}
+
+/*
+ * Check if parameters match the fp32 pattern.
+ */
+static inline bool isFp32Pattern(
+        size_t dstEltWidth,
+        const size_t* srcEltWidths,
+        const uint8_t* bitWidths,
+        size_t nbWidths)
+{
+    if (dstEltWidth != 4)
+        return false;
+    if (nbWidths != 3)
+        return false;
+    if (bitWidths[0] != 23 || bitWidths[1] != 8 || bitWidths[2] != 1)
+        return false;
+    if (srcEltWidths[0] != 4 || srcEltWidths[1] != 1 || srcEltWidths[2] != 1)
+        return false;
+    return true;
+}
+
+/*
+ * Check if parameters match the fp64 pattern.
+ */
+static inline bool isFp64Pattern(
+        size_t dstEltWidth,
+        const size_t* srcEltWidths,
+        const uint8_t* bitWidths,
+        size_t nbWidths)
+{
+    if (dstEltWidth != 8)
+        return false;
+    if (nbWidths != 3)
+        return false;
+    if (bitWidths[0] != 52 || bitWidths[1] != 11 || bitWidths[2] != 1)
+        return false;
+    if (srcEltWidths[0] != 8 || srcEltWidths[1] != 2 || srcEltWidths[2] != 1)
         return false;
     return true;
 }
@@ -147,6 +279,18 @@ void ZL_bitSplitDecode(
     /* Check for specialized patterns and dispatch */
     if (isBf16Pattern(dstEltWidth, srcEltWidths, bitWidths, nbWidths)) {
         decodeBf16(dst, nbElts, srcPtrs);
+        return;
+    }
+    if (isFp16Pattern(dstEltWidth, srcEltWidths, bitWidths, nbWidths)) {
+        decodeFp16(dst, nbElts, srcPtrs);
+        return;
+    }
+    if (isFp32Pattern(dstEltWidth, srcEltWidths, bitWidths, nbWidths)) {
+        decodeFp32(dst, nbElts, srcPtrs);
+        return;
+    }
+    if (isFp64Pattern(dstEltWidth, srcEltWidths, bitWidths, nbWidths)) {
+        decodeFp64(dst, nbElts, srcPtrs);
         return;
     }
 


### PR DESCRIPTION
Summary:

Add specialized decode functions for fp16, fp32, and fp64 IEEE floating-point
formats in bitSplit, mirroring the existing encode specializations. Each format
gets a dedicated decoder that reassembles {mantissa, exponent, sign} streams
without the overhead of the generic switch-based loop.

- `decodeFp16`: bitWidths {10, 5, 1}, srcEltWidths {2, 1, 1}, dstEltWidth=2
- `decodeFp32`: bitWidths {23, 8, 1}, srcEltWidths {4, 1, 1}, dstEltWidth=4
- `decodeFp64`: bitWidths {52, 11, 1}, srcEltWidths {8, 2, 1}, dstEltWidth=8

Pattern matchers and dispatch added to `ZL_bitSplitDecode`.

Kernel benchmarks added for fp16 and fp64 decode (fp32 decode already existed).

Updated unitbench skill to recommend `buck build/run @//mode/opt` for benchmarking.

Benchmark results (10MB, buck @//mode/opt):

| Format | Encode (MB/s) | Decode Generic (MB/s) | Decode Specialized (MB/s) | Decode Speedup |
|--------|---------------|-----------------------|---------------------------|----------------|
| bf16   | 23,289        | —                     | 49,423                    | —              |
| fp16   | 20,042        | 1,555                 | 54,102                    | ~35x           |
| fp32   | 25,872        | 2,093                 | 48,320                    | ~23x           |
| fp64   | 24,014        | 3,756                 | 47,330                    | ~13x           |

Reviewed By: terrelln

Differential Revision: D96359402
