### PR TITLE
Allow assignments of runtime values (#507)

### DIFF
--- a/tests/compress/graphs/sddl2/test_sddl2_code_execution.cpp
+++ b/tests/compress/graphs/sddl2/test_sddl2_code_execution.cpp
@@ -646,6 +646,31 @@ TEST_F(SDDL2CodeExecutionTest, WhenBlockInParameterizedRecordFalse)
 
     expect_success(prog, input, expected_sizes);
 }
+
+// ============================================================================
+// Runtime Value Assignment
+// ============================================================================
+
+TEST_F(SDDL2CodeExecutionTest, AssignRuntimeValue)
+{
+    const std::vector<size_t> expected_sizes = { 4, 4 };
+    std::vector<uint8_t> input               = {
+        0x05, 0x00, 0x00, 0x00, // x = 5
+        0x03, 0x00, 0x00, 0x00, // y = 3
+    };
+
+    const auto prog = R"(
+        x: Int32LE
+        y: Int32LE
+        sum = x + y
+        expect x == 5
+        expect y == 3
+        expect sum == 8
+    )";
+
+    expect_success(prog, input, expected_sizes);
+}
+
 } // namespace testing
 } // namespace sddl2
 } // namespace openzl

--- a/tools/sddl2/compiler/codegen/CodeGenerator.cpp
+++ b/tools/sddl2/compiler/codegen/CodeGenerator.cpp
@@ -427,11 +427,15 @@ class CodeGeneratorImpl {
             }
         }
 
-        auto [type_asm, type]     = generateType(rhs);
-        type_aliases_[var.name()] = type;
-
         AssemblyOutput output;
-        output += std::move(type_asm);
+        try {
+            auto [type_asm, type]     = generateType(rhs);
+            type_aliases_[var.name()] = type;
+            output += std::move(type_asm);
+        } catch (const InvariantViolation&) {
+            output += generateValue(rhs);
+        }
+
         output += "push.i64 " + std::to_string(registers_.assign(var.name()));
         output += "var.store";
         return output;


### PR DESCRIPTION
Summary:

## Diff
Allow assignment of runtime expression values to variables, enabling syntax like `sum = x + y` where the RHS is a runtime computation rather than a type definition.

Previously, all variable assignments expected a type on the right-hand side (e.g., `Foo = Int32LE`). This change extends the code generator to handle assignments where the RHS evaluates to a runtime numeric value by catching the `InvariantViolation` thrown when type generation fails and falling back to value generation.

Differential Revision: D96343046


