### PR TITLE
Refactor `processStream` (#510)

### DIFF
--- a/src/openzl/common/allocation.c
+++ b/src/openzl/common/allocation.c
@@ -3,12 +3,20 @@
 #include "openzl/common/allocation.h"
 #include "openzl/common/assertion.h"
 #include "openzl/common/limits.h"
+#include "openzl/common/map.h"
 #include "openzl/shared/overflow.h"
 #include "openzl/shared/utils.h"
 
 #include <stdalign.h>
+#include <stddef.h>
 #include <stdlib.h> // malloc, free
 #include <string.h> // memset
+
+#if ZL_POISON_SUPPORTED
+#    define ZL_REDZONE_SIZE 128
+#else
+#    define ZL_REDZONE_SIZE 0
+#endif
 
 #ifdef FUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION
 
@@ -125,6 +133,38 @@ size_t ALLOC_Arena_memUsed(const Arena* arena)
     return arena->memUsed(arena);
 }
 
+/*============================================================================
+ * RawAllocator: For internal allocator use for allocs that MUST NOT be part
+ * of the allocation failure injection mechanism.
+ *===========================================================================*/
+
+static void* raw_malloc(Arena* arena, size_t size)
+{
+    (void)arena;
+    return malloc(size);
+}
+static void* raw_calloc(Arena* arena, size_t size)
+{
+    (void)arena;
+    return calloc(1, size);
+}
+static void* raw_realloc(Arena* arena, void* ptr, size_t size)
+{
+    (void)arena;
+    return realloc(ptr, size);
+}
+static void raw_free(Arena* arena, void* ptr)
+{
+    (void)arena;
+    free(ptr);
+}
+static Arena kRawAllocator = {
+    .malloc  = raw_malloc,
+    .calloc  = raw_calloc,
+    .realloc = raw_realloc,
+    .free    = raw_free,
+};
+
 /*
  * ==============================================================
  * HeapArena:
@@ -134,6 +174,9 @@ size_t ALLOC_Arena_memUsed(const Arena* arena)
 typedef struct {
     size_t index;
     size_t size;
+#if ZL_POISON_SUPPORTED
+    uint8_t redzone[ZL_REDZONE_SIZE];
+#endif
 } HeapMeta;
 
 DECLARE_VECTOR_POINTERS_TYPE(HeapMeta)
@@ -159,6 +202,7 @@ ALLOC_HeapArena_allocImpl(HeapArena* arena, HeapMeta* meta, size_t size)
     ZL_ASSERT_EQ((uintptr_t)meta % alignof(HeapMeta), 0);
     meta->index = VECTOR_SIZE(arena->ptrs);
     meta->size  = size;
+    ZL_POISON_MEMORY(meta->redzone, sizeof(meta->redzone));
 
     if (!VECTOR_PUSHBACK(arena->ptrs, meta)) {
         ZL_LOG(ERROR, "Failed to push ptr into HeapArena");
@@ -166,8 +210,8 @@ ALLOC_HeapArena_allocImpl(HeapArena* arena, HeapMeta* meta, size_t size)
         return NULL;
     }
     ZL_STATIC_ASSERT(
-            sizeof(HeapMeta) == 16,
-            "sizeof(HeapMeta) must be 16 to guarantee alignment");
+            sizeof(HeapMeta) % 16 == 0,
+            "sizeof(HeapMeta) must be a multiple of 16 to guarantee alignment");
     return (void*)(meta + 1);
 }
 
@@ -203,11 +247,16 @@ static void* ALLOC_HeapArena_realloc(Arena* arena, void* ptr, size_t newSize)
     }
     HeapArena* heapArena    = ZL_CONTAINER_OF(arena, HeapArena, base);
     HeapMeta* const oldMeta = (HeapMeta*)ptr - 1;
-    HeapMeta* const newMeta = ZL_realloc(oldMeta, sizeof(HeapMeta) + newSize);
+    size_t allocSize;
+    if (ZL_overflowAddST(newSize, sizeof(HeapMeta), &allocSize)) {
+        return NULL;
+    }
+    HeapMeta* const newMeta = ZL_realloc(oldMeta, allocSize);
     if (newMeta == NULL) {
         return NULL;
     }
-    newMeta->size                              = newSize;
+    newMeta->size = newSize;
+    ZL_POISON_MEMORY(newMeta->redzone, sizeof(newMeta->redzone));
     VECTOR_AT(heapArena->ptrs, newMeta->index) = newMeta;
     return (void*)(newMeta + 1);
 }
@@ -338,6 +387,95 @@ Arena* ALLOC_HeapArena_create(void)
 
 typedef struct StackArena_s StackArena;
 
+#if ZL_POISON_SUPPORTED
+
+ZL_DECLARE_MAP_TYPE(AsanOnlySizeMap, uintptr_t, size_t);
+
+static void
+AsanOnlySizeMap_setPtrSize(AsanOnlySizeMap* map, void* ptr, size_t size)
+{
+    ZL_REQUIRE_NN(map);
+    ZL_REQUIRE_NN(ptr);
+    const AsanOnlySizeMap_Insert insert = AsanOnlySizeMap_insertVal(
+            map, (AsanOnlySizeMap_Entry){ (uintptr_t)ptr, size });
+    ZL_REQUIRE(insert.inserted, "ptr already exists in map");
+    ZL_REQUIRE(!insert.badAlloc);
+}
+
+static void AsanOnlySizeMap_erasePtrSize(AsanOnlySizeMap* map, void* ptr)
+{
+    ZL_REQUIRE_NN(map);
+    ZL_REQUIRE_NN(ptr);
+    const bool erased = AsanOnlySizeMap_eraseVal(map, (uintptr_t)ptr);
+    ZL_REQUIRE(erased, "ptr not found in map");
+}
+
+static size_t AsanOnlySizeMap_getPtrSize(AsanOnlySizeMap* map, void* ptr)
+{
+    ZL_REQUIRE_NN(map);
+    ZL_REQUIRE_NN(ptr);
+    const AsanOnlySizeMap_Entry* const entry =
+            AsanOnlySizeMap_findVal(map, (uintptr_t)ptr);
+    ZL_REQUIRE_NN(entry, "ptr not found in map");
+    return entry->val;
+}
+
+static void AsanOnlySizeMap_unpoisonAllPtrs(AsanOnlySizeMap* map)
+{
+    AsanOnlySizeMap_Iter iter = AsanOnlySizeMap_iter(map);
+    for (const AsanOnlySizeMap_Entry* entry;
+         (entry = AsanOnlySizeMap_Iter_next(&iter));) {
+        ZL_unpoisonMemory((const void*)entry->key, entry->val);
+    }
+}
+
+#else
+
+typedef int AsanOnlySizeMap;
+
+static void
+AsanOnlySizeMap_setPtrSize(AsanOnlySizeMap* map, void* ptr, size_t size)
+{
+    (void)map;
+    (void)ptr;
+    (void)size;
+}
+
+static void AsanOnlySizeMap_erasePtrSize(AsanOnlySizeMap* map, void* ptr)
+{
+    (void)map;
+    (void)ptr;
+}
+
+static void AsanOnlySizeMap_clear(AsanOnlySizeMap* map)
+{
+    (void)map;
+}
+
+static void AsanOnlySizeMap_destroy(AsanOnlySizeMap* map)
+{
+    (void)map;
+}
+
+static AsanOnlySizeMap AsanOnlySizeMap_createInArena(
+        Arena* arena,
+        uint32_t limit)
+{
+    (void)arena;
+    (void)limit;
+    return 0;
+}
+
+static void AsanOnlySizeMap_unpoisonAllPtrs(AsanOnlySizeMap* map)
+{
+    (void)map;
+}
+
+// Not defined if ASAN is not supported
+// static size_t AsanOnlySizeMap_getPtrSize(AsanOnlySizeMap* map, void* ptr);
+
+#endif
+
 struct StackArena_s {
     Arena base; // must be first member
     void* primaryBuffer;
@@ -350,15 +488,33 @@ struct StackArena_s {
     size_t wasted;          // pBuffCapacity * nbTimesUsedWastefully,
                             // to trigger a size-down event
     HeapArena heapBackup;
+    AsanOnlySizeMap asanOnlySizeMap;
 };
 
-static void* ALLOC_StackArena_malloc(Arena* arena, size_t size)
+// Track allocations in the primary buffer to poison memory
+static void
+ALLOC_StackArena_trackMalloc(StackArena* pba, void* ptr, size_t requestSize)
+{
+    AsanOnlySizeMap_setPtrSize(&pba->asanOnlySizeMap, ptr, requestSize);
+    ZL_unpoisonMemory(ptr, requestSize);
+}
+
+// Track frees in the primary buffer to poison memory
+static void ALLOC_StackArena_trackFree(StackArena* pba, void* ptr)
+{
+    ZL_POISON_MEMORY(
+            ptr, AsanOnlySizeMap_getPtrSize(&pba->asanOnlySizeMap, ptr));
+    AsanOnlySizeMap_erasePtrSize(&pba->asanOnlySizeMap, ptr);
+}
+
+static void* ALLOC_StackArena_malloc(Arena* arena, size_t requestSize)
 {
     ZL_ASSERT_NN(arena);
     StackArena* const pba = ZL_CONTAINER_OF(arena, StackArena, base);
     ZL_ASSERT_GE(pba->pBuffCapacity, pba->pBuffUsed);
     size_t pBuffAvailable         = pba->pBuffCapacity - pba->pBuffUsed;
     static const size_t alignment = 16; // could become a variable in the future
+    const size_t size             = requestSize + ZL_REDZONE_SIZE;
     size_t const neededSize       = size + (alignment - 1);
     pba->sessionUsage += neededSize;
 
@@ -385,6 +541,7 @@ static void* ALLOC_StackArena_malloc(Arena* arena, size_t size)
             pba->wouldHaveNeeded = ZL_MIN(pba->wouldHaveNeeded, pBuffSizeMax);
         }
         if (pba->primaryBuffer) {
+            ZL_poisonMemory(pba->primaryBuffer, toAllocate);
             pba->pBuffCapacity   = toAllocate;
             pba->pBuffUsed       = neededSize;
             pba->wouldHaveNeeded = toAllocate;
@@ -393,6 +550,7 @@ static void* ALLOC_StackArena_malloc(Arena* arena, size_t size)
                     0); /* note : this alignment method will have to change if
                            requested alignment is larger than base allocation of
                            primaryBuffer */
+            ALLOC_StackArena_trackMalloc(pba, pba->primaryBuffer, requestSize);
             return pba->primaryBuffer;
         }
         /* allocation failed */
@@ -417,6 +575,7 @@ static void* ALLOC_StackArena_malloc(Arena* arena, size_t size)
                        primaryBuffer */
         void* const r  = (char*)pba->primaryBuffer + start;
         pba->pBuffUsed = start + size;
+        ALLOC_StackArena_trackMalloc(pba, r, requestSize);
         return r;
     }
 
@@ -425,7 +584,7 @@ static void* ALLOC_StackArena_malloc(Arena* arena, size_t size)
      * and track necessary space, for next session */
     ZL_ASSERT_GE(pba->wouldHaveNeeded, pba->pBuffCapacity);
     pba->wouldHaveNeeded += neededSize;
-    return ALLOC_Arena_malloc(&pba->heapBackup.base, size);
+    return ALLOC_Arena_malloc(&pba->heapBackup.base, requestSize);
 }
 
 static void* ALLOC_StackArena_calloc(Arena* arena, size_t size)
@@ -469,7 +628,14 @@ static void* ALLOC_StackArena_realloc(Arena* arena, void* ptr, size_t newSize)
         ZL_ASSERT_NN(ptr);
         char* const pBuffEnd = (char*)pba->primaryBuffer + pba->pBuffCapacity;
         const size_t toCopy  = ZL_MIN((size_t)(pBuffEnd - (char*)ptr), newSize);
+
+        ZL_UNPOISON_MEMORY(pba->primaryBuffer, pba->pBuffCapacity);
         memcpy(newPtr, ptr, toCopy);
+        ZL_POISON_MEMORY(pba->primaryBuffer, pba->pBuffCapacity);
+        AsanOnlySizeMap_unpoisonAllPtrs(&pba->asanOnlySizeMap);
+
+        // Mark the old pointer as freed.
+        ALLOC_StackArena_trackFree(pba, ptr);
         return newPtr;
     } else {
         return ALLOC_HeapArena_realloc(&pba->heapBackup.base, ptr, newSize);
@@ -483,8 +649,9 @@ static void ALLOC_StackArena_freeSegment(Arena* arena, void* ptr)
     ZL_ASSERT_NN(arena);
     StackArena* const pba = ZL_CONTAINER_OF(arena, StackArena, base);
     if (ALLOC_StackArena_inPrimaryBuffer(pba, ptr)) {
-        /* this ptr owns a slice within primaryBuffer -> don't free anything
-         */
+        // This ptr owns a slice within primaryBuffer -> don't free anything
+        // Just mark it as freed in ASAN mode
+        ALLOC_StackArena_trackFree(pba, ptr);
         return;
     }
     /* this ptr is presumed tracked by heapBackup */
@@ -507,6 +674,13 @@ static void ALLOC_StackArena_freeAllSegments(Arena* arena)
     StackArena* const pba = ZL_CONTAINER_OF(arena, StackArena, base);
     pba->pBuffUsed        = 0;
     ALLOC_HeapArena_freeAllSegments(&pba->heapBackup.base);
+
+    // Reset ASAN size map & poison the primary buffer
+    AsanOnlySizeMap_clear(&pba->asanOnlySizeMap);
+    if (pba->primaryBuffer) {
+        ZL_poisonMemory(pba->primaryBuffer, pba->pBuffCapacity);
+    }
+
     if (pba->sessionUsage < PBUFF_USAGE_MIN(pba->pBuffCapacity)) {
         pba->wasted += pba->pBuffCapacity;
     } else {
@@ -520,6 +694,8 @@ static void ALLOC_StackArena_freeAllSegments(Arena* arena)
                 ZL_realloc(pba->primaryBuffer, pba->pBuffCapacity);
         if (newPBuffer != NULL) {
             pba->primaryBuffer = newPBuffer;
+            // Poison the new buffer
+            ZL_poisonMemory(pba->primaryBuffer, pba->pBuffCapacity);
         } else {
             // Failed realloc: Just give up the primary buffer
             ZL_free(pba->primaryBuffer);
@@ -540,6 +716,7 @@ static void ALLOC_StackArena_freeArena(Arena* arena)
     arena->freeAll(arena); /* note: freeAll doesn't free the primaryBuffer */
     StackArena* const pba = ZL_CONTAINER_OF(arena, StackArena, base);
     ALLOC_HeapArena_destroy(&pba->heapBackup);
+    AsanOnlySizeMap_destroy(&pba->asanOnlySizeMap);
     ZL_free(pba->primaryBuffer);
     ZL_free(pba);
 }
@@ -581,5 +758,7 @@ Arena* ALLOC_StackArena_create(void)
         return NULL;
     arena->base = kStackArena;
     ALLOC_HeapArena_init(&arena->heapBackup);
+    arena->asanOnlySizeMap = AsanOnlySizeMap_createInArena(
+            &kRawAllocator, ZL_CONTAINER_SIZE_LIMIT);
     return &arena->base;
 }

--- a/src/openzl/decompress/decompress2.c
+++ b/src/openzl/decompress/decompress2.c
@@ -81,7 +81,6 @@ typedef struct {
 struct ZL_DCtx_s {
     DTransforms_manager dtm;
     DFH_Struct dfh;
-    VECTOR_CONST_POINTERS(ZL_Data) transformInputStreams;
     ZL_DCtx_DataInfoArray dataInfo;
     ZL_Data** outputs;
     size_t nbOutputs;
@@ -133,9 +132,6 @@ ZL_DCtx* ZL_DCtx_create(void)
         return NULL;
     }
     DFH_init(&dctx->dfh);
-    VECTOR_INIT(
-            dctx->transformInputStreams,
-            ZL_transformOutStreamsLimit(ZL_MAX_FORMAT_VERSION));
     return dctx;
 }
 
@@ -179,7 +175,6 @@ void ZL_DCtx_free(ZL_DCtx* dctx)
 {
     if (dctx == NULL)
         return;
-    VECTOR_DESTROY(dctx->transformInputStreams);
     DCTX_freeStreams(dctx);
     DTM_destroy(&dctx->dtm);
     DFH_destroy(&dctx->dfh);
@@ -630,6 +625,75 @@ static ZL_Report ZL_AppendToOutputOptimization_newStreamHook(
     return ZL_returnValue(1);
 }
 
+/**
+ * Runs all node validation except checks that require the input and output
+ * streams to be materialized.
+ */
+static ZL_Report DCTX_validateNodeStatic(
+        ZL_DCtx* dctx,
+        const DTransform* dt,
+        const DFH_NodeInfo* nodeInfo)
+{
+    ZL_RESULT_DECLARE_SCOPE_REPORT(dctx);
+
+    if (dctx->dfh.formatVersion < 9) {
+        ZL_ERR_IF_EQ(
+                nodeInfo->numInputStreams,
+                0,
+                formatVersion_unsupported,
+                "0 output streams not supported until format version 9");
+    }
+    ZL_ERR_IF_GT(
+            nodeInfo->numInputStreams,
+            ZL_transformOutStreamsLimit(dctx->dfh.formatVersion),
+            formatVersion_unsupported);
+
+    ZL_ERR_IF_EQ(
+            nodeInfo->nbRegens,
+            0,
+            corruption,
+            "Graph inconsistency: Transform has no regenerated streams");
+    // Validate that nb of regen streams is compatible
+    ZL_ERR_IF_NOT(
+            DT_isNbRegensCompatible(dt, nodeInfo->nbRegens),
+            nodeRegen_countIncorrect,
+            "Transform '%s'(%u) is assigned %u streams to regenerate, but its signature specifies %u streams",
+            DT_getTransformName(dt),
+            nodeInfo->trpid.trid,
+            nodeInfo->nbRegens,
+            dt->miGraphDesc.nbInputs);
+
+    // Validate that we only have variable output streams when we have a
+    // non-zero number of variable output stream types. This is required
+    // to ensure that all non-variable transforms get the right number
+    // of streams.
+    if (dt->miGraphDesc.nbVOs == 0) {
+        ZL_ERR_IF_NE(
+                nodeInfo->nbVOs,
+                0,
+                corruption,
+                "Transform id=%u isn't accepting VO streams, "
+                "but %zu VO streams are nonetheless assigned to it in this graph.",
+                dt->miGraphDesc.CTid,
+                nodeInfo->nbVOs);
+    }
+
+    // We already validated the input streams during decode frame header.
+    // Though they may not all be filled, so we have to check that.
+    const size_t inputStreamEndIdx =
+            nodeInfo->inputStreamBaseIdx + nodeInfo->numInputStreams;
+    ZL_ERR_IF_GT(inputStreamEndIdx, dctx->dataInfo.size, graph_invalid);
+    ZL_ASSERT_LE(inputStreamEndIdx, dctx->dataInfo.size);
+    // Check that output streams are not used as input streams
+    ZL_ERR_IF_GT(
+            inputStreamEndIdx,
+            dctx->dataInfo.size - dctx->nbOutputs,
+            graph_invalid,
+            "Graph inconsistency: Output stream depends on another output stream");
+
+    return ZL_returnSuccess();
+}
+
 /* Reference streams stored in the frame.
  * Allocate them at their position in the graph.
  * @return size read from input
@@ -708,10 +772,12 @@ static ZL_Report fillStoredStreams(
                 DTM_getTransform(
                         &dctx->dtm, node->trpid, dctx->dfh.formatVersion));
         const size_t nbTrIns = wrappedTr->miGraphDesc.nbSOs + node->nbVOs;
-        ZL_ERR_IF_GT(
-                nbTrIns,
-                ZL_transformOutStreamsLimit(dctx->dfh.formatVersion),
-                formatVersion_unsupported);
+
+        nodeInfo[transformIdx].inputStreamBaseIdx = (ZL_IDType)streamIdx;
+        nodeInfo[transformIdx].numInputStreams    = (ZL_IDType)nbTrIns;
+
+        // Run all validation that can be done at header decode time.
+        ZL_ERR_IF_ERR(DCTX_validateNodeStatic(dctx, wrappedTr, node));
 
         ZL_DLOG(BLOCK,
                 "node %i : transform %i needs %i processed inputs",
@@ -719,19 +785,6 @@ static ZL_Report fillStoredStreams(
                 node->trpid.trid,
                 nbTrIns);
         size_t const inputEndIdx = streamIdx + nbTrIns;
-        ZL_ERR_IF_GT(
-                inputEndIdx,
-                firstOutputIdx,
-                corruption,
-                "Graph inconsistency: Output stream depends on another output stream");
-        ZL_ERR_IF_EQ(
-                node->nbRegens,
-                0,
-                corruption,
-                "Graph inconsistency: Transform has no regenerated streams");
-
-        nodeInfo[transformIdx].inputStreamBaseIdx = (ZL_IDType)streamIdx;
-        nodeInfo[transformIdx].numInputStreams    = (ZL_IDType)nbTrIns;
 
         for (size_t n = 0; n < node->nbRegens; n++) {
             size_t const outputStreamIdx =
@@ -1057,75 +1110,164 @@ ZL_Data* DCTX_newStreamFromStreamRef(
     return info->data;
 }
 
-// @return : nb of streams processed
-static ZL_Report processStream(
+static const ZL_Data** DCTX_getNodeInputs(
         ZL_DCtx* dctx,
-        ZL_IDType streamID,
-        const DTransform* dt,
         const DFH_NodeInfo* nodeInfo)
 {
-    ZL_RESULT_DECLARE_SCOPE_REPORT(dctx);
-    ZL_ASSERT_NN(dctx);
-    const char* const trName = DT_getTransformName(dt);
-    ZL_RESULT_SCOPE_ADD_GRAPH_CONTEXT((ZL_GraphContext){
-            .transformID = dt->miGraphDesc.CTid, .name = trName });
-    size_t const nbInStreams = dt->miGraphDesc.nbSOs + nodeInfo->nbVOs;
-    ZL_DLOG(BLOCK,
-            "processStream streams [%u-%u] with transform '%s'(%u)",
-            streamID,
-            streamID + (ZL_IDType)nbInStreams - 1,
-            trName,
-            nodeInfo->trpid.trid);
-    if (dctx->dfh.formatVersion < 9) {
-        ZL_ERR_IF_EQ(
-                nbInStreams,
-                0,
-                formatVersion_unsupported,
-                "0 output streams not supported until format version 9");
+    const ZL_Data** inputs = ALLOC_Arena_malloc(
+            dctx->workspaceArena,
+            nodeInfo->numInputStreams * sizeof(const ZL_Data*));
+    if (inputs == NULL) {
+        return NULL;
     }
-    ZL_ERR_IF_GT(
-            nbInStreams,
-            ZL_transformOutStreamsLimit(dctx->dfh.formatVersion),
-            formatVersion_unsupported);
-    // Validate that nb of regen streams is compatible
-    ZL_ERR_IF_NOT(
-            DT_isNbRegensCompatible(dt, nodeInfo->nbRegens),
-            nodeRegen_countIncorrect,
-            "Transform '%s'(%u) is assigned %u streams to regenerate, but its signature specifies %u streams",
-            DT_getTransformName(dt),
-            nodeInfo->trpid.trid,
-            nodeInfo->nbRegens,
-            dt->miGraphDesc.nbInputs);
 
-    // Validate that we only have variable output streams when we have a
-    // non-zero number of variable output stream types. This is required
-    // to ensure that all non-variable transforms get the right number
-    // of streams.
-    if (dt->miGraphDesc.nbVOs == 0) {
-        ZL_ERR_IF_NE(
-                nodeInfo->nbVOs,
-                0,
-                corruption,
-                "Transform id=%u isn't accepting VO streams, "
-                "but %zu VO streams are nonetheless assigned to it in this graph.",
-                dt->miGraphDesc.CTid,
-                nodeInfo->nbVOs);
+    for (ZL_IDType n = 0; n < nodeInfo->numInputStreams; n++) {
+        ZL_IDType const snb = nodeInfo->inputStreamBaseIdx + n;
+        size_t const inb = nodeInfo->numInputStreams - 1 - n; // reverse order
+        inputs[inb]      = dctx->dataInfo.ptr[snb].data;
     }
+
+    return inputs;
+}
+
+static ZL_Report DCTX_validateNodeInputs(
+        ZL_DCtx* dctx,
+        const DTransform* dt,
+        const DFH_NodeInfo* nodeInfo,
+        const ZL_Data* const* inputs,
+        size_t numInputs)
+{
+    ZL_RESULT_DECLARE_SCOPE_REPORT(dctx);
+    ZL_ASSERT_EQ(nodeInfo->numInputStreams, numInputs);
 
     ZL_Type allowedVOTypes = 0;
     for (size_t i = 0; i < dt->miGraphDesc.nbVOs; i++) {
         allowedVOTypes |= dt->miGraphDesc.voTypes[i];
     }
 
-    // We already validated the input streams during decode frame header.
-    // Though they may not all be filled, so we have to check that.
-    ZL_ASSERT_LE(streamID + nbInStreams, dctx->dataInfo.size);
-    // Check that output streams are not used as input streams
-    ZL_ERR_IF_GT(
-            streamID + nbInStreams,
-            dctx->dataInfo.size - dctx->nbOutputs,
-            graph_invalid);
+    // Validate input types
+    for (size_t i = 0; i < numInputs; ++i) {
+        ZL_ERR_IF_NULL(
+                inputs[i], graph_invalid, "Input stream %u not filled!", i);
 
+        // Validate the input type is correct
+        // (only for the compulsory output streams)
+        if (i < dt->miGraphDesc.nbSOs) {
+            // Compulsory range
+            if (ZL_Data_type(inputs[i]) != dt->miGraphDesc.soTypes[i]) {
+                ZL_ERR(graph_invalid,
+                       "Error processing stream transform %u: input stream %u has type %d, but we expected type %d",
+                       dt->miGraphDesc.CTid,
+                       (unsigned)i,
+                       ZL_Data_type(inputs[i]),
+                       dt->miGraphDesc.soTypes[i]);
+            }
+        } else {
+            // Validate that variable streams match one of the allowed types
+            // in the graph description. We can't validate more than that,
+            // the transform is responsible for everything else.
+            ZL_ERR_IF_NOT(
+                    ZL_Data_type(inputs[i]) & allowedVOTypes,
+                    graph_invalid,
+                    "Error processing transform %u: Variable input stream %u has type 0x%x, but we expected a type that matches the mask 0x%x",
+                    dt->miGraphDesc.CTid,
+                    (unsigned)(i - dt->miGraphDesc.nbSOs),
+                    ZL_Data_type(inputs[i]),
+                    allowedVOTypes);
+        }
+    }
+
+    return ZL_returnSuccess();
+}
+
+static const ZL_IDType* DCTX_getRegeneratedStreamIDs(
+        ZL_DCtx* dctx,
+        const DFH_NodeInfo* nodeInfo)
+{
+    ZL_IDType* const regensID = ALLOC_Arena_malloc(
+            dctx->workspaceArena, sizeof(ZL_IDType) * nodeInfo->nbRegens);
+    if (regensID == NULL) {
+        return NULL;
+    }
+
+    const ZL_IDType inputEndIdx =
+            nodeInfo->inputStreamBaseIdx + nodeInfo->numInputStreams;
+    for (size_t n = 0; n < nodeInfo->nbRegens; n++) {
+        regensID[n] = (ZL_IDType)(inputEndIdx + nodeInfo->regenDistances[n]);
+        ZL_ASSERT_LT(regensID[n], dctx->dataInfo.size);
+        ZL_ASSERT_NULL(
+                dctx->dataInfo.ptr[regensID[n]].data,
+                "Validated in frame header decoding");
+    }
+    return regensID;
+}
+
+static ZL_Report DCTX_validateNodeOutputs(
+        ZL_DCtx* dctx,
+        const ZL_IDType* regenStreamIDs,
+        size_t numRegens)
+{
+    ZL_RESULT_DECLARE_SCOPE_REPORT(dctx);
+
+    for (size_t n = 0; n < numRegens; n++) {
+        ZL_Data* outStream = dctx->dataInfo.ptr[regenStreamIDs[n]].data;
+        ZL_ERR_IF_NULL(
+                outStream,
+                transform_executionFailure,
+                "Node didn't create expected regenerated stream!");
+        ZL_ASSERT(
+                STREAM_isCommitted(outStream),
+                "Decoding transform did not provide its output size");
+    }
+
+    return ZL_returnSuccess();
+}
+
+static void DCTX_freeDecoderInputStreams(
+        ZL_DCtx* dctx,
+        const DFH_NodeInfo* nodeInfo)
+{
+    if (!dctx->preserveStreams) {
+        for (ZL_IDType n = 0; n < nodeInfo->numInputStreams; n++) {
+            ZL_IDType const snb       = nodeInfo->inputStreamBaseIdx + n;
+            ZL_Data** const streamPtr = &dctx->dataInfo.ptr[snb].data;
+            STREAM_free(*streamPtr);
+            *streamPtr = NULL;
+        }
+    }
+}
+
+// @return : nb of streams processed
+static ZL_Report runDecoder(ZL_DCtx* dctx, const DFH_NodeInfo* nodeInfo)
+{
+    ZL_RESULT_DECLARE_SCOPE_REPORT(dctx);
+    ZL_ASSERT_NN(dctx);
+    PublicTransformInfo const trid = nodeInfo->trpid;
+    ZL_TRY_LET(
+            DTrPtr,
+            dt,
+            DTM_getTransform(&dctx->dtm, trid, dctx->dfh.formatVersion));
+
+    const char* const trName = DT_getTransformName(dt);
+    ZL_RESULT_SCOPE_ADD_GRAPH_CONTEXT(
+            (ZL_GraphContext){ .transformID = trid.trid, .name = trName });
+
+    const ZL_IDType streamID = nodeInfo->inputStreamBaseIdx;
+    const size_t nbInStreams = nodeInfo->numInputStreams;
+
+    ZL_DLOG(BLOCK,
+            "transformID = %u '%s' (type:%u)",
+            trid.trid,
+            DTM_getTransformName(&dctx->dtm, trid, dctx->dfh.formatVersion),
+            trid.trt);
+    ZL_DLOG(BLOCK,
+            "runDecoder on input streams [%u-%u] with transform '%s'(%u)",
+            streamID,
+            streamID + (ZL_IDType)nbInStreams - 1,
+            trName,
+            nodeInfo->trpid.trid);
+
+    // Run append to output optimization
     if (nodeInfo->nbRegens == 1) {
         const size_t regenIdx =
                 streamID + nbInStreams + nodeInfo->regenDistances[0];
@@ -1154,73 +1296,24 @@ static ZL_Report processStream(
         }
     }
 
-    // Collect inputs and validate types
-    ZL_ERR_IF_NE(
-            nbInStreams,
-            VECTOR_RESIZE_UNINITIALIZED(
-                    dctx->transformInputStreams, nbInStreams),
-            allocation);
-    const ZL_Data** inputs = VECTOR_DATA(dctx->transformInputStreams);
-    for (ZL_IDType n = 0; n < nbInStreams; n++) {
-        ZL_IDType const snb = streamID + n;
-        size_t const inb    = nbInStreams - 1 - n; // reverse order
-        inputs[inb]         = dctx->dataInfo.ptr[snb].data;
+    // Collect input streams
+    const ZL_Data** inputs = DCTX_getNodeInputs(dctx, nodeInfo);
+    ZL_ERR_IF_NULL(inputs, allocation);
 
-        ZL_ERR_IF_NULL(
-                inputs[inb], graph_invalid, "Input stream %u not filled!", inb);
+    // Validate input types
+    ZL_ERR_IF_ERR(
+            DCTX_validateNodeInputs(dctx, dt, nodeInfo, inputs, nbInStreams));
 
-        // Validate the input type is correct
-        // (only for the compulsory output streams)
-        if (inb < dt->miGraphDesc.nbSOs) {
-            // Compulsory range
-            if (ZL_Data_type(inputs[inb]) != dt->miGraphDesc.soTypes[inb]) {
-                ZL_ERR(graph_invalid,
-                       "Error processing stream %u, transform %u: input stream %u has type %d, but we expected type %d",
-                       streamID,
-                       dt->miGraphDesc.CTid,
-                       (unsigned)inb,
-                       ZL_Data_type(inputs[inb]),
-                       dt->miGraphDesc.soTypes[inb]);
-            }
-        } else {
-            // Validate that variable streams match one of the allowed types
-            // in the graph description. We can't validate more than that,
-            // the transform is responsible for everything else.
-            ZL_ERR_IF_NOT(
-                    ZL_Data_type(inputs[inb]) & allowedVOTypes,
-                    graph_invalid,
-                    "Error processing stream %u, transform %u: Variable input stream %u has type 0x%x, but we expected a type that matches the mask 0x%x",
-                    streamID,
-                    dt->miGraphDesc.CTid,
-                    (unsigned)(inb - dt->miGraphDesc.nbSOs),
-                    ZL_Data_type(inputs[inb]),
-                    allowedVOTypes);
-        }
-    }
-
-    ZL_ASSERT_NN(dt->transformFn);
+    // Get the codec header
     ZL_TRY_LET(
             ZL_RBuffer,
             thContent,
             ZL_RBuffer_slice(
                     dctx->thstream, nodeInfo->trhStart, nodeInfo->trhSize));
 
-    // Determine regenerated streams slots (regensID)
-    ZL_IDType* const regensID = ALLOC_Arena_malloc(
-            dctx->workspaceArena, sizeof(ZL_IDType) * nodeInfo->nbRegens);
+    // Determine regenerated streams slots
+    const ZL_IDType* regensID = DCTX_getRegeneratedStreamIDs(dctx, nodeInfo);
     ZL_ERR_IF_NULL(regensID, allocation);
-    for (size_t n = 0; n < nodeInfo->nbRegens; n++) {
-        regensID[n] = (ZL_IDType)(streamID + nbInStreams
-                                  + nodeInfo->regenDistances[n]);
-    }
-    // Check that regenerated streams slots are not already filled
-    for (size_t n = 0; n < nodeInfo->nbRegens; n++) {
-        ZL_Data* outStream = dctx->dataInfo.ptr[regensID[n]].data;
-        ZL_ERR_IF_NN(
-                outStream,
-                graph_invalid,
-                "Regenerated stream slot already filled!");
-    }
 
     // Run the transform
     ZL_DLOG(SEQ,
@@ -1244,6 +1337,8 @@ static ZL_Report processStream(
             nodeInfo->trpid.trid);
 
     DWAYPOINT(on_codecDecode_start, &diState, inputs, nbInStreams);
+
+    ZL_ASSERT_NN(dt->transformFn);
     ZL_Report const report = dt->transformFn(&diState, dt, inputs, nbInStreams);
     if (ZL_isError(report)) {
         DWAYPOINT(on_codecDecode_end, &diState, NULL, 0, report);
@@ -1251,16 +1346,8 @@ static ZL_Report processStream(
     ZL_ERR_IF_ERR_COERCE(report);
 
     // Check transform's outcome
-    for (size_t n = 0; n < nodeInfo->nbRegens; n++) {
-        ZL_Data* outStream = dctx->dataInfo.ptr[regensID[n]].data;
-        ZL_ERR_IF_NULL(
-                outStream,
-                transform_executionFailure,
-                "Node didn't create expected regenerated stream!");
-        ZL_ASSERT(
-                STREAM_isCommitted(outStream),
-                "Decoding transform did not provide its output size");
-    }
+    ZL_ERR_IF_ERR(DCTX_validateNodeOutputs(dctx, regensID, nodeInfo->nbRegens));
+
     IF_DWAYPOINT_ENABLED(on_codecDecode_end, &diState)
     {
         VECTOR_CONST_POINTERS(ZL_Data) odata;
@@ -1282,23 +1369,18 @@ static ZL_Report processStream(
                 ZL_returnSuccess());
         VECTOR_DESTROY(odata);
     }
+
+    // Clear the workspace arena
     ALLOC_Arena_freeAll(dctx->workspaceArena);
+
+    // Free the input streams
+    DCTX_freeDecoderInputStreams(dctx, nodeInfo);
 
     ZL_DLOG(BLOCK,
             "decoder '%s' (id:%u) regenerated %zu streams",
             trName,
             dt->miGraphDesc.CTid,
             diState.nbRegens);
-
-    // Free the input streams
-    if (!dctx->preserveStreams) {
-        for (ZL_IDType n = 0; n < nbInStreams; n++) {
-            ZL_IDType const snb       = streamID + n;
-            ZL_Data** const streamPtr = &dctx->dataInfo.ptr[snb].data;
-            STREAM_free(*streamPtr);
-            *streamPtr = NULL;
-        }
-    }
 
     return ZL_returnValue(nbInStreams);
 }
@@ -1308,26 +1390,10 @@ static ZL_Report runDecoders(ZL_DCtx* dctx)
     ZL_RESULT_DECLARE_SCOPE_REPORT(dctx);
     ZL_DLOG(FRAME, "runDecoders (%zu stages)", dctx->dfh.nbDTransforms);
     ZL_ASSERT_NN(dctx);
-    for (size_t stage = 0, startingStream = 0; stage < dctx->dfh.nbDTransforms;
-         stage++) {
+    for (size_t stage = 0; stage < dctx->dfh.nbDTransforms; stage++) {
         ZL_DLOG(BLOCK, "decoding stage %zu", stage);
-        DFH_NodeInfo const* nodeInfo   = &VECTOR_AT(dctx->dfh.nodes, stage);
-        PublicTransformInfo const trid = nodeInfo->trpid;
-        ZL_DLOG(BLOCK,
-                "transformID = %u '%s' (type:%u)",
-                trid.trid,
-                DTM_getTransformName(&dctx->dtm, trid, dctx->dfh.formatVersion),
-                trid.trt);
-        ZL_RESULT_OF(DTrPtr)
-        const transform =
-                DTM_getTransform(&dctx->dtm, trid, dctx->dfh.formatVersion);
-        ZL_ERR_IF_ERR(transform);
-        DTrPtr const dt = ZL_RES_value(transform);
-        ZL_TRY_LET(
-                size_t,
-                nbps,
-                processStream(dctx, (ZL_IDType)startingStream, dt, nodeInfo));
-        startingStream += nbps;
+        DFH_NodeInfo const* nodeInfo = &VECTOR_AT(dctx->dfh.nodes, stage);
+        ZL_ERR_IF_ERR(runDecoder(dctx, nodeInfo));
     }
 
     return ZL_returnSuccess();
@@ -1348,15 +1414,7 @@ ZL_Report DCTX_runTransformID(ZL_DCtx* dctx, ZL_IDType transformID)
             continue;
         }
         ZL_DLOG(BLOCK, "transformID = %u (type:%u)", trid.trid, trid.trt);
-        ZL_RESULT_OF(DTrPtr)
-        const transform =
-                DTM_getTransform(&dctx->dtm, trid, dctx->dfh.formatVersion);
-        ZL_ERR_IF_ERR(transform);
-        DTrPtr const dt = ZL_RES_value(transform);
-        ZL_TRY_LET(
-                size_t,
-                nbps,
-                processStream(dctx, (ZL_IDType)startingStream, dt, node));
+        ZL_TRY_LET(size_t, nbps, runDecoder(dctx, node));
         startingStream += nbps;
         ZL_ERR_IF_NE(
                 node->nbRegens,

--- a/src/openzl/shared/portability.h
+++ b/src/openzl/shared/portability.h
@@ -104,6 +104,111 @@ ZL_BEGIN_C_DECLS
 #    define ZL_HAS_BUILTIN(x) 0
 #endif
 
+#ifdef __has_feature
+#    define ZL_HAS_FEATURE(x) __has_feature(x)
+#else
+#    define ZL_HAS_FEATURE(x) 0
+#endif
+
+#ifndef ZL_ADDRESS_SANITIZER
+#    if ZL_HAS_FEATURE(address_sanitizer)
+#        define ZL_ADDRESS_SANITIZER 1
+#    else
+#        define ZL_ADDRESS_SANITIZER 0
+#    endif
+#endif
+
+#if ZL_ADDRESS_SANITIZER
+/* Not all platforms that support asan provide sanitizers/asan_interface.h.
+ * We therefore declare the functions we need ourselves, rather than trying to
+ * include the header file... */
+
+/**
+ * Marks a memory region (<c>[addr, addr+size)</c>) as unaddressable.
+ *
+ * This memory must be previously allocated by your program. Instrumented
+ * code is forbidden from accessing addresses in this region until it is
+ * unpoisoned. This function is not guaranteed to poison the entire region -
+ * it could poison only a subregion of <c>[addr, addr+size)</c> due to ASan
+ * alignment restrictions.
+ *
+ * \note This function is not thread-safe because no two threads can poison or
+ * unpoison memory in the same memory region simultaneously.
+ *
+ * \param addr Start of memory region.
+ * \param size Size of memory region. */
+void __asan_poison_memory_region(void const volatile* addr, size_t size);
+
+/**
+ * Marks a memory region (<c>[addr, addr+size)</c>) as addressable.
+ *
+ * This memory must be previously allocated by your program. Accessing
+ * addresses in this region is allowed until this region is poisoned again.
+ * This function could unpoison a super-region of <c>[addr, addr+size)</c> due
+ * to ASan alignment restrictions.
+ *
+ * \note This function is not thread-safe because no two threads can
+ * poison or unpoison memory in the same memory region simultaneously.
+ *
+ * \param addr Start of memory region.
+ * \param size Size of memory region. */
+void __asan_unpoison_memory_region(void const volatile* addr, size_t size);
+
+/**
+ * Checks if an address is poisoned.
+ *
+ *  Returns 1 if <c><i>addr</i></c> is poisoned (that is, 1-byte read/write
+ *  access to this address would result in an error report from ASan).
+ *  Otherwise returns 0.
+ *
+ *  \param addr Address to check.
+ *
+ *  \retval 1 Address is poisoned.
+ *  \retval 0 Address is not poisoned.
+ */
+int __asan_address_is_poisoned(void const volatile* addr);
+#endif
+
+#define ZL_POISON_SUPPORTED ZL_ADDRESS_SANITIZER
+
+ZL_INLINE void ZL_poisonMemory(const void* ptr, size_t size)
+{
+#if ZL_ADDRESS_SANITIZER
+    __asan_poison_memory_region(ptr, size);
+#else
+    (void)ptr;
+    (void)size;
+#endif
+}
+
+ZL_INLINE void ZL_unpoisonMemory(const void* ptr, size_t size)
+{
+#if ZL_ADDRESS_SANITIZER
+    __asan_unpoison_memory_region(ptr, size);
+#else
+    (void)ptr;
+    (void)size;
+#endif
+}
+
+ZL_INLINE bool ZL_addressIsPoisoned(const void* ptr)
+{
+#if ZL_ADDRESS_SANITIZER
+    return __asan_address_is_poisoned(ptr);
+#else
+    (void)ptr;
+    return false;
+#endif
+}
+
+#if ZL_POISON_SUPPORTED
+#    define ZL_POISON_MEMORY(ptr, size) ZL_poisonMemory(ptr, size)
+#    define ZL_UNPOISON_MEMORY(ptr, size) ZL_unpoisonMemory(ptr, size)
+#else
+#    define ZL_POISON_MEMORY(ptr, size)
+#    define ZL_UNPOISON_MEMORY(ptr, size)
+#endif
+
 #define ZL_ARCH_FLAG_X86 (1 << 0)
 #define ZL_ARCH_FLAG_X86_64 ((1 << 1) | ZL_ARCH_FLAG_X86)
 #define ZL_ARCH_FLAG_I386 ((1 << 2) | ZL_ARCH_FLAG_X86)

--- a/tests/unittest/common/test_allocators.cpp
+++ b/tests/unittest/common/test_allocators.cpp
@@ -288,6 +288,182 @@ TEST_P(AllocatorTest, mallocAndReallocWithSeveralIterations)
     freeArena(arena);
 }
 
+TEST_P(AllocatorTest, redzoneIsPoisonedWithMallocAndFree)
+{
+    if (!ZL_POISON_SUPPORTED) {
+        return;
+    }
+
+    Arena* arena = createArena();
+
+    for (size_t i = 0; i < 5; ++i) {
+        for (size_t j = 0; j < 5; ++j) {
+            // Allocate a buffer
+            char* ptr = (char*)ALLOC_Arena_malloc(arena, 100);
+            ASSERT_NE(ptr, nullptr);
+
+            ASSERT_FALSE(ZL_addressIsPoisoned(ptr));
+            ASSERT_FALSE(ZL_addressIsPoisoned(ptr + 99));
+            ASSERT_TRUE(ZL_addressIsPoisoned(ptr + 100));
+            ASSERT_TRUE(ZL_addressIsPoisoned(ptr - 1));
+
+            // Free the buffer
+            ALLOC_Arena_free(arena, ptr);
+
+            ASSERT_TRUE(ZL_addressIsPoisoned(ptr));
+            ASSERT_TRUE(ZL_addressIsPoisoned(ptr + 99));
+            ASSERT_TRUE(ZL_addressIsPoisoned(ptr + 100));
+            ASSERT_TRUE(ZL_addressIsPoisoned(ptr - 1));
+        }
+
+        ALLOC_Arena_freeAll(arena);
+    }
+
+    freeArena(arena);
+}
+
+TEST_P(AllocatorTest, redzoneIsPoisonedWithMallocThenFreeAll)
+{
+    if (!ZL_POISON_SUPPORTED) {
+        return;
+    }
+
+    Arena* arena = createArena();
+
+    for (size_t i = 0; i < 5; ++i) {
+        std::array<char*, 5> ptrs;
+        for (size_t j = 0; j < 5; ++j) {
+            // Allocate a buffer
+            char* ptr = (char*)ALLOC_Arena_malloc(arena, 100);
+            ASSERT_NE(ptr, nullptr);
+
+            ASSERT_FALSE(ZL_addressIsPoisoned(ptr));
+            ASSERT_FALSE(ZL_addressIsPoisoned(ptr + 99));
+            ASSERT_TRUE(ZL_addressIsPoisoned(ptr + 100));
+            ASSERT_TRUE(ZL_addressIsPoisoned(ptr - 1));
+
+            ptrs[j] = ptr;
+        }
+
+        ALLOC_Arena_freeAll(arena);
+
+        for (char* ptr : ptrs) {
+            ASSERT_TRUE(ZL_addressIsPoisoned(ptr));
+            ASSERT_TRUE(ZL_addressIsPoisoned(ptr + 99));
+            ASSERT_TRUE(ZL_addressIsPoisoned(ptr + 100));
+            ASSERT_TRUE(ZL_addressIsPoisoned(ptr - 1));
+        }
+    }
+
+    freeArena(arena);
+}
+
+TEST_P(AllocatorTest, redzoneIsPoisonedWithMallocThenRealloc)
+{
+    if (!ZL_POISON_SUPPORTED) {
+        return;
+    }
+
+    Arena* arena = createArena();
+
+    for (size_t i = 0; i < 5; ++i) {
+        for (size_t j = 0; j < 5; ++j) {
+            // Allocate a buffer with realloc
+            char* ptr = (char*)ALLOC_Arena_malloc(arena, 100);
+            ASSERT_NE(ptr, nullptr);
+
+            ASSERT_FALSE(ZL_addressIsPoisoned(ptr));
+            ASSERT_FALSE(ZL_addressIsPoisoned(ptr + 99));
+            ASSERT_TRUE(ZL_addressIsPoisoned(ptr + 100));
+            ASSERT_TRUE(ZL_addressIsPoisoned(ptr - 1));
+
+            // Resize the buffer larger
+            ptr = (char*)ALLOC_Arena_realloc(arena, ptr, 200);
+            ASSERT_NE(ptr, nullptr);
+
+            ASSERT_FALSE(ZL_addressIsPoisoned(ptr));
+            ASSERT_FALSE(ZL_addressIsPoisoned(ptr + 199));
+            ASSERT_TRUE(ZL_addressIsPoisoned(ptr + 200));
+            ASSERT_TRUE(ZL_addressIsPoisoned(ptr - 1));
+
+            // Resize the buffer smaller
+            ptr = (char*)ALLOC_Arena_realloc(arena, ptr, 50);
+            ASSERT_NE(ptr, nullptr);
+
+            ASSERT_FALSE(ZL_addressIsPoisoned(ptr));
+            ASSERT_FALSE(ZL_addressIsPoisoned(ptr + 49));
+            ASSERT_TRUE(ZL_addressIsPoisoned(ptr + 50));
+            ASSERT_TRUE(ZL_addressIsPoisoned(ptr - 1));
+
+            // Free the buffer
+            ALLOC_Arena_free(arena, ptr);
+
+            ASSERT_TRUE(ZL_addressIsPoisoned(ptr));
+            ASSERT_TRUE(ZL_addressIsPoisoned(ptr + 49));
+            ASSERT_TRUE(ZL_addressIsPoisoned(ptr + 99));
+            ASSERT_TRUE(ZL_addressIsPoisoned(ptr + 199));
+            ASSERT_TRUE(ZL_addressIsPoisoned(ptr + 200));
+            ASSERT_TRUE(ZL_addressIsPoisoned(ptr - 1));
+        }
+        ALLOC_Arena_freeAll(arena);
+    }
+
+    freeArena(arena);
+}
+
+TEST_P(AllocatorTest, redzoneIsPoisonedWithReallocThenRealloc)
+{
+    if (!ZL_POISON_SUPPORTED) {
+        return;
+    }
+
+    Arena* arena = createArena();
+
+    for (size_t i = 0; i < 5; ++i) {
+        for (size_t j = 0; j < 5; ++j) {
+            // Allocate a buffer with realloc
+            char* ptr = (char*)ALLOC_Arena_realloc(arena, nullptr, 100);
+            ASSERT_NE(ptr, nullptr);
+
+            ASSERT_FALSE(ZL_addressIsPoisoned(ptr));
+            ASSERT_FALSE(ZL_addressIsPoisoned(ptr + 99));
+            ASSERT_TRUE(ZL_addressIsPoisoned(ptr + 100));
+            ASSERT_TRUE(ZL_addressIsPoisoned(ptr - 1));
+
+            // Resize the buffer larger
+            ptr = (char*)ALLOC_Arena_realloc(arena, ptr, 200);
+            ASSERT_NE(ptr, nullptr);
+
+            ASSERT_FALSE(ZL_addressIsPoisoned(ptr));
+            ASSERT_FALSE(ZL_addressIsPoisoned(ptr + 199));
+            ASSERT_TRUE(ZL_addressIsPoisoned(ptr + 200));
+            ASSERT_TRUE(ZL_addressIsPoisoned(ptr - 1));
+
+            // Resize the buffer smaller
+            ptr = (char*)ALLOC_Arena_realloc(arena, ptr, 50);
+            ASSERT_NE(ptr, nullptr);
+
+            ASSERT_FALSE(ZL_addressIsPoisoned(ptr));
+            ASSERT_FALSE(ZL_addressIsPoisoned(ptr + 49));
+            ASSERT_TRUE(ZL_addressIsPoisoned(ptr + 50));
+            ASSERT_TRUE(ZL_addressIsPoisoned(ptr - 1));
+
+            // Free the buffer
+            ALLOC_Arena_free(arena, ptr);
+
+            ASSERT_TRUE(ZL_addressIsPoisoned(ptr));
+            ASSERT_TRUE(ZL_addressIsPoisoned(ptr + 49));
+            ASSERT_TRUE(ZL_addressIsPoisoned(ptr + 99));
+            ASSERT_TRUE(ZL_addressIsPoisoned(ptr + 199));
+            ASSERT_TRUE(ZL_addressIsPoisoned(ptr + 200));
+            ASSERT_TRUE(ZL_addressIsPoisoned(ptr - 1));
+        }
+        ALLOC_Arena_freeAll(arena);
+    }
+
+    freeArena(arena);
+}
+
 // Instantiate tests for HeapArena
 
 class HeapArenaImplementation : public ArenaImplementation {


### PR DESCRIPTION
Summary:

Refactor `processStream` and rename to `runDecoder`. As part of the refactor I:
1. Moved all validation that can be done at header decode time to `fillStoredStreams()`
2. Split the function up into smaller helpers
3. Removed a check that the regenerated streams aren't filled, because we already check this in `fillStoredStreams()`
4. Deleted the `transformInputStreams` vector and use the `workspaceArena` instead

Reviewed By: Cyan4973

Differential Revision: D96396998


