### PR TITLE
Fix 8GB allocation crash in ZSTD parameter validation

### DIFF
--- a/src/openzl/codecs/zstd/encode_zstd_binding.c
+++ b/src/openzl/codecs/zstd/encode_zstd_binding.c
@@ -12,6 +12,10 @@
 #endif
 #include <zstd.h>
 
+// Approximately log2 of the factor for the allowed memory usage for the most
+// expensive zstd parameter configuration
+#define ZSTD_MEMORY_USAGE_CAP_LOG_FACTOR 3
+
 /// Determines if we should cut blocks for each element.
 /// E.g. if the input is transposed.
 static bool EI_zstd_shouldCutBlocks(ZL_Input const* in)
@@ -23,12 +27,31 @@ static bool EI_zstd_shouldCutBlocks(ZL_Input const* in)
     return nbElts > 0 && eltWidth >= kMinBlockSize && nbElts <= kMaxNbElts;
 }
 
-static bool EI_zstd_parameter_valid(ZSTD_cParameter param)
+// A more restrictive bounds check on parameters for running zstd that affect
+// how much memory is used, and preventing certain parameters from being
+// overriden.
+
+static bool EI_zstd_parameter_valid(ZSTD_cParameter param, int paramValue)
 {
-    if (param == ZSTD_c_format)
+    if (param == ZSTD_c_format || param == ZSTD_c_contentSizeFlag) {
         return false;
-    if (param == ZSTD_c_contentSizeFlag)
-        return false;
+    }
+    if (param == ZSTD_c_windowLog) {
+        return paramValue
+                <= ZSTD_WINDOWLOG_MAX - ZSTD_MEMORY_USAGE_CAP_LOG_FACTOR;
+    }
+    if (param == ZSTD_c_hashLog) {
+        return paramValue
+                <= ZSTD_HASHLOG_MAX - ZSTD_MEMORY_USAGE_CAP_LOG_FACTOR;
+    }
+    if (param == ZSTD_c_chainLog) {
+        return paramValue
+                <= ZSTD_CHAINLOG_MAX - ZSTD_MEMORY_USAGE_CAP_LOG_FACTOR;
+    }
+    if (param == ZSTD_c_ldmHashLog) {
+        return paramValue
+                <= ZSTD_LDM_HASHLOG_MAX - ZSTD_MEMORY_USAGE_CAP_LOG_FACTOR;
+    }
     return true;
 }
 
@@ -107,12 +130,11 @@ EI_zstdWithCCtx(ZL_Encoder* eictx, ZSTD_CCtx* cctx, const ZL_Input* src)
         ZL_IntParam const ip        = lips.intParams[n];
         ZSTD_cParameter const param = (ZSTD_cParameter)ip.paramId;
         ZL_ERR_IF_NOT(
-                EI_zstd_parameter_valid(param),
+                EI_zstd_parameter_valid(param, ip.paramValue),
                 nodeParameter_invalid,
                 "zstd parameter %i cannot be modified");
         ZL_ERR_IF_ZSTD_ERR(ZSTD_CCtx_setParameter(cctx, param, ip.paramValue));
     }
-
     if (blockSize == srcSize) {
         size_t const cSize = ZSTD_compress2(
                 cctx,


### PR DESCRIPTION
Summary:
Fuzzing discovered that memory usage in zstd exceeds bounds. Specifically in the failing case:
```
  LDM hashLog=30 -> ldmHSize = 2^30 = 1073741824 entries
  sizeof(ldmEntry_t) = 8 bytes
  ldmHashTable = ldmHSize * sizeof(ldmEntry_t) = 1073741824 * 8 = 8589934592 bytes (8.00 GB)
  bucketSizeLog=5 -> ldmBucketSize = 2^(30-5) = 33554432 entries (33554432 bytes)
  TOTAL ldmSpace = 8623489024 bytes (8.03 GB)
```
This diff reduces the possible memory usage by 8 times using the zstd binding in OpenZL by reducing the limits on the allowed parameters that affect memory.

Reviewed By: terrelln

Differential Revision: D96362712


