### PR TITLE
Fix fuzzing issues compress bounds

### DIFF
--- a/tests/zstrong/fuzz_variable.cpp
+++ b/tests/zstrong/fuzz_variable.cpp
@@ -200,7 +200,7 @@ FUZZ_F(VariableTest, FuzzDispatchStringRoundTrip)
             cgraph_, nbOutputs, indices.data());
     ZL_GraphID dispatchGraph = declareGraph(dispatchStringNode);
     finalizeGraph(dispatchGraph, 1);
-    setLargeCompressBound(1024);
+    setLargeCompressBound(4096);
 
     bool compressionShouldSucceed =
             std::all_of(indices.begin(), indices.end(), [nbOutputs](auto i) {


### PR DESCRIPTION
Summary: The compress bounds are insufficient for specific cases where the number of outputs are very large for specific transforms such as dispatch string. Increase the bound.

Reviewed By: terrelln

Differential Revision: D96501183


