### PR TITLE
Stage 2: Add C-level decompress introspection hooks (#518)

### DIFF
--- a/include/openzl/zl_decompress.h
+++ b/include/openzl/zl_decompress.h
@@ -5,7 +5,8 @@
 
 // basic definitions
 #include "openzl/zl_common_types.h"
-#include "openzl/zl_errors.h" // ZL_Report, ZL_isError()
+#include "openzl/zl_errors.h"        // ZL_Report, ZL_isError()
+#include "openzl/zl_introspection.h" // ZL_DecompressIntrospectionHooks
 #include "openzl/zl_output.h"
 
 #if defined(__cplusplus)
@@ -615,6 +616,29 @@ const uint32_t* ZL_TypedBuffer_rStringLens(const ZL_TypedBuffer* tbuffer);
  * versions
  */
 ZL_Report ZL_getHeaderSize(const void* src, size_t srcSize);
+
+// -----------------------------
+// Decompression Introspection
+// -----------------------------
+
+/**
+ * Attach introspection hooks to the DCtx. Hooks allow code to run at specific
+ * DWAYPOINTs during decompression. A hook set to NULL will simply be skipped.
+ * There can only be one set of hooks attached at a time; calling this again
+ * will overwrite the previous hooks. The caller is responsible for maintaining
+ * the lifetime of the objects referenced by the hooks.
+ *
+ * @note This will only do something if the library is compiled with the
+ * ALLOW_INTROSPECTION option. Otherwise, all the hooks will be no-ops.
+ */
+ZL_Report ZL_DCtx_attachDecompressIntrospectionHooks(
+        ZL_DCtx* dctx,
+        const ZL_DecompressIntrospectionHooks* hooks);
+
+/**
+ * Detach any decompression introspection hooks currently attached to the DCtx.
+ */
+ZL_Report ZL_DCtx_detachAllDecompressIntrospectionHooks(ZL_DCtx* dctx);
 
 #if defined(__cplusplus)
 } // extern "C"

--- a/include/openzl/zl_introspection.h
+++ b/include/openzl/zl_introspection.h
@@ -117,4 +117,52 @@ typedef struct ZL_CompressIntrospectionHooks_s {
             ZL_Report const result) ZL_NOEXCEPT_FUNC_PTR;
 } ZL_CompressIntrospectionHooks;
 
+// Introspection hooks for decompress
+typedef struct ZL_DecompressIntrospectionHooks_s {
+    void* opaque; // an opaque pointer, passed as-is to all the hooks as the
+    // first argument
+
+    /* ******** DCtx entrypoint ******** */
+    void (*on_ZL_DCtx_decompressMultiTBuffer_start)(
+            void* opaque,
+            ZL_DCtx* dctx,
+            size_t nbOutputs,
+            const void* framePtr,
+            size_t frameSize) ZL_NOEXCEPT_FUNC_PTR;
+    void (*on_ZL_DCtx_decompressMultiTBuffer_end)(
+            void* opaque,
+            ZL_DCtx* dctx,
+            ZL_Report result) ZL_NOEXCEPT_FUNC_PTR;
+
+    /* ******** Per-chunk ******** */
+    void (*on_decompressChunk_start)(
+            void* opaque,
+            ZL_DCtx* dctx,
+            size_t chunkIndex) ZL_NOEXCEPT_FUNC_PTR;
+    void (*on_decompressChunk_end)(
+            void* opaque,
+            ZL_DCtx* dctx,
+            ZL_Report result) ZL_NOEXCEPT_FUNC_PTR;
+
+    /* ******** Decoder API methods ******** */
+    void (*on_ZL_Decoder_getCodecHeader)(
+            void* opaque,
+            const ZL_Decoder* dictx,
+            const void* trh,
+            size_t trhSize) ZL_NOEXCEPT_FUNC_PTR;
+
+    /* ******** Per-codec/transform execution ******** */
+    void (*on_codecDecode_start)(
+            void* opaque,
+            ZL_Decoder* dictx,
+            const ZL_Data* const* inStreams,
+            size_t nbInStreams) ZL_NOEXCEPT_FUNC_PTR;
+    void (*on_codecDecode_end)(
+            void* opaque,
+            ZL_Decoder* dictx,
+            const ZL_Data* const* outStreams,
+            size_t nbOutStreams,
+            ZL_Report result) ZL_NOEXCEPT_FUNC_PTR;
+} ZL_DecompressIntrospectionHooks;
+
 #endif // OPENZL_ZL_INTROSPECTION_H

--- a/src/openzl/common/introspection.h
+++ b/src/openzl/common/introspection.h
@@ -47,10 +47,50 @@ extern "C" {
         if (_wpe_oc##hook->hasCompressionHooks                              \
             && _wpe_oc##hook->compressIntrospectionHooks.hook != NULL)
 
+/**
+ * Define an execution waypoint for decompression introspection. Same pattern
+ * as CWAYPOINT but accesses the decompressIntrospectionHooks.
+ *
+ * Prefer using DWAYPOINT() when @p ctx supports ZL_GET_OPERATION_CONTEXT
+ * directly. Use DWAYPOINT_WITH_OC() only when the operation context must be
+ * resolved from a different object than the one passed to the hook callback
+ * (e.g., when @p hook_ctx is const and ZL_GET_OPERATION_CONTEXT doesn't
+ * accept it).
+ *
+ * @p oc_src is used to resolve the OperationContext (via
+ * ZL_GET_OPERATION_CONTEXT), while @p hook_ctx is passed to the hook callback.
+ */
+#    define DWAYPOINT_WITH_OC(hook, oc_src, hook_ctx, ...)               \
+        do {                                                             \
+            ZL_OperationContext* _oc = ZL_GET_OPERATION_CONTEXT(oc_src); \
+            ZL_ASSERT_NN(_oc);                                           \
+            if (!_oc->hasDecompressionHooks) {                           \
+                break;                                                   \
+            }                                                            \
+            if (_oc->decompressIntrospectionHooks.hook != NULL) {        \
+                _oc->decompressIntrospectionHooks.hook(                  \
+                        _oc->decompressIntrospectionHooks.opaque,        \
+                        hook_ctx,                                        \
+                        __VA_ARGS__);                                    \
+            }                                                            \
+        } while (0)
+
+#    define DWAYPOINT(hook, ctx, ...) \
+        DWAYPOINT_WITH_OC(hook, ctx, ctx, __VA_ARGS__)
+
+#    define IF_DWAYPOINT_ENABLED(hook, ctx)                                 \
+        ZL_OperationContext* _wpe_oc##hook = ZL_GET_OPERATION_CONTEXT(ctx); \
+        ZL_ASSERT_NN(_wpe_oc##hook);                                        \
+        if (_wpe_oc##hook->hasDecompressionHooks                            \
+            && _wpe_oc##hook->decompressIntrospectionHooks.hook != NULL)
+
 #else
 
 #    define CWAYPOINT(hook, ctx, ...)
 #    define IF_CWAYPOINT_ENABLED(hook, ctx) if (false)
+#    define DWAYPOINT_WITH_OC(hook, oc_src, hook_ctx, ...)
+#    define DWAYPOINT(hook, ctx, ...)
+#    define IF_DWAYPOINT_ENABLED(hook, ctx) if (false)
 
 #endif
 

--- a/src/openzl/common/introspection.h
+++ b/src/openzl/common/introspection.h
@@ -13,42 +13,44 @@ extern "C" {
 #if ZL_ALLOW_INTROSPECTION
 
 /**
- * Define an execution waypoint for introspection. When inserted into an
- * existing code block, this macro will grab the relevant OperationContext from
- * the @p ctx object and call the corresponding @p hook function at the point of
- * insertion.
+ * Define an execution waypoint for compression introspection. When inserted
+ * into an existing code block, this macro will grab the relevant
+ * OperationContext from the @p ctx object and call the corresponding @p hook
+ * function at the point of insertion.
  *
  * If @p hook is not provided (function pointer points to NULL), the operation
  * is aborted. This is to save on the expensive computation to fill __VA_ARGS__.
- * If introspection is disabled, the whole WAYPOINT macro is no-oped.
+ * If introspection is disabled, the whole CWAYPOINT macro is no-oped.
  *
  * @note @p ctx must be a valid context object from which the OperationContext
  * can be extracted.
  */
-#    define WAYPOINT(hook, ctx, ...)                                       \
-        do {                                                               \
-            ZL_OperationContext* _oc = ZL_GET_OPERATION_CONTEXT(ctx);      \
-            ZL_ASSERT_NN(_oc);                                             \
-            if (!_oc->hasIntrospectionHooks) {                             \
-                break;                                                     \
-            }                                                              \
-            if (_oc->introspectionHooks.hook != NULL) {                    \
-                /* allow passing a C++ class */                            \
-                _oc->introspectionHooks.hook(                              \
-                        _oc->introspectionHooks.opaque, ctx, __VA_ARGS__); \
-            }                                                              \
+#    define CWAYPOINT(hook, ctx, ...)                                 \
+        do {                                                          \
+            ZL_OperationContext* _oc = ZL_GET_OPERATION_CONTEXT(ctx); \
+            ZL_ASSERT_NN(_oc);                                        \
+            if (!_oc->hasCompressionHooks) {                          \
+                break;                                                \
+            }                                                         \
+            if (_oc->compressIntrospectionHooks.hook != NULL) {       \
+                /* allow passing a C++ class */                       \
+                _oc->compressIntrospectionHooks.hook(                 \
+                        _oc->compressIntrospectionHooks.opaque,       \
+                        ctx,                                          \
+                        __VA_ARGS__);                                 \
+            }                                                         \
         } while (0)
 
-#    define IF_WAYPOINT_ENABLED(hook, ctx)                                  \
+#    define IF_CWAYPOINT_ENABLED(hook, ctx)                                 \
         ZL_OperationContext* _wpe_oc##hook = ZL_GET_OPERATION_CONTEXT(ctx); \
         ZL_ASSERT_NN(_wpe_oc##hook);                                        \
-        if (_wpe_oc##hook->hasIntrospectionHooks                            \
-            && _wpe_oc##hook->introspectionHooks.hook != NULL)
+        if (_wpe_oc##hook->hasCompressionHooks                              \
+            && _wpe_oc##hook->compressIntrospectionHooks.hook != NULL)
 
 #else
 
-#    define WAYPOINT(hook, ctx, ...)
-#    define IF_WAYPOINT_ENABLED(hook, ctx) if (false)
+#    define CWAYPOINT(hook, ctx, ...)
+#    define IF_CWAYPOINT_ENABLED(hook, ctx) if (false)
 
 #endif
 

--- a/src/openzl/common/operation_context.c
+++ b/src/openzl/common/operation_context.c
@@ -15,7 +15,8 @@ void ZL_OC_init(ZL_OperationContext* opCtx)
     memset(opCtx, 0, sizeof(*opCtx));
     VECTOR_INIT(opCtx->errorInfos, 1024);
     VECTOR_INIT(opCtx->warnings, 1024);
-    opCtx->hasIntrospectionHooks = false;
+    opCtx->hasCompressionHooks   = false;
+    opCtx->hasDecompressionHooks = false;
 }
 
 void ZL_OC_destroy(ZL_OperationContext* opCtx)

--- a/src/openzl/common/operation_context.h
+++ b/src/openzl/common/operation_context.h
@@ -52,10 +52,11 @@ struct ZL_OperationContext_s {
 
     // Introspection hooks for the current operation. Realistically only
     // relevant for CCtx and DCtx. These allow the user to execute custom code
-    // snippets at specified WAYPOINT()s within the operation. See
-    // common/introspection.h for more details.
-    ZL_CompressIntrospectionHooks introspectionHooks;
-    bool hasIntrospectionHooks;
+    // snippets at specified CWAYPOINT()s / DWAYPOINT()s within the operation.
+    // See common/introspection.h for more details.
+    ZL_CompressIntrospectionHooks compressIntrospectionHooks;
+    bool hasCompressionHooks;
+    bool hasDecompressionHooks;
 };
 
 void ZL_OC_init(ZL_OperationContext* opCtx);

--- a/src/openzl/common/operation_context.h
+++ b/src/openzl/common/operation_context.h
@@ -55,6 +55,7 @@ struct ZL_OperationContext_s {
     // snippets at specified CWAYPOINT()s / DWAYPOINT()s within the operation.
     // See common/introspection.h for more details.
     ZL_CompressIntrospectionHooks compressIntrospectionHooks;
+    ZL_DecompressIntrospectionHooks decompressIntrospectionHooks;
     bool hasCompressionHooks;
     bool hasDecompressionHooks;
 };

--- a/src/openzl/compress/cctx.c
+++ b/src/openzl/compress/cctx.c
@@ -242,8 +242,8 @@ ZL_Report ZL_CCtx_attachIntrospectionHooks(
     ZL_ERR_IF_NULL(hooks, allocation);
     ZL_OperationContext* oc = ZL_CCtx_getOperationContext(cctx);
     ZL_ASSERT_NN(oc);
-    oc->introspectionHooks    = *hooks;
-    oc->hasIntrospectionHooks = true;
+    oc->compressIntrospectionHooks = *hooks;
+    oc->hasCompressionHooks        = true;
     return ZL_returnSuccess();
 }
 
@@ -252,8 +252,10 @@ ZL_Report ZL_CCtx_detachAllIntrospectionHooks(ZL_CCtx* cctx)
     ZL_ASSERT_NN(cctx);
     ZL_OperationContext* oc = ZL_CCtx_getOperationContext(cctx);
     ZL_ASSERT_NN(oc);
-    ZL_zeroes(&oc->introspectionHooks, sizeof(oc->introspectionHooks));
-    oc->hasIntrospectionHooks = false;
+    ZL_zeroes(
+            &oc->compressIntrospectionHooks,
+            sizeof(oc->compressIntrospectionHooks));
+    oc->hasCompressionHooks = false;
     return ZL_returnSuccess();
 }
 
@@ -640,7 +642,7 @@ static ZL_Report CCTX_convertInputs(
                 input,
                 inType,
                 portTypeMask);
-        WAYPOINT(
+        CWAYPOINT(
                 on_cctx_convertOneInput,
                 cctx,
                 input,
@@ -788,7 +790,7 @@ static ZL_Report CCTX_runGraph_internal(
     (void)graphid; // required only for waypoints
     // All streams created after this index will be created by the dynamic
     // graph
-    WAYPOINT(
+    CWAYPOINT(
             on_migraphEncode_start,
             gctx,
             CCTX_getCGraph(cctx),
@@ -797,10 +799,11 @@ static ZL_Report CCTX_runGraph_internal(
             nbInputs);
     ZL_Report const graphExecutionReport =
             GCTX_runMultiInputGraph(gctx, inputs, nbInputs);
-    IF_WAYPOINT_ENABLED(on_migraphEncode_end, gctx)
+    IF_CWAYPOINT_ENABLED(on_migraphEncode_end, gctx)
     {
         if (ZL_isError(graphExecutionReport)) {
-            WAYPOINT(on_migraphEncode_end, gctx, NULL, 0, graphExecutionReport);
+            CWAYPOINT(
+                    on_migraphEncode_end, gctx, NULL, 0, graphExecutionReport);
         } else {
             size_t nbSuccs = VECTOR_SIZE(gctx->dstGraphDescs);
             DECLARE_VECTOR_TYPE(ZL_GraphID);
@@ -814,7 +817,7 @@ static ZL_Report CCTX_runGraph_internal(
                         allocation,
                         "Unable to append to the waypoint succGids vector");
             }
-            WAYPOINT(
+            CWAYPOINT(
                     on_migraphEncode_end,
                     gctx,
                     VECTOR_DATA(succGids),
@@ -983,9 +986,9 @@ static ZL_Report CCTX_runSegmenter(
             &cctx->rtgraph,
             cctx->sessionArena,
             cctx->chunkArena);
-    WAYPOINT(on_segmenterEncode_start, segmenterCtx, /* placeholder */ NULL);
+    CWAYPOINT(on_segmenterEncode_start, segmenterCtx, /* placeholder */ NULL);
     const ZL_Report r = SEGM_runSegmenter(segmenterCtx);
-    WAYPOINT(on_segmenterEncode_end, segmenterCtx, r);
+    CWAYPOINT(on_segmenterEncode_end, segmenterCtx, r);
 
     // Maybe clean up on-the-fly materialized params
     MPM_dematerializeOneshot(cctx->sessionArena, &segMatRes);

--- a/src/openzl/compress/compress2.c
+++ b/src/openzl/compress/compress2.c
@@ -340,7 +340,7 @@ ZL_Report ZL_CCtx_compressMultiTypedRef(
         size_t nbInputs)
 {
     ZL_RESULT_DECLARE_SCOPE_REPORT(cctx);
-    WAYPOINT(
+    CWAYPOINT(
             on_ZL_CCtx_compressMultiTypedRef_start,
             cctx,
             dst,
@@ -354,7 +354,7 @@ ZL_Report ZL_CCtx_compressMultiTypedRef(
     ZL_ERR_IF_NOT(CCTX_isGraphSet(cctx), compressionParameter_invalid);
     const ZL_Report rep = CCTX_compressInputs_withGraphSet(
             cctx, dst, dstCapacity, ZL_codemodInputsAsDatas(inputs), nbInputs);
-    WAYPOINT(on_ZL_CCtx_compressMultiTypedRef_end, cctx, rep);
+    CWAYPOINT(on_ZL_CCtx_compressMultiTypedRef_end, cctx, rep);
     return rep;
 }
 

--- a/src/openzl/compress/dyngraph_interface.c
+++ b/src/openzl/compress/dyngraph_interface.c
@@ -126,7 +126,7 @@ bool ZL_Graph_isNodeSupported(const ZL_Graph* gctx, ZL_NodeID nodeid)
 
 void* ZL_Graph_getScratchSpace(ZL_Graph* gctx, size_t size)
 {
-    WAYPOINT(on_ZL_Graph_getScratchSpace, gctx, size);
+    CWAYPOINT(on_ZL_Graph_getScratchSpace, gctx, size);
     return ALLOC_Arena_malloc(gctx->graphArena, size);
 }
 

--- a/src/openzl/compress/enc_interface.c
+++ b/src/openzl/compress/enc_interface.c
@@ -288,10 +288,11 @@ static ZL_Report ENC_runTransform_internal(
                     RTGM_getOutStreamID(rtgm, eictx->rtnodeid, (int)i);
             const ZL_Data* d     = RTGM_getRStream(rtgm, rtsid);
             bool pushbackSuccess = VECTOR_PUSHBACK(odata, d);
-            ZL_ERR_IF_NOT(
-                    pushbackSuccess,
-                    allocation,
-                    "Unable to append to the waypoint odata vector");
+            if (!pushbackSuccess) {
+                VECTOR_DESTROY(odata);
+                ZL_ERR(allocation,
+                       "Unable to append to the waypoint odata vector");
+            }
         }
         CWAYPOINT(
                 on_codecEncode_end,

--- a/src/openzl/compress/enc_interface.c
+++ b/src/openzl/compress/enc_interface.c
@@ -104,7 +104,7 @@ void ZL_Encoder_sendCodecHeader(
         size_t trhSize)
 {
     ZL_DLOG(SEQ, "ZL_Encoder_sendCodecHeader (%zu bytes)", trhSize);
-    WAYPOINT(on_ZL_Encoder_sendCodecHeader, eictx, trh, trhSize);
+    CWAYPOINT(on_ZL_Encoder_sendCodecHeader, eictx, trh, trhSize);
     ZL_ASSERT_NN(eictx);
     if (trhSize)
         ZL_ASSERT_NN(trh);
@@ -183,7 +183,7 @@ ZL_Output* ZL_Encoder_createTypedStream(
     ZL_ASSERT_NN(eic);
     ZL_Data* ret = CCTX_getNewStream(
             eic->cctx, eic->rtnodeid, outStreamIndex, eltWidth, eltsCapacity);
-    WAYPOINT(
+    CWAYPOINT(
             on_ZL_Encoder_createTypedStream,
             eic,
             outStreamIndex,
@@ -259,9 +259,9 @@ static ZL_Report ENC_runTransform_internal(
 
     // Run transform
     ZL_ASSERT_NN(trDesc->publicDesc.transform_f);
-    IF_WAYPOINT_ENABLED(on_codecEncode_start, eictx)
+    IF_CWAYPOINT_ENABLED(on_codecEncode_start, eictx)
     {
-        WAYPOINT(
+        CWAYPOINT(
                 on_codecEncode_start,
                 eictx,
                 CCTX_getCGraph(eictx->cctx),
@@ -272,13 +272,13 @@ static ZL_Report ENC_runTransform_internal(
     ZL_Report codecExecResult = (trDesc->publicDesc.transform_f(
             eictx, ZL_codemodDatasAsInputs(inStreams), nbInStreams));
     if (ZL_isError(codecExecResult)) {
-        WAYPOINT(on_codecEncode_end, eictx, NULL, 0, codecExecResult);
+        CWAYPOINT(on_codecEncode_end, eictx, NULL, 0, codecExecResult);
         ZL_RET_R_IF_ERR_COERCE(
                 codecExecResult, "transform %s failed", CT_getTrName(trDesc));
     }
     const RTGraph* rtgm       = CCTX_getRTGraph(eictx->cctx);
     const size_t nbOutStreams = RTGM_getNbOutStreams(rtgm, eictx->rtnodeid);
-    IF_WAYPOINT_ENABLED(on_codecEncode_end, eictx)
+    IF_CWAYPOINT_ENABLED(on_codecEncode_end, eictx)
     {
         DECLARE_VECTOR_CONST_POINTERS_TYPE(ZL_Data);
         VECTOR_CONST_POINTERS(ZL_Data) odata;
@@ -293,7 +293,7 @@ static ZL_Report ENC_runTransform_internal(
                     allocation,
                     "Unable to append to the waypoint odata vector");
         }
-        WAYPOINT(
+        CWAYPOINT(
                 on_codecEncode_end,
                 eictx,
                 ZL_codemodConstDatasAsOutputs(VECTOR_DATA(odata)),
@@ -365,7 +365,7 @@ ZL_Report ENC_runTransform(
 
 void* ZL_Encoder_getScratchSpace(ZL_Encoder* ei, size_t size)
 {
-    WAYPOINT(on_ZL_Encoder_getScratchSpace, ei, size);
+    CWAYPOINT(on_ZL_Encoder_getScratchSpace, ei, size);
     return ALLOC_Arena_malloc(ei->wkspArena, size);
 }
 

--- a/src/openzl/compress/segmenter.c
+++ b/src/openzl/compress/segmenter.c
@@ -266,7 +266,7 @@ ZL_Report ZL_Segmenter_processChunk(
         ZL_GraphID startingGraphID,
         const ZL_RuntimeGraphParameters* rGraphParams)
 {
-    WAYPOINT(
+    CWAYPOINT(
             on_ZL_Segmenter_processChunk_start,
             segCtx,
             numElts,
@@ -333,7 +333,7 @@ ZL_Report ZL_Segmenter_processChunk(
     }
     CCTX_cleanChunk(cctx);
 
-    WAYPOINT(on_ZL_Segmenter_processChunk_end, segCtx, r);
+    CWAYPOINT(on_ZL_Segmenter_processChunk_end, segCtx, r);
     return r;
 }
 

--- a/src/openzl/decompress/decompress2.c
+++ b/src/openzl/decompress/decompress2.c
@@ -1237,7 +1237,11 @@ static ZL_Report processStream(
             "Could not find state for transform %u",
             nodeInfo->trpid.trid);
 
+    DWAYPOINT(on_codecDecode_start, &diState, inputs, nbInStreams);
     ZL_Report const report = dt->transformFn(&diState, dt, inputs, nbInStreams);
+    if (ZL_isError(report)) {
+        DWAYPOINT(on_codecDecode_end, &diState, NULL, 0, report);
+    }
     ZL_RET_R_IF_ERR_COERCE(report);
 
     // Check transform's outcome
@@ -1250,6 +1254,27 @@ static ZL_Report processStream(
         ZL_ASSERT(
                 STREAM_isCommitted(outStream),
                 "Decoding transform did not provide its output size");
+    }
+    IF_DWAYPOINT_ENABLED(on_codecDecode_end, &diState)
+    {
+        VECTOR_CONST_POINTERS(ZL_Data) odata;
+        VECTOR_INIT(odata, nodeInfo->nbRegens);
+        for (size_t n = 0; n < nodeInfo->nbRegens; n++) {
+            const ZL_Data* d     = dctx->dataInfo.ptr[regensID[n]].data;
+            bool pushbackSuccess = VECTOR_PUSHBACK(odata, d);
+            if (!pushbackSuccess) {
+                VECTOR_DESTROY(odata);
+                ZL_ERR(allocation,
+                       "Unable to append to the waypoint odata vector");
+            }
+        }
+        DWAYPOINT(
+                on_codecDecode_end,
+                &diState,
+                VECTOR_DATA(odata),
+                VECTOR_SIZE(odata),
+                ZL_returnSuccess());
+        VECTOR_DESTROY(odata);
     }
     ALLOC_Arena_freeAll(dctx->workspaceArena);
 
@@ -1608,7 +1633,12 @@ ZL_Report ZL_DCtx_decompressMultiTBuffer(
     ZL_OC_startOperation(&dctx->opCtx, ZL_Operation_decompress);
     ZL_RESULT_DECLARE_SCOPE_REPORT(dctx);
 
-    // Set the applied parameters
+    DWAYPOINT(
+            on_ZL_DCtx_decompressMultiTBuffer_start,
+            dctx,
+            nbOutputs,
+            framePtr,
+            frameSize);
     ZL_ERR_IF_ERR(DCtx_setAppliedParameters(dctx));
 
     // Clean up state - may be dirty if previous decompression failed
@@ -1702,6 +1732,7 @@ ZL_Report ZL_DCtx_decompressMultiTBuffer(
     }
 
     // main decompression loop
+    size_t chunkIndex = 0;
     while (1) {
         // Check end of frame marker
         if (dctx->dfh.formatVersion >= ZL_CHUNK_VERSION_MIN) {
@@ -1718,13 +1749,16 @@ ZL_Report ZL_DCtx_decompressMultiTBuffer(
             }
         }
 
+        DWAYPOINT(on_decompressChunk_start, dctx, chunkIndex);
         ZL_TRY_LET(
                 size_t,
                 chunkSize,
                 ZL_DCtx_decompressChunk(
                         dctx, nbOutputs, framePtr, frameSize, consumed));
+        DWAYPOINT(on_decompressChunk_end, dctx, ZL_returnValue(chunkSize));
         ZL_DLOG(SEQ, "chunk size: %zu", chunkSize);
         consumed += chunkSize;
+        chunkIndex++;
 
         if (dctx->dfh.formatVersion < ZL_CHUNK_VERSION_MIN)
             break;
@@ -1785,6 +1819,10 @@ ZL_Report ZL_DCtx_decompressMultiTBuffer(
     ZL_DLOG(BLOCK,
             "ZL_DCtx_decompressMultiTBuffer: success: decompressed %zu Typed Buffers",
             nbOutputs);
+    DWAYPOINT(
+            on_ZL_DCtx_decompressMultiTBuffer_end,
+            dctx,
+            ZL_returnValue(nbOutputs));
     return ZL_returnValue(nbOutputs);
 }
 
@@ -1952,4 +1990,29 @@ const char* DCTX_getTrName(ZL_DCtx const* dctx, ZL_IDType decoderIdx)
 size_t DCTX_streamMemory(ZL_DCtx const* dctx)
 {
     return ALLOC_Arena_memAllocated(dctx->streamArena);
+}
+
+ZL_Report ZL_DCtx_attachDecompressIntrospectionHooks(
+        ZL_DCtx* dctx,
+        const ZL_DecompressIntrospectionHooks* hooks)
+{
+    ZL_ASSERT_NN(dctx);
+    ZL_RET_R_IF_NULL(allocation, hooks);
+    ZL_OperationContext* oc = ZL_DCtx_getOperationContext(dctx);
+    ZL_ASSERT_NN(oc);
+    oc->decompressIntrospectionHooks = *hooks;
+    oc->hasDecompressionHooks        = true;
+    return ZL_returnSuccess();
+}
+
+ZL_Report ZL_DCtx_detachAllDecompressIntrospectionHooks(ZL_DCtx* dctx)
+{
+    ZL_ASSERT_NN(dctx);
+    ZL_OperationContext* oc = ZL_DCtx_getOperationContext(dctx);
+    ZL_ASSERT_NN(oc);
+    ZL_zeroes(
+            &oc->decompressIntrospectionHooks,
+            sizeof(oc->decompressIntrospectionHooks));
+    oc->hasDecompressionHooks = false;
+    return ZL_returnSuccess();
 }

--- a/src/openzl/decompress/dictx.c
+++ b/src/openzl/decompress/dictx.c
@@ -3,7 +3,8 @@
 #include "openzl/decompress/dictx.h"
 #include "openzl/common/allocation.h"
 #include "openzl/common/logging.h"
-#include "openzl/decompress/dctx2.h" // DCTX_* declarations
+#include "openzl/common/operation_context.h" // ZL_OperationContext
+#include "openzl/decompress/dctx2.h"         // DCTX_* declarations
 #include "openzl/zl_data.h"
 
 ZL_Decoder* DI_createDICtx(ZL_DCtx* dctx)
@@ -107,6 +108,12 @@ ZL_Output* ZL_Decoder_create1StringStream(
 ZL_RBuffer ZL_Decoder_getCodecHeader(const ZL_Decoder* dictx)
 {
     ZL_ASSERT_NN(dictx);
+    DWAYPOINT_WITH_OC(
+            on_ZL_Decoder_getCodecHeader,
+            dictx->dctx,
+            dictx,
+            dictx->thContent.start,
+            dictx->thContent.size);
     return dictx->thContent;
 }
 

--- a/tests/integrationtest/CompressIntrospectionTest.cpp
+++ b/tests/integrationtest/CompressIntrospectionTest.cpp
@@ -97,7 +97,7 @@ TEST(CompressIntrospectionTest, IFnoHooksTHENnoop)
 // code snippet containing a waypoint
 static int func(ZL_CCtx* cctx)
 {
-    IF_WAYPOINT_ENABLED(on_codecEncode_start, cctx)
+    IF_CWAYPOINT_ENABLED(on_codecEncode_start, cctx)
     {
         return 1;
     }


### PR DESCRIPTION
Summary:

Defines the ZL_DecompressIntrospectionHooks struct with 8 hook function
pointers, adds the DWAYPOINT macro for decompression waypoints, instruments
decompress2.c with DWAYPOINTs at key decompression points
(decompressMultiTBuffer start/end, decompressChunk start/end, codecDecode
start/end, readCodecHeader, storedStream), and exposes attach/detach API
on ZL_DCtx.

Differential Revision: D96050996


