### PR TITLE
Fix bug in partition codec

### DIFF
--- a/src/openzl/codecs/partition/encode_partition_binding.c
+++ b/src/openzl/codecs/partition/encode_partition_binding.c
@@ -87,7 +87,7 @@ static ZL_Report ZL_PartitionParams_sendHeader(
         flags |= ZL_PARTITION_HEADER_IS_POW2_BIT;
 
         size_t numBits = (size_t)ZL_nextPow2(
-                NUMOP_findMaxU8(bits, params->numPartitions));
+                NUMOP_findMaxU8(bits, params->numPartitions) + 1);
         numBits = ZL_MAX(numBits, 3);
         ZL_ASSERT_LE(numBits, 6, "Impossible for valid params");
 

--- a/tests/integrationtest/OpenZLComponentTest.cpp
+++ b/tests/integrationtest/OpenZLComponentTest.cpp
@@ -74,7 +74,7 @@ class OpenZLComponentTest : public ::testing::TestWithParam<int> {
         }
         for (const auto graph : graphs) {
             for (const auto& input : component_->generateInputs(
-                         gen_, 3, 256 * 1024, compressor_, graph)) {
+                         gen_, 10, 256 * 1024, compressor_, graph)) {
                 testComponentWithGraphOnInput(graph, *input);
             }
         }
@@ -83,14 +83,14 @@ class OpenZLComponentTest : public ::testing::TestWithParam<int> {
     void testComponent()
     {
         auto graphs = component_->predefinedGraphs(compressor_);
-        for (auto graph : component_->generateGraphs(compressor_, gen_, 3)) {
+        for (auto graph : component_->generateGraphs(compressor_, gen_, 10)) {
             graphs.push_back(graph);
         }
 
         for (auto node : component_->predefinedNodes(compressor_)) {
             graphs.push_back(makeTrivialGraph(node));
         }
-        for (auto node : component_->generateNodes(compressor_, gen_, 3)) {
+        for (auto node : component_->generateNodes(compressor_, gen_, 10)) {
             graphs.push_back(makeTrivialGraph(node));
         }
 


### PR DESCRIPTION
Summary: When all the partition sizes are a power of 2 and the maximum partition size is of the form `2^2^N`, we corrupt the partition codec header causing corruption, because we use too few bits to encode the log2 of the partition sizes.

Differential Revision: D96541056


