### PR TITLE
Implement abs operator (#523)

### DIFF
--- a/tests/compress/graphs/sddl2/test_sddl2_code_execution.cpp
+++ b/tests/compress/graphs/sddl2/test_sddl2_code_execution.cpp
@@ -646,6 +646,31 @@ TEST_F(SDDL2CodeExecutionTest, WhenBlockInParameterizedRecordFalse)
 
     expect_success(prog, input, expected_sizes);
 }
+
+// ============================================================================
+// Runtime Value Assignment
+// ============================================================================
+
+TEST_F(SDDL2CodeExecutionTest, AssignRuntimeValue)
+{
+    const std::vector<size_t> expected_sizes = { 4, 4 };
+    std::vector<uint8_t> input               = {
+        0x05, 0x00, 0x00, 0x00, // x = 5
+        0x03, 0x00, 0x00, 0x00, // y = 3
+    };
+
+    const auto prog = R"(
+        x: Int32LE
+        y: Int32LE
+        sum = x + y
+        expect x == 5
+        expect y == 3
+        expect sum == 8
+    )";
+
+    expect_success(prog, input, expected_sizes);
+}
+
 } // namespace testing
 } // namespace sddl2
 } // namespace openzl

--- a/tools/sddl2/compiler/Syntax.cpp
+++ b/tools/sddl2/compiler/Syntax.cpp
@@ -77,6 +77,7 @@ static const std::map<Symbol, poly::string_view> syms_to_debug_strs{
     { Symbol::MUL, "MUL" },
     { Symbol::DIV, "DIV" },
     { Symbol::MOD, "MOD" },
+    { Symbol::ABS, "ABS" },
 
     { Symbol::BIT_AND, "BIT_AND" },
     { Symbol::BIT_OR, "BIT_OR" },
@@ -150,6 +151,7 @@ const std::vector<std::pair<poly::string_view, Symbol>> strs_to_syms{
     { "*", Symbol::MUL },
     { "/", Symbol::DIV },
     { "%", Symbol::MOD },
+    { "abs", Symbol::ABS },
     { "&&", Symbol::LOG_AND },
     { "||", Symbol::LOG_OR },
     { "!", Symbol::LOG_NOT },

--- a/tools/sddl2/compiler/Syntax.h
+++ b/tools/sddl2/compiler/Syntax.h
@@ -45,6 +45,7 @@ enum class Symbol {
     MUL,
     DIV,
     MOD,
+    ABS,
 
     // Bitwise Operators
     BIT_AND,

--- a/tools/sddl2/compiler/codegen/CodeGenerator.cpp
+++ b/tools/sddl2/compiler/codegen/CodeGenerator.cpp
@@ -427,11 +427,15 @@ class CodeGeneratorImpl {
             }
         }
 
-        auto [type_asm, type]     = generateType(rhs);
-        type_aliases_[var.name()] = type;
-
         AssemblyOutput output;
-        output += std::move(type_asm);
+        try {
+            auto [type_asm, type]     = generateType(rhs);
+            type_aliases_[var.name()] = type;
+            output += std::move(type_asm);
+        } catch (const InvariantViolation&) {
+            output += generateValue(rhs);
+        }
+
         output += "push.i64 " + std::to_string(registers_.assign(var.name()));
         output += "var.store";
         return output;

--- a/tools/sddl2/compiler/codegen/CodeGenerator.cpp
+++ b/tools/sddl2/compiler/codegen/CodeGenerator.cpp
@@ -25,6 +25,7 @@ const std::map<Op, std::string> op_to_asm = {
     { Op::ADD, "math.add" },       { Op::SUB, "math.sub" },
     { Op::MUL, "math.mul" },       { Op::DIV, "math.div" },
     { Op::MOD, "math.mod" },       { Op::NEG, "math.neg" },
+    { Op::ABS, "math.abs" },
 
     { Op::EQ, "cmp.eq" },          { Op::NE, "cmp.ne" },
     { Op::GT, "cmp.gt" },          { Op::GE, "cmp.ge" },
@@ -120,7 +121,8 @@ class CodeGeneratorImpl {
             case Op::EXPECT:
             case Op::NEG:
             case Op::LOG_NOT:
-            case Op::BIT_NOT: {
+            case Op::BIT_NOT:
+            case Op::ABS: {
                 output += generateValue(op.args()[0]);
                 output += op_to_asm.at(op.op());
                 return output;

--- a/tools/sddl2/compiler/optimizer/ConstFoldPass.cpp
+++ b/tools/sddl2/compiler/optimizer/ConstFoldPass.cpp
@@ -143,6 +143,8 @@ class ConstFoldImpl {
         switch (op.op()) {
             case Op::NEG:
                 return makeNum(loc, -num_at(0));
+            case Op::ABS:
+                return makeNum(loc, num_at(0) < 0 ? -num_at(0) : num_at(0));
             case Op::LOG_NOT:
                 return makeNum(loc, !num_at(0) ? 1 : 0);
             case Op::BIT_NOT:

--- a/tools/sddl2/compiler/parser/AST.h
+++ b/tools/sddl2/compiler/parser/AST.h
@@ -421,6 +421,11 @@ class Codegen {
         return op(Op::SIZEOF, std::move(arg));
     }
 
+    ASTPtr abs(ASTPtr arg) const
+    {
+        return op(Op::ABS, std::move(arg));
+    }
+
     ASTPtr assign(ASTPtr lhs, ASTPtr rhs) const
     {
         return op(Op::ASSIGN, std::move(lhs), std::move(rhs));

--- a/tools/sddl2/compiler/parser/Grammar.cpp
+++ b/tools/sddl2/compiler/parser/Grammar.cpp
@@ -128,7 +128,7 @@ const std::map<Symbol, Op> syms_to_ops{
 
     { Symbol::ADD, Op::ADD },         { Symbol::SUB, Op::SUB },
     { Symbol::MUL, Op::MUL },         { Symbol::DIV, Op::DIV },
-    { Symbol::MOD, Op::MOD },
+    { Symbol::MOD, Op::MOD },         { Symbol::ABS, Op::ABS },
 
     { Symbol::GT, Op::GT },           { Symbol::GE, Op::GE },
     { Symbol::LT, Op::LT },           { Symbol::LE, Op::LE },
@@ -561,6 +561,36 @@ class WhenRule : public GrammarRule {
     }
 };
 
+class AbsRule : public GrammarRule {
+   public:
+    explicit AbsRule()
+            : GrammarRule(
+                      Symbol::ABS,
+                      Precedence::ACCESS,
+                      std::vector<ArgType>({ ArgType::LIST_PAREN }))
+    {
+    }
+
+   private:
+    ASTPtr do_gen(ASTPtr op, ArgsVec args) const override
+    {
+        auto& paren_list = args.at(0);
+        const auto* list = some(paren_list).as_list();
+        if (list == nullptr) {
+            throw ParseError(some(op).loc(), "abs() requires a paren list.");
+        }
+
+        const auto& inner_args = list->nodes();
+        if (inner_args.size() != 1) {
+            throw ParseError(
+                    some(op).loc(), "abs() requires exactly 1 argument.");
+        }
+
+        return std::make_shared<ASTOp>(
+                op->loc(), Op::ABS, ArgsVec{ inner_args.at(0) });
+    }
+};
+
 template <typename RuleT, typename... Args>
 void add_rule(
         std::vector<std::unique_ptr<const GrammarRule>>& rules,
@@ -586,6 +616,7 @@ const std::vector<std::unique_ptr<const GrammarRule>> grammar_rules{ []() {
     add_rule<UnaryOpRule>(r, Symbol::EXPECT, Precedence::ASSIGNMENT);
     add_rule<UnaryOpRule>(r, Symbol::SIZEOF);
     add_rule<WhenRule>(r);
+    add_rule<AbsRule>(r);
 
     add_rule<BinaryOpRule>(r, Symbol::ASSIGN, Precedence::ASSIGNMENT);
     add_rule<BinaryOpRule>(r, Symbol::ASSUME, Precedence::ASSIGNMENT);

--- a/tools/sddl2/compiler/parser/Ops.cpp
+++ b/tools/sddl2/compiler/parser/Ops.cpp
@@ -29,6 +29,7 @@ static const std::map<Op, poly::string_view> ops_to_debug_strs{
     { Op::MUL, "MUL" },
     { Op::DIV, "DIV" },
     { Op::MOD, "MOD" },
+    { Op::ABS, "ABS" },
 
     // Bitwise Operators
     { Op::BIT_AND, "BIT_AND" },

--- a/tools/sddl2/compiler/parser/Ops.h
+++ b/tools/sddl2/compiler/parser/Ops.h
@@ -22,6 +22,7 @@ enum class Op {
     MUL,
     DIV,
     MOD,
+    ABS,
 
     // Comparison Operators
     EQ,

--- a/tools/sddl2/compiler/semantic_analyzer/SemanticAnalyzer.cpp
+++ b/tools/sddl2/compiler/semantic_analyzer/SemanticAnalyzer.cpp
@@ -241,6 +241,7 @@ class SemanticAnalyzerImpl {
             case Op::NEG:
             case Op::LOG_NOT:
             case Op::BIT_NOT:
+            case Op::ABS:
                 expectNumeric(analyzeNode(op.args()[0]));
                 return Type{ TypeKind::NUMERIC };
             case Op::ADD:

--- a/tools/sddl2/compiler/tests/OptimizerTest.cpp
+++ b/tools/sddl2/compiler/tests/OptimizerTest.cpp
@@ -232,4 +232,20 @@ TEST_F(OptimizerTest, WhenConstant)
     expect_ast(prog, expected);
 }
 
+TEST_F(OptimizerTest, AbsConstFold)
+{
+    const auto prog     = R"(
+        expect abs(-7) == 7
+        expect abs(5) == 5
+        expect abs(0) == 0
+        expect abs(3 - 10) == 7
+    )";
+    const auto cg       = Codegen(SourceLocation::null());
+    const auto expected = std::vector<ASTPtr>({ cg.expect(cg.num(1)),
+                                                cg.expect(cg.num(1)),
+                                                cg.expect(cg.num(1)),
+                                                cg.expect(cg.num(1)) });
+    expect_ast(prog, expected);
+}
+
 } // namespace openzl::sddl2::tests

--- a/tools/sddl2/compiler/tests/SemanticAnalyzerTest.cpp
+++ b/tools/sddl2/compiler/tests/SemanticAnalyzerTest.cpp
@@ -333,6 +333,14 @@ TEST_F(SemanticAnalyzerTest, WhenBlockInRecordWithFieldReference)
     expect_error(prog, "Undefined variable");
 }
 
+TEST_F(SemanticAnalyzerTest, AbsFieldType)
+{
+    const auto prog = R"(
+        tmp = abs(Int32LE)
+    )";
+    expect_error(prog, "numeric");
+}
+
 TEST_F(SemanticAnalyzerTest, MemberAccessOnConditionalField)
 {
     const auto prog = R"(


### PR DESCRIPTION
Summary:

Adds support for the `abs()` function in the sddl compiler to compute the absolute value of numeric expressions.

Differential Revision: D95945613
