### PR TITLE
Easy: Use Codegen default constructor in tests (#524)

### DIFF
--- a/tests/compress/graphs/sddl2/test_sddl2_code_execution.cpp
+++ b/tests/compress/graphs/sddl2/test_sddl2_code_execution.cpp
@@ -646,6 +646,31 @@ TEST_F(SDDL2CodeExecutionTest, WhenBlockInParameterizedRecordFalse)
 
     expect_success(prog, input, expected_sizes);
 }
+
+// ============================================================================
+// Runtime Value Assignment
+// ============================================================================
+
+TEST_F(SDDL2CodeExecutionTest, AssignRuntimeValue)
+{
+    const std::vector<size_t> expected_sizes = { 4, 4 };
+    std::vector<uint8_t> input               = {
+        0x05, 0x00, 0x00, 0x00, // x = 5
+        0x03, 0x00, 0x00, 0x00, // y = 3
+    };
+
+    const auto prog = R"(
+        x: Int32LE
+        y: Int32LE
+        sum = x + y
+        expect x == 5
+        expect y == 3
+        expect sum == 8
+    )";
+
+    expect_success(prog, input, expected_sizes);
+}
+
 } // namespace testing
 } // namespace sddl2
 } // namespace openzl

--- a/tools/sddl2/compiler/Syntax.cpp
+++ b/tools/sddl2/compiler/Syntax.cpp
@@ -77,6 +77,7 @@ static const std::map<Symbol, poly::string_view> syms_to_debug_strs{
     { Symbol::MUL, "MUL" },
     { Symbol::DIV, "DIV" },
     { Symbol::MOD, "MOD" },
+    { Symbol::ABS, "ABS" },
 
     { Symbol::BIT_AND, "BIT_AND" },
     { Symbol::BIT_OR, "BIT_OR" },
@@ -150,6 +151,7 @@ const std::vector<std::pair<poly::string_view, Symbol>> strs_to_syms{
     { "*", Symbol::MUL },
     { "/", Symbol::DIV },
     { "%", Symbol::MOD },
+    { "abs", Symbol::ABS },
     { "&&", Symbol::LOG_AND },
     { "||", Symbol::LOG_OR },
     { "!", Symbol::LOG_NOT },

--- a/tools/sddl2/compiler/Syntax.h
+++ b/tools/sddl2/compiler/Syntax.h
@@ -45,6 +45,7 @@ enum class Symbol {
     MUL,
     DIV,
     MOD,
+    ABS,
 
     // Bitwise Operators
     BIT_AND,

--- a/tools/sddl2/compiler/codegen/CodeGenerator.cpp
+++ b/tools/sddl2/compiler/codegen/CodeGenerator.cpp
@@ -427,11 +427,15 @@ class CodeGeneratorImpl {
             }
         }
 
-        auto [type_asm, type]     = generateType(rhs);
-        type_aliases_[var.name()] = type;
-
         AssemblyOutput output;
-        output += std::move(type_asm);
+        try {
+            auto [type_asm, type]     = generateType(rhs);
+            type_aliases_[var.name()] = type;
+            output += std::move(type_asm);
+        } catch (const InvariantViolation&) {
+            output += generateValue(rhs);
+        }
+
         output += "push.i64 " + std::to_string(registers_.assign(var.name()));
         output += "var.store";
         return output;

--- a/tools/sddl2/compiler/codegen/CodeGenerator.cpp
+++ b/tools/sddl2/compiler/codegen/CodeGenerator.cpp
@@ -25,6 +25,7 @@ const std::map<Op, std::string> op_to_asm = {
     { Op::ADD, "math.add" },       { Op::SUB, "math.sub" },
     { Op::MUL, "math.mul" },       { Op::DIV, "math.div" },
     { Op::MOD, "math.mod" },       { Op::NEG, "math.neg" },
+    { Op::ABS, "math.abs" },
 
     { Op::EQ, "cmp.eq" },          { Op::NE, "cmp.ne" },
     { Op::GT, "cmp.gt" },          { Op::GE, "cmp.ge" },
@@ -120,7 +121,8 @@ class CodeGeneratorImpl {
             case Op::EXPECT:
             case Op::NEG:
             case Op::LOG_NOT:
-            case Op::BIT_NOT: {
+            case Op::BIT_NOT:
+            case Op::ABS: {
                 output += generateValue(op.args()[0]);
                 output += op_to_asm.at(op.op());
                 return output;

--- a/tools/sddl2/compiler/optimizer/ConstFoldPass.cpp
+++ b/tools/sddl2/compiler/optimizer/ConstFoldPass.cpp
@@ -143,6 +143,8 @@ class ConstFoldImpl {
         switch (op.op()) {
             case Op::NEG:
                 return makeNum(loc, -num_at(0));
+            case Op::ABS:
+                return makeNum(loc, num_at(0) < 0 ? -num_at(0) : num_at(0));
             case Op::LOG_NOT:
                 return makeNum(loc, !num_at(0) ? 1 : 0);
             case Op::BIT_NOT:

--- a/tools/sddl2/compiler/parser/AST.h
+++ b/tools/sddl2/compiler/parser/AST.h
@@ -421,6 +421,11 @@ class Codegen {
         return op(Op::SIZEOF, std::move(arg));
     }
 
+    ASTPtr abs(ASTPtr arg) const
+    {
+        return op(Op::ABS, std::move(arg));
+    }
+
     ASTPtr assign(ASTPtr lhs, ASTPtr rhs) const
     {
         return op(Op::ASSIGN, std::move(lhs), std::move(rhs));

--- a/tools/sddl2/compiler/parser/Grammar.cpp
+++ b/tools/sddl2/compiler/parser/Grammar.cpp
@@ -128,7 +128,7 @@ const std::map<Symbol, Op> syms_to_ops{
 
     { Symbol::ADD, Op::ADD },         { Symbol::SUB, Op::SUB },
     { Symbol::MUL, Op::MUL },         { Symbol::DIV, Op::DIV },
-    { Symbol::MOD, Op::MOD },
+    { Symbol::MOD, Op::MOD },         { Symbol::ABS, Op::ABS },
 
     { Symbol::GT, Op::GT },           { Symbol::GE, Op::GE },
     { Symbol::LT, Op::LT },           { Symbol::LE, Op::LE },
@@ -561,6 +561,36 @@ class WhenRule : public GrammarRule {
     }
 };
 
+class AbsRule : public GrammarRule {
+   public:
+    explicit AbsRule()
+            : GrammarRule(
+                      Symbol::ABS,
+                      Precedence::ACCESS,
+                      std::vector<ArgType>({ ArgType::LIST_PAREN }))
+    {
+    }
+
+   private:
+    ASTPtr do_gen(ASTPtr op, ArgsVec args) const override
+    {
+        auto& paren_list = args.at(0);
+        const auto* list = some(paren_list).as_list();
+        if (list == nullptr) {
+            throw ParseError(some(op).loc(), "abs() requires a paren list.");
+        }
+
+        const auto& inner_args = list->nodes();
+        if (inner_args.size() != 1) {
+            throw ParseError(
+                    some(op).loc(), "abs() requires exactly 1 argument.");
+        }
+
+        return std::make_shared<ASTOp>(
+                op->loc(), Op::ABS, ArgsVec{ inner_args.at(0) });
+    }
+};
+
 template <typename RuleT, typename... Args>
 void add_rule(
         std::vector<std::unique_ptr<const GrammarRule>>& rules,
@@ -586,6 +616,7 @@ const std::vector<std::unique_ptr<const GrammarRule>> grammar_rules{ []() {
     add_rule<UnaryOpRule>(r, Symbol::EXPECT, Precedence::ASSIGNMENT);
     add_rule<UnaryOpRule>(r, Symbol::SIZEOF);
     add_rule<WhenRule>(r);
+    add_rule<AbsRule>(r);
 
     add_rule<BinaryOpRule>(r, Symbol::ASSIGN, Precedence::ASSIGNMENT);
     add_rule<BinaryOpRule>(r, Symbol::ASSUME, Precedence::ASSIGNMENT);

--- a/tools/sddl2/compiler/parser/Ops.cpp
+++ b/tools/sddl2/compiler/parser/Ops.cpp
@@ -29,6 +29,7 @@ static const std::map<Op, poly::string_view> ops_to_debug_strs{
     { Op::MUL, "MUL" },
     { Op::DIV, "DIV" },
     { Op::MOD, "MOD" },
+    { Op::ABS, "ABS" },
 
     // Bitwise Operators
     { Op::BIT_AND, "BIT_AND" },

--- a/tools/sddl2/compiler/parser/Ops.h
+++ b/tools/sddl2/compiler/parser/Ops.h
@@ -22,6 +22,7 @@ enum class Op {
     MUL,
     DIV,
     MOD,
+    ABS,
 
     // Comparison Operators
     EQ,

--- a/tools/sddl2/compiler/semantic_analyzer/SemanticAnalyzer.cpp
+++ b/tools/sddl2/compiler/semantic_analyzer/SemanticAnalyzer.cpp
@@ -241,6 +241,7 @@ class SemanticAnalyzerImpl {
             case Op::NEG:
             case Op::LOG_NOT:
             case Op::BIT_NOT:
+            case Op::ABS:
                 expectNumeric(analyzeNode(op.args()[0]));
                 return Type{ TypeKind::NUMERIC };
             case Op::ADD:

--- a/tools/sddl2/compiler/tests/OptimizerTest.cpp
+++ b/tools/sddl2/compiler/tests/OptimizerTest.cpp
@@ -232,4 +232,20 @@ TEST_F(OptimizerTest, WhenConstant)
     expect_ast(prog, expected);
 }
 
+TEST_F(OptimizerTest, AbsConstFold)
+{
+    const auto prog     = R"(
+        expect abs(-7) == 7
+        expect abs(5) == 5
+        expect abs(0) == 0
+        expect abs(3 - 10) == 7
+    )";
+    const auto cg       = Codegen(SourceLocation::null());
+    const auto expected = std::vector<ASTPtr>({ cg.expect(cg.num(1)),
+                                                cg.expect(cg.num(1)),
+                                                cg.expect(cg.num(1)),
+                                                cg.expect(cg.num(1)) });
+    expect_ast(prog, expected);
+}
+
 } // namespace openzl::sddl2::tests

--- a/tools/sddl2/compiler/tests/OptimizerTest.cpp
+++ b/tools/sddl2/compiler/tests/OptimizerTest.cpp
@@ -21,7 +21,7 @@ TEST_F(OptimizerTest, ArithmeticConstFold)
         c = 2 * 3 + b
         expect c == 1
     )";
-    const auto cg       = Codegen(SourceLocation::null());
+    const auto cg       = Codegen();
     const auto expected = std::vector<ASTPtr>({
             cg.expect(cg.num(1)),
     });
@@ -35,7 +35,7 @@ TEST_F(OptimizerTest, ComparisonConstFold)
         expect 5 >= 3
         expect 5 < 3
     )";
-    const auto cg       = Codegen(SourceLocation::null());
+    const auto cg       = Codegen();
     const auto expected = std::vector<ASTPtr>({ cg.expect(cg.num(1)),
                                                 cg.expect(cg.num(1)),
                                                 cg.expect(cg.num(0)) });
@@ -49,7 +49,7 @@ TEST_F(OptimizerTest, LogicalConstFold)
         expect 1 && 0
         expect 1 || 0
     )";
-    const auto cg       = Codegen(SourceLocation::null());
+    const auto cg       = Codegen();
     const auto expected = std::vector<ASTPtr>({ cg.expect(cg.num(1)),
                                                 cg.expect(cg.num(0)),
                                                 cg.expect(cg.num(1)) });
@@ -62,7 +62,7 @@ TEST_F(OptimizerTest, ConstPropagation)
         x = 5
         expect x + 1 == 6
     )";
-    const auto cg       = Codegen(SourceLocation::null());
+    const auto cg       = Codegen();
     const auto expected = std::vector<ASTPtr>({
             cg.expect(cg.num(1)),
     });
@@ -77,7 +77,7 @@ TEST_F(OptimizerTest, ChainedConstPropagation)
         c = 2 * b
         expect c == 4
     )";
-    const auto cg       = Codegen(SourceLocation::null());
+    const auto cg       = Codegen();
     const auto expected = std::vector<ASTPtr>({
             cg.expect(cg.num(1)),
     });
@@ -90,7 +90,7 @@ TEST_F(OptimizerTest, SimpleArithmeticAST)
        expect 1 + 2 == 3
     )";
 
-    const auto cg       = Codegen(SourceLocation::null());
+    const auto cg       = Codegen();
     const auto expected = std::vector<ASTPtr>({
             cg.expect(cg.num(1)),
     });
@@ -104,7 +104,7 @@ TEST_F(OptimizerTest, ComplexArithmeticExpressionAST)
         expect tmp == 5
     )";
 
-    const auto cg       = Codegen(SourceLocation::null());
+    const auto cg       = Codegen();
     const auto expected = std::vector<ASTPtr>({
             cg.expect(cg.num(1)),
     });
@@ -119,7 +119,7 @@ TEST_F(OptimizerTest, ArrayAST)
         : Byte[]
     )";
 
-    const auto cg       = Codegen(SourceLocation::null());
+    const auto cg       = Codegen();
     const auto expected = std::vector<ASTPtr>(
             { cg.consume(cg.array(cg.builtin_field(Symbol::BYTE), cg.num(3))),
               cg.consume(cg.array(cg.builtin_field(Symbol::BYTE))) });
@@ -136,7 +136,7 @@ TEST_F(OptimizerTest, RecordAST)
         : Entry
     )";
 
-    const auto cg       = Codegen(SourceLocation::null());
+    const auto cg       = Codegen();
     const auto expected = std::vector<ASTPtr>(
             { cg.assign(
                       cg.var("Entry"),
@@ -173,7 +173,7 @@ TEST_F(OptimizerTest, DeadRecordVarElimination)
         entry: Record() { id: Int32LE }
     )";
 
-    const auto cg       = Codegen(SourceLocation::null());
+    const auto cg       = Codegen();
     const auto expected = std::vector<ASTPtr>({
             cg.consume(cg.record(
                     ArgVec{},
@@ -195,7 +195,7 @@ TEST_F(OptimizerTest, RecordMemberLastReference)
         expect foo.y == 2
     )";
 
-    const auto cg       = Codegen(SourceLocation::null());
+    const auto cg       = Codegen();
     const auto expected = std::vector<ASTPtr>({
             cg.assign(
                     cg.var("Foo"),
@@ -226,7 +226,7 @@ TEST_F(OptimizerTest, WhenConstant)
             : Int16LE
         }
     )";
-    const auto cg       = Codegen(SourceLocation::null());
+    const auto cg       = Codegen();
     const auto expected = std::vector<ASTPtr>(
             { cg.consume(cg.builtin_field(Symbol::I32LE)) });
     expect_ast(prog, expected);
@@ -240,7 +240,7 @@ TEST_F(OptimizerTest, AbsConstFold)
         expect abs(0) == 0
         expect abs(3 - 10) == 7
     )";
-    const auto cg       = Codegen(SourceLocation::null());
+    const auto cg       = Codegen();
     const auto expected = std::vector<ASTPtr>({ cg.expect(cg.num(1)),
                                                 cg.expect(cg.num(1)),
                                                 cg.expect(cg.num(1)),

--- a/tools/sddl2/compiler/tests/ParserTest.cpp
+++ b/tools/sddl2/compiler/tests/ParserTest.cpp
@@ -97,7 +97,7 @@ TEST_F(ParserTest, ConsumeBuiltinFieldsAST)
         : BFloat16LE
         : BFloat16BE
     )";
-    const auto cg       = Codegen(SourceLocation::null());
+    const auto cg       = Codegen();
     const auto expected = std::vector<ASTPtr>({
             cg.consume(cg.builtin_field(Symbol::BYTE)),
             cg.consume(cg.builtin_field(Symbol::U8)),
@@ -133,7 +133,7 @@ TEST_F(ParserTest, UnaryNegationAST)
         expect tmp == 21
     )";
 
-    const auto cg       = Codegen(SourceLocation::null());
+    const auto cg       = Codegen();
     const auto expected = std::vector<ASTPtr>({
             cg.assign(cg.var("tmp"), cg.sub(cg.num(10), cg.neg(cg.num(11)))),
             cg.expect(cg.eq(cg.var("tmp"), cg.num(21))),
@@ -147,7 +147,7 @@ TEST_F(ParserTest, SimpleArithmeticAST)
        expect 1 + 2 == 3
     )";
 
-    const auto cg       = Codegen(SourceLocation::null());
+    const auto cg       = Codegen();
     const auto expected = std::vector<ASTPtr>({
             cg.expect(cg.eq(cg.add(cg.num(1), cg.num(2)), cg.num(3))),
     });
@@ -162,7 +162,7 @@ TEST_F(ParserTest, ArrayAST)
         : Byte[]
     )";
 
-    const auto cg       = Codegen(SourceLocation::null());
+    const auto cg       = Codegen();
     const auto expected = std::vector<ASTPtr>(
             { cg.assign(cg.var("len"), cg.add(cg.num(1), cg.num(2))),
               cg.consume(
@@ -181,7 +181,7 @@ TEST_F(ParserTest, RecordAST)
         : Entry
     )";
 
-    const auto cg       = Codegen(SourceLocation::null());
+    const auto cg       = Codegen();
     const auto expected = std::vector<ASTPtr>(
             { cg.assign(
                       cg.var("Entry"),
@@ -200,7 +200,7 @@ TEST_F(ParserTest, AnonymousRecordAST)
         : Record() {id: Int32LE, val: Int32LE}
     )";
 
-    const auto cg       = Codegen(SourceLocation::null());
+    const auto cg       = Codegen();
     const auto expected = std::vector<ASTPtr>({ cg.consume(cg.record(
             ArgVec{},
             ArgVec{ cg.assume(cg.var("id"), cg.builtin_field(Symbol::I32LE)),
@@ -217,7 +217,7 @@ TEST_F(ParserTest, ParenthesesOverridePrecedenceAST)
         expect tmp == -3
     )";
 
-    const auto cg       = Codegen(SourceLocation::null());
+    const auto cg       = Codegen();
     const auto expected = std::vector<ASTPtr>({
             cg.assign(
                     cg.var("tmp"),
@@ -234,7 +234,7 @@ TEST_F(ParserTest, NestedParenthesesAST)
         expect tmp == 21
     )";
 
-    const auto cg       = Codegen(SourceLocation::null());
+    const auto cg       = Codegen();
     const auto expected = std::vector<ASTPtr>({
             cg.assign(
                     cg.var("tmp"),
@@ -252,7 +252,7 @@ TEST_F(ParserTest, ComplexArithmeticExpressionAST)
         expect tmp == 5
     )";
 
-    const auto cg       = Codegen(SourceLocation::null());
+    const auto cg       = Codegen();
     const auto expected = std::vector<ASTPtr>({
             cg.assign(
                     cg.var("tmp"),
@@ -282,7 +282,7 @@ TEST_F(ParserTest, SimpleSaoAST)
     )";
 
     // TODO: Update this test once auto-sized arrays are supported
-    const auto cg       = Codegen(SourceLocation::null());
+    const auto cg       = Codegen();
     const auto expected = std::vector<ASTPtr>({
             cg.assign(
                     cg.var("StarEntry"),
@@ -324,7 +324,7 @@ TEST_F(ParserTest, CallAST)
         : Foo(3, 5)
     )";
 
-    const auto cg       = Codegen(SourceLocation::null());
+    const auto cg       = Codegen();
     const auto expected = std::vector<ASTPtr>({
             cg.assign(
                     cg.var("Foo"),
@@ -358,7 +358,7 @@ TEST_F(ParserTest, WhenBlockAST)
         }
     )";
 
-    const auto cg       = Codegen(SourceLocation::null());
+    const auto cg       = Codegen();
     const auto expected = std::vector<ASTPtr>({
             cg.assume(cg.var("flag"), cg.builtin_field(Symbol::U8)),
             cg.when(cg.eq(cg.var("flag"), cg.num(1)),
@@ -380,7 +380,7 @@ TEST_F(ParserTest, WhenBlockInRecordAST)
         : Data(1)
     )";
 
-    const auto cg       = Codegen(SourceLocation::null());
+    const auto cg       = Codegen();
     const auto expected = std::vector<ASTPtr>({
             cg.assign(
                     cg.var("Data"),

--- a/tools/sddl2/compiler/tests/SemanticAnalyzerTest.cpp
+++ b/tools/sddl2/compiler/tests/SemanticAnalyzerTest.cpp
@@ -333,6 +333,14 @@ TEST_F(SemanticAnalyzerTest, WhenBlockInRecordWithFieldReference)
     expect_error(prog, "Undefined variable");
 }
 
+TEST_F(SemanticAnalyzerTest, AbsFieldType)
+{
+    const auto prog = R"(
+        tmp = abs(Int32LE)
+    )";
+    expect_error(prog, "numeric");
+}
+
 TEST_F(SemanticAnalyzerTest, MemberAccessOnConditionalField)
 {
     const auto prog = R"(


### PR DESCRIPTION
Summary:

## Diff
Simplify test code by using the `Codegen()` default constructor instead of the verbose `Codegen(SourceLocation::null())`.

The `Codegen` class already has a default constructor that initializes `loc_` to `SourceLocation::null()`, making the explicit argument redundant.

### Changes

- Replace 14 occurrences of `Codegen(SourceLocation::null())` with `Codegen()` in `ParserTest.cpp`
- Replace 12 occurrences of `Codegen(SourceLocation::null())` with `Codegen()` in `OptimizerTest.cpp`

Reviewed By: felixhandte

Differential Revision: D96744066


