### PR TITLE
move usages of `ZL_Compressor_cloneNode()` to `ZL_Compressor_registerParameterizedNode()`

### DIFF
--- a/benchmark/e2e/e2e_zstrong_utils.h
+++ b/benchmark/e2e/e2e_zstrong_utils.h
@@ -107,8 +107,12 @@ inline ZL_GraphID addConversionFromSerial(
     if (inputType & ZL_Type_struct) {
         ZL_IntParam intParams = { ZL_trlip_tokenSize, (int)eltWidth };
         ZL_LocalParams params = { .intParams = { &intParams, 1 } };
-        auto const node       = ZL_Compressor_cloneNode(
-                cgraph, ZL_NODE_CONVERT_SERIAL_TO_TOKENX, &params);
+        const ZL_ParameterizedNodeDesc desc = {
+            .node        = ZL_NODE_CONVERT_SERIAL_TO_TOKENX,
+            .localParams = &params,
+        };
+        auto const node =
+                ZL_Compressor_registerParameterizedNode(cgraph, &desc);
         return ZL_Compressor_registerStaticGraph_fromNode1o(
                 cgraph, node, graph);
     }

--- a/contrib/lz-research/codecs/Lz.cpp
+++ b/contrib/lz-research/codecs/Lz.cpp
@@ -2705,7 +2705,11 @@ class Transform {
         }
         LocalParams lp;
         lp.addIntParam(0, params.llBits);
-        return ZL_Compressor_cloneNode(cgraph, node, lp.get());
+        const ZL_ParameterizedNodeDesc desc = {
+            .node        = node,
+            .localParams = lp.get(),
+        };
+        return ZL_Compressor_registerParameterizedNode(cgraph, &desc);
     }
 
     // static ZL_GraphID storeGraph(ZL_Compressor* cgraph)

--- a/custom_transforms/thrift/tests/util.cpp
+++ b/custom_transforms/thrift/tests/util.cpp
@@ -198,8 +198,12 @@ std::string thriftSplitCompress(
                                                          .nbCopyParams = 1 } };
     const ZL_NodeID nodeWithoutParams =
             ZL_Compressor_registerVOEncoder(cgraph.get(), &compress);
-    const ZL_NodeID nodeWithParams = ZL_Compressor_cloneNode(
-            cgraph.get(), nodeWithoutParams, &localParams);
+    const ZL_ParameterizedNodeDesc desc = {
+        .node        = nodeWithoutParams,
+        .localParams = &localParams,
+    };
+    const ZL_NodeID nodeWithParams =
+            ZL_Compressor_registerParameterizedNode(cgraph.get(), &desc);
 
     std::vector<ZL_GraphID> thriftSuccessors;
     for (size_t i = 0; i < compress.gd.nbSingletons; i++) {

--- a/custom_transforms/thrift/thrift_parsers.cpp
+++ b/custom_transforms/thrift/thrift_parsers.cpp
@@ -689,12 +689,16 @@ ZL_NodeID cloneThriftNodeWithLocalParams(
         ZL_NodeID nodeId,
         std::string_view serializedConfig)
 {
-    const ZL_CopyParam gp            = { .paramId   = 0,
-                                         .paramPtr  = serializedConfig.data(),
-                                         .paramSize = serializedConfig.size() };
-    const ZL_LocalParams localParams = { .copyParams = { .copyParams   = &gp,
-                                                         .nbCopyParams = 1 } };
-    return ZL_Compressor_cloneNode(cgraph, nodeId, &localParams);
+    const ZL_CopyParam gp               = { .paramId   = 0,
+                                            .paramPtr  = serializedConfig.data(),
+                                            .paramSize = serializedConfig.size() };
+    const ZL_LocalParams localParams    = { .copyParams = { .copyParams   = &gp,
+                                                            .nbCopyParams = 1 } };
+    const ZL_ParameterizedNodeDesc desc = {
+        .node        = nodeId,
+        .localParams = &localParams,
+    };
+    return ZL_Compressor_registerParameterizedNode(cgraph, &desc);
 }
 
 } // namespace zstrong::thrift

--- a/include/openzl/codecs/zl_bitunpack.h
+++ b/include/openzl/codecs/zl_bitunpack.h
@@ -24,15 +24,19 @@ extern "C" {
 // the checks fail.
 enum { ZL_Bitunpack_numBits = 1 };
 #define ZS2_NODE_BITUNPACK ZL_MAKE_NODE_ID(ZL_StandardNodeID_bitunpack)
-#define ZL_CREATENODE_BITUNPACK(graph, nbBits)                              \
-    ZL_Compressor_cloneNode(                                                \
-            graph,                                                          \
-            ZS2_NODE_BITUNPACK,                                             \
-            &(const ZL_LocalParams){                                        \
-                    { &(const ZL_IntParam){ ZL_Bitunpack_numBits, nbBits }, \
-                      1 },                                                  \
-                    { NULL, 0 },                                            \
-                    { NULL, 0 } })
+#define ZL_CREATENODE_BITUNPACK(graph, nbBits)                                \
+    ZL_Compressor_registerParameterizedNode(                                  \
+            graph,                                                            \
+            &(const ZL_ParameterizedNodeDesc){                                \
+                    .node = ZS2_NODE_BITUNPACK,                               \
+                    .localParams =                                            \
+                            &(const ZL_LocalParams){                          \
+                                    { &(const ZL_IntParam){                   \
+                                              ZL_Bitunpack_numBits, nbBits }, \
+                                      1 },                                    \
+                                    { NULL, 0 },                              \
+                                    { NULL, 0 } },                            \
+            })
 ZL_NodeID ZL_Compressor_registerBitunpackNode(
         ZL_Compressor* cgraph,
         int nbBits);

--- a/include/openzl/codecs/zl_conversion.h
+++ b/include/openzl/codecs/zl_conversion.h
@@ -324,14 +324,19 @@ ZL_Edge_runConvertSerialToStringNode(
 
 // Old names for nodes
 enum { ZL_trlip_tokenSize = 1 };
-#define ZL_CREATENODE_CONVERT_SERIAL_TO_TOKEN(g, l)                       \
-    ZL_Compressor_cloneNode(                                              \
-            g,                                                            \
-            ZL_NODE_CONVERT_SERIAL_TO_STRUCT,                             \
-            &(const ZL_LocalParams){                                      \
-                    { &(const ZL_IntParam){ ZL_trlip_tokenSize, l }, 1 }, \
-                    { NULL, 0 },                                          \
-                    { NULL, 0 } })
+#define ZL_CREATENODE_CONVERT_SERIAL_TO_TOKEN(g, l)                    \
+    ZL_Compressor_registerParameterizedNode(                           \
+            g,                                                         \
+            &(const ZL_ParameterizedNodeDesc){                         \
+                    .node = ZL_NODE_CONVERT_SERIAL_TO_STRUCT,          \
+                    .localParams =                                     \
+                            &(const ZL_LocalParams){                   \
+                                    { &(const ZL_IntParam){            \
+                                              ZL_trlip_tokenSize, l }, \
+                                      1 },                             \
+                                    { NULL, 0 },                       \
+                                    { NULL, 0 } },                     \
+            })
 
 #define ZL_NODE_CONVERT_SERIAL_TO_TOKENX ZL_NODE_CONVERT_SERIAL_TO_STRUCT
 #define ZL_NODE_CONVERT_SERIAL_TO_TOKEN2 ZL_NODE_CONVERT_SERIAL_TO_STRUCT2

--- a/include/openzl/codecs/zl_split.h
+++ b/include/openzl/codecs/zl_split.h
@@ -34,7 +34,9 @@ extern "C" {
 //     };
 // ZL_LocalCopyParams lcp = { &ssp, 1 };
 // ZL_LocalParams lParams = { .copyParams = lcp };
-// ZL_NodeID nid = ZL_Compressor_cloneNode(cgraph, ZS2_NODE_SPLITN, &lParams);
+// ZL_NodeID nid = ZL_Compressor_registerParameterizedNode(cgraph,
+//     &(const ZL_ParameterizedNodeDesc){ .node = ZS2_NODE_SPLITN, .localParams
+//     = &lParams });
 //
 // The whole declaration logic is abstracted behind a public function
 // ZL_Compressor_registerSplitNode_withParams(), which achieves the same thing

--- a/include/openzl/zl_compressor.h
+++ b/include/openzl/zl_compressor.h
@@ -379,21 +379,6 @@ ZL_NodeID ZL_Compressor_registerParameterizedNode(
         const ZL_ParameterizedNodeDesc* desc);
 
 /**
- * @brief Simplified variant of @ref ZL_Compressor_registerParameterizedNode().
- * Clone an existing @ref ZL_NodeID from an already registered
- * @p nodeid but employs new parameters, set via @p localParams.
- *
- * @returns The new node id of the cloned node.
- *
- * @param nodeid The node to clone.
- * @param localParams The local parameters to use for the node.
- **/
-ZL_NodeID ZL_Compressor_cloneNode(
-        ZL_Compressor* compressor,
-        ZL_NodeID nodeid,
-        const ZL_LocalParams* localParams);
-
-/**
  * @}
  */
 

--- a/include/openzl/zl_compressor_serialization.h
+++ b/include/openzl/zl_compressor_serialization.h
@@ -90,7 +90,7 @@ extern "C" {
  *     component, produced by modifying or composing the original
  *     non-serializable component, via, e.g.:
  *
- *     - ZL_Compressor_cloneNode (see note)
+ *     - ZL_Compressor_registerParameterizedNode (see note)
  *
  *     - ZL_Compressor_registerStaticGraph_fromNode1o
  *     - ZL_Compressor_registerStaticGraph_fromPipelineNodes1o

--- a/src/openzl/codecs/conversion/encode_setStringSizes_binding.c
+++ b/src/openzl/codecs/conversion/encode_setStringSizes_binding.c
@@ -135,7 +135,12 @@ ZL_NodeID ZL_Compressor_registerConvertSerialToStringNode(
 
     ZL_LocalCopyParams const lgp = { &ssp, 1 };
     ZL_LocalParams const lParams = { .copyParams = lgp };
-    return ZL_Compressor_cloneNode(cgraph, ZL_NODE_SETSTRINGLENS, &lParams);
+    return ZL_Compressor_registerParameterizedNode(
+            cgraph,
+            &(const ZL_ParameterizedNodeDesc){
+                    .node        = ZL_NODE_SETSTRINGLENS,
+                    .localParams = &lParams,
+            });
 }
 
 ZL_RESULT_OF(ZL_EdgeList)

--- a/src/openzl/codecs/dispatchN_byTag/encode_dispatchN_byTag_binding.c
+++ b/src/openzl/codecs/dispatchN_byTag/encode_dispatchN_byTag_binding.c
@@ -220,7 +220,12 @@ ZL_NodeID ZL_Compressor_registerDispatchNode(
 
     ZL_LocalCopyParams const lgp = { &ssp, 1 };
     ZL_LocalParams const lParams = { .copyParams = lgp };
-    return ZL_Compressor_cloneNode(cgraph, ZL_NODE_DISPATCH, &lParams);
+    return ZL_Compressor_registerParameterizedNode(
+            cgraph,
+            &(const ZL_ParameterizedNodeDesc){
+                    .node        = ZL_NODE_DISPATCH,
+                    .localParams = &lParams,
+            });
 }
 
 void* ZL_DispatchState_malloc(ZL_DispatchState* state, size_t size)

--- a/src/openzl/codecs/dispatch_string/encode_dispatch_string_binding.c
+++ b/src/openzl/codecs/dispatch_string/encode_dispatch_string_binding.c
@@ -146,8 +146,12 @@ ZL_NodeID ZL_Compressor_registerDispatchStringNode(
         .refParams = ZL_REFPARAMS(
                 { ZL_DISPATCH_STRING_INDICES_PID, dispatchIndicesParam }),
     };
-    return ZL_Compressor_cloneNode(
-            cgraph, ZL_NODE_DISPATCH_STRING, &localParams);
+    return ZL_Compressor_registerParameterizedNode(
+            cgraph,
+            &(const ZL_ParameterizedNodeDesc){
+                    .node        = ZL_NODE_DISPATCH_STRING,
+                    .localParams = &localParams,
+            });
 }
 
 ZL_RESULT_OF(ZL_EdgeList)

--- a/src/openzl/codecs/divide_by/encode_divide_by_binding.c
+++ b/src/openzl/codecs/divide_by/encode_divide_by_binding.c
@@ -126,8 +126,12 @@ ZL_NodeID ZL_Compressor_registerDivideByNode(
     ZL_LocalCopyParams copyParams = { .copyParams   = &copyParam,
                                       .nbCopyParams = 1 };
     ZL_LocalParams localParams    = { .copyParams = copyParams };
-    ZL_NodeID const node_divideBy =
-            ZL_Compressor_cloneNode(cgraph, ZL_NODE_DIVIDE_BY, &localParams);
+    ZL_NodeID const node_divideBy = ZL_Compressor_registerParameterizedNode(
+            cgraph,
+            &(const ZL_ParameterizedNodeDesc){
+                    .node        = ZL_NODE_DIVIDE_BY,
+                    .localParams = &localParams,
+            });
     return node_divideBy;
 }
 

--- a/src/openzl/codecs/splitN/encode_splitN_binding.c
+++ b/src/openzl/codecs/splitN/encode_splitN_binding.c
@@ -197,7 +197,12 @@ ZL_NodeID ZL_Compressor_registerSplitNode_withParams(
     ZL_LocalCopyParams const lgp = { &segmentSizesParam, 1 };
 
     ZL_LocalParams const lParams = { .copyParams = lgp };
-    return ZL_Compressor_cloneNode(cgraph, getSplitNNodeID(type), &lParams);
+    return ZL_Compressor_registerParameterizedNode(
+            cgraph,
+            &(const ZL_ParameterizedNodeDesc){
+                    .node        = getSplitNNodeID(type),
+                    .localParams = &lParams,
+            });
 }
 
 ZL_NodeID ZL_Compressor_registerSplitNode_withParser(
@@ -214,7 +219,12 @@ ZL_NodeID ZL_Compressor_registerSplitNode_withParser(
 
     ZL_LocalRefParams const lgp  = { refParams, 2 };
     ZL_LocalParams const lParams = { .refParams = lgp };
-    return ZL_Compressor_cloneNode(cgraph, getSplitNNodeID(type), &lParams);
+    return ZL_Compressor_registerParameterizedNode(
+            cgraph,
+            &(const ZL_ParameterizedNodeDesc){
+                    .node        = getSplitNNodeID(type),
+                    .localParams = &lParams,
+            });
 }
 
 void* ZL_SplitState_malloc(ZL_SplitState* state, size_t size)

--- a/src/openzl/codecs/tokenize/encode_tokenize_binding.c
+++ b/src/openzl/codecs/tokenize/encode_tokenize_binding.c
@@ -622,7 +622,12 @@ ZL_NodeID ZS2_createNode_customTokenize(
                     .paramId   = ZL_TOKENIZE_TOKENIZER_PID,
                     .paramPtr  = &param,
                     .paramSize = sizeof(param));
-    return ZL_Compressor_cloneNode(cgraph, ZL_NODE_TOKENIZE, &lParams);
+    return ZL_Compressor_registerParameterizedNode(
+            cgraph,
+            &(const ZL_ParameterizedNodeDesc){
+                    .node        = ZL_NODE_TOKENIZE,
+                    .localParams = &lParams,
+            });
 }
 
 ZL_GraphID ZL_Compressor_registerCustomTokenizeGraph(

--- a/src/openzl/codecs/zstd/encode_zstd_binding.c
+++ b/src/openzl/codecs/zstd/encode_zstd_binding.c
@@ -195,8 +195,12 @@ ZL_GraphID ZL_Compressor_registerZstdGraph_withLevel(
                                                    ZSTD_c_compressionLevel,
                                                    compressionLevel,
                                            }) };
-    ZL_NodeID node_zstd        = ZL_Compressor_cloneNode(
-            cgraph, (ZL_NodeID){ ZL_PrivateStandardNodeID_zstd }, &localParams);
+    ZL_NodeID node_zstd        = ZL_Compressor_registerParameterizedNode(
+            cgraph,
+            &(const ZL_ParameterizedNodeDesc){
+                           .node        = (ZL_NodeID){ ZL_PrivateStandardNodeID_zstd },
+                           .localParams = &localParams,
+            });
     return ZL_Compressor_registerStaticGraph_fromNode1o(
             cgraph, node_zstd, ZL_GRAPH_STORE);
 }

--- a/src/openzl/compress/cgraph.c
+++ b/src/openzl/compress/cgraph.c
@@ -437,19 +437,6 @@ ZL_NodeID ZL_Compressor_registerParameterizedNode(
     return ZL_RES_value(nodeidResult);
 }
 
-ZL_NodeID ZL_Compressor_cloneNode(
-        ZL_Compressor* cgraph,
-        ZL_NodeID nodeid,
-        const ZL_LocalParams* localParams)
-{
-    ZL_ParameterizedNodeDesc desc = {
-        .name        = NULL,
-        .node        = nodeid,
-        .localParams = localParams,
-    };
-    return ZL_Compressor_registerParameterizedNode(cgraph, &desc);
-}
-
 ZL_NodeID CGraph_registerStandardVOTransform(
         ZL_Compressor* cgraph,
         const ZL_VOEncoderDesc* votd,

--- a/src/openzl/compress/compressor_serialization.c
+++ b/src/openzl/compress/compressor_serialization.c
@@ -2193,8 +2193,12 @@ static ZL_Report ZL_CompressorDeserializer_tryBuildNode(
                     &base_local_params,
                     NULL));
 
-    const ZL_NodeID node_id =
-            ZL_Compressor_cloneNode(compressor, base_nid, &local_params);
+    const ZL_NodeID node_id = ZL_Compressor_registerParameterizedNode(
+            compressor,
+            &(const ZL_ParameterizedNodeDesc){
+                    .node        = base_nid,
+                    .localParams = &local_params,
+            });
     ZL_ERR_IF_EQ(node_id.nid, ZL_NODE_ILLEGAL.nid, corruption);
 
     const char* new_name = ZL_Compressor_Node_getName(compressor, node_id);

--- a/tests/BUCK
+++ b/tests/BUCK
@@ -127,7 +127,6 @@ zs_cxxlibrary(
     deps = [
         "..:zstronglib",
         "datagen:datagen",
-        "fbsource//third-party/googletest:gtest",
         ":utils",
     ],
     exported_deps = ["fbsource//third-party/googletest:gtest"],

--- a/tests/compress/test_compressor_serialization.cpp
+++ b/tests/compress/test_compressor_serialization.cpp
@@ -270,16 +270,25 @@ TEST_F(CompressorSerializationTest, Roundtrip)
                     },
         };
     };
-    auto lp     = make_lp();
-    auto cp_nid = ZL_Compressor_cloneNode(compressor, ZL_NODE_ZIGZAG, &lp);
+    auto lp                               = make_lp();
+    const ZL_ParameterizedNodeDesc pndesc = {
+        .node        = ZL_NODE_ZIGZAG,
+        .localParams = &lp,
+    };
+    auto cp_nid = ZL_Compressor_registerParameterizedNode(compressor, &pndesc);
     EXPECT_NE(cp_nid, ZL_NODE_ILLEGAL);
 
     ips.push_back((ZL_IntParam){
             .paramId    = 123,
             .paramValue = 5678,
     });
-    lp             = make_lp();
-    auto cp_cp_nid = ZL_Compressor_cloneNode(compressor, cp_nid, &lp);
+    lp                                     = make_lp();
+    const ZL_ParameterizedNodeDesc pndesc2 = {
+        .node        = cp_nid,
+        .localParams = &lp,
+    };
+    auto cp_cp_nid =
+            ZL_Compressor_registerParameterizedNode(compressor, &pndesc2);
     EXPECT_NE(cp_cp_nid, ZL_NODE_ILLEGAL);
 
     ZL_REQUIRE_SUCCESS(

--- a/tests/datagen/structures/CompressorProducer.cpp
+++ b/tests/datagen/structures/CompressorProducer.cpp
@@ -533,10 +533,14 @@ std::vector<std::string> RandomCompressorMultiBuilder::clone_node(
                 ZL_Compressor_Node_getLocalParams(c, base_nid);
         const auto new_params =
                 transform_localparams(LocalParams{ base_localparams });
-        auto new_localparams      = *new_params;
-        new_localparams.refParams = base_localparams.refParams;
+        auto new_localparams                  = *new_params;
+        new_localparams.refParams             = base_localparams.refParams;
+        const ZL_ParameterizedNodeDesc pndesc = {
+            .node        = base_nid,
+            .localParams = &new_localparams,
+        };
         const auto new_nid =
-                ZL_Compressor_cloneNode(c, base_nid, &new_localparams);
+                ZL_Compressor_registerParameterizedNode(c, &pndesc);
         const auto new_name = ZL_Compressor_Node_getName(c, new_nid);
         names.emplace_back(new_name);
     }

--- a/tests/round_trip/test_convert.cpp
+++ b/tests/round_trip/test_convert.cpp
@@ -44,6 +44,11 @@ static ZL_GraphID conversionGraph(ZL_Compressor* cgraph) noexcept
     ZL_IntParam const tokenL4              = { ZL_trlip_tokenSize, 4 };
     ZL_LocalParams const castToToken4Param = { .intParams = { &tokenL4, 1 } };
 
+    const ZL_ParameterizedNodeDesc pndesc = {
+        .node        = ZL_NODE_CONVERT_SERIAL_TO_TOKENX,
+        .localParams = &castToToken4Param,
+    };
+
     const ZL_NodeID pipeline[] = {
         ZL_NODE_INTERPRET_AS_LE32,
         ZL_NODE_DELTA_INT,
@@ -55,8 +60,7 @@ static ZL_GraphID conversionGraph(ZL_Compressor* cgraph) noexcept
         ZL_NODE_CONVERT_SERIAL_TO_TOKEN4,
         /* serial->token4 using generic TOKENX conversion transform with length
            parameter */
-        ZL_Compressor_cloneNode(
-                cgraph, ZL_NODE_CONVERT_SERIAL_TO_TOKENX, &castToToken4Param),
+        ZL_Compressor_registerParameterizedNode(cgraph, &pndesc),
         ZL_NODE_INTERPRET_TOKEN_AS_LE,
         ZL_NODE_CONVERT_NUM_TO_SERIAL,
     };

--- a/tests/round_trip/test_splitGraphs.cpp
+++ b/tests/round_trip/test_splitGraphs.cpp
@@ -233,11 +233,15 @@ static ZL_GraphID treeGraph(ZL_Compressor* cgraph) noexcept
             ZL_Compressor_registerPipeEncoder(cgraph, &add1_CDesc);
     EXPECT_NE(node_add1_orig, ZL_NODE_ILLEGAL);
 
-    // Let's exercise cloneNode on a PipeTransform
+    // Let's exercise registerParameterizedNode on a PipeTransform
     ZL_LocalParams lparams_add1;
     memset(&lparams_add1, 0, sizeof(lparams_add1));
+    const ZL_ParameterizedNodeDesc pndesc = {
+        .node        = node_add1_orig,
+        .localParams = &lparams_add1,
+    };
     ZL_NodeID const node_add1 =
-            ZL_Compressor_cloneNode(cgraph, node_add1_orig, &lparams_add1);
+            ZL_Compressor_registerParameterizedNode(cgraph, &pndesc);
     EXPECT_NE(node_add1, ZL_NODE_ILLEGAL);
     ZL_NodeID const node_split2 =
             ZL_Compressor_registerSplitEncoder(cgraph, &split2_CDesc);
@@ -249,9 +253,10 @@ static ZL_GraphID treeGraph(ZL_Compressor* cgraph) noexcept
             ZL_Compressor_registerSplitEncoder(cgraph, &add4_CDesc);
     EXPECT_NE(node_add4, ZL_NODE_ILLEGAL);
 
-    // Test : ZL_Compressor_cloneNode() with non-constant parameters
-    // Ensure it still works when @lparams lies in non-constant memory,
-    // in this case, on stack, memory content no longer valid at function's end
+    // Test : ZL_Compressor_registerParameterizedNode() with non-constant
+    // parameters Ensure it still works when @lparams lies in non-constant
+    // memory, in this case, on stack, memory content no longer valid at
+    // function's end
     ZL_IntParam intParam;
     intParam.paramId = add4_paramId;
     intParam.paramValue =
@@ -259,10 +264,14 @@ static ZL_GraphID treeGraph(ZL_Compressor* cgraph) noexcept
                   % add4_paramV_bound); // dynamic value => can't be a const
     ZL_LocalParams lparams;
     memset(&lparams, 0, sizeof(lparams));
-    lparams.intParams.nbIntParams = add4_nbParams;
-    lparams.intParams.intParams   = &intParam;
+    lparams.intParams.nbIntParams          = add4_nbParams;
+    lparams.intParams.intParams            = &intParam;
+    const ZL_ParameterizedNodeDesc pndesc2 = {
+        .node        = node_add4,
+        .localParams = &lparams,
+    };
     ZL_NodeID const node_add4_v2 =
-            ZL_Compressor_cloneNode(cgraph, node_add4, &lparams);
+            ZL_Compressor_registerParameterizedNode(cgraph, &pndesc2);
     EXPECT_NE(node_add4_v2, ZL_NODE_ILLEGAL);
 
     // Create & combine sub-graphs

--- a/tests/round_trip/test_typedGraphs.cpp
+++ b/tests/round_trip/test_typedGraphs.cpp
@@ -223,12 +223,17 @@ static ZL_GraphID typedGraph(ZL_Compressor* cgraph) noexcept
     ZL_NodeID const node_add1 =
             ZL_Compressor_registerTypedEncoder(cgraph, &add1_CDesc);
 
-    // test exercising ZL_Compressor_cloneNode() from a standard Node
-    ZL_LocalParams const lp = { { nullptr, 0 },
-                                { nullptr, 0 },
-                                { nullptr, 0 } };
+    // test exercising ZL_Compressor_registerParameterizedNode() from a standard
+    // Node
+    ZL_LocalParams const lp               = { { nullptr, 0 },
+                                              { nullptr, 0 },
+                                              { nullptr, 0 } };
+    const ZL_ParameterizedNodeDesc pndesc = {
+        .node        = ZL_NODE_TRANSPOSE_SPLIT,
+        .localParams = &lp,
+    };
     ZL_NodeID const node_myTranspose =
-            ZL_Compressor_cloneNode(cgraph, ZL_NODE_TRANSPOSE_SPLIT, &lp);
+            ZL_Compressor_registerParameterizedNode(cgraph, &pndesc);
 
     // Graph : src => serial->int32 => add1 => delta => convertToken (implicit)
     // => tselect

--- a/tests/utils.cpp
+++ b/tests/utils.cpp
@@ -1177,8 +1177,12 @@ ZL_GraphID addConversionToGraph(
             ZL_REQUIRE_NE(eltWidth, 0);
             ZL_IntParam intParams = { ZL_trlip_tokenSize, (int)eltWidth };
             ZL_LocalParams params = { .intParams = { &intParams, 1 } };
-            auto const node       = ZL_Compressor_cloneNode(
-                    cgraph, ZL_NODE_CONVERT_SERIAL_TO_TOKENX, &params);
+            const ZL_ParameterizedNodeDesc pndesc = {
+                .node        = ZL_NODE_CONVERT_SERIAL_TO_TOKENX,
+                .localParams = &params,
+            };
+            auto const node =
+                    ZL_Compressor_registerParameterizedNode(cgraph, &pndesc);
             return ZL_Compressor_registerStaticGraph_fromNode1o(
                     cgraph, node, graph);
         }

--- a/tests/version/VersionTestInterfaceABI.cpp
+++ b/tests/version/VersionTestInterfaceABI.cpp
@@ -285,8 +285,12 @@ convertFromSerial(ZL_Compressor* cgraph, ZL_GraphID graphID, unsigned eltWidth)
             ZL_LocalParams const params = {
                 .intParams = { .intParams = &param, .nbIntParams = 1 },
             };
-            ZL_NodeID const convert = ZL_Compressor_cloneNode(
-                    cgraph, ZL_NODE_CONVERT_SERIAL_TO_TOKENX, &params);
+            const ZL_ParameterizedNodeDesc pndesc = {
+                .node        = ZL_NODE_CONVERT_SERIAL_TO_TOKENX,
+                .localParams = &params,
+            };
+            ZL_NodeID const convert =
+                    ZL_Compressor_registerParameterizedNode(cgraph, &pndesc);
             return ZL_Compressor_registerStaticGraph_fromNode1o(
                     cgraph, convert, graphID);
         }

--- a/tests/zstrong/test_opaque.cpp
+++ b/tests/zstrong/test_opaque.cpp
@@ -612,7 +612,11 @@ TEST_F(OpaqueTest, ParameterizeNodeWithOpaque)
             .nbIntParams = 1,
         },
     };
-    node = ZL_Compressor_cloneNode(compressor_, node, &params);
+    const ZL_ParameterizedNodeDesc pndesc = {
+        .node        = node,
+        .localParams = &params,
+    };
+    node = ZL_Compressor_registerParameterizedNode(compressor_, &pndesc);
 
     graph = ZL_Compressor_registerStaticGraph_fromNode1o(
             compressor_, node, graph);

--- a/tests/zstrong/test_zstrong_fixture.cpp
+++ b/tests/zstrong/test_zstrong_fixture.cpp
@@ -42,7 +42,7 @@ void ZStrongTest::reset()
     inType_                 = std::nullopt;
     vsfFieldSizesInstructs_ = {};
 
-    // Default the format version to the max format verison.
+    // Default the format version to the max format version.
     // Set it in the cgraph because these parameters have lower priority.
     ZL_REQUIRE_SUCCESS(ZL_Compressor_setParameter(
             cgraph_,
@@ -127,7 +127,11 @@ ZL_NodeID ZStrongTest::createParameterizedNode(
         ZL_NodeID node,
         const ZL_LocalParams& localParams)
 {
-    return ZL_Compressor_cloneNode(cgraph_, node, &localParams);
+    const ZL_ParameterizedNodeDesc pndesc = {
+        .node        = node,
+        .localParams = &localParams,
+    };
+    return ZL_Compressor_registerParameterizedNode(cgraph_, &pndesc);
 }
 
 ZL_GraphID ZStrongTest::convertSerializedToType(
@@ -164,8 +168,12 @@ ZL_GraphID ZStrongTest::convertSerializedToType(
         ZL_LocalParams const params = {
             .intParams = { .intParams = &param, .nbIntParams = 1 },
         };
-        ZL_NodeID const convert = ZL_Compressor_cloneNode(
-                cgraph_, ZL_NODE_CONVERT_SERIAL_TO_TOKENX, &params);
+        const ZL_ParameterizedNodeDesc pndesc2 = {
+            .node        = ZL_NODE_CONVERT_SERIAL_TO_TOKENX,
+            .localParams = &params,
+        };
+        ZL_NodeID const convert =
+                ZL_Compressor_registerParameterizedNode(cgraph_, &pndesc2);
         return declareGraph(convert, graph);
     } else if (type & ZL_Type_string) {
         ZL_SetStringLensParserFn parser =

--- a/tools/zstrong_cpp.cpp
+++ b/tools/zstrong_cpp.cpp
@@ -104,7 +104,11 @@ class StandardTransform : public ParameterizedTransform {
             // parameters that were already set on the standard node.
             // TODO: Standard nodes probably shouldn't "internally" use
             // parameters like convert_serial_to_token2 does.
-            node = ZL_Compressor_cloneNode(&cgraph, node_, &params);
+            const ZL_ParameterizedNodeDesc desc = {
+                .node        = node_,
+                .localParams = &params,
+            };
+            node = ZL_Compressor_registerParameterizedNode(&cgraph, &desc);
         }
         return ZL_Compressor_registerStaticGraph_fromNode(
                 &cgraph, node, successors.data(), successors.size());
@@ -300,8 +304,12 @@ class ThriftTransform : public StandardFnTransform {
                                       &cgraph,
                                       thrift::kThriftBinaryConfigurable);
                           }
-                          node = ZL_Compressor_cloneNode(
-                                  &cgraph, node, &params);
+                          const ZL_ParameterizedNodeDesc desc = {
+                              .node        = node,
+                              .localParams = &params,
+                          };
+                          node = ZL_Compressor_registerParameterizedNode(
+                                  &cgraph, &desc);
                           return ZL_Compressor_registerStaticGraph_fromNode(
                                   &cgraph,
                                   node,


### PR DESCRIPTION
Summary: The `cloneNode` function is a two-line wrapper around `registerParameterizedNode`. Removal is justified by its lack of usefulness plus the risk of confusion via a cluttered API.

Differential Revision: D96495444


