### PR TITLE
Return illegal on using anchor name instead of crashing

### DIFF
--- a/src/openzl/compress/graphmgr.c
+++ b/src/openzl/compress/graphmgr.c
@@ -770,6 +770,10 @@ ZL_GraphID GM_getLastRegisteredGraph(const GraphsMgr* gm)
 
 ZL_GraphID GM_getGraphByName(const GraphsMgr* gm, const char* graph)
 {
+    // Lookup should not be done using anchor names
+    if (graph == NULL || ZL_keyIsAnchor(graph)) {
+        return ZL_GRAPH_ILLEGAL;
+    }
     const ZL_Name key           = ZL_Name_wrapKey(graph);
     const GraphMap_Entry* entry = GraphMap_find(&gm->nameMap, &key);
     if (entry != NULL) {

--- a/src/openzl/compress/name.h
+++ b/src/openzl/compress/name.h
@@ -81,6 +81,11 @@ ZL_INLINE ZL_Name ZL_Name_wrapKey(const char* key)
     return name;
 }
 
+ZL_INLINE bool ZL_keyIsAnchor(const char* key)
+{
+    return key[0] == '!';
+}
+
 /// @returns True if the name object is empty (standard graphs / nodes don't
 /// fill their ZL_Name)
 ZL_INLINE bool ZL_Name_isEmpty(const ZL_Name* name)

--- a/src/openzl/compress/nodemgr.c
+++ b/src/openzl/compress/nodemgr.c
@@ -159,6 +159,10 @@ const CNode* NM_getCNode(const Nodes_manager* nmgr, ZL_NodeID nodeid)
 
 ZL_NodeID NM_getNodeByName(const Nodes_manager* nmgr, const char* node)
 {
+    // Lookup should not be done using anchor names
+    if (node == NULL || ZL_keyIsAnchor(node)) {
+        return ZL_NODE_ILLEGAL;
+    }
     const ZL_Name key          = ZL_Name_wrapKey(node);
     const NodeMap_Entry* entry = NodeMap_find(&nmgr->nameMap, &key);
     if (entry != NULL) {

--- a/tests/unittest/compress/CompressorUnitTest.cpp
+++ b/tests/unittest/compress/CompressorUnitTest.cpp
@@ -718,6 +718,18 @@ TEST_F(CompressorTest, GetNode)
     ASSERT_EQ(node, ZL_NODE_FIELD_LZ);
 }
 
+TEST_F(CompressorTest, GetNodeBadInputs)
+{
+    auto node = ZL_Compressor_getNode(compressor_.get(), NULL);
+    ASSERT_EQ(node, ZL_NODE_ILLEGAL);
+
+    node = ZL_Compressor_getNode(compressor_.get(), "");
+    ASSERT_EQ(node, ZL_NODE_ILLEGAL);
+
+    node = ZL_Compressor_getNode(compressor_.get(), "!");
+    ASSERT_EQ(node, ZL_NODE_ILLEGAL);
+}
+
 TEST_F(CompressorTest, RegisterParameterizedNode)
 {
     auto node                     = ZL_NODE_FIELD_LZ;
@@ -819,6 +831,18 @@ TEST_F(CompressorTest, GetGraph)
     ASSERT_EQ(multiInput1, graph);
     graph = ZL_Compressor_getGraph(compressor_.get(), "multi_input#10");
     ASSERT_EQ(multiInput0, graph);
+}
+
+TEST_F(CompressorTest, GetGraphBadInputs)
+{
+    auto graph = ZL_Compressor_getGraph(compressor_.get(), NULL);
+    ASSERT_EQ(graph, ZL_GRAPH_ILLEGAL);
+
+    graph = ZL_Compressor_getGraph(compressor_.get(), "");
+    ASSERT_EQ(graph, ZL_GRAPH_ILLEGAL);
+
+    graph = ZL_Compressor_getGraph(compressor_.get(), "!");
+    ASSERT_EQ(graph, ZL_GRAPH_ILLEGAL);
 }
 
 TEST_F(CompressorTest, ForEachGraph)


### PR DESCRIPTION
Summary: For `ZL_Compressor_get*` API, return `ZL_ILLEGAL_*` instead of crashing the program on bad inputs. Deserialization can crash on these bad inputs otherwise.

Reviewed By: terrelln

Differential Revision: D96822735


