### PR TITLE
Fix DivideBy component fuzzing error

### DIFF
--- a/tests/registry/components/DivideBy.cpp
+++ b/tests/registry/components/DivideBy.cpp
@@ -57,7 +57,10 @@ class DivideByComponent : public OpenZLComponent {
 
     uint64_t getDivisor(const Compressor& compressor, GraphID graph) const
     {
-        auto node   = ZL_Compressor_Graph_getHeadNode(compressor.get(), graph);
+        auto node = ZL_Compressor_Graph_getHeadNode(compressor.get(), graph);
+        if (node.nid == ZL_NODE_ILLEGAL.nid) {
+            throw std::runtime_error("Failed to get head node in graph");
+        }
         auto params = ZL_Compressor_Node_getLocalParams(compressor.get(), node);
         if (params.copyParams.nbCopyParams == 0) {
             // Use GCD => any values are okay


### PR DESCRIPTION
Summary: Throw when `DivideBy` component tries to get divisor from a configured graph with no head node.

Reviewed By: daniellerozenblit

Differential Revision: D96939962


