### PR TITLE
Throw when bitUnpack parameters are invalid

### DIFF
--- a/tests/registry/components/Bitunpack.cpp
+++ b/tests/registry/components/Bitunpack.cpp
@@ -92,6 +92,10 @@ class BitunpackComponent : public OpenZLComponent {
             GraphID graph) const override
     {
         auto numBits = getNumBits(compressor, graph);
+        if (numBits <= 0 || numBits > 64) {
+            throw std::runtime_error(
+                    "Invalid numBits: must be in range [1, 64]");
+        }
         std::vector<std::unique_ptr<OpenZLInput>> inputs;
         inputs.reserve(num);
         for (size_t i = 0; i < num; ++i) {


### PR DESCRIPTION
Summary: Fix fuzzer issues with component `BitUnpack` generating inputs when the graph provided has invalid parameters.

Reviewed By: daniellerozenblit

Differential Revision: D96836995


