### PR TITLE
Stage 3a: Rename and refactor compress trace files, extract shared ChunkTraceCore (#537)

### DIFF
--- a/cpp/src/openzl/cpp/experimental/trace/CborHelpers.hpp
+++ b/cpp/src/openzl/cpp/experimental/trace/CborHelpers.hpp
@@ -1,6 +1,9 @@
 // Copyright (c) Meta Platforms, Inc. and affiliates.
 #pragma once
 
+#include <string>
+#include <vector>
+
 #include "openzl/cpp/LocalParams.hpp"
 #include "openzl/shared/a1cbor.h"
 #include "openzl/zl_errors.h"

--- a/cpp/src/openzl/cpp/experimental/trace/ChunkTraceCore.cpp
+++ b/cpp/src/openzl/cpp/experimental/trace/ChunkTraceCore.cpp
@@ -1,0 +1,114 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#include "openzl/cpp/experimental/trace/ChunkTraceCore.hpp"
+
+#include "openzl/common/a1cbor_helpers.h"
+#include "openzl/cpp/experimental/trace/CborHelpers.hpp"
+
+namespace openzl::visualizer {
+
+void ChunkTraceCore::initTrace(
+        std::vector<Codec>& codecInfo,
+        size_t& currCodecNum,
+        size_t chunkId)
+{
+    Codec startCodec = {
+        .name         = "zl.#start",
+        .cType        = true, // standard
+        .cID          = 0,
+        .cHeaderSize  = 0,
+        .cLocalParams = {},
+        .chunkId      = chunkId,
+    };
+    startCodec.codecNum = currCodecNum;
+    codecInfo.push_back(std::move(startCodec));
+    ++currCodecNum;
+}
+
+void ChunkTraceCore::finalizeUnconsumedStreams(
+        const char* terminalCodecName,
+        std::map<ZL_DataID, Stream, ZL_DataIDCustomComparator>& streamInfo,
+        std::vector<Codec>& codecInfo,
+        size_t& currCodecNum,
+        size_t chunkId)
+{
+    for (auto& [streamID, stream] : streamInfo) {
+        if (!stream.consumerCodec.has_value()) {
+            Codec terminal = {
+                .name         = terminalCodecName,
+                .cType        = true, // standard
+                .cID          = 0,
+                .cHeaderSize  = 0,
+                .cLocalParams = {},
+                .chunkId      = chunkId,
+            };
+            terminal.codecNum = currCodecNum;
+            codecInfo.push_back(std::move(terminal));
+            codecInfo[currCodecNum].inEdges.push_back(streamID);
+            stream.consumerCodec = currCodecNum;
+            ++currCodecNum;
+        }
+    }
+}
+
+ZL_Report ChunkTraceCore::serializeChunkDataToCBOR(
+        A1C_Arena* a1c_arena,
+        A1C_ArrayBuilder* chunkArrayBuilder,
+        size_t chunkId,
+        std::map<ZL_DataID, Stream, ZL_DataIDCustomComparator>& streamInfo,
+        std::vector<Codec>& codecInfo,
+        std::vector<Graph>& graphInfo,
+        const ZL_CCtx* cctx)
+{
+    A1C_ARRAY_TRY_ADD_R(chunkItem, *chunkArrayBuilder);
+    A1C_MapBuilder chunkBuilder = A1C_Item_map_builder(chunkItem, 4, a1c_arena);
+    ZL_RET_R_IF_NULL(allocation, chunkBuilder.map);
+
+    ZL_RET_R_IF_ERR(addIntValue(chunkBuilder, "chunkId", chunkId));
+
+    // Streams
+    A1C_MAP_TRY_ADD_R(streamsPair, chunkBuilder);
+    A1C_Item_string_refCStr(&streamsPair->key, "streams");
+    A1C_ArrayBuilder streamsBuilder = A1C_Item_array_builder(
+            &streamsPair->val, streamInfo.size(), a1c_arena);
+    ZL_RET_R_IF_NULL(allocation, streamsBuilder.array);
+    for (auto& stream : streamInfo) {
+        A1C_ARRAY_TRY_ADD_R(a1c_stream, streamsBuilder);
+        ZL_RET_R_IF_ERR(stream.second.serializeStream(a1c_arena, a1c_stream));
+    }
+
+    // Codecs
+    A1C_MAP_TRY_ADD_R(codecsPair, chunkBuilder);
+    A1C_Item_string_refCStr(&codecsPair->key, "codecs");
+    A1C_ArrayBuilder codecsBuilder = A1C_Item_array_builder(
+            &codecsPair->val, codecInfo.size(), a1c_arena);
+    ZL_RET_R_IF_NULL(allocation, codecsBuilder.array);
+    for (size_t codecNum = 0; codecNum < codecInfo.size(); ++codecNum) {
+        Codec& codec = codecInfo[codecNum];
+        A1C_ARRAY_TRY_ADD_R(a1c_codec, codecsBuilder);
+        ZL_RET_R_IF_ERR(codec.serializeCodec(a1c_arena, a1c_codec, cctx));
+    }
+
+    // Graphs (empty array for decompress)
+    A1C_MAP_TRY_ADD_R(graphsPair, chunkBuilder);
+    A1C_Item_string_refCStr(&graphsPair->key, "graphs");
+    A1C_ArrayBuilder graphsBuilder = A1C_Item_array_builder(
+            &graphsPair->val, graphInfo.size(), a1c_arena);
+    ZL_RET_R_IF_NULL(allocation, graphsBuilder.array);
+    for (auto& graph : graphInfo) {
+        A1C_ARRAY_TRY_ADD_R(a1c_graph, graphsBuilder);
+        ZL_RET_R_IF_ERR(graph.serializeGraph(a1c_arena, a1c_graph, cctx));
+    }
+
+    return ZL_returnSuccess();
+}
+
+ZL_Report ChunkTraceCore::writeSerializedStreamdump(
+        std::vector<uint8_t>& buffer,
+        std::string& outTrace)
+{
+    outTrace = std::string(buffer.begin(), buffer.end());
+    return ZL_returnSuccess();
+}
+
+} // namespace openzl::visualizer

--- a/cpp/src/openzl/cpp/experimental/trace/ChunkTraceCore.hpp
+++ b/cpp/src/openzl/cpp/experimental/trace/ChunkTraceCore.hpp
@@ -1,0 +1,78 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#pragma once
+
+#include <map>
+#include <string>
+#include <vector>
+
+#include "openzl/cpp/experimental/trace/Codec.hpp"
+#include "openzl/cpp/experimental/trace/Graph.hpp"
+#include "openzl/cpp/experimental/trace/StreamVisualizer.hpp"
+
+namespace openzl::visualizer {
+
+struct StreamdumpEntry {
+    size_t streamId;
+    std::string content;
+    std::string strLens;
+};
+
+struct TraceResult {
+    std::string trace;
+    std::vector<std::vector<StreamdumpEntry>> streamdump;
+};
+
+/**
+ * Static-only helper class for shared ChunkTrace logic between
+ * CompressChunkTrace and DecompressChunkTrace.
+ * Owns no data — all state is passed in by the caller.
+ */
+class ChunkTraceCore {
+   public:
+    ChunkTraceCore() = delete; // non-instantiable
+
+    /**
+     * Creates a "zl.#start" placeholder codec and appends it to codecInfo.
+     * Increments currCodecNum.
+     */
+    static void initTrace(
+            std::vector<Codec>& codecInfo,
+            size_t& currCodecNum,
+            size_t chunkId);
+
+    /**
+     * For each unconsumed stream (no consumerCodec), creates a terminal codec
+     * with the given name, wires it up, and increments currCodecNum.
+     */
+    static void finalizeUnconsumedStreams(
+            const char* terminalCodecName,
+            std::map<ZL_DataID, Stream, ZL_DataIDCustomComparator>& streamInfo,
+            std::vector<Codec>& codecInfo,
+            size_t& currCodecNum,
+            size_t chunkId);
+
+    /**
+     * Serializes chunkId, streams, codecs, and optionally graphs into
+     * a CBOR chunk item appended to chunkArrayBuilder.
+     * cctx may be nullptr (decompress side).
+     * graphInfo may be empty (decompress side has no graphs).
+     */
+    static ZL_Report serializeChunkDataToCBOR(
+            A1C_Arena* a1c_arena,
+            A1C_ArrayBuilder* chunkArrayBuilder,
+            size_t chunkId,
+            std::map<ZL_DataID, Stream, ZL_DataIDCustomComparator>& streamInfo,
+            std::vector<Codec>& codecInfo,
+            std::vector<Graph>& graphInfo,
+            const ZL_CCtx* cctx);
+
+    /**
+     * Encodes CBOR buffer bytes into a string (for trace output).
+     */
+    static ZL_Report writeSerializedStreamdump(
+            std::vector<uint8_t>& buffer,
+            std::string& outTrace);
+};
+
+} // namespace openzl::visualizer

--- a/cpp/src/openzl/cpp/experimental/trace/CompressChunkTrace.cpp
+++ b/cpp/src/openzl/cpp/experimental/trace/CompressChunkTrace.cpp
@@ -1,6 +1,6 @@
 // (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
 
-#include "openzl/cpp/experimental/trace/ChunkTrace.hpp"
+#include "openzl/cpp/experimental/trace/CompressChunkTrace.hpp"
 
 #include "openzl/common/a1cbor_helpers.h"
 #include "openzl/compress/dyngraph_interface.h"
@@ -139,22 +139,12 @@ static StreamPreview getStreamPreviewData(
     }
 }
 
-void ChunkTrace::initTrace()
+void CompressChunkTrace::initTrace()
 {
-    Codec compressionStart = {
-        .name         = "zl.#start",
-        .cType        = true, // standard
-        .cID          = 0,
-        .cHeaderSize  = 0,
-        .cLocalParams = {},
-        .chunkId      = chunkId_,
-    };
-    compressionStart.codecNum = currCodecNum_;
-    codecInfo_.push_back(std::move(compressionStart));
-    ++currCodecNum_;
+    ChunkTraceCore::initTrace(codecInfo_, currCodecNum_, chunkId_);
 }
 
-void ChunkTrace::recordStartStreams(
+void CompressChunkTrace::recordStartStreams(
         const ZL_Input* inStreams[],
         size_t numInStreams)
 {
@@ -188,109 +178,52 @@ void ChunkTrace::recordStartStreams(
     }
 }
 
-void ChunkTrace::finalizeTrace(ZL_Report const result)
+void CompressChunkTrace::finalizeTrace(ZL_Report const result)
 {
     if (ZL_isError(result)) {
         ZL_LOG(ALWAYS, "Compression not successful!");
         std::cerr << "Compression not successful!" << std::endl;
-        // temp: in-flight streams go to an "in-progress" node
-        for (unsigned i = 0; i < streamInfo_.size(); ++i) {
-            const StreamID streamID = { .sid = i };
-            if (!streamInfo_.at(streamID).consumerCodec.has_value()) {
-                Codec inProgress = {
-                    .name         = "zl.#in_progress",
-                    .cType        = true, // standard
-                    .cID          = 0,
-                    .cHeaderSize  = 0,
-                    .cLocalParams = {},
-                    .chunkId      = chunkId_,
-                };
-                if (maybeConversionError_.has_value()
-                    && maybeConversionError_->streamId.sid == streamID.sid) {
-                    inProgress.cFailure = maybeConversionError_->failureReport;
-                }
-                inProgress.codecNum = currCodecNum_;
-                codecInfo_.push_back(std::move(inProgress));
-                codecInfo_[currCodecNum_].inEdges.push_back(streamID);
-                streamInfo_[streamID].consumerCodec = currCodecNum_;
-                ++currCodecNum_;
+        ChunkTraceCore::finalizeUnconsumedStreams(
+                "zl.#in_progress",
+                streamInfo_,
+                codecInfo_,
+                currCodecNum_,
+                chunkId_);
+        // Apply conversion error to the relevant terminal codec
+        if (maybeConversionError_.has_value()) {
+            auto it = streamInfo_.find(maybeConversionError_->streamId);
+            if (it != streamInfo_.end()
+                && it->second.consumerCodec.has_value()) {
+                codecInfo_[it->second.consumerCodec.value()].cFailure =
+                        maybeConversionError_->failureReport;
             }
         }
     } else {
         compressedSize_ = ZL_validResult(result);
-        for (unsigned i = 0; i < streamInfo_.size(); ++i) {
-            const StreamID streamID = { .sid = i };
-            if (!streamInfo_.at(streamID).consumerCodec.has_value()) {
-                Codec store = {
-                    .name         = "zl.store",
-                    .cType        = true, // standard
-                    .cID          = 0,
-                    .cHeaderSize  = 0,
-                    .cLocalParams = {},
-                    .chunkId      = chunkId_,
-                };
-                store.codecNum = currCodecNum_;
-                codecInfo_.push_back(std::move(store));
-                codecInfo_[currCodecNum_].inEdges.push_back(streamID);
-                streamInfo_[streamID].consumerCodec = currCodecNum_;
-                ++currCodecNum_;
-            }
-        }
+        ChunkTraceCore::finalizeUnconsumedStreams(
+                "zl.store", streamInfo_, codecInfo_, currCodecNum_, chunkId_);
     }
 
     printStreamMetadata();
     printCodecMetadata();
 }
 
-ZL_Report ChunkTrace::serializeToCBOR(
+ZL_Report CompressChunkTrace::serializeToCBOR(
         A1C_Arena* a1c_arena,
         A1C_ArrayBuilder* chunkArrayBuilder,
         const ZL_CCtx* cctx)
 {
-    A1C_ARRAY_TRY_ADD_R(chunkItem, *chunkArrayBuilder);
-    A1C_MapBuilder chunkBuilder = A1C_Item_map_builder(chunkItem, 4, a1c_arena);
-    ZL_RET_R_IF_NULL(allocation, chunkBuilder.map);
-
-    // Add chunkId to the chunk
-    ZL_RET_R_IF_ERR(addIntValue(chunkBuilder, "chunkId", chunkId_));
-
-    // 1. Make the streams map
-    A1C_MAP_TRY_ADD_R(streamsPair, chunkBuilder);
-    A1C_Item_string_refCStr(&streamsPair->key, "streams");
-    A1C_ArrayBuilder streamsBuilder = A1C_Item_array_builder(
-            &streamsPair->val, streamInfo_.size(), a1c_arena);
-    ZL_RET_R_IF_NULL(allocation, streamsBuilder.array);
-    for (auto& stream : streamInfo_) {
-        A1C_ARRAY_TRY_ADD_R(a1c_stream, streamsBuilder);
-        ZL_RET_R_IF_ERR(stream.second.serializeStream(a1c_arena, a1c_stream));
-    }
-
-    // 2. Make the codecs map + their in and out edges as part of metadata
-    A1C_MAP_TRY_ADD_R(codecsPair, chunkBuilder);
-    A1C_Item_string_refCStr(&codecsPair->key, "codecs");
-    A1C_ArrayBuilder codecsBuilder = A1C_Item_array_builder(
-            &codecsPair->val, codecInfo_.size(), a1c_arena);
-    ZL_RET_R_IF_NULL(allocation, codecsBuilder.array);
-    for (size_t codecNum = 0; codecNum < codecInfo_.size(); ++codecNum) {
-        Codec& codec = codecInfo_[codecNum];
-        A1C_ARRAY_TRY_ADD_R(a1c_codec, codecsBuilder);
-        ZL_RET_R_IF_ERR(codec.serializeCodec(a1c_arena, a1c_codec, cctx));
-    }
-
-    // 3. graph info map
-    A1C_MAP_TRY_ADD_R(graphsPair, chunkBuilder);
-    A1C_Item_string_refCStr(&graphsPair->key, "graphs");
-    A1C_ArrayBuilder graphsBuilder = A1C_Item_array_builder(
-            &graphsPair->val, graphInfo_.size(), a1c_arena);
-    ZL_RET_R_IF_NULL(allocation, graphsBuilder.array);
-    for (auto& graph : graphInfo_) {
-        A1C_ARRAY_TRY_ADD_R(a1c_graph, graphsBuilder);
-        ZL_RET_R_IF_ERR(graph.serializeGraph(a1c_arena, a1c_graph, cctx));
-    }
-    return ZL_returnSuccess();
+    return ChunkTraceCore::serializeChunkDataToCBOR(
+            a1c_arena,
+            chunkArrayBuilder,
+            chunkId_,
+            streamInfo_,
+            codecInfo_,
+            graphInfo_,
+            cctx);
 }
 
-size_t ChunkTrace::getCompressedSize()
+size_t CompressChunkTrace::getCompressedSize()
 {
     return compressedSize_;
 }
@@ -311,7 +244,7 @@ inline std::string streamTypeToStr(ZL_Type stype)
     }
 }
 
-void ChunkTrace::printStreamMetadata()
+void CompressChunkTrace::printStreamMetadata()
 {
     std::vector<size_t> cSize(streamInfo_.size(), SIZE_MAX);
     std::cout << "digraph stream_topo {" << std::endl;
@@ -394,7 +327,7 @@ inline std::string graphTypeToStr(ZL_GraphType gtype)
     }
 }
 
-void ChunkTrace::printCodecMetadata()
+void CompressChunkTrace::printCodecMetadata()
 {
     size_t graphInfoIdx = 0;
     for (size_t codecNum = 0; codecNum < codecInfo_.size(); ++codecNum) {
@@ -469,7 +402,7 @@ void ChunkTrace::printCodecMetadata()
     std::cout << "}" << std::endl;
 }
 
-size_t ChunkTrace::fillCSize(
+size_t CompressChunkTrace::fillCSize(
         std::vector<size_t>& cSize,
         const StreamID streamID)
 {
@@ -506,7 +439,7 @@ size_t ChunkTrace::fillCSize(
     return cSize[cSize_idx];
 }
 
-void ChunkTrace::on_codecEncode_start(
+void CompressChunkTrace::on_codecEncode_start(
         ZL_Encoder* encoder,
         const ZL_Compressor* compressor,
         ZL_NodeID nid,
@@ -539,7 +472,7 @@ void ChunkTrace::on_codecEncode_start(
     }
 }
 
-void ChunkTrace::on_codecEncode_end(
+void CompressChunkTrace::on_codecEncode_end(
         ZL_Encoder*,
         const ZL_Output* outStreams[],
         size_t nbOutputs,
@@ -590,13 +523,13 @@ void ChunkTrace::on_codecEncode_end(
     ++currCodecNum_;
 }
 
-void ChunkTrace::on_ZL_Encoder_getScratchSpace(
+void CompressChunkTrace::on_ZL_Encoder_getScratchSpace(
         ZL_Encoder* /*ei*/,
         size_t /*size*/)
 {
 }
 
-void ChunkTrace::on_ZL_Encoder_sendCodecHeader(
+void CompressChunkTrace::on_ZL_Encoder_sendCodecHeader(
         ZL_Encoder* /*encoder*/,
         const void* /*trh*/,
         size_t trhSize)
@@ -604,7 +537,7 @@ void ChunkTrace::on_ZL_Encoder_sendCodecHeader(
     codecInfo_[currCodecNum_].cHeaderSize = trhSize;
 }
 
-void ChunkTrace::on_ZL_Encoder_createTypedStream(
+void CompressChunkTrace::on_ZL_Encoder_createTypedStream(
         ZL_Encoder* /*encoder*/,
         int /*outStreamIndex*/,
         size_t /*eltsCapacity*/,
@@ -613,7 +546,7 @@ void ChunkTrace::on_ZL_Encoder_createTypedStream(
 {
 }
 
-void ChunkTrace::on_migraphEncode_start(
+void CompressChunkTrace::on_migraphEncode_start(
         ZL_Graph* graph,
         const ZL_Compressor* compressor,
         ZL_GraphID gid,
@@ -635,7 +568,7 @@ void ChunkTrace::on_migraphEncode_start(
     graphInfo_.push_back(std::move(currGraph));
 }
 
-void ChunkTrace::on_migraphEncode_end(
+void CompressChunkTrace::on_migraphEncode_end(
         ZL_Graph*,
         ZL_GraphID[],
         size_t,
@@ -686,7 +619,7 @@ void ChunkTrace::on_migraphEncode_end(
     currEncompassingGraph_ = false;
 }
 
-void ChunkTrace::on_cctx_convertOneInput(
+void CompressChunkTrace::on_cctx_convertOneInput(
         const ZL_CCtx* const /*cctx*/,
         const ZL_Data* const input,
         const ZL_Type /*inType*/,
@@ -701,7 +634,7 @@ void ChunkTrace::on_cctx_convertOneInput(
     }
 }
 
-void ChunkTrace::on_segmenterEncode_start(ZL_Segmenter* segCtx)
+void CompressChunkTrace::on_segmenterEncode_start(ZL_Segmenter* segCtx)
 {
     const auto nbInStreams = ZL_Segmenter_numInputs(segCtx);
 
@@ -738,14 +671,16 @@ void ChunkTrace::on_segmenterEncode_start(ZL_Segmenter* segCtx)
     }
 }
 
-void ChunkTrace::on_segmenterEncode_end(ZL_Segmenter* /*segCtx*/, ZL_Report r)
+void CompressChunkTrace::on_segmenterEncode_end(
+        ZL_Segmenter* /*segCtx*/,
+        ZL_Report r)
 {
     if (ZL_isError(r)) {
         codecInfo_[currCodecNum_].cFailure = r;
     }
 }
 
-void ChunkTrace::on_ZL_Segmenter_processChunk_start(
+void CompressChunkTrace::on_ZL_Segmenter_processChunk_start(
         ZL_Segmenter* /*segCtx*/,
         const size_t /*numElts*/[],
         size_t /*numInputs*/,
@@ -755,14 +690,14 @@ void ChunkTrace::on_ZL_Segmenter_processChunk_start(
     initTrace();
 }
 
-void ChunkTrace::on_ZL_Segmenter_processChunk_end(
+void CompressChunkTrace::on_ZL_Segmenter_processChunk_end(
         ZL_Segmenter* /*segCtx*/,
         ZL_Report r)
 {
     finalizeTrace(r);
 }
 
-void ChunkTrace::streamdump(const ZL_Output* createdStream)
+void CompressChunkTrace::streamdump(const ZL_Output* createdStream)
 {
     auto content = std::string(
             (const char*)ZL_Output_constPtr(createdStream),
@@ -778,7 +713,7 @@ void ChunkTrace::streamdump(const ZL_Output* createdStream)
     streamdump_[ZL_Output_id(createdStream).sid] = { content, strLens };
 }
 std::map<size_t, std::pair<std::string, std::string>>&&
-ChunkTrace::getStreamdump()
+CompressChunkTrace::getStreamdump()
 {
     return std::move(streamdump_);
 }

--- a/cpp/src/openzl/cpp/experimental/trace/CompressChunkTrace.hpp
+++ b/cpp/src/openzl/cpp/experimental/trace/CompressChunkTrace.hpp
@@ -6,6 +6,7 @@
 #include <optional>
 #include <vector>
 
+#include "openzl/cpp/experimental/trace/ChunkTraceCore.hpp"
 #include "openzl/cpp/experimental/trace/Codec.hpp"
 #include "openzl/cpp/experimental/trace/Graph.hpp"
 #include "openzl/cpp/experimental/trace/StreamVisualizer.hpp"
@@ -17,10 +18,10 @@ namespace openzl::visualizer {
  * ingests stream 0). A chunked compression will have multiple such top-level
  * invocations.
  */
-class ChunkTrace {
+class CompressChunkTrace {
    public:
-    ChunkTrace() = delete;
-    explicit ChunkTrace(size_t chunkId) : chunkId_(chunkId) {}
+    CompressChunkTrace() = delete;
+    explicit CompressChunkTrace(size_t chunkId) : chunkId_(chunkId) {}
 
     /**
      * Callback function to start the trace.

--- a/cpp/src/openzl/cpp/experimental/trace/CompressTracer.cpp
+++ b/cpp/src/openzl/cpp/experimental/trace/CompressTracer.cpp
@@ -1,6 +1,6 @@
 // (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
 
-#include "openzl/cpp/experimental/trace/Tracer.hpp"
+#include "openzl/cpp/experimental/trace/CompressTracer.hpp"
 
 #include "openzl/common/a1cbor_helpers.h"
 #include "openzl/common/logging.h"
@@ -10,9 +10,7 @@
 #include "openzl/zl_opaque_types.h"
 
 #include <cstdlib>
-#include <iostream>
 #include <map>
-#include <sstream>
 #include <utility>
 #include <vector>
 
@@ -20,7 +18,7 @@ namespace openzl::visualizer {
 
 static constexpr size_t MAIN_TRACE_IDX = 0;
 
-Tracer::TraceResult Tracer::extractTrace()
+TraceResult CompressTracer::extractTrace()
 {
     // Aggregate streamdump from all chunks
     trace.streamdump.reserve(graphRuns.size());
@@ -33,12 +31,12 @@ Tracer::TraceResult Tracer::extractTrace()
                     StreamdumpEntry{
                             k, std::move(v.first), std::move(v.second) });
         }
-        trace.streamdump.push_back(tmp);
+        trace.streamdump.push_back(std::move(tmp));
     }
     return std::move(trace);
 }
 
-void Tracer::on_segmenterEncode_start(ZL_Segmenter* segCtx)
+void CompressTracer::on_segmenterEncode_start(ZL_Segmenter* segCtx)
 {
     if (graphRuns.size() != 1) {
         throw std::runtime_error(
@@ -48,13 +46,13 @@ void Tracer::on_segmenterEncode_start(ZL_Segmenter* segCtx)
     graphRuns[MAIN_TRACE_IDX].on_segmenterEncode_start(segCtx);
 }
 
-void Tracer::on_segmenterEncode_end(ZL_Segmenter* segCtx, ZL_Report r)
+void CompressTracer::on_segmenterEncode_end(ZL_Segmenter* segCtx, ZL_Report r)
 {
     currChunk = &graphRuns[MAIN_TRACE_IDX];
     currChunk->on_segmenterEncode_end(segCtx, r);
 }
 
-void Tracer::on_ZL_Segmenter_processChunk_start(
+void CompressTracer::on_ZL_Segmenter_processChunk_start(
         ZL_Segmenter* segCtx,
         const size_t numElts[],
         size_t numInputs,
@@ -68,12 +66,14 @@ void Tracer::on_ZL_Segmenter_processChunk_start(
             segCtx, numElts, numInputs, startingGraphID, rGraphParams);
 }
 
-void Tracer::on_ZL_Segmenter_processChunk_end(ZL_Segmenter* segCtx, ZL_Report r)
+void CompressTracer::on_ZL_Segmenter_processChunk_end(
+        ZL_Segmenter* segCtx,
+        ZL_Report r)
 {
     currChunk->on_ZL_Segmenter_processChunk_end(segCtx, r);
 }
 
-void Tracer::on_codecEncode_start(
+void CompressTracer::on_codecEncode_start(
         ZL_Encoder* encoder,
         const ZL_Compressor* compressor,
         ZL_NodeID nid,
@@ -84,7 +84,7 @@ void Tracer::on_codecEncode_start(
             encoder, compressor, nid, inStreams, nbInStreams);
 }
 
-void Tracer::on_codecEncode_end(
+void CompressTracer::on_codecEncode_end(
         ZL_Encoder* encoder,
         const ZL_Output* outStreams[],
         size_t nbOutputs,
@@ -94,12 +94,12 @@ void Tracer::on_codecEncode_end(
             encoder, outStreams, nbOutputs, codecExecResult);
 }
 
-void Tracer::on_ZL_Encoder_getScratchSpace(ZL_Encoder* ei, size_t size)
+void CompressTracer::on_ZL_Encoder_getScratchSpace(ZL_Encoder* ei, size_t size)
 {
     currChunk->on_ZL_Encoder_getScratchSpace(ei, size);
 }
 
-void Tracer::on_ZL_Encoder_sendCodecHeader(
+void CompressTracer::on_ZL_Encoder_sendCodecHeader(
         ZL_Encoder* encoder,
         const void* trh,
         size_t trhSize)
@@ -107,16 +107,16 @@ void Tracer::on_ZL_Encoder_sendCodecHeader(
     currChunk->on_ZL_Encoder_sendCodecHeader(encoder, trh, trhSize);
 }
 
-void Tracer::on_ZL_Encoder_createTypedStream(
+void CompressTracer::on_ZL_Encoder_createTypedStream(
         ZL_Encoder*,
         int,
-        size_t eltsCapacity,
-        size_t eltWidth,
-        ZL_Output* createdStream)
+        size_t,
+        size_t,
+        ZL_Output*)
 {
 }
 
-void Tracer::on_migraphEncode_start(
+void CompressTracer::on_migraphEncode_start(
         ZL_Graph* graph,
         const ZL_Compressor* compressor,
         ZL_GraphID gid,
@@ -126,7 +126,7 @@ void Tracer::on_migraphEncode_start(
     currChunk->on_migraphEncode_start(graph, compressor, gid, edges, nbEdges);
 }
 
-void Tracer::on_migraphEncode_end(
+void CompressTracer::on_migraphEncode_end(
         ZL_Graph* graph,
         ZL_GraphID successorGraphs[],
         size_t nbSuccessors,
@@ -136,7 +136,7 @@ void Tracer::on_migraphEncode_end(
             graph, successorGraphs, nbSuccessors, graphExecResult);
 }
 
-void Tracer::on_cctx_convertOneInput(
+void CompressTracer::on_cctx_convertOneInput(
         const ZL_CCtx* const cctx,
         const ZL_Data* const input,
         const ZL_Type inType,
@@ -147,9 +147,9 @@ void Tracer::on_cctx_convertOneInput(
             cctx, input, inType, portTypeMask, conversionResult);
 }
 
-void Tracer::on_ZL_Graph_getScratchSpace(ZL_Graph*, size_t) {}
+void CompressTracer::on_ZL_Graph_getScratchSpace(ZL_Graph*, size_t) {}
 
-void Tracer::on_ZL_Edge_setMultiInputDestination_wParams(
+void CompressTracer::on_ZL_Edge_setMultiInputDestination_wParams(
         ZL_Graph*,
         ZL_Edge*[],
         size_t,
@@ -158,12 +158,12 @@ void Tracer::on_ZL_Edge_setMultiInputDestination_wParams(
 {
 }
 
-void Tracer::on_ZL_CCtx_compressMultiTypedRef_start(
+void CompressTracer::on_ZL_CCtx_compressMultiTypedRef_start(
         ZL_CCtx const* const cctx,
-        void const* const dst,
-        size_t const dstCapacity,
-        ZL_TypedRef const* const inputs[],
-        size_t const nbInputs)
+        void const* const,
+        size_t const,
+        ZL_TypedRef const* const[],
+        size_t const)
 {
     frameVersion = ZL_CCtx_getParameter(cctx, ZL_CParam_formatVersion);
     // The "main" trace is located at idx 0 of graphRuns
@@ -172,7 +172,7 @@ void Tracer::on_ZL_CCtx_compressMultiTypedRef_start(
     currChunk->initTrace();
 }
 
-void Tracer::on_ZL_CCtx_compressMultiTypedRef_end(
+void CompressTracer::on_ZL_CCtx_compressMultiTypedRef_end(
         ZL_CCtx const* const,
         ZL_Report const result)
 {
@@ -191,8 +191,10 @@ void Tracer::on_ZL_CCtx_compressMultiTypedRef_end(
         throw std::runtime_error("Failed to serialize streamdump content.");
     }
     ALLOC_Arena_freeArena(arena);
-    // Write the serialized streamdump content to a file
-    if (ZL_isError(writeSerializedStreamdump(buffer))) {
+    // Write the serialized streamdump content to a string
+    if (ZL_isError(
+                ChunkTraceCore::writeSerializedStreamdump(
+                        buffer, trace.trace))) {
         ZL_LOG(ERROR,
                "Failed to write serialized streamdump content to a file!");
         throw std::runtime_error(
@@ -200,27 +202,12 @@ void Tracer::on_ZL_CCtx_compressMultiTypedRef_end(
     }
 }
 
-void Tracer::setCompressedSize(size_t compressionResultSize)
+void CompressTracer::setCompressedSize(size_t compressionResultSize)
 {
     compressedSize_ = compressionResultSize;
 }
 
-static bool writeToFile(const std::vector<uint8_t>& buffer, std::ostream& out)
-{
-    if (!out.good()) {
-        return false;
-    }
-    std::string bufferString(buffer.begin(), buffer.end());
-    out.write(bufferString.c_str(), bufferString.size());
-    out.flush();
-    if (out.fail()) {
-        return false;
-    }
-
-    return true;
-}
-
-ZL_Report Tracer::serializeStreamdumpToCbor(
+ZL_Report CompressTracer::serializeStreamdumpToCbor(
         A1C_Arena* a1c_arena,
         std::vector<uint8_t>& buffer)
 {
@@ -268,19 +255,6 @@ ZL_Report Tracer::serializeStreamdumpToCbor(
         ZL_RET_R_WRAP_ERR(A1C_Error_convert(NULL, error));
     }
     ZL_RET_R_IF_NE(allocation, bytesWritten, encodedSize);
-
-    return ZL_returnSuccess();
-}
-
-ZL_Report Tracer::writeSerializedStreamdump(std::vector<uint8_t>& buffer)
-{
-    std::stringstream ss;
-    bool successfulWrite = writeToFile(buffer, ss);
-    if (!successfulWrite) {
-        ZL_RET_R_ERR(GENERIC, "Failed to write to streamdump CBOR file");
-    }
-    trace.trace = ss.str();
-    ZL_LOG(ALWAYS, "Successfully wrote streamdump CBOR");
 
     return ZL_returnSuccess();
 }

--- a/cpp/src/openzl/cpp/experimental/trace/CompressTracer.hpp
+++ b/cpp/src/openzl/cpp/experimental/trace/CompressTracer.hpp
@@ -5,27 +5,16 @@
 #include <map>
 #include <optional>
 
-#include "openzl/cpp/experimental/trace/ChunkTrace.hpp"
 #include "openzl/cpp/experimental/trace/Codec.hpp"
+#include "openzl/cpp/experimental/trace/CompressChunkTrace.hpp"
 #include "openzl/cpp/experimental/trace/Graph.hpp"
 #include "openzl/cpp/experimental/trace/StreamVisualizer.hpp"
 
 namespace openzl::visualizer {
 
-class Tracer {
+class CompressTracer {
    public:
-    explicit Tracer(const ZL_CCtx* const cctx) : cctx_(cctx) {}
-
-    struct StreamdumpEntry {
-        size_t streamId;
-        std::string content;
-        std::string strLens;
-    };
-
-    struct TraceResult {
-        std::string trace;
-        std::vector<std::vector<StreamdumpEntry>> streamdump;
-    };
+    explicit CompressTracer(const ZL_CCtx* const cctx) : cctx_(cctx) {}
 
     TraceResult extractTrace();
 
@@ -113,7 +102,6 @@ class Tracer {
     ZL_Report serializeStreamdumpToCbor(
             A1C_Arena* a1c_arena,
             std::vector<uint8_t>& buffer);
-    ZL_Report writeSerializedStreamdump(std::vector<uint8_t>& buffer);
 
     void setCompressedSize(size_t compressionResultSize);
     size_t fillCSize(std::vector<size_t>& cSize, const ZL_DataID streamID);
@@ -129,8 +117,8 @@ class Tracer {
     static constexpr uint32_t traceVersion = 1;
     size_t compressedSize_{};
 
-    std::vector<ChunkTrace> graphRuns;
-    ChunkTrace* currChunk =
+    std::vector<CompressChunkTrace> graphRuns;
+    CompressChunkTrace* currChunk =
             nullptr; // convenience pointer to the current chunk trace
     bool segmented = false;
 

--- a/cpp/src/openzl/cpp/experimental/trace/CompressionTraceHooks.cpp
+++ b/cpp/src/openzl/cpp/experimental/trace/CompressionTraceHooks.cpp
@@ -52,14 +52,14 @@ inline std::string graphTypeToStr(ZL_GraphType gtype)
 
 void CompressionTraceHooks::on_segmenterEncode_start(ZL_Segmenter* segCtx)
 {
-    // Trampoline to Tracer
+    // Trampoline to CompressTracer
     tracer_->on_segmenterEncode_start(segCtx);
 }
 void CompressionTraceHooks::on_segmenterEncode_end(
         ZL_Segmenter* segCtx,
         ZL_Report r)
 {
-    // Trampoline to Tracer
+    // Trampoline to CompressTracer
     tracer_->on_segmenterEncode_end(segCtx, r);
 }
 void CompressionTraceHooks::on_ZL_Segmenter_processChunk_start(
@@ -69,7 +69,7 @@ void CompressionTraceHooks::on_ZL_Segmenter_processChunk_start(
         ZL_GraphID startingGraphID,
         const ZL_RuntimeGraphParameters* rGraphParams)
 {
-    // Trampoline to Tracer
+    // Trampoline to CompressTracer
     tracer_->on_ZL_Segmenter_processChunk_start(
             segCtx, numElts, numInputs, startingGraphID, rGraphParams);
 }
@@ -78,7 +78,7 @@ void CompressionTraceHooks::on_ZL_Segmenter_processChunk_end(
         ZL_Segmenter* segCtx,
         ZL_Report r)
 {
-    // Trampoline to Tracer
+    // Trampoline to CompressTracer
     tracer_->on_ZL_Segmenter_processChunk_end(segCtx, r);
 }
 
@@ -89,7 +89,7 @@ void CompressionTraceHooks::on_codecEncode_start(
         const ZL_Input* inStreams[],
         size_t nbInStreams)
 {
-    // Trampoline to Tracer
+    // Trampoline to CompressTracer
     tracer_->on_codecEncode_start(
             encoder, compressor, nid, inStreams, nbInStreams);
 }
@@ -100,7 +100,7 @@ void CompressionTraceHooks::on_codecEncode_end(
         size_t nbOutputs,
         ZL_Report codecExecResult)
 {
-    // Trampoline to Tracer
+    // Trampoline to CompressTracer
     tracer_->on_codecEncode_end(eictx, outStreams, nbOutputs, codecExecResult);
 }
 
@@ -115,7 +115,7 @@ void CompressionTraceHooks::on_ZL_Encoder_sendCodecHeader(
         const void* trh,
         size_t trhSize)
 {
-    // Trampoline to Tracer
+    // Trampoline to CompressTracer
     tracer_->on_ZL_Encoder_sendCodecHeader(eictx, trh, trhSize);
 }
 
@@ -135,7 +135,7 @@ void CompressionTraceHooks::on_migraphEncode_start(
         ZL_Edge* edges[],
         size_t nbEdges)
 {
-    // Trampoline to Tracer
+    // Trampoline to CompressTracer
     tracer_->on_migraphEncode_start(graph, compressor, gid, edges, nbEdges);
 }
 
@@ -145,7 +145,7 @@ void CompressionTraceHooks::on_migraphEncode_end(
         size_t nbSuccessors,
         ZL_Report graphExecResult)
 {
-    // Trampoline to Tracer
+    // Trampoline to CompressTracer
     tracer_->on_migraphEncode_end(
             gctx, ssuccesorGraphs, nbSuccessors, graphExecResult);
 }
@@ -157,7 +157,7 @@ void CompressionTraceHooks::on_cctx_convertOneInput(
         const ZL_Type portTypeMask,
         const ZL_Report conversionResult)
 {
-    // Trampoline to Tracer
+    // Trampoline to CompressTracer
     tracer_->on_cctx_convertOneInput(
             cctx, input, inType, portTypeMask, conversionResult);
 }
@@ -193,7 +193,7 @@ void CompressionTraceHooks::on_ZL_CCtx_compressMultiTypedRef_start(
         throw std::runtime_error(
                 "Corrupted state. Trace context already exists!");
     }
-    tracer_ = std::make_unique<Tracer>(cctx);
+    tracer_ = std::make_unique<CompressTracer>(cctx);
     tracer_->on_ZL_CCtx_compressMultiTypedRef_start(
             cctx, dst, dstCapacity, inputs, nbInputs);
 }

--- a/cpp/src/openzl/cpp/experimental/trace/CompressionTraceHooks.hpp
+++ b/cpp/src/openzl/cpp/experimental/trace/CompressionTraceHooks.hpp
@@ -3,7 +3,7 @@
 #pragma once
 
 #include "openzl/cpp/CompressIntrospectionHooks.hpp"
-#include "openzl/cpp/experimental/trace/Tracer.hpp"
+#include "openzl/cpp/experimental/trace/CompressTracer.hpp"
 #include "openzl/cpp/poly/StringView.hpp"
 #include "openzl/shared/a1cbor.h"
 #include "openzl/zl_opaque_types.h"
@@ -110,14 +110,14 @@ class CompressionTraceHooks : public openzl::CompressIntrospectionHooks {
 
    private:
     std::stringstream outStream_; // output stream to write to
-    std::vector<std::vector<Tracer::StreamdumpEntry>>
+    std::vector<std::vector<StreamdumpEntry>>
             latestStreamdumpCache_; // cache for latest streamdumps. Key
                                     // is the stream ID, value is a pair
                                     // of strings (content, string
                                     // lengths (or ""))
     std::string latestTraceCache_;  // cache for latest trace
 
-    std::unique_ptr<Tracer>
+    std::unique_ptr<CompressTracer>
             tracer_; // pointer to the actual class that does a trace
 };
 } // namespace openzl::visualizer


### PR DESCRIPTION
Summary:

Renames compress-side trace files for clarity and extracts shared logic
into a reusable static helper class `ChunkTraceCore`:

- Renames `ChunkTrace` → `CompressChunkTrace` and `Tracer` →
  `CompressTracer` to clarify that these are compress-specific, making
  room for their decompress counterparts

- Extracts `initTrace()`, `finalizeUnconsumedStreams()`,
  `serializeChunkDataToCBOR()`, and `writeSerializedStreamdump()` into
  `ChunkTraceCore` — previously duplicated logic that will be shared
  with the decompress side

- Moves `StreamdumpEntry` and `TraceResult` structs to namespace scope
  in `ChunkTraceCore.hpp` for reuse by both compress and decompress sides

Pure refactor — no behavioral changes.

Reviewed By: terrelln

Differential Revision: D96836952
