### PR TITLE
C++: Expose Underlying ZL_Graph Object from SelectorState

### DIFF
--- a/cpp/include/openzl/cpp/Selector.hpp
+++ b/cpp/include/openzl/cpp/Selector.hpp
@@ -20,6 +20,16 @@ class SelectorState {
    public:
     explicit SelectorState(GraphState& state) : state_(&state) {}
 
+    ZL_Graph* get()
+    {
+        return state_->get();
+    }
+
+    const ZL_Graph* get() const
+    {
+        return state_->get();
+    }
+
     poly::span<const GraphID> customGraphs() const
     {
         return state_->customGraphs();


### PR DESCRIPTION
Summary:
Implementors of selectors need access to the underlying object so that they
can do, e.g., error operations which need to be able to retrieve an opctx.
(In general, sure, you can just throw exceptions, but currently there's no
C++-y analog to the warnings system with `ZL_E_convertToWarning()`.)

Reviewed By: daniellerozenblit

Differential Revision: D97847858


