### PR TITLE
Fix heap buffer overflow in FieldLZ fast decompression path

### DIFF
--- a/src/openzl/codecs/lz/decode_field_lz.c
+++ b/src/openzl/codecs/lz/decode_field_lz.c
@@ -175,8 +175,10 @@ ZL_FORCE_INLINE ZL_Report ZL_FieldLz_decompress_impl2(
     ZL_ASSERT(kShortLL % 16 == 0 || kShortLLCode == kMaxLitLengthCode - 1);
     ZL_ASSERT(kShortML % 16 == 0 || kShortMLCode == kMaxMatchLengthCode - 1);
 
-    uint8_t const* const outLimit   = outEnd - kUnroll * (kTokenLL + kTokenML);
-    uint8_t const* const litsLimit  = litsEnd - kUnroll * kTokenLL;
+    uint8_t const* const outLimit =
+            outEnd - kUnroll * (kTokenLL + kTokenML) - ZS_WILDCOPY_OVERLENGTH;
+    uint8_t const* const litsLimit =
+            litsEnd - kUnroll * kTokenLL - ZS_WILDCOPY_OVERLENGTH;
     uint16_t const* const toksLimit = toksEnd - kUnroll + 1;
     uint32_t const* const offsLimit = offsEnd - kUnroll + 1;
 


### PR DESCRIPTION
Summary:
The fast decompression path in FieldLZ uses ZS_copy16() to copy match data
in 16-byte chunks. When the match length (kShortML or kTokenML) is not a
multiple of 16, the last chunk over-writes past the actual match data. The
outLimit guard reserved space for the maximum data output of 4 unrolled
tokens, but did not account for this ZS_copy16 over-copy.

The same thing applies to the `litsLimit`.

The fix subtracts ZS_WILDCOPY_OVERLENGTH (32 bytes) from outLimit, pushing
tokens near the buffer end into the safe path (ZS_safecopy) which copies
byte-by-byte and never over-writes.

Reviewed By: Cyan4973

Differential Revision: D97842807


