### PR TITLE
Add --trace and --trace-streams-dir flags to zli decompress

### DIFF
--- a/cli/args/DecompressArgs.h
+++ b/cli/args/DecompressArgs.h
@@ -4,6 +4,8 @@
 
 #include <filesystem>
 #include <memory>
+#include <optional>
+#include <string>
 
 #include "cli/args/ArgsUtils.h"
 #include "cli/args/GlobalArgs.h"
@@ -26,6 +28,18 @@ class DecompressArgs : GlobalArgs {
         parser.addCommandFlag(cmd(), kOutput, 'o', true, "Output file path.");
         parser.addCommandFlag(
                 cmd(), kForce, 'f', false, "Overwrite output file.");
+        parser.addCommandFlag(
+                cmd(),
+                kTrace,
+                0,
+                true,
+                "Record a trace of the decompression to be visualized with streamdump. Writes a CBOR file to the provided path.");
+        parser.addCommandFlag(
+                cmd(),
+                kTraceStreamsDir,
+                0,
+                true,
+                "Directory to write trace streamdump to.");
     }
 
     explicit DecompressArgs(const arg::ParsedArgs& parsed) : GlobalArgs(parsed)
@@ -48,6 +62,13 @@ class DecompressArgs : GlobalArgs {
         input  = std::make_unique<tools::io::InputFile>(std::move(inputPath));
         output = std::make_unique<tools::io::OutputFile>(
                 std::move(outputPath).value());
+
+        if (parsed.cmdHasFlag(cmd(), kTrace)) {
+            auto path   = parsed.cmdFlag(cmd(), kTrace).value();
+            traceOutput = std::make_shared<tools::io::OutputFile>(path);
+        }
+
+        traceStreamsDir = parsed.cmdFlag(cmd(), kTraceStreamsDir);
     }
 
     static Cmd cmd()
@@ -58,10 +79,15 @@ class DecompressArgs : GlobalArgs {
     std::unique_ptr<tools::io::Input> input;
     std::unique_ptr<tools::io::Output> output;
 
+    std::shared_ptr<tools::io::Output> traceOutput;
+    std::optional<std::string> traceStreamsDir;
+
    private:
-    inline static const std::string kInput  = "input";
-    inline static const std::string kOutput = "output";
-    inline static const std::string kForce  = "force";
+    inline static const std::string kInput           = "input";
+    inline static const std::string kOutput          = "output";
+    inline static const std::string kForce           = "force";
+    inline static const std::string kTrace           = "trace";
+    inline static const std::string kTraceStreamsDir = "trace-streams-dir";
 };
 
 } // namespace openzl::cli

--- a/cli/commands/cmd_decompress.cpp
+++ b/cli/commands/cmd_decompress.cpp
@@ -4,6 +4,8 @@
 #include "cli/utils/util.h"
 
 #include <chrono>
+#include <filesystem>
+#include <fstream>
 
 #include "tools/logger/Logger.h"
 
@@ -14,6 +16,50 @@ namespace openzl::cli {
 constexpr size_t BYTES_TO_MB = 1000 * 1000;
 
 using namespace tools::logger;
+
+namespace {
+
+void writeTrace(DCtx& dctx, const DecompressArgs& args)
+{
+    const auto trace = dctx.getLatestTrace();
+    args.traceOutput->write(trace.first);
+    args.traceOutput->close();
+    if (args.traceStreamsDir) {
+        std::filesystem::path dir{ *args.traceStreamsDir };
+        if (!std::filesystem::is_directory(dir)) {
+            std::string msg = "Streamdump trace directory does not exist: "
+                    + dir.string();
+            throw InvalidArgsException(msg);
+        }
+        for (const auto& [id, stream] : trace.second) {
+            std::filesystem::path path = dir / (id + ".sdd");
+            std::ofstream file{ path, std::ios::binary };
+            if (!file.is_open()) {
+                Logger::log(
+                        ERRORS,
+                        "Failed to open streamdump file: ",
+                        path.string().c_str());
+                continue;
+            }
+            file.write(stream.first.data(), stream.first.size());
+            if (stream.second != "") {
+                std::filesystem::path strLensPath = dir / (id + ".sdlens");
+                std::ofstream strLensFile{ strLensPath, std::ios::binary };
+                if (!strLensFile.is_open()) {
+                    Logger::log(
+                            ERRORS,
+                            "Failed to open streamdump strlens file: ",
+                            strLensPath.string().c_str());
+                    continue;
+                }
+                strLensFile.write(stream.second.data(), stream.second.size());
+            }
+            file.close();
+        }
+    }
+}
+
+} // anonymous namespace
 
 int cmdDecompress(const DecompressArgs& args)
 {
@@ -40,8 +86,26 @@ int cmdDecompress(const DecompressArgs& args)
 
     DCtx dctx;
 
+    if (args.traceOutput) {
+        args.traceOutput->open();
+        Logger::log(
+                VERBOSE1,
+                "Tracing decompression to ",
+                args.traceOutput->name().data());
+        dctx.writeTraces(true);
+    }
+
     // decompress
-    std::string dstBuffer = dctx.decompressSerial(srcBuffer);
+    std::string dstBuffer;
+    try {
+        dstBuffer = dctx.decompressSerial(srcBuffer);
+    } catch (const openzl::Exception&) {
+        // if tracing, write the error trace to the output file
+        if (args.traceOutput) {
+            writeTrace(dctx, args);
+        }
+        throw;
+    }
 
     util::logWarnings(dctx);
 
@@ -63,6 +127,11 @@ int cmdDecompress(const DecompressArgs& args)
             compressionSpeed);
     output.write(std::move(dstBuffer));
     output.close();
+
+    // if tracing, write the trace to the output file
+    if (args.traceOutput) {
+        writeTrace(dctx, args);
+    }
     return 0;
 }
 

--- a/cli/tests/BUCK
+++ b/cli/tests/BUCK
@@ -277,6 +277,20 @@ python_library(
 )
 
 custom_unittest(
+    name = "trace_test",
+    command = [
+        "$(location :integration_test_bin)",
+        "$(location ..:zli)",
+        "TraceTest.test_compress_decompress_with_trace",
+    ],
+    type = "simple",
+    deps = [
+        "..:zli",
+        ":integration_test_bin",
+    ],
+)
+
+custom_unittest(
     name = "ml_selector_test",
     command = [
         "$(location :integration_test_bin)",

--- a/cli/tests/cli_integration_tests.py
+++ b/cli/tests/cli_integration_tests.py
@@ -17,6 +17,7 @@ from command_utils import (
     CompressorInfo,
     CompressorType,
     execute_compress,
+    execute_decompress,
     execute_train,
 )
 from file_utils import input_dir_path
@@ -492,6 +493,102 @@ class BenchmarkCsvCompressionTest(_BenchmarkBaseTest):
 
     def test_benchmark(self):
         self.benchmark()
+
+
+class TraceTest(_CompressDecompressBaseTest):
+    """
+    Test case for compression and decompression with tracing enabled.
+
+    This test verifies that the --trace and --trace-streams-dir flags work
+    correctly during compress and decompress without crashing, and that
+    trace output files are actually created.
+    """
+
+    @property
+    def input_dir_name(self) -> str:
+        return "trace"
+
+    @property
+    def compressor_profile_name(self) -> str:
+        return "csv"
+
+    def test_compress_decompress_with_trace(self):
+        """
+        Test that compress and decompress with --trace flags produce trace files
+        and roundtrip correctly.
+
+        This test:
+        1. Compresses a CSV sample with --trace and --trace-streams-dir
+        2. Asserts the compress trace CBOR file exists and is non-empty
+        3. Decompresses with --trace
+        4. Asserts the decompress trace CBOR file exists and is non-empty
+        5. Verifies the decompressed file matches the original (roundtrip check)
+        """
+        sample = self.input_samples[0]
+
+        compress_trace_path = os.path.join(self.output_dir_path, "compress_trace.cbor")
+        decompress_trace_path = os.path.join(
+            self.output_dir_path, "decompress_trace.cbor"
+        )
+        streams_dir = os.path.join(self.output_dir_path, "streams")
+        os.makedirs(streams_dir, exist_ok=True)
+
+        execute_compress(
+            file_to_compress_path=sample.orig_file_path,
+            compressor_info=self.compressor_info,
+            compressed_file_path=sample.compressed_file_path,
+            extra_args=f"--trace {compress_trace_path} --trace-streams-dir {streams_dir}",
+        )
+
+        self.assertTrue(
+            os.path.exists(sample.compressed_file_path),
+            "Compressed file was not created",
+        )
+        self.assertTrue(
+            os.path.exists(compress_trace_path),
+            "Compress trace file was not created",
+        )
+        self.assertGreater(
+            os.path.getsize(compress_trace_path),
+            0,
+            "Compress trace file is empty",
+        )
+        self.assertGreater(
+            len(os.listdir(streams_dir)),
+            0,
+            "Compress streams dir is empty",
+        )
+
+        decompress_streams_dir = os.path.join(
+            self.output_dir_path, "decompress_streams"
+        )
+        os.makedirs(decompress_streams_dir, exist_ok=True)
+
+        execute_decompress(
+            compressed_file_path=sample.compressed_file_path,
+            decompressed_file_path=sample.decompressed_file_path,
+            extra_args=f"--trace {decompress_trace_path} --trace-streams-dir {decompress_streams_dir}",
+        )
+
+        self.assertTrue(
+            os.path.exists(decompress_trace_path),
+            "Decompress trace file was not created",
+        )
+        self.assertGreater(
+            os.path.getsize(decompress_trace_path),
+            0,
+            "Decompress trace file is empty",
+        )
+        self.assertGreater(
+            len(os.listdir(decompress_streams_dir)),
+            0,
+            "Decompress streams dir is empty",
+        )
+
+        self.assertTrue(
+            sample.original_matches_decompressed,
+            f"Decompressed file does not match original: {sample.orig_file_path}",
+        )
 
 
 class StrictModeTest(_CompressDecompressBaseTest):

--- a/cli/tests/command_utils.py
+++ b/cli/tests/command_utils.py
@@ -145,6 +145,7 @@ def execute_compress(
 def execute_decompress(
     compressed_file_path: str,
     decompressed_file_path: str,
+    extra_args: str | None = None,
 ) -> None:
     """
     Execute the decompress command to decompress a file.
@@ -159,13 +160,12 @@ def execute_decompress(
     Args:
         compressed_file_path: Path to the compressed file
         decompressed_file_path: Path where the decompressed file will be saved
+        extra_args: Additional arguments to pass to the decompress command (optional)
 
     Raises:
         ValueError: If the decompression fails or the decompressed file is not created
     """
-    decompress_args = (
-        f"decompress {str(compressed_file_path)} -o {str(decompressed_file_path)}"
-    )
+    decompress_args = f"decompress {str(compressed_file_path)} -o {str(decompressed_file_path)} {extra_args or ''}"
 
     if execute_command(decompress_args) != 0:
         raise ValueError("Executing decompress command failed")

--- a/cli/tests/sample_files/trace/input_experiments.csv
+++ b/cli/tests/sample_files/trace/input_experiments.csv
@@ -1,0 +1,5 @@
+universe,experiment_id,segment_id_list
+universe_1,1,"[1,2]"
+universe_1,2,"[3]"
+universe_2,2,"[1]"
+universe_2,3,"[2,3,4]"


### PR DESCRIPTION
Summary: Enable CLI access to decompression tracing.

Reviewed By: terrelln

Differential Revision: D96837115


