### PR TITLE
add no stream preview flag (#546)

### DIFF
--- a/cli/args/CompressArgs.h
+++ b/cli/args/CompressArgs.h
@@ -67,6 +67,12 @@ struct CompressArgs : public GlobalArgs, public ProfileArgs {
                 0,
                 false,
                 "Enforce strict mode compression. Fail on errors instead of falling back to generic compression.");
+        parser.addCommandFlag(
+                cmd(),
+                kNoStreamPreview,
+                0,
+                false,
+                "Omit stream preview data from the trace CBOR output. Requires --trace.");
     }
 
     explicit CompressArgs(const arg::ParsedArgs& parsed)
@@ -97,6 +103,12 @@ struct CompressArgs : public GlobalArgs, public ProfileArgs {
 
         traceStreamsDir = parsed.cmdFlag(cmd(), kTraceStreamsDir);
         strict          = parsed.cmdHasFlag(cmd(), kStrict);
+        streamPreview   = !parsed.cmdHasFlag(cmd(), kNoStreamPreview);
+
+        if (!streamPreview && !traceOutput) {
+            throw InvalidArgsException(
+                    "--no-stream-preview requires --trace to be specified.");
+        }
     }
 
     static Cmd cmd()
@@ -112,7 +124,8 @@ struct CompressArgs : public GlobalArgs, public ProfileArgs {
 
     std::shared_ptr<tools::io::Output> traceOutput;
     std::optional<std::string> traceStreamsDir;
-    bool strict = false;
+    bool strict        = false;
+    bool streamPreview = true;
 
    private:
     inline static const std::string kInput      = "input";
@@ -128,6 +141,7 @@ struct CompressArgs : public GlobalArgs, public ProfileArgs {
     inline static const std::string kTrace           = "trace";
     inline static const std::string kTraceStreamsDir = "trace-streams-dir";
     inline static const std::string kStrict          = "strict";
+    inline static const std::string kNoStreamPreview = "no-stream-preview";
 };
 
 } // namespace openzl::cli

--- a/cli/args/DecompressArgs.h
+++ b/cli/args/DecompressArgs.h
@@ -40,6 +40,12 @@ class DecompressArgs : GlobalArgs {
                 0,
                 true,
                 "Directory to write trace streamdump to.");
+        parser.addCommandFlag(
+                cmd(),
+                kNoStreamPreview,
+                0,
+                false,
+                "Omit stream preview data from the trace CBOR output. Requires --trace.");
     }
 
     explicit DecompressArgs(const arg::ParsedArgs& parsed) : GlobalArgs(parsed)
@@ -69,6 +75,12 @@ class DecompressArgs : GlobalArgs {
         }
 
         traceStreamsDir = parsed.cmdFlag(cmd(), kTraceStreamsDir);
+        streamPreview   = !parsed.cmdHasFlag(cmd(), kNoStreamPreview);
+
+        if (!streamPreview && !traceOutput) {
+            throw InvalidArgsException(
+                    "--no-stream-preview requires --trace to be specified.");
+        }
     }
 
     static Cmd cmd()
@@ -81,6 +93,7 @@ class DecompressArgs : GlobalArgs {
 
     std::shared_ptr<tools::io::Output> traceOutput;
     std::optional<std::string> traceStreamsDir;
+    bool streamPreview = true;
 
    private:
     inline static const std::string kInput           = "input";
@@ -88,6 +101,7 @@ class DecompressArgs : GlobalArgs {
     inline static const std::string kForce           = "force";
     inline static const std::string kTrace           = "trace";
     inline static const std::string kTraceStreamsDir = "trace-streams-dir";
+    inline static const std::string kNoStreamPreview = "no-stream-preview";
 };
 
 } // namespace openzl::cli

--- a/cli/commands/cmd_compress.cpp
+++ b/cli/commands/cmd_compress.cpp
@@ -138,7 +138,7 @@ int performCompression(const CompressArgs& args)
                 VERBOSE1,
                 "Tracing compression to ",
                 args.traceOutput->name().data());
-        cctx.writeTraces(true);
+        cctx.writeTraces(true, args.streamPreview);
     }
 
     auto& input  = *args.input;

--- a/cli/commands/cmd_decompress.cpp
+++ b/cli/commands/cmd_decompress.cpp
@@ -92,7 +92,7 @@ int cmdDecompress(const DecompressArgs& args)
                 VERBOSE1,
                 "Tracing decompression to ",
                 args.traceOutput->name().data());
-        dctx.writeTraces(true);
+        dctx.writeTraces(true, args.streamPreview);
     }
 
     // decompress

--- a/cpp/include/openzl/cpp/CCtx.hpp
+++ b/cpp/include/openzl/cpp/CCtx.hpp
@@ -96,7 +96,7 @@ class CCtx {
             GraphID graph,
             const poly::optional<GraphParameters>& params = poly::nullopt);
 
-    void writeTraces(bool enabled);
+    void writeTraces(bool enabled, bool streamPreview = true);
 
     /**
      * @returns a pair of the latest trace, and a map from internal stream IDs

--- a/cpp/include/openzl/cpp/DCtx.hpp
+++ b/cpp/include/openzl/cpp/DCtx.hpp
@@ -74,7 +74,7 @@ class DCtx {
     void registerCustomDecoder(const ZL_MIDecoderDesc& desc);
     void registerCustomDecoder(std::shared_ptr<CustomDecoder> decoder);
 
-    void writeTraces(bool enabled);
+    void writeTraces(bool enabled, bool streamPreview = true);
 
     /**
      * @returns a pair of the latest trace, and a map from internal stream IDs

--- a/cpp/src/openzl/cpp/CCtx.cpp
+++ b/cpp/src/openzl/cpp/CCtx.cpp
@@ -149,13 +149,14 @@ void CCtx::selectStartingGraph(
     selectStartingGraphImpl(*this, compressor.get(), graph, params);
 }
 
-void CCtx::writeTraces(bool enabled)
+void CCtx::writeTraces(bool enabled, bool streamPreview)
 {
     if ((bool)visHooks_ == enabled) {
         return; // no need to re-create or re-destroy the hooks
     }
     if (enabled) {
-        visHooks_ = std::make_unique<visualizer::CompressionTraceHooks>();
+        visHooks_ = std::make_unique<visualizer::CompressionTraceHooks>(
+                streamPreview);
         unwrap(ZL_CCtx_attachIntrospectionHooks(
                 get(), visHooks_->getRawHooks()));
     } else {

--- a/cpp/src/openzl/cpp/DCtx.cpp
+++ b/cpp/src/openzl/cpp/DCtx.cpp
@@ -101,13 +101,14 @@ poly::string_view DCtx::getErrorContextString(ZL_Error error) const
     return ZL_DCtx_getErrorContextString_fromError(get(), error);
 }
 
-void DCtx::writeTraces(bool enabled)
+void DCtx::writeTraces(bool enabled, bool streamPreview)
 {
     if ((bool)visHooks_ == enabled) {
         return; // no need to re-create or re-destroy the hooks
     }
     if (enabled) {
-        visHooks_ = std::make_unique<visualizer::DecompressionTraceHooks>();
+        visHooks_ = std::make_unique<visualizer::DecompressionTraceHooks>(
+                streamPreview);
         unwrap(ZL_DCtx_attachDecompressIntrospectionHooks(
                 get(), visHooks_->getRawHooks()));
     } else {

--- a/cpp/src/openzl/cpp/experimental/trace/ChunkTraceCore.cpp
+++ b/cpp/src/openzl/cpp/experimental/trace/ChunkTraceCore.cpp
@@ -195,6 +195,20 @@ void ChunkTraceCore::finalizeUnconsumedStreams(
     }
 }
 
+StreamPreview ChunkTraceCore::emptyPreview(ZL_Type type)
+{
+    switch (type) {
+        case ZL_Type_string:
+            return std::vector<std::string>{};
+        case ZL_Type_numeric:
+            return std::vector<int64_t>{};
+        case ZL_Type_serial:
+        case ZL_Type_struct:
+        default:
+            return std::vector<uint8_t>{};
+    }
+}
+
 StreamPreview ChunkTraceCore::getStreamPreview(
         const void* data,
         ZL_Type type,

--- a/cpp/src/openzl/cpp/experimental/trace/ChunkTraceCore.hpp
+++ b/cpp/src/openzl/cpp/experimental/trace/ChunkTraceCore.hpp
@@ -91,6 +91,13 @@ class ChunkTraceCore {
             const uint32_t* stringLens = nullptr);
 
     /**
+     * Returns a type-correct empty StreamPreview for the given ZL_Type.
+     * Used when stream preview is disabled to avoid variant type mismatches
+     * during serialization.
+     */
+    static StreamPreview emptyPreview(ZL_Type type);
+
+    /**
      * Recursively computes the compressed size (cSize) of a stream by
      * summing the cSize of its successors. Uses Stream::cSize directly
      * for memoization (0 means not yet computed).

--- a/cpp/src/openzl/cpp/experimental/trace/CompressChunkTrace.cpp
+++ b/cpp/src/openzl/cpp/experimental/trace/CompressChunkTrace.cpp
@@ -32,12 +32,14 @@ void CompressChunkTrace::recordStartStreams(
             size_t numElts     = ZL_Input_numElts(inStreams[i]);
             size_t contentSize = ZL_Input_contentSize(inStreams[i]);
 
-            StreamPreview preview = ChunkTraceCore::getStreamPreview(
-                    ZL_Input_ptr(inStreams[i]),
-                    type,
-                    eltWidth,
-                    numElts,
-                    ZL_Input_stringLens(inStreams[i]));
+            StreamPreview preview = showStreamPreview_
+                    ? ChunkTraceCore::getStreamPreview(
+                              ZL_Input_ptr(inStreams[i]),
+                              type,
+                              eltWidth,
+                              numElts,
+                              ZL_Input_stringLens(inStreams[i]))
+                    : ChunkTraceCore::emptyPreview(type);
 
             streamInfo_[streamID] = Stream{
                 .id            = streamID,
@@ -347,12 +349,14 @@ void CompressChunkTrace::on_codecEncode_end(
         size_t contentSize =
                 openzl::unwrap(ZL_Output_contentSize(createdStream));
 
-        StreamPreview preview = ChunkTraceCore::getStreamPreview(
-                ZL_Output_constPtr(createdStream),
-                type,
-                eltWidth,
-                numElts,
-                ZL_Output_constStringLens(createdStream));
+        StreamPreview preview = showStreamPreview_
+                ? ChunkTraceCore::getStreamPreview(
+                          ZL_Output_constPtr(createdStream),
+                          type,
+                          eltWidth,
+                          numElts,
+                          ZL_Output_constStringLens(createdStream))
+                : ChunkTraceCore::emptyPreview(type);
 
         streamInfo_[streamID] = {
             .id            = streamID,

--- a/cpp/src/openzl/cpp/experimental/trace/CompressChunkTrace.hpp
+++ b/cpp/src/openzl/cpp/experimental/trace/CompressChunkTrace.hpp
@@ -21,7 +21,10 @@ namespace openzl::visualizer {
 class CompressChunkTrace {
    public:
     CompressChunkTrace() = delete;
-    explicit CompressChunkTrace(size_t chunkId) : chunkId_(chunkId) {}
+    explicit CompressChunkTrace(size_t chunkId, bool showStreamPreview)
+            : chunkId_(chunkId), showStreamPreview_(showStreamPreview)
+    {
+    }
 
     /**
      * Callback to record the first streams (aka user-input). They are never
@@ -127,6 +130,7 @@ class CompressChunkTrace {
     std::map<size_t, std::pair<std::string, std::string>> streamdump_;
     std::vector<Codec> codecInfo_;
     std::vector<Graph> graphInfo_;
+    bool showStreamPreview_     = true;  // show stream preview data from trace
     bool currEncompassingGraph_ = false; // if codecs are running within a graph
     std::optional<ConversionError> maybeConversionError_ = std::nullopt;
     void streamdump(const ZL_Output* createdStream);

--- a/cpp/src/openzl/cpp/experimental/trace/CompressTracer.cpp
+++ b/cpp/src/openzl/cpp/experimental/trace/CompressTracer.cpp
@@ -61,7 +61,7 @@ void CompressTracer::on_ZL_Segmenter_processChunk_start(
         const ZL_RuntimeGraphParameters* rGraphParams)
 {
     auto chunkNum = graphRuns.size();
-    graphRuns.emplace_back(chunkNum);
+    graphRuns.emplace_back(chunkNum, showStreamPreview_);
     currChunk = &(graphRuns[chunkNum]);
     currChunk->on_ZL_Segmenter_processChunk_start(
             segCtx, numElts, numInputs, startingGraphID, rGraphParams);
@@ -169,7 +169,7 @@ void CompressTracer::on_ZL_CCtx_compressMultiTypedRef_start(
     frameVersion = ZL_CCtx_getParameter(cctx, ZL_CParam_formatVersion);
     opCtx_       = ZL_GET_OPERATION_CONTEXT(cctx);
     // The "main" trace is located at idx 0 of graphRuns
-    graphRuns.emplace_back(MAIN_TRACE_IDX);
+    graphRuns.emplace_back(MAIN_TRACE_IDX, showStreamPreview_);
     currChunk = &graphRuns[MAIN_TRACE_IDX];
 }
 

--- a/cpp/src/openzl/cpp/experimental/trace/CompressTracer.hpp
+++ b/cpp/src/openzl/cpp/experimental/trace/CompressTracer.hpp
@@ -15,6 +15,10 @@ namespace openzl::visualizer {
 class CompressTracer {
    public:
     CompressTracer() = default;
+    explicit CompressTracer(bool showStreamPreview)
+            : showStreamPreview_(showStreamPreview)
+    {
+    }
 
     TraceResult extractTrace();
 
@@ -121,6 +125,7 @@ class CompressTracer {
             nullptr; // convenience pointer to the current chunk trace
     bool segmented              = false;
     ZL_OperationContext* opCtx_ = nullptr;
+    bool showStreamPreview_     = true; // show stream preview data from trace
 
     TraceResult trace;
 };

--- a/cpp/src/openzl/cpp/experimental/trace/CompressionTraceHooks.cpp
+++ b/cpp/src/openzl/cpp/experimental/trace/CompressionTraceHooks.cpp
@@ -193,7 +193,7 @@ void CompressionTraceHooks::on_ZL_CCtx_compressMultiTypedRef_start(
         throw std::runtime_error(
                 "Corrupted state. Trace context already exists!");
     }
-    tracer_ = std::make_unique<CompressTracer>();
+    tracer_ = std::make_unique<CompressTracer>(showStreamPreview_);
     tracer_->on_ZL_CCtx_compressMultiTypedRef_start(
             cctx, dst, dstCapacity, inputs, nbInputs);
 }

--- a/cpp/src/openzl/cpp/experimental/trace/CompressionTraceHooks.hpp
+++ b/cpp/src/openzl/cpp/experimental/trace/CompressionTraceHooks.hpp
@@ -17,7 +17,10 @@
 namespace openzl::visualizer {
 class CompressionTraceHooks : public openzl::CompressIntrospectionHooks {
    public:
-    CompressionTraceHooks()           = default;
+    explicit CompressionTraceHooks(bool showStreamPreview)
+            : showStreamPreview_(showStreamPreview)
+    {
+    }
     ~CompressionTraceHooks() override = default;
 
     std::pair<
@@ -117,6 +120,7 @@ class CompressionTraceHooks : public openzl::CompressIntrospectionHooks {
                                     // lengths (or ""))
     std::string latestTraceCache_;  // cache for latest trace
 
+    bool showStreamPreview_ = true;
     std::unique_ptr<CompressTracer>
             tracer_; // pointer to the actual class that does a trace
 };

--- a/cpp/src/openzl/cpp/experimental/trace/DecompressChunkTrace.cpp
+++ b/cpp/src/openzl/cpp/experimental/trace/DecompressChunkTrace.cpp
@@ -14,9 +14,11 @@
 
 namespace openzl::visualizer {
 
-DecompressChunkTrace DecompressChunkTrace::makeSegmenterChunk(size_t chunkId)
+DecompressChunkTrace DecompressChunkTrace::makeSegmenterChunk(
+        size_t chunkId,
+        bool showStreamPreview)
 {
-    auto ret = DecompressChunkTrace(chunkId);
+    auto ret = DecompressChunkTrace(chunkId, showStreamPreview);
     Codec newCodec{ .name  = "segmenter", // TODO(segm): expose segmenter name
                     .cType = false,
                     .cID   = 0, // eh?
@@ -89,12 +91,14 @@ void DecompressChunkTrace::on_codecDecode_start(
             size_t eltWidth = ZL_Data_eltWidth(inStreams[i]);
             size_t numElts  = ZL_Data_numElts(inStreams[i]);
 
-            StreamPreview preview = ChunkTraceCore::getStreamPreview(
-                    ZL_Data_rPtr(inStreams[i]),
-                    type,
-                    eltWidth,
-                    numElts,
-                    ZL_Data_rStringLens(inStreams[i]));
+            StreamPreview preview = showStreamPreview_
+                    ? ChunkTraceCore::getStreamPreview(
+                              ZL_Data_rPtr(inStreams[i]),
+                              type,
+                              eltWidth,
+                              numElts,
+                              ZL_Data_rStringLens(inStreams[i]))
+                    : ChunkTraceCore::emptyPreview(type);
 
             streamInfo_[streamID] = Stream{
                 .id            = streamID,
@@ -156,12 +160,14 @@ void DecompressChunkTrace::on_codecDecode_end(
             size_t eltWidth = ZL_Data_eltWidth(outStreams[i]);
             size_t numElts  = ZL_Data_numElts(outStreams[i]);
 
-            StreamPreview preview = ChunkTraceCore::getStreamPreview(
-                    ZL_Data_rPtr(outStreams[i]),
-                    type,
-                    eltWidth,
-                    numElts,
-                    ZL_Data_rStringLens(outStreams[i]));
+            StreamPreview preview = showStreamPreview_
+                    ? ChunkTraceCore::getStreamPreview(
+                              ZL_Data_rPtr(outStreams[i]),
+                              type,
+                              eltWidth,
+                              numElts,
+                              ZL_Data_rStringLens(outStreams[i]))
+                    : ChunkTraceCore::emptyPreview(type);
 
             streamInfo_[streamID] = Stream{
                 .id            = streamID,

--- a/cpp/src/openzl/cpp/experimental/trace/DecompressChunkTrace.hpp
+++ b/cpp/src/openzl/cpp/experimental/trace/DecompressChunkTrace.hpp
@@ -19,13 +19,18 @@ namespace openzl::visualizer {
 class DecompressChunkTrace {
    public:
     DecompressChunkTrace() = delete;
-    explicit DecompressChunkTrace(size_t chunkId) : chunkId_(chunkId) {}
+    explicit DecompressChunkTrace(size_t chunkId, bool showStreamPreview)
+            : chunkId_(chunkId), showStreamPreview_(showStreamPreview)
+    {
+    }
 
     /**
      * Helper function to create a dummy chunk that just contains a segmenter
      * node, in cases where the trace is a multi-chunk run.
      */
-    static DecompressChunkTrace makeSegmenterChunk(size_t chunkId);
+    static DecompressChunkTrace makeSegmenterChunk(
+            size_t chunkId,
+            bool showStreamPreview);
     /**
      * Finalize the trace.
      * - On success, unsourced streams (decoded outputs) go to "zl.regen".
@@ -67,6 +72,7 @@ class DecompressChunkTrace {
     void streamdump(const ZL_Data* data);
 
     const size_t chunkId_;
+    bool showStreamPreview_     = true; // show stream preview data from trace
     size_t totalCompressedSize_ = 0;
     size_t currCodecNum_        = 0;
     std::map<ZL_DataID, Stream, ZL_DataIDCustomComparator> streamInfo_;

--- a/cpp/src/openzl/cpp/experimental/trace/DecompressTracer.cpp
+++ b/cpp/src/openzl/cpp/experimental/trace/DecompressTracer.cpp
@@ -44,7 +44,7 @@ void DecompressTracer::on_ZL_DCtx_decompressMultiTBuffer_start(
             ZL_validResult(ZL_getFormatVersionFromFrame(framePtr, frameSize)));
 
     // Create the main chunk at index 0
-    chunks_.emplace_back(MAIN_CHUNK_IDX);
+    chunks_.emplace_back(MAIN_CHUNK_IDX, showStreamPreview_);
     currChunk_ = &chunks_[MAIN_CHUNK_IDX];
     opCtx_     = ZL_GET_OPERATION_CONTEXT(dctx);
 }
@@ -60,8 +60,8 @@ void DecompressTracer::on_ZL_DCtx_decompressMultiTBuffer_end(
 
     // Create a dummy "main" chunk, if necessary
     if (chunks_.size() > 1) {
-        auto dummyChunk =
-                DecompressChunkTrace::makeSegmenterChunk(chunks_.size());
+        auto dummyChunk = DecompressChunkTrace::makeSegmenterChunk(
+                chunks_.size(), showStreamPreview_);
         std::vector<DecompressChunkTrace> newChunks = { std::move(dummyChunk) };
         for (auto& chunk : chunks_) {
             newChunks.push_back(std::move(chunk));
@@ -95,7 +95,7 @@ void DecompressTracer::on_decompressChunk_start(
 {
     if (chunkIndex > 0) {
         // Multi-chunk frame: create additional chunk traces
-        chunks_.emplace_back(chunkIndex);
+        chunks_.emplace_back(chunkIndex, showStreamPreview_);
         currChunk_ = &chunks_.back();
     }
 }

--- a/cpp/src/openzl/cpp/experimental/trace/DecompressTracer.hpp
+++ b/cpp/src/openzl/cpp/experimental/trace/DecompressTracer.hpp
@@ -14,6 +14,10 @@ namespace openzl::visualizer {
 class DecompressTracer {
    public:
     DecompressTracer() = default;
+    explicit DecompressTracer(bool showStreamPreview)
+            : showStreamPreview_(showStreamPreview)
+    {
+    }
 
     TraceResult extractTrace();
 
@@ -56,6 +60,7 @@ class DecompressTracer {
     DecompressChunkTrace* currChunk_ =
             nullptr; // convenience pointer to the current chunk trace
     ZL_OperationContext* opCtx_ = nullptr;
+    bool showStreamPreview_     = true; // show stream preview data from trace
 
     TraceResult trace_;
 };

--- a/cpp/src/openzl/cpp/experimental/trace/DecompressionTraceHooks.cpp
+++ b/cpp/src/openzl/cpp/experimental/trace/DecompressionTraceHooks.cpp
@@ -21,7 +21,7 @@ void DecompressionTraceHooks::on_ZL_DCtx_decompressMultiTBuffer_start(
         throw std::runtime_error(
                 "Corrupted state. Trace context already exists!");
     }
-    tracer_ = std::make_unique<DecompressTracer>();
+    tracer_ = std::make_unique<DecompressTracer>(showStreamPreview_);
     tracer_->on_ZL_DCtx_decompressMultiTBuffer_start(
             dctx, nbOutputs, framePtr, frameSize);
 }

--- a/cpp/src/openzl/cpp/experimental/trace/DecompressionTraceHooks.hpp
+++ b/cpp/src/openzl/cpp/experimental/trace/DecompressionTraceHooks.hpp
@@ -15,7 +15,10 @@ namespace openzl::visualizer {
 
 class DecompressionTraceHooks : public openzl::DecompressIntrospectionHooks {
    public:
-    DecompressionTraceHooks()           = default;
+    explicit DecompressionTraceHooks(bool showStreamPreview)
+            : showStreamPreview_(showStreamPreview)
+    {
+    }
     ~DecompressionTraceHooks() override = default;
 
     std::pair<
@@ -58,6 +61,7 @@ class DecompressionTraceHooks : public openzl::DecompressIntrospectionHooks {
     std::vector<std::vector<StreamdumpEntry>> latestStreamdumpCache_;
     std::string latestTraceCache_;
 
+    bool showStreamPreview_ = true;
     std::unique_ptr<DecompressTracer> tracer_;
 };
 

--- a/tools/visualization_app/src/graphVisualization/views/EdgeView.tsx
+++ b/tools/visualization_app/src/graphVisualization/views/EdgeView.tsx
@@ -199,7 +199,7 @@ function formatStringPreview(strings: string[]): ReactNode {
 function formatPreview(edge: InternalEdge): ReactNode | null {
   const {type, eltWidth, streamPreview} = edge;
 
-  if (!streamPreview) {
+  if (!streamPreview || streamPreview.length === 0) {
     return null;
   }
 


### PR DESCRIPTION
Summary:

Add stream preview flag to toggle on/off preview ui

Example command:
```
./zli compress --no-stream-preview --trace  ./streamdump.cbor -p serial -o /dev/null ./examples/getting_started/sample_inputs/lorem_ipsum.txt
```

Reviewed By: Victor-C-Zhang

Differential Revision: D97973846


