### PR TITLE
Visualizer: Distinguish compression and decompression traces end-to-end (#549)

### DIFF
--- a/cpp/src/openzl/cpp/experimental/trace/CompressTracer.cpp
+++ b/cpp/src/openzl/cpp/experimental/trace/CompressTracer.cpp
@@ -219,13 +219,14 @@ ZL_Report CompressTracer::serializeStreamdumpToCbor(
      * 3. graph info, specifically, which codecs and edges are within a
      * graph
      */
-    A1C_MapBuilder rootBuilder = A1C_Item_map_builder(root, 4, a1c_arena);
+    A1C_MapBuilder rootBuilder = A1C_Item_map_builder(root, 5, a1c_arena);
 
     ZL_RET_R_IF_NULL(allocation, rootBuilder.map);
 
     ZL_RET_R_IF_ERR(addIntValue(rootBuilder, "libraryVersion", libraryVersion));
     ZL_RET_R_IF_ERR(addIntValue(rootBuilder, "frameVersion", frameVersion));
     ZL_RET_R_IF_ERR(addIntValue(rootBuilder, "traceVersion", traceVersion));
+    ZL_RET_R_IF_ERR(addIntValue(rootBuilder, "operationType", 0));
 
     // Wrap streams, codecs, and graphs in a "chunks" array
     // Non-segmented runs will have 1 chunk in idx 0.

--- a/cpp/src/openzl/cpp/experimental/trace/DecompressTracer.cpp
+++ b/cpp/src/openzl/cpp/experimental/trace/DecompressTracer.cpp
@@ -131,13 +131,15 @@ ZL_Report DecompressTracer::serializeStreamdumpToCbor(
     A1C_Item* root = A1C_Item_root(a1c_arena);
     ZL_RET_R_IF_NULL(allocation, root);
 
-    // 4 top-level fields: libraryVersion, frameVersion, traceVersion, chunks
-    A1C_MapBuilder rootBuilder = A1C_Item_map_builder(root, 4, a1c_arena);
+    // 5 top-level fields: libraryVersion, frameVersion, traceVersion,
+    // operationType, chunks
+    A1C_MapBuilder rootBuilder = A1C_Item_map_builder(root, 5, a1c_arena);
     ZL_RET_R_IF_NULL(allocation, rootBuilder.map);
 
     ZL_RET_R_IF_ERR(addIntValue(rootBuilder, "libraryVersion", libraryVersion));
     ZL_RET_R_IF_ERR(addIntValue(rootBuilder, "frameVersion", frameVersion_));
     ZL_RET_R_IF_ERR(addIntValue(rootBuilder, "traceVersion", traceVersion));
+    ZL_RET_R_IF_ERR(addIntValue(rootBuilder, "operationType", 1));
 
     // Wrap chunks in a "chunks" array
     A1C_MAP_TRY_ADD_R(chunksPair, rootBuilder);

--- a/tools/visualization_app/src/components/StreamdumpGraph.tsx
+++ b/tools/visualization_app/src/components/StreamdumpGraph.tsx
@@ -9,6 +9,7 @@ import {ReactFlowProvider} from '@xyflow/react';
 import {Box, Code, CodeBlock, Float, IconButton, Text, Tabs, useTabs, Heading, Span} from '@chakra-ui/react';
 
 const cliInvocation = 'zli compress --trace /tmp/streamdump.cbor -p serial -o /dev/null myfile.txt';
+const cliDecompressInvocation = 'zli decompress --trace /tmp/decompress_trace.cbor -o myfile.txt myfile.txt.zl';
 const files = [
   {
     language: 'C++',
@@ -21,6 +22,17 @@ myCCtx.writeTraces(true);
 myCCtx.compress(/* input */);
 std::string trace = myCCtx.getLatestTrace().first;
 std::ofstream out{"/home/user/trace.cbor"};
+out << trace;
+out.close();
+
+
+#include "openzl/cpp/DCtx.hpp"
+
+DCtx myDCtx;
+myDCtx.writeTraces(true);
+myDCtx.decompressSerial(/* compressed input */);
+std::string trace = myDCtx.getLatestTrace().first;
+std::ofstream out{"/home/user/decompress_trace.cbor"};
 out << trace;
 out.close();
 `,
@@ -66,10 +78,33 @@ function NoDataHelper() {
         Using the CLI
       </Heading>
       <Text className="no-data-helper-text">
-        Specify the &lsquo;trace&rsquo; option when compressing, and provide a .cbor path to write the trace to. For
-        example:
+        Specify the &lsquo;trace&rsquo; option when compressing or decompressing, and provide a .cbor path to write the
+        trace to. For example:
+      </Text>
+      <Text className="no-data-helper-text" fontWeight="bold" mt="2">
+        Compression:
       </Text>
       <CodeBlock.Root code={cliInvocation} language={'bash'} display="inline-flex">
+        <CodeBlock.Content>
+          <Float placement="middle-end" offsetX="6" zIndex="1">
+            <CodeBlock.CopyTrigger asChild>
+              <IconButton variant="ghost" size="2xs">
+                <CodeBlock.CopyIndicator />
+              </IconButton>
+            </CodeBlock.CopyTrigger>
+          </Float>
+          <CodeBlock.Code pe="14">
+            <Span color="fg.muted" ms="4" userSelect="none">
+              $
+            </Span>
+            <CodeBlock.CodeText display="inline-block" />
+          </CodeBlock.Code>
+        </CodeBlock.Content>
+      </CodeBlock.Root>
+      <Text className="no-data-helper-text" fontWeight="bold" mt="2">
+        Decompression:
+      </Text>
+      <CodeBlock.Root code={cliDecompressInvocation} language={'bash'} display="inline-flex">
         <CodeBlock.Content>
           <Float placement="middle-end" offsetX="6" zIndex="1">
             <CodeBlock.CopyTrigger asChild>
@@ -92,7 +127,7 @@ function NoDataHelper() {
       <Heading className="no-data-helper-text" size="lg">
         Using the C++ API
       </Heading>
-      <Text className="no-data-helper-text">Enable tracing in the CCtx</Text>
+      <Text className="no-data-helper-text">Enable tracing in the CCtx or DCtx</Text>
       <Tabs.RootProvider value={tabs} size="sm" variant="line">
         <CodeBlock.Root code={activeTab.code} language={activeTab.language}>
           <CodeBlock.Header borderBottomWidth="1px">
@@ -149,6 +184,7 @@ function StreamdumpGraphContent({data}: NullableStreamdump) {
     libraryVersion: data.libraryVersion,
     frameVersion: data.frameVersion,
     traceVersion: data.traceVersion,
+    operationType: data.operationType,
   };
 
   return (

--- a/tools/visualization_app/src/graphVisualization/views/StreamdumpGraphView.tsx
+++ b/tools/visualization_app/src/graphVisualization/views/StreamdumpGraphView.tsx
@@ -9,12 +9,15 @@ import {Box} from '@chakra-ui/react/box';
 import {Button} from '@chakra-ui/react/button';
 import {Flex} from '@chakra-ui/react/flex';
 
+import {OperationType} from '../../models/idTypes';
+
 const showExpansionButton = false;
 
 interface VersionInfo {
   libraryVersion: number;
   frameVersion: number;
   traceVersion: number;
+  operationType: OperationType;
 }
 
 interface StreamdumpGraphViewProps {
@@ -44,7 +47,10 @@ export function StreamdumpGraphView({
     // The controller will use this instance for viewport manipulation, which is handled internally by React Flow
   }, [reactFlowInstance]);
   return (
-    <Box w={'100%'} h={'100%'}>
+    <Box
+      w={'100%'}
+      h={'100%'}
+      className={versionInfo.operationType === OperationType.Decompress ? 'decompress-trace' : ''}>
       <ReactFlow
         nodes={nodes}
         edges={edges}
@@ -71,6 +77,9 @@ export function StreamdumpGraphView({
               {isTrackpadMode ? 'Switch to Mouse Controls' : 'Switch to Trackpad Controls'}
             </Button>
             <div className="header-text">
+              <p style={{fontWeight: 'bold'}}>
+                {versionInfo.operationType === OperationType.Decompress ? 'Decompression Trace' : 'Compression Trace'}
+              </p>
               <p>Library Version: {versionInfo.libraryVersion}</p>
               <p>Frame Version: {versionInfo.frameVersion}</p>
               <p>Trace Version: {versionInfo.traceVersion}</p>

--- a/tools/visualization_app/src/interfaces/SerializedStreamdump.ts
+++ b/tools/visualization_app/src/interfaces/SerializedStreamdump.ts
@@ -9,6 +9,7 @@ export interface SerializedStreamdumpV1 {
   libraryVersion: number;
   frameVersion: number;
   traceVersion: number;
+  operationType?: number; // 0 = compress, 1 = decompress
   chunks: SerializedChunk[];
 }
 

--- a/tools/visualization_app/src/models/Streamdump.ts
+++ b/tools/visualization_app/src/models/Streamdump.ts
@@ -2,25 +2,36 @@
 
 import type {SerializedStreamdumpV1} from '../interfaces/SerializedStreamdump';
 import {Chunk} from './Chunk';
+import {OperationType} from './idTypes';
 
 export class Streamdump {
   readonly libraryVersion: number;
   readonly frameVersion: number;
   readonly traceVersion: number;
+  readonly operationType: OperationType;
   readonly chunks: Chunk[];
 
-  constructor(libraryVersion: number, frameVersion: number, traceVersion: number, chunks: Chunk[]) {
+  constructor(
+    libraryVersion: number,
+    frameVersion: number,
+    traceVersion: number,
+    operationType: OperationType,
+    chunks: Chunk[],
+  ) {
     this.libraryVersion = libraryVersion;
     this.frameVersion = frameVersion;
     this.traceVersion = traceVersion;
+    this.operationType = operationType;
     this.chunks = chunks;
   }
 
   static fromObject(obj: SerializedStreamdumpV1): Streamdump {
+    const operationType = obj.operationType === 1 ? OperationType.Decompress : OperationType.Compress;
     return new Streamdump(
       obj.libraryVersion,
       obj.frameVersion,
       obj.traceVersion,
+      operationType,
       obj.chunks.map((chunk, chunkId) => Chunk.fromObject(chunk, chunkId)),
     );
   }

--- a/tools/visualization_app/src/models/idTypes.ts
+++ b/tools/visualization_app/src/models/idTypes.ts
@@ -15,6 +15,11 @@ export enum ZL_Type {
   ZL_Type_string = 8,
 }
 
+export enum OperationType {
+  Compress = 0,
+  Decompress = 1,
+}
+
 export enum ZL_GraphType {
   ZL_GraphType_standard = 0,
   ZL_GraphType_static = 1,

--- a/tools/visualization_app/src/styles/streamdumpGraph.css
+++ b/tools/visualization_app/src/styles/streamdumpGraph.css
@@ -298,3 +298,19 @@
   min-width: 400px;
   max-width: 600px;
 }
+
+/* Decompress trace theme: teal/cyan accent instead of blue */
+.decompress-trace .codec-node {
+  background-color: #d0f2e8;
+  border-color: #2b9e8f;
+}
+
+.decompress-trace .codec-node.collapsed {
+  background-color: #e0f0ff;
+  border-color: #4a90d9;
+}
+
+.decompress-trace .codec-node.special-node {
+  background-color: #dadee2ad;
+  border-color: #a5a5a5;
+}

--- a/tools/visualization_app/src/utils/decodeCbor.ts
+++ b/tools/visualization_app/src/utils/decodeCbor.ts
@@ -90,6 +90,7 @@ function marshallV1(obj: object): SerializedStreamdumpV1 {
     libraryVersion: obj.libraryVersion,
     frameVersion: obj.frameVersion,
     traceVersion: 1,
+    operationType: 'operationType' in obj && typeof obj.operationType === 'number' ? obj.operationType : 0,
     chunks: obj.chunks,
   };
 }


### PR DESCRIPTION
Summary:

  C++ — CBOR serialization
  - CompressTracer.cpp: Add operationType: 0 to the root CBOR map (bump map size 4 → 5).
  - DecompressTracer.cpp: Add operationType: 1 to the root CBOR map (bump map size 4 → 5).

  TypeScript — Data model
  - idTypes.ts: Add OperationType enum (Compress = 0, Decompress = 1).
  - SerializedStreamdump.ts: Add optional operationType field to SerializedStreamdumpV1.
  - decodeCbor.ts: Read operationType from decoded CBOR in marshallV1, defaulting to 0 for older traces without the field.
  - Streamdump.ts: Add operationType field to the model class and constructor; fromObject() converts the wire integer to the enum.

  TypeScript — Visualization
  - StreamdumpGraphView.tsx: Add operationType to VersionInfo interface. Display "Compression Trace" vs "Decompression Trace" header. Apply decompress-trace CSS class for visual theming.
  - streamdumpGraph.css: Add teal/cyan decompress-trace theme for codec nodes (normal, collapsed, and special-node states).
  - StreamdumpGraph.tsx: Pass operationType through to versionInfo. Add decompression CLI invocation example and DCtx C++ API example to the usage help page.

Reviewed By: terrelln

Differential Revision: D96837186
