### PR TITLE
reverse the order of decompression graph population (#550)

### DIFF
--- a/cpp/src/openzl/cpp/experimental/trace/ChunkTraceCore.cpp
+++ b/cpp/src/openzl/cpp/experimental/trace/ChunkTraceCore.cpp
@@ -7,22 +7,70 @@
 
 namespace openzl::visualizer {
 
-void ChunkTraceCore::initTrace(
+void ChunkTraceCore::createSourceForStream(
+        const char* sourceCodecName,
+        const StreamID& streamID,
+        Stream& stream,
         std::vector<Codec>& codecInfo,
         size_t& currCodecNum,
         size_t chunkId)
 {
-    Codec startCodec = {
-        .name         = "zl.#start",
+    Codec source = {
+        .name         = sourceCodecName,
         .cType        = true, // standard
         .cID          = 0,
         .cHeaderSize  = 0,
         .cLocalParams = {},
         .chunkId      = chunkId,
     };
-    startCodec.codecNum = currCodecNum;
-    codecInfo.push_back(std::move(startCodec));
+    source.codecNum = currCodecNum;
+    codecInfo.push_back(std::move(source));
+    codecInfo[currCodecNum].outEdges.push_back(streamID);
+    stream.producerCodec = currCodecNum;
     ++currCodecNum;
+}
+
+void ChunkTraceCore::createSinkForStream(
+        const char* sinkCodecName,
+        const StreamID& streamID,
+        Stream& stream,
+        std::vector<Codec>& codecInfo,
+        size_t& currCodecNum,
+        size_t chunkId)
+{
+    Codec sink = {
+        .name         = sinkCodecName,
+        .cType        = true, // standard
+        .cID          = 0,
+        .cHeaderSize  = 0,
+        .cLocalParams = {},
+        .chunkId      = chunkId,
+    };
+    sink.codecNum = currCodecNum;
+    codecInfo.push_back(std::move(sink));
+    codecInfo[currCodecNum].inEdges.push_back(streamID);
+    stream.consumerCodec = currCodecNum;
+    ++currCodecNum;
+}
+
+void ChunkTraceCore::finalizeUnsourcedStreams(
+        const char* sourceCodecName,
+        std::map<ZL_DataID, Stream, ZL_DataIDCustomComparator>& streamInfo,
+        std::vector<Codec>& codecInfo,
+        size_t& currCodecNum,
+        size_t chunkId)
+{
+    for (auto& [streamID, stream] : streamInfo) {
+        if (!stream.producerCodec.has_value()) {
+            createSourceForStream(
+                    sourceCodecName,
+                    streamID,
+                    stream,
+                    codecInfo,
+                    currCodecNum,
+                    chunkId);
+        }
+    }
 }
 
 void ChunkTraceCore::finalizeUnconsumedStreams(
@@ -34,19 +82,13 @@ void ChunkTraceCore::finalizeUnconsumedStreams(
 {
     for (auto& [streamID, stream] : streamInfo) {
         if (!stream.consumerCodec.has_value()) {
-            Codec terminal = {
-                .name         = terminalCodecName,
-                .cType        = true, // standard
-                .cID          = 0,
-                .cHeaderSize  = 0,
-                .cLocalParams = {},
-                .chunkId      = chunkId,
-            };
-            terminal.codecNum = currCodecNum;
-            codecInfo.push_back(std::move(terminal));
-            codecInfo[currCodecNum].inEdges.push_back(streamID);
-            stream.consumerCodec = currCodecNum;
-            ++currCodecNum;
+            createSinkForStream(
+                    terminalCodecName,
+                    streamID,
+                    stream,
+                    codecInfo,
+                    currCodecNum,
+                    chunkId);
         }
     }
 }

--- a/cpp/src/openzl/cpp/experimental/trace/ChunkTraceCore.hpp
+++ b/cpp/src/openzl/cpp/experimental/trace/ChunkTraceCore.hpp
@@ -33,17 +33,45 @@ class ChunkTraceCore {
     ChunkTraceCore() = delete; // non-instantiable
 
     /**
-     * Creates a "zl.#start" placeholder codec and appends it to codecInfo.
-     * Increments currCodecNum.
+     * Creates a source codec with the given name for a single stream.
+     * Wires the stream into the source codec's outEdges, sets producerCodec,
+     * and increments currCodecNum.
      */
-    static void initTrace(
+    static void createSourceForStream(
+            const char* sourceCodecName,
+            const StreamID& streamID,
+            Stream& stream,
+            std::vector<Codec>& codecInfo,
+            size_t& currCodecNum,
+            size_t chunkId);
+
+    /**
+     * Creates a sink codec with the given name for a single stream.
+     * Wires the stream into the sink codec's inEdges, sets consumerCodec,
+     * and increments currCodecNum.
+     */
+    static void createSinkForStream(
+            const char* sinkCodecName,
+            const StreamID& streamID,
+            Stream& stream,
+            std::vector<Codec>& codecInfo,
+            size_t& currCodecNum,
+            size_t chunkId);
+
+    /**
+     * For each unsourced stream (no producerCodec), creates a source codec
+     * with the given name via createSourceForStream.
+     */
+    static void finalizeUnsourcedStreams(
+            const char* sourceCodecName,
+            std::map<ZL_DataID, Stream, ZL_DataIDCustomComparator>& streamInfo,
             std::vector<Codec>& codecInfo,
             size_t& currCodecNum,
             size_t chunkId);
 
     /**
      * For each unconsumed stream (no consumerCodec), creates a terminal codec
-     * with the given name, wires it up, and increments currCodecNum.
+     * with the given name via createSinkForStream.
      */
     static void finalizeUnconsumedStreams(
             const char* terminalCodecName,

--- a/cpp/src/openzl/cpp/experimental/trace/CompressChunkTrace.cpp
+++ b/cpp/src/openzl/cpp/experimental/trace/CompressChunkTrace.cpp
@@ -139,11 +139,6 @@ static StreamPreview getStreamPreviewData(
     }
 }
 
-void CompressChunkTrace::initTrace()
-{
-    ChunkTraceCore::initTrace(codecInfo_, currCodecNum_, chunkId_);
-}
-
 void CompressChunkTrace::recordStartStreams(
         const ZL_Input* inStreams[],
         size_t numInStreams)
@@ -173,7 +168,13 @@ void CompressChunkTrace::recordStartStreams(
                 .chunkId       = chunkId_,
                 .streamPreview = std::move(preview),
             };
-            codecInfo_[0].outEdges.push_back(streamID);
+            ChunkTraceCore::createSourceForStream(
+                    "zl.#start",
+                    streamID,
+                    streamInfo_[streamID],
+                    codecInfo_,
+                    currCodecNum_,
+                    chunkId_);
         }
     }
 }
@@ -511,6 +512,7 @@ void CompressChunkTrace::on_codecEncode_end(
             .streamPreview = std::move(preview),
         };
 
+        streamInfo_[streamID].producerCodec = currCodecNum_;
         codecInfo_[currCodecNum_].outEdges.push_back(streamID);
         streamdump(outStreams[i]);
     }
@@ -687,7 +689,6 @@ void CompressChunkTrace::on_ZL_Segmenter_processChunk_start(
         ZL_GraphID /*startingGraphID*/,
         const ZL_RuntimeGraphParameters* /*rGraphParams*/)
 {
-    initTrace();
 }
 
 void CompressChunkTrace::on_ZL_Segmenter_processChunk_end(

--- a/cpp/src/openzl/cpp/experimental/trace/CompressChunkTrace.hpp
+++ b/cpp/src/openzl/cpp/experimental/trace/CompressChunkTrace.hpp
@@ -24,13 +24,6 @@ class CompressChunkTrace {
     explicit CompressChunkTrace(size_t chunkId) : chunkId_(chunkId) {}
 
     /**
-     * Callback function to start the trace.
-     * - Placeholder start node is inserted
-     * - (Maybe?) start streams are recorded
-     */
-    void initTrace();
-
-    /**
      * Callback to record the first streams (aka user-input). They are never
      * surfaced to the hooks (properly) until either a codec or segmenter takes
      * them in as input.

--- a/cpp/src/openzl/cpp/experimental/trace/CompressTracer.cpp
+++ b/cpp/src/openzl/cpp/experimental/trace/CompressTracer.cpp
@@ -219,13 +219,14 @@ ZL_Report CompressTracer::serializeStreamdumpToCbor(
      * 3. graph info, specifically, which codecs and edges are within a
      * graph
      */
-    A1C_MapBuilder rootBuilder = A1C_Item_map_builder(root, 4, a1c_arena);
+    A1C_MapBuilder rootBuilder = A1C_Item_map_builder(root, 5, a1c_arena);
 
     ZL_RET_R_IF_NULL(allocation, rootBuilder.map);
 
     ZL_RET_R_IF_ERR(addIntValue(rootBuilder, "libraryVersion", libraryVersion));
     ZL_RET_R_IF_ERR(addIntValue(rootBuilder, "frameVersion", frameVersion));
     ZL_RET_R_IF_ERR(addIntValue(rootBuilder, "traceVersion", traceVersion));
+    ZL_RET_R_IF_ERR(addIntValue(rootBuilder, "operationType", 0));
 
     // Wrap streams, codecs, and graphs in a "chunks" array
     // Non-segmented runs will have 1 chunk in idx 0.

--- a/cpp/src/openzl/cpp/experimental/trace/CompressTracer.cpp
+++ b/cpp/src/openzl/cpp/experimental/trace/CompressTracer.cpp
@@ -169,7 +169,6 @@ void CompressTracer::on_ZL_CCtx_compressMultiTypedRef_start(
     // The "main" trace is located at idx 0 of graphRuns
     graphRuns.emplace_back(MAIN_TRACE_IDX);
     currChunk = &graphRuns[MAIN_TRACE_IDX];
-    currChunk->initTrace();
 }
 
 void CompressTracer::on_ZL_CCtx_compressMultiTypedRef_end(

--- a/cpp/src/openzl/cpp/experimental/trace/DecompressChunkTrace.cpp
+++ b/cpp/src/openzl/cpp/experimental/trace/DecompressChunkTrace.cpp
@@ -33,22 +33,17 @@ emptyPreview(ZL_Type type)
 }
 } // namespace
 
-void DecompressChunkTrace::initTrace()
-{
-    ChunkTraceCore::initTrace(codecInfo_, currCodecNum_, chunkId_);
-}
-
 void DecompressChunkTrace::finalizeTrace(ZL_Report result)
 {
     if (ZL_isError(result)) {
-        ChunkTraceCore::finalizeUnconsumedStreams(
+        ChunkTraceCore::finalizeUnsourcedStreams(
                 "zl.#in_progress",
                 streamInfo_,
                 codecInfo_,
                 currCodecNum_,
                 chunkId_);
     } else {
-        ChunkTraceCore::finalizeUnconsumedStreams(
+        ChunkTraceCore::finalizeUnsourcedStreams(
                 "zl.regen", streamInfo_, codecInfo_, currCodecNum_, chunkId_);
     }
 }
@@ -73,6 +68,32 @@ void DecompressChunkTrace::on_codecDecode_start(
         const ZL_Data* const* inStreams,
         size_t nbInStreams)
 {
+    // Discover new streams and create sink placeholders before pushing the
+    // decode codec, so that currCodecNum_ remains valid for the decode codec.
+    for (size_t i = 0; i < nbInStreams; ++i) {
+        StreamID streamID = ZL_Data_id(inStreams[i]);
+        if (streamInfo_.find(streamID) == streamInfo_.end()) {
+            ZL_Type type          = ZL_Data_type(inStreams[i]);
+            streamInfo_[streamID] = Stream{
+                .id            = streamID,
+                .type          = type,
+                .outputIdx     = i,
+                .eltWidth      = ZL_Data_eltWidth(inStreams[i]),
+                .numElts       = ZL_Data_numElts(inStreams[i]),
+                .contentSize   = ZL_Data_contentSize(inStreams[i]),
+                .chunkId       = chunkId_,
+                .streamPreview = emptyPreview(type),
+            };
+            ChunkTraceCore::createSinkForStream(
+                    "zl.store",
+                    streamID,
+                    streamInfo_[streamID],
+                    codecInfo_,
+                    currCodecNum_,
+                    chunkId_);
+        }
+    }
+
     // Extract transform info from ZL_Decoder
     const char* transformName = DT_getTransformName(dictx->dt);
 
@@ -88,25 +109,8 @@ void DecompressChunkTrace::on_codecDecode_start(
     codecInfo_.push_back(std::move(newCodec));
 
     for (size_t i = 0; i < nbInStreams; ++i) {
-        StreamID streamID = ZL_Data_id(inStreams[i]);
-        // Lazy discovery: if stream not yet seen, it's a stored/initial stream
-        if (streamInfo_.find(streamID) == streamInfo_.end()) {
-            ZL_Type type          = ZL_Data_type(inStreams[i]);
-            streamInfo_[streamID] = Stream{
-                .id            = streamID,
-                .type          = type,
-                .outputIdx     = i,
-                .eltWidth      = ZL_Data_eltWidth(inStreams[i]),
-                .numElts       = ZL_Data_numElts(inStreams[i]),
-                .contentSize   = ZL_Data_contentSize(inStreams[i]),
-                .chunkId       = chunkId_,
-                .streamPreview = emptyPreview(type),
-            };
-            // Link as output of start node (codec 0)
-            codecInfo_[0].outEdges.push_back(streamID);
-        }
-        codecInfo_[currCodecNum_].inEdges.push_back(streamID);
-        streamInfo_[streamID].consumerCodec = currCodecNum_;
+        codecInfo_[currCodecNum_].outEdges.push_back(ZL_Data_id(inStreams[i]));
+        streamInfo_[ZL_Data_id(inStreams[i])].producerCodec = currCodecNum_;
     }
 }
 
@@ -136,7 +140,8 @@ void DecompressChunkTrace::on_codecDecode_end(
                 .streamPreview = emptyPreview(type),
             };
         }
-        codecInfo_[currCodecNum_].outEdges.push_back(streamID);
+        codecInfo_[currCodecNum_].inEdges.push_back(streamID);
+        streamInfo_[streamID].consumerCodec = currCodecNum_;
     }
 
     // Capture streamdump for each output stream

--- a/cpp/src/openzl/cpp/experimental/trace/DecompressChunkTrace.hpp
+++ b/cpp/src/openzl/cpp/experimental/trace/DecompressChunkTrace.hpp
@@ -22,13 +22,9 @@ class DecompressChunkTrace {
     explicit DecompressChunkTrace(size_t chunkId) : chunkId_(chunkId) {}
 
     /**
-     * Initialize the trace with a placeholder start node.
-     */
-    void initTrace();
-
-    /**
-     * Finalize the trace. On success, unconsumed streams go to "zl.store".
-     * On failure, unconsumed streams go to "zl.#in_progress".
+     * Finalize the trace.
+     * - On success, unsourced streams (decoded outputs) go to "zl.regen".
+     * - On failure, unsourced streams go to "zl.#in_progress".
      */
     void finalizeTrace(ZL_Report result);
 

--- a/cpp/src/openzl/cpp/experimental/trace/DecompressTracer.cpp
+++ b/cpp/src/openzl/cpp/experimental/trace/DecompressTracer.cpp
@@ -45,7 +45,6 @@ void DecompressTracer::on_ZL_DCtx_decompressMultiTBuffer_start(
     // Create the main chunk at index 0
     chunks_.emplace_back(MAIN_CHUNK_IDX);
     currChunk_ = &chunks_[MAIN_CHUNK_IDX];
-    currChunk_->initTrace();
 }
 
 void DecompressTracer::on_ZL_DCtx_decompressMultiTBuffer_end(
@@ -83,7 +82,6 @@ void DecompressTracer::on_decompressChunk_start(
         // Multi-chunk frame: create additional chunk traces
         chunks_.emplace_back(chunkIndex);
         currChunk_ = &chunks_.back();
-        currChunk_->initTrace();
     }
     // For chunkIndex == 0, we reuse the main chunk created in
     // decompressMultiTBuffer_start

--- a/cpp/src/openzl/cpp/experimental/trace/DecompressTracer.cpp
+++ b/cpp/src/openzl/cpp/experimental/trace/DecompressTracer.cpp
@@ -131,13 +131,15 @@ ZL_Report DecompressTracer::serializeStreamdumpToCbor(
     A1C_Item* root = A1C_Item_root(a1c_arena);
     ZL_RET_R_IF_NULL(allocation, root);
 
-    // 4 top-level fields: libraryVersion, frameVersion, traceVersion, chunks
-    A1C_MapBuilder rootBuilder = A1C_Item_map_builder(root, 4, a1c_arena);
+    // 5 top-level fields: libraryVersion, frameVersion, traceVersion,
+    // operationType, chunks
+    A1C_MapBuilder rootBuilder = A1C_Item_map_builder(root, 5, a1c_arena);
     ZL_RET_R_IF_NULL(allocation, rootBuilder.map);
 
     ZL_RET_R_IF_ERR(addIntValue(rootBuilder, "libraryVersion", libraryVersion));
     ZL_RET_R_IF_ERR(addIntValue(rootBuilder, "frameVersion", frameVersion_));
     ZL_RET_R_IF_ERR(addIntValue(rootBuilder, "traceVersion", traceVersion));
+    ZL_RET_R_IF_ERR(addIntValue(rootBuilder, "operationType", 1));
 
     // Wrap chunks in a "chunks" array
     A1C_MAP_TRY_ADD_R(chunksPair, rootBuilder);

--- a/cpp/src/openzl/cpp/experimental/trace/StreamVisualizer.hpp
+++ b/cpp/src/openzl/cpp/experimental/trace/StreamVisualizer.hpp
@@ -27,6 +27,7 @@ struct Stream {
     size_t chunkId{};
     std::vector<StreamID> successors;
     std::optional<CodecID> consumerCodec;
+    std::optional<CodecID> producerCodec;
     std::variant<
             std::vector<std::string>,
             std::vector<int64_t>,

--- a/tools/visualization_app/src/components/StreamdumpGraph.tsx
+++ b/tools/visualization_app/src/components/StreamdumpGraph.tsx
@@ -9,6 +9,7 @@ import {ReactFlowProvider} from '@xyflow/react';
 import {Box, Code, CodeBlock, Float, IconButton, Text, Tabs, useTabs, Heading, Span} from '@chakra-ui/react';
 
 const cliInvocation = 'zli compress --trace /tmp/streamdump.cbor -p serial -o /dev/null myfile.txt';
+const cliDecompressInvocation = 'zli decompress --trace /tmp/decompress_trace.cbor -o myfile.txt myfile.txt.zl';
 const files = [
   {
     language: 'C++',
@@ -21,6 +22,17 @@ myCCtx.writeTraces(true);
 myCCtx.compress(/* input */);
 std::string trace = myCCtx.getLatestTrace().first;
 std::ofstream out{"/home/user/trace.cbor"};
+out << trace;
+out.close();
+
+
+#include "openzl/cpp/DCtx.hpp"
+
+DCtx myDCtx;
+myDCtx.writeTraces(true);
+myDCtx.decompressSerial(/* compressed input */);
+std::string trace = myDCtx.getLatestTrace().first;
+std::ofstream out{"/home/user/decompress_trace.cbor"};
 out << trace;
 out.close();
 `,
@@ -66,10 +78,33 @@ function NoDataHelper() {
         Using the CLI
       </Heading>
       <Text className="no-data-helper-text">
-        Specify the &lsquo;trace&rsquo; option when compressing, and provide a .cbor path to write the trace to. For
-        example:
+        Specify the &lsquo;trace&rsquo; option when compressing or decompressing, and provide a .cbor path to write the
+        trace to. For example:
+      </Text>
+      <Text className="no-data-helper-text" fontWeight="bold" mt="2">
+        Compression:
       </Text>
       <CodeBlock.Root code={cliInvocation} language={'bash'} display="inline-flex">
+        <CodeBlock.Content>
+          <Float placement="middle-end" offsetX="6" zIndex="1">
+            <CodeBlock.CopyTrigger asChild>
+              <IconButton variant="ghost" size="2xs">
+                <CodeBlock.CopyIndicator />
+              </IconButton>
+            </CodeBlock.CopyTrigger>
+          </Float>
+          <CodeBlock.Code pe="14">
+            <Span color="fg.muted" ms="4" userSelect="none">
+              $
+            </Span>
+            <CodeBlock.CodeText display="inline-block" />
+          </CodeBlock.Code>
+        </CodeBlock.Content>
+      </CodeBlock.Root>
+      <Text className="no-data-helper-text" fontWeight="bold" mt="2">
+        Decompression:
+      </Text>
+      <CodeBlock.Root code={cliDecompressInvocation} language={'bash'} display="inline-flex">
         <CodeBlock.Content>
           <Float placement="middle-end" offsetX="6" zIndex="1">
             <CodeBlock.CopyTrigger asChild>
@@ -92,7 +127,7 @@ function NoDataHelper() {
       <Heading className="no-data-helper-text" size="lg">
         Using the C++ API
       </Heading>
-      <Text className="no-data-helper-text">Enable tracing in the CCtx</Text>
+      <Text className="no-data-helper-text">Enable tracing in the CCtx or DCtx</Text>
       <Tabs.RootProvider value={tabs} size="sm" variant="line">
         <CodeBlock.Root code={activeTab.code} language={activeTab.language}>
           <CodeBlock.Header borderBottomWidth="1px">
@@ -149,6 +184,7 @@ function StreamdumpGraphContent({data}: NullableStreamdump) {
     libraryVersion: data.libraryVersion,
     frameVersion: data.frameVersion,
     traceVersion: data.traceVersion,
+    operationType: data.operationType,
   };
 
   return (

--- a/tools/visualization_app/src/graphVisualization/models/CodecDag.ts
+++ b/tools/visualization_app/src/graphVisualization/models/CodecDag.ts
@@ -27,9 +27,6 @@ export class CodecDag {
     });
     console.assert(codecs.length === this.adjList.size);
 
-    // Ensure codec at index 0 is the root
-    console.assert(codecs[0].inputStreams.length === 0);
-
     // generate dag order
     this.dagOrderList = this.findTopologicalSort(this.adjList).map((id) => this.codecList[id]);
   }

--- a/tools/visualization_app/src/graphVisualization/views/StreamdumpGraphView.tsx
+++ b/tools/visualization_app/src/graphVisualization/views/StreamdumpGraphView.tsx
@@ -9,12 +9,15 @@ import {Box} from '@chakra-ui/react/box';
 import {Button} from '@chakra-ui/react/button';
 import {Flex} from '@chakra-ui/react/flex';
 
+import {OperationType} from '../../models/idTypes';
+
 const showExpansionButton = false;
 
 interface VersionInfo {
   libraryVersion: number;
   frameVersion: number;
   traceVersion: number;
+  operationType: OperationType;
 }
 
 interface StreamdumpGraphViewProps {
@@ -44,7 +47,10 @@ export function StreamdumpGraphView({
     // The controller will use this instance for viewport manipulation, which is handled internally by React Flow
   }, [reactFlowInstance]);
   return (
-    <Box w={'100%'} h={'100%'}>
+    <Box
+      w={'100%'}
+      h={'100%'}
+      className={versionInfo.operationType === OperationType.Decompress ? 'decompress-trace' : ''}>
       <ReactFlow
         nodes={nodes}
         edges={edges}
@@ -71,6 +77,9 @@ export function StreamdumpGraphView({
               {isTrackpadMode ? 'Switch to Mouse Controls' : 'Switch to Trackpad Controls'}
             </Button>
             <div className="header-text">
+              <p style={{fontWeight: 'bold'}}>
+                {versionInfo.operationType === OperationType.Decompress ? 'Decompression Trace' : 'Compression Trace'}
+              </p>
               <p>Library Version: {versionInfo.libraryVersion}</p>
               <p>Frame Version: {versionInfo.frameVersion}</p>
               <p>Trace Version: {versionInfo.traceVersion}</p>

--- a/tools/visualization_app/src/interfaces/SerializedStreamdump.ts
+++ b/tools/visualization_app/src/interfaces/SerializedStreamdump.ts
@@ -9,6 +9,7 @@ export interface SerializedStreamdumpV1 {
   libraryVersion: number;
   frameVersion: number;
   traceVersion: number;
+  operationType?: number; // 0 = compress, 1 = decompress
   chunks: SerializedChunk[];
 }
 

--- a/tools/visualization_app/src/models/Streamdump.ts
+++ b/tools/visualization_app/src/models/Streamdump.ts
@@ -2,25 +2,36 @@
 
 import type {SerializedStreamdumpV1} from '../interfaces/SerializedStreamdump';
 import {Chunk} from './Chunk';
+import {OperationType} from './idTypes';
 
 export class Streamdump {
   readonly libraryVersion: number;
   readonly frameVersion: number;
   readonly traceVersion: number;
+  readonly operationType: OperationType;
   readonly chunks: Chunk[];
 
-  constructor(libraryVersion: number, frameVersion: number, traceVersion: number, chunks: Chunk[]) {
+  constructor(
+    libraryVersion: number,
+    frameVersion: number,
+    traceVersion: number,
+    operationType: OperationType,
+    chunks: Chunk[],
+  ) {
     this.libraryVersion = libraryVersion;
     this.frameVersion = frameVersion;
     this.traceVersion = traceVersion;
+    this.operationType = operationType;
     this.chunks = chunks;
   }
 
   static fromObject(obj: SerializedStreamdumpV1): Streamdump {
+    const operationType = obj.operationType === 1 ? OperationType.Decompress : OperationType.Compress;
     return new Streamdump(
       obj.libraryVersion,
       obj.frameVersion,
       obj.traceVersion,
+      operationType,
       obj.chunks.map((chunk, chunkId) => Chunk.fromObject(chunk, chunkId)),
     );
   }

--- a/tools/visualization_app/src/models/idTypes.ts
+++ b/tools/visualization_app/src/models/idTypes.ts
@@ -15,6 +15,11 @@ export enum ZL_Type {
   ZL_Type_string = 8,
 }
 
+export enum OperationType {
+  Compress = 0,
+  Decompress = 1,
+}
+
 export enum ZL_GraphType {
   ZL_GraphType_standard = 0,
   ZL_GraphType_static = 1,

--- a/tools/visualization_app/src/styles/streamdumpGraph.css
+++ b/tools/visualization_app/src/styles/streamdumpGraph.css
@@ -298,3 +298,19 @@
   min-width: 400px;
   max-width: 600px;
 }
+
+/* Decompress trace theme: teal/cyan accent instead of blue */
+.decompress-trace .codec-node {
+  background-color: #d0f2e8;
+  border-color: #2b9e8f;
+}
+
+.decompress-trace .codec-node.collapsed {
+  background-color: #e0f0ff;
+  border-color: #4a90d9;
+}
+
+.decompress-trace .codec-node.special-node {
+  background-color: #dadee2ad;
+  border-color: #a5a5a5;
+}

--- a/tools/visualization_app/src/utils/decodeCbor.ts
+++ b/tools/visualization_app/src/utils/decodeCbor.ts
@@ -90,6 +90,7 @@ function marshallV1(obj: object): SerializedStreamdumpV1 {
     libraryVersion: obj.libraryVersion,
     frameVersion: obj.frameVersion,
     traceVersion: 1,
+    operationType: 'operationType' in obj && typeof obj.operationType === 'number' ? obj.operationType : 0,
     chunks: obj.chunks,
   };
 }


### PR DESCRIPTION
Summary:

Mirror the visual layout of the compression graph by swapping the correspondence between codec start/end and stream in/out for decompression. This allows us to reuse the tree-structured visualization familiar to existing uses.

Reviewed By: terrelln

Differential Revision: D96990269
