### PR TITLE
split_byrange: optimization (#551)

### DIFF
--- a/include/openzl/codecs/zl_split.h
+++ b/include/openzl/codecs/zl_split.h
@@ -27,14 +27,15 @@ extern "C" {
 // will not be split.
 //
 // Optional parameter:
-//   ZL_SPLIT_BYRANGE_MIN_SEGMENT_SIZE_PID (int, default 16):
+//   ZL_SPLIT_BYRANGE_MIN_SEGMENT_SIZE_PID (int):
 //     Minimum number of elements per segment. A split is rejected if either
 //     side would have fewer elements. Higher values reduce false positives
 //     from noise; lower values allow detecting shorter segments.
+//     Default is width-dependent: larger for narrow types (u8).
 #define ZL_NODE_SPLIT_BYRANGE ZL_MAKE_NODE_ID(ZL_StandardNodeID_split_byrange)
 
 /// Optional int param: minimum segment size for split_byrange.
-/// If unset, defaults to 16.
+/// If unset, uses a width-dependent default (larger for narrow types).
 #define ZL_SPLIT_BYRANGE_MIN_SEGMENT_SIZE_PID 324
 
 // SplitN

--- a/src/openzl/codecs/splitN/encode_split_byrange_binding.c
+++ b/src/openzl/codecs/splitN/encode_split_byrange_binding.c
@@ -18,26 +18,54 @@
  * A split is rejected if either side would have fewer elements.
  * This prevents false positives from noise within a single range
  * (e.g. a single extreme value at the start of a segment).
- * Can be overridden via ZL_SPLIT_BYRANGE_MIN_SEGMENT_SIZE_PID parameter. */
-#define DEFAULT_MIN_SEGMENT_SIZE 16
+ * Can be overridden via ZL_SPLIT_BYRANGE_MIN_SEGMENT_SIZE_PID parameter.
+ * Narrow types (u8) use a larger default for robust min/max statistics. */
+#define DEFAULT_MIN_SEGMENT_SIZE 32
+
+static inline size_t defaultMinSegSizeForWidth(size_t eltWidth)
+{
+    if (eltWidth <= 1)
+        return 4 * DEFAULT_MIN_SEGMENT_SIZE; /* u8: 128 */
+    if (eltWidth <= 2)
+        return 2 * DEFAULT_MIN_SEGMENT_SIZE; /* u16: 64 */
+    return DEFAULT_MIN_SEGMENT_SIZE;         /* u32/u64: 32 */
+}
 
 /* Number of blocks on each side of a candidate split that must show
- * non-overlapping, stable ranges. M=3 allows detecting segments as short
- * as 3*blockSize (12 elements for blockSize=4), while the stability +
- * monotonicity checks prevent false positives on overlapping/monotonic data.*/
-#define CONFIRMATION_WINDOW 3
+ * non-overlapping, stable ranges. */
+#define CONFIRMATION_WINDOW 7
 
-/* Window stability factor: a window of M blocks is "stable" (from same range)
- * if windowRange <= STABILITY_K * maxBlockRange. For monotonic data, blocks
- * stack up so windowRange = M * blockRange >> STABILITY_K * blockRange.
- * For uniform random from a fixed range, all blocks have similar ranges
- * so windowRange ≈ blockRange <= STABILITY_K * blockRange. */
-#define STABILITY_K 2
+/* Gap significance factor: after confirming non-overlap between left and right
+ * windows, the split is accepted only if the gap (or transition block
+ * amplitude) exceeds GAP_FACTOR × the typical block amplitude. This rejects
+ * splits within monotonic ramps (where gap ≈ blockRange) while accepting
+ * true range boundaries (where gap >> blockRange). */
+#define GAP_FACTOR 2
 
-/* Block size is minSegSize / BLOCK_DIVISOR, with a floor of MIN_BLOCK_SIZE.
- * Smaller blocks give better boundary resolution at the cost of more blocks. */
-#define BLOCK_DIVISOR 4
-#define MIN_BLOCK_SIZE 4
+/* Stationarity factor: a window of M blocks is "stationary" (all blocks from
+ * the same range) if windowRange <= STATIONARITY_MARGIN * maxBlockRange.
+ *
+ * For n uniform samples from [0, R], expected block range = R*(n-1)/(n+1).
+ * So the theoretical ratio windowRange/maxBlockRange → (n+1)/(n-1) ≈ 1.13
+ * for n=16. In practice the ratio is even closer to 1.0 (max of M blocks
+ * pushes maxBlockRange toward R). A linear ramp gives ratio ≈ M (=7).
+ *
+ * 1.3 provides margin above the theoretical 1.13 for noisy stationary data
+ * while staying well below M. A noisy ramp needs noise > 19× the per-block
+ * trend to fool this check — at that point the trend is negligible. */
+#define STATIONARITY_NUM 13 /* windowRange * 10 <= maxBlockRange * 13 */
+#define STATIONARITY_DEN 10 /* i.e. windowRange / maxBlockRange <= 1.3 */
+
+/* Each minimum-sized segment spans BLOCK_DIVISOR blocks, giving
+ * sub-segment resolution while keeping the block count low.
+ * blockSize = minSegSize / BLOCK_DIVISOR. */
+#define BLOCK_DIVISOR 2
+
+/* Expose min block size so tests can adapt segment sizes. */
+size_t ZL_splitByRange_minBlockSize(size_t eltWidth)
+{
+    return defaultMinSegSizeForWidth(eltWidth) / BLOCK_DIVISOR;
+}
 
 /* Read element at index as uint64_t regardless of element width.
  * When called with a compile-time constant eltWidth (via force-inlined
@@ -97,8 +125,13 @@ ZL_FORCE_INLINE void computeBlockStats(
  * A candidate split between blocks b and b+1 is confirmed when:
  *   - Left window [b-M+1 .. b] and right window [b+2 .. b+M+1]
  *     (skipping transition block b+1) have non-overlapping ranges.
- *   - Both windows are "stable": windowRange <= STABILITY_K * maxBlockRange.
- *     This rejects monotonic progressions where blocks stack up.
+ *   - The separation is significant (any of three signals):
+ *     1. Gap: gap > GAP_FACTOR × typAmp (large discrete jump).
+ *     2. TransAmp: transition block amplitude > GAP_FACTOR × typAmp
+ *        (boundary falls mid-block, spanning both ranges).
+ *     3. Stationarity: both windows have windowRange / maxBlockRange
+ *        <= 1.3 (neither side is trending → non-overlap is a real
+ *        range boundary, not a ramp artifact).
  *
  * After confirming a split at block b, set leftBound=b+2 and advance
  * b by 2 to skip the transition block. The leftBound prevents the
@@ -173,51 +206,44 @@ static size_t findConfirmedSplitBlocks(
         int nonOverlap = (leftMax < rightMin) || (rightMax < leftMin);
 
         if (nonOverlap) {
-            /* Stability check: window range must not grow much beyond
-             * individual block ranges. Monotonic data fails this because
-             * each block covers a different sub-range, making the window
-             * range grow linearly with M. Uniform random from a fixed range
-             * passes because all blocks have similar ranges. */
-            uint64_t leftRange  = leftMax - leftMin;
-            uint64_t rightRange = rightMax - rightMin;
-            int leftStable =
-                    (leftMaxBR == 0) || (leftRange <= STABILITY_K * leftMaxBR);
-            int rightStable = (rightMaxBR == 0)
-                    || (rightRange <= STABILITY_K * rightMaxBR);
+            /* Significance check: accept only if the separation is
+             * meaningful, using three independent signals.
+             *
+             * Signal 1 (gap): gap between ranges > GAP_FACTOR × typAmp.
+             *   Catches boundaries aligned with block edges.
+             * Signal 2 (transAmp): transition block amplitude > GAP_FACTOR ×
+             * typAmp. Catches boundaries that fall mid-block. Signal 3
+             * (stationarity): both windows are stationary (windowRange ≈
+             * blockRange, not trending). If neither side is a ramp, non-overlap
+             * proves a real range boundary. */
+            uint64_t typAmp = (leftMaxBR > rightMaxBR) ? leftMaxBR : rightMaxBR;
+            uint64_t gap    = (leftMax < rightMin) ? rightMin - leftMax
+                                                   : leftMin - rightMax;
+            uint64_t transAmp = blockMax[b + 1] - blockMin[b + 1];
 
-            /* When the ratio-based stability check fails, it may be a
-             * false negative: the window is from a single wide range but
-             * individual blocks happen to have small ranges (high variance
-             * with small blockSize). Override if the blocks are NOT
-             * monotonically ordered — i.e., consecutive blocks overlap,
-             * confirming they're from the same range, not stacked sub-ranges.
-             * For monotonic data, consecutive blocks don't overlap. */
-            if (!leftStable && lSize >= 2) {
-                size_t ordered = 0;
-                for (size_t i = lStart; i < b; i++) {
-                    if (blockMin[i + 1] > blockMax[i]
-                        || blockMax[i + 1] < blockMin[i])
-                        ordered++;
-                }
-                /* Override if at least one pair overlaps: blocks from the
-                 * same range almost always have some overlapping pairs.
-                 * Truly monotonic data has ALL pairs non-overlapping. */
-                if (ordered < lSize - 1)
-                    leftStable = 1;
-            }
-            if (!rightStable) {
-                size_t ordered = 0;
-                for (size_t i = rStart; i < rEnd; i++) {
-                    if (blockMin[i + 1] > blockMax[i]
-                        || blockMax[i + 1] < blockMin[i])
-                        ordered++;
-                }
-                size_t rSize = rEnd - rStart + 1;
-                if (ordered < rSize - 1)
-                    rightStable = 1;
+            int significant = (typAmp == 0) || (gap > GAP_FACTOR * typAmp)
+                    || (transAmp > GAP_FACTOR * typAmp);
+
+            if (!significant) {
+                /* Stationarity: windowRange * DEN <= maxBlockRange * NUM
+                 * i.e. windowRange / maxBlockRange <= 1.3.
+                 * Guard: windowRange <= UINT64_MAX / DEN avoids overflow
+                 * on both sides (maxBlockRange <= windowRange always). */
+                uint64_t leftRange  = leftMax - leftMin;
+                uint64_t rightRange = rightMax - rightMin;
+                int leftStationary  = (leftMaxBR == 0)
+                        || (leftRange <= UINT64_MAX / STATIONARITY_DEN
+                            && leftRange * STATIONARITY_DEN
+                                    <= STATIONARITY_NUM * leftMaxBR);
+                int rightStationary = (rightMaxBR == 0)
+                        || (rightRange <= UINT64_MAX / STATIONARITY_DEN
+                            && rightRange * STATIONARITY_DEN
+                                    <= STATIONARITY_NUM * rightMaxBR);
+                if (leftStationary && rightStationary)
+                    significant = 1;
             }
 
-            if (leftStable && rightStable) {
+            if (significant) {
                 splitBlocks[nbSplits++] = b;
                 leftBound = b + 2; /* next segment starts after transition */
                 b += 2;
@@ -350,21 +376,19 @@ ZL_FORCE_INLINE void detectBoundaries_internal(
         size_t* nbSegments,
         size_t maxSegments)
 {
-    size_t const blockSize = (minSegSize / BLOCK_DIVISOR > MIN_BLOCK_SIZE)
-            ? minSegSize / BLOCK_DIVISOR
-            : MIN_BLOCK_SIZE;
-    size_t const nbBlocks  = (nbElts + blockSize - 1) / blockSize;
-    size_t const M_raw     = (nbBlocks >= 3) ? (nbBlocks - 1) / 2 : 0;
+    size_t const blockSize =
+            (minSegSize / BLOCK_DIVISOR > 0) ? minSegSize / BLOCK_DIVISOR : 1;
+    size_t const nbBlocks = (nbElts + blockSize - 1) / blockSize;
+    size_t const M_raw    = (nbBlocks >= 3) ? (nbBlocks - 1) / 2 : 0;
     size_t const M =
             (M_raw < CONFIRMATION_WINDOW) ? M_raw : CONFIRMATION_WINDOW;
 
     /* Too few blocks for confirmation windows → use M=1 (no stability
      * check, just non-overlap). This is safe for small inputs where
      * there's little room for false positives.
-     * With default parameters (minSegSize=16, blockSize=4, M=3),
-     * this branch is unreachable since the caller already handles
-     * nbElts < 2*minSegSize (=32) as a single segment. It fires
-     * only with custom small minSegmentSize values. */
+     * With default parameters, this branch is unreachable since the
+     * caller already handles nbElts < 2*minSegSize as a single segment.
+     * It fires only with custom small minSegmentSize values. */
     size_t const Meff = (M >= 2 && nbBlocks >= 2 * M + 1) ? M : 1;
     if (nbBlocks < 3) {
         segmentSizes[0] = nbElts;
@@ -597,8 +621,8 @@ EI_split_byrange(ZL_Encoder* eictx, const ZL_Input* ins[], size_t nbIns)
     size_t const eltWidth = ZL_Input_eltWidth(in);
     ZL_ASSERT(eltWidth == 1 || eltWidth == 2 || eltWidth == 4 || eltWidth == 8);
 
-    /* Read optional min segment size parameter, default to 16 */
-    size_t minSegSize = DEFAULT_MIN_SEGMENT_SIZE;
+    /* Read optional min segment size parameter, default is width-dependent */
+    size_t minSegSize = defaultMinSegSizeForWidth(eltWidth);
     {
         ZL_IntParam const mss = ZL_Encoder_getLocalIntParam(
                 eictx, ZL_SPLIT_BYRANGE_MIN_SEGMENT_SIZE_PID);
@@ -634,11 +658,10 @@ EI_split_byrange(ZL_Encoder* eictx, const ZL_Input* ins[], size_t nbIns)
     }
 
     /* Compute block parameters */
-    size_t const blockSize = (minSegSize / BLOCK_DIVISOR > MIN_BLOCK_SIZE)
-            ? minSegSize / BLOCK_DIVISOR
-            : MIN_BLOCK_SIZE;
-    size_t const nbBlocks  = (nbElts + blockSize - 1) / blockSize;
-    size_t const maxZone   = 4 * blockSize + 1;
+    size_t const blockSize =
+            (minSegSize / BLOCK_DIVISOR > 0) ? minSegSize / BLOCK_DIVISOR : 1;
+    size_t const nbBlocks = (nbElts + blockSize - 1) / blockSize;
+    size_t const maxZone  = 4 * blockSize + 1;
 
     /* Allocate scratch for block algorithm:
      *   blockMin[nb] + blockMax[nb] + suffBuf[maxZone] + suffBufMax[maxZone]

--- a/src/openzl/codecs/splitN/encode_split_byrange_binding.h
+++ b/src/openzl/codecs/splitN/encode_split_byrange_binding.h
@@ -33,6 +33,12 @@ EI_split_byrange(ZL_Encoder* eictx, const ZL_Input* ins[], size_t nbIns);
       .transform_f = EI_split_byrange, \
       .name        = "!zl.split_byrange" }
 
+/// Returns the minimum block size used by split_byrange for a given element
+/// width (in bytes: 1, 2, 4, or 8).  Block size is the granularity at which
+/// min/max statistics are computed.  Tests can use this to size segments
+/// appropriately.
+size_t ZL_splitByRange_minBlockSize(size_t eltWidth);
+
 ZL_END_C_DECLS
 
 #endif // OPENZL_CODECS_SPLITN_ENCODE_SPLIT_BYRANGE_BINDING_H

--- a/tests/codecs/test_split_byrange.cpp
+++ b/tests/codecs/test_split_byrange.cpp
@@ -144,12 +144,15 @@ TEST_F(SplitByRangeTest, MaxValues)
 
 TEST_F(SplitByRangeTest, Width8bit)
 {
+    // u8 uses large blocks (blockSize=64), so segments need many elements
+    // for reliable boundary detection with M=7.
     std::vector<uint8_t> input;
-    for (uint8_t i = 0; i < 100; i++) {
-        input.push_back(200 + (i % 50));
+    input.reserve(1200);
+    for (int i = 0; i < 600; i++) {
+        input.push_back(static_cast<uint8_t>(200 + (i % 50)));
     }
-    for (uint8_t i = 0; i < 100; i++) {
-        input.push_back(i % 50);
+    for (int i = 0; i < 600; i++) {
+        input.push_back(static_cast<uint8_t>(i % 50));
     }
     testSplitByRangeRoundTrip(input);
 }

--- a/tests/codecs/test_split_byrange_generator.cpp
+++ b/tests/codecs/test_split_byrange_generator.cpp
@@ -198,37 +198,38 @@ TEST_F(SplitByRangeGeneratorTest, Stage1_TwoRanges_HighThenLow)
 
 TEST_F(SplitByRangeGeneratorTest, Stage2_ThreeRanges_HighLowHigher)
 {
-    // A=[100,200], B=[5,50], C=[500,600]
-    // First pass finds boundary between [A,B] and C.
-    // Second pass (recursive) finds boundary between A and B.
+    // A=[500,600], B=[0,50], C=[1500,1600]
+    // Gaps (400, 1450) >> 2×typAmp (~100) for reliable detection.
     auto data = generateSample(
             {
-                    { 100, 200, 300 },
-                    { 5, 50, 200 },
-                    { 500, 600, 400 },
+                    { 500, 600, 300 },
+                    { 0, 50, 200 },
+                    { 1500, 1600, 400 },
             });
-    printf("Stage 2: Three ranges high-low-higher (100-200, 5-50, 500-600)\n");
+    printf("Stage 2: Three ranges high-low-higher (500-600, 0-50, 1500-1600)\n");
     verifyExactBoundaries(data, { 300, 200, 400 });
 }
 
 TEST_F(SplitByRangeGeneratorTest, Stage2_ThreeRanges_Ascending)
 {
+    // Gaps (300) >> 2×typAmp (~100) for reliable detection.
     auto data = generateSample(
             {
                     { 0, 100, 200 },
-                    { 200, 300, 200 },
                     { 400, 500, 200 },
+                    { 800, 900, 200 },
             });
-    printf("Stage 2: Three ascending ranges (0-100, 200-300, 400-500)\n");
+    printf("Stage 2: Three ascending ranges (0-100, 400-500, 800-900)\n");
     verifyExactBoundaries(data, { 200, 200, 200 });
 }
 
 TEST_F(SplitByRangeGeneratorTest, Stage2_ThreeRanges_Descending)
 {
+    // Gaps (300) >> 2×typAmp (~100) for reliable detection.
     auto data = generateSample(
             {
+                    { 800, 900, 200 },
                     { 400, 500, 200 },
-                    { 200, 300, 200 },
                     { 0, 100, 200 },
             });
     printf("Stage 2: Three descending ranges\n");
@@ -241,17 +242,18 @@ TEST_F(SplitByRangeGeneratorTest, Stage2_ThreeRanges_Descending)
 
 TEST_F(SplitByRangeGeneratorTest, Stage3_FiveRanges_Ascending)
 {
-    // Ranges in ascending order: prefix max always < suffix min at boundaries
+    // Ranges in ascending order: prefix max always < suffix min at boundaries.
+    // Each segment needs >= M*blockSize = 7*16 = 112 elements for u32.
     auto data = generateSample(
             {
-                    { 0, 50, 100 },
-                    { 500, 550, 150 },
-                    { 1000, 1100, 200 },
-                    { 2000, 2100, 100 },
-                    { 3000, 3100, 150 },
+                    { 0, 50, 150 },
+                    { 500, 550, 200 },
+                    { 1000, 1100, 250 },
+                    { 2000, 2100, 150 },
+                    { 3000, 3100, 200 },
             });
     printf("Stage 3: Five ascending ranges\n");
-    verifyExactBoundaries(data, { 100, 150, 200, 100, 150 });
+    verifyExactBoundaries(data, { 150, 200, 250, 150, 200 });
 }
 
 TEST_F(SplitByRangeGeneratorTest, Stage3_FiveRanges_Descending)
@@ -259,14 +261,14 @@ TEST_F(SplitByRangeGeneratorTest, Stage3_FiveRanges_Descending)
     // Ranges in descending order: suffix max always < prefix min at boundaries
     auto data = generateSample(
             {
-                    { 3000, 3100, 150 },
-                    { 2000, 2100, 100 },
-                    { 1000, 1100, 200 },
-                    { 500, 550, 150 },
-                    { 0, 50, 100 },
+                    { 3000, 3100, 200 },
+                    { 2000, 2100, 150 },
+                    { 1000, 1100, 250 },
+                    { 500, 550, 200 },
+                    { 0, 50, 150 },
             });
     printf("Stage 3: Five descending ranges\n");
-    verifyExactBoundaries(data, { 150, 100, 200, 150, 100 });
+    verifyExactBoundaries(data, { 200, 150, 250, 200, 150 });
 }
 
 TEST_F(SplitByRangeGeneratorTest, Stage3_FourRanges_Valley)
@@ -274,12 +276,12 @@ TEST_F(SplitByRangeGeneratorTest, Stage3_FourRanges_Valley)
     // Valley pattern: high, low, high — prefix/suffix splits find boundaries
     auto data = generateSample(
             {
-                    { 2000, 2100, 100 },
-                    { 0, 50, 200 },
-                    { 3000, 3100, 150 },
+                    { 2000, 2100, 150 },
+                    { 0, 50, 250 },
+                    { 3000, 3100, 200 },
             });
     printf("Stage 3: Valley pattern (high, low, high)\n");
-    verifyExactBoundaries(data, { 100, 200, 150 });
+    verifyExactBoundaries(data, { 150, 250, 200 });
 }
 
 // =============================================================================
@@ -314,16 +316,17 @@ TEST_F(SplitByRangeGeneratorTest, Stage4_NearRanges_Gap10)
 
 TEST_F(SplitByRangeGeneratorTest, Stage5_TenAscendingSegments)
 {
-    // 10 contiguous segments with ascending ranges — algorithm can split these
+    // 10 contiguous segments with ascending ranges — algorithm can split these.
+    // Each segment needs >= M*blockSize = 7*16 = 112 elements for u32.
     std::vector<RangeSpec> specs;
     std::vector<size_t> expectedSizes;
     for (int i = 0; i < 10; i++) {
         uint32_t base = static_cast<uint32_t>(i) * 1000;
-        specs.push_back({ base, base + 100, 50 });
-        expectedSizes.push_back(50);
+        specs.push_back({ base, base + 100, 150 });
+        expectedSizes.push_back(150);
     }
     auto data = generateSample(specs);
-    printf("Stage 5: 10 ascending segments of 50 elements each\n");
+    printf("Stage 5: 10 ascending segments of 150 elements each\n");
     verifyExactBoundaries(data, expectedSizes);
 }
 
@@ -376,26 +379,29 @@ TEST_F(SplitByRangeGeneratorTest, Stage7_OverlappingRanges_NoSplit)
 
 TEST_F(SplitByRangeGeneratorTest, Stage8_MinSizeSegments)
 {
-    // Each segment has exactly 16 elements (the default minimum)
+    // Each segment has exactly minSegSize=32 elements (the default for u32).
+    // With blockSize=16 and M=7, 2 blocks per segment is too few for full
+    // confirmation, but the Meff fallback to 1 still detects well-separated
+    // ranges.
+    auto data = generateSample(
+            {
+                    { 1000, 1100, 150 },
+                    { 0, 50, 150 },
+            });
+    printf("Stage 8: Two segments of 150 elements each\n");
+    verifyExactBoundaries(data, { 150, 150 });
+}
+
+TEST_F(SplitByRangeGeneratorTest, Stage8b_BelowMinSize_NoSplit)
+{
+    // 32 elements total < 2*DEFAULT_MIN_SEGMENT_SIZE=64, so no split
     auto data = generateSample(
             {
                     { 1000, 1100, 16 },
                     { 0, 50, 16 },
             });
-    printf("Stage 8: Two segments of 16 elements each (default min size)\n");
-    verifyExactBoundaries(data, { 16, 16 });
-}
-
-TEST_F(SplitByRangeGeneratorTest, Stage8b_BelowMinSize_NoSplit)
-{
-    // 16 elements total < 2*DEFAULT_MIN_SEGMENT_SIZE=32, so no split
-    auto data = generateSample(
-            {
-                    { 1000, 1100, 8 },
-                    { 0, 50, 8 },
-            });
     printf("Stage 8b: Below default min size, no split expected\n");
-    verifyExactBoundaries(data, { 16 });
+    verifyExactBoundaries(data, { 32 });
 }
 
 // =============================================================================
@@ -471,13 +477,13 @@ TEST_F(SplitByRangeGeneratorTest, Stage11_FourRanges_Shuffled)
     // D=[3000,3100], A=[0,50], C=[1000,1100], B=[500,550]
     auto data = generateSample(
             {
-                    { 3000, 3100, 100 },
-                    { 0, 50, 150 },
-                    { 1000, 1100, 100 },
-                    { 500, 550, 200 },
+                    { 3000, 3100, 150 },
+                    { 0, 50, 200 },
+                    { 1000, 1100, 150 },
+                    { 500, 550, 250 },
             });
     printf("Stage 11: Four ranges in non-monotonic order\n");
-    verifyExactBoundaries(data, { 100, 150, 100, 200 });
+    verifyExactBoundaries(data, { 150, 200, 150, 250 });
 }
 
 // =============================================================================
@@ -486,44 +492,48 @@ TEST_F(SplitByRangeGeneratorTest, Stage11_FourRanges_Shuffled)
 
 TEST_F(SplitByRangeGeneratorTest, Stage12_Width8bit)
 {
+    // u8: minSegSize=128, blockSize=64. Need >= M*64 = 448 elts per segment.
     auto data = generateTypedSample<uint8_t>({
-            { 200, 250, 50 },
-            { 0, 30, 50 },
+            { 200, 250, 512 },
+            { 0, 30, 512 },
     });
     printf("Stage 12: u8 two ranges (200-250, 0-30)\n");
-    verifyTypedExactBoundaries<uint8_t>(data, { 50, 50 });
+    verifyTypedExactBoundaries<uint8_t>(data, { 512, 512 });
 }
 
 TEST_F(SplitByRangeGeneratorTest, Stage12_Width16bit)
 {
+    // u16: minSegSize=64, blockSize=32. Need >= M*32 = 224 elts per segment.
     auto data = generateTypedSample<uint16_t>({
-            { 0, 100, 100 },
-            { 50000, 60000, 100 },
-            { 200, 300, 100 },
+            { 0, 100, 256 },
+            { 50000, 60000, 256 },
+            { 200, 300, 256 },
     });
     printf("Stage 12: u16 three ascending-then-low ranges\n");
-    verifyTypedExactBoundaries<uint16_t>(data, { 100, 100, 100 });
+    verifyTypedExactBoundaries<uint16_t>(data, { 256, 256, 256 });
 }
 
 TEST_F(SplitByRangeGeneratorTest, Stage12_Width64bit)
 {
+    // u64: minSegSize=32, blockSize=16. Need >= M*16 = 112 elts per segment.
     auto data = generateTypedSample<uint64_t>({
-            { 1000000000ULL, 1000001000ULL, 100 },
-            { 0, 500, 100 },
+            { 1000000000ULL, 1000001000ULL, 150 },
+            { 0, 500, 150 },
     });
     printf("Stage 12: u64 two ranges (1e9-range, 0-500)\n");
-    verifyTypedExactBoundaries<uint64_t>(data, { 100, 100 });
+    verifyTypedExactBoundaries<uint64_t>(data, { 150, 150 });
 }
 
 TEST_F(SplitByRangeGeneratorTest, Stage12_Width8bit_ThreeRanges)
 {
+    // u8: blockSize=64, need >= 448 elts per segment for M=7.
     auto data = generateTypedSample<uint8_t>({
-            { 0, 10, 30 },
-            { 100, 110, 30 },
-            { 200, 210, 30 },
+            { 0, 10, 512 },
+            { 100, 110, 512 },
+            { 200, 210, 512 },
     });
     printf("Stage 12: u8 three ascending ranges\n");
-    verifyTypedExactBoundaries<uint8_t>(data, { 30, 30, 30 });
+    verifyTypedExactBoundaries<uint8_t>(data, { 512, 512, 512 });
 }
 
 // =============================================================================
@@ -532,15 +542,17 @@ TEST_F(SplitByRangeGeneratorTest, Stage12_Width8bit_ThreeRanges)
 
 TEST_F(SplitByRangeGeneratorTest, Stage13_SmallMinSegSize_AllowsSmallSegments)
 {
-    // With default minSegmentSize=16, 8-element segments can't be detected.
-    // With minSegmentSize=4, they can.
+    // With default minSegmentSize (32 for u32), total < 2*32 triggers early
+    // exit (no split).  With minSegmentSize=4, the early exit threshold drops
+    // to 2*4=8, allowing the split to proceed.  blockSize=4/2=2, so 24/2=12
+    // blocks per segment, enough for M=7 confirmation.
     auto data = generateSample(
             {
-                    { 1000, 1100, 8 },
-                    { 0, 50, 8 },
+                    { 1000, 1100, 24 },
+                    { 0, 50, 24 },
             });
-    printf("Stage 13: minSegmentSize=4 allows 8-element segments\n");
-    verifyExactBoundariesWithMinSegSize(data, { 8, 8 }, 4);
+    printf("Stage 13: minSegmentSize=4 allows 24-element segments\n");
+    verifyExactBoundariesWithMinSegSize(data, { 24, 24 }, 4);
 }
 
 TEST_F(SplitByRangeGeneratorTest, Stage13_LargeMinSegSize_PreventsSmallSplits)
@@ -563,8 +575,8 @@ TEST_F(SplitByRangeGeneratorTest, Stage13_DefaultParam_SameAsUnparameterized)
                     { 0, 100, 200 },
                     { 1000, 1100, 200 },
             });
-    printf("Stage 13: Explicit default minSegmentSize=16\n");
-    verifyExactBoundariesWithMinSegSize(data, { 200, 200 }, 16);
+    printf("Stage 13: Explicit default minSegmentSize=32\n");
+    verifyExactBoundariesWithMinSegSize(data, { 200, 200 }, 32);
 }
 
 // =============================================================================
@@ -605,85 +617,85 @@ TEST_F(SplitByRangeGeneratorTest, Stage14_ABCBA_Palindrome)
     // Palindrome pattern: ranges go up then back down to same values.
     auto data = generateSample(
             {
-                    { 0, 50, 100 },
-                    { 500, 600, 100 },
-                    { 2000, 2100, 100 },
-                    { 500, 600, 100 },
-                    { 0, 50, 100 },
+                    { 0, 50, 150 },
+                    { 500, 600, 150 },
+                    { 2000, 2100, 150 },
+                    { 500, 600, 150 },
+                    { 0, 50, 150 },
             });
     printf("Stage 14: A-B-C-B-A palindrome pattern\n");
-    verifyExactBoundaries(data, { 100, 100, 100, 100, 100 });
+    verifyExactBoundaries(data, { 150, 150, 150, 150, 150 });
 }
 
 // =============================================================================
 // Stage 15: Short segments between larger ones (confirmation window stress)
 // =============================================================================
 
-TEST_F(SplitByRangeGeneratorTest, Stage15_ShortMiddle_16elts)
+TEST_F(SplitByRangeGeneratorTest, Stage15_ShortMiddle)
 {
-    // Short segment (exactly minSegSize=16) between two large segments.
-    // Requires M <= 3 to detect — M=4 can't fit a confirmation window.
+    // Short segment between two large segments.  Must span >= M blocks
+    // (7*16=112 for u32) for both adjacent boundaries' confirmation windows.
     auto data = generateSample(
             {
-                    { 5000, 6000, 200 },
-                    { 0, 100, 16 },
-                    { 8000, 9000, 200 },
+                    { 5000, 6000, 300 },
+                    { 0, 100, 128 },
+                    { 8000, 9000, 300 },
             });
-    printf("Stage 15: Short middle segment (16 elements)\n");
-    verifyExactBoundaries(data, { 200, 16, 200 });
+    printf("Stage 15: Short middle segment\n");
+    verifyExactBoundaries(data, { 300, 128, 300 });
 }
 
 TEST_F(SplitByRangeGeneratorTest, Stage15_TwoShortMiddles)
 {
-    // Two short segments, each 16 elements, between larger ones.
+    // Two short segments between larger ones.
     auto data = generateSample(
             {
-                    { 5000, 6000, 100 },
-                    { 0, 100, 16 },
-                    { 8000, 9000, 100 },
-                    { 200, 300, 16 },
-                    { 12000, 13000, 100 },
+                    { 5000, 6000, 200 },
+                    { 0, 100, 128 },
+                    { 8000, 9000, 200 },
+                    { 200, 300, 128 },
+                    { 12000, 13000, 200 },
             });
-    printf("Stage 15: Two short middle segments (16 elements each)\n");
-    verifyExactBoundaries(data, { 100, 16, 100, 16, 100 });
+    printf("Stage 15: Two short middle segments\n");
+    verifyExactBoundaries(data, { 200, 128, 200, 128, 200 });
 }
 
-TEST_F(SplitByRangeGeneratorTest, Stage15_ShortFirst_16elts)
+TEST_F(SplitByRangeGeneratorTest, Stage15_ShortFirst)
 {
     // Short segment at the beginning.
     auto data = generateSample(
             {
-                    { 0, 100, 16 },
-                    { 5000, 6000, 200 },
+                    { 0, 100, 128 },
+                    { 5000, 6000, 300 },
             });
-    printf("Stage 15: Short first segment (16 elements)\n");
-    verifyExactBoundaries(data, { 16, 200 });
+    printf("Stage 15: Short first segment\n");
+    verifyExactBoundaries(data, { 128, 300 });
 }
 
-TEST_F(SplitByRangeGeneratorTest, Stage15_ShortLast_16elts)
+TEST_F(SplitByRangeGeneratorTest, Stage15_ShortLast)
 {
     // Short segment at the end.
     auto data = generateSample(
             {
-                    { 5000, 6000, 200 },
-                    { 0, 100, 16 },
+                    { 5000, 6000, 300 },
+                    { 0, 100, 128 },
             });
-    printf("Stage 15: Short last segment (16 elements)\n");
-    verifyExactBoundaries(data, { 200, 16 });
+    printf("Stage 15: Short last segment\n");
+    verifyExactBoundaries(data, { 300, 128 });
 }
 
 TEST_F(SplitByRangeGeneratorTest, Stage15_ConsecutiveShort)
 {
-    // Two consecutive short (16-element) segments.
+    // Two consecutive short segments.
     auto data = generateSample(
             {
-                    { 5000, 6000, 100 },
-                    { 0, 100, 16 },
-                    { 2000, 2100, 16 },
-                    { 8000, 9000, 100 },
+                    { 5000, 6000, 200 },
+                    { 0, 100, 128 },
+                    { 2000, 2100, 128 },
+                    { 8000, 9000, 200 },
             });
     printf("Stage 15: Two consecutive short segments\n");
-    verifyExactBoundaries(data, { 100, 16, 16, 100 });
+    verifyExactBoundaries(data, { 200, 128, 128, 200 });
 }
 
 // =============================================================================
@@ -692,15 +704,15 @@ TEST_F(SplitByRangeGeneratorTest, Stage15_ConsecutiveShort)
 
 TEST_F(SplitByRangeGeneratorTest, Stage16_ABA_ShortB)
 {
-    // A-B-A where B is the minimum size (16 elements).
+    // A-B-A where B is a short segment (>= M*blockSize = 112 for u32).
     auto data = generateSample(
             {
-                    { 100, 200, 200 },
-                    { 5000, 6000, 16 },
-                    { 100, 200, 200 },
+                    { 100, 200, 300 },
+                    { 5000, 6000, 128 },
+                    { 100, 200, 300 },
             });
-    printf("Stage 16: A-B-A with short B (16 elements)\n");
-    verifyExactBoundaries(data, { 200, 16, 200 });
+    printf("Stage 16: A-B-A with short B\n");
+    verifyExactBoundaries(data, { 300, 128, 300 });
 }
 
 TEST_F(SplitByRangeGeneratorTest, Stage16_ABAB_ShortB)
@@ -708,13 +720,13 @@ TEST_F(SplitByRangeGeneratorTest, Stage16_ABAB_ShortB)
     // A-B-A-B where both B segments are short.
     auto data = generateSample(
             {
-                    { 0, 100, 100 },
-                    { 5000, 6000, 16 },
-                    { 0, 100, 100 },
-                    { 5000, 6000, 16 },
+                    { 0, 100, 200 },
+                    { 5000, 6000, 128 },
+                    { 0, 100, 200 },
+                    { 5000, 6000, 128 },
             });
     printf("Stage 16: A-B-A-B with short B segments\n");
-    verifyExactBoundaries(data, { 100, 16, 100, 16 });
+    verifyExactBoundaries(data, { 200, 128, 200, 128 });
 }
 
 // =============================================================================
@@ -743,12 +755,12 @@ static unsigned getNumSeeds()
 //    sides. We pre-generate all amplitudes, then compute each gap based
 //    on the actual adjacent pair — no global worst-case needed.
 //
-// 2. Each segment ≥ 256 elements (32 blocks at blockSize=8).
-//    Well above the 7-block minimum for M=3 confirmation windows.
+// 2. Each segment ≥ 512 elements (32 blocks at blockSize=16).
+//    Well above the 7-block minimum for M=7 confirmation windows.
 //
-// 3. minSegSize=32 → blockSize=max(32/4,4)=8. With 8 elements per block,
-//    the probability of the stability heuristic false-negative drops to
-//    ~6e-9 per boundary. (With blockSize=4, it's ~2e-4.)
+// 3. FIXED_MIN_SEG_SIZE=32 → blockSize=32/2=16. With 16 elements per
+//    block, the probability of the stability heuristic false-negative
+//    is negligible.
 //    Custom minSegSize values are tested deterministically in Stage 13.
 //
 // These invariants are symmetric — ascending/descending/valley all use
@@ -757,7 +769,7 @@ static unsigned getNumSeeds()
 static constexpr uint64_t AMP_MIN       = 50;
 static constexpr uint64_t AMP_MAX       = 500;
 static constexpr int FIXED_MIN_SEG_SIZE = 32;
-static constexpr size_t MIN_SEG_ELTS    = 256;
+static constexpr size_t MIN_SEG_ELTS    = 512;
 
 // Helper: build ascending ranges from pre-generated parameters.
 // Returns the number of ranges that fit in the value space.


### PR DESCRIPTION
Summary:

Improve splitting logic, to reduce the number of spurious segments, and improve speed.
Removed the ad-hoc STABILITY_K ratio check + monotonic overlap override with
three principled, independent signals for confirming range boundaries:

1. **Gap signal**: gap > 2 × typAmp — catches boundaries aligned with block
   edges where the inter-range gap is much larger than block-level noise.

2. **Transition signal**: transAmp > 2 × typAmp — catches boundaries that fall
    mid-block, where the transition block spans elements from both ranges.

3. **Stationarity signal**: both windows have windowRange/maxBlockRange ≤ 1.3 —
    confirms neither side is a ramp/trend. For n uniform samples from [0,R],
    the theoretical ratio is (n+1)/(n-1) ≈ 1.13 for n=16; a linear ramp gives
    ratio ≈ M (=7). The 1.3 threshold provides margin above 1.13 while rejecting
    any meaningful trend.

Also widens gaps in Stage2 deterministic tests to avoid block-boundary alignment
edge cases (gap must be > 2× typAmp for the gap signal; with gap ≈ amplitude and
boundary on a block edge, only stationarity saves it, which is correct but makes
test expectations depend on block alignment).

Validated on real datasets:
- air_co: all 12 files → 1 segment (no false positives, was 17 spurious segments
   with pre-BLOCK_DIVISOR params)
- sao_sdec0: 17 boundaries detected → 18 segments (all meaningful range splits)

Encode speed (splitByRange → STORE, 256 KB u32 data, best of 3 runs, opt build):

    | Width | nosplit | 2ranges | 5ranges | 10ranges | ascending | valley | speed% |
    |-------|---------|---------|---------|----------|-----------|--------|--------|
    | u8    |     949 |     946 |     952 |      954 |       952 |    953 |  +170% |
    | u16   |    1497 |    1483 |    1489 |     1480 |      1484 |   1484 |  +120% |
    | u32   |    1791 |    1518 |    1377 |     1309 |      1353 |   1374 |   +36% |
    | u64   |    2831 |    2455 |    2244 |     2119 |      2212 |   2241 |   +16% |
    (MB/s, higher is better)




