### PR TITLE
Share fillCSize between compress and decompress traces

### DIFF
--- a/cpp/src/openzl/cpp/experimental/trace/ChunkTraceCore.cpp
+++ b/cpp/src/openzl/cpp/experimental/trace/ChunkTraceCore.cpp
@@ -93,6 +93,50 @@ void ChunkTraceCore::finalizeUnconsumedStreams(
     }
 }
 
+size_t ChunkTraceCore::fillCSize(
+        const StreamID& streamID,
+        std::map<ZL_DataID, Stream, ZL_DataIDCustomComparator>& streamInfo,
+        const std::vector<Codec>& codecInfo,
+        size_t totalSize)
+{
+    Stream& stream = streamInfo.at(streamID);
+
+    // Already computed
+    if (stream.cSize != 0) {
+        return stream.cSize;
+    }
+
+    // Base case: stream has no successors
+    if (stream.successors.empty()) {
+        stream.cSize = stream.contentSize;
+        stream.share = totalSize > 0 ? static_cast<double>(stream.cSize)
+                        / static_cast<double>(totalSize) * 100
+                                     : 0;
+        return stream.cSize;
+    }
+
+    // Start with the header size from the consumer codec
+    if (stream.consumerCodec.has_value()) {
+        stream.cSize = codecInfo[stream.consumerCodec.value()].cHeaderSize;
+    }
+
+    // Recursively sum the cSize of successor streams
+    for (const auto& successor : stream.successors) {
+        stream.cSize += fillCSize(successor, streamInfo, codecInfo, totalSize);
+    }
+
+    // If the consumer codec has multiple inputs, assume each input
+    // provides equal contribution
+    if (stream.consumerCodec.has_value()) {
+        stream.cSize /= codecInfo[stream.consumerCodec.value()].inEdges.size();
+    }
+
+    stream.share = totalSize > 0 ? static_cast<double>(stream.cSize)
+                    / static_cast<double>(totalSize) * 100
+                                 : 0;
+    return stream.cSize;
+}
+
 ZL_Report ChunkTraceCore::serializeChunkDataToCBOR(
         A1C_Arena* a1c_arena,
         A1C_ArrayBuilder* chunkArrayBuilder,

--- a/cpp/src/openzl/cpp/experimental/trace/ChunkTraceCore.hpp
+++ b/cpp/src/openzl/cpp/experimental/trace/ChunkTraceCore.hpp
@@ -81,6 +81,17 @@ class ChunkTraceCore {
             size_t chunkId);
 
     /**
+     * Recursively computes the compressed size (cSize) of a stream by
+     * summing the cSize of its successors. Uses Stream::cSize directly
+     * for memoization (0 means not yet computed).
+     */
+    static size_t fillCSize(
+            const StreamID& streamID,
+            std::map<ZL_DataID, Stream, ZL_DataIDCustomComparator>& streamInfo,
+            const std::vector<Codec>& codecInfo,
+            size_t totalSize);
+
+    /**
      * Serializes chunkId, streams, codecs, and optionally graphs into
      * a CBOR chunk item appended to chunkArrayBuilder.
      * cctx may be nullptr (decompress side).

--- a/cpp/src/openzl/cpp/experimental/trace/CompressChunkTrace.cpp
+++ b/cpp/src/openzl/cpp/experimental/trace/CompressChunkTrace.cpp
@@ -247,15 +247,12 @@ inline std::string streamTypeToStr(ZL_Type stype)
 
 void CompressChunkTrace::printStreamMetadata()
 {
-    std::vector<size_t> cSize(streamInfo_.size(), SIZE_MAX);
     std::cout << "digraph stream_topo {" << std::endl;
     for (auto& s : streamInfo_) {
-        const StreamID streamID     = s.first;
-        ZL_IDType sid               = streamID.sid;
-        streamInfo_[streamID].cSize = fillCSize(cSize, streamID);
-        streamInfo_[streamID].share =
-                static_cast<double>(streamInfo_[streamID].cSize)
-                / static_cast<double>(compressedSize_) * 100;
+        const StreamID streamID = s.first;
+        ZL_IDType sid           = streamID.sid;
+        ChunkTraceCore::fillCSize(
+                streamID, streamInfo_, codecInfo_, compressedSize_);
 
         Stream metadata = s.second;
         std::cout << 'S' << sid << " [shape=record, label=\"Stream: " << sid
@@ -401,43 +398,6 @@ void CompressChunkTrace::printCodecMetadata()
     }
 
     std::cout << "}" << std::endl;
-}
-
-size_t CompressChunkTrace::fillCSize(
-        std::vector<size_t>& cSize,
-        const StreamID streamID)
-{
-    size_t cSize_idx = streamID.sid;
-    // already filled up
-    if (cSize.size() != 0 && cSize[cSize_idx] != SIZE_MAX) {
-        return cSize[cSize_idx];
-    }
-
-    const Stream& stream = streamInfo_.at(streamID);
-
-    // base case: stream has no successors, and is input to the frame
-    if (stream.successors.empty()) {
-        cSize[cSize_idx] = stream.contentSize;
-        return cSize[cSize_idx];
-    }
-
-    // Get the header size
-    if (stream.consumerCodec.has_value()) {
-        cSize[cSize_idx] = codecInfo_[stream.consumerCodec.value()].cHeaderSize;
-    } else {
-        cSize[cSize_idx] = 0;
-    }
-
-    // recursively fill cSize of this stream by summing the cSize of its
-    // successor streams
-    for (const auto& successor : stream.successors) {
-        cSize[cSize_idx] += fillCSize(cSize, successor);
-    }
-
-    // if the consumer codec has multiple inputs, assume each input provides
-    // equal contribution
-    cSize[cSize_idx] /= codecInfo_[stream.consumerCodec.value()].inEdges.size();
-    return cSize[cSize_idx];
 }
 
 void CompressChunkTrace::on_codecEncode_start(

--- a/cpp/src/openzl/cpp/experimental/trace/CompressChunkTrace.hpp
+++ b/cpp/src/openzl/cpp/experimental/trace/CompressChunkTrace.hpp
@@ -113,7 +113,6 @@ class CompressChunkTrace {
    private:
     void printStreamMetadata();
     void printCodecMetadata();
-    size_t fillCSize(std::vector<size_t>& cSize, const ZL_DataID streamID);
 
     const size_t chunkId_;    // chunk ID for this specific chunk trace
     size_t compressedSize_{}; // compressed size for this specific chunk

--- a/cpp/src/openzl/cpp/experimental/trace/DecompressChunkTrace.cpp
+++ b/cpp/src/openzl/cpp/experimental/trace/DecompressChunkTrace.cpp
@@ -46,6 +46,12 @@ void DecompressChunkTrace::finalizeTrace(ZL_Report result)
         ChunkTraceCore::finalizeUnsourcedStreams(
                 "zl.regen", streamInfo_, codecInfo_, currCodecNum_, chunkId_);
     }
+
+    // Fill cSize and share for all streams
+    for (auto& [streamID, stream] : streamInfo_) {
+        ChunkTraceCore::fillCSize(
+                streamID, streamInfo_, codecInfo_, totalCompressedSize_);
+    }
 }
 
 ZL_Report DecompressChunkTrace::serializeToCBOR(
@@ -91,6 +97,8 @@ void DecompressChunkTrace::on_codecDecode_start(
                     codecInfo_,
                     currCodecNum_,
                     chunkId_);
+            // NB: this does not account for the various non-codec header costs
+            totalCompressedSize_ += streamInfo_[streamID].contentSize;
         }
     }
 

--- a/cpp/src/openzl/cpp/experimental/trace/DecompressChunkTrace.hpp
+++ b/cpp/src/openzl/cpp/experimental/trace/DecompressChunkTrace.hpp
@@ -55,7 +55,8 @@ class DecompressChunkTrace {
     void streamdump(const ZL_Data* data);
 
     const size_t chunkId_;
-    size_t currCodecNum_ = 0;
+    size_t totalCompressedSize_ = 0;
+    size_t currCodecNum_        = 0;
     std::map<ZL_DataID, Stream, ZL_DataIDCustomComparator> streamInfo_;
     std::map<size_t, std::pair<std::string, std::string>> streamdump_;
     std::vector<Codec> codecInfo_;


### PR DESCRIPTION
Summary:
Pull `fillCSize` into shared `ChunkTraceCore` so both compress and decompress traces can compute per-stream compressed size and share. The shared version uses `Stream::cSize` directly for memoization (replacing the old `std::vector<size_t>` cache) and computes `share` inline.

On the decompress side, `totalCompressedSize` is accumulated eagerly in `on_codecDecode_start` as stored input streams are discovered, since post-finalization heuristics (e.g. `successors.empty()`) are unreliable after source/sink codecs have been wired up. This does not account for non-codec header costs.

Changes:
- `ChunkTraceCore`: Added shared `fillCSize` that recursively computes `cSize` and `share` on `Stream` metadata directly
- `CompressChunkTrace`: Replaced private `fillCSize` (with `std::vector<size_t>` cache) with `ChunkTraceCore::fillCSize`; removed separate `share` calculation
- `DecompressChunkTrace`: Added `totalCompressedSize_` member accumulated during `on_codecDecode_start`; calls `ChunkTraceCore::fillCSize` in `finalizeTrace`

Reviewed By: terrelln

Differential Revision: D97007149


