### PR TITLE
Eagerly resolve error strings in trace codecs and graphs

### DIFF
--- a/cpp/src/openzl/cpp/experimental/trace/ChunkTraceCore.cpp
+++ b/cpp/src/openzl/cpp/experimental/trace/ChunkTraceCore.cpp
@@ -265,8 +265,7 @@ ZL_Report ChunkTraceCore::serializeChunkDataToCBOR(
         size_t chunkId,
         std::map<ZL_DataID, Stream, ZL_DataIDCustomComparator>& streamInfo,
         std::vector<Codec>& codecInfo,
-        std::vector<Graph>& graphInfo,
-        const ZL_CCtx* cctx)
+        std::vector<Graph>& graphInfo)
 {
     A1C_ARRAY_TRY_ADD_R(chunkItem, *chunkArrayBuilder);
     A1C_MapBuilder chunkBuilder = A1C_Item_map_builder(chunkItem, 4, a1c_arena);
@@ -294,7 +293,7 @@ ZL_Report ChunkTraceCore::serializeChunkDataToCBOR(
     for (size_t codecNum = 0; codecNum < codecInfo.size(); ++codecNum) {
         Codec& codec = codecInfo[codecNum];
         A1C_ARRAY_TRY_ADD_R(a1c_codec, codecsBuilder);
-        ZL_RET_R_IF_ERR(codec.serializeCodec(a1c_arena, a1c_codec, cctx));
+        ZL_RET_R_IF_ERR(codec.serializeCodec(a1c_arena, a1c_codec));
     }
 
     // Graphs (empty array for decompress)
@@ -305,7 +304,7 @@ ZL_Report ChunkTraceCore::serializeChunkDataToCBOR(
     ZL_RET_R_IF_NULL(allocation, graphsBuilder.array);
     for (auto& graph : graphInfo) {
         A1C_ARRAY_TRY_ADD_R(a1c_graph, graphsBuilder);
-        ZL_RET_R_IF_ERR(graph.serializeGraph(a1c_arena, a1c_graph, cctx));
+        ZL_RET_R_IF_ERR(graph.serializeGraph(a1c_arena, a1c_graph));
     }
 
     return ZL_returnSuccess();

--- a/cpp/src/openzl/cpp/experimental/trace/ChunkTraceCore.cpp
+++ b/cpp/src/openzl/cpp/experimental/trace/ChunkTraceCore.cpp
@@ -93,6 +93,50 @@ void ChunkTraceCore::finalizeUnconsumedStreams(
     }
 }
 
+size_t ChunkTraceCore::fillCSize(
+        const StreamID& streamID,
+        std::map<ZL_DataID, Stream, ZL_DataIDCustomComparator>& streamInfo,
+        const std::vector<Codec>& codecInfo,
+        size_t totalSize)
+{
+    Stream& stream = streamInfo.at(streamID);
+
+    // Already computed
+    if (stream.cSize != 0) {
+        return stream.cSize;
+    }
+
+    // Base case: stream has no successors
+    if (stream.successors.empty()) {
+        stream.cSize = stream.contentSize;
+        stream.share = totalSize > 0 ? static_cast<double>(stream.cSize)
+                        / static_cast<double>(totalSize) * 100
+                                     : 0;
+        return stream.cSize;
+    }
+
+    // Start with the header size from the consumer codec
+    if (stream.consumerCodec.has_value()) {
+        stream.cSize = codecInfo[stream.consumerCodec.value()].cHeaderSize;
+    }
+
+    // Recursively sum the cSize of successor streams
+    for (const auto& successor : stream.successors) {
+        stream.cSize += fillCSize(successor, streamInfo, codecInfo, totalSize);
+    }
+
+    // If the consumer codec has multiple inputs, assume each input
+    // provides equal contribution
+    if (stream.consumerCodec.has_value()) {
+        stream.cSize /= codecInfo[stream.consumerCodec.value()].inEdges.size();
+    }
+
+    stream.share = totalSize > 0 ? static_cast<double>(stream.cSize)
+                    / static_cast<double>(totalSize) * 100
+                                 : 0;
+    return stream.cSize;
+}
+
 ZL_Report ChunkTraceCore::serializeChunkDataToCBOR(
         A1C_Arena* a1c_arena,
         A1C_ArrayBuilder* chunkArrayBuilder,

--- a/cpp/src/openzl/cpp/experimental/trace/ChunkTraceCore.cpp
+++ b/cpp/src/openzl/cpp/experimental/trace/ChunkTraceCore.cpp
@@ -5,7 +5,109 @@
 #include "openzl/common/a1cbor_helpers.h"
 #include "openzl/cpp/experimental/trace/CborHelpers.hpp"
 
+#include <sstream>
+#include <stdexcept>
+
 namespace openzl::visualizer {
+
+namespace {
+
+std::vector<int64_t>
+getNumericData(const void* data, size_t eltWidth, size_t numElts)
+{
+    if (data == nullptr || numElts == 0) {
+        return {};
+    }
+
+    std::vector<int64_t> numericData;
+    numericData.reserve(numElts);
+
+    const auto* bytes = reinterpret_cast<const uint8_t*>(data);
+    for (size_t i = 0; i < numElts; ++i) {
+        int64_t val = 0;
+        switch (eltWidth) {
+            case 1:
+                val = reinterpret_cast<const int8_t*>(bytes)[i];
+                break;
+            case 2:
+                val = reinterpret_cast<const int16_t*>(bytes)[i];
+                break;
+            case 4:
+                val = reinterpret_cast<const int32_t*>(bytes)[i];
+                break;
+            case 8:
+                val = reinterpret_cast<const int64_t*>(bytes)[i];
+                break;
+            default:
+                throw std::runtime_error("Unexpected numeric eltWidth!");
+        }
+        numericData.push_back(val);
+    }
+
+    return numericData;
+}
+
+std::vector<std::string>
+getStringData(const void* data, size_t numStrings, const uint32_t* stringLens)
+{
+    if (data == nullptr || stringLens == nullptr || numStrings == 0) {
+        return {};
+    }
+
+    std::vector<std::string> strings;
+    strings.reserve(numStrings);
+
+    const auto* bytes = reinterpret_cast<const char*>(data);
+    size_t offset     = 0;
+
+    for (size_t i = 0; i < numStrings; ++i) {
+        uint32_t len          = stringLens[i];
+        std::string rawStr    = std::string(bytes + offset, len);
+        std::string parsedStr = "";
+        if (rawStr.find('\n') != std::string::npos
+            || rawStr.find('\t') != std::string::npos
+            || rawStr.find('\r') != std::string::npos) {
+            for (char c : rawStr) {
+                switch (c) {
+                    case '\n':
+                        parsedStr += "\\n";
+                        break;
+                    case '\t':
+                        parsedStr += "\\t";
+                        break;
+                    case '\r':
+                        parsedStr += "\\r";
+                        break;
+                    default:
+                        parsedStr += c;
+                        break;
+                }
+            }
+        } else {
+            parsedStr = std::move(rawStr);
+        }
+
+        strings.push_back(parsedStr);
+        offset += len;
+    }
+
+    return strings;
+}
+
+std::vector<uint8_t> getSerialData(const void* data, size_t numBytes)
+{
+    if (data == nullptr || numBytes == 0) {
+        return {};
+    }
+
+    std::vector<uint8_t> bytes;
+    const auto* rawBytes = reinterpret_cast<const uint8_t*>(data);
+    bytes.assign(rawBytes, rawBytes + numBytes);
+
+    return bytes;
+}
+
+} // namespace
 
 void ChunkTraceCore::createSourceForStream(
         const char* sourceCodecName,
@@ -90,6 +192,26 @@ void ChunkTraceCore::finalizeUnconsumedStreams(
                     currCodecNum,
                     chunkId);
         }
+    }
+}
+
+StreamPreview ChunkTraceCore::getStreamPreview(
+        const void* data,
+        ZL_Type type,
+        size_t eltWidth,
+        size_t numElts,
+        const uint32_t* stringLens)
+{
+    switch (type) {
+        case ZL_Type_numeric:
+            return getNumericData(data, eltWidth, numElts);
+        case ZL_Type_string:
+            return getStringData(data, numElts, stringLens);
+        case ZL_Type_struct:
+        case ZL_Type_serial:
+            return getSerialData(data, numElts);
+        default:
+            throw std::runtime_error("Unsupported stream preview type!");
     }
 }
 

--- a/cpp/src/openzl/cpp/experimental/trace/ChunkTraceCore.hpp
+++ b/cpp/src/openzl/cpp/experimental/trace/ChunkTraceCore.hpp
@@ -111,7 +111,6 @@ class ChunkTraceCore {
     /**
      * Serializes chunkId, streams, codecs, and optionally graphs into
      * a CBOR chunk item appended to chunkArrayBuilder.
-     * cctx may be nullptr (decompress side).
      * graphInfo may be empty (decompress side has no graphs).
      */
     static ZL_Report serializeChunkDataToCBOR(
@@ -120,8 +119,7 @@ class ChunkTraceCore {
             size_t chunkId,
             std::map<ZL_DataID, Stream, ZL_DataIDCustomComparator>& streamInfo,
             std::vector<Codec>& codecInfo,
-            std::vector<Graph>& graphInfo,
-            const ZL_CCtx* cctx);
+            std::vector<Graph>& graphInfo);
 
     /**
      * Encodes CBOR buffer bytes into a string (for trace output).

--- a/cpp/src/openzl/cpp/experimental/trace/ChunkTraceCore.hpp
+++ b/cpp/src/openzl/cpp/experimental/trace/ChunkTraceCore.hpp
@@ -81,6 +81,17 @@ class ChunkTraceCore {
             size_t chunkId);
 
     /**
+     * Recursively computes the compressed size (cSize) of a stream by
+     * summing the cSize of its successors. Uses Stream::cSize directly
+     * for memoization (0 means not yet computed).
+     */
+    static size_t fillCSize(
+            const StreamID& streamID,
+            std::map<ZL_DataID, Stream, ZL_DataIDCustomComparator>& streamInfo,
+            const std::vector<Codec>& codecInfo,
+            size_t totalSize);
+
+    /**
      * Serializes chunkId, streams, codecs, and optionally graphs into
      * a CBOR chunk item appended to chunkArrayBuilder.
      * cctx may be nullptr (decompress side).

--- a/cpp/src/openzl/cpp/experimental/trace/ChunkTraceCore.hpp
+++ b/cpp/src/openzl/cpp/experimental/trace/ChunkTraceCore.hpp
@@ -4,6 +4,7 @@
 
 #include <map>
 #include <string>
+#include <variant>
 #include <vector>
 
 #include "openzl/cpp/experimental/trace/Codec.hpp"
@@ -11,6 +12,11 @@
 #include "openzl/cpp/experimental/trace/StreamVisualizer.hpp"
 
 namespace openzl::visualizer {
+
+using StreamPreview = std::variant<
+        std::vector<std::string>,
+        std::vector<int64_t>,
+        std::vector<uint8_t>>;
 
 struct StreamdumpEntry {
     size_t streamId;
@@ -79,6 +85,17 @@ class ChunkTraceCore {
             std::vector<Codec>& codecInfo,
             size_t& currCodecNum,
             size_t chunkId);
+
+    /**
+     * Builds a StreamPreview from raw stream data, dispatching by ZL_Type.
+     * stringLens is only used for ZL_Type_string streams.
+     */
+    static StreamPreview getStreamPreview(
+            const void* data,
+            ZL_Type type,
+            size_t eltWidth,
+            size_t numElts,
+            const uint32_t* stringLens = nullptr);
 
     /**
      * Recursively computes the compressed size (cSize) of a stream by

--- a/cpp/src/openzl/cpp/experimental/trace/Codec.cpp
+++ b/cpp/src/openzl/cpp/experimental/trace/Codec.cpp
@@ -5,7 +5,6 @@
 #include "openzl/common/a1cbor_helpers.h"
 #include "openzl/cpp/experimental/trace/CborHelpers.hpp"
 #include "openzl/shared/a1cbor.h"
-#include "openzl/zl_compress.h"
 #include "openzl/zl_errors.h"
 
 namespace openzl::visualizer {
@@ -26,10 +25,7 @@ static ZL_Report serializeCodecEdges(
     return ZL_returnSuccess();
 }
 
-const ZL_Report Codec::serializeCodec(
-        A1C_Arena* a1c_arena,
-        A1C_Item* arrayItem,
-        const ZL_CCtx* const cctx)
+const ZL_Report Codec::serializeCodec(A1C_Arena* a1c_arena, A1C_Item* arrayItem)
 {
     A1C_MapBuilder builder = A1C_Item_map_builder(arrayItem, 9, a1c_arena);
     ZL_RET_R_IF_NULL(allocation, builder.map);
@@ -39,11 +35,9 @@ const ZL_Report Codec::serializeCodec(
     ZL_RET_R_IF_ERR(addBooleanValue(builder, "cType", cType));
     ZL_RET_R_IF_ERR(addIntValue(builder, "cID", cID));
     ZL_RET_R_IF_ERR(addIntValue(builder, "cHeaderSize", cHeaderSize));
-    if (ZL_isError(cFailure)) {
+    if (!cFailureString.empty()) {
         ZL_RET_R_IF_ERR(addStringValue(
-                builder,
-                "cFailureString",
-                ZL_CCtx_getErrorContextString(cctx, cFailure)));
+                builder, "cFailureString", cFailureString.c_str()));
     }
 
     // local params

--- a/cpp/src/openzl/cpp/experimental/trace/Codec.hpp
+++ b/cpp/src/openzl/cpp/experimental/trace/Codec.hpp
@@ -19,16 +19,14 @@ struct Codec {
     ZL_IDType cID{};
     size_t cHeaderSize{};
     ZL_Report cFailure = ZL_returnSuccess();
+    std::string cFailureString;
     LocalParams cLocalParams{};
     size_t chunkId{};
     size_t codecNum{};
     std::vector<StreamID> inEdges;
     std::vector<StreamID> outEdges;
 
-    const ZL_Report serializeCodec(
-            A1C_Arena* a1c_arena,
-            A1C_Item* arrayItem,
-            const ZL_CCtx* const cctx);
+    const ZL_Report serializeCodec(A1C_Arena* a1c_arena, A1C_Item* arrayItem);
 };
 
 } // namespace openzl::visualizer

--- a/cpp/src/openzl/cpp/experimental/trace/CompressChunkTrace.cpp
+++ b/cpp/src/openzl/cpp/experimental/trace/CompressChunkTrace.cpp
@@ -247,15 +247,12 @@ inline std::string streamTypeToStr(ZL_Type stype)
 
 void CompressChunkTrace::printStreamMetadata()
 {
-    std::vector<size_t> cSize(streamInfo_.size(), SIZE_MAX);
     std::cout << "digraph stream_topo {" << std::endl;
     for (auto& s : streamInfo_) {
-        const StreamID streamID     = s.first;
-        ZL_IDType sid               = streamID.sid;
-        streamInfo_[streamID].cSize = fillCSize(cSize, streamID);
-        streamInfo_[streamID].share =
-                static_cast<double>(streamInfo_[streamID].cSize)
-                / static_cast<double>(compressedSize_) * 100;
+        const StreamID streamID = s.first;
+        ZL_IDType sid           = streamID.sid;
+        ChunkTraceCore::fillCSize(
+                streamID, streamInfo_, codecInfo_, compressedSize_);
 
         Stream metadata = s.second;
         std::cout << 'S' << sid << " [shape=record, label=\"Stream: " << sid
@@ -401,43 +398,6 @@ void CompressChunkTrace::printCodecMetadata()
     }
 
     std::cout << "}" << std::endl;
-}
-
-size_t CompressChunkTrace::fillCSize(
-        std::vector<size_t>& cSize,
-        const StreamID streamID)
-{
-    size_t cSize_idx = streamID.sid;
-    // already filled up
-    if (cSize.size() != 0 && cSize[cSize_idx] != SIZE_MAX) {
-        return cSize[cSize_idx];
-    }
-
-    const Stream& stream = streamInfo_.at(streamID);
-
-    // base case: stream has no successors, and is input to the frame
-    if (stream.successors.empty()) {
-        cSize[cSize_idx] = stream.contentSize;
-        return cSize[cSize_idx];
-    }
-
-    // Get the header size
-    if (stream.consumerCodec.has_value()) {
-        cSize[cSize_idx] = codecInfo_[stream.consumerCodec.value()].cHeaderSize;
-    } else {
-        cSize[cSize_idx] = 0;
-    }
-
-    // recursively fill cSize of this stream by summing the cSize of its
-    // successor streams
-    for (const auto& successor : stream.successors) {
-        cSize[cSize_idx] += fillCSize(cSize, successor);
-    }
-
-    // if the consumer codec has multiple inputs, assume each input provides
-    // equal contribution
-    cSize[cSize_idx] /= codecInfo_[stream.consumerCodec.value()].inEdges.size();
-    return cSize[cSize_idx];
 }
 
 void CompressChunkTrace::on_codecEncode_start(

--- a/cpp/src/openzl/cpp/experimental/trace/CompressChunkTrace.cpp
+++ b/cpp/src/openzl/cpp/experimental/trace/CompressChunkTrace.cpp
@@ -6,6 +6,7 @@
 #include "openzl/compress/dyngraph_interface.h"
 #include "openzl/cpp/Exception.hpp"
 #include "openzl/cpp/experimental/trace/CborHelpers.hpp"
+#include "openzl/zl_compress.h"
 #include "openzl/zl_input.h"
 #include "openzl/zl_output.h"
 #include "openzl/zl_reflection.h"
@@ -89,10 +90,27 @@ void CompressChunkTrace::finalizeTrace(ZL_Report const result)
     printCodecMetadata();
 }
 
+void CompressChunkTrace::resolveErrorStrings(const ZL_CCtx* cctx)
+{
+    for (auto& codec : codecInfo_) {
+        if (ZL_isError(codec.cFailure)) {
+            const char* str =
+                    ZL_CCtx_getErrorContextString(cctx, codec.cFailure);
+            codec.cFailureString = str ? str : "";
+        }
+    }
+    for (auto& graph : graphInfo_) {
+        if (ZL_isError(graph.gFailure)) {
+            const char* str =
+                    ZL_CCtx_getErrorContextString(cctx, graph.gFailure);
+            graph.gFailureString = str ? str : "";
+        }
+    }
+}
+
 ZL_Report CompressChunkTrace::serializeToCBOR(
         A1C_Arena* a1c_arena,
-        A1C_ArrayBuilder* chunkArrayBuilder,
-        const ZL_CCtx* cctx)
+        A1C_ArrayBuilder* chunkArrayBuilder)
 {
     return ChunkTraceCore::serializeChunkDataToCBOR(
             a1c_arena,
@@ -100,8 +118,7 @@ ZL_Report CompressChunkTrace::serializeToCBOR(
             chunkId_,
             streamInfo_,
             codecInfo_,
-            graphInfo_,
-            cctx);
+            graphInfo_);
 }
 
 size_t CompressChunkTrace::getCompressedSize()
@@ -218,11 +235,8 @@ void CompressChunkTrace::printCodecMetadata()
             std::cout << "subgraph cluster_" << graphInfoIdx << '{' << std::endl
                       << "label=\"" << graph.gName
                       << "\\ntype=" << graphTypeToStr(graph.gType);
-            if (ZL_isError(graph.gFailure)) {
-                std::cout << "\\nFailure: "
-                          << "[PLACEHOLDER]";
-                // << ZL_CCtx_getErrorContextString(
-                //            cctx_, graph.gFailure);
+            if (!graph.gFailureString.empty()) {
+                std::cout << "\\nFailure: " << graph.gFailureString;
             }
             printLocalParams(graph.gLocalParams);
             std::cout << "\";" << std::endl << "color=maroon" << std::endl;
@@ -234,11 +248,8 @@ void CompressChunkTrace::printCodecMetadata()
                   << metadata.name << "(ID: " << metadata.cID << ")\\n "
                   << codecName << " transform " << codecNum
                   << "\\n Header size: " << metadata.cHeaderSize;
-        if (ZL_isError(metadata.cFailure)) {
-            std::cout << "\\n Failure: "
-                      << "[PLACEHOLDER]";
-            // << ZL_CCtx_getErrorContextString(
-            //            cctx_, metadata.cFailure);
+        if (!metadata.cFailureString.empty()) {
+            std::cout << "\\n Failure: " << metadata.cFailureString;
         }
         printLocalParams(metadata.cLocalParams);
         std::cout << "\"];" << std::endl;
@@ -401,12 +412,13 @@ void CompressChunkTrace::on_migraphEncode_start(
     for (size_t i = 0; i < nbEdges; ++i) {
         inEdges.push_back(edges[i]);
     }
-    Graph currGraph = Graph{ ZL_Compressor_getGraphType(compressor, gid),
-                             ZL_Compressor_Graph_getName(compressor, gid),
-                             ZL_returnSuccess(),
-                             LocalParams(*GCTX_getAllLocalParams(graph)),
-                             chunkId_,
-                             std::move(inEdges) };
+    Graph currGraph =
+            Graph{ .gType        = ZL_Compressor_getGraphType(compressor, gid),
+                   .gName        = ZL_Compressor_Graph_getName(compressor, gid),
+                   .gFailure     = ZL_returnSuccess(),
+                   .gLocalParams = LocalParams(*GCTX_getAllLocalParams(graph)),
+                   .chunkId      = chunkId_,
+                   .inEdges      = std::move(inEdges) };
     graphInfo_.push_back(std::move(currGraph));
 }
 

--- a/cpp/src/openzl/cpp/experimental/trace/CompressChunkTrace.cpp
+++ b/cpp/src/openzl/cpp/experimental/trace/CompressChunkTrace.cpp
@@ -19,126 +19,6 @@
 
 namespace openzl::visualizer {
 
-using StreamPreview = std::variant<
-        std::vector<std::string>,
-        std::vector<int64_t>,
-        std::vector<uint8_t>>;
-
-static std::vector<int64_t>
-getNumericData(const void* data, size_t eltWidth, size_t numElts)
-{
-    if (data == nullptr || numElts == 0) {
-        return {};
-    }
-
-    std::vector<int64_t> numericData;
-    numericData.reserve(numElts);
-
-    const auto* bytes = reinterpret_cast<const uint8_t*>(data);
-    for (size_t i = 0; i < numElts; ++i) {
-        int64_t val = 0;
-        switch (eltWidth) {
-            case 1:
-                val = reinterpret_cast<const int8_t*>(bytes)[i];
-                break;
-            case 2:
-                val = reinterpret_cast<const int16_t*>(bytes)[i];
-                break;
-            case 4:
-                val = reinterpret_cast<const int32_t*>(bytes)[i];
-                break;
-            case 8:
-                val = reinterpret_cast<const int64_t*>(bytes)[i];
-                break;
-            default:
-                throw std::runtime_error("Unexpected numeric eltWidth!");
-        }
-        numericData.push_back(val);
-    }
-
-    return numericData;
-}
-
-static std::vector<std::string>
-getStringData(const void* data, size_t numStrings, const uint32_t* stringLens)
-{
-    if (data == nullptr || stringLens == nullptr || numStrings == 0) {
-        return {};
-    }
-
-    std::vector<std::string> strings;
-    strings.reserve(numStrings);
-
-    const auto* bytes = reinterpret_cast<const char*>(data);
-    size_t offset     = 0;
-
-    for (size_t i = 0; i < numStrings; ++i) {
-        uint32_t len          = stringLens[i];
-        std::string rawStr    = std::string(bytes + offset, len);
-        std::string parsedStr = "";
-        if (rawStr.find('\n') != std::string::npos
-            || rawStr.find('\t') != std::string::npos
-            || rawStr.find('\r') != std::string::npos) {
-            for (char c : rawStr) {
-                switch (c) {
-                    case '\n':
-                        parsedStr += "\\n";
-                        break;
-                    case '\t':
-                        parsedStr += "\\t";
-                        break;
-                    case '\r':
-                        parsedStr += "\\r";
-                        break;
-                    default:
-                        parsedStr += c;
-                        break;
-                }
-            }
-        } else {
-            parsedStr = std::move(rawStr);
-        }
-
-        strings.push_back(parsedStr);
-        offset += len;
-    }
-
-    return strings;
-}
-
-static std::vector<uint8_t> getSerialData(const void* data, size_t numBytes)
-{
-    if (data == nullptr || numBytes == 0) {
-        return {};
-    }
-
-    std::vector<uint8_t> bytes;
-    const auto* rawBytes = reinterpret_cast<const uint8_t*>(data);
-    bytes.assign(rawBytes, rawBytes + numBytes);
-
-    return bytes;
-}
-
-static StreamPreview getStreamPreviewData(
-        const void* data,
-        ZL_Type type,
-        size_t eltWidth,
-        size_t numElts,
-        const uint32_t* stringLens = nullptr)
-{
-    switch (type) {
-        case ZL_Type_numeric:
-            return getNumericData(data, eltWidth, numElts);
-        case ZL_Type_string:
-            return getStringData(data, numElts, stringLens);
-        case ZL_Type_struct:
-        case ZL_Type_serial:
-            return getSerialData(data, numElts);
-        default:
-            throw std::runtime_error("Unsupported stream preview type!");
-    }
-}
-
 void CompressChunkTrace::recordStartStreams(
         const ZL_Input* inStreams[],
         size_t numInStreams)
@@ -151,7 +31,7 @@ void CompressChunkTrace::recordStartStreams(
             size_t numElts     = ZL_Input_numElts(inStreams[i]);
             size_t contentSize = ZL_Input_contentSize(inStreams[i]);
 
-            StreamPreview preview = getStreamPreviewData(
+            StreamPreview preview = ChunkTraceCore::getStreamPreview(
                     ZL_Input_ptr(inStreams[i]),
                     type,
                     eltWidth,
@@ -454,7 +334,7 @@ void CompressChunkTrace::on_codecEncode_end(
         size_t contentSize =
                 openzl::unwrap(ZL_Output_contentSize(createdStream));
 
-        StreamPreview preview = getStreamPreviewData(
+        StreamPreview preview = ChunkTraceCore::getStreamPreview(
                 ZL_Output_constPtr(createdStream),
                 type,
                 eltWidth,

--- a/cpp/src/openzl/cpp/experimental/trace/CompressChunkTrace.hpp
+++ b/cpp/src/openzl/cpp/experimental/trace/CompressChunkTrace.hpp
@@ -38,10 +38,15 @@ class CompressChunkTrace {
      */
     void finalizeTrace(ZL_Report const result);
 
+    /**
+     * Resolve error context strings for all codecs and graphs.
+     * Must be called while the CCtx is still alive.
+     */
+    void resolveErrorStrings(const ZL_CCtx* cctx);
+
     ZL_Report serializeToCBOR(
             A1C_Arena* a1c_arena,
-            A1C_ArrayBuilder* chunkArrayBuilder,
-            const ZL_CCtx* cctx);
+            A1C_ArrayBuilder* chunkArrayBuilder);
 
     size_t getCompressedSize();
 

--- a/cpp/src/openzl/cpp/experimental/trace/CompressChunkTrace.hpp
+++ b/cpp/src/openzl/cpp/experimental/trace/CompressChunkTrace.hpp
@@ -113,7 +113,6 @@ class CompressChunkTrace {
    private:
     void printStreamMetadata();
     void printCodecMetadata();
-    size_t fillCSize(std::vector<size_t>& cSize, const ZL_DataID streamID);
 
     const size_t chunkId_;    // chunk ID for this specific chunk trace
     size_t compressedSize_{}; // compressed size for this specific chunk

--- a/cpp/src/openzl/cpp/experimental/trace/CompressTracer.cpp
+++ b/cpp/src/openzl/cpp/experimental/trace/CompressTracer.cpp
@@ -5,6 +5,7 @@
 #include "openzl/common/a1cbor_helpers.h"
 #include "openzl/common/logging.h"
 #include "openzl/cpp/experimental/trace/CborHelpers.hpp"
+#include "openzl/zl_compress.h"
 #include "openzl/zl_data.h"
 #include "openzl/zl_errors.h"
 #include "openzl/zl_opaque_types.h"
@@ -172,12 +173,17 @@ void CompressTracer::on_ZL_CCtx_compressMultiTypedRef_start(
 }
 
 void CompressTracer::on_ZL_CCtx_compressMultiTypedRef_end(
-        ZL_CCtx const* const,
+        ZL_CCtx const* const cctx,
         ZL_Report const result)
 {
     // If the compression is successful, we can assume all the streams
     // without targets go to STORE
     graphRuns[MAIN_TRACE_IDX].finalizeTrace(result);
+
+    // Resolve error strings while the CCtx is still alive
+    for (auto& graphRun : graphRuns) {
+        graphRun.resolveErrorStrings(cctx);
+    }
 
     // convert compression data into a1c_items to write to a CBOR file
     Arena* arena        = ALLOC_HeapArena_create();
@@ -241,8 +247,7 @@ ZL_Report CompressTracer::serializeStreamdumpToCbor(
 
     // Add additional chunks from graphRuns
     for (auto& graphRun : graphRuns) {
-        ZL_RET_R_IF_ERR(
-                graphRun.serializeToCBOR(a1c_arena, &chunksBuilder, cctx_));
+        ZL_RET_R_IF_ERR(graphRun.serializeToCBOR(a1c_arena, &chunksBuilder));
     }
 
     // encode + write data to a buffer

--- a/cpp/src/openzl/cpp/experimental/trace/CompressTracer.hpp
+++ b/cpp/src/openzl/cpp/experimental/trace/CompressTracer.hpp
@@ -14,7 +14,7 @@ namespace openzl::visualizer {
 
 class CompressTracer {
    public:
-    explicit CompressTracer(const ZL_CCtx* const cctx) : cctx_(cctx) {}
+    CompressTracer() = default;
 
     TraceResult extractTrace();
 
@@ -111,7 +111,6 @@ class CompressTracer {
         ZL_Report failureReport;
     };
 
-    const ZL_CCtx* cctx_{};
     static constexpr uint32_t libraryVersion = ZL_LIBRARY_VERSION_NUMBER;
     uint32_t frameVersion;
     static constexpr uint32_t traceVersion = 1;

--- a/cpp/src/openzl/cpp/experimental/trace/CompressionTraceHooks.cpp
+++ b/cpp/src/openzl/cpp/experimental/trace/CompressionTraceHooks.cpp
@@ -193,7 +193,7 @@ void CompressionTraceHooks::on_ZL_CCtx_compressMultiTypedRef_start(
         throw std::runtime_error(
                 "Corrupted state. Trace context already exists!");
     }
-    tracer_ = std::make_unique<CompressTracer>(cctx);
+    tracer_ = std::make_unique<CompressTracer>();
     tracer_->on_ZL_CCtx_compressMultiTypedRef_start(
             cctx, dst, dstCapacity, inputs, nbInputs);
 }

--- a/cpp/src/openzl/cpp/experimental/trace/DecompressChunkTrace.cpp
+++ b/cpp/src/openzl/cpp/experimental/trace/DecompressChunkTrace.cpp
@@ -13,26 +13,6 @@
 
 namespace openzl::visualizer {
 
-namespace {
-std::variant<
-        std::vector<std::string>,
-        std::vector<int64_t>,
-        std::vector<uint8_t>>
-emptyPreview(ZL_Type type)
-{
-    switch (type) {
-        case ZL_Type_string:
-            return std::vector<std::string>{};
-        case ZL_Type_numeric:
-            return std::vector<int64_t>{};
-        case ZL_Type_struct:
-        case ZL_Type_serial:
-        default:
-            return std::vector<uint8_t>{};
-    }
-}
-} // namespace
-
 DecompressChunkTrace DecompressChunkTrace::makeSegmenterChunk(size_t chunkId)
 {
     auto ret = DecompressChunkTrace(chunkId);
@@ -92,16 +72,26 @@ void DecompressChunkTrace::on_codecDecode_start(
     for (size_t i = 0; i < nbInStreams; ++i) {
         StreamID streamID = ZL_Data_id(inStreams[i]);
         if (streamInfo_.find(streamID) == streamInfo_.end()) {
-            ZL_Type type          = ZL_Data_type(inStreams[i]);
+            ZL_Type type    = ZL_Data_type(inStreams[i]);
+            size_t eltWidth = ZL_Data_eltWidth(inStreams[i]);
+            size_t numElts  = ZL_Data_numElts(inStreams[i]);
+
+            StreamPreview preview = ChunkTraceCore::getStreamPreview(
+                    ZL_Data_rPtr(inStreams[i]),
+                    type,
+                    eltWidth,
+                    numElts,
+                    ZL_Data_rStringLens(inStreams[i]));
+
             streamInfo_[streamID] = Stream{
                 .id            = streamID,
                 .type          = type,
                 .outputIdx     = i,
-                .eltWidth      = ZL_Data_eltWidth(inStreams[i]),
-                .numElts       = ZL_Data_numElts(inStreams[i]),
+                .eltWidth      = eltWidth,
+                .numElts       = numElts,
                 .contentSize   = ZL_Data_contentSize(inStreams[i]),
                 .chunkId       = chunkId_,
-                .streamPreview = emptyPreview(type),
+                .streamPreview = std::move(preview),
             };
             ChunkTraceCore::createSinkForStream(
                     "zl.store",
@@ -149,16 +139,26 @@ void DecompressChunkTrace::on_codecDecode_end(
     for (size_t i = 0; i < nbOutStreams; ++i) {
         StreamID streamID = ZL_Data_id(outStreams[i]);
         if (streamInfo_.find(streamID) == streamInfo_.end()) {
-            ZL_Type type          = ZL_Data_type(outStreams[i]);
+            ZL_Type type    = ZL_Data_type(outStreams[i]);
+            size_t eltWidth = ZL_Data_eltWidth(outStreams[i]);
+            size_t numElts  = ZL_Data_numElts(outStreams[i]);
+
+            StreamPreview preview = ChunkTraceCore::getStreamPreview(
+                    ZL_Data_rPtr(outStreams[i]),
+                    type,
+                    eltWidth,
+                    numElts,
+                    ZL_Data_rStringLens(outStreams[i]));
+
             streamInfo_[streamID] = Stream{
                 .id            = streamID,
                 .type          = type,
                 .outputIdx     = i,
-                .eltWidth      = ZL_Data_eltWidth(outStreams[i]),
-                .numElts       = ZL_Data_numElts(outStreams[i]),
+                .eltWidth      = eltWidth,
+                .numElts       = numElts,
                 .contentSize   = ZL_Data_contentSize(outStreams[i]),
                 .chunkId       = chunkId_,
-                .streamPreview = emptyPreview(type),
+                .streamPreview = std::move(preview),
             };
         }
         codecInfo_[currCodecNum_].inEdges.push_back(streamID);

--- a/cpp/src/openzl/cpp/experimental/trace/DecompressChunkTrace.cpp
+++ b/cpp/src/openzl/cpp/experimental/trace/DecompressChunkTrace.cpp
@@ -7,6 +7,7 @@
 #include "openzl/cpp/experimental/trace/CborHelpers.hpp"
 #include "openzl/decompress/dictx.h"
 #include "openzl/zl_data.h"
+#include "openzl/zl_decompress.h"
 #include "openzl/zl_errors.h"
 
 #include <variant>
@@ -47,6 +48,17 @@ void DecompressChunkTrace::finalizeTrace(ZL_Report result)
     }
 }
 
+void DecompressChunkTrace::resolveErrorStrings(const ZL_DCtx* dctx)
+{
+    for (auto& codec : codecInfo_) {
+        if (ZL_isError(codec.cFailure)) {
+            const char* str =
+                    ZL_DCtx_getErrorContextString(dctx, codec.cFailure);
+            codec.cFailureString = str ? str : "";
+        }
+    }
+}
+
 ZL_Report DecompressChunkTrace::serializeToCBOR(
         A1C_Arena* a1c_arena,
         A1C_ArrayBuilder* chunkArrayBuilder)
@@ -58,8 +70,7 @@ ZL_Report DecompressChunkTrace::serializeToCBOR(
             chunkId_,
             streamInfo_,
             codecInfo_,
-            noGraphs,
-            nullptr);
+            noGraphs);
 }
 
 void DecompressChunkTrace::on_codecDecode_start(

--- a/cpp/src/openzl/cpp/experimental/trace/DecompressChunkTrace.cpp
+++ b/cpp/src/openzl/cpp/experimental/trace/DecompressChunkTrace.cpp
@@ -46,6 +46,12 @@ void DecompressChunkTrace::finalizeTrace(ZL_Report result)
         ChunkTraceCore::finalizeUnsourcedStreams(
                 "zl.regen", streamInfo_, codecInfo_, currCodecNum_, chunkId_);
     }
+
+    // Fill cSize and share for all streams
+    for (auto& [streamID, stream] : streamInfo_) {
+        ChunkTraceCore::fillCSize(
+                streamID, streamInfo_, codecInfo_, totalCompressedSize_);
+    }
 }
 
 ZL_Report DecompressChunkTrace::serializeToCBOR(
@@ -91,6 +97,8 @@ void DecompressChunkTrace::on_codecDecode_start(
                     codecInfo_,
                     currCodecNum_,
                     chunkId_);
+            // NB: this does not account for the various non-codec header costs
+            totalCompressedSize_ += streamInfo_[streamID].contentSize;
         }
     }
 

--- a/cpp/src/openzl/cpp/experimental/trace/DecompressChunkTrace.cpp
+++ b/cpp/src/openzl/cpp/experimental/trace/DecompressChunkTrace.cpp
@@ -33,6 +33,19 @@ emptyPreview(ZL_Type type)
 }
 } // namespace
 
+DecompressChunkTrace DecompressChunkTrace::makeSegmenterChunk(size_t chunkId)
+{
+    auto ret = DecompressChunkTrace(chunkId);
+    Codec newCodec{ .name  = "segmenter", // TODO(segm): expose segmenter name
+                    .cType = false,
+                    .cID   = 0, // eh?
+                    .cHeaderSize = 0,
+                    .chunkId     = chunkId };
+    newCodec.codecNum = 0;
+    ret.codecInfo_.push_back(newCodec);
+    return ret;
+}
+
 void DecompressChunkTrace::finalizeTrace(ZL_Report result)
 {
     if (ZL_isError(result)) {
@@ -44,7 +57,7 @@ void DecompressChunkTrace::finalizeTrace(ZL_Report result)
                 chunkId_);
     } else {
         ChunkTraceCore::finalizeUnsourcedStreams(
-                "zl.regen", streamInfo_, codecInfo_, currCodecNum_, chunkId_);
+                "zl.#regen", streamInfo_, codecInfo_, currCodecNum_, chunkId_);
     }
 
     // Fill cSize and share for all streams

--- a/cpp/src/openzl/cpp/experimental/trace/DecompressChunkTrace.hpp
+++ b/cpp/src/openzl/cpp/experimental/trace/DecompressChunkTrace.hpp
@@ -33,6 +33,12 @@ class DecompressChunkTrace {
      */
     void finalizeTrace(ZL_Report result);
 
+    /**
+     * Resolve error context strings for all codecs.
+     * Must be called while the DCtx is still alive.
+     */
+    void resolveErrorStrings(const ZL_DCtx* dctx);
+
     ZL_Report serializeToCBOR(
             A1C_Arena* a1c_arena,
             A1C_ArrayBuilder* chunkArrayBuilder);

--- a/cpp/src/openzl/cpp/experimental/trace/DecompressChunkTrace.hpp
+++ b/cpp/src/openzl/cpp/experimental/trace/DecompressChunkTrace.hpp
@@ -55,7 +55,8 @@ class DecompressChunkTrace {
     void streamdump(const ZL_Data* data);
 
     const size_t chunkId_;
-    size_t currCodecNum_ = 0;
+    size_t totalCompressedSize_ = 0;
+    size_t currCodecNum_        = 0;
     std::map<ZL_DataID, Stream, ZL_DataIDCustomComparator> streamInfo_;
     std::map<size_t, std::pair<std::string, std::string>> streamdump_;
     std::vector<Codec> codecInfo_;

--- a/cpp/src/openzl/cpp/experimental/trace/DecompressChunkTrace.hpp
+++ b/cpp/src/openzl/cpp/experimental/trace/DecompressChunkTrace.hpp
@@ -22,6 +22,11 @@ class DecompressChunkTrace {
     explicit DecompressChunkTrace(size_t chunkId) : chunkId_(chunkId) {}
 
     /**
+     * Helper function to create a dummy chunk that just contains a segmenter
+     * node, in cases where the trace is a multi-chunk run.
+     */
+    static DecompressChunkTrace makeSegmenterChunk(size_t chunkId);
+    /**
      * Finalize the trace.
      * - On success, unsourced streams (decoded outputs) go to "zl.regen".
      * - On failure, unsourced streams go to "zl.#in_progress".

--- a/cpp/src/openzl/cpp/experimental/trace/DecompressTracer.cpp
+++ b/cpp/src/openzl/cpp/experimental/trace/DecompressTracer.cpp
@@ -49,10 +49,18 @@ void DecompressTracer::on_ZL_DCtx_decompressMultiTBuffer_start(
 
 void DecompressTracer::on_ZL_DCtx_decompressMultiTBuffer_end(
         ZL_DCtx* /* dctx */,
-        ZL_Report result)
+        ZL_Report /* result */)
 {
-    // Finalize the main chunk (or the last active chunk)
-    chunks_[MAIN_CHUNK_IDX].finalizeTrace(result);
+    // Create a dummy "main" chunk, if necessary
+    if (chunks_.size() > 1) {
+        auto dummyChunk =
+                DecompressChunkTrace::makeSegmenterChunk(chunks_.size());
+        std::vector<DecompressChunkTrace> newChunks = { std::move(dummyChunk) };
+        for (auto& chunk : chunks_) {
+            newChunks.push_back(std::move(chunk));
+        }
+        this->chunks_ = std::move(newChunks);
+    }
 
     // Serialize the trace to CBOR
     Arena* arena        = ALLOC_HeapArena_create();
@@ -83,17 +91,13 @@ void DecompressTracer::on_decompressChunk_start(
         chunks_.emplace_back(chunkIndex);
         currChunk_ = &chunks_.back();
     }
-    // For chunkIndex == 0, we reuse the main chunk created in
-    // decompressMultiTBuffer_start
 }
 
 void DecompressTracer::on_decompressChunk_end(
         ZL_DCtx* /* dctx */,
         ZL_Report result)
 {
-    if (chunks_.size() > 1 && currChunk_ != &chunks_[MAIN_CHUNK_IDX]) {
-        currChunk_->finalizeTrace(result);
-    }
+    currChunk_->finalizeTrace(result);
     // The main chunk is finalized in decompressMultiTBuffer_end
 }
 

--- a/cpp/src/openzl/cpp/experimental/trace/DecompressTracer.cpp
+++ b/cpp/src/openzl/cpp/experimental/trace/DecompressTracer.cpp
@@ -6,6 +6,7 @@
 #include "openzl/common/logging.h"
 #include "openzl/cpp/Exception.hpp"
 #include "openzl/cpp/experimental/trace/CborHelpers.hpp"
+#include "openzl/zl_decompress.h"
 #include "openzl/zl_errors.h"
 
 #include <utility>
@@ -48,9 +49,14 @@ void DecompressTracer::on_ZL_DCtx_decompressMultiTBuffer_start(
 }
 
 void DecompressTracer::on_ZL_DCtx_decompressMultiTBuffer_end(
-        ZL_DCtx* /* dctx */,
+        ZL_DCtx* dctx,
         ZL_Report /* result */)
 {
+    // Resolve error strings while the DCtx is still alive
+    for (auto& chunk : chunks_) {
+        chunk.resolveErrorStrings(dctx);
+    }
+
     // Create a dummy "main" chunk, if necessary
     if (chunks_.size() > 1) {
         auto dummyChunk =

--- a/cpp/src/openzl/cpp/experimental/trace/Graph.cpp
+++ b/cpp/src/openzl/cpp/experimental/trace/Graph.cpp
@@ -9,10 +9,7 @@
 
 namespace openzl::visualizer {
 
-const ZL_Report Graph::serializeGraph(
-        A1C_Arena* a1c_arena,
-        A1C_Item* arrayItem,
-        const ZL_CCtx* const cctx)
+const ZL_Report Graph::serializeGraph(A1C_Arena* a1c_arena, A1C_Item* arrayItem)
 {
     A1C_MapBuilder builder = A1C_Item_map_builder(arrayItem, 6, a1c_arena);
     ZL_RET_R_IF_NULL(allocation, builder.map);
@@ -20,11 +17,9 @@ const ZL_Report Graph::serializeGraph(
     ZL_RET_R_IF_ERR(addIntValue(builder, "chunkId", this->chunkId));
     ZL_RET_R_IF_ERR(addIntValue(builder, "gType", gType));
     ZL_RET_R_IF_ERR(addStringValue(builder, "gName", gName));
-    if (ZL_isError(gFailure)) {
+    if (!gFailureString.empty()) {
         ZL_RET_R_IF_ERR(addStringValue(
-                builder,
-                "gFailureString",
-                ZL_CCtx_getErrorContextString(cctx, gFailure)));
+                builder, "gFailureString", gFailureString.c_str()));
     }
 
     // local params

--- a/cpp/src/openzl/cpp/experimental/trace/Graph.hpp
+++ b/cpp/src/openzl/cpp/experimental/trace/Graph.hpp
@@ -8,6 +8,7 @@
 #include "openzl/zl_errors.h"
 #include "openzl/zl_reflection.h"
 
+#include <string>
 #include <vector>
 
 namespace openzl::visualizer {
@@ -16,6 +17,7 @@ struct Graph {
     ZL_GraphType gType{};
     const char* gName{};
     ZL_Report gFailure = ZL_returnSuccess();
+    std::string gFailureString;
     LocalParams gLocalParams{};
     size_t chunkId{};
 
@@ -25,10 +27,7 @@ struct Graph {
     std::vector<ZL_Edge*> inEdges;
     std::vector<CodecID> codecs;
 
-    const ZL_Report serializeGraph(
-            A1C_Arena* a1c_arena,
-            A1C_Item* arrayItem,
-            const ZL_CCtx* const cctx);
+    const ZL_Report serializeGraph(A1C_Arena* a1c_arena, A1C_Item* arrayItem);
 };
 
 } // namespace openzl::visualizer

--- a/tools/visualization_app/src/graphVisualization/models/InteractiveStreamdumpGraph.ts
+++ b/tools/visualization_app/src/graphVisualization/models/InteractiveStreamdumpGraph.ts
@@ -9,13 +9,16 @@ import type {InternalNode} from './InternalNode';
 import {InternalEdge} from './InternalEdge';
 import {InsertOnlyJournal} from '../../utils/InsertOnlyJournal';
 import {InternalSegmenterNode} from './InternalSegmenterNode';
+import {OperationType} from '../../models/idTypes';
 
 export class InteractiveStreamdumpGraph {
   private chunkGraphs: InteractiveChunkGraph[] = [];
   private visibleChunkIndex: number | null = 0;
+  private operationType: OperationType;
 
   constructor(obj: SerializedStreamdumpV1, isDefaultCollapsed = false) {
     // Create a chunk graph for each chunk in the streamdump
+    this.operationType = obj.operationType === 1 ? OperationType.Decompress : OperationType.Compress;
     this.chunkGraphs = obj.chunks.map((chunk) => new InteractiveChunkGraph(chunk, isDefaultCollapsed));
     const maybeSegmenterNode = this.chunkGraphs[0].findCodecByName('segmenter');
     if (maybeSegmenterNode) {
@@ -46,16 +49,17 @@ export class InteractiveStreamdumpGraph {
     const chunkN = this.chunkGraphs[this.visibleChunkIndex].getVisibleStreamdumpGraph();
 
     const segmenterCodec = this.chunkGraphs[0].findCodecByName('segmenter') as InternalSegmenterNode;
-    // todo: no need for this hack if we set it correctly
-    segmenterCodec.numChunks = this.chunkGraphs.length - 1;
-
-    const zlStartCodec = this.chunkGraphs[this.visibleChunkIndex].findCodecByName('zl.#start');
     if (!segmenterCodec) {
       console.warn('Could not find segmenter codec in chunk 0');
       return chunk0;
     }
+    // todo: no need for this hack if we set it correctly
+    segmenterCodec.numChunks = this.chunkGraphs.length - 1;
+
+    const startCodecName = this.operationType === OperationType.Compress ? 'zl.#start' : 'zl.#regen';
+    const zlStartCodec = this.chunkGraphs[this.visibleChunkIndex].findCodecByName(startCodecName);
     if (!zlStartCodec) {
-      console.warn(`Could not find zl.#start codec in chunk ${this.visibleChunkIndex}`);
+      console.warn(`Could not find ${startCodecName} codec in chunk ${this.visibleChunkIndex}`);
       return chunk0;
     }
 


### PR DESCRIPTION
Summary:
Instead of lazily resolving error context strings during CBOR serialization
(which required threading a `ZL_CCtx*` through the serialization path and
didn't work for decompress), error strings are now eagerly resolved into
`cFailureString`/`gFailureString` fields while the context is still alive.

Each chunk trace has a concrete `resolveErrorStrings` method that takes its
specific context type (`const ZL_CCtx*` for compress, `const ZL_DCtx*` for
decompress). These are called from the top-level tracer end hooks before
serialization.

This also enables decompress traces to report codec failures with rich error
messages, which was previously not possible.

Changes:
- `Codec`: Added `cFailureString` field; `serializeCodec` uses pre-resolved
  string, no longer takes `cctx`
- `Graph`: Added `gFailureString` field; `serializeGraph` uses pre-resolved
  string, no longer takes `cctx`
- `ChunkTraceCore::serializeChunkDataToCBOR`: Removed `cctx` parameter
- `CompressChunkTrace`: Added `resolveErrorStrings(const ZL_CCtx*)`;
  `serializeToCBOR` no longer takes `cctx`; fixed placeholder error strings
  in `printCodecMetadata`
- `DecompressChunkTrace`: Added `resolveErrorStrings(const ZL_DCtx*)`
- `CompressTracer`: Removed stored `cctx_` member; calls
  `resolveErrorStrings` in `on_ZL_CCtx_compressMultiTypedRef_end`
- `DecompressTracer`: Calls `resolveErrorStrings` in
  `on_ZL_DCtx_decompressMultiTBuffer_end`

Reviewed By: terrelln

Differential Revision: D97012673


