### PR TITLE
Migrate trace CBOR serialization to new-style ZL_ERR error macros

### DIFF
--- a/cpp/include/openzl/cpp/CompressIntrospectionHooks.hpp
+++ b/cpp/include/openzl/cpp/CompressIntrospectionHooks.hpp
@@ -153,7 +153,7 @@ class CompressIntrospectionHooks {
     }
 
     virtual void on_ZL_CCtx_compressMultiTypedRef_start(
-            ZL_CCtx const* const cctx,
+            ZL_CCtx* cctx,
             void const* const dst,
             size_t const dstCapacity,
             ZL_TypedRef const* const inputs[],

--- a/cpp/src/openzl/cpp/CompressIntrospectionHooks.cpp
+++ b/cpp/src/openzl/cpp/CompressIntrospectionHooks.cpp
@@ -137,7 +137,7 @@ CompressIntrospectionHooks::CompressIntrospectionHooks()
 
     rawHooks_.on_ZL_CCtx_compressMultiTypedRef_start =
             [](void* this_ptr,
-               ZL_CCtx const* const cctx,
+               ZL_CCtx* cctx,
                void const* const dst,
                size_t const dstCapacity,
                ZL_TypedRef const* const inputs[],

--- a/cpp/src/openzl/cpp/experimental/trace/CborHelpers.cpp
+++ b/cpp/src/openzl/cpp/experimental/trace/CborHelpers.cpp
@@ -8,34 +8,53 @@
 
 namespace openzl::visualizer {
 
-ZL_Report addIntValue(A1C_MapBuilder& builder, const char* key, size_t val)
+ZL_Report addIntValue(
+        A1C_MapBuilder& builder,
+        const char* key,
+        size_t val,
+        ZL_OperationContext* opCtx)
 {
-    A1C_MAP_TRY_ADD_R(pair, builder);
+    ZL_RESULT_DECLARE_SCOPE_REPORT(opCtx);
+    A1C_MAP_TRY_ADD(pair, builder);
     A1C_Item_string_refCStr(&pair->key, key);
     A1C_Item_int64(&pair->val, val);
     return ZL_returnSuccess();
 };
 
-ZL_Report addFloatValue(A1C_MapBuilder& builder, const char* key, double val)
+ZL_Report addFloatValue(
+        A1C_MapBuilder& builder,
+        const char* key,
+        double val,
+        ZL_OperationContext* opCtx)
 {
-    A1C_MAP_TRY_ADD_R(pair, builder);
+    ZL_RESULT_DECLARE_SCOPE_REPORT(opCtx);
+    A1C_MAP_TRY_ADD(pair, builder);
     A1C_Item_string_refCStr(&pair->key, key);
     A1C_Item_float64(&pair->val, val);
     return ZL_returnSuccess();
 }
 
-ZL_Report
-addStringValue(A1C_MapBuilder& builder, const char* key, const char* val)
+ZL_Report addStringValue(
+        A1C_MapBuilder& builder,
+        const char* key,
+        const char* val,
+        ZL_OperationContext* opCtx)
 {
-    A1C_MAP_TRY_ADD_R(pair, builder);
+    ZL_RESULT_DECLARE_SCOPE_REPORT(opCtx);
+    A1C_MAP_TRY_ADD(pair, builder);
     A1C_Item_string_refCStr(&pair->key, key);
     A1C_Item_string_refCStr(&pair->val, val);
     return ZL_returnSuccess();
 }
 
-ZL_Report addBooleanValue(A1C_MapBuilder& builder, const char* key, bool val)
+ZL_Report addBooleanValue(
+        A1C_MapBuilder& builder,
+        const char* key,
+        bool val,
+        ZL_OperationContext* opCtx)
 {
-    A1C_MAP_TRY_ADD_R(pair, builder);
+    ZL_RESULT_DECLARE_SCOPE_REPORT(opCtx);
+    A1C_MAP_TRY_ADD(pair, builder);
     A1C_Item_string_refCStr(&pair->key, key);
     A1C_Item_boolean(&pair->val, val);
     return ZL_returnSuccess();
@@ -45,15 +64,17 @@ ZL_Report addBytesArray(
         A1C_Arena* a1c_arena,
         A1C_MapBuilder& builder,
         const char* key,
-        const std::vector<uint8_t>& bytes)
+        const std::vector<uint8_t>& bytes,
+        ZL_OperationContext* opCtx)
 {
-    A1C_MAP_TRY_ADD_R(pair, builder);
+    ZL_RESULT_DECLARE_SCOPE_REPORT(opCtx);
+    A1C_MAP_TRY_ADD(pair, builder);
     A1C_Item_string_refCStr(&pair->key, key);
 
     if (!bytes.empty()) {
         bool success = A1C_Item_bytes_copy(
                 &pair->val, bytes.data(), bytes.size(), a1c_arena);
-        ZL_RET_R_IF(allocation, !success, "Failed to copy bytes data.");
+        ZL_ERR_IF(!success, allocation, "Failed to copy bytes data.");
     } else {
         A1C_Item_bytes_ref(&pair->val, nullptr, 0);
     }
@@ -65,17 +86,19 @@ ZL_Report addNumArray(
         A1C_Arena* a1c_arena,
         A1C_MapBuilder& builder,
         const char* key,
-        const std::vector<int64_t>& numbers)
+        const std::vector<int64_t>& numbers,
+        ZL_OperationContext* opCtx)
 {
-    A1C_MAP_TRY_ADD_R(pair, builder);
+    ZL_RESULT_DECLARE_SCOPE_REPORT(opCtx);
+    A1C_MAP_TRY_ADD(pair, builder);
     A1C_Item_string_refCStr(&pair->key, key);
 
     A1C_ArrayBuilder arrayBuilder =
             A1C_Item_array_builder(&pair->val, numbers.size(), a1c_arena);
-    ZL_RET_R_IF_NULL(allocation, arrayBuilder.array);
+    ZL_ERR_IF_NULL(arrayBuilder.array, allocation);
 
     for (const int64_t val : numbers) {
-        A1C_ARRAY_TRY_ADD_R(item, arrayBuilder);
+        A1C_ARRAY_TRY_ADD(item, arrayBuilder);
         A1C_Item_int64(item, val);
     }
     return ZL_returnSuccess();
@@ -85,17 +108,19 @@ ZL_Report addStrArray(
         A1C_Arena* a1c_arena,
         A1C_MapBuilder& builder,
         const char* key,
-        const std::vector<std::string>& strs)
+        const std::vector<std::string>& strs,
+        ZL_OperationContext* opCtx)
 {
-    A1C_MAP_TRY_ADD_R(pair, builder);
+    ZL_RESULT_DECLARE_SCOPE_REPORT(opCtx);
+    A1C_MAP_TRY_ADD(pair, builder);
     A1C_Item_string_refCStr(&pair->key, key);
 
     A1C_ArrayBuilder arrayBuilder =
             A1C_Item_array_builder(&pair->val, strs.size(), a1c_arena);
-    ZL_RET_R_IF_NULL(allocation, arrayBuilder.array);
+    ZL_ERR_IF_NULL(arrayBuilder.array, allocation);
 
     for (const std::string& str : strs) {
-        A1C_ARRAY_TRY_ADD_R(item, arrayBuilder);
+        A1C_ARRAY_TRY_ADD(item, arrayBuilder);
         A1C_Item_string_refCStr(item, str.c_str());
     }
     return ZL_returnSuccess();
@@ -104,45 +129,47 @@ ZL_Report addStrArray(
 ZL_Report serializeLocalParams(
         A1C_Arena* a1c_arena,
         A1C_Item* a1c_localParamsParent,
-        const LocalParams& lpi)
+        const LocalParams& lpi,
+        ZL_OperationContext* opCtx)
 {
+    ZL_RESULT_DECLARE_SCOPE_REPORT(opCtx);
     A1C_MapBuilder localParamsBuilder =
             A1C_Item_map_builder(a1c_localParamsParent, 3, a1c_arena);
-    ZL_RET_R_IF_NULL(allocation, localParamsBuilder.map);
+    ZL_ERR_IF_NULL(localParamsBuilder.map, allocation);
 
     // local params: IntParams
-    A1C_MAP_TRY_ADD_R(a1c_intParams, localParamsBuilder);
+    A1C_MAP_TRY_ADD(a1c_intParams, localParamsBuilder);
     A1C_Item_string_refCStr(&a1c_intParams->key, "intParams");
     A1C_ArrayBuilder intParamsBuilder = A1C_Item_array_builder(
             &a1c_intParams->val, lpi.getIntParams().size(), a1c_arena);
-    ZL_RET_R_IF_NULL(allocation, intParamsBuilder.array);
+    ZL_ERR_IF_NULL(intParamsBuilder.array, allocation);
     for (const auto& intParam : lpi.getIntParams()) {
-        A1C_ARRAY_TRY_ADD_R(a1c_intParam, intParamsBuilder);
+        A1C_ARRAY_TRY_ADD(a1c_intParam, intParamsBuilder);
         A1C_MapBuilder currIntParamBuilder =
                 A1C_Item_map_builder(a1c_intParam, 2, a1c_arena);
-        ZL_RET_R_IF_NULL(allocation, currIntParamBuilder.map);
-        ZL_RET_R_IF_ERR(
-                addIntValue(currIntParamBuilder, "paramId", intParam.paramId));
-        ZL_RET_R_IF_ERR(addIntValue(
-                currIntParamBuilder, "paramValue", intParam.paramValue));
+        ZL_ERR_IF_NULL(currIntParamBuilder.map, allocation);
+        ZL_ERR_IF_ERR(addIntValue(
+                currIntParamBuilder, "paramId", intParam.paramId, opCtx));
+        ZL_ERR_IF_ERR(addIntValue(
+                currIntParamBuilder, "paramValue", intParam.paramValue, opCtx));
     }
 
     // local params: CopyParams
-    A1C_MAP_TRY_ADD_R(a1c_copyParams, localParamsBuilder);
+    A1C_MAP_TRY_ADD(a1c_copyParams, localParamsBuilder);
     A1C_Item_string_refCStr(&a1c_copyParams->key, "copyParams");
     A1C_ArrayBuilder copyParamsBuilder = A1C_Item_array_builder(
             &a1c_copyParams->val, lpi.getCopyParams().size(), a1c_arena);
-    ZL_RET_R_IF_NULL(allocation, copyParamsBuilder.array);
+    ZL_ERR_IF_NULL(copyParamsBuilder.array, allocation);
     for (const auto& copyParam : lpi.getCopyParams()) {
-        A1C_ARRAY_TRY_ADD_R(a1c_copyParam, copyParamsBuilder);
+        A1C_ARRAY_TRY_ADD(a1c_copyParam, copyParamsBuilder);
         A1C_MapBuilder currCopyParamBuilder =
                 A1C_Item_map_builder(a1c_copyParam, 3, a1c_arena);
-        ZL_RET_R_IF_NULL(allocation, currCopyParamBuilder.map);
-        ZL_RET_R_IF_ERR(addIntValue(
-                currCopyParamBuilder, "paramId", copyParam.paramId));
-        ZL_RET_R_IF_ERR(addIntValue(
-                currCopyParamBuilder, "paramSize", copyParam.paramSize));
-        A1C_MAP_TRY_ADD_R(a1c_copyParam_paramData, currCopyParamBuilder);
+        ZL_ERR_IF_NULL(currCopyParamBuilder.map, allocation);
+        ZL_ERR_IF_ERR(addIntValue(
+                currCopyParamBuilder, "paramId", copyParam.paramId, opCtx));
+        ZL_ERR_IF_ERR(addIntValue(
+                currCopyParamBuilder, "paramSize", copyParam.paramSize, opCtx));
+        A1C_MAP_TRY_ADD(a1c_copyParam_paramData, currCopyParamBuilder);
         A1C_Item_string_refCStr(&a1c_copyParam_paramData->key, "paramData");
         // copy if the paramPtr is not null, and its size is greater than 0
         if (copyParam.paramPtr != nullptr && copyParam.paramSize > 0) {
@@ -151,9 +178,9 @@ ZL_Report serializeLocalParams(
                     static_cast<const uint8_t*>(copyParam.paramPtr),
                     copyParam.paramSize,
                     a1c_arena);
-            ZL_RET_R_IF(
-                    allocation,
+            ZL_ERR_IF(
                     !success,
+                    allocation,
                     "Failed to copy CopyParam data from pointer.");
         } else {
             A1C_Item_bytes_ref(&a1c_copyParam_paramData->val, nullptr, 0);
@@ -161,18 +188,18 @@ ZL_Report serializeLocalParams(
     }
 
     // local params: refParams
-    A1C_MAP_TRY_ADD_R(a1c_refParams, localParamsBuilder);
+    A1C_MAP_TRY_ADD(a1c_refParams, localParamsBuilder);
     A1C_Item_string_refCStr(&a1c_refParams->key, "refParams");
     A1C_ArrayBuilder refParamsBuilder = A1C_Item_array_builder(
             &a1c_refParams->val, lpi.getRefParams().size(), a1c_arena);
-    ZL_RET_R_IF_NULL(allocation, refParamsBuilder.array);
+    ZL_ERR_IF_NULL(refParamsBuilder.array, allocation);
     for (const auto& refParam : lpi.getRefParams()) {
-        A1C_ARRAY_TRY_ADD_R(a1c_refParam, refParamsBuilder);
+        A1C_ARRAY_TRY_ADD(a1c_refParam, refParamsBuilder);
         A1C_MapBuilder currRefParamBuilder =
                 A1C_Item_map_builder(a1c_refParam, 1, a1c_arena);
-        ZL_RET_R_IF_NULL(allocation, currRefParamBuilder.map);
-        ZL_RET_R_IF_ERR(
-                addIntValue(currRefParamBuilder, "paramId", refParam.paramId));
+        ZL_ERR_IF_NULL(currRefParamBuilder.map, allocation);
+        ZL_ERR_IF_ERR(addIntValue(
+                currRefParamBuilder, "paramId", refParam.paramId, opCtx));
     }
 
     return ZL_returnSuccess();

--- a/cpp/src/openzl/cpp/experimental/trace/CborHelpers.hpp
+++ b/cpp/src/openzl/cpp/experimental/trace/CborHelpers.hpp
@@ -10,35 +10,54 @@
 
 namespace openzl::visualizer {
 
-ZL_Report addIntValue(A1C_MapBuilder& builder, const char* key, size_t val);
+ZL_Report addIntValue(
+        A1C_MapBuilder& builder,
+        const char* key,
+        size_t val,
+        ZL_OperationContext* opCtx);
 
-ZL_Report addFloatValue(A1C_MapBuilder& builder, const char* key, double val);
+ZL_Report addFloatValue(
+        A1C_MapBuilder& builder,
+        const char* key,
+        double val,
+        ZL_OperationContext* opCtx);
 
-ZL_Report
-addStringValue(A1C_MapBuilder& builder, const char* key, const char* val);
+ZL_Report addStringValue(
+        A1C_MapBuilder& builder,
+        const char* key,
+        const char* val,
+        ZL_OperationContext* opCtx);
 
-ZL_Report addBooleanValue(A1C_MapBuilder& builder, const char* key, bool val);
+ZL_Report addBooleanValue(
+        A1C_MapBuilder& builder,
+        const char* key,
+        bool val,
+        ZL_OperationContext* opCtx);
 
 ZL_Report addStrArray(
         A1C_Arena* a1c_arena,
         A1C_MapBuilder& builder,
         const char* key,
-        const std::vector<std::string>& strs);
+        const std::vector<std::string>& strs,
+        ZL_OperationContext* opCtx);
 
 ZL_Report addNumArray(
         A1C_Arena* a1c_arena,
         A1C_MapBuilder& builder,
         const char* key,
-        const std::vector<int64_t>& numbers);
+        const std::vector<int64_t>& numbers,
+        ZL_OperationContext* opCtx);
 
 ZL_Report addBytesArray(
         A1C_Arena* a1c_arena,
         A1C_MapBuilder& builder,
         const char* key,
-        const std::vector<uint8_t>& bytes);
+        const std::vector<uint8_t>& bytes,
+        ZL_OperationContext* opCtx);
 
 ZL_Report serializeLocalParams(
         A1C_Arena* a1c_arena,
         A1C_Item* a1c_localParamsParent,
-        const LocalParams& lpi);
+        const LocalParams& lpi,
+        ZL_OperationContext* opCtx);
 } // namespace openzl::visualizer

--- a/cpp/src/openzl/cpp/experimental/trace/ChunkTraceCore.cpp
+++ b/cpp/src/openzl/cpp/experimental/trace/ChunkTraceCore.cpp
@@ -87,7 +87,7 @@ getStringData(const void* data, size_t numStrings, const uint32_t* stringLens)
             parsedStr = std::move(rawStr);
         }
 
-        strings.push_back(parsedStr);
+        strings.push_back(std::move(parsedStr));
         offset += len;
     }
 
@@ -265,46 +265,49 @@ ZL_Report ChunkTraceCore::serializeChunkDataToCBOR(
         size_t chunkId,
         std::map<ZL_DataID, Stream, ZL_DataIDCustomComparator>& streamInfo,
         std::vector<Codec>& codecInfo,
-        std::vector<Graph>& graphInfo)
+        std::vector<Graph>& graphInfo,
+        ZL_OperationContext* opCtx)
 {
-    A1C_ARRAY_TRY_ADD_R(chunkItem, *chunkArrayBuilder);
+    ZL_RESULT_DECLARE_SCOPE_REPORT(opCtx);
+    A1C_ARRAY_TRY_ADD(chunkItem, *chunkArrayBuilder);
     A1C_MapBuilder chunkBuilder = A1C_Item_map_builder(chunkItem, 4, a1c_arena);
-    ZL_RET_R_IF_NULL(allocation, chunkBuilder.map);
+    ZL_ERR_IF_NULL(chunkBuilder.map, allocation);
 
-    ZL_RET_R_IF_ERR(addIntValue(chunkBuilder, "chunkId", chunkId));
+    ZL_ERR_IF_ERR(addIntValue(chunkBuilder, "chunkId", chunkId, opCtx));
 
     // Streams
-    A1C_MAP_TRY_ADD_R(streamsPair, chunkBuilder);
+    A1C_MAP_TRY_ADD(streamsPair, chunkBuilder);
     A1C_Item_string_refCStr(&streamsPair->key, "streams");
     A1C_ArrayBuilder streamsBuilder = A1C_Item_array_builder(
             &streamsPair->val, streamInfo.size(), a1c_arena);
-    ZL_RET_R_IF_NULL(allocation, streamsBuilder.array);
+    ZL_ERR_IF_NULL(streamsBuilder.array, allocation);
     for (auto& stream : streamInfo) {
-        A1C_ARRAY_TRY_ADD_R(a1c_stream, streamsBuilder);
-        ZL_RET_R_IF_ERR(stream.second.serializeStream(a1c_arena, a1c_stream));
+        A1C_ARRAY_TRY_ADD(a1c_stream, streamsBuilder);
+        ZL_ERR_IF_ERR(
+                stream.second.serializeStream(a1c_arena, a1c_stream, opCtx));
     }
 
     // Codecs
-    A1C_MAP_TRY_ADD_R(codecsPair, chunkBuilder);
+    A1C_MAP_TRY_ADD(codecsPair, chunkBuilder);
     A1C_Item_string_refCStr(&codecsPair->key, "codecs");
     A1C_ArrayBuilder codecsBuilder = A1C_Item_array_builder(
             &codecsPair->val, codecInfo.size(), a1c_arena);
-    ZL_RET_R_IF_NULL(allocation, codecsBuilder.array);
+    ZL_ERR_IF_NULL(codecsBuilder.array, allocation);
     for (size_t codecNum = 0; codecNum < codecInfo.size(); ++codecNum) {
         Codec& codec = codecInfo[codecNum];
-        A1C_ARRAY_TRY_ADD_R(a1c_codec, codecsBuilder);
-        ZL_RET_R_IF_ERR(codec.serializeCodec(a1c_arena, a1c_codec));
+        A1C_ARRAY_TRY_ADD(a1c_codec, codecsBuilder);
+        ZL_ERR_IF_ERR(codec.serializeCodec(a1c_arena, a1c_codec, opCtx));
     }
 
     // Graphs (empty array for decompress)
-    A1C_MAP_TRY_ADD_R(graphsPair, chunkBuilder);
+    A1C_MAP_TRY_ADD(graphsPair, chunkBuilder);
     A1C_Item_string_refCStr(&graphsPair->key, "graphs");
     A1C_ArrayBuilder graphsBuilder = A1C_Item_array_builder(
             &graphsPair->val, graphInfo.size(), a1c_arena);
-    ZL_RET_R_IF_NULL(allocation, graphsBuilder.array);
+    ZL_ERR_IF_NULL(graphsBuilder.array, allocation);
     for (auto& graph : graphInfo) {
-        A1C_ARRAY_TRY_ADD_R(a1c_graph, graphsBuilder);
-        ZL_RET_R_IF_ERR(graph.serializeGraph(a1c_arena, a1c_graph));
+        A1C_ARRAY_TRY_ADD(a1c_graph, graphsBuilder);
+        ZL_ERR_IF_ERR(graph.serializeGraph(a1c_arena, a1c_graph, opCtx));
     }
 
     return ZL_returnSuccess();

--- a/cpp/src/openzl/cpp/experimental/trace/ChunkTraceCore.hpp
+++ b/cpp/src/openzl/cpp/experimental/trace/ChunkTraceCore.hpp
@@ -112,7 +112,8 @@ class ChunkTraceCore {
             size_t chunkId,
             std::map<ZL_DataID, Stream, ZL_DataIDCustomComparator>& streamInfo,
             std::vector<Codec>& codecInfo,
-            std::vector<Graph>& graphInfo);
+            std::vector<Graph>& graphInfo,
+            ZL_OperationContext* opCtx);
 
     /**
      * Encodes CBOR buffer bytes into a string (for trace output).

--- a/cpp/src/openzl/cpp/experimental/trace/ChunkTraceCore.hpp
+++ b/cpp/src/openzl/cpp/experimental/trace/ChunkTraceCore.hpp
@@ -3,8 +3,6 @@
 #pragma once
 
 #include <map>
-#include <string>
-#include <variant>
 #include <vector>
 
 #include "openzl/cpp/experimental/trace/Codec.hpp"
@@ -12,11 +10,6 @@
 #include "openzl/cpp/experimental/trace/StreamVisualizer.hpp"
 
 namespace openzl::visualizer {
-
-using StreamPreview = std::variant<
-        std::vector<std::string>,
-        std::vector<int64_t>,
-        std::vector<uint8_t>>;
 
 struct StreamdumpEntry {
     size_t streamId;

--- a/cpp/src/openzl/cpp/experimental/trace/Codec.cpp
+++ b/cpp/src/openzl/cpp/experimental/trace/Codec.cpp
@@ -12,51 +12,57 @@ namespace openzl::visualizer {
 static ZL_Report serializeCodecEdges(
         A1C_Arena* a1c_arena,
         A1C_Item* a1c_edgesParent,
-        const std::vector<StreamID>& edges)
+        const std::vector<StreamID>& edges,
+        ZL_OperationContext* opCtx)
 {
+    ZL_RESULT_DECLARE_SCOPE_REPORT(opCtx);
     A1C_ArrayBuilder inEdgesBuilder =
             A1C_Item_array_builder(a1c_edgesParent, edges.size(), a1c_arena);
-    ZL_RET_R_IF_NULL(allocation, inEdgesBuilder.array);
+    ZL_ERR_IF_NULL(inEdgesBuilder.array, allocation);
     for (const auto& streamId : edges) {
-        A1C_ARRAY_TRY_ADD_R(a1c_streamID, inEdgesBuilder);
+        A1C_ARRAY_TRY_ADD(a1c_streamID, inEdgesBuilder);
         A1C_Item_int64(a1c_streamID, streamId.sid);
     }
 
     return ZL_returnSuccess();
 }
 
-const ZL_Report Codec::serializeCodec(A1C_Arena* a1c_arena, A1C_Item* arrayItem)
+const ZL_Report Codec::serializeCodec(
+        A1C_Arena* a1c_arena,
+        A1C_Item* arrayItem,
+        ZL_OperationContext* opCtx)
 {
+    ZL_RESULT_DECLARE_SCOPE_REPORT(opCtx);
     A1C_MapBuilder builder = A1C_Item_map_builder(arrayItem, 9, a1c_arena);
-    ZL_RET_R_IF_NULL(allocation, builder.map);
+    ZL_ERR_IF_NULL(builder.map, allocation);
 
-    ZL_RET_R_IF_ERR(addIntValue(builder, "chunkId", this->chunkId));
-    ZL_RET_R_IF_ERR(addStringValue(builder, "name", name.c_str()));
-    ZL_RET_R_IF_ERR(addBooleanValue(builder, "cType", cType));
-    ZL_RET_R_IF_ERR(addIntValue(builder, "cID", cID));
-    ZL_RET_R_IF_ERR(addIntValue(builder, "cHeaderSize", cHeaderSize));
+    ZL_ERR_IF_ERR(addIntValue(builder, "chunkId", this->chunkId, opCtx));
+    ZL_ERR_IF_ERR(addStringValue(builder, "name", name.c_str(), opCtx));
+    ZL_ERR_IF_ERR(addBooleanValue(builder, "cType", cType, opCtx));
+    ZL_ERR_IF_ERR(addIntValue(builder, "cID", cID, opCtx));
+    ZL_ERR_IF_ERR(addIntValue(builder, "cHeaderSize", cHeaderSize, opCtx));
     if (!cFailureString.empty()) {
-        ZL_RET_R_IF_ERR(addStringValue(
-                builder, "cFailureString", cFailureString.c_str()));
+        ZL_ERR_IF_ERR(addStringValue(
+                builder, "cFailureString", cFailureString.c_str(), opCtx));
     }
 
     // local params
-    A1C_MAP_TRY_ADD_R(a1c_cLocalParams, builder);
+    A1C_MAP_TRY_ADD(a1c_cLocalParams, builder);
     A1C_Item_string_refCStr(&a1c_cLocalParams->key, "cLocalParams");
-    ZL_RET_R_IF_ERR(serializeLocalParams(
-            a1c_arena, &a1c_cLocalParams->val, cLocalParams));
+    ZL_ERR_IF_ERR(serializeLocalParams(
+            a1c_arena, &a1c_cLocalParams->val, cLocalParams, opCtx));
 
     // codec in-edges
-    A1C_MAP_TRY_ADD_R(a1c_inEdges, builder);
+    A1C_MAP_TRY_ADD(a1c_inEdges, builder);
     A1C_Item_string_refCStr(&a1c_inEdges->key, "inputStreams");
-    ZL_RET_R_IF_ERR(
-            serializeCodecEdges(a1c_arena, &a1c_inEdges->val, this->inEdges));
+    ZL_ERR_IF_ERR(serializeCodecEdges(
+            a1c_arena, &a1c_inEdges->val, this->inEdges, opCtx));
 
     // codec out-edges
-    A1C_MAP_TRY_ADD_R(a1c_outEdges, builder);
+    A1C_MAP_TRY_ADD(a1c_outEdges, builder);
     A1C_Item_string_refCStr(&a1c_outEdges->key, "outputStreams");
-    ZL_RET_R_IF_ERR(
-            serializeCodecEdges(a1c_arena, &a1c_outEdges->val, this->outEdges));
+    ZL_ERR_IF_ERR(serializeCodecEdges(
+            a1c_arena, &a1c_outEdges->val, this->outEdges, opCtx));
 
     return ZL_returnSuccess();
 }

--- a/cpp/src/openzl/cpp/experimental/trace/Codec.hpp
+++ b/cpp/src/openzl/cpp/experimental/trace/Codec.hpp
@@ -26,7 +26,10 @@ struct Codec {
     std::vector<StreamID> inEdges;
     std::vector<StreamID> outEdges;
 
-    const ZL_Report serializeCodec(A1C_Arena* a1c_arena, A1C_Item* arrayItem);
+    const ZL_Report serializeCodec(
+            A1C_Arena* a1c_arena,
+            A1C_Item* arrayItem,
+            ZL_OperationContext* opCtx);
 };
 
 } // namespace openzl::visualizer

--- a/cpp/src/openzl/cpp/experimental/trace/CompressChunkTrace.cpp
+++ b/cpp/src/openzl/cpp/experimental/trace/CompressChunkTrace.cpp
@@ -110,7 +110,8 @@ void CompressChunkTrace::resolveErrorStrings(const ZL_CCtx* cctx)
 
 ZL_Report CompressChunkTrace::serializeToCBOR(
         A1C_Arena* a1c_arena,
-        A1C_ArrayBuilder* chunkArrayBuilder)
+        A1C_ArrayBuilder* chunkArrayBuilder,
+        ZL_OperationContext* opCtx)
 {
     return ChunkTraceCore::serializeChunkDataToCBOR(
             a1c_arena,
@@ -118,7 +119,8 @@ ZL_Report CompressChunkTrace::serializeToCBOR(
             chunkId_,
             streamInfo_,
             codecInfo_,
-            graphInfo_);
+            graphInfo_,
+            opCtx);
 }
 
 size_t CompressChunkTrace::getCompressedSize()
@@ -308,7 +310,7 @@ void CompressChunkTrace::on_codecEncode_start(
                             LocalParams(*ZL_Encoder_getLocalParams(encoder)),
                     .chunkId = chunkId_ };
     newCodec.codecNum = currCodecNum_;
-    codecInfo_.push_back(newCodec);
+    codecInfo_.push_back(std::move(newCodec));
     for (size_t i = 0; i < nbInStreams; ++i) {
         StreamID streamID = ZL_Input_id(inStreams[i]);
         codecInfo_[currCodecNum_].inEdges.push_back(
@@ -513,7 +515,7 @@ void CompressChunkTrace::on_segmenterEncode_start(ZL_Segmenter* segCtx)
                             LocalParams(*ZL_Segmenter_getLocalParams(segCtx)),
                     .chunkId = chunkId_ };
     newCodec.codecNum = currCodecNum_;
-    codecInfo_.push_back(newCodec);
+    codecInfo_.push_back(std::move(newCodec));
     for (size_t i = 0; i < nbInStreams; ++i) {
         StreamID streamID = ZL_Input_id(ZL_Segmenter_getInput(segCtx, i));
         codecInfo_[currCodecNum_].inEdges.push_back(

--- a/cpp/src/openzl/cpp/experimental/trace/CompressChunkTrace.hpp
+++ b/cpp/src/openzl/cpp/experimental/trace/CompressChunkTrace.hpp
@@ -46,7 +46,8 @@ class CompressChunkTrace {
 
     ZL_Report serializeToCBOR(
             A1C_Arena* a1c_arena,
-            A1C_ArrayBuilder* chunkArrayBuilder);
+            A1C_ArrayBuilder* chunkArrayBuilder,
+            ZL_OperationContext* opCtx);
 
     size_t getCompressedSize();
 

--- a/cpp/src/openzl/cpp/experimental/trace/CompressTracer.cpp
+++ b/cpp/src/openzl/cpp/experimental/trace/CompressTracer.cpp
@@ -160,13 +160,14 @@ void CompressTracer::on_ZL_Edge_setMultiInputDestination_wParams(
 }
 
 void CompressTracer::on_ZL_CCtx_compressMultiTypedRef_start(
-        ZL_CCtx const* const cctx,
+        ZL_CCtx* cctx,
         void const* const,
         size_t const,
         ZL_TypedRef const* const[],
         size_t const)
 {
     frameVersion = ZL_CCtx_getParameter(cctx, ZL_CParam_formatVersion);
+    opCtx_       = ZL_GET_OPERATION_CONTEXT(cctx);
     // The "main" trace is located at idx 0 of graphRuns
     graphRuns.emplace_back(MAIN_TRACE_IDX);
     currChunk = &graphRuns[MAIN_TRACE_IDX];
@@ -216,8 +217,9 @@ ZL_Report CompressTracer::serializeStreamdumpToCbor(
         A1C_Arena* a1c_arena,
         std::vector<uint8_t>& buffer)
 {
+    ZL_RESULT_DECLARE_SCOPE_REPORT(opCtx_);
     A1C_Item* root = A1C_Item_root(a1c_arena);
-    ZL_RET_R_IF_NULL(allocation, root);
+    ZL_ERR_IF_NULL(root, allocation);
     /* want 3 inner maps:
      * 1. streams and their associated metadata
      * 2. codecs and their associated metadata, and their in/out edges
@@ -226,12 +228,15 @@ ZL_Report CompressTracer::serializeStreamdumpToCbor(
      */
     A1C_MapBuilder rootBuilder = A1C_Item_map_builder(root, 5, a1c_arena);
 
-    ZL_RET_R_IF_NULL(allocation, rootBuilder.map);
+    ZL_ERR_IF_NULL(rootBuilder.map, allocation);
 
-    ZL_RET_R_IF_ERR(addIntValue(rootBuilder, "libraryVersion", libraryVersion));
-    ZL_RET_R_IF_ERR(addIntValue(rootBuilder, "frameVersion", frameVersion));
-    ZL_RET_R_IF_ERR(addIntValue(rootBuilder, "traceVersion", traceVersion));
-    ZL_RET_R_IF_ERR(addIntValue(rootBuilder, "operationType", 0));
+    ZL_ERR_IF_ERR(
+            addIntValue(rootBuilder, "libraryVersion", libraryVersion, opCtx_));
+    ZL_ERR_IF_ERR(
+            addIntValue(rootBuilder, "frameVersion", frameVersion, opCtx_));
+    ZL_ERR_IF_ERR(
+            addIntValue(rootBuilder, "traceVersion", traceVersion, opCtx_));
+    ZL_ERR_IF_ERR(addIntValue(rootBuilder, "operationType", 0, opCtx_));
 
     // Wrap streams, codecs, and graphs in a "chunks" array
     // Non-segmented runs will have 1 chunk in idx 0.
@@ -239,15 +244,16 @@ ZL_Report CompressTracer::serializeStreamdumpToCbor(
     // chunks in idx 1+. By the "main" trace we mean the trace that includes the
     // start of the compression, up to the segmenter but not including child
     // chunk traces.
-    A1C_MAP_TRY_ADD_R(chunksPair, rootBuilder);
+    A1C_MAP_TRY_ADD(chunksPair, rootBuilder);
     A1C_Item_string_refCStr(&chunksPair->key, "chunks");
     A1C_ArrayBuilder chunksBuilder = A1C_Item_array_builder(
             &chunksPair->val, 1 + graphRuns.size(), a1c_arena);
-    ZL_RET_R_IF_NULL(allocation, chunksBuilder.array);
+    ZL_ERR_IF_NULL(chunksBuilder.array, allocation);
 
     // Add additional chunks from graphRuns
     for (auto& graphRun : graphRuns) {
-        ZL_RET_R_IF_ERR(graphRun.serializeToCBOR(a1c_arena, &chunksBuilder));
+        ZL_ERR_IF_ERR(
+                graphRun.serializeToCBOR(a1c_arena, &chunksBuilder, opCtx_));
     }
 
     // encode + write data to a buffer
@@ -257,9 +263,9 @@ ZL_Report CompressTracer::serializeStreamdumpToCbor(
     size_t bytesWritten =
             A1C_Item_encode(root, buffer.data(), encodedSize, &error);
     if (bytesWritten == 0) {
-        ZL_RET_R_WRAP_ERR(A1C_Error_convert(NULL, error));
+        return ZL_WRAP_ERROR(A1C_Error_convert(NULL, error));
     }
-    ZL_RET_R_IF_NE(allocation, bytesWritten, encodedSize);
+    ZL_ERR_IF_NE(bytesWritten, encodedSize, allocation);
 
     return ZL_returnSuccess();
 }

--- a/cpp/src/openzl/cpp/experimental/trace/CompressTracer.hpp
+++ b/cpp/src/openzl/cpp/experimental/trace/CompressTracer.hpp
@@ -86,7 +86,7 @@ class CompressTracer {
             const ZL_LocalParams* lparams);
 
     void on_ZL_CCtx_compressMultiTypedRef_start(
-            ZL_CCtx const* const cctx,
+            ZL_CCtx* cctx,
             void const* const dst,
             size_t const dstCapacity,
             ZL_TypedRef const* const inputs[],
@@ -119,7 +119,8 @@ class CompressTracer {
     std::vector<CompressChunkTrace> graphRuns;
     CompressChunkTrace* currChunk =
             nullptr; // convenience pointer to the current chunk trace
-    bool segmented = false;
+    bool segmented              = false;
+    ZL_OperationContext* opCtx_ = nullptr;
 
     TraceResult trace;
 };

--- a/cpp/src/openzl/cpp/experimental/trace/CompressionTraceHooks.cpp
+++ b/cpp/src/openzl/cpp/experimental/trace/CompressionTraceHooks.cpp
@@ -178,7 +178,7 @@ void CompressionTraceHooks::on_ZL_Edge_setMultiInputDestination_wParams(
 }
 
 void CompressionTraceHooks::on_ZL_CCtx_compressMultiTypedRef_start(
-        ZL_CCtx const* const cctx,
+        ZL_CCtx* cctx,
         void const* const dst,
         size_t const dstCapacity,
         ZL_TypedRef const* const inputs[],

--- a/cpp/src/openzl/cpp/experimental/trace/CompressionTraceHooks.hpp
+++ b/cpp/src/openzl/cpp/experimental/trace/CompressionTraceHooks.hpp
@@ -99,7 +99,7 @@ class CompressionTraceHooks : public openzl::CompressIntrospectionHooks {
             const ZL_LocalParams* lparams) override;
 
     void on_ZL_CCtx_compressMultiTypedRef_start(
-            ZL_CCtx const* const cctx,
+            ZL_CCtx* cctx,
             void const* const dst,
             size_t const dstCapacity,
             ZL_TypedRef const* const inputs[],

--- a/cpp/src/openzl/cpp/experimental/trace/DecompressChunkTrace.cpp
+++ b/cpp/src/openzl/cpp/experimental/trace/DecompressChunkTrace.cpp
@@ -23,7 +23,7 @@ DecompressChunkTrace DecompressChunkTrace::makeSegmenterChunk(size_t chunkId)
                     .cHeaderSize = 0,
                     .chunkId     = chunkId };
     newCodec.codecNum = 0;
-    ret.codecInfo_.push_back(newCodec);
+    ret.codecInfo_.push_back(std::move(newCodec));
     return ret;
 }
 
@@ -61,7 +61,8 @@ void DecompressChunkTrace::resolveErrorStrings(const ZL_DCtx* dctx)
 
 ZL_Report DecompressChunkTrace::serializeToCBOR(
         A1C_Arena* a1c_arena,
-        A1C_ArrayBuilder* chunkArrayBuilder)
+        A1C_ArrayBuilder* chunkArrayBuilder,
+        ZL_OperationContext* opCtx)
 {
     std::vector<Graph> noGraphs;
     return ChunkTraceCore::serializeChunkDataToCBOR(
@@ -70,7 +71,8 @@ ZL_Report DecompressChunkTrace::serializeToCBOR(
             chunkId_,
             streamInfo_,
             codecInfo_,
-            noGraphs);
+            noGraphs,
+            opCtx);
 }
 
 void DecompressChunkTrace::on_codecDecode_start(

--- a/cpp/src/openzl/cpp/experimental/trace/DecompressChunkTrace.hpp
+++ b/cpp/src/openzl/cpp/experimental/trace/DecompressChunkTrace.hpp
@@ -41,7 +41,8 @@ class DecompressChunkTrace {
 
     ZL_Report serializeToCBOR(
             A1C_Arena* a1c_arena,
-            A1C_ArrayBuilder* chunkArrayBuilder);
+            A1C_ArrayBuilder* chunkArrayBuilder,
+            ZL_OperationContext* opCtx);
 
     /* ************** Trampolined hook calls ************** */
     void on_ZL_Decoder_getCodecHeader(

--- a/cpp/src/openzl/cpp/experimental/trace/DecompressTracer.cpp
+++ b/cpp/src/openzl/cpp/experimental/trace/DecompressTracer.cpp
@@ -35,7 +35,7 @@ TraceResult DecompressTracer::extractTrace()
 }
 
 void DecompressTracer::on_ZL_DCtx_decompressMultiTBuffer_start(
-        ZL_DCtx* /* dctx */,
+        ZL_DCtx* dctx,
         size_t /* nbOutputs */,
         const void* framePtr,
         size_t frameSize)
@@ -46,6 +46,7 @@ void DecompressTracer::on_ZL_DCtx_decompressMultiTBuffer_start(
     // Create the main chunk at index 0
     chunks_.emplace_back(MAIN_CHUNK_IDX);
     currChunk_ = &chunks_[MAIN_CHUNK_IDX];
+    opCtx_     = ZL_GET_OPERATION_CONTEXT(dctx);
 }
 
 void DecompressTracer::on_ZL_DCtx_decompressMultiTBuffer_end(
@@ -136,28 +137,32 @@ ZL_Report DecompressTracer::serializeStreamdumpToCbor(
         A1C_Arena* a1c_arena,
         std::vector<uint8_t>& buffer)
 {
+    ZL_RESULT_DECLARE_SCOPE_REPORT(opCtx_);
     A1C_Item* root = A1C_Item_root(a1c_arena);
-    ZL_RET_R_IF_NULL(allocation, root);
+    ZL_ERR_IF_NULL(root, allocation);
 
     // 5 top-level fields: libraryVersion, frameVersion, traceVersion,
     // operationType, chunks
     A1C_MapBuilder rootBuilder = A1C_Item_map_builder(root, 5, a1c_arena);
-    ZL_RET_R_IF_NULL(allocation, rootBuilder.map);
+    ZL_ERR_IF_NULL(rootBuilder.map, allocation);
 
-    ZL_RET_R_IF_ERR(addIntValue(rootBuilder, "libraryVersion", libraryVersion));
-    ZL_RET_R_IF_ERR(addIntValue(rootBuilder, "frameVersion", frameVersion_));
-    ZL_RET_R_IF_ERR(addIntValue(rootBuilder, "traceVersion", traceVersion));
-    ZL_RET_R_IF_ERR(addIntValue(rootBuilder, "operationType", 1));
+    ZL_ERR_IF_ERR(
+            addIntValue(rootBuilder, "libraryVersion", libraryVersion, opCtx_));
+    ZL_ERR_IF_ERR(
+            addIntValue(rootBuilder, "frameVersion", frameVersion_, opCtx_));
+    ZL_ERR_IF_ERR(
+            addIntValue(rootBuilder, "traceVersion", traceVersion, opCtx_));
+    ZL_ERR_IF_ERR(addIntValue(rootBuilder, "operationType", 1, opCtx_));
 
     // Wrap chunks in a "chunks" array
-    A1C_MAP_TRY_ADD_R(chunksPair, rootBuilder);
+    A1C_MAP_TRY_ADD(chunksPair, rootBuilder);
     A1C_Item_string_refCStr(&chunksPair->key, "chunks");
     A1C_ArrayBuilder chunksBuilder =
             A1C_Item_array_builder(&chunksPair->val, chunks_.size(), a1c_arena);
-    ZL_RET_R_IF_NULL(allocation, chunksBuilder.array);
+    ZL_ERR_IF_NULL(chunksBuilder.array, allocation);
 
     for (auto& chunk : chunks_) {
-        ZL_RET_R_IF_ERR(chunk.serializeToCBOR(a1c_arena, &chunksBuilder));
+        ZL_ERR_IF_ERR(chunk.serializeToCBOR(a1c_arena, &chunksBuilder, opCtx_));
     }
 
     // Encode to buffer
@@ -167,9 +172,9 @@ ZL_Report DecompressTracer::serializeStreamdumpToCbor(
     size_t bytesWritten =
             A1C_Item_encode(root, buffer.data(), encodedSize, &error);
     if (bytesWritten == 0) {
-        ZL_RET_R_WRAP_ERR(A1C_Error_convert(NULL, error));
+        return ZL_WRAP_ERROR(A1C_Error_convert(NULL, error));
     }
-    ZL_RET_R_IF_NE(allocation, bytesWritten, encodedSize);
+    ZL_ERR_IF_NE(bytesWritten, encodedSize, allocation);
 
     return ZL_returnSuccess();
 }

--- a/cpp/src/openzl/cpp/experimental/trace/DecompressTracer.hpp
+++ b/cpp/src/openzl/cpp/experimental/trace/DecompressTracer.hpp
@@ -55,6 +55,7 @@ class DecompressTracer {
     std::vector<DecompressChunkTrace> chunks_;
     DecompressChunkTrace* currChunk_ =
             nullptr; // convenience pointer to the current chunk trace
+    ZL_OperationContext* opCtx_ = nullptr;
 
     TraceResult trace_;
 };

--- a/cpp/src/openzl/cpp/experimental/trace/Graph.cpp
+++ b/cpp/src/openzl/cpp/experimental/trace/Graph.cpp
@@ -9,35 +9,39 @@
 
 namespace openzl::visualizer {
 
-const ZL_Report Graph::serializeGraph(A1C_Arena* a1c_arena, A1C_Item* arrayItem)
+const ZL_Report Graph::serializeGraph(
+        A1C_Arena* a1c_arena,
+        A1C_Item* arrayItem,
+        ZL_OperationContext* opCtx)
 {
+    ZL_RESULT_DECLARE_SCOPE_REPORT(opCtx);
     A1C_MapBuilder builder = A1C_Item_map_builder(arrayItem, 6, a1c_arena);
-    ZL_RET_R_IF_NULL(allocation, builder.map);
+    ZL_ERR_IF_NULL(builder.map, allocation);
 
-    ZL_RET_R_IF_ERR(addIntValue(builder, "chunkId", this->chunkId));
-    ZL_RET_R_IF_ERR(addIntValue(builder, "gType", gType));
-    ZL_RET_R_IF_ERR(addStringValue(builder, "gName", gName));
+    ZL_ERR_IF_ERR(addIntValue(builder, "chunkId", this->chunkId, opCtx));
+    ZL_ERR_IF_ERR(addIntValue(builder, "gType", gType, opCtx));
+    ZL_ERR_IF_ERR(addStringValue(builder, "gName", gName, opCtx));
     if (!gFailureString.empty()) {
-        ZL_RET_R_IF_ERR(addStringValue(
-                builder, "gFailureString", gFailureString.c_str()));
+        ZL_ERR_IF_ERR(addStringValue(
+                builder, "gFailureString", gFailureString.c_str(), opCtx));
     }
 
     // local params
-    A1C_MAP_TRY_ADD_R(a1c_gLocalParams, builder);
+    A1C_MAP_TRY_ADD(a1c_gLocalParams, builder);
     A1C_Item_string_refCStr(&a1c_gLocalParams->key, "gLocalParams");
 
     ZL_Report serializeLocalParamsReport = serializeLocalParams(
-            a1c_arena, &a1c_gLocalParams->val, gLocalParams);
-    ZL_RET_R_IF_ERR(serializeLocalParamsReport);
+            a1c_arena, &a1c_gLocalParams->val, gLocalParams, opCtx);
+    ZL_ERR_IF_ERR(serializeLocalParamsReport);
 
     // codec in graph
-    A1C_MAP_TRY_ADD_R(a1c_codecIDs, builder);
+    A1C_MAP_TRY_ADD(a1c_codecIDs, builder);
     A1C_Item_string_refCStr(&a1c_codecIDs->key, "codecIDs");
     A1C_ArrayBuilder codecIDsBuilder = A1C_Item_array_builder(
             &a1c_codecIDs->val, this->codecs.size(), a1c_arena);
-    ZL_RET_R_IF_NULL(allocation, codecIDsBuilder.array);
+    ZL_ERR_IF_NULL(codecIDsBuilder.array, allocation);
     for (const auto& codecId : this->codecs) {
-        A1C_ARRAY_TRY_ADD_R(a1c_codecID, codecIDsBuilder);
+        A1C_ARRAY_TRY_ADD(a1c_codecID, codecIDsBuilder);
         A1C_Item_int64(a1c_codecID, codecId);
     }
 

--- a/cpp/src/openzl/cpp/experimental/trace/Graph.hpp
+++ b/cpp/src/openzl/cpp/experimental/trace/Graph.hpp
@@ -27,7 +27,10 @@ struct Graph {
     std::vector<ZL_Edge*> inEdges;
     std::vector<CodecID> codecs;
 
-    const ZL_Report serializeGraph(A1C_Arena* a1c_arena, A1C_Item* arrayItem);
+    const ZL_Report serializeGraph(
+            A1C_Arena* a1c_arena,
+            A1C_Item* arrayItem,
+            ZL_OperationContext* opCtx);
 };
 
 } // namespace openzl::visualizer

--- a/cpp/src/openzl/cpp/experimental/trace/StreamVisualizer.cpp
+++ b/cpp/src/openzl/cpp/experimental/trace/StreamVisualizer.cpp
@@ -9,38 +9,43 @@
 namespace openzl::visualizer {
 const ZL_Report Stream::serializeStream(
         A1C_Arena* a1c_arena,
-        A1C_Item* arrayItem)
+        A1C_Item* arrayItem,
+        ZL_OperationContext* opCtx)
 {
+    ZL_RESULT_DECLARE_SCOPE_REPORT(opCtx);
     A1C_MapBuilder builder = A1C_Item_map_builder(arrayItem, 9, a1c_arena);
-    ZL_RET_R_IF_NULL(allocation, builder.map);
+    ZL_ERR_IF_NULL(builder.map, allocation);
 
-    ZL_RET_R_IF_ERR(addIntValue(builder, "chunkId", this->chunkId));
-    ZL_RET_R_IF_ERR(addIntValue(builder, "type", type));
-    ZL_RET_R_IF_ERR(addIntValue(builder, "outputIdx", outputIdx));
-    ZL_RET_R_IF_ERR(addIntValue(builder, "eltWidth", eltWidth));
-    ZL_RET_R_IF_ERR(addIntValue(builder, "numElts", numElts));
-    ZL_RET_R_IF_ERR(addIntValue(builder, "cSize", cSize));
-    ZL_RET_R_IF_ERR(addFloatValue(builder, "share", share));
-    ZL_RET_R_IF_ERR(addIntValue(builder, "contentSize", contentSize));
+    ZL_ERR_IF_ERR(addIntValue(builder, "chunkId", this->chunkId, opCtx));
+    ZL_ERR_IF_ERR(addIntValue(builder, "type", type, opCtx));
+    ZL_ERR_IF_ERR(addIntValue(builder, "outputIdx", outputIdx, opCtx));
+    ZL_ERR_IF_ERR(addIntValue(builder, "eltWidth", eltWidth, opCtx));
+    ZL_ERR_IF_ERR(addIntValue(builder, "numElts", numElts, opCtx));
+    ZL_ERR_IF_ERR(addIntValue(builder, "cSize", cSize, opCtx));
+    ZL_ERR_IF_ERR(addFloatValue(builder, "share", share, opCtx));
+    ZL_ERR_IF_ERR(addIntValue(builder, "contentSize", contentSize, opCtx));
 
     if (type == ZL_Type_string) {
-        ZL_RET_R_IF_ERR(addStrArray(
+        ZL_ERR_IF_ERR(addStrArray(
                 a1c_arena,
                 builder,
                 "streamPreview",
-                std::get<std::vector<std::string>>(streamPreview)));
+                std::get<std::vector<std::string>>(streamPreview),
+                opCtx));
     } else if (type == ZL_Type_numeric) {
-        ZL_RET_R_IF_ERR(addNumArray(
+        ZL_ERR_IF_ERR(addNumArray(
                 a1c_arena,
                 builder,
                 "streamPreview",
-                std::get<std::vector<int64_t>>(streamPreview)));
+                std::get<std::vector<int64_t>>(streamPreview),
+                opCtx));
     } else {
-        ZL_RET_R_IF_ERR(addBytesArray(
+        ZL_ERR_IF_ERR(addBytesArray(
                 a1c_arena,
                 builder,
                 "streamPreview",
-                std::get<std::vector<uint8_t>>(streamPreview)));
+                std::get<std::vector<uint8_t>>(streamPreview),
+                opCtx));
     }
 
     return ZL_returnSuccess();

--- a/cpp/src/openzl/cpp/experimental/trace/StreamVisualizer.hpp
+++ b/cpp/src/openzl/cpp/experimental/trace/StreamVisualizer.hpp
@@ -9,8 +9,6 @@
 
 #include <functional>
 #include <optional>
-#include <string>
-#include <variant>
 #include <vector>
 
 namespace openzl::visualizer {
@@ -28,11 +26,7 @@ struct Stream {
     std::vector<StreamID> successors;
     std::optional<CodecID> consumerCodec;
     std::optional<CodecID> producerCodec;
-    std::variant<
-            std::vector<std::string>,
-            std::vector<int64_t>,
-            std::vector<uint8_t>>
-            streamPreview;
+    StreamPreview streamPreview;
 
     const ZL_Report serializeStream(A1C_Arena* a1c_arena, A1C_Item* arrayItem);
 };

--- a/cpp/src/openzl/cpp/experimental/trace/StreamVisualizer.hpp
+++ b/cpp/src/openzl/cpp/experimental/trace/StreamVisualizer.hpp
@@ -28,7 +28,10 @@ struct Stream {
     std::optional<CodecID> producerCodec;
     StreamPreview streamPreview;
 
-    const ZL_Report serializeStream(A1C_Arena* a1c_arena, A1C_Item* arrayItem);
+    const ZL_Report serializeStream(
+            A1C_Arena* a1c_arena,
+            A1C_Item* arrayItem,
+            ZL_OperationContext* opCtx);
 };
 
 // custom operators for maps using ZL_DataID as a key to identify streams

--- a/cpp/src/openzl/cpp/experimental/trace/types.hpp
+++ b/cpp/src/openzl/cpp/experimental/trace/types.hpp
@@ -5,6 +5,10 @@
 #include "openzl/zl_opaque_types.h"
 
 #include <cstddef>
+#include <cstdint>
+#include <string>
+#include <variant>
+#include <vector>
 
 namespace openzl::visualizer {
 
@@ -18,5 +22,10 @@ namespace openzl::visualizer {
 using StreamID = ZL_DataID;
 using CodecID  = size_t;
 using GraphID  = size_t;
+
+using StreamPreview = std::variant<
+        std::vector<uint8_t>, // default
+        std::vector<int64_t>,
+        std::vector<std::string>>;
 
 } // namespace openzl::visualizer

--- a/cpp/tests/experimental/trace/CompressTraceErrorTest.cpp
+++ b/cpp/tests/experimental/trace/CompressTraceErrorTest.cpp
@@ -6,47 +6,726 @@
 
 #    include <gtest/gtest.h>
 
+#    include <cstring>
+#    include <filesystem>
+#    include <fstream>
+
 #    include "cpp/tests/experimental/trace/TraceTestHelpers.hpp"
 #    include "openzl/cpp/CCtx.hpp"
 #    include "openzl/cpp/Compressor.hpp"
+#    include "openzl/cpp/CustomEncoder.hpp"
+#    include "openzl/cpp/Exception.hpp"
+#    include "openzl/cpp/FunctionGraph.hpp"
+#    include "openzl/cpp/codecs/Conversion.hpp"
+#    include "openzl/zl_errors.h"
+#    include "openzl/zl_segmenter.h"
 
 using namespace ::testing;
 
 namespace openzl {
+namespace {
+
+// ---------------------------------------------------------------------------
+// Reusable custom encoders / graphs
+// ---------------------------------------------------------------------------
+
+// A custom encoder that copies input to output unchanged (always succeeds).
+class NoOpEncoder : public CustomEncoder {
+    SimpleCodecDescription simpleCodecDescription() const override
+    {
+        return SimpleCodecDescription{
+            .id          = 9998,
+            .name        = "NoOpEncoder",
+            .inputType   = Type::Numeric,
+            .outputTypes = { Type::Numeric },
+        };
+    }
+
+    void encode(EncoderState& encoder) const override
+    {
+        auto& input = encoder.inputs()[0];
+        auto output =
+                encoder.createOutput(0, input.numElts(), input.eltWidth());
+        memcpy(output.ptr(), input.ptr(), input.contentSize());
+        output.commit(input.numElts());
+    }
+};
+
+// A custom encoder that always fails with a known error message.
+// Accepts serial input so it can be chained after SeparateStringComponents.
+class FailingEncoder : public CustomEncoder {
+    SimpleCodecDescription simpleCodecDescription() const override
+    {
+        return SimpleCodecDescription{
+            .id          = 9999,
+            .name        = "FailingEncoder",
+            .inputType   = Type::Serial,
+            .outputTypes = { Type::Serial },
+        };
+    }
+
+    void encode(EncoderState& /* encoder */) const override
+    {
+        throw std::runtime_error("deliberate codec failure");
+    }
+};
+
+// FunctionGraph that splits string input via SeparateStringComponents, then
+// sends the content (serial) stream to a failing codec. The lengths (numeric)
+// stream is left unconsumed and should become "zl.#in_progress" on failure.
+class SplitThenFailGraph : public FunctionGraph {
+   public:
+    explicit SplitThenFailGraph(NodeID failingNode) : failingNode_(failingNode)
+    {
+    }
+
+    FunctionGraphDescription functionGraphDescription() const override
+    {
+        return {
+            .name           = "SplitThenFail",
+            .inputTypeMasks = { TypeMask::String },
+            .customNodes    = { nodes::SeparateStringComponents::node,
+                                failingNode_ },
+        };
+    }
+
+    void graph(GraphState& state) const override
+    {
+        auto& edge = state.edges()[0];
+        // SeparateStringComponents: string -> [serial content, numeric lengths]
+        auto outputs = edge.runNode(nodes::SeparateStringComponents::node);
+        // Send content (output 0) to the failing encoder
+        outputs[0].runNode(failingNode_);
+        // Leave lengths (output 1) unconsumed
+    }
+
+   private:
+    NodeID failingNode_;
+};
+
+// ---------------------------------------------------------------------------
+// Test fixture
+// ---------------------------------------------------------------------------
+
+class CompressTraceErrorTest : public Test {
+   protected:
+    Compressor compressor_;
+    CCtx cctx_;
+    std::string rawTrace_;
+
+    void SetUp() override
+    {
+        compressor_.setParameter(CParam::FormatVersion, ZL_MAX_FORMAT_VERSION);
+    }
+
+    void TearDown() override
+    {
+        if (rawTrace_.empty()) {
+            return;
+        }
+        // Write the raw CBOR trace to /tmp for manual visualizer testing.
+        // Enable by changing `if (0)` to `if (1)`.
+        if ((0)) {
+            std::filesystem::create_directories("/tmp/openzl_trace");
+            auto* info       = UnitTest::GetInstance()->current_test_info();
+            std::string path = std::string("/tmp/openzl_trace/")
+                    + info->test_suite_name() + "_" + info->name() + ".cbor";
+            std::ofstream out(path, std::ios::binary);
+            if (out) {
+                out.write(rawTrace_.data(), rawTrace_.size());
+            }
+            out.close();
+        }
+    }
+
+    // Compress with tracing, store the raw trace, and return the parsed result.
+    // Expects compression to succeed.
+    test::ParsedTrace compressAndParse(Input& input)
+    {
+        cctx_.refCompressor(compressor_);
+        cctx_.writeTraces(true);
+
+        cctx_.compressOne(input);
+        return extractTrace();
+    }
+
+    // Compress with tracing, expecting compression to throw.
+    // Stores the raw trace and returns the parsed result.
+    test::ParsedTrace compressExpectFailAndParse(Input& input)
+    {
+        cctx_.refCompressor(compressor_);
+        cctx_.writeTraces(true);
+
+        EXPECT_THROW(cctx_.compressOne(input), Exception);
+        return extractTrace();
+    }
+
+    // Look up a codec by (substring) name in a chunk. Returns nullptr if not
+    // found.
+    static const test::ParsedCodec* findCodec(
+            const test::ParsedChunk& chunk,
+            const std::string& name)
+    {
+        for (const auto& codec : chunk.codecs) {
+            if (codec.name.find(name) != std::string::npos) {
+                return &codec;
+            }
+        }
+        return nullptr;
+    }
+
+    // Look up a graph by (substring) name in a chunk.
+    static const test::ParsedGraph* findGraph(
+            const test::ParsedChunk& chunk,
+            const std::string& name)
+    {
+        for (const auto& g : chunk.graphs) {
+            if (g.gName.find(name) != std::string::npos) {
+                return &g;
+            }
+        }
+        return nullptr;
+    }
+
+   private:
+    test::ParsedTrace extractTrace()
+    {
+        auto traceResult = cctx_.getLatestTrace();
+        rawTrace_ =
+                std::string(traceResult.first.data(), traceResult.first.size());
+        EXPECT_FALSE(rawTrace_.empty()) << "Trace should be non-empty";
+
+        auto parsed = test::parseTrace(traceResult.first);
+        EXPECT_TRUE(parsed.has_value()) << "Failed to parse trace CBOR";
+        EXPECT_FALSE(parsed->chunks.empty()) << "Trace should have chunks";
+        return parsed.value();
+    }
+};
+
+// Helper to build string input from a list of strings.
+Input makeStringInput(
+        const std::vector<std::string>& strings,
+        std::string& contentBuf,
+        std::vector<uint32_t>& lengthsBuf)
+{
+    contentBuf.clear();
+    lengthsBuf.clear();
+    for (const auto& s : strings) {
+        contentBuf += s;
+        lengthsBuf.push_back(static_cast<uint32_t>(s.size()));
+    }
+    return Input::refString(
+            contentBuf.data(),
+            contentBuf.size(),
+            lengthsBuf.data(),
+            lengthsBuf.size());
+}
+
+} // namespace
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
 
 // Smoke test: verify TraceTestHelpers can parse a successful compression trace.
-TEST(CompressTraceErrorTest, ParseHelperSmokeTest)
+TEST_F(CompressTraceErrorTest, ParseHelperSmokeTest)
 {
-    Compressor compressor;
-    compressor.setParameter(CParam::FormatVersion, ZL_MAX_FORMAT_VERSION);
-    compressor.selectStartingGraph(ZL_GRAPH_COMPRESS_GENERIC);
+    compressor_.selectStartingGraph(ZL_GRAPH_COMPRESS_GENERIC);
 
     std::vector<int64_t> data(1000, 42);
     auto input = Input::refNumeric(data.data(), sizeof(int64_t), data.size());
 
-    CCtx cctx;
-    cctx.refCompressor(compressor);
-    cctx.writeTraces(true);
+    auto parsed = compressAndParse(input);
 
-    auto compressed  = cctx.compressOne(input);
-    auto traceResult = cctx.getLatestTrace();
+    EXPECT_EQ(parsed.operationType, 0) << "Should be compression";
 
-    ASSERT_FALSE(traceResult.first.empty());
-
-    auto parsed = test::parseTrace(traceResult.first);
-    ASSERT_TRUE(parsed.has_value()) << "Failed to parse trace CBOR";
-
-    EXPECT_EQ(parsed->operationType, 0) << "Should be compression";
-    EXPECT_FALSE(parsed->chunks.empty()) << "Should have at least one chunk";
-
-    // At least one chunk should have codecs
     bool foundCodecs = false;
-    for (const auto& chunk : parsed->chunks) {
+    for (const auto& chunk : parsed.chunks) {
         if (!chunk.codecs.empty()) {
             foundCodecs = true;
         }
     }
     EXPECT_TRUE(foundCodecs) << "Should have codecs in at least one chunk";
+}
+
+// Step 1: Verify that a codec encode failure is captured in the trace.
+// Uses SeparateStringComponents to produce two outputs: the content stream
+// goes to the FailingEncoder (which fails), and the lengths stream goes to
+// STORE but remains unconsumed due to the failure (becomes zl.#in_progress).
+TEST_F(CompressTraceErrorTest, CodecEncodeFailure)
+{
+    auto failingNode = CustomEncoder::registerCustomEncoder(
+            compressor_, std::make_shared<FailingEncoder>());
+    auto failGraph =
+            compressor_.buildStaticGraph(failingNode, { ZL_GRAPH_STORE });
+    // SeparateStringComponents: string -> [serial content, numeric lengths]
+    // content (output 0) -> failGraph, lengths (output 1) -> STORE
+    auto graph = nodes::SeparateStringComponents{}(
+            compressor_, failGraph, ZL_GRAPH_STORE);
+    compressor_.selectStartingGraph(graph);
+
+    std::string content;
+    std::vector<uint32_t> lengths;
+    auto input =
+            makeStringInput({ "hello", "world", "test" }, content, lengths);
+
+    auto parsed = compressExpectFailAndParse(input);
+    EXPECT_EQ(parsed.operationType, 0) << "Should be compression";
+
+    const auto& chunk = parsed.chunks[0];
+
+    // Find the failing codec by name (name may have a suffix like "#0")
+    auto* failingCodec = findCodec(chunk, "FailingEncoder");
+    ASSERT_NE(failingCodec, nullptr) << "Should find FailingEncoder in trace";
+
+    // The codec should have a failure string
+    EXPECT_FALSE(failingCodec->cFailureString.empty())
+            << "Failed codec should have a non-empty cFailureString";
+    EXPECT_NE(
+            failingCodec->cFailureString.find("deliberate codec failure"),
+            std::string::npos)
+            << "cFailureString should contain the error message, got: "
+            << failingCodec->cFailureString;
+
+    // Failed codec should have inputs but no outputs
+    EXPECT_FALSE(failingCodec->inputStreams.empty())
+            << "Failed codec should still have input streams";
+    EXPECT_TRUE(failingCodec->outputStreams.empty())
+            << "Failed codec should have no output streams";
+
+    // The unconsumed lengths stream should get a "zl.#in_progress" terminal
+    bool hasInProgress = false;
+    for (const auto& codec : chunk.codecs) {
+        if (codec.name == "zl.#in_progress") {
+            hasInProgress = true;
+        }
+        EXPECT_NE(codec.name, "zl.store")
+                << "Failed compression should not have zl.store terminals";
+    }
+    EXPECT_TRUE(hasInProgress)
+            << "Failed compression should have zl.#in_progress terminals";
+}
+
+// Step 2a: Verify that a graph failure (with no codec errors) is captured in
+// the trace. When a FunctionGraph::graph() throws before running any codecs,
+// the graph gets gFailure set and a synthetic "zl.#in_progress" placeholder
+// codec is injected.
+TEST_F(CompressTraceErrorTest, GraphFailureNoCodecErrors)
+{
+    // A FunctionGraph that immediately throws without running any codecs.
+    class AlwaysFailGraph : public FunctionGraph {
+        FunctionGraphDescription functionGraphDescription() const override
+        {
+            return {
+                .name           = "AlwaysFailGraph",
+                .inputTypeMasks = { TypeMask::Numeric },
+            };
+        }
+
+        void graph(GraphState& /* state */) const override
+        {
+            throw std::runtime_error("deliberate graph failure");
+        }
+    };
+
+    auto graph = FunctionGraph::registerFunctionGraph(
+            compressor_, std::make_shared<AlwaysFailGraph>());
+    compressor_.selectStartingGraph(graph);
+
+    std::vector<int64_t> data(100, 42);
+    auto input = Input::refNumeric(data.data(), sizeof(int64_t), data.size());
+
+    auto parsed       = compressExpectFailAndParse(input);
+    const auto& chunk = parsed.chunks[0];
+
+    // The trace should contain a graph with gFailureString
+    auto* failedGraph = findGraph(chunk, "AlwaysFailGraph");
+    ASSERT_NE(failedGraph, nullptr)
+            << "Should find AlwaysFailGraph in trace graphs";
+
+    EXPECT_FALSE(failedGraph->gFailureString.empty())
+            << "Failed graph should have a non-empty gFailureString";
+    EXPECT_NE(
+            failedGraph->gFailureString.find("deliberate graph failure"),
+            std::string::npos)
+            << "gFailureString should contain the error message, got: "
+            << failedGraph->gFailureString;
+
+    // Since the graph failed before running any codecs, a synthetic
+    // "zl.#in_progress" placeholder codec should be injected into the graph.
+    ASSERT_FALSE(failedGraph->codecIDs.empty())
+            << "Failed graph should have a placeholder codec in codecIDs";
+
+    // Find the placeholder codec and verify it
+    bool foundPlaceholder = false;
+    for (int64_t codecID : failedGraph->codecIDs) {
+        for (const auto& codec : chunk.codecs) {
+            if (static_cast<int64_t>(codec.cID) == codecID
+                && codec.name == "zl.#in_progress") {
+                foundPlaceholder = true;
+                // The placeholder should consume the graph's input streams
+                EXPECT_FALSE(codec.inputStreams.empty())
+                        << "Placeholder codec should have input streams from "
+                           "the graph's edges";
+            }
+        }
+    }
+    EXPECT_TRUE(foundPlaceholder)
+            << "Should find a zl.#in_progress placeholder codec in the "
+               "failed graph's codecIDs";
+}
+
+// Step 2b: Verify that a graph failure is captured even when some codecs ran
+// successfully. The graph throws *after* a codec completes (not inside a
+// codec), so codecs.size() > 0 but codecsHaveErrors == false. The trace
+// should set gFailureString on the graph without injecting a placeholder
+// codec.
+TEST_F(CompressTraceErrorTest, GraphFailureAfterSuccessfulCodec)
+{
+    // A FunctionGraph that runs a NoOpEncoder successfully, then throws.
+    class FailAfterCodecGraph : public FunctionGraph {
+       public:
+        explicit FailAfterCodecGraph(NodeID noopNode) : noopNode_(noopNode) {}
+
+        FunctionGraphDescription functionGraphDescription() const override
+        {
+            return {
+                .name           = "FailAfterCodecGraph",
+                .inputTypeMasks = { TypeMask::Numeric },
+                .customNodes    = { noopNode_ },
+            };
+        }
+
+        void graph(GraphState& state) const override
+        {
+            auto& edge = state.edges()[0];
+            // Run the NoOpEncoder -- this succeeds
+            edge.runNode(noopNode_);
+            // Then fail outside of any codec
+            throw std::runtime_error("graph failure after codec");
+        }
+
+       private:
+        NodeID noopNode_;
+    };
+
+    auto noopNode = CustomEncoder::registerCustomEncoder(
+            compressor_, std::make_shared<NoOpEncoder>());
+    auto graph = FunctionGraph::registerFunctionGraph(
+            compressor_, std::make_shared<FailAfterCodecGraph>(noopNode));
+    compressor_.selectStartingGraph(graph);
+
+    std::vector<int64_t> data(100, 42);
+    auto input = Input::refNumeric(data.data(), sizeof(int64_t), data.size());
+
+    auto parsed       = compressExpectFailAndParse(input);
+    const auto& chunk = parsed.chunks[0];
+
+    // Find the failed graph
+    auto* failedGraph = findGraph(chunk, "FailAfterCodecGraph");
+    ASSERT_NE(failedGraph, nullptr)
+            << "Should find FailAfterCodecGraph in trace graphs";
+
+    // The graph should have gFailureString set
+    EXPECT_FALSE(failedGraph->gFailureString.empty())
+            << "Failed graph should have a non-empty gFailureString";
+    EXPECT_NE(
+            failedGraph->gFailureString.find("graph failure after codec"),
+            std::string::npos)
+            << "gFailureString should contain the error message, got: "
+            << failedGraph->gFailureString;
+
+    // The graph should have codec(s) from the successful NoOpEncoder run
+    EXPECT_FALSE(failedGraph->codecIDs.empty())
+            << "Graph should have codecs from the successful NoOpEncoder";
+
+    // Find the NoOpEncoder codec -- it should have no cFailureString
+    auto* noopCodec = findCodec(chunk, "NoOpEncoder");
+    ASSERT_NE(noopCodec, nullptr) << "Should find NoOpEncoder in trace codecs";
+    EXPECT_TRUE(noopCodec->cFailureString.empty())
+            << "NoOpEncoder should have no failure (it succeeded), got: "
+            << noopCodec->cFailureString;
+
+    // No placeholder codec should be injected since codecs.size() > 0
+    bool foundPlaceholder = false;
+    for (int64_t codecID : failedGraph->codecIDs) {
+        for (const auto& codec : chunk.codecs) {
+            if (static_cast<int64_t>(codec.cID) == codecID
+                && codec.name == "zl.#in_progress") {
+                foundPlaceholder = true;
+            }
+        }
+    }
+    EXPECT_FALSE(foundPlaceholder)
+            << "Graph with successful codecs should NOT have a placeholder "
+               "codec injected";
+}
+
+// Step 3: Verify error deduplication -- when a codec inside a graph fails,
+// the graph-level gFailureString should be suppressed (empty) because the
+// codec already reported the error via cFailureString.
+TEST_F(CompressTraceErrorTest, GraphFailureWithCodecErrorDeduplication)
+{
+    auto failingNode = CustomEncoder::registerCustomEncoder(
+            compressor_, std::make_shared<FailingEncoder>());
+    auto graph = FunctionGraph::registerFunctionGraph(
+            compressor_, std::make_shared<SplitThenFailGraph>(failingNode));
+    compressor_.selectStartingGraph(graph);
+
+    // String input for SeparateStringComponents
+    std::string content;
+    std::vector<uint32_t> lengths;
+    auto input =
+            makeStringInput({ "hello", "world", "test" }, content, lengths);
+
+    auto parsed       = compressExpectFailAndParse(input);
+    const auto& chunk = parsed.chunks[0];
+
+    // The FailingEncoder codec should have cFailureString
+    auto* failingCodec = findCodec(chunk, "FailingEncoder");
+    ASSERT_NE(failingCodec, nullptr)
+            << "Should find FailingEncoder in trace codecs";
+    EXPECT_FALSE(failingCodec->cFailureString.empty())
+            << "FailingEncoder should have a cFailureString";
+    EXPECT_NE(
+            failingCodec->cFailureString.find("deliberate codec failure"),
+            std::string::npos)
+            << "cFailureString should contain the error message, got: "
+            << failingCodec->cFailureString;
+
+    // The SplitThenFail graph should exist but its gFailureString should be
+    // empty -- the error is already reported by the codec, so the graph-level
+    // error is suppressed (deduplication).
+    auto* splitGraph = findGraph(chunk, "SplitThenFail");
+    ASSERT_NE(splitGraph, nullptr)
+            << "Should find SplitThenFail graph in trace";
+    EXPECT_TRUE(splitGraph->gFailureString.empty())
+            << "Graph gFailureString should be suppressed when a child codec "
+               "already has the error, got: "
+            << splitGraph->gFailureString;
+}
+
+// Step 4: Verify that a type conversion failure is captured in the trace.
+// When the CCtx tries to convert input data to match a subgraph's expected
+// type and the conversion fails, the error is attributed to the codec that
+// would have consumed the mistyped stream.
+//
+// The conversion check happens in CCTX_runSupervisedGraphID_internal *before*
+// the subgraph's on_migraphEncode_start hook fires. To get trace content, we
+// use a FunctionGraph that accepts any type and runs a codec (NoOpEncoder for
+// serial input), then routes one output to a numeric-only subgraph. The parent
+// graph's hooks fire and record trace data; the subgraph's conversion failure
+// is then captured.
+TEST_F(CompressTraceErrorTest, TypeConversionFailure)
+{
+    // A custom encoder that accepts serial and outputs serial (succeeds).
+    class SerialNoOpEncoder : public CustomEncoder {
+        SimpleCodecDescription simpleCodecDescription() const override
+        {
+            return SimpleCodecDescription{
+                .id          = 9997,
+                .name        = "SerialNoOpEncoder",
+                .inputType   = Type::Serial,
+                .outputTypes = { Type::Serial },
+            };
+        }
+
+        void encode(EncoderState& encoder) const override
+        {
+            auto& input = encoder.inputs()[0];
+            auto output =
+                    encoder.createOutput(0, input.numElts(), input.eltWidth());
+            memcpy(output.ptr(), input.ptr(), input.contentSize());
+            output.commit(input.numElts());
+        }
+    };
+
+    // A FunctionGraph that runs a serial codec, then routes its output to a
+    // numeric-only subgraph (which will fail type conversion).
+    class SerialThenNumericGraph : public FunctionGraph {
+       public:
+        SerialThenNumericGraph(NodeID serialNode, GraphID numericSubgraph)
+                : serialNode_(serialNode), numericSubgraph_(numericSubgraph)
+        {
+        }
+
+        FunctionGraphDescription functionGraphDescription() const override
+        {
+            return {
+                .name           = "SerialThenNumericGraph",
+                .inputTypeMasks = { TypeMask::Serial },
+                .customNodes    = { serialNode_ },
+            };
+        }
+
+        void graph(GraphState& state) const override
+        {
+            auto& edge   = state.edges()[0];
+            auto outputs = edge.runNode(serialNode_);
+            // Route the serial output to a numeric-only subgraph — this will
+            // trigger a conversion error since serial → numeric is unsupported
+            outputs[0].setDestination(numericSubgraph_);
+        }
+
+       private:
+        NodeID serialNode_;
+        GraphID numericSubgraph_;
+    };
+
+    // Build the numeric-only subgraph: NoOpEncoder (numeric) → STORE
+    auto noopNode = CustomEncoder::registerCustomEncoder(
+            compressor_, std::make_shared<NoOpEncoder>());
+    auto numericSubgraph =
+            compressor_.buildStaticGraph(noopNode, { ZL_GRAPH_STORE });
+
+    // Build the parent graph that runs serial codec then routes to numeric
+    auto serialNode = CustomEncoder::registerCustomEncoder(
+            compressor_, std::make_shared<SerialNoOpEncoder>());
+    auto parentGraph = FunctionGraph::registerFunctionGraph(
+            compressor_,
+            std::make_shared<SerialThenNumericGraph>(
+                    serialNode, numericSubgraph));
+    compressor_.selectStartingGraph(parentGraph);
+
+    // Supply serial data
+    std::vector<uint8_t> serialData(1000, 0x42);
+    auto input = Input::refSerial(serialData.data(), serialData.size());
+
+    auto parsed       = compressExpectFailAndParse(input);
+    const auto& chunk = parsed.chunks[0];
+
+    // Some codec should have a cFailureString from the conversion error
+    const test::ParsedCodec* failedCodec = nullptr;
+    for (const auto& codec : chunk.codecs) {
+        if (!codec.cFailureString.empty()) {
+            failedCodec = &codec;
+            break;
+        }
+    }
+    ASSERT_NE(failedCodec, nullptr)
+            << "Should find a codec with cFailureString from conversion error";
+
+    // Graphs should not have gFailureString -- the error is a conversion
+    // failure attributed to a codec, not a graph-level error.
+    for (const auto& g : chunk.graphs) {
+        EXPECT_TRUE(g.gFailureString.empty())
+                << "Graph '" << g.gName
+                << "' should not have gFailureString for a conversion error, "
+                   "got: "
+                << g.gFailureString;
+    }
+
+    // Terminal streams should be "zl.#in_progress" (compression failed)
+    bool hasInProgress = false;
+    for (const auto& codec : chunk.codecs) {
+        if (codec.name == "zl.#in_progress") {
+            hasInProgress = true;
+        }
+        EXPECT_NE(codec.name, "zl.store")
+                << "Failed compression should not have zl.store terminals";
+    }
+    EXPECT_TRUE(hasInProgress)
+            << "Failed compression should have zl.#in_progress terminals";
+}
+
+// Step 5: Baseline negative test — successful compression should have no
+// error strings and terminal streams should end at "zl.store".
+TEST_F(CompressTraceErrorTest, SuccessfulCompressionNoErrors)
+{
+    compressor_.selectStartingGraph(ZL_GRAPH_COMPRESS_GENERIC);
+
+    std::vector<int64_t> data(1000, 42);
+    auto input = Input::refNumeric(data.data(), sizeof(int64_t), data.size());
+
+    auto parsed = compressAndParse(input);
+
+    EXPECT_EQ(parsed.operationType, 0) << "Should be compression";
+
+    for (const auto& chunk : parsed.chunks) {
+        // No codec should have cFailureString
+        for (const auto& codec : chunk.codecs) {
+            EXPECT_TRUE(codec.cFailureString.empty())
+                    << "Codec '" << codec.name
+                    << "' should not have cFailureString in successful "
+                       "compression, got: "
+                    << codec.cFailureString;
+            // No "zl.#in_progress" terminals in successful compression
+            EXPECT_NE(codec.name, "zl.#in_progress")
+                    << "Successful compression should not have "
+                       "zl.#in_progress terminals";
+        }
+
+        // No graph should have gFailureString
+        for (const auto& g : chunk.graphs) {
+            EXPECT_TRUE(g.gFailureString.empty())
+                    << "Graph '" << g.gName
+                    << "' should not have gFailureString in successful "
+                       "compression, got: "
+                    << g.gFailureString;
+        }
+
+        // Should have "zl.store" terminal codecs
+        bool hasStore = false;
+        for (const auto& codec : chunk.codecs) {
+            if (codec.name == "zl.store") {
+                hasStore = true;
+            }
+        }
+        EXPECT_TRUE(hasStore)
+                << "Successful compression should have zl.store terminals";
+    }
+}
+
+// Step 6: Verify that a segmenter failure is captured in the trace.
+// The segmenter is represented as a pseudo-codec named "segmenter" in the
+// trace. When the segmenter function returns an error, on_segmenterEncode_end
+// sets cFailure on that pseudo-codec.
+TEST_F(CompressTraceErrorTest, SegmenterFailure)
+{
+    // A segmenter that immediately fails without processing any chunks.
+    static auto failingSegmenterFn = [](ZL_Segmenter* sctx) -> ZL_Report {
+        ZL_RESULT_DECLARE_SCOPE_REPORT(sctx);
+        ZL_ERR(transform_executionFailure, "deliberate segmenter failure");
+    };
+
+    static const ZL_Type segInputTypes[]               = { ZL_Type_numeric };
+    static const ZL_SegmenterDesc failingSegmenterDesc = {
+        .name                = "FailingSegmenter",
+        .segmenterFn         = failingSegmenterFn,
+        .inputTypeMasks      = segInputTypes,
+        .numInputs           = 1,
+        .lastInputIsVariable = false,
+    };
+
+    ZL_GraphID segId = ZL_Compressor_registerSegmenter(
+            compressor_.get(), &failingSegmenterDesc);
+    ASSERT_TRUE(ZL_GraphID_isValid(segId));
+    compressor_.selectStartingGraph(segId);
+
+    std::vector<int64_t> data(1000, 42);
+    auto input = Input::refNumeric(data.data(), sizeof(int64_t), data.size());
+
+    auto parsed       = compressExpectFailAndParse(input);
+    const auto& chunk = parsed.chunks[0];
+
+    // Find the segmenter pseudo-codec
+    auto* segmenterCodec = findCodec(chunk, "segmenter");
+    ASSERT_NE(segmenterCodec, nullptr)
+            << "Should find a 'segmenter' pseudo-codec in the trace";
+
+    EXPECT_FALSE(segmenterCodec->cFailureString.empty())
+            << "Failed segmenter should have a non-empty cFailureString";
+    EXPECT_NE(
+            segmenterCodec->cFailureString.find("deliberate segmenter failure"),
+            std::string::npos)
+            << "cFailureString should contain the error message, got: "
+            << segmenterCodec->cFailureString;
+
+    // No "zl.store" terminals — compression failed
+    for (const auto& codec : chunk.codecs) {
+        EXPECT_NE(codec.name, "zl.store")
+                << "Failed compression should not have zl.store terminals";
+    }
 }
 
 } // namespace openzl

--- a/include/openzl/zl_introspection.h
+++ b/include/openzl/zl_introspection.h
@@ -106,7 +106,7 @@ typedef struct ZL_CompressIntrospectionHooks_s {
     /* ******** CCtx entrypoint ******** */
     void (*on_ZL_CCtx_compressMultiTypedRef_start)(
             void* opaque,
-            ZL_CCtx const* const cctx,
+            ZL_CCtx* cctx,
             void const* const dst,
             size_t const dstCapacity,
             ZL_TypedRef const* const inputs[],

--- a/tests/integrationtest/CompressIntrospectionTest.cpp
+++ b/tests/integrationtest/CompressIntrospectionTest.cpp
@@ -28,7 +28,7 @@ static int ctr = 0;
 class IncrementingHooks : public openzl::CompressIntrospectionHooks {
    public:
     void on_ZL_CCtx_compressMultiTypedRef_start(
-            const ZL_CCtx* const,
+            ZL_CCtx*,
             const void* const,
             const size_t,
             const ZL_TypedRef* const*,

--- a/tests/integrationtest/NoIntrospectionTest.cpp
+++ b/tests/integrationtest/NoIntrospectionTest.cpp
@@ -27,7 +27,7 @@ static int ctr = 0;
 class IncrementingHooks : public ::openzl::CompressIntrospectionHooks {
    public:
     void on_ZL_CCtx_compressMultiTypedRef_start(
-            const ZL_CCtx* const,
+            ZL_CCtx*,
             const void* const,
             const size_t,
             const ZL_TypedRef* const*,


### PR DESCRIPTION
Summary:
Migrate all trace CBOR serialization code from the deprecated ZL_RET_R_IF_*
/ A1C_*_TRY_ADD_R macros to the new scope-based ZL_ERR_IF_* / A1C_*_TRY_ADD
macros, which use ZL_RESULT_DECLARE_SCOPE_REPORT() instead of hardcoding
the return type at each call site.

Thread ZL_OperationContext* through the entire serialization call chain so
every function has a proper error context scope:
- CompressTracer extracts opCtx from ZL_Encoder* during on_codecEncode_start
- DecompressTracer extracts opCtx from ZL_DCtx* during _start callback
- opCtx is passed through serializeStreamdumpToCbor → serializeToCBOR →
  serializeChunkDataToCBOR → serializeCodec/serializeGraph/serializeStream
  → CborHelper leaf functions

Reviewed By: terrelln

Differential Revision: D97534084


