### PR TITLE
Add function to attach graph context to error scope

### DIFF
--- a/src/openzl/common/errors_internal.h
+++ b/src/openzl/common/errors_internal.h
@@ -611,6 +611,14 @@ void ZL_EE_log(ZL_ErrorInfo ei, int level);
         ZL_RET_IF_ERR_IMPL(type, _res, __VA_ARGS__);                                                                                                                                                                  \
     } while (0)
 
+/**
+ * Adds a ZL_GraphContext to the error scope
+ */
+#define ZL_RESULT_SCOPE_ADD_GRAPH_CONTEXT(...)   \
+    do {                                         \
+        ZL__errorContext.graphCtx = __VA_ARGS__; \
+    } while (0)
+
 ZL_END_C_DECLS
 
 #endif // ZSTRONG_COMMON_ERRORS_INTERNAL_H

--- a/src/openzl/common/stream.c
+++ b/src/openzl/common/stream.c
@@ -105,37 +105,38 @@ void STREAM_free(Stream* s)
 
 static ZL_Report STREAM_validateTypeWidth(ZL_Type type, size_t eltWidth)
 {
+    ZL_RESULT_DECLARE_SCOPE_REPORT(NULL);
     switch (type) {
         case ZL_Type_serial:
-            ZL_RET_R_IF_NE(
-                    streamParameter_invalid,
+            ZL_ERR_IF_NE(
                     eltWidth,
                     1,
+                    streamParameter_invalid,
                     "Serialized must set width == 1");
             break;
         case ZL_Type_string:
-            ZL_RET_R_IF_NE(
-                    streamParameter_invalid,
+            ZL_ERR_IF_NE(
                     eltWidth,
                     1,
+                    streamParameter_invalid,
                     "String must set width == 1");
             break;
         case ZL_Type_struct:
-            ZL_RET_R_IF_EQ(
-                    streamParameter_invalid,
+            ZL_ERR_IF_EQ(
                     eltWidth,
                     0,
+                    streamParameter_invalid,
                     "Struct size must be > 0");
             break;
         case ZL_Type_numeric:
-            ZL_RET_R_IF_NOT(
-                    streamParameter_invalid,
+            ZL_ERR_IF_NOT(
                     eltWidth == 1 || eltWidth == 2 || eltWidth == 4
                             || eltWidth == 8,
+                    streamParameter_invalid,
                     "Numeric must be width 1, 2, 4, or 8");
             break;
         default:
-            ZL_RET_R_ERR(streamParameter_invalid, "Unknown type");
+            ZL_ERR(streamParameter_invalid, "Unknown type");
     }
     ZL_ASSERT_NE(eltWidth, 0);
     return ZL_returnSuccess();
@@ -149,23 +150,24 @@ ZL_Report STREAM_typeAttachedBuffer(
         size_t eltWidth,
         size_t eltCapacity)
 {
+    ZL_RESULT_DECLARE_SCOPE_REPORT(NULL);
     ZL_DLOG(SEQ, "STREAM_typeAttachedBuffer (type:%u)", type);
     ZL_ASSERT_NN(s);
     if (s->type != 0) {
         ZL_DLOG(SEQ, "already initialized");
-        ZL_RET_R_IF_NE(corruption, s->type, type);
-        ZL_RET_R_IF_NE(corruption, s->eltWidth, eltWidth);
-        ZL_RET_R_IF_LT(corruption, s->bufferCapacity, eltCapacity * eltWidth);
+        ZL_ERR_IF_NE(s->type, type, corruption);
+        ZL_ERR_IF_NE(s->eltWidth, eltWidth, corruption);
+        ZL_ERR_IF_LT(s->bufferCapacity, eltCapacity * eltWidth, corruption);
         return ZL_returnSuccess();
     }
 
     /* Here, buffer exists, but nothing else is initialized */
-    ZL_RET_R_IF_ERR(STREAM_validateTypeWidth(type, eltWidth));
+    ZL_ERR_IF_ERR(STREAM_validateTypeWidth(type, eltWidth));
     s->type = type;
     // control eltWidth validity
     ZL_ASSERT_NN(eltWidth);
-    ZL_RET_R_IF_LT(
-            streamCapacity_tooSmall, s->bufferCapacity / eltWidth, eltCapacity);
+    ZL_ERR_IF_LT(
+            s->bufferCapacity / eltWidth, eltCapacity, streamCapacity_tooSmall);
     s->eltWidth     = eltWidth;
     s->eltsCapacity = s->bufferCapacity / eltWidth;
     return ZL_returnSuccess();
@@ -173,6 +175,7 @@ ZL_Report STREAM_typeAttachedBuffer(
 
 ZL_Report STREAM_reserveRawBuffer(Stream* s, size_t byteCapacity)
 {
+    ZL_RESULT_DECLARE_SCOPE_REPORT(NULL);
     ZL_ASSERT_NN(s);
     // For the time being, only one allocation is allowed. No resizing.
     ZL_ASSERT(ZL_Refcount_null(&s->buffer));
@@ -181,9 +184,9 @@ ZL_Report STREAM_reserveRawBuffer(Stream* s, size_t byteCapacity)
 
     void* const buffer =
             ZL_Refcount_inArena(&s->buffer, s->alloc, byteCapacity);
-    ZL_RET_R_IF_NULL(
-            allocation,
+    ZL_ERR_IF_NULL(
             buffer,
+            allocation,
             "STREAM_reserveRawBuffer: Failed allocating stream's buffer");
 
     ZL_DLOG(SEQ,
@@ -196,12 +199,13 @@ ZL_Report STREAM_reserveRawBuffer(Stream* s, size_t byteCapacity)
 ZL_Report
 STREAM_reserve(Stream* s, ZL_Type type, size_t eltWidth, size_t eltsCapacity)
 {
+    ZL_RESULT_DECLARE_SCOPE_REPORT(NULL);
     size_t byteCapacity;
-    ZL_RET_R_IF(
-            allocation,
+    ZL_ERR_IF(
             ZL_overflowMulST(eltsCapacity, eltWidth, &byteCapacity),
+            allocation,
             "Allocation overflows size_t");
-    ZL_RET_R_IF_ERR(STREAM_reserveRawBuffer(s, byteCapacity));
+    ZL_ERR_IF_ERR(STREAM_reserveRawBuffer(s, byteCapacity));
     ZL_Report const r =
             STREAM_typeAttachedBuffer(s, type, eltWidth, eltsCapacity);
     if (ZL_isError(r)) {
@@ -245,7 +249,8 @@ uint32_t* STREAM_reserveStringLens(Stream* stream, size_t nbStrings)
 ZL_Report
 STREAM_reserveStrings(Stream* s, size_t numStrings, size_t bufferCapacity)
 {
-    ZL_RET_R_IF_ERR(STREAM_reserveRawBuffer(s, bufferCapacity));
+    ZL_RESULT_DECLARE_SCOPE_REPORT(NULL);
+    ZL_ERR_IF_ERR(STREAM_reserveRawBuffer(s, bufferCapacity));
     ZL_ASSERT_EQ(s->type, 0);
     s->type = ZL_Type_string;
 
@@ -271,19 +276,19 @@ static ZL_Report STREAM_referenceInternal(
         size_t eltCount,
         const void* ref)
 {
+    ZL_RESULT_DECLARE_SCOPE_REPORT(NULL);
     ZL_DLOG(SEQ,
             "STREAM_referenceInternal (%zu elts of width %zu)",
             eltCount,
             eltWidth);
-    ZL_RET_R_IF(
-            stream_wrongInit, s->writeCommitted, "Stream already committed");
+    ZL_ERR_IF(s->writeCommitted, stream_wrongInit, "Stream already committed");
     // ZL_ASSERT(!ZL_Refcount_null(&s->buffer));
-    ZL_RET_R_IF_ERR(STREAM_validateTypeWidth(type, eltWidth));
+    ZL_ERR_IF_ERR(STREAM_validateTypeWidth(type, eltWidth));
     s->type = type;
     if (type == ZL_Type_numeric) {
-        ZL_RET_R_IF_NOT(
-                userBuffer_alignmentIncorrect,
+        ZL_ERR_IF_NOT(
                 MEM_IS_ALIGNED_N(ref, MEM_alignmentForNumericWidth(eltWidth)),
+                userBuffer_alignmentIncorrect,
                 "provided src buffer is incorrectly aligned for numerics of width %zu bytes",
                 eltWidth);
     }
@@ -310,12 +315,13 @@ ZL_Report STREAM_refConstBuffer(
         size_t eltWidth,
         size_t eltCount)
 {
+    ZL_RESULT_DECLARE_SCOPE_REPORT(NULL);
     ZL_ASSERT_NN(s);
     ZL_ASSERT(ZL_Refcount_null(&s->buffer));
     ZL_ASSERT_NE(type, ZL_Type_string);
     if (eltCount > 0)
         ZL_ASSERT_NN(ref);
-    ZL_RET_R_IF_ERR(ZL_Refcount_initConstRef(&s->buffer, ref));
+    ZL_ERR_IF_ERR(ZL_Refcount_initConstRef(&s->buffer, ref));
     return STREAM_referenceInternal(s, type, eltWidth, eltCount, ref);
 }
 
@@ -326,19 +332,19 @@ ZL_Report STREAM_refConstExtString(
         const uint32_t* strLengths,
         size_t nbStrings)
 {
+    ZL_RESULT_DECLARE_SCOPE_REPORT(NULL);
     ZL_ASSERT_NN(s);
     ZL_ASSERT(ZL_Refcount_null(&s->buffer));
     ZL_ASSERT(ZL_Refcount_null(&s->stringLens));
-    ZL_RET_R_IF(
-            stream_wrongInit, s->writeCommitted, "Stream already committed");
+    ZL_ERR_IF(s->writeCommitted, stream_wrongInit, "Stream already committed");
     if (nbStrings)
         ZL_ASSERT_NN(strLengths);
-    ZL_RET_R_IF_ERR(ZL_Refcount_initConstRef(&s->buffer, strBuffer));
-    ZL_RET_R_IF_ERR(STREAM_referenceInternal(
+    ZL_ERR_IF_ERR(ZL_Refcount_initConstRef(&s->buffer, strBuffer));
+    ZL_ERR_IF_ERR(STREAM_referenceInternal(
             s, ZL_Type_string, 1, bufferSize, strBuffer));
-    ZL_RET_R_IF_ERR(ZL_Refcount_initConstRef(&s->stringLens, strLengths));
+    ZL_ERR_IF_ERR(ZL_Refcount_initConstRef(&s->stringLens, strLengths));
     s->eltsCapacity = nbStrings;
-    ZL_RET_R_IF_ERR(STREAM_commit(s, nbStrings));
+    ZL_ERR_IF_ERR(STREAM_commit(s, nbStrings));
     return ZL_returnSuccess();
 }
 
@@ -349,6 +355,7 @@ ZL_Report STREAM_attachWritableBuffer(
         size_t eltWidth,
         size_t eltCount)
 {
+    ZL_RESULT_DECLARE_SCOPE_REPORT(NULL);
     ZL_DLOG(SEQ, "STREAM_attachWritableBuffer (eltCount=%zu)", eltCount);
     ZL_ASSERT_NN(s);
     ZL_ASSERT(ZL_Refcount_null(&s->buffer));
@@ -356,7 +363,7 @@ ZL_Report STREAM_attachWritableBuffer(
     ZL_ASSERT_GT(eltWidth, 0);
     if (eltCount > 0)
         ZL_ASSERT_NN(ref);
-    ZL_RET_R_IF_ERR(ZL_Refcount_initMutRef(&s->buffer, ref));
+    ZL_ERR_IF_ERR(ZL_Refcount_initMutRef(&s->buffer, ref));
     s->bufferCapacity = eltCount * eltWidth;
     return STREAM_typeAttachedBuffer(s, type, eltWidth, eltCount);
 }
@@ -364,35 +371,37 @@ ZL_Report STREAM_attachWritableBuffer(
 ZL_Report
 STREAM_refMutStringLens(Stream* s, uint32_t* stringLens, size_t eltsCapacity)
 {
+    ZL_RESULT_DECLARE_SCOPE_REPORT(NULL);
     ZL_ASSERT_NN(s);
-    ZL_RET_R_IF_NE(streamType_incorrect, s->type, ZL_Type_string);
-    ZL_RET_R_IF_NOT(stream_wrongInit, ZL_Refcount_null(&s->stringLens));
+    ZL_ERR_IF_NE(s->type, ZL_Type_string, streamType_incorrect);
+    ZL_ERR_IF_NOT(ZL_Refcount_null(&s->stringLens), stream_wrongInit);
     if (eltsCapacity > 0)
         ZL_ASSERT_NN(stringLens);
-    ZL_RET_R_IF_ERR(ZL_Refcount_initMutRef(&s->stringLens, stringLens));
+    ZL_ERR_IF_ERR(ZL_Refcount_initMutRef(&s->stringLens, stringLens));
     s->eltsCapacity = eltsCapacity;
     return ZL_returnSuccess();
 }
 
 ZL_Report STREAM_attachRawBuffer(Stream* s, void* rawBuf, size_t bufByteSize)
 {
+    ZL_RESULT_DECLARE_SCOPE_REPORT(NULL);
     ZL_DLOG(SEQ, "STREAM_attachRawBuffer (bufByteSize=%zu)", bufByteSize);
     ZL_ASSERT_NN(s);
     ZL_ASSERT(ZL_Refcount_null(&s->buffer));
     if (bufByteSize > 0)
         ZL_ASSERT_NN(rawBuf);
-    ZL_RET_R_IF_ERR(ZL_Refcount_initMutRef(&s->buffer, rawBuf));
+    ZL_ERR_IF_ERR(ZL_Refcount_initMutRef(&s->buffer, rawBuf));
     s->bufferCapacity = bufByteSize;
     return ZL_returnSuccess();
 }
 
 ZL_Report STREAM_refStreamWithoutRefCount(Stream* s, const Stream* ref)
 {
+    ZL_RESULT_DECLARE_SCOPE_REPORT(NULL);
     ZL_ASSERT_NN(s);
     ZL_ASSERT_NN(ref);
     ZL_ASSERT(ref->writeCommitted);
-    ZL_RET_R_IF(
-            stream_wrongInit, s->writeCommitted, "Stream already committed");
+    ZL_ERR_IF(s->writeCommitted, stream_wrongInit, "Stream already committed");
     s->type           = ref->type;
     s->eltCount       = ref->eltCount;
     s->eltWidth       = ref->eltWidth;
@@ -414,9 +423,9 @@ ZL_Report STREAM_refStreamWithoutRefCount(Stream* s, const Stream* ref)
         }
     }
 
-    ZL_RET_R_IF_ERR(ZL_Refcount_initConstRef(
+    ZL_ERR_IF_ERR(ZL_Refcount_initConstRef(
             &s->buffer, ZL_Refcount_get(&ref->buffer)));
-    ZL_RET_R_IF_ERR(ZL_Refcount_initConstRef(
+    ZL_ERR_IF_ERR(ZL_Refcount_initConstRef(
             &s->stringLens, ZL_Refcount_get(&ref->stringLens)));
 
     // Turn our buffers into immutable references
@@ -434,17 +443,18 @@ ZL_Report STREAM_refStreamByteSlice(
         size_t eltWidth,
         size_t eltCount)
 {
+    ZL_RESULT_DECLARE_SCOPE_REPORT(NULL);
     size_t const streamBytes = STREAM_byteSize(src);
     size_t neededBytes;
-    ZL_RET_R_IF(
-            allocation,
+    ZL_ERR_IF(
             ZL_overflowMulST(eltCount, eltWidth, &neededBytes),
-            "Size overflows size_t");
-    ZL_RET_R_IF(
             allocation,
-            ZL_overflowAddST(offsetBytes, neededBytes, &neededBytes),
             "Size overflows size_t");
-    ZL_RET_R_IF_GT(allocation, neededBytes, streamBytes);
+    ZL_ERR_IF(
+            ZL_overflowAddST(offsetBytes, neededBytes, &neededBytes),
+            allocation,
+            "Size overflows size_t");
+    ZL_ERR_IF_GT(neededBytes, streamBytes, allocation);
     dst->buffer = ZL_Refcount_aliasOffset(&src->buffer, offsetBytes);
     // Turn our buffer into an immutable reference
     ZL_Refcount_constify(&dst->buffer);
@@ -497,6 +507,7 @@ ZL_Report STREAM_refStreamSliceWithoutRefCount(
         size_t startingEltNum,
         size_t eltCount)
 {
+    ZL_RESULT_DECLARE_SCOPE_REPORT(NULL);
     ZL_DLOG(SEQ,
             "STREAM_refStreamSliceWithoutRefCount (start:%zu, eltCount=%zu)",
             startingEltNum,
@@ -504,7 +515,7 @@ ZL_Report STREAM_refStreamSliceWithoutRefCount(
     ZL_ASSERT_NN(src);
     ZL_ASSERT_LE(startingEltNum + eltCount, STREAM_eltCount(src));
     ZL_ASSERT_NN(dst);
-    ZL_RET_R_IF_ERR(STREAM_refStreamWithoutRefCount(dst, src));
+    ZL_ERR_IF_ERR(STREAM_refStreamWithoutRefCount(dst, src));
     if (eltCount == STREAM_eltCount(src))
         return ZL_returnSuccess();
 
@@ -730,6 +741,7 @@ ZL_Report STREAM_hashLastCommit_xxh3low32(
         size_t nbStreams,
         unsigned formatVersion)
 {
+    ZL_RESULT_DECLARE_SCOPE_REPORT(NULL);
     ZL_DLOG(SEQ,
             "STREAM_hashLastCommit_xxh3low32 (nbStreams=%zu, formatVersion=%u)",
             nbStreams,
@@ -737,10 +749,10 @@ ZL_Report STREAM_hashLastCommit_xxh3low32(
     ZL_ASSERT_GT(nbStreams, 0);
     ZL_ASSERT_NN(streams);
     XXH3_state_t xxh3;
-    ZL_RET_R_IF_NE(GENERIC, XXH3_64bits_reset(&xxh3), XXH_OK);
+    ZL_ERR_IF_NE(XXH3_64bits_reset(&xxh3), XXH_OK, GENERIC);
     for (size_t n = 0; n < nbStreams; n++) {
         // Hashing content only makes sense if content has been committed
-        ZL_RET_R_IF_NOT(GENERIC, STREAM_isCommitted(streams[n]));
+        ZL_ERR_IF_NOT(STREAM_isCommitted(streams[n]), GENERIC);
         // Numeric data might have a different endianness depending on the
         // platform which might lead to checksum errors.
         // For that reason, one convention must be selected, so that
@@ -749,23 +761,23 @@ ZL_Report STREAM_hashLastCommit_xxh3low32(
         // For now, the library is not able calculate checksum on Numeric
         // input on non-little-endian platforms
         if (STREAM_type(streams[n]) == ZL_Type_numeric) {
-            ZL_RET_R_IF_NOT(
-                    temporaryLibraryLimitation,
+            ZL_ERR_IF_NOT(
                     ZL_isLittleEndian(),
+                    temporaryLibraryLimitation,
                     "Cannot calculate hash of numeric input on non little-endian platforms");
         }
         ZL_RBuffer const rb = STREAM_lastCommittedBufferContent(streams[n]);
-        ZL_RET_R_IF_NE(
-                GENERIC, XXH3_64bits_update(&xxh3, rb.start, rb.size), XXH_OK);
+        ZL_ERR_IF_NE(
+                XXH3_64bits_update(&xxh3, rb.start, rb.size), XXH_OK, GENERIC);
         if ((STREAM_type(streams[n]) == ZL_Type_string)
             && (formatVersion >= 15)) {
             /** @note format v14 supports Type String, but did not checksum the
              * array of lengths (just skipping it) */
             ZL_RBuffer const lcslb = STREAM_lastCommittedStringLens(streams[n]);
-            ZL_RET_R_IF_NE(
-                    GENERIC,
+            ZL_ERR_IF_NE(
                     XXH3_64bits_update(&xxh3, lcslb.start, lcslb.size),
-                    XXH_OK);
+                    XXH_OK,
+                    GENERIC);
         }
     }
     uint32_t const hash = (uint32_t)XXH3_64bits_digest(&xxh3);
@@ -778,22 +790,23 @@ ZL_Report STREAM_hashLastCommit_xxh3low32(
 
 static ZL_Report STREAM_commitStrings(Stream* s, size_t numStrings)
 {
+    ZL_RESULT_DECLARE_SCOPE_REPORT(NULL);
     ZL_DLOG(SEQ, "STREAM_commitStrings (numStrings=%zu)", numStrings);
     ZL_ASSERT_NN(s);
     ZL_ASSERT_EQ(s->type, ZL_Type_string);
     const uint32_t* const stringLens = ZL_Refcount_get(&s->stringLens);
 
-    ZL_RET_R_IF_GT(
-            streamCapacity_tooSmall,
+    ZL_ERR_IF_GT(
             numStrings,
             s->eltsCapacity,
+            streamCapacity_tooSmall,
             "Number of strings committed is greater than capacity");
     uint64_t const totalStringsSize = NUMOP_sumArray32(
             s->eltCount ? stringLens + s->eltCount : stringLens, numStrings);
-    ZL_RET_R_IF_GT(
-            streamCapacity_tooSmall,
+    ZL_ERR_IF_GT(
             totalStringsSize,
             (uint64_t)s->bufferCapacity,
+            streamCapacity_tooSmall,
             "Total string content size is greater than capacity");
 
     // All conditions fulfilled : now set
@@ -807,16 +820,17 @@ static ZL_Report STREAM_commitStrings(Stream* s, size_t numStrings)
 
 ZL_Report STREAM_commit(Stream* s, size_t eltCount)
 {
+    ZL_RESULT_DECLARE_SCOPE_REPORT(NULL);
     ZL_DLOG(SEQ, "STREAM_commit (eltCount=%zu)", eltCount);
     ZL_ASSERT_NN(s);
     if (s->writeCommitted == 0) {
         ZL_ASSERT_EQ(s->eltCount, 0);
         ZL_ASSERT_EQ(s->bufferUsed, 0);
     }
-    ZL_RET_R_IF_GT(
-            stream_wrongInit,
+    ZL_ERR_IF_GT(
             s->eltCount + eltCount,
             s->eltsCapacity,
+            stream_wrongInit,
             "Stream capacity too small");
     if (s->type == ZL_Type_string) {
         return STREAM_commitStrings(s, eltCount);
@@ -959,6 +973,7 @@ ZL_Report STREAM_copyBytes(Stream* dst, const Stream* src, size_t size)
 
 ZL_Report STREAM_copyStringStream(Stream* dst, const Stream* src)
 {
+    ZL_RESULT_DECLARE_SCOPE_REPORT(NULL);
     ZL_ASSERT_NN(dst);
     ZL_ASSERT_NN(src);
     ZL_ASSERT(!STREAM_hasBuffer(dst));
@@ -966,37 +981,38 @@ ZL_Report STREAM_copyStringStream(Stream* dst, const Stream* src)
     size_t const nbStrings        = STREAM_eltCount(src);
     size_t const stringsTotalSize = STREAM_byteSize(src);
 
-    ZL_RET_R_IF_ERR(STREAM_reserve(dst, ZL_Type_string, 1, stringsTotalSize));
+    ZL_ERR_IF_ERR(STREAM_reserve(dst, ZL_Type_string, 1, stringsTotalSize));
 
     uint32_t* const lens = STREAM_reserveStringLens(dst, nbStrings);
-    ZL_RET_R_IF_NULL(allocation, lens);
+    ZL_ERR_IF_NULL(lens, allocation);
 
     size_t lensSize;
-    ZL_RET_R_IF(
-            allocation,
+    ZL_ERR_IF(
             ZL_overflowMulST(nbStrings, sizeof(uint32_t), &lensSize),
+            allocation,
             "String lengths size overflows size_t");
 
     ZL_memcpy(STREAM_wPtr(dst), STREAM_rPtr(src), stringsTotalSize);
     ZL_memcpy(lens, STREAM_rStringLens(src), lensSize);
 
-    ZL_RET_R_IF_ERR(STREAM_commit(dst, nbStrings));
+    ZL_ERR_IF_ERR(STREAM_commit(dst, nbStrings));
     return ZL_returnValue(stringsTotalSize);
 }
 
 static ZL_Report STREAM_copyIntMetas(Stream* dst, const Stream* src)
 {
+    ZL_RESULT_DECLARE_SCOPE_REPORT(NULL);
     ZL_ASSERT_NN(dst);
     ZL_ASSERT_NN(src);
 
     size_t const meta_size = VECTOR_SIZE(src->intMetas);
     VECTOR_CLEAR(dst->intMetas);
-    ZL_RET_R_IF_LT(
-            allocation, VECTOR_RESERVE(dst->intMetas, meta_size), meta_size);
+    ZL_ERR_IF_LT(
+            VECTOR_RESERVE(dst->intMetas, meta_size), meta_size, allocation);
 
     for (size_t pos = 0; pos < meta_size; pos++) {
         IntMeta e = VECTOR_AT(src->intMetas, pos);
-        ZL_RET_R_IF_NOT(allocation, VECTOR_PUSHBACK(dst->intMetas, e));
+        ZL_ERR_IF_NOT(VECTOR_PUSHBACK(dst->intMetas, e), allocation);
     }
 
     return ZL_returnSuccess();
@@ -1004,19 +1020,20 @@ static ZL_Report STREAM_copyIntMetas(Stream* dst, const Stream* src)
 
 ZL_Report STREAM_copy(Stream* dst, const Stream* src)
 {
+    ZL_RESULT_DECLARE_SCOPE_REPORT(NULL);
     ZL_ASSERT(!STREAM_hasBuffer(dst));
     ZL_ASSERT(src->writeCommitted);
     const ZL_Type type = STREAM_type(src);
 
-    ZL_RET_R_IF_ERR(STREAM_copyIntMetas(dst, src));
+    ZL_ERR_IF_ERR(STREAM_copyIntMetas(dst, src));
 
     if (type == ZL_Type_string) {
         return STREAM_copyStringStream(dst, src);
     }
 
-    ZL_RET_R_IF_ERR(STREAM_reserve(
+    ZL_ERR_IF_ERR(STREAM_reserve(
             dst, type, STREAM_eltWidth(src), STREAM_eltCount(src)));
-    ZL_RET_R_IF_ERR(STREAM_copyBytes(dst, src, STREAM_byteSize(src)));
+    ZL_ERR_IF_ERR(STREAM_copyBytes(dst, src, STREAM_byteSize(src)));
     return ZL_returnSuccess();
 }
 
@@ -1024,19 +1041,21 @@ ZL_Report STREAM_copy(Stream* dst, const Stream* src)
 // eltCount must be <= eltCount(data)
 static ZL_Report STREAM_consumeStrings(Stream* data, size_t eltCount)
 {
+    ZL_RESULT_DECLARE_SCOPE_REPORT(NULL);
     ZL_ASSERT_NN(data);
     ZL_ASSERT_LE(eltCount, STREAM_eltCount(data));
     // unfinished
-    ZL_RET_R_IF(GENERIC, 1);
+    ZL_ERR_IF(1, GENERIC);
 }
 
 // data must be valid
 // eltCount must be <= eltCount(data)
 ZL_Report STREAM_consume(Stream* data, size_t eltCount)
 {
+    ZL_RESULT_DECLARE_SCOPE_REPORT(NULL);
     ZL_ASSERT_NN(data);
     ZL_ASSERT_EQ(data->writeCommitted, 1);
-    ZL_RET_R_IF_GT(parameter_invalid, eltCount, STREAM_eltCount(data));
+    ZL_ERR_IF_GT(eltCount, STREAM_eltCount(data), parameter_invalid);
     if (STREAM_type(data) == ZL_Type_string)
         return STREAM_consumeStrings(data, eltCount);
     size_t eltSize    = STREAM_eltWidth(data);
@@ -1065,16 +1084,17 @@ static int findIntMeta(VECTOR(IntMeta) m, int id)
 
 ZL_Report STREAM_setIntMetadata(Stream* s, int mId, int mValue)
 {
+    ZL_RESULT_DECLARE_SCOPE_REPORT(NULL);
     ZL_ASSERT_NN(s);
     // Currently forbids setting same metadata ID multiple times
-    ZL_RET_R_IF_NE(
-            streamParameter_invalid,
+    ZL_ERR_IF_NE(
             findIntMeta(s->intMetas, mId),
             -1,
+            streamParameter_invalid,
             "Int Metadata ID already present");
-    ZL_RET_R_IF_NOT(
-            allocation,
-            VECTOR_PUSHBACK(s->intMetas, ((IntMeta){ mId, mValue })));
+    ZL_ERR_IF_NOT(
+            VECTOR_PUSHBACK(s->intMetas, ((IntMeta){ mId, mValue })),
+            allocation);
     return ZL_returnSuccess();
 }
 
@@ -1227,33 +1247,38 @@ ZL_wrapGeneric(ZL_Type type, size_t eltWidth, size_t eltCapacity, void* buffer)
 
 ZL_Report ZL_Output_eltWidth(const ZL_Output* output)
 {
+    ZL_RESULT_DECLARE_SCOPE_REPORT(NULL);
     if (ZL_Output_type(output) != ZL_Type_string) {
-        ZL_RET_R_IF_EQ(outputNotReserved, output->data.eltWidth, 0);
+        ZL_ERR_IF_EQ(output->data.eltWidth, 0, outputNotReserved);
     }
     return ZL_returnValue(output->data.eltWidth);
 }
 
 ZL_Report ZL_Output_numElts(const ZL_Output* output)
 {
-    ZL_RET_R_IF_EQ(outputNotCommitted, output->data.writeCommitted, 0);
+    ZL_RESULT_DECLARE_SCOPE_REPORT(NULL);
+    ZL_ERR_IF_EQ(output->data.writeCommitted, 0, outputNotCommitted);
     return ZL_returnValue(output->data.eltCount);
 }
 
 ZL_Report ZL_Output_contentSize(const ZL_Output* output)
 {
-    ZL_RET_R_IF_NOT(outputNotCommitted, STREAM_isCommitted(&output->data));
+    ZL_RESULT_DECLARE_SCOPE_REPORT(NULL);
+    ZL_ERR_IF_NOT(STREAM_isCommitted(&output->data), outputNotCommitted);
     return ZL_returnValue(STREAM_byteSize(&output->data));
 }
 
 ZL_Report ZL_Output_eltsCapacity(const ZL_Output* output)
 {
-    ZL_RET_R_IF(outputNotReserved, !STREAM_hasBuffer(&output->data));
+    ZL_RESULT_DECLARE_SCOPE_REPORT(NULL);
+    ZL_ERR_IF(!STREAM_hasBuffer(&output->data), outputNotReserved);
     return ZL_returnValue(output->data.eltsCapacity);
 }
 
 ZL_Report ZL_Output_contentCapacity(const ZL_Output* output)
 {
-    ZL_RET_R_IF(outputNotReserved, !STREAM_hasBuffer(&output->data));
+    ZL_RESULT_DECLARE_SCOPE_REPORT(NULL);
+    ZL_ERR_IF(!STREAM_hasBuffer(&output->data), outputNotReserved);
     return ZL_returnValue(output->data.bufferCapacity);
 }
 

--- a/src/openzl/decompress/decode_frameheader.c
+++ b/src/openzl/decompress/decode_frameheader.c
@@ -62,13 +62,14 @@ static ZL_Report DFH_decodeNbOutputs(
         size_t* consumedPtr,
         size_t formatVersion)
 {
+    ZL_RESULT_DECLARE_SCOPE_REPORT(NULL);
     ZL_ASSERT_LE(*consumedPtr, cSize);
     if (formatVersion <= 14) {
         // single input only
         *consumedPtr += (formatVersion == 14);
         return ZL_returnValue(1);
     } else if (formatVersion < ZL_CHUNK_VERSION_MIN) {
-        ZL_RET_R_IF_LT(srcSize_tooSmall, cSize, *consumedPtr + 1 + 4);
+        ZL_ERR_IF_LT(cSize, *consumedPtr + 1 + 4, srcSize_tooSmall);
         size_t nbOutputs =
                 (size_t)(((const uint8_t*)cSrc)[*consumedPtr] >> 6) + 1;
         *consumedPtr += 1;
@@ -92,7 +93,7 @@ static ZL_Report DFH_decodeNbOutputs(
         }
         return ZL_returnValue(nbOutputs);
     } else { // format >= ZL_CHUNK_VERSION_MIN
-        ZL_RET_R_IF_LT(srcSize_tooSmall, cSize, *consumedPtr + 1 + 4);
+        ZL_ERR_IF_LT(cSize, *consumedPtr + 1 + 4, srcSize_tooSmall);
         uint8_t token1 = ((const uint8_t*)cSrc)[*consumedPtr];
         *consumedPtr += 1;
         size_t nbOutputs = (size_t)(token1 & 15);
@@ -113,19 +114,20 @@ static ZL_Report DFH_decoderOutputTypes(
         size_t* consumedPtr,
         size_t formatVersion)
 {
+    ZL_RESULT_DECLARE_SCOPE_REPORT(NULL);
     if (formatVersion < 14) {
         // no type
         types[0] = ZL_Type_serial;
     } else if (formatVersion < ZL_CHUNK_VERSION_MIN) {
         size_t firstToken = ZL_MIN(nbOutputs, 3);
-        ZL_RET_R_IF_LT(srcSize_tooSmall, cSize, 5);
+        ZL_ERR_IF_LT(cSize, 5, srcSize_tooSmall);
         for (size_t n = 0; n < firstToken; n++) {
             size_t shift = n * 2;
             types[n] = decodeType(((((const uint8_t*)cSrc)[4]) >> shift) & 3);
         }
         if (nbOutputs > 3) {
             size_t const limit = ZL_MIN(nbOutputs, 5);
-            ZL_RET_R_IF_LT(srcSize_tooSmall, cSize, 6);
+            ZL_ERR_IF_LT(cSize, 6, srcSize_tooSmall);
             for (size_t n = 3; n < limit; n++) {
                 size_t shift = (n - 3) * 2;
                 types[n] =
@@ -134,7 +136,7 @@ static ZL_Report DFH_decoderOutputTypes(
         }
         if (nbOutputs > 5) {
             size_t const neededBytes = ((nbOutputs - 5) + 3) / 4;
-            ZL_RET_R_IF_LT(srcSize_tooSmall, cSize, *consumedPtr + neededBytes);
+            ZL_ERR_IF_LT(cSize, *consumedPtr + neededBytes, srcSize_tooSmall);
             uint8_t token = 0;
             for (size_t n = 5; n < nbOutputs; n++) {
                 size_t shift = ((n - 5) % 4) * 2;
@@ -161,7 +163,7 @@ static ZL_Report DFH_decoderOutputTypes(
         }
         /* nbOutputs > 2 */
         size_t const neededBytes = (nbOutputs - done + 3) / 4;
-        ZL_RET_R_IF_LT(srcSize_tooSmall, cSize, *consumedPtr + neededBytes);
+        ZL_ERR_IF_LT(cSize, *consumedPtr + neededBytes, srcSize_tooSmall);
         uint8_t token = 0;
         for (size_t n = done; n < nbOutputs; n++) {
             size_t shift = ((n - done) % 4) * 2;
@@ -182,8 +184,9 @@ static ZL_Report DFH_decodeOutputSizes_v20(
         size_t cSize,
         size_t nbOutputs)
 {
+    ZL_RESULT_DECLARE_SCOPE_REPORT(NULL);
     (void)numElts; // not used for versions <= 20
-    ZL_RET_R_IF_LT(srcSize_tooSmall, cSize, 4 * nbOutputs);
+    ZL_ERR_IF_LT(cSize, 4 * nbOutputs, srcSize_tooSmall);
     for (size_t n = 0; n < nbOutputs; n++) {
         dSizes[n] = ZL_readLE32((const char*)src + 4 * n);
     }
@@ -198,26 +201,27 @@ static ZL_Report DFH_decodeOutputSizes_v21(
         const ZL_Type* types,
         size_t nbOutputs)
 {
+    ZL_RESULT_DECLARE_SCOPE_REPORT(NULL);
     const uint8_t* ptr = src;
     const uint8_t* end = ptr + cSize;
 
-    ZL_RET_R_IF_LT(srcSize_tooSmall, cSize, 1);
+    ZL_ERR_IF_LT(cSize, 1, srcSize_tooSmall);
     {
         uint8_t const firstByte = ((const uint8_t*)src)[0];
         // 0 means "final output size(s) are unknown"
-        ZL_RET_R_IF_EQ(
-                temporaryLibraryLimitation,
+        ZL_ERR_IF_EQ(
                 firstByte,
                 0x0,
+                temporaryLibraryLimitation,
                 "doesn't support unknown size outputs for the time being");
     }
 
     for (size_t n = 0; n < nbOutputs; n++) {
-        ZL_TRY_LET_T(uint64_t, v64, ZL_varintDecode(&ptr, end));
-        ZL_RET_R_IF_EQ(
-                temporaryLibraryLimitation,
+        ZL_TRY_LET(uint64_t, v64, ZL_varintDecode(&ptr, end));
+        ZL_ERR_IF_EQ(
                 v64,
                 0,
+                temporaryLibraryLimitation,
                 "does not support unknown decompressed size");
         dSizes[n] = v64 - 1;
     }
@@ -234,7 +238,7 @@ static ZL_Report DFH_decodeOutputSizes_v21(
                 numElts[n] = dSizes[n];
                 break;
             case ZL_Type_string:
-                ZL_TRY_SET_T(uint64_t, numElts[n], ZL_varintDecode(&ptr, end));
+                ZL_TRY_SET(uint64_t, numElts[n], ZL_varintDecode(&ptr, end));
                 break;
             default:
                 ZL_ASSERT_FAIL("invalid type");
@@ -269,10 +273,11 @@ static ZL_Report DFH_FrameInfo_decodeFrameHeader(
         const void* cSrc,
         size_t cSize)
 {
-    ZL_RESULT_DECLARE_SCOPE_REPORT(NULL); // T258630070
+    ZL_RESULT_DECLARE_SCOPE_REPORT(NULL);
     ZL_DLOG(BLOCK, "*****   DFH_FrameInfo_decodeFrameHeader   ***** \n");
     memset(zfi, 0, sizeof(*zfi));
-    ZL_TRY_LET_R(formatVersion, ZL_getFormatVersionFromFrame(cSrc, cSize));
+    ZL_TRY_LET(
+            size_t, formatVersion, ZL_getFormatVersionFromFrame(cSrc, cSize));
     ZL_ASSERT_NN(zfi);
     zfi->formatVersion = formatVersion;
     size_t consumed    = 4;
@@ -280,7 +285,7 @@ static ZL_Report DFH_FrameInfo_decodeFrameHeader(
 
     /* frame properties, such as checksums */
     if (zfi->formatVersion >= ZL_CHUNK_VERSION_MIN) {
-        ZL_RET_R_IF_LE(srcSize_tooSmall, cSize, consumed);
+        ZL_ERR_IF_LE(cSize, consumed, srcSize_tooSmall);
         uint8_t const flags                   = ptr[consumed++];
         zfi->properties.hasContentChecksum    = ((flags & (1 << 0)) != 0);
         zfi->properties.hasCompressedChecksum = ((flags & (1 << 1)) != 0);
@@ -288,26 +293,27 @@ static ZL_Report DFH_FrameInfo_decodeFrameHeader(
     }
 
     /* nb of outputs */
-    ZL_TRY_SET_R(
+    ZL_TRY_SET(
+            size_t,
             zfi->nbOutputs,
             DFH_decodeNbOutputs(cSrc, cSize, &consumed, formatVersion));
     ZL_DLOG(BLOCK,
             "frame format %u, hosts %u output streams",
             formatVersion,
             zfi->nbOutputs);
-    ZL_RET_R_IF_GT(
-            outputs_tooNumerous,
+    ZL_ERR_IF_GT(
             zfi->nbOutputs,
             ZL_runtimeInputLimit((unsigned)formatVersion),
+            outputs_tooNumerous,
             "Too many outputs for this format version");
     // @note for the time being, do not support 0 output
     // (which is different from an empty output).
-    ZL_RET_R_IF_EQ(GENERIC, zfi->nbOutputs, 0, "doesn't support 0 output");
+    ZL_ERR_IF_EQ(zfi->nbOutputs, 0, GENERIC, "doesn't support 0 output");
 
     // Decode Output Types
     ALLOC_MALLOC_CHECKED(ZL_Type, types, zfi->nbOutputs);
     zfi->types = types;
-    ZL_RET_R_IF_ERR(DFH_decoderOutputTypes(
+    ZL_ERR_IF_ERR(DFH_decoderOutputTypes(
             types, zfi->nbOutputs, cSrc, cSize, &consumed, formatVersion));
 
     // Decode Output Sizes
@@ -316,7 +322,8 @@ static ZL_Report DFH_FrameInfo_decodeFrameHeader(
     zfi->decompressedSizes = dSizes;
     ALLOC_MALLOC_CHECKED(uint64_t, numElts, zfi->nbOutputs);
     zfi->numElts = numElts;
-    ZL_TRY_LET_R(
+    ZL_TRY_LET(
+            size_t,
             oss,
             DFH_decodeOutputSizes(
                     dSizes,
@@ -334,23 +341,23 @@ static ZL_Report DFH_FrameInfo_decodeFrameHeader(
     // Decode Comment
     if (formatVersion >= ZL_COMMENT_VERSION_MIN && zfi->properties.hasComment) {
         const uint8_t* cSrcCur = ptr + consumed;
-        ZL_TRY_LET_CONST_T(
+        ZL_TRY_LET_CONST(
                 uint64_t, commentSize, ZL_varintDecode(&cSrcCur, ptr + cSize));
-        ZL_RET_R_IF_EQ(
-                corruption,
+        ZL_ERR_IF_EQ(
                 commentSize,
                 0,
-                "Invalid frame header: comment size cannot be 0 when flag is set.");
-        ZL_RET_R_IF_GT(
                 corruption,
+                "Invalid frame header: comment size cannot be 0 when flag is set.");
+        ZL_ERR_IF_GT(
                 commentSize,
                 ZL_MAX_HEADER_COMMENT_SIZE_LIMIT,
+                corruption,
                 "Invalid frame header: frame max comment size exceeded.");
         zfi->commentSize = commentSize;
         consumed += (size_t)(cSrcCur - (ptr + consumed));
         zfi->comment = ZL_malloc(commentSize);
-        ZL_RET_R_IF_NULL(allocation, zfi->comment);
-        ZL_RET_R_IF_GT(corruption, consumed + commentSize, cSize);
+        ZL_ERR_IF_NULL(zfi->comment, allocation);
+        ZL_ERR_IF_GT(consumed + commentSize, cSize, corruption);
         memcpy(zfi->comment, ptr + consumed, commentSize);
         consumed += commentSize;
     }
@@ -359,9 +366,9 @@ static ZL_Report DFH_FrameInfo_decodeFrameHeader(
         && zfi->properties.hasCompressedChecksum) {
         // Frame header checksum
         uint64_t const fhchk = XXH3_64bits(cSrc, consumed) & 255;
-        ZL_RET_R_IF_LT(srcSize_tooSmall, cSize, consumed + 1);
+        ZL_ERR_IF_LT(cSize, consumed + 1, srcSize_tooSmall);
         uint64_t const rhchk = ((const uint8_t*)cSrc)[consumed++];
-        ZL_RET_R_IF_NE(corruption, fhchk, rhchk);
+        ZL_ERR_IF_NE(fhchk, rhchk, corruption);
     }
 
     if (formatVersion >= ZL_CHUNK_VERSION_MIN) {
@@ -398,25 +405,28 @@ void ZL_FrameInfo_free(ZL_FrameInfo* zfi)
 
 ZL_Report ZL_FrameInfo_getFormatVersion(const ZL_FrameInfo* zfi)
 {
-    ZL_RET_R_IF_NULL(GENERIC, zfi);
+    ZL_RESULT_DECLARE_SCOPE_REPORT(NULL);
+    ZL_ERR_IF_NULL(zfi, GENERIC);
     return ZL_returnValue(zfi->formatVersion);
 }
 
 ZL_Report ZL_FrameInfo_getNumOutputs(const ZL_FrameInfo* zfi)
 {
-    ZL_RET_R_IF_NULL(GENERIC, zfi);
+    ZL_RESULT_DECLARE_SCOPE_REPORT(NULL);
+    ZL_ERR_IF_NULL(zfi, GENERIC);
     ZL_ASSERT_GT(zfi->nbOutputs, 0);
     return ZL_returnValue(zfi->nbOutputs);
 }
 
 ZL_Report ZL_FrameInfo_getOutputType(const ZL_FrameInfo* zfi, int outputID)
 {
+    ZL_RESULT_DECLARE_SCOPE_REPORT(NULL);
     ZL_DLOG(SEQ, "ZL_FrameInfo_getOutputType (outputID:%i)", outputID);
     ZL_ASSERT_NN(zfi);
-    ZL_RET_R_IF_GE(
-            outputID_invalid,
+    ZL_ERR_IF_GE(
             outputID,
             (int)zfi->nbOutputs,
+            outputID_invalid,
             "This frame only contains %zu outputs",
             zfi->nbOutputs);
     return ZL_returnValue((size_t)zfi->types[outputID]);
@@ -426,11 +436,12 @@ ZL_Report ZL_FrameInfo_getDecompressedSize(
         const ZL_FrameInfo* zfi,
         int outputID)
 {
+    ZL_RESULT_DECLARE_SCOPE_REPORT(NULL);
     ZL_ASSERT_NN(zfi);
-    ZL_RET_R_IF_GE(
-            outputID_invalid,
+    ZL_ERR_IF_GE(
             outputID,
             (int)zfi->nbOutputs,
+            outputID_invalid,
             "This frame only contains %zu outputs",
             zfi->nbOutputs);
     ZL_ASSERT_NN(zfi->decompressedSizes);
@@ -439,32 +450,33 @@ ZL_Report ZL_FrameInfo_getDecompressedSize(
 
 ZL_Report ZL_FrameInfo_getNumElts(const ZL_FrameInfo* zfi, int outputID)
 {
+    ZL_RESULT_DECLARE_SCOPE_REPORT(NULL);
     ZL_ASSERT_NN(zfi);
-    ZL_RET_R_IF_GE(
-            outputID_invalid,
+    ZL_ERR_IF_GE(
             outputID,
             (int)zfi->nbOutputs,
+            outputID_invalid,
             "This frame only contains %zu outputs",
             zfi->nbOutputs);
-    ZL_RET_R_IF_LT(
-            GENERIC,
+    ZL_ERR_IF_LT(
             zfi->formatVersion,
             ZL_CHUNK_VERSION_MIN,
+            GENERIC,
             "This method only works on frames with version >= %zu",
             ZL_CHUNK_VERSION_MIN);
 
     // Currently only supports string & serial
     ZL_ASSERT_NN(zfi->types);
     ZL_Type const outType = zfi->types[outputID];
-    ZL_RET_R_IF_EQ(
-            temporaryLibraryLimitation,
+    ZL_ERR_IF_EQ(
             outType,
             ZL_Type_struct,
-            "this method doesn't support Struct type yet");
-    ZL_RET_R_IF_EQ(
             temporaryLibraryLimitation,
+            "this method doesn't support Struct type yet");
+    ZL_ERR_IF_EQ(
             outType,
             ZL_Type_numeric,
+            temporaryLibraryLimitation,
             "this method doesn't support Numeric type yet");
 
     ZL_ASSERT_NN(zfi->numElts);
@@ -473,18 +485,18 @@ ZL_Report ZL_FrameInfo_getNumElts(const ZL_FrameInfo* zfi, int outputID)
 
 ZL_RESULT_OF(ZL_Comment) ZL_FrameInfo_getComment(const ZL_FrameInfo* zfi)
 {
+    ZL_RESULT_DECLARE_SCOPE(ZL_Comment, NULL);
     ZL_Comment comment;
     ZL_ASSERT_NN(zfi);
-    ZL_RET_T_IF_LT(
-            ZL_Comment,
-            GENERIC,
+    ZL_ERR_IF_LT(
             zfi->formatVersion,
             ZL_COMMENT_VERSION_MIN,
+            GENERIC,
             "This method only works on frames with version >= %zu",
             ZL_COMMENT_VERSION_MIN);
     comment.data = zfi->comment;
     comment.size = zfi->commentSize;
-    return ZL_RESULT_WRAP_VALUE(ZL_Comment, comment);
+    return ZL_WRAP_VALUE(comment);
 }
 
 // --------------------------
@@ -562,7 +574,9 @@ void DFH_destroy(DFH_Struct* dfh)
 // Public Symbol
 ZL_Report ZL_getDecompressedSize(const void* cSrc, size_t cSize)
 {
-    ZL_TRY_LET_R(formatVersion, ZL_getFormatVersionFromFrame(cSrc, cSize));
+    ZL_RESULT_DECLARE_SCOPE_REPORT(NULL);
+    ZL_TRY_LET(
+            size_t, formatVersion, ZL_getFormatVersionFromFrame(cSrc, cSize));
     DFH_Interface const decoder =
             DFH_getFrameHeaderDecoder((uint32_t)formatVersion);
     return decoder.getDecompressedSize(&decoder, cSrc, cSize);
@@ -581,19 +595,20 @@ ZL_Report ZL_getNumOutputs(const void* cSrc, size_t cSize)
 // but it creates an additional sync burden when wire format evolves.
 ZL_Report ZL_getOutputType(ZL_Type* typePtr, const void* cSrc, size_t cSize)
 {
-    ZL_TRY_LET_R(formatVersion, ZL_getFormatVersionFromFrame(cSrc, cSize));
+    ZL_RESULT_DECLARE_SCOPE_REPORT(NULL);
+    ZL_TRY_LET(
+            size_t, formatVersion, ZL_getFormatVersionFromFrame(cSrc, cSize));
     if (formatVersion <= 13) {
         *typePtr = ZL_Type_serial;
     } else if (formatVersion < ZL_CHUNK_VERSION_MIN) {
-        ZL_RET_R_IF_LT(srcSize_tooSmall, cSize, 5);
+        ZL_ERR_IF_LT(cSize, 5, srcSize_tooSmall);
         uint8_t const typeEncoded = ((const uint8_t*)cSrc)[4];
-        ZL_RET_R_IF_GT(invalidRequest_singleOutputFrameOnly, typeEncoded, 3);
+        ZL_ERR_IF_GT(typeEncoded, 3, invalidRequest_singleOutputFrameOnly);
         *typePtr = decodeType(typeEncoded);
     } else { // formatVersion >= ZL_CHUNK_VERSION_MIN
-        ZL_RET_R_IF_LT(srcSize_tooSmall, cSize, 6);
+        ZL_ERR_IF_LT(cSize, 6, srcSize_tooSmall);
         uint8_t const typeEncoded = ((const uint8_t*)cSrc)[5];
-        ZL_RET_R_IF_NE(
-                invalidRequest_singleOutputFrameOnly, typeEncoded & 15, 1);
+        ZL_ERR_IF_NE(typeEncoded & 15, 1, invalidRequest_singleOutputFrameOnly);
         *typePtr = decodeType((typeEncoded >> 4) & 3);
     }
     return ZL_returnSuccess();
@@ -601,8 +616,10 @@ ZL_Report ZL_getOutputType(ZL_Type* typePtr, const void* cSrc, size_t cSize)
 
 ZL_Report ZL_getCompressedSize(const void* src, size_t srcSize)
 {
+    ZL_RESULT_DECLARE_SCOPE_REPORT(NULL);
     ZL_DLOG(SEQ, "ZL_getCompressedSize");
-    ZL_TRY_LET_R(formatVersion, ZL_getFormatVersionFromFrame(src, srcSize));
+    ZL_TRY_LET(
+            size_t, formatVersion, ZL_getFormatVersionFromFrame(src, srcSize));
     DFH_Interface const decoder =
             DFH_getFrameHeaderDecoder((uint32_t)formatVersion);
     return decoder.getCompressedSize(&decoder, src, srcSize);
@@ -610,7 +627,9 @@ ZL_Report ZL_getCompressedSize(const void* src, size_t srcSize)
 
 ZL_Report ZL_getHeaderSize(const void* src, size_t srcSize)
 {
-    ZL_TRY_LET_R(formatVersion, ZL_getFormatVersionFromFrame(src, srcSize));
+    ZL_RESULT_DECLARE_SCOPE_REPORT(NULL);
+    ZL_TRY_LET(
+            size_t, formatVersion, ZL_getFormatVersionFromFrame(src, srcSize));
     DFH_Interface const decoder =
             DFH_getFrameHeaderDecoder((uint32_t)formatVersion);
     return decoder.getHeaderSize(&decoder, src, srcSize);
@@ -637,14 +656,15 @@ size_t FrameInfo_frameHeaderSize(const ZL_FrameInfo* fi)
 static ZL_Report
 checkedBitpackDecode8(uint8_t* dst, size_t nbElts, ZL_RC* src, int nbBits)
 {
+    ZL_RESULT_DECLARE_SCOPE_REPORT(NULL);
     // Prevalidated
     ZL_ASSERT_GE(nbBits, 0);
 
-    ZL_RET_R_IF_GT(GENERIC, nbBits, 8, "corruption");
-    ZL_RET_R_IF_GT(
-            internalBuffer_tooSmall,
+    ZL_ERR_IF_GT(nbBits, 8, GENERIC, "corruption");
+    ZL_ERR_IF_GT(
             (nbElts * (size_t)nbBits + 7) / 8,
-            ZL_RC_avail(src));
+            ZL_RC_avail(src),
+            internalBuffer_tooSmall);
     size_t const srcSize = ZS_bitpackDecode8(
             dst, nbElts, ZL_RC_ptr(src), ZL_RC_avail(src), nbBits);
     ZL_RC_advance(src, srcSize);
@@ -654,14 +674,15 @@ checkedBitpackDecode8(uint8_t* dst, size_t nbElts, ZL_RC* src, int nbBits)
 static ZL_Report
 checkedBitpackDecode32(uint32_t* dst, size_t nbElts, ZL_RC* src, int nbBits)
 {
+    ZL_RESULT_DECLARE_SCOPE_REPORT(NULL);
     // Prevalidated
     ZL_ASSERT_GE(nbBits, 0);
 
-    ZL_RET_R_IF_GT(GENERIC, nbBits, 32, "corruption");
-    ZL_RET_R_IF_GT(
-            internalBuffer_tooSmall,
+    ZL_ERR_IF_GT(nbBits, 32, GENERIC, "corruption");
+    ZL_ERR_IF_GT(
             (nbElts * (size_t)nbBits + 7) / 8,
-            ZL_RC_avail(src));
+            ZL_RC_avail(src),
+            internalBuffer_tooSmall);
     size_t const srcSize = ZS_bitpackDecode32(
             dst, nbElts, ZL_RC_ptr(src), ZL_RC_avail(src), nbBits);
     ZL_RC_advance(src, srcSize);
@@ -672,7 +693,8 @@ checkedBitpackDecode32(uint32_t* dst, size_t nbElts, ZL_RC* src, int nbBits)
 // Simple bit packing, 1 bit per transform (for the time being)
 static ZL_Report decompressTrt(uint8_t array8[], size_t nbFlags, ZL_RC* src)
 {
-    ZL_TRY_LET_R(r, checkedBitpackDecode8(array8, nbFlags, src, 1));
+    ZL_RESULT_DECLARE_SCOPE_REPORT(NULL);
+    ZL_TRY_LET(size_t, r, checkedBitpackDecode8(array8, nbFlags, src, 1));
     ZL_DLOG(BLOCK, "Decoding %zu codec types, using %zu bytes", nbFlags, r);
     return ZL_returnSuccess();
 }
@@ -686,6 +708,7 @@ static ZL_Report decompressTrID(
         uint32_t scratch[],
         unsigned formatVersion)
 {
+    ZL_RESULT_DECLARE_SCOPE_REPORT(NULL);
     if (!nbTransforms)
         return ZL_returnSuccess();
 
@@ -699,9 +722,9 @@ static ZL_Report decompressTrID(
     unsigned cardinality = 0;
     size_t const r       = HIST_count_simple(
             nbTrs, &maxTrtValue, &cardinality, trt8, nbTransforms);
-    ZL_RET_R_IF(
-            corruption,
+    ZL_ERR_IF(
             HIST_isError(r),
+            corruption,
             "histogram error: %s",
             FSE_getErrorName(r));
     ZL_ASSERT_LE(maxTrtValue, 1);
@@ -710,16 +733,15 @@ static ZL_Report decompressTrID(
     // start decoding standard nodes
     uint32_t* snodeids = scratch;
     int const nbBits   = ZL_StandardTransformID_numBits(formatVersion);
-    ZL_RET_R_IF_ERR(checkedBitpackDecode32(snodeids, nbTrs[0], src, nbBits));
+    ZL_ERR_IF_ERR(checkedBitpackDecode32(snodeids, nbTrs[0], src, nbBits));
 
     // then decode custom nodes
     uint32_t* cnodeids = scratch + nbTrs[0];
     for (size_t u = 0; u < nbTrs[1]; u++) {
         ZL_RESULT_OF(uint64_t) const res = ZL_RC_popVarint(src);
-        ZL_RET_R_IF_ERR(res);
+        ZL_ERR_IF_ERR(res);
         uint64_t const trid64 = ZL_RES_value(res);
-        ZL_RET_R_IF_GT(
-                corruption, trid64, UINT32_MAX, "Transform ID too large");
+        ZL_ERR_IF_GT(trid64, UINT32_MAX, corruption, "Transform ID too large");
         cnodeids[u] = (uint32_t)trid64;
     }
 
@@ -746,21 +768,22 @@ static ZL_Report decompressTrID(
 static ZL_Report
 decompressTrHSize(uint32_t trhSizes[], size_t nbTransforms, ZL_RC* src)
 {
+    ZL_RESULT_DECLARE_SCOPE_REPORT(NULL);
     // Store 0-size flags in trhSizes temporarily
     // 1s will be replaced by the header size
-    ZL_RET_R_IF_ERR(checkedBitpackDecode32(trhSizes, nbTransforms, src, 1));
+    ZL_ERR_IF_ERR(checkedBitpackDecode32(trhSizes, nbTransforms, src, 1));
 
     // decode non-zero private header sizes
     for (size_t u = 0; u < nbTransforms; u++) {
         if (trhSizes[u] != 0) {
             // varint decoded
             ZL_RESULT_OF(uint64_t) const res = ZL_RC_popVarint(src);
-            ZL_RET_R_IF_ERR(res);
+            ZL_ERR_IF_ERR(res);
             uint64_t const trhSize64 = ZL_RES_value(res);
-            ZL_RET_R_IF_GE(
-                    corruption,
+            ZL_ERR_IF_GE(
                     trhSize64,
                     UINT32_MAX - 1,
+                    corruption,
                     "Transform header size too large");
             trhSizes[u] = (uint32_t)trhSize64 + 1;
         }
@@ -775,9 +798,10 @@ decompressTrHSize(uint32_t trhSizes[], size_t nbTransforms, ZL_RC* src)
 static ZL_Report
 decompressNbVOs(uint32_t nbVOs[], size_t nbTransforms, ZL_RC* src)
 {
+    ZL_RESULT_DECLARE_SCOPE_REPORT(NULL);
     // Store 0-size flags in nbVOs temporarily
     // 1s will be replaced later by actual nbVOs
-    ZL_RET_R_IF_ERR(checkedBitpackDecode32(nbVOs, nbTransforms, src, 1));
+    ZL_ERR_IF_ERR(checkedBitpackDecode32(nbVOs, nbTransforms, src, 1));
 
     // decode non-zero nbVOs (8-bit encoded, shifted by 1)
     for (size_t u = 0; u < nbTransforms; u++) {
@@ -786,7 +810,7 @@ decompressNbVOs(uint32_t nbVOs[], size_t nbTransforms, ZL_RC* src)
             // value was < 128. In this case varint is exactly equivalent to
             // byte encoding.
             ZL_ASSERT_LT(ZL_transformOutStreamsLimit(8), 128);
-            ZL_TRY_LET_T(uint64_t, nbVOsMinus1, ZL_RC_popVarint(src));
+            ZL_TRY_LET(uint64_t, nbVOsMinus1, ZL_RC_popVarint(src));
             nbVOs[u] = (uint32_t)nbVOsMinus1 + 1;
         }
     }
@@ -803,21 +827,22 @@ static ZL_Report decompressNbRegens(
         ZL_RC* src,
         unsigned formatVersion)
 {
+    ZL_RESULT_DECLARE_SCOPE_REPORT(NULL);
     ZL_DLOG(SEQ, "decompressNbRegens (nbTransforms = %zu)", nbTransforms);
     ZL_ASSERT_GE(formatVersion, 16);
     // Store 1-size flags in nbRegens temporarily
     // 1s will be replaced later by actual nbRegens
-    ZL_RET_R_IF_ERR(checkedBitpackDecode32(nbRegens, nbTransforms, src, 1));
+    ZL_ERR_IF_ERR(checkedBitpackDecode32(nbRegens, nbTransforms, src, 1));
 
     // decode non-1 nbRegens (varint encoded, shifted by 2)
     for (size_t u = 0; u < nbTransforms; u++) {
         if (nbRegens[u] != 0) {
-            ZL_TRY_LET_T(uint64_t, nbRegensMinus2, ZL_RC_popVarint(src));
+            ZL_TRY_LET(uint64_t, nbRegensMinus2, ZL_RC_popVarint(src));
             nbRegens[u] = (uint32_t)nbRegensMinus2 + 2;
-            ZL_RET_R_IF_GT(
-                    corruption,
+            ZL_ERR_IF_GT(
                     nbRegens[u],
-                    ZL_runtimeNodeInputLimit(formatVersion));
+                    ZL_runtimeNodeInputLimit(formatVersion),
+                    corruption);
         } else {
             nbRegens[u] = 1;
         }
@@ -834,11 +859,14 @@ static ZL_Report decompress_regenStreamID_distances(
         ZL_RC* src,
         size_t nbStoredStreams)
 {
+    ZL_RESULT_DECLARE_SCOPE_REPORT(NULL);
     // Note : distance can never be > (nbDistances + nbStreams)
     size_t const maxDistance = nbGenStreams + nbStoredStreams;
     int const nbBits         = ZL_nextPow2(maxDistance);
-    ZL_TRY_LET_R(
-            r, checkedBitpackDecode32(distances, nbGenStreams, src, nbBits));
+    ZL_TRY_LET(
+            size_t,
+            r,
+            checkedBitpackDecode32(distances, nbGenStreams, src, nbBits));
     ZL_DLOG(BLOCK,
             "decompress_regenStreamID_distances : read %zu bytes, using %i bits per %zu entries",
             r,
@@ -852,17 +880,18 @@ static ZL_Report decompress_regenStreamID_distances(
 static ZL_Report
 decompressStrSizes(size_t streamSizes[], size_t nbStreams, ZL_RC* src)
 {
-    ZL_RET_R_IF_LT(
-            corruption,
+    ZL_RESULT_DECLARE_SCOPE_REPORT(NULL);
+    ZL_ERR_IF_LT(
             ZL_RC_avail(src),
             nbStreams * 1,
+            corruption,
             "Stream sizes header smaller than minimum size");
     for (unsigned u = 0; u < nbStreams; u++) {
         ZL_RESULT_OF(uint64_t) const res = ZL_RC_popVarint(src);
-        ZL_RET_R_IF_ERR(res);
+        ZL_ERR_IF_ERR(res);
         uint64_t const streamSize64 = ZL_RES_value(res);
-        ZL_RET_R_IF_GE(
-                corruption, streamSize64, UINT32_MAX, "Stream size too large");
+        ZL_ERR_IF_GE(
+                streamSize64, UINT32_MAX, corruption, "Stream size too large");
         streamSizes[u] = (size_t)streamSize64;
         ZL_DLOG(FRAME, "stream %u => %u bytes", u, streamSizes[u]);
     }
@@ -894,13 +923,14 @@ static ZL_Report DFH_Workspace_init(
         unsigned nbTransforms,
         VECTOR(uint32_t) * scratch)
 {
+    ZL_RESULT_DECLARE_SCOPE_REPORT(NULL);
     size_t const allocationSize = DFH_scratchSize(nbTransforms);
     ZL_ASSERT_EQ(VECTOR_MAX_CAPACITY(*scratch), 0);
     VECTOR_INIT(*scratch, allocationSize);
-    ZL_RET_R_IF_NE(
-            allocation,
+    ZL_ERR_IF_NE(
             allocationSize,
-            VECTOR_RESIZE(*scratch, allocationSize));
+            VECTOR_RESIZE(*scratch, allocationSize),
+            allocation);
 
     wksp->scratch0 = VECTOR_DATA(*scratch);
     wksp->scratch1 =
@@ -923,8 +953,9 @@ static ZL_Report DFH_decodeFrameHeader_V3orMore(
         size_t srcSize,
         unsigned formatVersion)
 {
+    ZL_RESULT_DECLARE_SCOPE_REPORT(NULL);
     ZL_DLOG(FRAME, "decodeFrameHeader (srcSize = %zu)", srcSize);
-    ZL_RET_R_IF_LT(srcSize_tooSmall, srcSize, FRAME_HEADER_SIZE_MIN);
+    ZL_ERR_IF_LT(srcSize, FRAME_HEADER_SIZE_MIN, srcSize_tooSmall);
 
     ZL_ASSERT_GE(formatVersion, 3);
     dfh->formatVersion = formatVersion;
@@ -932,7 +963,7 @@ static ZL_Report DFH_decodeFrameHeader_V3orMore(
     if (dfh->frameinfo)
         ZL_FrameInfo_free(dfh->frameinfo);
     dfh->frameinfo = ZL_malloc(sizeof(*(dfh->frameinfo)));
-    ZL_RET_R_IF_NULL(allocation, dfh->frameinfo);
+    ZL_ERR_IF_NULL(dfh->frameinfo, allocation);
     return DFH_FrameInfo_decodeFrameHeader(dfh->frameinfo, src, srcSize);
 }
 
@@ -944,8 +975,9 @@ static ZL_Report decodeChunkHeader_internal(
         const DFH_Interface* decoder,
         VECTOR(uint32_t) * scratch)
 {
+    ZL_RESULT_DECLARE_SCOPE_REPORT(NULL);
     ZL_DLOG(FRAME, "decodeChunkHeader_internal (srcSize = %zu)", srcSize);
-    ZL_RET_R_IF_LT(srcSize_tooSmall, srcSize, CHUNK_HEADER_SIZE_MIN);
+    ZL_ERR_IF_LT(srcSize, CHUNK_HEADER_SIZE_MIN, srcSize_tooSmall);
 
     ZL_ASSERT_GE(decoder->formatVersion, 3);
 
@@ -958,45 +990,44 @@ static ZL_Report decodeChunkHeader_internal(
         nbStoredStreams = ZL_RC_pop(&in);
     } else {
         ZL_RESULT_OF(uint64_t) res = ZL_RC_popVarint(&in);
-        ZL_RET_R_IF_ERR(res);
+        ZL_ERR_IF_ERR(res);
         nbDecoders = ZL_RES_value(res);
 
         if (decoder->formatVersion >= ZL_CHUNK_VERSION_MIN) {
-            ZL_RET_R_IF_EQ(corruption, nbDecoders, 0, "invalid field value");
+            ZL_ERR_IF_EQ(nbDecoders, 0, corruption, "invalid field value");
             nbDecoders--;
         }
 
         res = ZL_RC_popVarint(&in);
-        ZL_RET_R_IF_ERR(res);
+        ZL_ERR_IF_ERR(res);
         nbStoredStreams = ZL_RES_value(res);
     }
     ZL_DLOG(FRAME,
             "nbDecoders = %u | nbStoredStreams = %u",
             nbDecoders,
             nbStoredStreams);
-    ZL_RET_R_IF_GE(
-            temporaryLibraryLimitation,
+    ZL_ERR_IF_GE(
             nbDecoders,
             ZL_runtimeNodeLimit(decoder->formatVersion),
-            "OpenZL refuses to process graphs with this many nodes");
-    ZL_RET_R_IF_GE(
             temporaryLibraryLimitation,
+            "OpenZL refuses to process graphs with this many nodes");
+    ZL_ERR_IF_GE(
             nbStoredStreams,
             ZL_runtimeStreamLimit(decoder->formatVersion),
+            temporaryLibraryLimitation,
             "OpenZL refuses to process graphs with this many streams");
 
     dfh->nbDTransforms   = (size_t)nbDecoders;
     dfh->nbStoredStreams = (size_t)nbStoredStreams;
 
-    ZL_RET_R_IF_NE(
-            allocation, nbDecoders, VECTOR_RESIZE(dfh->nodes, nbDecoders));
-    ZL_RET_R_IF_NE(
-            allocation,
+    ZL_ERR_IF_NE(nbDecoders, VECTOR_RESIZE(dfh->nodes, nbDecoders), allocation);
+    ZL_ERR_IF_NE(
             nbStoredStreams,
-            VECTOR_RESIZE(dfh->storedStreamSizes, nbStoredStreams));
+            VECTOR_RESIZE(dfh->storedStreamSizes, nbStoredStreams),
+            allocation);
 
     DFH_Workspace wksp = { 0 };
-    ZL_RET_R_IF_ERR(DFH_Workspace_init(&wksp, (unsigned)nbDecoders, scratch));
+    ZL_ERR_IF_ERR(DFH_Workspace_init(&wksp, (unsigned)nbDecoders, scratch));
 
     DFH_NodeInfo* const nodes = VECTOR_DATA(dfh->nodes);
 
@@ -1004,7 +1035,7 @@ static ZL_Report decodeChunkHeader_internal(
     // ZL_CHUNK_VERSION_MIN
     if (4 <= decoder->formatVersion
         && decoder->formatVersion < ZL_CHUNK_VERSION_MIN) {
-        ZL_RET_R_IF_LT(srcSize_tooSmall, ZL_RC_avail(&in), 1);
+        ZL_ERR_IF_LT(ZL_RC_avail(&in), 1, srcSize_tooSmall);
         uint8_t const flags = ZL_RC_pop(&in);
         dfh->frameinfo->properties.hasContentChecksum =
                 ((flags & (1 << 0)) != 0);
@@ -1016,7 +1047,7 @@ static ZL_Report decodeChunkHeader_internal(
         // Collect list of decoders
         uint8_t* trt8 = wksp.scratch2;
 
-        ZL_RET_R_IF_ERR(decompressTrt(trt8, nbDecoders, &in));
+        ZL_ERR_IF_ERR(decompressTrt(trt8, nbDecoders, &in));
         for (unsigned u = 0; u < nbDecoders; u++) {
             TransformType_e const trt = trt8[u];
             nodes[u].trpid.trt        = trt;
@@ -1024,7 +1055,7 @@ static ZL_Report decodeChunkHeader_internal(
         }
 
         uint32_t* trIDs = wksp.scratch0;
-        ZL_RET_R_IF_ERR(decompressTrID(
+        ZL_ERR_IF_ERR(decompressTrID(
                 trIDs,
                 nbDecoders,
                 &in,
@@ -1034,11 +1065,10 @@ static ZL_Report decodeChunkHeader_internal(
         for (unsigned u = 0; u < nbDecoders; u++) {
             if (nodes[u].trpid.trt == trt_standard
                 && trIDs[u] >= ZL_StandardTransformID_end) {
-                ZL_RET_R_ERR(
-                        invalidTransform,
-                        "Standard Codec ID %u too large, must be <= %u",
-                        trIDs[u],
-                        ZL_StandardTransformID_end);
+                ZL_ERR(invalidTransform,
+                       "Standard Codec ID %u too large, must be <= %u",
+                       trIDs[u],
+                       ZL_StandardTransformID_end);
             }
             nodes[u].trpid.trid = trIDs[u];
         }
@@ -1048,7 +1078,7 @@ static ZL_Report decodeChunkHeader_internal(
     {
         uint32_t* const trHeaderSizes = wksp.scratch0;
         size_t totalTHSize            = 0;
-        ZL_RET_R_IF_ERR(decompressTrHSize(trHeaderSizes, nbDecoders, &in));
+        ZL_ERR_IF_ERR(decompressTrHSize(trHeaderSizes, nbDecoders, &in));
         for (unsigned u = 0; u < nbDecoders; u++) {
             nodes[u].trhSize  = trHeaderSizes[u];
             nodes[u].trhStart = totalTHSize;
@@ -1060,7 +1090,7 @@ static ZL_Report decodeChunkHeader_internal(
     // Decode nbVOs per Transform
     if (decoder->formatVersion >= 8) {
         uint32_t* const nbVOs = wksp.scratch0;
-        ZL_RET_R_IF_ERR(decompressNbVOs(nbVOs, nbDecoders, &in));
+        ZL_ERR_IF_ERR(decompressNbVOs(nbVOs, nbDecoders, &in));
         for (unsigned u = 0; u < nbDecoders; u++) {
             nodes[u].nbVOs = nbVOs[u];
         }
@@ -1075,7 +1105,7 @@ static ZL_Report decodeChunkHeader_internal(
     size_t totalNbRegens = 0;
     if (decoder->formatVersion >= 16) {
         uint32_t* const nbRegens = wksp.scratch0;
-        ZL_RET_R_IF_ERR(decompressNbRegens(
+        ZL_ERR_IF_ERR(decompressNbRegens(
                 nbRegens, nbDecoders, &in, decoder->formatVersion));
         for (unsigned u = 0; u < nbDecoders; u++) {
             nodes[u].nbRegens = nbRegens[u];
@@ -1091,17 +1121,17 @@ static ZL_Report decodeChunkHeader_internal(
 
     // Decode regen stream id distance (1 per Transform)
     ZL_DLOG(SEQ, "totalNbRegens = %zu", totalNbRegens);
-    ZL_RET_R_IF_NE(
-            allocation,
+    ZL_ERR_IF_NE(
             totalNbRegens,
-            VECTOR_RESIZE(dfh->regenDistances, totalNbRegens));
+            VECTOR_RESIZE(dfh->regenDistances, totalNbRegens),
+            allocation);
     dfh->nbRegens = totalNbRegens;
     /* warning: do NOT reallocate or update VECTOR distances after that point,
      * there are pointers referencing its content */
     /* Note: this array should rather be hosted within a session-level arena */
     {
         uint32_t* const distances = VECTOR_DATA(dfh->regenDistances);
-        ZL_RET_R_IF_ERR(decompress_regenStreamID_distances(
+        ZL_ERR_IF_ERR(decompress_regenStreamID_distances(
                 distances, totalNbRegens, &in, nbStoredStreams));
         for (unsigned t = 0, d = 0; t < nbDecoders; t++) {
             nodes[t].regenDistances = distances + d;
@@ -1122,7 +1152,7 @@ static ZL_Report decodeChunkHeader_internal(
     ZL_ASSERT_LE(
             nbStoredStreams, ZL_runtimeStreamLimit(decoder->formatVersion));
 
-    ZL_RET_R_IF_ERR(decompressStrSizes(
+    ZL_ERR_IF_ERR(decompressStrSizes(
             VECTOR_DATA(dfh->storedStreamSizes), nbStoredStreams, &in));
 
     ZL_DLOG(SEQ,
@@ -1156,17 +1186,18 @@ static ZL_Report getDecompressedSizeV3orMore(
         const void* src,
         size_t srcSize)
 {
+    ZL_RESULT_DECLARE_SCOPE_REPORT(NULL);
     ZL_DLOG(FRAME, "getDecompressedSizeV3orMore (from srcSize=%zu)", srcSize);
     size_t const hSize = (size_t)4 + (decoder->formatVersion > 13)
             + (decoder->formatVersion >= ZL_CHUNK_VERSION_MIN);
-    ZL_RET_R_IF_LT(srcSize_tooSmall, srcSize, hSize + 4);
+    ZL_ERR_IF_LT(srcSize, hSize + 4, srcSize_tooSmall);
     if (decoder->formatVersion > 14) {
         uint8_t token1 = ((const uint8_t*)src)
                 [4 + (decoder->formatVersion >= ZL_CHUNK_VERSION_MIN)];
-        ZL_RET_R_IF_GE(
-                invalidRequest_singleOutputFrameOnly,
+        ZL_ERR_IF_GE(
                 token1,
                 64,
+                invalidRequest_singleOutputFrameOnly,
                 "getDecompressedSize is only meaningful for single-output frames");
     }
     if (decoder->formatVersion < ZL_CHUNK_VERSION_MIN) {
@@ -1181,17 +1212,17 @@ static ZL_Report getDecompressedSizeV3orMore(
     ZL_ASSERT_LE(hSize, srcSize);
     const uint8_t* ptr = (const uint8_t*)src + hSize;
     const uint8_t* end = (const uint8_t*)src + srcSize;
-    ZL_TRY_SET_T(uint64_t, oSize, ZL_varintDecode(&ptr, end));
-    ZL_RET_R_IF_EQ(
-            temporaryLibraryLimitation,
+    ZL_TRY_SET(uint64_t, oSize, ZL_varintDecode(&ptr, end));
+    ZL_ERR_IF_EQ(
             oSize,
             0,
+            temporaryLibraryLimitation,
             "size must be registered in the frame header"); // 0 means "unknown"
     ZL_DLOG(BLOCK, "1 stream, of decompressed size %llu bytes", oSize - 1);
-    ZL_RET_R_IF_GE(
-            GENERIC,
+    ZL_ERR_IF_GE(
             oSize,
             (uint64_t)SIZE_MAX,
+            GENERIC,
             "large size (%llu): unsupported on current system");
     return ZL_returnValue((size_t)oSize - 1);
 }
@@ -1206,11 +1237,12 @@ static ZL_Report getCompressedSizeV3orMore_inner(
         size_t srcSize,
         DFH_Struct* dfh)
 {
+    ZL_RESULT_DECLARE_SCOPE_REPORT(NULL);
     ZL_Report fhSize = decoder->decodeFrameHeader(
             dfh, src, srcSize, decoder->formatVersion);
     size_t frameSize = 0;
     if (ZL_isError(fhSize)) {
-        ZL_RET_R(fhSize);
+        return fhSize;
     }
 
     frameSize += ZL_RES_value(fhSize); // Add header size.
@@ -1219,17 +1251,18 @@ static ZL_Report getCompressedSizeV3orMore_inner(
 
     while (oneMoreBlock) {
         if (dfh->formatVersion >= ZL_CHUNK_VERSION_MIN) {
-            ZL_RET_R_IF_GE(
-                    srcSize_tooSmall,
+            ZL_ERR_IF_GE(
                     frameSize,
-                    srcSize); // need at least one byte
+                    srcSize,
+                    srcSize_tooSmall); // need at least one byte
             if (((const char*)src)[frameSize] == 0) {
                 // frame footer
                 frameSize++;
                 break;
             }
         }
-        ZL_TRY_LET_R(
+        ZL_TRY_LET(
+                size_t,
                 chhSize,
                 decoder->decodeChunkHeader(
                         decoder,
@@ -1251,7 +1284,7 @@ static ZL_Report getCompressedSizeV3orMore_inner(
         if (dfh->formatVersion < ZL_CHUNK_VERSION_MIN)
             break; // single block for v20-
     }
-    ZL_RET_R_IF_GT(srcSize_tooSmall, frameSize, srcSize);
+    ZL_ERR_IF_GT(frameSize, srcSize, srcSize_tooSmall);
 
     return ZL_returnValue(frameSize);
 }
@@ -1307,7 +1340,9 @@ DFH_Interface DFH_getFrameHeaderDecoder(uint32_t formatVersion)
 ZL_Report
 DFH_decodeFrameHeader(DFH_Struct* dfh, const void* src, size_t srcSize)
 {
-    ZL_TRY_LET_R(formatVersion, ZL_getFormatVersionFromFrame(src, srcSize));
+    ZL_RESULT_DECLARE_SCOPE_REPORT(NULL);
+    ZL_TRY_LET(
+            size_t, formatVersion, ZL_getFormatVersionFromFrame(src, srcSize));
     DFH_Interface const decoder =
             DFH_getFrameHeaderDecoder((uint32_t)formatVersion);
     return decoder.decodeFrameHeader(dfh, src, srcSize, decoder.formatVersion);


### PR DESCRIPTION
Summary: Add a function to attach a `ZL_GraphContext` to the `ZL_ErrorContext` so we can get the graph / codec name in the error messages.

Reviewed By: daniellerozenblit

Differential Revision: D98328994


