### PR TITLE
Optimize bitpack+partition encoding for small inputs (#571)

### DIFF
--- a/benchmark/BUCK
+++ b/benchmark/BUCK
@@ -1,5 +1,6 @@
 # Copyright (c) Meta Platforms, Inc. and affiliates.
 
+load("@fbcode_macros//build_defs:cpp_binary.bzl", "cpp_binary")
 load("@fbcode_macros//build_defs:native_rules.bzl", "buck_filegroup")
 load("@fbsource//tools/build_defs:manifold.bzl", "manifold_get")
 load("../defs.bzl", "zs_cxxbinary")
@@ -28,9 +29,14 @@ zs_cxxbinary(
     srcs = [(
         src_file,
         SRC_FILE_FLAGS.get(src_file, []),
-    ) for src_file in glob([
-        "**/*.cpp",
-    ])],
+    ) for src_file in glob(
+        [
+            "**/*.cpp",
+        ],
+        exclude = [
+            "BenchmarkComponents.cpp",
+        ],
+    )],
     headers = glob([
         "**/*.h",
     ]),
@@ -54,6 +60,17 @@ zs_cxxbinary(
         "//folly:demangle",
         "//folly:dynamic",
         "//folly:json",
+    ],
+)
+
+cpp_binary(
+    # @autodeps-skip
+    name = "benchmark_components",
+    srcs = ["BenchmarkComponents.cpp"],
+    deps = [
+        "..:zstronglib",
+        "../tests/registry:openzl_components",
+        "fbsource//third-party/benchmark:benchmark",
     ],
 )
 

--- a/benchmark/BenchmarkComponents.cpp
+++ b/benchmark/BenchmarkComponents.cpp
@@ -1,0 +1,401 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#include <benchmark/benchmark.h>
+
+#include "openzl/cpp/CCtx.hpp"
+#include "openzl/cpp/Compressor.hpp"
+#include "openzl/cpp/DCtx.hpp"
+#include "openzl/cpp/FrameInfo.hpp"
+#include "tests/registry/OpenZLComponent.h"
+#include "tests/registry/OpenZLComponents.h"
+
+namespace {
+using namespace openzl;
+using namespace openzl::tests;
+
+bool detailedBenchmark(int* argc, char** argv)
+{
+    for (int i = 0; i < *argc; ++i) {
+        if (std::string_view{ argv[i] } == std::string_view{ "--detailed" }) {
+            for (int j = i; j < *argc - 1; ++j) {
+                argv[j] = argv[j + 1];
+            }
+            *argc -= 1;
+            return true;
+        }
+    }
+    return false;
+}
+
+class ComponentBenchmark {
+   public:
+    explicit ComponentBenchmark(const OpenZLComponent& component)
+            : component_(&component)
+    {
+        compressor_.selectStartingGraph(ZL_GRAPH_STORE);
+        component_->registerComponent(compressor_);
+        datagen::DataGen gen(0xdeadbeef);
+        benchmarks_ = component_->benchmarks(compressor_, gen);
+    }
+
+    static void registerCompressOverallBenchmark(
+            std::shared_ptr<ComponentBenchmark> self)
+    {
+        if (self->benchmarks_.empty()) {
+            return;
+        }
+        auto bench = [self](benchmark::State& state) {
+            self->benchCompressOverall(state);
+        };
+        benchmark::RegisterBenchmark(
+                ("Compress/Component:" + self->component_->name() + "/Overall")
+                        .c_str(),
+                std::move(bench));
+    }
+
+    static void registerCompressDetailedBenchmarks(
+            std::shared_ptr<ComponentBenchmark> self)
+    {
+        for (const auto& benchmark : self->benchmarks_) {
+            auto bench = [self, &benchmark](benchmark::State& state) {
+                self->benchCompressDetailed(state, benchmark);
+            };
+            benchmark::RegisterBenchmark(
+                    ("Compress/Component:" + self->component_->name()
+                     + "/Detailed/" + benchmark.name)
+                            .c_str(),
+                    std::move(bench));
+        }
+    }
+
+    static void registerDecompressOverallBenchmark(
+            std::shared_ptr<ComponentBenchmark> self)
+    {
+        if (self->benchmarks_.empty()) {
+            return;
+        }
+        auto bench = [self](benchmark::State& state) {
+            self->benchDecompressOverall(state);
+        };
+        benchmark::RegisterBenchmark(
+                ("Decompress/Component:" + self->component_->name()
+                 + "/Overall")
+                        .c_str(),
+                std::move(bench));
+    }
+
+    static void registerDecompressDetailedBenchmarks(
+            std::shared_ptr<ComponentBenchmark> self)
+    {
+        for (const auto& benchmark : self->benchmarks_) {
+            auto bench = [self, &benchmark](benchmark::State& state) {
+                self->benchDecompressDetailed(state, benchmark);
+            };
+            benchmark::RegisterBenchmark(
+                    ("Decompress/Component:" + self->component_->name()
+                     + "/Detailed/" + benchmark.name)
+                            .c_str(),
+                    std::move(bench));
+        }
+    }
+
+   private:
+    void setParameters(CCtx& cctx) const
+    {
+        cctx.refCompressor(compressor_);
+        cctx.setParameter(CParam::StickyParameters, true);
+        // Disable checksumming
+        cctx.setParameter(CParam::CompressedChecksum, ZL_TernaryParam_disable);
+        cctx.setParameter(CParam::ContentChecksum, ZL_TernaryParam_disable);
+        // Set format version (currently can only be max)
+        cctx.setParameter(CParam::FormatVersion, formatVersion_);
+    }
+
+    void benchCompressOverall(benchmark::State& state) const
+    {
+        CCtx cctx;
+        setParameters(cctx);
+
+        size_t compressBound = 0;
+        std::vector<std::vector<std::vector<Input>>> benchmarkInputs;
+        benchmarkInputs.reserve(benchmarks_.size());
+        size_t totalSrcSize = 0;
+        for (const auto& benchmark : benchmarks_) {
+            std::vector<std::vector<Input>> inputs;
+            inputs.reserve(benchmark.inputs.size());
+            for (const auto& input : benchmark.inputs) {
+                auto in = input->inputs();
+                compressBound =
+                        std::max(compressBound, component_->compressBound(in));
+                inputs.push_back(std::move(in));
+                totalSrcSize += input->sizeBytes();
+            }
+            benchmarkInputs.push_back(std::move(inputs));
+        }
+
+        std::string compressed(compressBound, '\0');
+        size_t totalCompressedSize = 0;
+        for (size_t i = 0; i < benchmarks_.size(); ++i) {
+            const auto& benchmark = benchmarks_[i];
+            for (const auto& input : benchmarkInputs[i]) {
+                cctx.selectStartingGraph(benchmark.graph);
+                const size_t cSize = cctx.compress(compressed, input);
+                totalCompressedSize += cSize;
+            }
+        }
+
+        for (auto _ : state) {
+            for (size_t i = 0; i < benchmarks_.size(); ++i) {
+                const auto& benchmark = benchmarks_[i];
+                for (const auto& input : benchmarkInputs[i]) {
+                    cctx.selectStartingGraph(benchmark.graph);
+                    cctx.compress(compressed, input);
+                    benchmark::DoNotOptimize(compressed);
+                    benchmark::ClobberMemory();
+                }
+            }
+        }
+
+        state.SetBytesProcessed((int64_t)(totalSrcSize * state.iterations()));
+        state.counters["CompressedSize"] = (double)totalCompressedSize;
+        state.counters["Size"]           = (double)totalSrcSize;
+        state.counters["CompressionRatio"] =
+                (double)totalSrcSize / totalCompressedSize;
+    }
+
+    void benchDecompressOverall(benchmark::State& state) const
+    {
+        CCtx cctx;
+        setParameters(cctx);
+        DCtx dctx;
+        component_->registerComponent(dctx);
+
+        size_t compressBound = 0;
+        size_t totalSrcSize  = 0;
+        std::vector<std::vector<std::vector<Input>>> benchmarkInputs;
+        benchmarkInputs.reserve(benchmarks_.size());
+        for (const auto& benchmark : benchmarks_) {
+            std::vector<std::vector<Input>> inputs;
+            inputs.reserve(benchmark.inputs.size());
+            for (const auto& input : benchmark.inputs) {
+                auto in = input->inputs();
+                compressBound =
+                        std::max(compressBound, component_->compressBound(in));
+                inputs.push_back(std::move(in));
+                totalSrcSize += input->sizeBytes();
+            }
+            benchmarkInputs.push_back(std::move(inputs));
+        }
+
+        // Compress all inputs and collect frame info
+        std::string compressBuffer(compressBound, '\0');
+        std::vector<CompressedFrame> frames;
+        for (size_t i = 0; i < benchmarks_.size(); ++i) {
+            for (const auto& input : benchmarkInputs[i]) {
+                frames.push_back(compressFrame(
+                        cctx, benchmarks_[i].graph, input, compressBuffer));
+            }
+        }
+        size_t totalCompressedSize = 0;
+        for (const auto& frame : frames) {
+            totalCompressedSize += frame.data.size();
+        }
+
+        std::vector<Output> outputs;
+        outputs.reserve(100);
+        for (auto _ : state) {
+            for (auto& frame : frames) {
+                outputs.clear();
+                for (size_t i = 0; i < frame.outputTypes.size(); ++i) {
+                    outputs.push_back(wrapOutput(
+                            frame.outputTypes[i],
+                            frame.outputEltWidths[i],
+                            frame.buffers[i]));
+                }
+                dctx.decompress(outputs, frame.data);
+                benchmark::DoNotOptimize(outputs);
+                benchmark::ClobberMemory();
+            }
+        }
+
+        state.SetBytesProcessed((int64_t)(totalSrcSize * state.iterations()));
+        state.counters["CompressedSize"] = (double)totalCompressedSize;
+        state.counters["Size"]           = (double)totalSrcSize;
+        state.counters["CompressionRatio"] =
+                (double)totalSrcSize / totalCompressedSize;
+    }
+
+    void benchCompressDetailed(
+            benchmark::State& state,
+            const OpenZLComponent::Benchmark& benchmark) const
+    {
+        CCtx cctx;
+        setParameters(cctx);
+
+        size_t compressBound = 0;
+        std::vector<std::vector<Input>> inputs;
+        inputs.reserve(benchmark.inputs.size());
+        size_t totalSrcSize = 0;
+        for (const auto& input : benchmark.inputs) {
+            auto in = input->inputs();
+            compressBound =
+                    std::max(compressBound, component_->compressBound(in));
+            inputs.push_back(std::move(in));
+            totalSrcSize += input->sizeBytes();
+        }
+
+        std::string compressed(compressBound, '\0');
+        size_t totalCompressedSize = 0;
+        for (const auto& input : inputs) {
+            cctx.selectStartingGraph(benchmark.graph);
+            const size_t cSize = cctx.compress(compressed, input);
+            totalCompressedSize += cSize;
+        }
+
+        for (auto _ : state) {
+            for (const auto& input : inputs) {
+                cctx.selectStartingGraph(benchmark.graph);
+                cctx.compress(compressed, input);
+            }
+        }
+
+        state.SetBytesProcessed((int64_t)(totalSrcSize * state.iterations()));
+        state.counters["CompressedSize"] = (double)totalCompressedSize;
+        state.counters["Size"]           = (double)totalSrcSize;
+        state.counters["CompressionRatio"] =
+                (double)totalSrcSize / totalCompressedSize;
+    }
+
+    void benchDecompressDetailed(
+            benchmark::State& state,
+            const OpenZLComponent::Benchmark& bm) const
+    {
+        CCtx cctx;
+        setParameters(cctx);
+        DCtx dctx;
+        component_->registerComponent(dctx);
+
+        size_t compressBound = 0;
+        std::vector<std::vector<Input>> inputs;
+        inputs.reserve(bm.inputs.size());
+        size_t totalSrcSize = 0;
+        for (const auto& input : bm.inputs) {
+            auto in = input->inputs();
+            compressBound =
+                    std::max(compressBound, component_->compressBound(in));
+            inputs.push_back(std::move(in));
+            totalSrcSize += input->sizeBytes();
+        }
+
+        // Compress all inputs and collect frame info
+        std::string compressBuffer(compressBound, '\0');
+        std::vector<CompressedFrame> frames;
+        frames.reserve(inputs.size());
+        for (const auto& input : inputs) {
+            frames.push_back(
+                    compressFrame(cctx, bm.graph, input, compressBuffer));
+        }
+        size_t totalCompressedSize = 0;
+        for (const auto& frame : frames) {
+            totalCompressedSize += frame.data.size();
+        }
+
+        std::vector<Output> outputs;
+        outputs.reserve(100);
+        for (auto _ : state) {
+            for (auto& frame : frames) {
+                outputs.clear();
+                for (size_t i = 0; i < frame.outputTypes.size(); ++i) {
+                    outputs.push_back(wrapOutput(
+                            frame.outputTypes[i],
+                            frame.outputEltWidths[i],
+                            frame.buffers[i]));
+                }
+                dctx.decompress(outputs, frame.data);
+                benchmark::DoNotOptimize(outputs);
+                benchmark::ClobberMemory();
+            }
+        }
+
+        state.SetBytesProcessed((int64_t)(totalSrcSize * state.iterations()));
+        state.counters["CompressedSize"] = (double)totalCompressedSize;
+        state.counters["Size"]           = (double)totalSrcSize;
+        state.counters["CompressionRatio"] =
+                (double)totalSrcSize / totalCompressedSize;
+    }
+
+    struct CompressedFrame {
+        std::string data;
+        std::vector<Type> outputTypes;
+        std::vector<size_t> outputEltWidths;
+        std::vector<std::vector<char>> buffers;
+    };
+
+    static CompressedFrame compressFrame(
+            CCtx& cctx,
+            GraphID graph,
+            poly::span<const Input> inputs,
+            std::string& compressBuffer)
+    {
+        cctx.selectStartingGraph(graph);
+        const size_t cSize = cctx.compress(compressBuffer, inputs);
+
+        CompressedFrame frame;
+        frame.data = compressBuffer.substr(0, cSize);
+        FrameInfo info(frame.data);
+        for (size_t i = 0; i < info.numOutputs(); ++i) {
+            frame.outputTypes.push_back(info.outputType(i));
+            frame.outputEltWidths.push_back(inputs[i].eltWidth());
+            if (info.outputType(i) != Type::String) {
+                frame.buffers.emplace_back(info.outputContentSize(i));
+            } else {
+                frame.buffers.emplace_back();
+            }
+        }
+        return frame;
+    }
+
+    static Output
+    wrapOutput(Type type, size_t eltWidth, std::vector<char>& buffer)
+    {
+        switch (type) {
+            case Type::Serial:
+                return Output::wrapSerial(buffer.data(), buffer.size());
+            case Type::Struct:
+                return Output::wrapStruct(
+                        buffer.data(), eltWidth, buffer.size() / eltWidth);
+            case Type::Numeric:
+                return Output::wrapNumeric(
+                        buffer.data(), eltWidth, buffer.size() / eltWidth);
+            case Type::String:
+                return Output();
+        }
+        return Output();
+    }
+
+    Compressor compressor_;
+    const OpenZLComponent* component_;
+    std::vector<OpenZLComponent::Benchmark> benchmarks_;
+    int formatVersion_ = ZL_MAX_FORMAT_VERSION;
+};
+
+} // namespace
+
+int main(int argc, char** argv)
+{
+    const bool detailed = detailedBenchmark(&argc, argv);
+
+    for (const auto& component : getAllOpenZLComponents()) {
+        auto bench = std::make_shared<ComponentBenchmark>(*component);
+        ComponentBenchmark::registerCompressOverallBenchmark(bench);
+        ComponentBenchmark::registerDecompressOverallBenchmark(bench);
+        if (detailed) {
+            ComponentBenchmark::registerCompressDetailedBenchmarks(bench);
+            ComponentBenchmark::registerDecompressDetailedBenchmarks(bench);
+        }
+    }
+
+    benchmark::Initialize(&argc, argv);
+    benchmark::RunSpecifiedBenchmarks();
+    benchmark::Shutdown();
+}

--- a/benchmark/CMakeLists.txt
+++ b/benchmark/CMakeLists.txt
@@ -25,6 +25,8 @@ file(
     "${CMAKE_CURRENT_LIST_DIR}/unitBench/**/*.c")
 list(FILTER openzl_benchmark_sources
      EXCLUDE REGEX "${CMAKE_CURRENT_LIST_DIR}/tools/.*$")
+list(FILTER openzl_benchmark_sources
+     EXCLUDE REGEX "${CMAKE_CURRENT_LIST_DIR}/BenchmarkComponents.cpp$")
 file(
     GLOB_RECURSE openzl_benchmark_headers
     CONFIGURE_DEPENDS

--- a/src/openzl/codecs/partition/encode_partition_bitpack.c
+++ b/src/openzl/codecs/partition/encode_partition_bitpack.c
@@ -212,91 +212,174 @@ typedef struct {
     uint32_t* scratch;
 } PB_GreedyOpt;
 
+/// @returns The cost of a single partition [b, e) excluding the global
+/// bucketBits term (which is independent of the partition sizes).
+static uint32_t
+PB_singlePartitionCost(const uint32_t* cumHist, uint32_t b, uint32_t e)
+{
+    const uint32_t count   = cumHist[e] - cumHist[b];
+    const uint32_t offBits = (uint32_t)ZL_nextPow2(PB_bucketSize(b, e));
+    return PB_OVERHEAD_BITS + count * offBits;
+}
+
+/// @returns the end of partition @p i.
+static uint32_t PB_partitionEnd(
+        const uint32_t* partitions,
+        size_t numPartitions,
+        uint32_t histSize,
+        size_t i)
+{
+    return (i + 1 == numPartitions) ? histSize : partitions[i + 1];
+}
+
 /// @returns true iff the partition from [begin, end) is legal
 static bool PB_isLegalPartition(uint32_t begin, uint32_t end)
 {
     return begin < end && (end - begin) <= PB_idx2bucket(PB_MAX_BUCKET_SIZE);
 }
 
-/// @returns true iff the partitioning is legal
-static bool PB_isLegal(const PB_GreedyOpt* opt, const uint32_t* p, size_t n)
+/// Grows partition @p idx by doubling its size, and rounding all following
+/// partition sizes up to powers of two in @p out until a partition size is
+/// unchanged.
+/// @returns cascadeEnd: the first index NOT modified.
+static size_t PB_growPartitions(
+        const uint32_t* partitions,
+        size_t idx,
+        uint32_t* out,
+        size_t n)
 {
-    if (n == 0) {
-        return false;
-    }
-    if (p[n - 1] >= opt->histSize) {
-        return false;
-    }
-    for (size_t i = 0; i < n; ++i) {
-        const uint32_t begin = p[i];
-        const uint32_t end   = (i + 1 == n) ? opt->histSize : p[i + 1];
-        if (!PB_isLegalPartition(begin, end)) {
-            return false;
-        }
-    }
-    return true;
-}
-
-/// The cost of a partitioning, or UINT32_MAX if it is illegal
-static uint32_t PB_cost(const PB_GreedyOpt* opt, const uint32_t* p, size_t n)
-{
-    if (!PB_isLegal(opt, p, n)) {
-        return UINT32_MAX;
-    }
-    return PB_fixedBucketCost(
-            opt->cumHist, opt->histSize, p, n, opt->targetPartitions);
-}
-
-/// Grow the partition at @p n to the next power of two and fix up following
-/// partitions to all have power of two sizes.
-static void
-PB_growPartitions(PB_GreedyOpt* opt, size_t idx, uint32_t* out, size_t n)
-{
-    memcpy(out, opt->partitions, n * sizeof(uint32_t));
     if (idx + 1 == n) {
-        return;
+        return idx;
     }
-    uint32_t begin   = out[idx];
-    uint32_t end     = out[idx + 1];
+    uint32_t begin   = partitions[idx];
+    uint32_t end     = partitions[idx + 1];
     uint32_t sz      = end - begin;
     uint32_t newSize = 1u << ((unsigned)ZL_nextPow2(sz) + 1);
     out[idx + 1]     = begin + newSize;
 
     for (size_t j = idx + 1; j + 1 < n; ++j) {
-        begin        = out[j];
-        end          = out[j + 1];
-        sz           = end > begin ? end - begin : 1;
-        uint32_t alt = 1u << (unsigned)ZL_nextPow2(sz);
-        out[j + 1]   = begin + ZL_MAX(newSize, alt);
+        begin           = out[j];
+        end             = partitions[j + 1];
+        sz              = end > begin ? end - begin : 1;
+        uint32_t alt    = 1u << (unsigned)ZL_nextPow2(sz);
+        uint32_t newEnd = begin + ZL_MAX(newSize, alt);
+        if (newEnd == end) {
+            return j + 1;
+        }
+        out[j + 1] = newEnd;
     }
+    return n;
 }
 
-/// Shrink the partition at @p n to the previous power of two and fix up the
-/// following partitions to all have power of two sizes.
-static void
-PB_shrinkPartitions(PB_GreedyOpt* opt, size_t idx, uint32_t* out, size_t n)
+/// Shrinks partition @p idx by halving its size, and rounding all following
+/// partition sizes up to powers of two in @p out until a partition size is
+/// unchanged.
+/// @returns cascadeEnd: the first index NOT modified.
+static size_t PB_shrinkPartitions(
+        const uint32_t* partitions,
+        size_t idx,
+        uint32_t* out,
+        size_t n)
 {
-    memcpy(out, opt->partitions, n * sizeof(uint32_t));
     if (idx + 1 == n) {
-        return;
+        return idx;
     }
-    uint32_t begin = out[idx];
-    uint32_t end   = out[idx + 1];
+    uint32_t begin = partitions[idx];
+    uint32_t end   = partitions[idx + 1];
     uint32_t sz    = end - begin;
     if (sz <= 1) {
-        return;
+        return idx;
     }
     uint32_t newSize = 1u << ((unsigned)ZL_nextPow2(sz) - 1);
     out[idx + 1]     = begin + newSize;
 
     for (size_t j = idx + 1; j + 1 < n; ++j) {
         begin = out[j];
-        end   = out[j + 1];
+        end   = partitions[j + 1];
         sz    = end - begin;
         if (!ZL_isPow2(sz)) {
-            out[j + 1] = begin + (1u << ((unsigned)ZL_nextPow2(sz) - 1));
+            uint32_t newEnd = begin + (1u << ((unsigned)ZL_nextPow2(sz) - 1));
+            if (newEnd == end) {
+                return j + 1;
+            }
+            out[j + 1] = newEnd;
+        } else {
+            return j + 1;
         }
     }
+    return n;
+}
+
+/// Compute cost of modified partitions [from, to), where out contains the
+/// modified boundaries and partitions has the original values (used for the
+/// end of partition to-1 if to < n, and partition from's begin is unchanged).
+static uint32_t PB_modifiedRangeCost(
+        const uint32_t* cumHist,
+        const uint32_t* partitions,
+        const uint32_t* out,
+        size_t n,
+        uint32_t histSize,
+        size_t from,
+        size_t to)
+{
+    uint32_t cost = 0;
+    for (size_t i = from; i < to; ++i) {
+        const uint32_t b = (i == from) ? partitions[i] : out[i];
+        uint32_t e;
+        if (i + 1 == n) {
+            e = histSize;
+        } else if (i + 1 < to) {
+            e = out[i + 1];
+        } else {
+            e = partitions[i + 1];
+        }
+        if (e > histSize || !PB_isLegalPartition(b, e)) {
+            return UINT32_MAX;
+        }
+        cost += PB_singlePartitionCost(cumHist, b, e);
+    }
+    return cost;
+}
+
+/// Try applying a cascaded mutation from scratch and accept if it reduces cost.
+/// Returns true if the mutation was accepted.
+static bool PB_tryMutation(
+        PB_GreedyOpt* opt,
+        uint32_t* partCost,
+        uint32_t* currentCost,
+        size_t n,
+        size_t idx,
+        size_t cascadeEnd)
+{
+    uint32_t newRangeCost = PB_modifiedRangeCost(
+            opt->cumHist,
+            opt->partitions,
+            opt->scratch,
+            n,
+            opt->histSize,
+            idx,
+            cascadeEnd);
+    if (newRangeCost == UINT32_MAX) {
+        return false;
+    }
+    uint32_t oldRangeCost = 0;
+    for (size_t j = idx; j < cascadeEnd; ++j) {
+        oldRangeCost += partCost[j];
+    }
+    if (newRangeCost >= oldRangeCost) {
+        return false;
+    }
+    for (size_t j = idx + 1; j < cascadeEnd && j < n; ++j) {
+        opt->partitions[j] = opt->scratch[j];
+    }
+    *currentCost = *currentCost - oldRangeCost + newRangeCost;
+    for (size_t j = idx; j < cascadeEnd; ++j) {
+        const uint32_t b = opt->partitions[j];
+        const uint32_t e =
+                PB_partitionEnd(opt->partitions, n, opt->histSize, j);
+        partCost[j] = PB_singlePartitionCost(opt->cumHist, b, e);
+    }
+    return true;
 }
 
 /**
@@ -310,25 +393,37 @@ PB_shrinkPartitions(PB_GreedyOpt* opt, size_t idx, uint32_t* out, size_t n)
 static void PB_iterativeImprovement(PB_GreedyOpt* opt)
 {
     const size_t n = opt->numPartitions;
+    if (n < 2) {
+        return;
+    }
+
+    uint32_t partCost[PB_MAX_PARTITIONS];
+    uint32_t sumCost = 0;
+    for (size_t i = 0; i < n; ++i) {
+        const uint32_t b = opt->partitions[i];
+        const uint32_t e =
+                PB_partitionEnd(opt->partitions, n, opt->histSize, i);
+        partCost[i] = PB_singlePartitionCost(opt->cumHist, b, e);
+        sumCost += partCost[i];
+    }
+
+    const uint32_t totalCount = opt->cumHist[opt->histSize];
+    const uint32_t bucketBits = (uint32_t)ZL_nextPow2(opt->targetPartitions);
+    const uint32_t baseCost   = totalCount * bucketBits;
+    uint32_t currentCost      = baseCost + sumCost;
+
     for (;;) {
-        const uint32_t startCost = PB_cost(opt, opt->partitions, n);
-        uint32_t currentCost     = startCost;
-        for (size_t idx = 0; idx + 1 < n;) {
-            PB_growPartitions(opt, idx, opt->scratch, n);
-            uint32_t newCost = PB_cost(opt, opt->scratch, n);
-            if (newCost < currentCost) {
-                memcpy(opt->partitions, opt->scratch, n * sizeof(uint32_t));
-                currentCost = newCost;
-                break;
+        const uint32_t startCost = currentCost;
+        for (size_t idx = 0; idx + 1 < n; ++idx) {
+            size_t cascadeEnd =
+                    PB_growPartitions(opt->partitions, idx, opt->scratch, n);
+            if (PB_tryMutation(
+                        opt, partCost, &currentCost, n, idx, cascadeEnd)) {
+                continue;
             }
-            PB_shrinkPartitions(opt, idx, opt->scratch, n);
-            newCost = PB_cost(opt, opt->scratch, n);
-            if (newCost < currentCost) {
-                memcpy(opt->partitions, opt->scratch, n * sizeof(uint32_t));
-                currentCost = newCost;
-                break;
-            }
-            ++idx;
+            cascadeEnd =
+                    PB_shrinkPartitions(opt->partitions, idx, opt->scratch, n);
+            PB_tryMutation(opt, partCost, &currentCost, n, idx, cascadeEnd);
         }
         if (currentCost == startCost) {
             break;
@@ -343,9 +438,9 @@ static void PB_iterativeImprovement(PB_GreedyOpt* opt)
 static void
 PB_dividePartitionAt(const PB_GreedyOpt* opt, uint32_t* out, size_t i)
 {
-    const uint32_t begin   = opt->partitions[i];
-    const uint32_t end     = (i + 1 == opt->numPartitions) ? opt->histSize
-                                                           : opt->partitions[i + 1];
+    const uint32_t begin = opt->partitions[i];
+    const uint32_t end   = PB_partitionEnd(
+            opt->partitions, opt->numPartitions, opt->histSize, i);
     const uint32_t sz      = end - begin;
     const uint32_t newSize = 1u << ((unsigned)ZL_nextPow2(sz) - 1);
 
@@ -359,45 +454,88 @@ PB_dividePartitionAt(const PB_GreedyOpt* opt, uint32_t* out, size_t i)
     out[i + 1] = begin + newSize;
 }
 
-/**
- * Divide a single partition into two using PB_dividePartitionAt(). The selected
- * partition is either:
- * - The first illegal partition (if any)
- * - The partition with the highest gain from dividing it
- */
-static bool PB_dividePartition(PB_GreedyOpt* opt)
+/// @returns the gain from splitting partition [begin, end) into two where the
+/// first partition is the largest power of two smaller than the current size.
+static int32_t
+PB_splitGain(const uint32_t* cumHist, uint32_t begin, uint32_t end)
 {
-    const size_t n     = opt->numPartitions;
-    const size_t start = opt->prefixSize > 0 ? opt->prefixSize - 1 : 0;
-    uint32_t bestCost  = UINT32_MAX;
-    size_t bestIdx     = (size_t)-1;
+    assert(end - begin > 1);
+    assert(PB_isLegalPartition(begin, end));
+    const uint32_t oldCost   = PB_singlePartitionCost(cumHist, begin, end);
+    const uint32_t sz        = end - begin;
+    const uint32_t newSize   = 1u << ((unsigned)ZL_nextPow2(sz) - 1);
+    const uint32_t mid       = begin + newSize;
+    const uint32_t leftCost  = PB_singlePartitionCost(cumHist, begin, mid);
+    const uint32_t rightCost = PB_singlePartitionCost(cumHist, mid, end);
+    return (int32_t)oldCost - (int32_t)(leftCost + rightCost);
+}
 
-    for (size_t i = start; i < n; ++i) {
-        const uint32_t begin = opt->partitions[i];
-        const uint32_t end =
-                (i + 1 == n) ? opt->histSize : opt->partitions[i + 1];
-        if (end - begin == 1) {
-            continue;
+/**
+ * Greedily divide the partition that is either illegal or provides the biggest
+ * gain from division until we hit @p targetPartitions.
+ * Run in O(targetPartitions^2) time.
+ */
+static void PB_dividePartitions(PB_GreedyOpt* opt, size_t targetPartitions)
+{
+    // Cache split gains to avoid O(N^2) rescanning.
+    // gains[i] = gain from splitting partition i; INT32_MIN = unsplittable.
+    int32_t gains[PB_MAX_PARTITIONS];
+    {
+        const size_t n     = opt->numPartitions;
+        const size_t start = opt->prefixSize > 0 ? opt->prefixSize - 1 : 0;
+        for (size_t i = 0; i < start; ++i) {
+            gains[i] = INT32_MIN;
         }
-        if (!PB_isLegalPartition(begin, end)) {
-            // Prioritize fixing illegal partitions
-            PB_dividePartitionAt(opt, opt->partitions, i);
-            ++opt->numPartitions;
-            return true;
-        }
-        PB_dividePartitionAt(opt, opt->scratch, i);
-        const uint32_t cost = PB_cost(opt, opt->scratch, n + 1);
-        if (cost < bestCost) {
-            bestCost = cost;
-            bestIdx  = i;
+        for (size_t i = start; i < n; ++i) {
+            const uint32_t b = opt->partitions[i];
+            const uint32_t e =
+                    PB_partitionEnd(opt->partitions, n, opt->histSize, i);
+            gains[i] = (e - b <= 1) ? INT32_MIN
+                    : !PB_isLegalPartition(b, e)
+                    ? INT32_MAX
+                    : PB_splitGain(opt->cumHist, b, e);
         }
     }
-    if (bestIdx == (size_t)-1) {
-        return false;
+
+    while (opt->numPartitions < targetPartitions) {
+        const size_t n   = opt->numPartitions;
+        int32_t bestGain = INT32_MIN;
+        size_t bestIdx   = (size_t)-1;
+        for (size_t i = 0; i < n; ++i) {
+            if (gains[i] == INT32_MAX) {
+                // Illegal partition - must split immediately
+                bestIdx = i;
+                break;
+            }
+            if (gains[i] > bestGain) {
+                bestGain = gains[i];
+                bestIdx  = i;
+            }
+        }
+        if (bestIdx == (size_t)-1) {
+            break;
+        }
+
+        PB_dividePartitionAt(opt, opt->partitions, bestIdx);
+        ++opt->numPartitions;
+
+        // Shift gains right for indices after bestIdx
+        for (size_t j = opt->numPartitions - 1; j > bestIdx + 1; --j) {
+            gains[j] = gains[j - 1];
+        }
+
+        // Recompute gains for the two new partitions at bestIdx and bestIdx+1
+        for (size_t j = bestIdx; j <= bestIdx + 1 && j < opt->numPartitions;
+             ++j) {
+            const uint32_t b = opt->partitions[j];
+            const uint32_t e = PB_partitionEnd(
+                    opt->partitions, opt->numPartitions, opt->histSize, j);
+            gains[j] = (e - b <= 1) ? INT32_MIN
+                    : !PB_isLegalPartition(b, e)
+                    ? INT32_MAX
+                    : PB_splitGain(opt->cumHist, b, e);
+        }
     }
-    PB_dividePartitionAt(opt, opt->partitions, bestIdx);
-    ++opt->numPartitions;
-    return true;
 }
 
 /// Run the greedy optimizer.
@@ -436,17 +574,17 @@ static size_t PB_greedyOptimize(
         opt.prefixSize    = prefixSize;
     }
 
-    // Greedily sub-divide the partition that gets the most gain until we have
-    // enough partitions.
-    while (opt.numPartitions < targetPartitions) {
-        if (!PB_dividePartition(&opt)) {
-            break;
-        }
-    }
+    // Greedily divide the current partitions until we have targetPartitions or
+    // can't divide further.
+    PB_dividePartitions(&opt, targetPartitions);
 
-    // Iteratively improve the partition boundries one at a time until we reach
-    // a local minima.
-    PB_iterativeImprovement(&opt);
+    // If there are at least 10K elements in the histogram, run the iterative
+    // improvement pass. Otherwise, it is too expensive.
+    if (cumHist.cumHist[cumHist.histSize] >= 10000) {
+        // Iteratively improve the partition boundries one at a time until we
+        // reach a local minima.
+        PB_iterativeImprovement(&opt);
+    }
 
     return opt.numPartitions;
 }

--- a/tests/datagen/distributions/ConstantDistribution.h
+++ b/tests/datagen/distributions/ConstantDistribution.h
@@ -9,7 +9,10 @@ namespace openzl::tests::datagen {
 template <typename RetType>
 class ConstantDistribution : public Distribution<RetType> {
    public:
-    explicit ConstantDistribution(RetType value) : value_(value) {}
+    explicit ConstantDistribution(RetType value)
+            : Distribution<RetType>(nullptr), value_(value)
+    {
+    }
 
     RetType operator()(RandWrapper::NameType) override
     {

--- a/tests/datagen/distributions/LogUniformDistribution.h
+++ b/tests/datagen/distributions/LogUniformDistribution.h
@@ -1,0 +1,52 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#pragma once
+
+#include "tests/datagen/distributions/Distribution.h"
+
+#include <cmath>
+
+namespace openzl::tests::datagen {
+
+/// Used to generate values that look like offsets in LZ, which typically follow
+/// a log-uniform distribution.
+/// See https://en.wikipedia.org/wiki/Reciprocal_distribution
+template <typename RetType>
+class LogUniformDistribution : public Distribution<RetType> {
+   public:
+    static_assert(std::is_integral<RetType>::value);
+    static_assert(std::is_unsigned<RetType>::value);
+
+    explicit LogUniformDistribution(
+            std::shared_ptr<RandWrapper> rw,
+            RetType min = 1,
+            RetType max = std::numeric_limits<RetType>::max())
+            : Distribution<RetType>(std::move(rw)),
+              min_(min),
+              max_(max),
+              logMin_(std::log(min_)),
+              logAMinusB_(std::log(max_) - std::log(min_))
+    {
+    }
+
+    RetType operator()(RandWrapper::NameType) override
+    {
+        return (RetType)std::round(
+                std::exp(
+                        logMin_
+                        + this->rw_->f32_range("float", 0, 1) * logAMinusB_));
+    }
+
+    void print(std::ostream& os) const override
+    {
+        os << "LogUniformDistribution(" << min_ << "," << max_ << ")";
+    }
+
+   private:
+    RetType min_;
+    RetType max_;
+    float logMin_;
+    float logAMinusB_;
+};
+
+} // namespace openzl::tests::datagen

--- a/tests/registry/BUCK
+++ b/tests/registry/BUCK
@@ -33,6 +33,7 @@ zs_cxxlibrary(
     ]),
     headers = ["OpenZLComponents.h"],
     deps = [
+        "../datagen:datagen",
         "fbsource//third-party/zstd:zstd",
     ],
     exported_deps = [

--- a/tests/registry/OpenZLComponent.h
+++ b/tests/registry/OpenZLComponent.h
@@ -211,6 +211,36 @@ class OpenZLComponent {
         return {};
     }
 
+    struct Benchmark {
+        std::string name;
+        GraphID graph;
+        std::vector<std::unique_ptr<OpenZLInput>> inputs;
+    };
+
+    /**
+     * @returns A list of benchmarks to run.
+     *
+     * These benchmarks will be run in two modes:
+     *
+     * - Overall mode: All the benchmarks will be combined into a single summary
+     *                 benchmark for the component.
+     * - Detailed Mode: Each benchmark will be run individually.
+     *
+     * It is recommended to make each benchmark approximately the same "weight"
+     * so that in summary mode they all contribute to the overall result. E.g.
+     * if one scenario processes 100 bytes, and another processes 1MB, the first
+     * scenario won't practically contribute to the summary result.
+     *
+     * These benchmarks should aim to be the minimal set that captures the
+     * interesting behavior of the component.
+     */
+    virtual std::vector<Benchmark> benchmarks(
+            Compressor& compressor,
+            datagen::DataGen& gen) const
+    {
+        return {};
+    }
+
     virtual ~OpenZLComponent() = default;
 
    private:

--- a/tests/registry/OpenZLInput.h
+++ b/tests/registry/OpenZLInput.h
@@ -23,6 +23,9 @@ class OpenZLInput {
    public:
     virtual std::vector<Input> inputs() const = 0;
 
+    /// @returns the size of the input in bytes
+    virtual size_t sizeBytes() const = 0;
+
     std::string serialize() const;
     static std::string serialize(poly::span<const Input> inputs);
     static std::unique_ptr<OpenZLInput> deserialize(std::string_view data);
@@ -47,6 +50,11 @@ class SerialOpenZLInput : public OpenZLInput {
         std::vector<Input> result;
         result.push_back(Input::refSerial(str_));
         return result;
+    }
+
+    size_t sizeBytes() const override
+    {
+        return str_.size();
     }
 
     ~SerialOpenZLInput() override = default;
@@ -92,6 +100,11 @@ class NumericOpenZLInput : public OpenZLInput {
         std::vector<Input> result;
         result.push_back(Input::refNumeric(poly::span<const T>(vec_)));
         return result;
+    }
+
+    size_t sizeBytes() const override
+    {
+        return vec_.size() * sizeof(T);
     }
 
     ~NumericOpenZLInput() override = default;
@@ -156,6 +169,11 @@ class StructOpenZLInput : public OpenZLInput {
         return result;
     }
 
+    size_t sizeBytes() const override
+    {
+        return data_.size();
+    }
+
     ~StructOpenZLInput() override = default;
 
    private:
@@ -195,6 +213,11 @@ class StringOpenZLInput : public OpenZLInput {
         return result;
     }
 
+    size_t sizeBytes() const override
+    {
+        return data_.size() + lens_.size() * sizeof(uint32_t);
+    }
+
     ~StringOpenZLInput() override = default;
 
    private:
@@ -228,6 +251,15 @@ class MultiOpenZLInput : public OpenZLInput {
             ins.push_back(std::move(inner[0]));
         }
         return ins;
+    }
+
+    size_t sizeBytes() const override
+    {
+        size_t size = 0;
+        for (const auto& input : inputs_) {
+            size += input->sizeBytes();
+        }
+        return size;
     }
 
     ~MultiOpenZLInput() override = default;

--- a/tests/registry/components/PartitionBitpack.cpp
+++ b/tests/registry/components/PartitionBitpack.cpp
@@ -2,8 +2,14 @@
 
 #include "openzl/codecs/zl_partition.h"
 #include "openzl/cpp/codecs/Partition.hpp"
+#include "tests/datagen/distributions/ConstantDistribution.h"
+#include "tests/datagen/distributions/LogUniformDistribution.h"
+#include "tests/datagen/distributions/UniformDistribution.h"
+#include "tests/datagen/structures/VectorProducer.h"
 #include "tests/registry/OpenZLComponents.h"
 #include "tests/registry/OpenZLInput.h"
+
+#include "openzl/shared/bits.h"
 
 namespace openzl::tests::components {
 namespace {
@@ -103,6 +109,30 @@ class PartitionBitpackComponent : public OpenZLComponent {
         return inputs;
     }
 
+    std::unique_ptr<OpenZLInput> generateLogUniformInput(
+            datagen::DataGen& gen,
+            size_t inputSize) const
+    {
+        datagen::VectorProducer<uint16_t> dist(
+                std::make_unique<datagen::LogUniformDistribution<uint16_t>>(
+                        gen.getRandWrapper()),
+                std::make_unique<datagen::ConstantDistribution<size_t>>(
+                        inputSize));
+        return NumericOpenZLInput<uint16_t>::make(dist("vector"));
+    }
+
+    std::unique_ptr<OpenZLInput> generateUniformInput(
+            datagen::DataGen& gen,
+            size_t inputSize) const
+    {
+        datagen::VectorProducer<uint16_t> dist(
+                std::make_unique<datagen::UniformDistribution<uint16_t>>(
+                        gen.getRandWrapper()),
+                std::make_unique<datagen::ConstantDistribution<size_t>>(
+                        inputSize));
+        return NumericOpenZLInput<uint16_t>::make(dist("vector"));
+    }
+
     std::vector<std::unique_ptr<OpenZLInput>> generateInputs(
             datagen::DataGen& gen,
             size_t num,
@@ -113,14 +143,50 @@ class PartitionBitpackComponent : public OpenZLComponent {
         std::vector<std::unique_ptr<OpenZLInput>> inputs;
         inputs.reserve(num);
         for (size_t i = 0; i < num; ++i) {
-            auto maxElts = maxInputSize / sizeof(uint16_t);
-            auto minVal  = gen.u16_range("min_val", 0, UINT16_MAX);
-            auto maxVal  = gen.u16_range("max_val", minVal, UINT16_MAX);
-            inputs.push_back(
-                    U16OpenZLInput::make(gen.randVector<uint16_t>(
-                            "values", minVal, maxVal, maxElts)));
+            auto numElts = gen.usize_range(
+                    "num_elts", 0, maxInputSize / sizeof(uint16_t));
+            if (gen.coin("log_uniform", 0.5)) {
+                inputs.push_back(generateLogUniformInput(gen, numElts));
+            } else {
+                inputs.push_back(generateUniformInput(gen, numElts));
+            }
         }
         return inputs;
+    }
+
+    std::vector<Benchmark> benchmarks(
+            Compressor& compressor,
+            datagen::DataGen& gen) const override
+    {
+        struct BenchmarkParams {
+            size_t inputSize;
+            size_t numInputs;
+        };
+        // Tuned so that each benchmark takes approximately the same amount
+        // of compression time, so each scenario is approximately evenly
+        // weighted.
+        std::array<BenchmarkParams, 3> kParams = {
+            BenchmarkParams{ 1000, 20 },
+            BenchmarkParams{ 10000, 20 },
+            BenchmarkParams{ 100000, 10 },
+        };
+        std::vector<Benchmark> benchmarks;
+        benchmarks.reserve(kParams.size());
+        for (auto param : kParams) {
+            std::vector<std::unique_ptr<OpenZLInput>> inputs;
+            inputs.reserve(param.numInputs);
+            for (size_t i = 0; i < param.numInputs; ++i) {
+                inputs.push_back(generateLogUniformInput(gen, param.inputSize));
+            }
+            benchmarks.push_back(
+                    Benchmark{
+                            .name = "InputSize:"
+                                    + std::to_string(param.inputSize),
+                            .graph  = ZL_GRAPH_PARTITION_BITPACK,
+                            .inputs = std::move(inputs),
+                    });
+        }
+        return benchmarks;
     }
 };
 


### PR DESCRIPTION
Summary:

Optimize the partition selection process, which dominates the cost for smaller inputs:

1. Speed up the `PB_dividePartitions()` by only computing the gain from a single split in O(1) time, rather than the O(N) time partitioning cost.
2. Rather than computing the gain on each iteration, cache it and each time just pick the best and update the cached gains for the split partitions.
3. Only run the iterative improvements when we have >= 10K elements, because it is relatively expensive and only provides marginal gains.
4. Optimize `PB_iterativeImprovement()` slightly by only tracking the changed partitions.

Reviewed By: Cyan4973

Differential Revision: D98793422


