### PR TITLE
Migrate batch of codecs

### DIFF
--- a/benchmark/unitBench/scenarios/split_byrange_graph.c
+++ b/benchmark/unitBench/scenarios/split_byrange_graph.c
@@ -201,10 +201,11 @@ ZL_GraphID tokenSort64_splitIndices_graph(ZL_Compressor* cgraph)
 static ZL_Report
 splitByRange_concatAlpha_fn(ZL_Graph* graph, ZL_Edge* inputs[], size_t nbInputs)
 {
+    ZL_RESULT_DECLARE_SCOPE_REPORT(graph);
     (void)nbInputs;
 
     /* Step 1: Split by range */
-    ZL_TRY_LET_T(
+    ZL_TRY_LET(
             ZL_EdgeList,
             segments,
             ZL_Edge_runNode(inputs[0], ZL_NODE_SPLIT_BYRANGE));
@@ -219,31 +220,31 @@ splitByRange_concatAlpha_fn(ZL_Graph* graph, ZL_Edge* inputs[], size_t nbInputs)
             (ZL_Edge**)ZL_Graph_getScratchSpace(graph, N * sizeof(ZL_Edge*));
 
     for (size_t i = 0; i < N; i++) {
-        ZL_TRY_LET_T(
+        ZL_TRY_LET(
                 ZL_EdgeList,
                 tokenized,
                 ZL_Edge_runNode(segments.edges[i], tokenNode));
         /* tokenized.edges[0] = alphabet, tokenized.edges[1] = indices */
         alphabets[i] = tokenized.edges[0];
         /* Send indices to NUMERIC */
-        ZL_RET_R_IF_ERR(
+        ZL_ERR_IF_ERR(
                 ZL_Edge_setDestination(tokenized.edges[1], ZL_GRAPH_NUMERIC));
     }
 
     /* Step 3: Concat all alphabets into one stream */
-    ZL_TRY_LET_T(
+    ZL_TRY_LET(
             ZL_EdgeList,
             concatResult,
             ZL_Edge_runMultiInputNode(alphabets, N, ZL_NODE_CONCAT_NUMERIC));
     /* concatResult.edges[0] = sizes, concatResult.edges[1] = merged data */
 
     /* Step 4: Send concat sizes to NUMERIC */
-    ZL_RET_R_IF_ERR(
+    ZL_ERR_IF_ERR(
             ZL_Edge_setDestination(concatResult.edges[0], ZL_GRAPH_NUMERIC));
 
     /* Step 5: Send merged alphabet to delta_int → NUMERIC */
     ZL_GraphIDList gids = ZL_Graph_getCustomGraphs(graph);
-    ZL_RET_R_IF_ERR(
+    ZL_ERR_IF_ERR(
             ZL_Edge_setDestination(concatResult.edges[1], gids.graphids[0]));
 
     return ZL_returnSuccess();

--- a/src/openzl/codecs/constant/decode_constant_binding.c
+++ b/src/openzl/codecs/constant/decode_constant_binding.c
@@ -28,7 +28,7 @@ ZL_Report DI_constant_typed(ZL_Decoder* dictx, const ZL_Input* ins[])
     ZL_RBuffer const header = ZL_Decoder_getCodecHeader(dictx);
     uint8_t const* hdrStart = (uint8_t const*)header.start;
     uint8_t const* hdrEnd   = hdrStart + header.size;
-    ZL_TRY_LET_T(uint64_t, dstNbElts, ZL_varintDecode(&hdrStart, hdrEnd));
+    ZL_TRY_LET(uint64_t, dstNbElts, ZL_varintDecode(&hdrStart, hdrEnd));
     ZL_ERR_IF_NE(hdrStart, hdrEnd, corruption);
     ZL_ERR_IF_LT(dstNbElts, 1, corruption);
 

--- a/src/openzl/codecs/dispatchN_byTag/encode_dispatchN_byTag_binding.c
+++ b/src/openzl/codecs/dispatchN_byTag/encode_dispatchN_byTag_binding.c
@@ -60,6 +60,7 @@ static DispatchNBT_ExtParser_s const* getExtParser(ZL_Encoder const* eictx)
 static ZL_RESULT_OF(ZL_DispatchInstructions)
         getSplitInstructions(ZL_Encoder* eictx, const ZL_Input* in)
 {
+    ZL_RESULT_DECLARE_SCOPE(ZL_DispatchInstructions, eictx);
     ZL_DLOG(SEQ, "getSplitInstructions()");
 
     if (ZL_Input_numElts(in) == 0) {
@@ -79,25 +80,17 @@ static ZL_RESULT_OF(ZL_DispatchInstructions)
     ZL_DispatchState state = { eictx, NULL };
 
     DispatchNBT_ExtParser_s const* s = getExtParser(eictx);
-    ZL_RET_T_IF_NULL(
-            ZL_DispatchInstructions,
-            nodeParameter_invalid,
-            s,
-            "dispatchN parser not provided");
+    ZL_ERR_IF_NULL(s, nodeParameter_invalid, "dispatchN parser not provided");
     ZL_DispatchParserFn f      = s->f;
     ZL_DispatchInstructions si = f(&state, in);
     if (si.segmentSizes == NULL) {
         if (state.message != NULL) {
-            ZL_RET_T_ERR(
-                    ZL_DispatchInstructions,
-                    nodeParameter_invalid,
-                    "External dispatchN parser failed with message: %s",
-                    state.message);
+            ZL_ERR(nodeParameter_invalid,
+                   "External dispatchN parser failed with message: %s",
+                   state.message);
         } else {
-            ZL_RET_T_ERR(
-                    ZL_DispatchInstructions,
-                    nodeParameter_invalid,
-                    "external dispatchN parser failed to provide split instructions");
+            ZL_ERR(nodeParameter_invalid,
+                   "external dispatchN parser failed to provide split instructions");
         }
     }
     return ZL_RESULT_WRAP_VALUE(ZL_DispatchInstructions, si);
@@ -116,7 +109,7 @@ EI_dispatchN_byTag(ZL_Encoder* eictx, const ZL_Input* ins[], size_t nbIns)
     ZL_ASSERT_EQ(ZL_Input_type(in), ZL_Type_serial);
     ZL_ASSERT_NN(eictx);
 
-    ZL_TRY_LET_CONST_T(
+    ZL_TRY_LET_CONST(
             ZL_DispatchInstructions, si, getSplitInstructions(eictx, in));
 
     ZL_DLOG(BLOCK,

--- a/src/openzl/codecs/dispatch_string/encode_dispatch_string_binding.c
+++ b/src/openzl/codecs/dispatch_string/encode_dispatch_string_binding.c
@@ -160,10 +160,10 @@ ZL_Edge_runDispatchStringNode(
         int nbOutputs,
         const uint16_t* indices)
 {
-    ZL_RET_T_IF(
-            ZL_EdgeList,
-            nodeParameter_invalid,
+    ZL_RESULT_DECLARE_SCOPE(ZL_EdgeList, sctx);
+    ZL_ERR_IF(
             nbOutputs < 0 || nbOutputs > ZL_DISPATCH_STRING_MAX_DISPATCHES,
+            nodeParameter_invalid,
             "dispatch_string: invalid number of outputs (%i)",
             nbOutputs);
 

--- a/src/openzl/codecs/encoder_registry.c
+++ b/src/openzl/codecs/encoder_registry.c
@@ -179,9 +179,10 @@ void ER_getAllStandardNodeIDs(ZL_NodeID* nodes, size_t nodesSize)
 
 ZL_Report ER_forEachStandardNode(ER_StandardNodesCallback cb, void* opaque)
 {
+    ZL_RESULT_DECLARE_SCOPE_REPORT(NULL);
     for (ZL_IDType nid = 0; nid < ZL_ARRAY_SIZE(ER_standardNodes); ++nid) {
         if (ER_standardNodes[nid].nodetype == node_internalTransform) {
-            ZL_RET_R_IF_ERR(
+            ZL_ERR_IF_ERR(
                     cb(opaque, (ZL_NodeID){ nid }, &ER_standardNodes[nid]));
         }
     }

--- a/src/openzl/codecs/entropy/deprecated/encode_fse_kernel.c
+++ b/src/openzl/codecs/entropy/deprecated/encode_fse_kernel.c
@@ -67,6 +67,7 @@ ZL_Report ZS_fseContextEncode(
         ZL_RC* ctx,
         ZL_ContextClustering const* clustering)
 {
+    ZL_RESULT_DECLARE_SCOPE_REPORT(NULL);
     size_t const numClusters = clustering->numClusters;
     ZL_ASSERT_LE(numClusters, 256);
     ZL_ASSERT_EQ(ZL_RC_avail(ctx), ZL_RC_avail(src));
@@ -86,7 +87,7 @@ ZL_Report ZS_fseContextEncode(
     }
 
     //> Write the clustering
-    ZL_RET_R_IF_ERR(ZL_ContextClustering_encode(dst, clustering));
+    ZL_ERR_IF_ERR(ZL_ContextClustering_encode(dst, clustering));
 
     //> Initialize the FSE infos & write the NCounts
     ZS_FseClusterCStates* states;

--- a/src/openzl/codecs/float_deconstruct/decode_float_deconstruct_binding.c
+++ b/src/openzl/codecs/float_deconstruct/decode_float_deconstruct_binding.c
@@ -31,12 +31,12 @@ ZL_Report DI_float_deconstruct(ZL_Decoder* dictx, const ZL_Input* ins[])
         eltType = (FLTDECON_ElementType_e)(*hdr);
     }
 
-    ZL_TRY_LET_R(signFracWidth, FLTDECON_SignFracWidth(eltType));
-    ZL_TRY_LET_R(exponentWidth, FLTDECON_ExponentWidth(eltType));
+    ZL_TRY_LET(size_t, signFracWidth, FLTDECON_SignFracWidth(eltType));
+    ZL_TRY_LET(size_t, exponentWidth, FLTDECON_ExponentWidth(eltType));
     ZL_ERR_IF_NE(ZL_Input_eltWidth(signFracStream), signFracWidth, corruption);
     ZL_ERR_IF_NE(ZL_Input_eltWidth(exponentStream), exponentWidth, corruption);
 
-    ZL_TRY_LET_R(eltWidth, FLTDECON_ElementWidth(eltType));
+    ZL_TRY_LET(size_t, eltWidth, FLTDECON_ElementWidth(eltType));
     ZL_Output* const out = ZL_Decoder_create1OutStream(dictx, nbElts, eltWidth);
     ZL_ERR_IF_NULL(out, allocation);
 

--- a/src/openzl/codecs/float_deconstruct/encode_float_deconstruct_binding.c
+++ b/src/openzl/codecs/float_deconstruct/encode_float_deconstruct_binding.c
@@ -13,7 +13,7 @@ ZL_INLINE_KEYWORD ZL_Report float_deconstruct(
 {
     ZL_RESULT_DECLARE_SCOPE_REPORT(eictx);
     ZL_ERR_IF_GT(eltType, FLTDECON_ElementTypeEnumMaxValue, logicError);
-    ZL_TRY_LET_R(expectedEltWidth, FLTDECON_ElementWidth(eltType));
+    ZL_TRY_LET(size_t, expectedEltWidth, FLTDECON_ElementWidth(eltType));
     ZL_ERR_IF_NE(
             ZL_Input_eltWidth(in), expectedEltWidth, streamParameter_invalid);
     ZL_ASSERT_EQ(ZL_Input_type(in), ZL_Type_numeric);
@@ -29,11 +29,11 @@ ZL_INLINE_KEYWORD ZL_Report float_deconstruct(
         ZL_ERR_IF_NE(eltType, FLTDECON_ElementType_float32, logicError);
     }
 
-    ZL_TRY_LET_R(signFracWidth, FLTDECON_SignFracWidth(eltType));
+    ZL_TRY_LET(size_t, signFracWidth, FLTDECON_SignFracWidth(eltType));
     ZL_Output* signFracStream =
             ZL_Encoder_createTypedStream(eictx, 0, nbElts, signFracWidth);
 
-    ZL_TRY_LET_R(exponentWidth, FLTDECON_ExponentWidth(eltType));
+    ZL_TRY_LET(size_t, exponentWidth, FLTDECON_ExponentWidth(eltType));
     ZL_Output* exponentStream =
             ZL_Encoder_createTypedStream(eictx, 1, nbElts, exponentWidth);
 

--- a/src/openzl/codecs/merge_sorted/decode_merge_sorted_binding.c
+++ b/src/openzl/codecs/merge_sorted/decode_merge_sorted_binding.c
@@ -26,7 +26,7 @@ static ZL_Report fillDstPtrsFromHeader(
     uint8_t const* hp       = hs;
     uint64_t dstSize        = 0;
     while (hp != he) {
-        ZL_TRY_LET_T(uint64_t, size, ZL_varintDecode(&hp, he));
+        ZL_TRY_LET(uint64_t, size, ZL_varintDecode(&hp, he));
         ZL_ERR_IF(
                 ZL_overflowAddU64(dstSize, size, &dstSize),
                 corruption,

--- a/src/openzl/codecs/merge_sorted/encode_merge_sorted_binding.c
+++ b/src/openzl/codecs/merge_sorted/encode_merge_sorted_binding.c
@@ -22,6 +22,7 @@ static ZL_Report getSortedRuns(
         uint32_t const* srcs[64],
         uint32_t const* srcEnds[64])
 {
+    ZL_RESULT_DECLARE_SCOPE_REPORT(NULL);
     size_t const kMaxNbSrcs    = 64;
     uint32_t const* ip         = (uint32_t const*)ZL_Input_ptr(in);
     uint32_t const* const iend = ip + ZL_Input_numElts(in);
@@ -34,7 +35,7 @@ static ZL_Report getSortedRuns(
         if (ip[0] <= ip[-1]) {
             srcEnds[nbSrcs] = ip;
             ++nbSrcs;
-            ZL_RET_R_IF_GE(node_invalid_input, nbSrcs, kMaxNbSrcs);
+            ZL_ERR_IF_GE(nbSrcs, kMaxNbSrcs, node_invalid_input);
             srcs[nbSrcs] = ip;
         }
     }
@@ -74,7 +75,7 @@ ZL_Report EI_mergeSorted(ZL_Encoder* eictx, const ZL_Input* ins[], size_t nbIns)
     ZL_ERR_IF_NE(ZL_Input_eltWidth(in), 4, node_invalid_input);
     uint32_t const* srcs[64];
     uint32_t const* srcEnds[64];
-    ZL_TRY_LET_R(nbSrcs, getSortedRuns(in, srcs, srcEnds));
+    ZL_TRY_LET(size_t, nbSrcs, getSortedRuns(in, srcs, srcEnds));
 
     int const bitsetWidthLog = nbSrcs == 0 ? 1 : ZL_nextPow2((nbSrcs + 7) / 8);
     size_t const bitsetWidth = (size_t)1 << bitsetWidthLog;

--- a/src/openzl/codecs/merge_sorted/encode_merge_sorted_kernel.c
+++ b/src/openzl/codecs/merge_sorted/encode_merge_sorted_kernel.c
@@ -123,9 +123,10 @@ ZL_FORCE_INLINE ZL_Report ZS2_MergeSorted_merge(
         size_t nbSrcs,
         size_t kBitsetWidth)
 {
+    ZL_RESULT_DECLARE_SCOPE_REPORT(NULL);
     assert(kBitsetWidth <= 8);
     assert(nbSrcs <= kBitsetWidth * 8);
-    ZL_RET_R_IF_NOT(allocation, PQ_init(pq, nbSrcs));
+    ZL_ERR_IF_NOT(PQ_init(pq, nbSrcs), allocation);
 
     const uint32_t* srcs[64];
     memcpy((void*)srcs, (const void*)srcStarts, sizeof(*srcs) * nbSrcs);

--- a/src/openzl/codecs/quantize/decode_quantize_kernel.c
+++ b/src/openzl/codecs/quantize/decode_quantize_kernel.c
@@ -36,6 +36,7 @@ ZL_FORCE_INLINE ZL_Report ZL_quantize32Decode_impl(
         ZL_Quantize32Params const* params,
         size_t const kUnroll)
 {
+    ZL_RESULT_DECLARE_SCOPE_REPORT(NULL);
     ZS_BitDStreamFF bitstream  = ZS_BitDStreamFF_init(extraBits, extraBitsSize);
     uint32_t const* const base = params->base;
     uint8_t const* const bits  = params->bits;
@@ -60,7 +61,7 @@ ZL_FORCE_INLINE ZL_Report ZL_quantize32Decode_impl(
     }
 
     ZL_Report const ret = ZS_BitDStreamFF_finish(&bitstream);
-    ZL_RET_R_IF(srcSize_tooSmall, ZL_isError(ret));
+    ZL_ERR_IF(ZL_isError(ret), srcSize_tooSmall);
 
     return ZL_returnSuccess();
 }
@@ -80,6 +81,7 @@ ZL_FORCE_INLINE ZL_Report ZL_quantize32DecodePow2_impl(
         size_t extraBitsSize,
         size_t const kUnroll)
 {
+    ZL_RESULT_DECLARE_SCOPE_REPORT(NULL);
     ZS_BitDStreamFF bitstream = ZS_BitDStreamFF_init(extraBits, extraBitsSize);
 
     size_t const preamble = nbCodes % kUnroll;
@@ -102,7 +104,7 @@ ZL_FORCE_INLINE ZL_Report ZL_quantize32DecodePow2_impl(
     }
 
     ZL_Report const ret = ZS_BitDStreamFF_finish(&bitstream);
-    ZL_RET_R_IF(srcSize_tooSmall, ZL_isError(ret));
+    ZL_ERR_IF(ZL_isError(ret), srcSize_tooSmall);
 
     return ZL_returnSuccess();
 }
@@ -168,7 +170,8 @@ ZL_Report ZS2_quantize32Decode(
         size_t bitsSize,
         ZL_Quantize32Params const* params)
 {
-    ZL_RET_R_IF_GE(corruption, maxCode, params->nbCodes);
+    ZL_RESULT_DECLARE_SCOPE_REPORT(NULL);
+    ZL_ERR_IF_GE(maxCode, params->nbCodes, corruption);
 
     size_t const maxNbBits = params->bits[maxCode];
 

--- a/src/openzl/codecs/quantize/encode_quantize_kernel.c
+++ b/src/openzl/codecs/quantize/encode_quantize_kernel.c
@@ -26,12 +26,13 @@ ZL_Report ZS2_quantize32Encode(
         ZL_Quantize32Params const* params)
 {
     ZL_ASSERT(ZL_isPow2(params->maxPow2));
+    ZL_RESULT_DECLARE_SCOPE_REPORT(NULL);
 
     ZS_BitCStreamFF bitstream = ZS_BitCStreamFF_init(bits, bitsCapacity);
     for (size_t i = 0; i < srcSize; ++i) {
         uint32_t const value = src[i];
         if (params->maxPow2 == 0 && value == 0) {
-            ZL_RET_R_ERR(GENERIC);
+            ZL_ERR(GENERIC);
         }
         uint8_t const code = ZL_code32(value, params);
         codes[i]           = code;
@@ -39,6 +40,6 @@ ZL_Report ZS2_quantize32Encode(
         ZS_BitCStreamFF_flush(&bitstream);
     }
     ZL_Report const ret = ZS_BitCStreamFF_finish(&bitstream);
-    ZL_RET_R_IF(internalBuffer_tooSmall, ZL_isError(ret));
+    ZL_ERR_IF(ZL_isError(ret), internalBuffer_tooSmall);
     return ret;
 }

--- a/src/openzl/codecs/rolz/decode_rolz_kernel.c
+++ b/src/openzl/codecs/rolz/decode_rolz_kernel.c
@@ -12,15 +12,16 @@ ZL_Report ZL_rolzDecompress(
         void const* src,
         size_t srcSize)
 {
+    ZL_RESULT_DECLARE_SCOPE_REPORT(NULL);
     ZS_decoderCtx* const ctx = ZS_rolzDecoder->ctx_create();
     if (ctx == NULL) {
-        ZL_RET_R_ERR(GENERIC);
+        ZL_ERR(GENERIC);
     }
     ZL_Report const dstSize = ZS_rolzDecoder->decompress(
             ctx, (uint8_t*)dst, dstCapacity, (uint8_t const*)src, srcSize);
     ZS_rolzDecoder->ctx_release(ctx);
     if (ZL_isError(dstSize))
-        ZL_RET_R_ERR(GENERIC);
+        ZL_ERR(GENERIC);
     return dstSize;
 }
 
@@ -30,15 +31,16 @@ ZL_Report ZS_fastLzDecompress(
         void const* src,
         size_t srcSize)
 {
+    ZL_RESULT_DECLARE_SCOPE_REPORT(NULL);
     ZS_decoderCtx* const ctx = ZS_fastLzDecoder->ctx_create();
     if (ctx == NULL) {
-        ZL_RET_R_ERR(GENERIC);
+        ZL_ERR(GENERIC);
     }
     ZL_Report const dstSize = ZS_fastLzDecoder->decompress(
             ctx, (uint8_t*)dst, dstCapacity, (uint8_t const*)src, srcSize);
     ZS_fastLzDecoder->ctx_release(ctx);
     if (ZL_isError(dstSize))
-        ZL_RET_R_ERR(GENERIC);
+        ZL_ERR(GENERIC);
     return dstSize;
 }
 
@@ -154,6 +156,7 @@ ZL_Report ZS_RolzDTable2_init(
         uint32_t minLength,
         bool predictMatchLength)
 {
+    ZL_RESULT_DECLARE_SCOPE_REPORT(NULL);
     table->contextDepth       = contextDepth;
     table->contextLog         = contextLog;
     table->rowLog             = rowLog;
@@ -163,7 +166,7 @@ ZL_Report ZS_RolzDTable2_init(
     size_t const tableSize    = sizeof(*table->table) << (contextLog + rowLog);
     table->table              = (ZS_RolzDEntry2*)ZL_calloc(tableSize);
     if (table->table == NULL)
-        ZL_RET_R_ERR(GENERIC);
+        ZL_ERR(GENERIC);
     return ZL_returnSuccess();
 }
 

--- a/src/openzl/codecs/splitN/decode_splitN_binding.c
+++ b/src/openzl/codecs/splitN/decode_splitN_binding.c
@@ -34,7 +34,7 @@ ZL_Report DI_splitN(
         ZL_RBuffer header = ZL_Decoder_getCodecHeader(dictx);
         if (header.size != 0) {
             uint8_t const* ptr = (uint8_t const*)header.start;
-            ZL_TRY_LET_T(
+            ZL_TRY_LET(
                     uint64_t,
                     eltWidth64,
                     ZL_varintDecode(&ptr, ptr + header.size));

--- a/src/openzl/codecs/splitN/encode_splitN_binding.c
+++ b/src/openzl/codecs/splitN/encode_splitN_binding.c
@@ -59,6 +59,7 @@ static SplitN_ExtParser_s getExtParser(ZL_Encoder const* eictx)
 static ZL_RESULT_OF(ZL_SplitInstructions)
         getSplitInstructions(ZL_Encoder* eictx, const ZL_Input* in)
 {
+    ZL_RESULT_DECLARE_SCOPE(ZL_SplitInstructions, eictx);
     ZL_DLOG(SEQ, "getSplitInstructions()");
 
     ZL_SplitState allocState = { eictx };
@@ -68,10 +69,9 @@ static ZL_RESULT_OF(ZL_SplitInstructions)
     if (extParser.f != NULL) {
         ZL_SplitParserFn f      = extParser.f;
         ZL_SplitInstructions si = f(&allocState, in);
-        ZL_RET_T_IF_NULL(
-                ZL_SplitInstructions,
-                nodeParameter_invalid,
+        ZL_ERR_IF_NULL(
                 si.segmentSizes,
+                nodeParameter_invalid,
                 "external parser failed to provide split instructions");
         return ZL_RESULT_WRAP_VALUE(ZL_SplitInstructions, si);
     }
@@ -79,16 +79,14 @@ static ZL_RESULT_OF(ZL_SplitInstructions)
     // Priority 2 : check for fixed-size parameters
     ZL_RefParam const segmentSizes =
             ZL_Encoder_getLocalParam(eictx, ZL_SPLITN_SEGMENTSIZES_PID);
-    ZL_RET_T_IF_EQ(
-            ZL_SplitInstructions,
-            nodeParameter_invalid,
+    ZL_ERR_IF_EQ(
             segmentSizes.paramId,
             ZL_LP_INVALID_PARAMID,
-            "can't find any instruction to split");
-    ZL_RET_T_IF_NULL(
-            ZL_SplitInstructions,
             nodeParameter_invalid,
+            "can't find any instruction to split");
+    ZL_ERR_IF_NULL(
             segmentSizes.paramRef,
+            nodeParameter_invalid,
             "instructions to split are NULL");
     // Handle the case of 0 segments (empty split)
     if (segmentSizes.paramSize == 0) {
@@ -119,7 +117,7 @@ ZL_Report EI_splitN(ZL_Encoder* eictx, const ZL_Input* ins[], size_t nbIns)
                     & ~(ZL_Type_serial | ZL_Type_struct | ZL_Type_numeric),
             0);
 
-    ZL_TRY_LET_T(ZL_SplitInstructions, si, getSplitInstructions(eictx, in));
+    ZL_TRY_LET(ZL_SplitInstructions, si, getSplitInstructions(eictx, in));
 
     size_t const inSize   = ZL_Input_numElts(in);
     size_t const eltWidth = ZL_Input_eltWidth(in);
@@ -285,12 +283,12 @@ ZL_Edge_runSplitNode(
         const size_t* segmentSizes,
         size_t nbSegments)
 {
+    ZL_RESULT_DECLARE_SCOPE(ZL_EdgeList, input);
     ZL_DLOG(SEQ, "ZL_Edge_runSplitNode");
-    ZL_RET_T_IF_GT(
-            ZL_EdgeList,
-            nodeParameter_invalid,
+    ZL_ERR_IF_GT(
             nbSegments,
             (size_t)INT_MAX,
+            nodeParameter_invalid,
             "nbSegments is too large (temporary limitation)");
 
     ZL_RefParam const segmentSizesParam = {

--- a/tests/compress/test_gbt.cpp
+++ b/tests/compress/test_gbt.cpp
@@ -369,6 +369,7 @@ class GBTBinaryModelTest : public Test {
         auto featureGen_binaryModelTest = [](const ZL_Input* inputStream,
                                              VECTOR(LabeledFeature)
                                                      * features) -> ZL_Report {
+            ZL_RESULT_DECLARE_SCOPE_REPORT(nullptr);
             ZL_ASSERT(ZL_Input_type(inputStream) == ZL_Type_numeric);
 
             LabeledFeature meanFeature             = { "mean", 2.0f };
@@ -392,8 +393,7 @@ class GBTBinaryModelTest : public Test {
             badAlloc |= !VECTOR_PUSHBACK(*features, meanFeature);
             badAlloc |= !VECTOR_PUSHBACK(*features, varianceFeature);
 
-            ZL_RET_R_IF(
-                    allocation, badAlloc, "Failed to add features to vector");
+            ZL_ERR_IF(badAlloc, allocation, "Failed to add features to vector");
             return ZL_returnSuccess();
         };
 
@@ -488,6 +488,7 @@ class GBTMultiClassModelTest : public GBTMultiClassForestTest {
         auto featureGen_multiClassModelTest =
                 [](const ZL_Input* inputStream,
                    VECTOR(LabeledFeature) * features) -> ZL_Report {
+            ZL_RESULT_DECLARE_SCOPE_REPORT(nullptr);
             ZL_ASSERT(ZL_Input_type(inputStream) == ZL_Type_numeric);
 
             LabeledFeature meanFeature             = { "mean", 5.0f };
@@ -511,8 +512,7 @@ class GBTMultiClassModelTest : public GBTMultiClassForestTest {
             badAlloc |= !VECTOR_PUSHBACK(*features, meanFeature);
             badAlloc |= !VECTOR_PUSHBACK(*features, varianceFeature);
 
-            ZL_RET_R_IF(
-                    allocation, badAlloc, "Failed to add features to vector");
+            ZL_ERR_IF(badAlloc, allocation, "Failed to add features to vector");
             return ZL_returnSuccess();
         };
         model = { .predictor        = multiClassPredictor.get(),

--- a/tests/compress/test_zstrong_ml_core_models_generator.cpp
+++ b/tests/compress/test_zstrong_ml_core_models_generator.cpp
@@ -55,6 +55,7 @@ class ZstrongCoreBinaryMLTest : public Test {
             const ZL_Input* inputStream,
             VECTOR(LabeledFeature) * features)
     {
+        ZL_RESULT_DECLARE_SCOPE_REPORT(nullptr);
         ZL_ASSERT_EQ((int)ZL_Input_type(inputStream), (int)ZL_Type_numeric);
 
         ZL_ASSERT_EQ(ZL_Input_eltWidth(inputStream), 4);
@@ -67,7 +68,7 @@ class ZstrongCoreBinaryMLTest : public Test {
         badAlloc |= !VECTOR_PUSHBACK(*features, aFeature);
         badAlloc |= !VECTOR_PUSHBACK(*features, bFeature);
 
-        ZL_RET_R_IF(allocation, badAlloc, "Failed to add features to vector");
+        ZL_ERR_IF(badAlloc, allocation, "Failed to add features to vector");
         return ZL_returnSuccess();
     }
 
@@ -88,6 +89,7 @@ class ZstrongCoreMultiMLTest : public Test {
             const ZL_Input* inputStream,
             VECTOR(LabeledFeature) * features)
     {
+        ZL_RESULT_DECLARE_SCOPE_REPORT(nullptr);
         ZL_ASSERT_EQ((int)ZL_Input_type(inputStream), (int)ZL_Type_numeric);
 
         ZL_ASSERT_EQ(ZL_Input_eltWidth(inputStream), 4);
@@ -102,7 +104,7 @@ class ZstrongCoreMultiMLTest : public Test {
         badAlloc |= !VECTOR_PUSHBACK(*features, bFeature);
         badAlloc |= !VECTOR_PUSHBACK(*features, cFeature);
 
-        ZL_RET_R_IF(allocation, badAlloc, "Failed to add features to vector");
+        ZL_ERR_IF(badAlloc, allocation, "Failed to add features to vector");
         return ZL_returnSuccess();
     }
 

--- a/tests/datagen/structures/CompressorProducer.cpp
+++ b/tests/datagen/structures/CompressorProducer.cpp
@@ -296,8 +296,9 @@ std::vector<std::string> RandomCompressorMultiBuilder::register_split_node()
 {
     const auto name = make_unique_name("!tests.rand_graph.nodes.split.");
     const auto transform =
-            [](ZL_Encoder*, size_t[], const void*, size_t) noexcept {
-                ZL_RET_R_ERR(GENERIC, "Unimplemented! Can't actually run.");
+            [](ZL_Encoder* eictx, size_t[], const void*, size_t) noexcept {
+                ZL_RESULT_DECLARE_SCOPE_REPORT(eictx);
+                ZL_ERR(GENERIC, "Unimplemented! Can't actually run.");
             };
     const auto lp   = get_params();
     const auto desc = (ZL_SplitEncoderDesc){
@@ -321,8 +322,9 @@ std::vector<std::string> RandomCompressorMultiBuilder::register_typed_node(
         const TypeSpec ts)
 {
     const auto name      = make_unique_name("!tests.rand_graph.nodes.typed.");
-    const auto transform = [](ZL_Encoder*, const ZL_Input*) noexcept {
-        ZL_RET_R_ERR(GENERIC, "Unimplemented! Can't actually run.");
+    const auto transform = [](ZL_Encoder* eictx, const ZL_Input*) noexcept {
+        ZL_RESULT_DECLARE_SCOPE_REPORT(eictx);
+        ZL_ERR(GENERIC, "Unimplemented! Can't actually run.");
     };
     const auto lp        = get_params();
     const auto state_mgr = (ZL_CodecStateManager){
@@ -358,8 +360,9 @@ std::vector<std::string> RandomCompressorMultiBuilder::register_vo_node(
         const TypeSpec ts)
 {
     const auto name      = make_unique_name("!tests.rand_graph.nodes.vo.");
-    const auto transform = [](ZL_Encoder*, const ZL_Input*) noexcept {
-        ZL_RET_R_ERR(GENERIC, "Unimplemented! Can't actually run.");
+    const auto transform = [](ZL_Encoder* eictx, const ZL_Input*) noexcept {
+        ZL_RESULT_DECLARE_SCOPE_REPORT(eictx);
+        ZL_ERR(GENERIC, "Unimplemented! Can't actually run.");
     };
     const auto lp        = get_params();
     const auto state_mgr = (ZL_CodecStateManager){
@@ -396,10 +399,12 @@ std::vector<std::string> RandomCompressorMultiBuilder::register_vo_node(
 
 std::vector<std::string> RandomCompressorMultiBuilder::register_mi_node()
 {
-    const auto name      = make_unique_name("!tests.rand_graph.nodes.mi.");
-    const auto transform = [](ZL_Encoder*, const ZL_Input*[], size_t) noexcept {
-        ZL_RET_R_ERR(GENERIC, "Unimplemented! Can't actually run.");
-    };
+    const auto name = make_unique_name("!tests.rand_graph.nodes.mi.");
+    const auto transform =
+            [](ZL_Encoder* eictx, const ZL_Input*[], size_t) noexcept {
+                ZL_RESULT_DECLARE_SCOPE_REPORT(eictx);
+                ZL_ERR(GENERIC, "Unimplemented! Can't actually run.");
+            };
     const auto lp        = get_params();
     const auto state_mgr = (ZL_CodecStateManager){
         .stateAlloc      = NULL, // TODO?
@@ -782,8 +787,9 @@ std::vector<std::string> RandomCompressorMultiBuilder::make_multi_input_graph(
         size_t depth)
 {
     const auto name       = make_unique_name("!tests.rand_graph.graphs.multi.");
-    const auto graph_func = [](ZL_Graph*, ZL_Edge*[], size_t) noexcept {
-        ZL_RET_R_ERR(GENERIC, "Unimplemented! Can't actually run.");
+    const auto graph_func = [](ZL_Graph* gctx, ZL_Edge*[], size_t) noexcept {
+        ZL_RESULT_DECLARE_SCOPE_REPORT(gctx);
+        ZL_ERR(GENERIC, "Unimplemented! Can't actually run.");
     };
     const auto validate_func = [](const ZL_Compressor*,
                                   const ZL_FunctionGraphDesc*) noexcept {

--- a/tests/datagen/test_registry/CustomNodes.cpp
+++ b/tests/datagen/test_registry/CustomNodes.cpp
@@ -64,8 +64,9 @@ ZL_NodeID createCustomTokenizeNode(ZL_Compressor* cg)
 {
     auto tokenize = [](ZL_CustomTokenizeState* ctx,
                        ZL_Input const* input) -> ZL_Report {
+        ZL_RESULT_DECLARE_SCOPE_REPORT(nullptr);
         if (ZL_Input_eltWidth(input) != 4) {
-            ZL_RET_R_ERR(node_invalid_input);
+            ZL_ERR(node_invalid_input);
         }
 
         std::unordered_map<uint32_t, uint32_t> valueToIndex;
@@ -75,7 +76,7 @@ ZL_NodeID createCustomTokenizeNode(ZL_Compressor* cg)
         uint32_t* indices =
                 (uint32_t*)ZL_CustomTokenizeState_createIndexOutput(ctx, 4);
         if (indices == nullptr) {
-            ZL_RET_R_ERR(allocation);
+            ZL_ERR(allocation);
         }
 
         for (size_t i = 0; i < srcSize; ++i) {
@@ -87,7 +88,7 @@ ZL_NodeID createCustomTokenizeNode(ZL_Compressor* cg)
                 (uint32_t*)ZL_CustomTokenizeState_createAlphabetOutput(
                         ctx, valueToIndex.size());
         if (alphabet == nullptr) {
-            ZL_RET_R_ERR(allocation);
+            ZL_ERR(allocation);
         }
 
         for (auto [value, index] : valueToIndex) {

--- a/tests/integrationtest/GraphTest.cpp
+++ b/tests/integrationtest/GraphTest.cpp
@@ -254,7 +254,7 @@ TEST_F(GraphTest,
 
         // Run first encoder node without custom params (uses registered local
         // params)
-        ZL_TRY_LET_T(ZL_EdgeList, edges1, ZL_Edge_runNode(inputs[0], encNode));
+        ZL_TRY_LET(ZL_EdgeList, edges1, ZL_Edge_runNode(inputs[0], encNode));
         ZL_ERR_IF_NE(edges1.nbEdges, 1, GENERIC);
 
         // Get the opaque pointer which contains the params for the second call
@@ -284,7 +284,7 @@ TEST_F(GraphTest,
         };
 
         // Run second encoder node with custom params (override)
-        ZL_TRY_LET_T(
+        ZL_TRY_LET(
                 ZL_EdgeList,
                 edges2,
                 ZL_Edge_runNode_withParams(edges1.edges[0], encNode, &lp2));
@@ -809,7 +809,7 @@ TEST_F(GraphTest,
         ZL_ERR_IF_NULL(input, GENERIC);
 
         // Try the graph with runtime parameters
-        ZL_TRY_LET_T(
+        ZL_TRY_LET(
                 ZL_GraphPerformance,
                 perf,
                 ZL_Graph_tryGraph(graph, input, exfiltratingGraph, &rgp));

--- a/tests/unittest/common/test_operation_context.cpp
+++ b/tests/unittest/common/test_operation_context.cpp
@@ -206,8 +206,10 @@ TEST(OperationContextTest, Warnings)
 
     {
         // Coerce static info and convert into dynamic
-        auto e4 = ZL_RES_error(
-                []() { ZL_RET_R_ERR(corruption, "qwerty %d", 1234); }());
+        auto e4 = ZL_RES_error([]() {
+            ZL_RESULT_DECLARE_SCOPE_REPORT(nullptr);
+            ZL_ERR(corruption, "qwerty %d", 1234);
+        }());
 
         EXPECT_EQ(ZL_E_dy(e4), nullptr);
 

--- a/tests/unittest/compress/CompressorUnitTest.cpp
+++ b/tests/unittest/compress/CompressorUnitTest.cpp
@@ -1557,7 +1557,7 @@ TEST_F(CompressorTest, BaseGraphDynamic)
 {
     const auto name       = "!tests.graph.dyn.stub";
     const auto graph_func = [](ZL_Graph*, ZL_Edge*[], size_t) noexcept {
-        ZL_RET_R_ERR(GENERIC, "Unimplemented! Can't actually run.");
+        return ZL_REPORT_ERROR(GENERIC, "Unimplemented! Can't actually run.");
     };
     const auto validate_func = [](const ZL_Compressor*,
                                   const ZL_FunctionGraphDesc*) noexcept {
@@ -1630,7 +1630,7 @@ TEST_F(CompressorTest, CannotReplaceName)
         .name = "testParameterized",
     };
     const auto graph_func = [](ZL_Graph*, ZL_Edge*[], size_t) noexcept {
-        ZL_RET_R_ERR(GENERIC, "Unimplemented! Can't actually run.");
+        return ZL_REPORT_ERROR(GENERIC, "Unimplemented! Can't actually run.");
     };
     ZL_FunctionGraphDesc desc = {
         .name    = "testBase",
@@ -1652,7 +1652,7 @@ TEST_F(CompressorTest, CannotReplaceWhenGraphIsNotParameterized)
                        .nbCustomGraphs = 1,
     };
     const auto graph_func = [](ZL_Graph*, ZL_Edge*[], size_t) noexcept {
-        ZL_RET_R_ERR(GENERIC, "Unimplemented! Can't actually run.");
+        return ZL_REPORT_ERROR(GENERIC, "Unimplemented! Can't actually run.");
     };
     ZL_FunctionGraphDesc desc = {
         .name    = "testBase",
@@ -1675,7 +1675,7 @@ TEST_F(CompressorTest, CannotReplaceWhenGraphIsNotParameterized)
 TEST_F(CompressorTest, ReplaceGraphParamsOnlyWhenParamExists)
 {
     const auto graph_func = [](ZL_Graph*, ZL_Edge*[], size_t) noexcept {
-        ZL_RET_R_ERR(GENERIC, "Unimplemented! Can't actually run.");
+        return ZL_REPORT_ERROR(GENERIC, "Unimplemented! Can't actually run.");
     };
     ZL_GraphID customGraphs[1] = { ZL_GRAPH_ZSTD };
     ZL_NodeID customNodes[1]   = { ZL_NODE_ZIGZAG };

--- a/tests/zstrong/fuzz_compress_reuse.cpp
+++ b/tests/zstrong/fuzz_compress_reuse.cpp
@@ -29,13 +29,14 @@ constexpr ZL_TypedEncoderDesc kCTransform = {
     .gd = kGraphDesc,
     .transform_f =
             [](ZL_Encoder* eictx, ZL_Input const* in) noexcept {
+                ZL_RESULT_DECLARE_SCOPE_REPORT(eictx);
                 ZL_Output* out = ZL_Encoder_createTypedStream(
                         eictx, 0, ZL_Input_numElts(in), 1);
-                ZL_RET_R_IF_NULL(allocation, out);
+                ZL_ERR_IF_NULL(out, allocation);
                 memcpy(ZL_Output_ptr(out),
                        ZL_Input_ptr(in),
                        ZL_Input_numElts(in));
-                ZL_RET_R_IF_ERR(ZL_Output_commit(out, ZL_Input_numElts(in)));
+                ZL_ERR_IF_ERR(ZL_Output_commit(out, ZL_Input_numElts(in)));
                 return ZL_returnSuccess();
             },
 };
@@ -44,14 +45,14 @@ constexpr ZL_TypedDecoderDesc kDTransform = {
     .gd = kGraphDesc,
     .transform_f =
             [](ZL_Decoder* dictx, ZL_Input const* ins[]) noexcept {
+                ZL_RESULT_DECLARE_SCOPE_REPORT(dictx);
                 ZL_Output* out = ZL_Decoder_create1OutStream(
                         dictx, 0, ZL_Input_numElts(ins[0]));
-                ZL_RET_R_IF_NULL(allocation, out);
+                ZL_ERR_IF_NULL(out, allocation);
                 memcpy(ZL_Output_ptr(out),
                        ZL_Input_ptr(ins[0]),
                        ZL_Input_numElts(ins[0]));
-                ZL_RET_R_IF_ERR(
-                        ZL_Output_commit(out, ZL_Input_numElts(ins[0])));
+                ZL_ERR_IF_ERR(ZL_Output_commit(out, ZL_Input_numElts(ins[0])));
                 return ZL_returnSuccess();
             },
 };

--- a/tests/zstrong/fuzz_decompress_reuse.cpp
+++ b/tests/zstrong/fuzz_decompress_reuse.cpp
@@ -24,10 +24,11 @@ constexpr ZL_TypedDecoderDesc kTransform = {
         .nbOutStreams = kOutStreamTypes.size(),
     },
     .transform_f = [](ZL_Decoder* dictx, ZL_Input const* ins[]) noexcept {
+        ZL_RESULT_DECLARE_SCOPE_REPORT(dictx);
         ZL_Output* out = ZL_Decoder_create1OutStream(dictx, ZL_Input_numElts(ins[0]), 1);
-        ZL_RET_R_IF_NULL(allocation, out);
+        ZL_ERR_IF_NULL(out, allocation);
         memcpy(ZL_Output_ptr(out), ZL_Input_ptr(ins[0]), ZL_Input_numElts(ins[0]));
-        ZL_RET_R_IF_ERR(ZL_Output_commit(out, ZL_Input_numElts(ins[0])));
+        ZL_ERR_IF_ERR(ZL_Output_commit(out, ZL_Input_numElts(ins[0])));
         return ZL_returnSuccess();
     },
 };

--- a/tests/zstrong/test_serialized.cpp
+++ b/tests/zstrong/test_serialized.cpp
@@ -314,6 +314,7 @@ ZL_Report splitOptimizationBackendGraph(
         size_t nbInputs,
         std::mt19937& gen)
 {
+    ZL_RESULT_DECLARE_SCOPE_REPORT(gctx);
     std::array<std::vector<ZL_Edge*>, 2> concats;
     std::uniform_int_distribution<size_t> destDist(0, 2);
     std::uniform_int_distribution<size_t> flushDist(0, 4);
@@ -326,29 +327,27 @@ ZL_Report splitOptimizationBackendGraph(
         if (ZL_Input_numElts(data) % 8 == 0) {
             std::uniform_int_distribution<size_t> convertDist(0, 2);
             if (convertDist(gen) == 0) {
-                ZL_TRY_LET_T(
+                ZL_TRY_LET(
                         ZL_EdgeList,
                         successors,
                         ZL_Edge_runNode(edge, ZL_NODE_INTERPRET_AS_LE64));
                 edge = successors.edges[0];
                 if (std::uniform_int_distribution<size_t>(0, 1)(gen) == 0) {
-                    ZL_RET_R_IF_ERR(
-                            ZL_Edge_setDestination(edge, ZL_GRAPH_STORE));
+                    ZL_ERR_IF_ERR(ZL_Edge_setDestination(edge, ZL_GRAPH_STORE));
                 } else {
-                    ZL_RET_R_IF_ERR(
-                            ZL_Edge_setDestination(edge, ZL_GRAPH_ZSTD));
+                    ZL_ERR_IF_ERR(ZL_Edge_setDestination(edge, ZL_GRAPH_ZSTD));
                 }
                 return ZL_returnSuccess();
             }
         }
         auto graph = graphs.graphids[graphDist(gen)];
-        ZL_RET_R_IF_ERR(ZL_Edge_setDestination(edge, graph));
+        ZL_ERR_IF_ERR(ZL_Edge_setDestination(edge, graph));
         return ZL_returnSuccess();
     };
 
     auto flush = [&](std::vector<ZL_Edge*>& concat) -> ZL_Report {
         if (!concat.empty()) {
-            ZL_TRY_LET_T(
+            ZL_TRY_LET(
                     ZL_EdgeList,
                     successors,
                     ZL_Edge_runMultiInputNode(
@@ -356,9 +355,9 @@ ZL_Report splitOptimizationBackendGraph(
                             concat.size(),
                             ZL_NODE_CONCAT_SERIAL));
             ZL_ASSERT_EQ(successors.nbEdges, 2);
-            ZL_RET_R_IF_ERR(ZL_Edge_setDestination(
+            ZL_ERR_IF_ERR(ZL_Edge_setDestination(
                     successors.edges[0], ZL_GRAPH_FIELD_LZ));
-            ZL_RET_R_IF_ERR(finish(successors.edges[1]));
+            ZL_ERR_IF_ERR(finish(successors.edges[1]));
         }
         concat.clear();
         return ZL_returnSuccess();
@@ -373,15 +372,15 @@ ZL_Report splitOptimizationBackendGraph(
             concats[dest].push_back(input);
 
             if (flushDist(gen) == 0) {
-                ZL_RET_R_IF_ERR(flush(concats[dest]));
+                ZL_ERR_IF_ERR(flush(concats[dest]));
             }
         } else {
-            ZL_RET_R_IF_ERR(finish(input));
+            ZL_ERR_IF_ERR(finish(input));
         }
     }
 
     for (auto& concat : concats) {
-        ZL_RET_R_IF_ERR(flush(concat));
+        ZL_ERR_IF_ERR(flush(concat));
     }
 
     return ZL_returnSuccess();
@@ -392,6 +391,7 @@ ZL_Report splitOptimizationGraph(
         ZL_Edge* inputs[],
         size_t nbInputs) noexcept
 {
+    ZL_RESULT_DECLARE_SCOPE_REPORT(gctx);
     const ZL_IntParam seed = ZL_Graph_getLocalIntParam(gctx, 0);
     std::mt19937 gen(seed.paramValue);
 
@@ -411,7 +411,7 @@ ZL_Report splitOptimizationGraph(
                 segmentSizes.push_back(segmentDist(gen));
                 remaining -= segmentSizes.back();
             }
-            ZL_TRY_LET_T(
+            ZL_TRY_LET(
                     ZL_EdgeList,
                     splitSuccessors,
                     ZL_Edge_runSplitNode(

--- a/tests/zstrong/test_zstrong_selector.cpp
+++ b/tests/zstrong/test_zstrong_selector.cpp
@@ -239,13 +239,14 @@ TEST_F(SelectorTest, TestSetSuccessorParams)
     const auto successorDgFn = [](ZL_Graph* gctx,
                                   ZL_Edge* inputs[],
                                   size_t nbIns) noexcept -> ZL_Report {
+        ZL_RESULT_DECLARE_SCOPE_REPORT(gctx);
         // verify passed params
         const auto p1 = ZL_Graph_getLocalIntParam(gctx, 1);
-        ZL_RET_R_IF_NE(GENERIC, p1.paramValue, 2);
+        ZL_ERR_IF_NE(p1.paramValue, 2, GENERIC);
         const auto p2 = ZL_Graph_getLocalIntParam(gctx, 2);
-        ZL_RET_R_IF_NE(GENERIC, p2.paramValue, 4);
+        ZL_ERR_IF_NE(p2.paramValue, 4, GENERIC);
         const auto p3 = ZL_Graph_getLocalIntParam(gctx, 3);
-        ZL_RET_R_IF_NE(GENERIC, p3.paramValue, 6);
+        ZL_ERR_IF_NE(p3.paramValue, 6, GENERIC);
         const auto p4 = ZL_Graph_getLocalRefParam(gctx, 4);
         if (std::string((const char*)p4.paramRef, 4) != std::string("I am")) {
             return ZL_returnError(ZL_ErrorCode_GENERIC);
@@ -254,7 +255,7 @@ TEST_F(SelectorTest, TestSetSuccessorParams)
         if (std::string((const char*)p5.paramRef, 4) != std::string(" the")) {
             return ZL_returnError(ZL_ErrorCode_GENERIC);
         }
-        ZL_RET_R_IF(graph_invalidNumInputs, nbIns != 1);
+        ZL_ERR_IF(nbIns != 1, graph_invalidNumInputs);
         ZL_Edge* input = inputs[0];
         ZL_REQUIRE_SUCCESS(ZL_Edge_setDestination(input, ZL_GRAPH_STORE));
         return ZL_returnSuccess();

--- a/tools/zstrong_cpp.cpp
+++ b/tools/zstrong_cpp.cpp
@@ -1011,9 +1011,10 @@ ZL_Report CustomTransform::encode(ZL_Encoder* eictx, ZL_Input const* input)
     return encode(eictx, &input, 1);
 }
 
-ZL_Report CustomTransform::decode(ZL_Decoder*, ZL_Input const*[]) const
+ZL_Report CustomTransform::decode(ZL_Decoder* dictx, ZL_Input const*[]) const
 {
-    ZL_RET_R_ERR(logicError);
+    ZL_RESULT_DECLARE_SCOPE_REPORT(dictx);
+    ZL_ERR(logicError);
 }
 
 ZL_Report CustomTransform::decode(


### PR DESCRIPTION
Summary:
Migrate old error macros (ZL_RET_R_*, ZL_RET_T_*, ZL_TRY_{SET,LET,LET_CONST}_{R,T,TT})
to new error framework (ZL_ERR_*, ZL_TRY_{SET,LET,LET_CONST}).

Reviewed By: daniellerozenblit

Differential Revision: D98318714


