### PR TITLE
Migrate error macros: error test files

### DIFF
--- a/benchmark/unitBench/scenarios/split_byrange_graph.c
+++ b/benchmark/unitBench/scenarios/split_byrange_graph.c
@@ -201,10 +201,11 @@ ZL_GraphID tokenSort64_splitIndices_graph(ZL_Compressor* cgraph)
 static ZL_Report
 splitByRange_concatAlpha_fn(ZL_Graph* graph, ZL_Edge* inputs[], size_t nbInputs)
 {
+    ZL_RESULT_DECLARE_SCOPE_REPORT(graph);
     (void)nbInputs;
 
     /* Step 1: Split by range */
-    ZL_TRY_LET_T(
+    ZL_TRY_LET(
             ZL_EdgeList,
             segments,
             ZL_Edge_runNode(inputs[0], ZL_NODE_SPLIT_BYRANGE));
@@ -219,31 +220,31 @@ splitByRange_concatAlpha_fn(ZL_Graph* graph, ZL_Edge* inputs[], size_t nbInputs)
             (ZL_Edge**)ZL_Graph_getScratchSpace(graph, N * sizeof(ZL_Edge*));
 
     for (size_t i = 0; i < N; i++) {
-        ZL_TRY_LET_T(
+        ZL_TRY_LET(
                 ZL_EdgeList,
                 tokenized,
                 ZL_Edge_runNode(segments.edges[i], tokenNode));
         /* tokenized.edges[0] = alphabet, tokenized.edges[1] = indices */
         alphabets[i] = tokenized.edges[0];
         /* Send indices to NUMERIC */
-        ZL_RET_R_IF_ERR(
+        ZL_ERR_IF_ERR(
                 ZL_Edge_setDestination(tokenized.edges[1], ZL_GRAPH_NUMERIC));
     }
 
     /* Step 3: Concat all alphabets into one stream */
-    ZL_TRY_LET_T(
+    ZL_TRY_LET(
             ZL_EdgeList,
             concatResult,
             ZL_Edge_runMultiInputNode(alphabets, N, ZL_NODE_CONCAT_NUMERIC));
     /* concatResult.edges[0] = sizes, concatResult.edges[1] = merged data */
 
     /* Step 4: Send concat sizes to NUMERIC */
-    ZL_RET_R_IF_ERR(
+    ZL_ERR_IF_ERR(
             ZL_Edge_setDestination(concatResult.edges[0], ZL_GRAPH_NUMERIC));
 
     /* Step 5: Send merged alphabet to delta_int → NUMERIC */
     ZL_GraphIDList gids = ZL_Graph_getCustomGraphs(graph);
-    ZL_RET_R_IF_ERR(
+    ZL_ERR_IF_ERR(
             ZL_Edge_setDestination(concatResult.edges[1], gids.graphids[0]));
 
     return ZL_returnSuccess();

--- a/cpp/tests/TestDCtx.cpp
+++ b/cpp/tests/TestDCtx.cpp
@@ -186,8 +186,8 @@ TEST_F(TestDCtx, decoderFailureHasCodecName)
                 .soTypes =  &type,
                 .nbSOs = 1,
             },
-            .transform_f = [](ZL_Decoder* , const ZL_Input**, size_t, const ZL_Input**, size_t) noexcept -> ZL_Report {
-                ZL_RET_R_ERR(GENERIC, "my codec failed for some reason");
+            .transform_f = [](ZL_Decoder*, const ZL_Input**, size_t, const ZL_Input**, size_t) noexcept -> ZL_Report {
+                return ZL_REPORT_ERROR(GENERIC, "my codec failed for some reason");
             },
             .name = name.get(),
         };

--- a/custom_parsers/csv/csv_parser.c
+++ b/custom_parsers/csv/csv_parser.c
@@ -146,7 +146,7 @@ csvParserGraphFn(ZL_Graph* gctx, ZL_Edge* inputs[], size_t numInputs)
     const size_t numOutputs = numCols + 1 + (hasHeader ? 1 : 0);
 
     // Run newly created Node, collect outputs at intermediate output
-    ZL_TRY_LET_T(
+    ZL_TRY_LET(
             ZL_EdgeList,
             io,
             ZL_Edge_runConvertSerialToStringNode(inputs[0], sizes, numTokens));

--- a/custom_parsers/pytorch_model_parser.c
+++ b/custom_parsers/pytorch_model_parser.c
@@ -137,7 +137,7 @@ pytorchModelDynGraph(ZL_Graph* gctx, ZL_Edge* sctxs[], size_t nbIns)
     }
 
     // Split the input according to segmentSizes
-    ZL_TRY_LET_T(
+    ZL_TRY_LET(
             ZL_EdgeList,
             streams,
             ZL_Edge_runSplitNode(sctx, segmentSizes, nbSegments));
@@ -189,7 +189,7 @@ static ZL_Report pytorchModelSegmenter(ZL_Segmenter* sctx)
 
     while (!ZS2_ZipLexer_finished(&lexer)) {
         ZS2_ZipToken tokens[32];
-        ZL_TRY_LET_R(nbTokens, ZS2_ZipLexer_lex(&lexer, tokens, 32));
+        ZL_TRY_LET(size_t, nbTokens, ZS2_ZipLexer_lex(&lexer, tokens, 32));
         for (size_t i = 0; i < nbTokens; ++i) {
             const ZS2_ZipToken token = tokens[i];
 

--- a/custom_parsers/tests/csv_main.cpp
+++ b/custom_parsers/tests/csv_main.cpp
@@ -781,6 +781,7 @@ class TestCsv {
 
 ZL_Report TestCsv::run(const std::string& csvFile)
 {
+    ZL_RESULT_DECLARE_SCOPE_REPORT(nullptr);
     SetUp();
     ZL_g_logLevel = ZL_LOG_LVL_DEBUG;
 
@@ -815,14 +816,14 @@ ZL_Report TestCsv::run(const std::string& csvFile)
 
     for (auto clevel : { 1, 6 }) {
         for (ZL_GraphID csvParserGid : toTest) {
-            ZL_RET_R_IF_ERR(ZL_CCtx_setParameter(
+            ZL_ERR_IF_ERR(ZL_CCtx_setParameter(
                     cctx, ZL_CParam_formatVersion, ZL_MAX_FORMAT_VERSION));
-            ZL_RET_R_IF_ERR(ZL_CCtx_refCompressor(cctx, compressor_));
-            ZL_RET_R_IF_ERR(ZL_CCtx_setParameter(
+            ZL_ERR_IF_ERR(ZL_CCtx_refCompressor(cctx, compressor_));
+            ZL_ERR_IF_ERR(ZL_CCtx_setParameter(
                     cctx, ZL_CParam_compressionLevel, clevel));
             auto gssr = ZL_Compressor_selectStartingGraphID(
                     compressor_, csvParserGid);
-            ZL_RET_R_IF_ERR(gssr);
+            ZL_ERR_IF_ERR(gssr);
             std::string dst(src.size() * 2, 0);
 
             auto start = std::chrono::high_resolution_clock::now();

--- a/include/openzl/detail/zl_errors_detail.h
+++ b/include/openzl/detail/zl_errors_detail.h
@@ -241,6 +241,20 @@ struct ZL_Error_s {
         ((ZL_Error){ ._code = ZL_ErrorCode_no_error, ._info = ZL_EE_EMPTY })
 #endif
 
+ZL_INLINE ZL_ErrorInfo ZL_EE_fromStaticErrorInfo(const ZL_StaticErrorInfo* st)
+{
+    ZL_ErrorInfo ei = ZL_EE_EMPTY;
+    ei._st          = st;
+    return ei;
+}
+
+#if ZL_ERROR_ENABLE_STATIC_ERROR_INFO
+#    define ZL_EE_FROM_STATIC(name) \
+        ZL_EE_fromStaticErrorInfo(ZL_E_POINTER_TO_STATIC_ERROR_INFO(name))
+#else
+#    define ZL_EE_FROM_STATIC(name) ZL_EE_EMPTY
+#endif
+
 // Returns the ZL_Error descriptor from a ZL_RESULT_OF(<T>) object.
 #define ZL_RES_error(res) ((res)._error)
 
@@ -293,9 +307,9 @@ void ZL_E_appendToMessage(ZL_Error err, char const* fmt, ...);
  *
  * This function can be called directly, but is primarily used indirectly.
  * Firstly, if you want to invoke this function yourself, it's easier to use
- * @ref ZL_E_ADDFRAME_PUBLIC instead since it populates some of the arguments
+ * @ref ZL_E_ADDFRAME instead since it populates some of the arguments
  * for you. Secondly, this is an implementation detail mostly here to be used
- * by @ref ZL_RET_T_IF_ERR and friends, which call this to add more context to
+ * by @ref ZL_ERR_IF_ERR and friends, which call this to add more context to
  * the error as it passes by.
  *
  * @note OpenZL must have been compiled with ZL_ERROR_ENABLE_STACKS defined to
@@ -303,9 +317,10 @@ void ZL_E_appendToMessage(ZL_Error err, char const* fmt, ...);
  *
  * @returns the modified error.
  */
-ZL_Error ZL_E_addFrame_public(
+ZL_Error ZL_E_addFrame(
         ZL_ErrorContext const* ctx,
         ZL_Error error,
+        ZL_ErrorInfo backup,
         const char* file,
         const char* func,
         int line,
@@ -313,11 +328,18 @@ ZL_Error ZL_E_addFrame_public(
         ...);
 
 /**
- * Macro wrapper around @ref ZL_E_addFrame_public that automatically adds the
- * file, function, and line number macros to the args.
+ * Macro wrapper around @ref ZL_E_addFrame that automatically adds the
+ * scope context, file, function, and line number macros to the args.
  */
-#define ZL_E_ADDFRAME_PUBLIC(ctx, error, ...) \
-    ZL_E_addFrame_public(ctx, error, __FILE__, __func__, __LINE__, __VA_ARGS__)
+#define ZL_E_ADDFRAME(error, backup, ...) \
+    ZL_E_addFrame(                        \
+            &ZL__errorContext,            \
+            error,                        \
+            backup,                       \
+            __FILE__,                     \
+            __func__,                     \
+            __LINE__,                     \
+            __VA_ARGS__)
 
 /**
  * ZL_Error_Array: a const view into an array of errors, returned by some
@@ -674,8 +696,7 @@ extern "C" {
 //////////////////////////////////////////////
 
 #define ZL_WRAP_ERROR_ADD_FRAME(error) \
-    ZL_WRAP_ERROR_NO_FRAME(            \
-            ZL_E_ADDFRAME_PUBLIC(&ZL__errorContext, error, "Wrapping error."))
+    ZL_WRAP_ERROR_NO_FRAME(ZL_E_ADDFRAME(error, ZL_EE_EMPTY, "Wrapping error."))
 
 #define ZL_ERR_RET_IMPL(errcode, ...)                                      \
     do {                                                                   \
@@ -694,14 +715,20 @@ extern "C" {
         return ZL_WRAP_ERROR_NO_FRAME(__zl_tmp_error);                     \
     } while (0)
 
-#define ZL_ERR_IF_ERR_IMPL(expr, ...)                                       \
-    do {                                                                    \
-        ZL__RetType _result = ZL_WRAP_ERROR_NO_FRAME(ZL_RES_error(expr));   \
-        if (ZL_UNLIKELY(ZL_RES_isError(_result))) {                         \
-            ZL_RES_error(_result) = ZL_E_ADDFRAME_PUBLIC(                   \
-                    &ZL__errorContext, ZL_RES_error(_result), __VA_ARGS__); \
-            return _result;                                                 \
-        }                                                                   \
+#define ZL_ERR_IF_ERR_IMPL(expr, ...)                                     \
+    do {                                                                  \
+        ZL__RetType _result = ZL_WRAP_ERROR_NO_FRAME(ZL_RES_error(expr)); \
+        if (ZL_UNLIKELY(ZL_RES_isError(_result))) {                       \
+            ZL_E_DECLARE_STATIC_ERROR_INFO(                               \
+                    __zl_static_error_info,                               \
+                    ZL_ErrorCode_GENERIC,                                 \
+                    "Forwarding error: " ZS_MACRO_1ST_ARG(__VA_ARGS__));  \
+            ZL_RES_error(_result) = ZL_E_ADDFRAME(                        \
+                    ZL_RES_error(_result),                                \
+                    ZL_EE_FROM_STATIC(__zl_static_error_info),            \
+                    __VA_ARGS__);                                         \
+            return _result;                                               \
+        }                                                                 \
     } while (0)
 
 #define ZL_ERR_IF_UNARY_IMPL(expr, errcode, ...)                               \

--- a/src/openzl/codecs/bitpack/encode_bitpack_binding.c
+++ b/src/openzl/codecs/bitpack/encode_bitpack_binding.c
@@ -77,6 +77,7 @@ static int computeNbBits(ZL_Input const* in)
 
 static ZL_Report checkEtlWidth(size_t eltWidth)
 {
+    ZL_RESULT_DECLARE_SCOPE_REPORT(NULL);
     switch (eltWidth) {
         case 1:
         case 2:
@@ -84,8 +85,7 @@ static ZL_Report checkEtlWidth(size_t eltWidth)
         case 8:
             return ZL_returnSuccess();
         default:
-            ZL_RET_R_ERR(
-                    GENERIC, "Bitpack expects element width of 1, 2, 4 or 8");
+            ZL_ERR(GENERIC, "Bitpack expects element width of 1, 2, 4 or 8");
     }
 }
 

--- a/src/openzl/codecs/bitunpack/encode_bitunpack_binding.c
+++ b/src/openzl/codecs/bitunpack/encode_bitunpack_binding.c
@@ -46,7 +46,7 @@ ZL_Report EI_bitunpack(ZL_Encoder* eictx, const ZL_Input* ins[], size_t nbIns)
     ZL_ASSERT_NN(eictx);
     ZL_ASSERT_NN(in);
     ZL_ASSERT(ZL_Input_type(in) == ZL_Type_serial);
-    ZL_TRY_LET_R(nbBits, getNbBits(eictx));
+    ZL_TRY_LET(size_t, nbBits, getNbBits(eictx));
     const void* const src = ZL_Input_ptr(in);
     size_t const srcSize  = ZL_Input_numElts(in);
 

--- a/src/openzl/codecs/common/bitstream/bf_bitstream.h
+++ b/src/openzl/codecs/common/bitstream/bf_bitstream.h
@@ -77,12 +77,13 @@ ZL_INLINE void ZS_BitCStreamBF_flush(ZS_BitCStreamBF* bits)
 
 ZL_INLINE ZL_Report ZS_BitCStreamBF_finish(ZS_BitCStreamBF* bits)
 {
+    ZL_RESULT_DECLARE_SCOPE_REPORT((ZL_OperationContext*)NULL);
     ZS_BitCStreamBF_flush(bits);
     size_t extraBits = 8 - (bits->nbBits % 8);
     ZS_BitCStreamBF_write(bits, 1 << (extraBits - 1), extraBits);
     ZL_ASSERT_EQ(bits->nbBits % 8, 0);
     ZS_BitCStreamBF_flush(bits);
-    ZL_RET_R_IF(dstCapacity_tooSmall, bits->nbBits);
+    ZL_ERR_IF(bits->nbBits, dstCapacity_tooSmall);
     return ZL_returnValue((size_t)(bits->end - bits->ptr));
 }
 

--- a/src/openzl/codecs/common/bitstream/ff_bitstream.h
+++ b/src/openzl/codecs/common/bitstream/ff_bitstream.h
@@ -92,9 +92,10 @@ ZL_INLINE ZS_BitCStreamFF ZS_BitCStreamFF_init(uint8_t* dst, size_t dstCapacity)
 
 ZL_INLINE ZL_Report ZS_BitCStreamFF_finish(ZS_BitCStreamFF* bits)
 {
+    ZL_RESULT_DECLARE_SCOPE_REPORT((ZL_OperationContext*)NULL);
     size_t bytesToWrite = (bits->nbBits + 7) / 8;
     if (bits->end < bits->ptr + bytesToWrite)
-        ZL_RET_R_ERR(internalBuffer_tooSmall);
+        ZL_ERR(internalBuffer_tooSmall);
     if (bytesToWrite) {
         ZL_ASSERT_EQ(
                 bits->container,
@@ -154,8 +155,9 @@ ZS_BitDStreamFF_init(uint8_t const* src, size_t srcSize)
 
 ZL_INLINE ZL_Report ZS_BitDStreamFF_finish(ZS_BitDStreamFF const* bits)
 {
+    ZL_RESULT_DECLARE_SCOPE_REPORT((ZL_OperationContext*)NULL);
     if (bits->nbBitsRead > ZS_BITSTREAM_READ_MAX_BITS) {
-        ZL_RET_R_ERR(GENERIC);
+        ZL_ERR(GENERIC);
     }
     return ZL_returnSuccess();
 }

--- a/src/openzl/codecs/constant/decode_constant_binding.c
+++ b/src/openzl/codecs/constant/decode_constant_binding.c
@@ -28,7 +28,7 @@ ZL_Report DI_constant_typed(ZL_Decoder* dictx, const ZL_Input* ins[])
     ZL_RBuffer const header = ZL_Decoder_getCodecHeader(dictx);
     uint8_t const* hdrStart = (uint8_t const*)header.start;
     uint8_t const* hdrEnd   = hdrStart + header.size;
-    ZL_TRY_LET_T(uint64_t, dstNbElts, ZL_varintDecode(&hdrStart, hdrEnd));
+    ZL_TRY_LET(uint64_t, dstNbElts, ZL_varintDecode(&hdrStart, hdrEnd));
     ZL_ERR_IF_NE(hdrStart, hdrEnd, corruption);
     ZL_ERR_IF_LT(dstNbElts, 1, corruption);
 

--- a/src/openzl/codecs/dispatchN_byTag/encode_dispatchN_byTag_binding.c
+++ b/src/openzl/codecs/dispatchN_byTag/encode_dispatchN_byTag_binding.c
@@ -60,6 +60,7 @@ static DispatchNBT_ExtParser_s const* getExtParser(ZL_Encoder const* eictx)
 static ZL_RESULT_OF(ZL_DispatchInstructions)
         getSplitInstructions(ZL_Encoder* eictx, const ZL_Input* in)
 {
+    ZL_RESULT_DECLARE_SCOPE(ZL_DispatchInstructions, eictx);
     ZL_DLOG(SEQ, "getSplitInstructions()");
 
     if (ZL_Input_numElts(in) == 0) {
@@ -79,25 +80,17 @@ static ZL_RESULT_OF(ZL_DispatchInstructions)
     ZL_DispatchState state = { eictx, NULL };
 
     DispatchNBT_ExtParser_s const* s = getExtParser(eictx);
-    ZL_RET_T_IF_NULL(
-            ZL_DispatchInstructions,
-            nodeParameter_invalid,
-            s,
-            "dispatchN parser not provided");
+    ZL_ERR_IF_NULL(s, nodeParameter_invalid, "dispatchN parser not provided");
     ZL_DispatchParserFn f      = s->f;
     ZL_DispatchInstructions si = f(&state, in);
     if (si.segmentSizes == NULL) {
         if (state.message != NULL) {
-            ZL_RET_T_ERR(
-                    ZL_DispatchInstructions,
-                    nodeParameter_invalid,
-                    "External dispatchN parser failed with message: %s",
-                    state.message);
+            ZL_ERR(nodeParameter_invalid,
+                   "External dispatchN parser failed with message: %s",
+                   state.message);
         } else {
-            ZL_RET_T_ERR(
-                    ZL_DispatchInstructions,
-                    nodeParameter_invalid,
-                    "external dispatchN parser failed to provide split instructions");
+            ZL_ERR(nodeParameter_invalid,
+                   "external dispatchN parser failed to provide split instructions");
         }
     }
     return ZL_RESULT_WRAP_VALUE(ZL_DispatchInstructions, si);
@@ -116,7 +109,7 @@ EI_dispatchN_byTag(ZL_Encoder* eictx, const ZL_Input* ins[], size_t nbIns)
     ZL_ASSERT_EQ(ZL_Input_type(in), ZL_Type_serial);
     ZL_ASSERT_NN(eictx);
 
-    ZL_TRY_LET_CONST_T(
+    ZL_TRY_LET_CONST(
             ZL_DispatchInstructions, si, getSplitInstructions(eictx, in));
 
     ZL_DLOG(BLOCK,

--- a/src/openzl/codecs/dispatch_string/encode_dispatch_string_binding.c
+++ b/src/openzl/codecs/dispatch_string/encode_dispatch_string_binding.c
@@ -160,10 +160,10 @@ ZL_Edge_runDispatchStringNode(
         int nbOutputs,
         const uint16_t* indices)
 {
-    ZL_RET_T_IF(
-            ZL_EdgeList,
-            nodeParameter_invalid,
+    ZL_RESULT_DECLARE_SCOPE(ZL_EdgeList, sctx);
+    ZL_ERR_IF(
             nbOutputs < 0 || nbOutputs > ZL_DISPATCH_STRING_MAX_DISPATCHES,
+            nodeParameter_invalid,
             "dispatch_string: invalid number of outputs (%i)",
             nbOutputs);
 

--- a/src/openzl/codecs/divide_by/decode_divide_by_binding.c
+++ b/src/openzl/codecs/divide_by/decode_divide_by_binding.c
@@ -31,7 +31,7 @@ ZL_Report DI_divide_by_int(ZL_Decoder* dictx, const ZL_Input* ins[])
     ZL_RESULT_OF(uint64_t)
     const varint = ZL_varintDecode(
             &headerPtr, (const uint8_t*)header.start + header.size);
-    ZL_TRY_LET_T(uint64_t, divisor, varint);
+    ZL_TRY_LET(uint64_t, divisor, varint);
     ZL_ERR_IF_EQ(divisor, 0, node_invalid_input, "Attempt to divide by 0");
     switch (intWidth) {
         case 1:

--- a/src/openzl/codecs/divide_by/encode_divide_by_binding.c
+++ b/src/openzl/codecs/divide_by/encode_divide_by_binding.c
@@ -21,56 +21,47 @@ static ZL_RESULT_OF(uint64_t) getDivisor(
         uint64_t divisor,
         const void* src)
 {
+    ZL_RESULT_DECLARE_SCOPE(uint64_t, NULL);
     if (divisor == 0) {
         divisor = ZL_gcdVec(src, nbInts, intWidth);
         return ZL_RESULT_WRAP_VALUE(uint64_t, divisor);
     }
     switch (intWidth) {
         case 1:
-            ZL_RET_T_IF_GT(
-                    uint64_t,
-                    node_invalid_input,
+            ZL_ERR_IF_GT(
                     divisor,
                     UCHAR_MAX,
-                    "Divisor too large");
-            ZL_RET_T_IF_NE(
-                    uint64_t,
                     node_invalid_input,
+                    "Divisor too large");
+            ZL_ERR_IF_NE(
                     ZL_firstIndexNotDivisibleBy8(src, nbInts, divisor),
-                    nbInts);
+                    nbInts,
+                    node_invalid_input);
             break;
         case 2:
-            ZL_RET_T_IF_GT(
-                    uint64_t,
-                    node_invalid_input,
+            ZL_ERR_IF_GT(
                     divisor,
                     USHRT_MAX,
-                    "Divisor too large");
-            ZL_RET_T_IF_NE(
-                    uint64_t,
                     node_invalid_input,
+                    "Divisor too large");
+            ZL_ERR_IF_NE(
                     ZL_firstIndexNotDivisibleBy16(src, nbInts, divisor),
-                    nbInts);
+                    nbInts,
+                    node_invalid_input);
             break;
         case 4:
-            ZL_RET_T_IF_GT(
-                    uint64_t,
-                    node_invalid_input,
-                    divisor,
-                    UINT_MAX,
-                    "Divisor too large");
-            ZL_RET_T_IF_NE(
-                    uint64_t,
-                    node_invalid_input,
+            ZL_ERR_IF_GT(
+                    divisor, UINT_MAX, node_invalid_input, "Divisor too large");
+            ZL_ERR_IF_NE(
                     ZL_firstIndexNotDivisibleBy32(src, nbInts, divisor),
-                    nbInts);
+                    nbInts,
+                    node_invalid_input);
             break;
         case 8:
-            ZL_RET_T_IF_NE(
-                    uint64_t,
-                    node_invalid_input,
+            ZL_ERR_IF_NE(
                     ZL_firstIndexNotDivisibleBy64(src, nbInts, divisor),
-                    nbInts);
+                    nbInts,
+                    node_invalid_input);
             break;
         default:
             ZL_ASSERT_FAIL("Unsupported int width");

--- a/src/openzl/codecs/encoder_registry.c
+++ b/src/openzl/codecs/encoder_registry.c
@@ -179,9 +179,10 @@ void ER_getAllStandardNodeIDs(ZL_NodeID* nodes, size_t nodesSize)
 
 ZL_Report ER_forEachStandardNode(ER_StandardNodesCallback cb, void* opaque)
 {
+    ZL_RESULT_DECLARE_SCOPE_REPORT(NULL);
     for (ZL_IDType nid = 0; nid < ZL_ARRAY_SIZE(ER_standardNodes); ++nid) {
         if (ER_standardNodes[nid].nodetype == node_internalTransform) {
-            ZL_RET_R_IF_ERR(
+            ZL_ERR_IF_ERR(
                     cb(opaque, (ZL_NodeID){ nid }, &ER_standardNodes[nid]));
         }
     }

--- a/src/openzl/codecs/entropy/deprecated/encode_fse_kernel.c
+++ b/src/openzl/codecs/entropy/deprecated/encode_fse_kernel.c
@@ -67,6 +67,7 @@ ZL_Report ZS_fseContextEncode(
         ZL_RC* ctx,
         ZL_ContextClustering const* clustering)
 {
+    ZL_RESULT_DECLARE_SCOPE_REPORT(NULL);
     size_t const numClusters = clustering->numClusters;
     ZL_ASSERT_LE(numClusters, 256);
     ZL_ASSERT_EQ(ZL_RC_avail(ctx), ZL_RC_avail(src));
@@ -86,7 +87,7 @@ ZL_Report ZS_fseContextEncode(
     }
 
     //> Write the clustering
-    ZL_RET_R_IF_ERR(ZL_ContextClustering_encode(dst, clustering));
+    ZL_ERR_IF_ERR(ZL_ContextClustering_encode(dst, clustering));
 
     //> Initialize the FSE infos & write the NCounts
     ZS_FseClusterCStates* states;

--- a/src/openzl/codecs/float_deconstruct/common_float_deconstruct_binding.h
+++ b/src/openzl/codecs/float_deconstruct/common_float_deconstruct_binding.h
@@ -23,6 +23,7 @@ static const FLTDECON_ElementType_e FLTDECON_ElementTypeEnumMaxValue =
 
 ZL_INLINE_KEYWORD ZL_Report FLTDECON_ElementWidth(FLTDECON_ElementType_e type)
 {
+    ZL_RESULT_DECLARE_SCOPE_REPORT((ZL_OperationContext*)NULL);
     switch (type) {
         case FLTDECON_ElementType_float32:
             return ZL_returnValue(4);
@@ -31,11 +32,12 @@ ZL_INLINE_KEYWORD ZL_Report FLTDECON_ElementWidth(FLTDECON_ElementType_e type)
         case FLTDECON_ElementType_float16:
             return ZL_returnValue(2);
     }
-    ZL_RET_R_ERR(logicError);
+    ZL_ERR(logicError);
 }
 
 ZL_INLINE_KEYWORD ZL_Report FLTDECON_SignFracWidth(FLTDECON_ElementType_e type)
 {
+    ZL_RESULT_DECLARE_SCOPE_REPORT((ZL_OperationContext*)NULL);
     switch (type) {
         case FLTDECON_ElementType_float32:
             return ZL_returnValue(3);
@@ -44,12 +46,13 @@ ZL_INLINE_KEYWORD ZL_Report FLTDECON_SignFracWidth(FLTDECON_ElementType_e type)
         case FLTDECON_ElementType_float16:
             return ZL_returnValue(2);
     }
-    ZL_RET_R_ERR(logicError);
+    ZL_ERR(logicError);
 }
 
 ZL_INLINE_KEYWORD ZL_Report FLTDECON_ExponentWidth(FLTDECON_ElementType_e type)
 {
-    ZL_RET_R_IF_GT(logicError, type, FLTDECON_ElementTypeEnumMaxValue);
+    ZL_RESULT_DECLARE_SCOPE_REPORT((ZL_OperationContext*)NULL);
+    ZL_ERR_IF_GT(type, FLTDECON_ElementTypeEnumMaxValue, logicError);
     return ZL_returnValue(1);
 }
 

--- a/src/openzl/codecs/float_deconstruct/decode_float_deconstruct_binding.c
+++ b/src/openzl/codecs/float_deconstruct/decode_float_deconstruct_binding.c
@@ -31,12 +31,12 @@ ZL_Report DI_float_deconstruct(ZL_Decoder* dictx, const ZL_Input* ins[])
         eltType = (FLTDECON_ElementType_e)(*hdr);
     }
 
-    ZL_TRY_LET_R(signFracWidth, FLTDECON_SignFracWidth(eltType));
-    ZL_TRY_LET_R(exponentWidth, FLTDECON_ExponentWidth(eltType));
+    ZL_TRY_LET(size_t, signFracWidth, FLTDECON_SignFracWidth(eltType));
+    ZL_TRY_LET(size_t, exponentWidth, FLTDECON_ExponentWidth(eltType));
     ZL_ERR_IF_NE(ZL_Input_eltWidth(signFracStream), signFracWidth, corruption);
     ZL_ERR_IF_NE(ZL_Input_eltWidth(exponentStream), exponentWidth, corruption);
 
-    ZL_TRY_LET_R(eltWidth, FLTDECON_ElementWidth(eltType));
+    ZL_TRY_LET(size_t, eltWidth, FLTDECON_ElementWidth(eltType));
     ZL_Output* const out = ZL_Decoder_create1OutStream(dictx, nbElts, eltWidth);
     ZL_ERR_IF_NULL(out, allocation);
 

--- a/src/openzl/codecs/float_deconstruct/encode_float_deconstruct_binding.c
+++ b/src/openzl/codecs/float_deconstruct/encode_float_deconstruct_binding.c
@@ -13,7 +13,7 @@ ZL_INLINE_KEYWORD ZL_Report float_deconstruct(
 {
     ZL_RESULT_DECLARE_SCOPE_REPORT(eictx);
     ZL_ERR_IF_GT(eltType, FLTDECON_ElementTypeEnumMaxValue, logicError);
-    ZL_TRY_LET_R(expectedEltWidth, FLTDECON_ElementWidth(eltType));
+    ZL_TRY_LET(size_t, expectedEltWidth, FLTDECON_ElementWidth(eltType));
     ZL_ERR_IF_NE(
             ZL_Input_eltWidth(in), expectedEltWidth, streamParameter_invalid);
     ZL_ASSERT_EQ(ZL_Input_type(in), ZL_Type_numeric);
@@ -29,11 +29,11 @@ ZL_INLINE_KEYWORD ZL_Report float_deconstruct(
         ZL_ERR_IF_NE(eltType, FLTDECON_ElementType_float32, logicError);
     }
 
-    ZL_TRY_LET_R(signFracWidth, FLTDECON_SignFracWidth(eltType));
+    ZL_TRY_LET(size_t, signFracWidth, FLTDECON_SignFracWidth(eltType));
     ZL_Output* signFracStream =
             ZL_Encoder_createTypedStream(eictx, 0, nbElts, signFracWidth);
 
-    ZL_TRY_LET_R(exponentWidth, FLTDECON_ExponentWidth(eltType));
+    ZL_TRY_LET(size_t, exponentWidth, FLTDECON_ExponentWidth(eltType));
     ZL_Output* exponentStream =
             ZL_Encoder_createTypedStream(eictx, 1, nbElts, exponentWidth);
 

--- a/src/openzl/codecs/merge_sorted/decode_merge_sorted_binding.c
+++ b/src/openzl/codecs/merge_sorted/decode_merge_sorted_binding.c
@@ -26,7 +26,7 @@ static ZL_Report fillDstPtrsFromHeader(
     uint8_t const* hp       = hs;
     uint64_t dstSize        = 0;
     while (hp != he) {
-        ZL_TRY_LET_T(uint64_t, size, ZL_varintDecode(&hp, he));
+        ZL_TRY_LET(uint64_t, size, ZL_varintDecode(&hp, he));
         ZL_ERR_IF(
                 ZL_overflowAddU64(dstSize, size, &dstSize),
                 corruption,

--- a/src/openzl/codecs/merge_sorted/encode_merge_sorted_binding.c
+++ b/src/openzl/codecs/merge_sorted/encode_merge_sorted_binding.c
@@ -22,6 +22,7 @@ static ZL_Report getSortedRuns(
         uint32_t const* srcs[64],
         uint32_t const* srcEnds[64])
 {
+    ZL_RESULT_DECLARE_SCOPE_REPORT(NULL);
     size_t const kMaxNbSrcs    = 64;
     uint32_t const* ip         = (uint32_t const*)ZL_Input_ptr(in);
     uint32_t const* const iend = ip + ZL_Input_numElts(in);
@@ -34,7 +35,7 @@ static ZL_Report getSortedRuns(
         if (ip[0] <= ip[-1]) {
             srcEnds[nbSrcs] = ip;
             ++nbSrcs;
-            ZL_RET_R_IF_GE(node_invalid_input, nbSrcs, kMaxNbSrcs);
+            ZL_ERR_IF_GE(nbSrcs, kMaxNbSrcs, node_invalid_input);
             srcs[nbSrcs] = ip;
         }
     }
@@ -74,7 +75,7 @@ ZL_Report EI_mergeSorted(ZL_Encoder* eictx, const ZL_Input* ins[], size_t nbIns)
     ZL_ERR_IF_NE(ZL_Input_eltWidth(in), 4, node_invalid_input);
     uint32_t const* srcs[64];
     uint32_t const* srcEnds[64];
-    ZL_TRY_LET_R(nbSrcs, getSortedRuns(in, srcs, srcEnds));
+    ZL_TRY_LET(size_t, nbSrcs, getSortedRuns(in, srcs, srcEnds));
 
     int const bitsetWidthLog = nbSrcs == 0 ? 1 : ZL_nextPow2((nbSrcs + 7) / 8);
     size_t const bitsetWidth = (size_t)1 << bitsetWidthLog;

--- a/src/openzl/codecs/merge_sorted/encode_merge_sorted_kernel.c
+++ b/src/openzl/codecs/merge_sorted/encode_merge_sorted_kernel.c
@@ -123,9 +123,10 @@ ZL_FORCE_INLINE ZL_Report ZS2_MergeSorted_merge(
         size_t nbSrcs,
         size_t kBitsetWidth)
 {
+    ZL_RESULT_DECLARE_SCOPE_REPORT(NULL);
     assert(kBitsetWidth <= 8);
     assert(nbSrcs <= kBitsetWidth * 8);
-    ZL_RET_R_IF_NOT(allocation, PQ_init(pq, nbSrcs));
+    ZL_ERR_IF_NOT(PQ_init(pq, nbSrcs), allocation);
 
     const uint32_t* srcs[64];
     memcpy((void*)srcs, (const void*)srcStarts, sizeof(*srcs) * nbSrcs);

--- a/src/openzl/codecs/parse_int/encode_parse_int_binding.c
+++ b/src/openzl/codecs/parse_int/encode_parse_int_binding.c
@@ -83,7 +83,7 @@ ZL_Report parseIntSafeFnGraph(ZL_Graph* graph, ZL_Edge* edges[], size_t nbEdges)
                                              .nbRefParams = 1 } };
     if (numParsed == nbElts) {
         // Run parse int node with localParam of pre-parsed integers
-        ZL_TRY_LET_T(
+        ZL_TRY_LET(
                 ZL_EdgeList,
                 so,
                 ZL_Edge_runNode_withParams(
@@ -94,7 +94,7 @@ ZL_Report parseIntSafeFnGraph(ZL_Graph* graph, ZL_Edge* edges[], size_t nbEdges)
     } else if (numParsed == 0) {
         ZL_ERR_IF_ERR(ZL_Edge_setDestination(edges[0], succList.graphids[1]));
     } else {
-        ZL_TRY_LET_T(
+        ZL_TRY_LET(
                 ZL_EdgeList,
                 dispatchedEdges,
                 ZL_Edge_runDispatchStringNode(edges[0], 2, indices));
@@ -104,7 +104,7 @@ ZL_Report parseIntSafeFnGraph(ZL_Graph* graph, ZL_Edge* edges[], size_t nbEdges)
         ZL_ERR_IF_ERR(ZL_Edge_setDestination(
                 dispatchedEdges.edges[0], succList.graphids[2]));
         // Run parse int node with localParam of pre-parsed integers
-        ZL_TRY_LET_T(
+        ZL_TRY_LET(
                 ZL_EdgeList,
                 so,
                 ZL_Edge_runNode_withParams(

--- a/src/openzl/codecs/quantize/decode_quantize_kernel.c
+++ b/src/openzl/codecs/quantize/decode_quantize_kernel.c
@@ -36,6 +36,7 @@ ZL_FORCE_INLINE ZL_Report ZL_quantize32Decode_impl(
         ZL_Quantize32Params const* params,
         size_t const kUnroll)
 {
+    ZL_RESULT_DECLARE_SCOPE_REPORT(NULL);
     ZS_BitDStreamFF bitstream  = ZS_BitDStreamFF_init(extraBits, extraBitsSize);
     uint32_t const* const base = params->base;
     uint8_t const* const bits  = params->bits;
@@ -60,7 +61,7 @@ ZL_FORCE_INLINE ZL_Report ZL_quantize32Decode_impl(
     }
 
     ZL_Report const ret = ZS_BitDStreamFF_finish(&bitstream);
-    ZL_RET_R_IF(srcSize_tooSmall, ZL_isError(ret));
+    ZL_ERR_IF(ZL_isError(ret), srcSize_tooSmall);
 
     return ZL_returnSuccess();
 }
@@ -80,6 +81,7 @@ ZL_FORCE_INLINE ZL_Report ZL_quantize32DecodePow2_impl(
         size_t extraBitsSize,
         size_t const kUnroll)
 {
+    ZL_RESULT_DECLARE_SCOPE_REPORT(NULL);
     ZS_BitDStreamFF bitstream = ZS_BitDStreamFF_init(extraBits, extraBitsSize);
 
     size_t const preamble = nbCodes % kUnroll;
@@ -102,7 +104,7 @@ ZL_FORCE_INLINE ZL_Report ZL_quantize32DecodePow2_impl(
     }
 
     ZL_Report const ret = ZS_BitDStreamFF_finish(&bitstream);
-    ZL_RET_R_IF(srcSize_tooSmall, ZL_isError(ret));
+    ZL_ERR_IF(ZL_isError(ret), srcSize_tooSmall);
 
     return ZL_returnSuccess();
 }
@@ -168,7 +170,8 @@ ZL_Report ZS2_quantize32Decode(
         size_t bitsSize,
         ZL_Quantize32Params const* params)
 {
-    ZL_RET_R_IF_GE(corruption, maxCode, params->nbCodes);
+    ZL_RESULT_DECLARE_SCOPE_REPORT(NULL);
+    ZL_ERR_IF_GE(maxCode, params->nbCodes, corruption);
 
     size_t const maxNbBits = params->bits[maxCode];
 

--- a/src/openzl/codecs/quantize/encode_quantize_kernel.c
+++ b/src/openzl/codecs/quantize/encode_quantize_kernel.c
@@ -26,12 +26,13 @@ ZL_Report ZS2_quantize32Encode(
         ZL_Quantize32Params const* params)
 {
     ZL_ASSERT(ZL_isPow2(params->maxPow2));
+    ZL_RESULT_DECLARE_SCOPE_REPORT(NULL);
 
     ZS_BitCStreamFF bitstream = ZS_BitCStreamFF_init(bits, bitsCapacity);
     for (size_t i = 0; i < srcSize; ++i) {
         uint32_t const value = src[i];
         if (params->maxPow2 == 0 && value == 0) {
-            ZL_RET_R_ERR(GENERIC);
+            ZL_ERR(GENERIC);
         }
         uint8_t const code = ZL_code32(value, params);
         codes[i]           = code;
@@ -39,6 +40,6 @@ ZL_Report ZS2_quantize32Encode(
         ZS_BitCStreamFF_flush(&bitstream);
     }
     ZL_Report const ret = ZS_BitCStreamFF_finish(&bitstream);
-    ZL_RET_R_IF(internalBuffer_tooSmall, ZL_isError(ret));
+    ZL_ERR_IF(ZL_isError(ret), internalBuffer_tooSmall);
     return ret;
 }

--- a/src/openzl/codecs/rolz/common_rolz.h
+++ b/src/openzl/codecs/rolz/common_rolz.h
@@ -199,6 +199,7 @@ ZL_INLINE void ZS_RolzTable_destroy(ZS_RolzTable* table)
 ZL_INLINE ZL_Report
 ZS_RolzTable_init(ZS_RolzTable* table, size_t contextLog, size_t chunkLog)
 {
+    ZL_RESULT_DECLARE_SCOPE_REPORT((ZL_OperationContext*)NULL);
     uint32_t const nbBuckets = 1u << contextLog;
     uint32_t const nbChunks  = 1u << chunkLog;
     ZL_REQUIRE_UINT_FITS(nbBuckets - 1, uint16_t);
@@ -212,7 +213,7 @@ ZS_RolzTable_init(ZS_RolzTable* table, size_t contextLog, size_t chunkLog)
             (ZS_RolzTable_Chunk*)calloc(nbChunks, sizeof(ZS_RolzTable_Chunk));
     if (table->buckets == NULL || table->chunks == NULL) {
         ZS_RolzTable_destroy(table);
-        ZL_RET_R_ERR(GENERIC);
+        ZL_ERR(GENERIC);
     }
     ZL_REQUIRE_EQ((uintptr_t)table->buckets & 64, 0);
     ZL_REQUIRE_EQ((uintptr_t)table->chunks & 64, 0);

--- a/src/openzl/codecs/rolz/decode_rolz_kernel.c
+++ b/src/openzl/codecs/rolz/decode_rolz_kernel.c
@@ -12,15 +12,16 @@ ZL_Report ZL_rolzDecompress(
         void const* src,
         size_t srcSize)
 {
+    ZL_RESULT_DECLARE_SCOPE_REPORT(NULL);
     ZS_decoderCtx* const ctx = ZS_rolzDecoder->ctx_create();
     if (ctx == NULL) {
-        ZL_RET_R_ERR(GENERIC);
+        ZL_ERR(GENERIC);
     }
     ZL_Report const dstSize = ZS_rolzDecoder->decompress(
             ctx, (uint8_t*)dst, dstCapacity, (uint8_t const*)src, srcSize);
     ZS_rolzDecoder->ctx_release(ctx);
     if (ZL_isError(dstSize))
-        ZL_RET_R_ERR(GENERIC);
+        ZL_ERR(GENERIC);
     return dstSize;
 }
 
@@ -30,15 +31,16 @@ ZL_Report ZS_fastLzDecompress(
         void const* src,
         size_t srcSize)
 {
+    ZL_RESULT_DECLARE_SCOPE_REPORT(NULL);
     ZS_decoderCtx* const ctx = ZS_fastLzDecoder->ctx_create();
     if (ctx == NULL) {
-        ZL_RET_R_ERR(GENERIC);
+        ZL_ERR(GENERIC);
     }
     ZL_Report const dstSize = ZS_fastLzDecoder->decompress(
             ctx, (uint8_t*)dst, dstCapacity, (uint8_t const*)src, srcSize);
     ZS_fastLzDecoder->ctx_release(ctx);
     if (ZL_isError(dstSize))
-        ZL_RET_R_ERR(GENERIC);
+        ZL_ERR(GENERIC);
     return dstSize;
 }
 
@@ -154,6 +156,7 @@ ZL_Report ZS_RolzDTable2_init(
         uint32_t minLength,
         bool predictMatchLength)
 {
+    ZL_RESULT_DECLARE_SCOPE_REPORT(NULL);
     table->contextDepth       = contextDepth;
     table->contextLog         = contextLog;
     table->rowLog             = rowLog;
@@ -163,7 +166,7 @@ ZL_Report ZS_RolzDTable2_init(
     size_t const tableSize    = sizeof(*table->table) << (contextLog + rowLog);
     table->table              = (ZS_RolzDEntry2*)ZL_calloc(tableSize);
     if (table->table == NULL)
-        ZL_RET_R_ERR(GENERIC);
+        ZL_ERR(GENERIC);
     return ZL_returnSuccess();
 }
 

--- a/src/openzl/codecs/rolz/encode_rolz_kernel.c
+++ b/src/openzl/codecs/rolz/encode_rolz_kernel.c
@@ -96,6 +96,7 @@ static ZS_EncoderParameters ZS_encoderParams(
 ZL_Report
 ZS_rolzCompress(void* dst, size_t dstCapacity, void const* src, size_t srcSize)
 {
+    ZL_RESULT_DECLARE_SCOPE_REPORT(NULL);
     ZL_Report ret;
     // Initialization
     int error = 0;
@@ -136,6 +137,7 @@ ZL_Report ZS_fastLzCompress(
         void const* src,
         size_t srcSize)
 {
+    ZL_RESULT_DECLARE_SCOPE_REPORT(NULL);
     ZL_Report ret;
     // Initialization
     int error = 0;

--- a/src/openzl/codecs/splitN/decode_splitN_binding.c
+++ b/src/openzl/codecs/splitN/decode_splitN_binding.c
@@ -34,7 +34,7 @@ ZL_Report DI_splitN(
         ZL_RBuffer header = ZL_Decoder_getCodecHeader(dictx);
         if (header.size != 0) {
             uint8_t const* ptr = (uint8_t const*)header.start;
-            ZL_TRY_LET_T(
+            ZL_TRY_LET(
                     uint64_t,
                     eltWidth64,
                     ZL_varintDecode(&ptr, ptr + header.size));

--- a/src/openzl/codecs/splitN/encode_splitN_binding.c
+++ b/src/openzl/codecs/splitN/encode_splitN_binding.c
@@ -59,6 +59,7 @@ static SplitN_ExtParser_s getExtParser(ZL_Encoder const* eictx)
 static ZL_RESULT_OF(ZL_SplitInstructions)
         getSplitInstructions(ZL_Encoder* eictx, const ZL_Input* in)
 {
+    ZL_RESULT_DECLARE_SCOPE(ZL_SplitInstructions, eictx);
     ZL_DLOG(SEQ, "getSplitInstructions()");
 
     ZL_SplitState allocState = { eictx };
@@ -68,10 +69,9 @@ static ZL_RESULT_OF(ZL_SplitInstructions)
     if (extParser.f != NULL) {
         ZL_SplitParserFn f      = extParser.f;
         ZL_SplitInstructions si = f(&allocState, in);
-        ZL_RET_T_IF_NULL(
-                ZL_SplitInstructions,
-                nodeParameter_invalid,
+        ZL_ERR_IF_NULL(
                 si.segmentSizes,
+                nodeParameter_invalid,
                 "external parser failed to provide split instructions");
         return ZL_RESULT_WRAP_VALUE(ZL_SplitInstructions, si);
     }
@@ -79,16 +79,14 @@ static ZL_RESULT_OF(ZL_SplitInstructions)
     // Priority 2 : check for fixed-size parameters
     ZL_RefParam const segmentSizes =
             ZL_Encoder_getLocalParam(eictx, ZL_SPLITN_SEGMENTSIZES_PID);
-    ZL_RET_T_IF_EQ(
-            ZL_SplitInstructions,
-            nodeParameter_invalid,
+    ZL_ERR_IF_EQ(
             segmentSizes.paramId,
             ZL_LP_INVALID_PARAMID,
-            "can't find any instruction to split");
-    ZL_RET_T_IF_NULL(
-            ZL_SplitInstructions,
             nodeParameter_invalid,
+            "can't find any instruction to split");
+    ZL_ERR_IF_NULL(
             segmentSizes.paramRef,
+            nodeParameter_invalid,
             "instructions to split are NULL");
     // Handle the case of 0 segments (empty split)
     if (segmentSizes.paramSize == 0) {
@@ -119,7 +117,7 @@ ZL_Report EI_splitN(ZL_Encoder* eictx, const ZL_Input* ins[], size_t nbIns)
                     & ~(ZL_Type_serial | ZL_Type_struct | ZL_Type_numeric),
             0);
 
-    ZL_TRY_LET_T(ZL_SplitInstructions, si, getSplitInstructions(eictx, in));
+    ZL_TRY_LET(ZL_SplitInstructions, si, getSplitInstructions(eictx, in));
 
     size_t const inSize   = ZL_Input_numElts(in);
     size_t const eltWidth = ZL_Input_eltWidth(in);
@@ -285,12 +283,12 @@ ZL_Edge_runSplitNode(
         const size_t* segmentSizes,
         size_t nbSegments)
 {
+    ZL_RESULT_DECLARE_SCOPE(ZL_EdgeList, input);
     ZL_DLOG(SEQ, "ZL_Edge_runSplitNode");
-    ZL_RET_T_IF_GT(
-            ZL_EdgeList,
-            nodeParameter_invalid,
+    ZL_ERR_IF_GT(
             nbSegments,
             (size_t)INT_MAX,
+            nodeParameter_invalid,
             "nbSegments is too large (temporary limitation)");
 
     ZL_RefParam const segmentSizesParam = {

--- a/src/openzl/codecs/zstd/decode_zstd_binding.c
+++ b/src/openzl/codecs/zstd/decode_zstd_binding.c
@@ -24,35 +24,30 @@ static bool useMagicless(ZL_Decoder const* dictx)
     return DI_getFrameFormatVersion(dictx) >= 9;
 }
 
-static ZL_RESULT_OF(uint64_t) getFrameContentSize(
-        ZL_Decoder const* dictx,
-        void const* src,
-        size_t srcSize)
+static ZL_RESULT_OF(uint64_t)
+        getFrameContentSize(ZL_Decoder* dictx, void const* src, size_t srcSize)
 {
+    ZL_RESULT_DECLARE_SCOPE(uint64_t, dictx);
     ZSTD_format_e const format =
             useMagicless(dictx) ? ZSTD_f_zstd1_magicless : ZSTD_f_zstd1;
     ZSTD_frameHeader frameHeader;
     size_t const ret =
             ZSTD_getFrameHeader_advanced(&frameHeader, src, srcSize, format);
-    ZL_RET_T_IF(
-            uint64_t,
-            corruption,
+    ZL_ERR_IF(
             ZSTD_isError(ret),
+            corruption,
             "Unable to read zstd frame header: %s",
             ZSTD_getErrorName(ret));
-    ZL_RET_T_IF_NE(
-            uint64_t, srcSize_tooSmall, ret, 0, "Incomplete frame header");
-    ZL_RET_T_IF_EQ(
-            uint64_t,
-            corruption,
+    ZL_ERR_IF_NE(ret, 0, srcSize_tooSmall, "Incomplete frame header");
+    ZL_ERR_IF_EQ(
             frameHeader.frameContentSize,
             ZSTD_CONTENTSIZE_ERROR,
-            "content size is error (reject to be safe)");
-    ZL_RET_T_IF_EQ(
-            uint64_t,
             corruption,
+            "content size is error (reject to be safe)");
+    ZL_ERR_IF_EQ(
             frameHeader.frameContentSize,
             ZSTD_CONTENTSIZE_UNKNOWN,
+            corruption,
             "content size not present");
     return ZL_RESULT_WRAP_VALUE(uint64_t, frameHeader.frameContentSize);
 }
@@ -70,11 +65,11 @@ ZL_Report DI_zstd(ZL_Decoder* dictx, ZL_Input const* ins[])
     uint8_t const* src          = (uint8_t const*)ZL_Input_ptr(in);
     uint8_t const* const srcEnd = src + ZL_Input_numElts(in);
 
-    ZL_TRY_LET_T(uint64_t, dstEltWidth, ZL_varintDecode(&src, srcEnd));
+    ZL_TRY_LET(uint64_t, dstEltWidth, ZL_varintDecode(&src, srcEnd));
     ZL_ERR_IF_EQ(dstEltWidth, 0, corruption);
 
     size_t const srcSize = (size_t)(srcEnd - src);
-    ZL_TRY_LET_T(uint64_t, dstSize, getFrameContentSize(dictx, src, srcSize));
+    ZL_TRY_LET(uint64_t, dstSize, getFrameContentSize(dictx, src, srcSize));
     ZL_ERR_IF_NE(
             dstSize % dstEltWidth,
             0,

--- a/src/openzl/common/a1cbor_helpers.c
+++ b/src/openzl/common/a1cbor_helpers.c
@@ -92,6 +92,7 @@ ZL_Error A1C_Error_convert(
         const ZL_ErrorContext* const error_context,
         A1C_Error a1c_err)
 {
+    ZL_RESULT_DECLARE_SCOPE_REPORT(error_context->opCtx);
     if (a1c_err.type == A1C_ErrorType_ok) {
         return ZL_E_EMPTY;
     }
@@ -104,7 +105,7 @@ ZL_Error A1C_Error_convert(
             A1C_Error_convertCode(a1c_err.type),
             "Encountered error in A1CBOR library with code \"%s\".",
             A1C_ErrorType_getString(a1c_err.type));
-    ZL_E_ADDFRAME(&zs_err, ZL_EE_EMPTY, "");
+    zs_err = ZL_E_ADDFRAME(zs_err, ZL_EE_EMPTY, "");
     return zs_err;
 }
 

--- a/src/openzl/common/a1cbor_helpers.h
+++ b/src/openzl/common/a1cbor_helpers.h
@@ -86,21 +86,22 @@ ZL_RESULT_DECLARE_TYPE(A1C_PairPtr);
 /**
  * Helper function to try adding an item using a map builder. Converts the
  * failure paths to Zstrong errors. Mostly intended to be an implementation
- * detail of @ref A1C_MAP_TRY_ADD_R(), which is the easy way to consume the
+ * detail of @ref A1C_MAP_TRY_ADD(), which is the easy way to consume the
  * returned result.
  */
 ZL_INLINE ZL_RESULT_OF(A1C_PairPtr)
         A1C_MapBuilder_tryAdd(const A1C_MapBuilder builder)
 {
+    ZL_RESULT_DECLARE_SCOPE(A1C_PairPtr, (ZL_OperationContext*)NULL);
     A1C_Pair* const pair = A1C_MapBuilder_add(builder);
     if (pair == NULL) {
         if (builder.map == NULL) {
-            ZL_RET_T_IF_NULL(A1C_PairPtr, allocation, pair);
+            ZL_ERR_IF_NULL(pair, allocation);
         } else {
-            ZL_RET_T_IF_NULL(A1C_PairPtr, GENERIC, pair);
+            ZL_ERR_IF_NULL(pair, GENERIC);
         }
     }
-    return ZL_RESULT_WRAP_VALUE(A1C_PairPtr, pair);
+    return ZL_WRAP_VALUE(pair);
 }
 
 typedef A1C_Item* A1C_ItemPtr;
@@ -109,21 +110,22 @@ ZL_RESULT_DECLARE_TYPE(A1C_ItemPtr);
 /**
  * Helper function to try adding an item using an array builder. Converts the
  * failure paths to Zstrong errors. Mostly intended to be an implementation
- * detail of @ref A1C_ARRAY_TRY_ADD_R(), which is the easy way to consume the
+ * detail of @ref A1C_ARRAY_TRY_ADD(), which is the easy way to consume the
  * returned result.
  */
 ZL_INLINE ZL_RESULT_OF(A1C_ItemPtr)
         A1C_ArrayBuilder_tryAdd(const A1C_ArrayBuilder builder)
 {
+    ZL_RESULT_DECLARE_SCOPE(A1C_ItemPtr, (ZL_OperationContext*)NULL);
     A1C_Item* const item = A1C_ArrayBuilder_add(builder);
     if (item == NULL) {
         if (builder.array == NULL) {
-            ZL_RET_T_IF_NULL(A1C_ItemPtr, allocation, item);
+            ZL_ERR_IF_NULL(item, allocation);
         } else {
-            ZL_RET_T_IF_NULL(A1C_ItemPtr, GENERIC, item);
+            ZL_ERR_IF_NULL(item, GENERIC);
         }
     }
-    return ZL_RESULT_WRAP_VALUE(A1C_ItemPtr, item);
+    return ZL_WRAP_VALUE(item);
 }
 
 /**
@@ -154,25 +156,6 @@ ZL_INLINE ZL_RESULT_OF(A1C_ItemPtr)
     ZL_TRY_LET_CONST(A1C_PairPtr, _var, A1C_MapBuilder_tryAdd(_builder));
 #define A1C_ARRAY_TRY_ADD(_var, _builder) \
     ZL_TRY_LET_CONST(A1C_ItemPtr, _var, A1C_ArrayBuilder_tryAdd(_builder));
-
-/**
- * Deprecated versions using the old error type-passing pattern.
- */
-
-#define A1C_MAP_TRY_ADD_R(_var, _builder) \
-    A1C_MAP_TRY_ADD_T(size_t, _var, _builder)
-#define A1C_ARRAY_TRY_ADD_R(_var, _builder) \
-    A1C_ARRAY_TRY_ADD_T(size_t, _var, _builder)
-
-#define A1C_MAP_TRY_ADD_T(_return_type, _var, _builder) \
-    ZL_TRY_LET_CONST_TT(                                \
-            _return_type, A1C_PairPtr, _var, A1C_MapBuilder_tryAdd(_builder));
-#define A1C_ARRAY_TRY_ADD_T(_return_type, _var, _builder) \
-    ZL_TRY_LET_CONST_TT(                                  \
-            _return_type,                                 \
-            A1C_ItemPtr,                                  \
-            _var,                                         \
-            A1C_ArrayBuilder_tryAdd(_builder));
 
 /**
  * Helper macros to instantiate a new (const) variable with the contents of an
@@ -208,57 +191,6 @@ ZL_INLINE ZL_RESULT_OF(A1C_ItemPtr)
 #define A1C_TRY_EXTRACT_SIMPLE(_var, _expr) A1C_TRY_EXTRACT(Simple, _var, _expr)
 #define A1C_TRY_EXTRACT_TAG(_var, _expr) A1C_TRY_EXTRACT(Tag, _var, _expr)
 
-#define A1C_TRY_EXTRACT_T_BOOL(_return_type, _var, _expr) \
-    A1C_TRY_EXTRACT_TT(_return_type, Bool, _var, _expr)
-#define A1C_TRY_EXTRACT_T_INT64(_return_type, _var, _expr) \
-    A1C_TRY_EXTRACT_TT(_return_type, Int64, _var, _expr)
-#define A1C_TRY_EXTRACT_T_FLOAT16(_return_type, _var, _expr) \
-    A1C_TRY_EXTRACT_TT(_return_type, Float16, _var, _expr)
-#define A1C_TRY_EXTRACT_T_FLOAT32(_return_type, _var, _expr) \
-    A1C_TRY_EXTRACT_TT(_return_type, Float32, _var, _expr)
-#define A1C_TRY_EXTRACT_T_FLOAT64(_return_type, _var, _expr) \
-    A1C_TRY_EXTRACT_TT(_return_type, Float64, _var, _expr)
-#define A1C_TRY_EXTRACT_T_BYTES(_return_type, _var, _expr) \
-    A1C_TRY_EXTRACT_TT(_return_type, Bytes, _var, _expr)
-#define A1C_TRY_EXTRACT_T_STRING(_return_type, _var, _expr) \
-    A1C_TRY_EXTRACT_TT(_return_type, String, _var, _expr)
-#define A1C_TRY_EXTRACT_T_MAP(_return_type, _var, _expr) \
-    A1C_TRY_EXTRACT_TT(_return_type, Map, _var, _expr)
-#define A1C_TRY_EXTRACT_T_ARRAY(_return_type, _var, _expr) \
-    A1C_TRY_EXTRACT_TT(_return_type, Array, _var, _expr)
-#define A1C_TRY_EXTRACT_T_SIMPLE(_return_type, _var, _expr) \
-    A1C_TRY_EXTRACT_TT(_return_type, Simple, _var, _expr)
-#define A1C_TRY_EXTRACT_T_TAG(_return_type, _var, _expr) \
-    A1C_TRY_EXTRACT_TT(_return_type, Tag, _var, _expr)
-
-/**
- * Specializations of the above for when the enclosing scope has a return type
- * of `ZL_Report`.
- */
-
-#define A1C_TRY_EXTRACT_R_BOOL(_var, _expr) \
-    A1C_TRY_EXTRACT_T_BOOL(size_t, _var, _expr)
-#define A1C_TRY_EXTRACT_R_INT64(_var, _expr) \
-    A1C_TRY_EXTRACT_T_INT64(size_t, _var, _expr)
-#define A1C_TRY_EXTRACT_R_FLOAT16(_var, _expr) \
-    A1C_TRY_EXTRACT_T_FLOAT16(size_t, _var, _expr)
-#define A1C_TRY_EXTRACT_R_FLOAT32(_var, _expr) \
-    A1C_TRY_EXTRACT_T_FLOAT32(size_t, _var, _expr)
-#define A1C_TRY_EXTRACT_R_FLOAT64(_var, _expr) \
-    A1C_TRY_EXTRACT_T_FLOAT64(size_t, _var, _expr)
-#define A1C_TRY_EXTRACT_R_BYTES(_var, _expr) \
-    A1C_TRY_EXTRACT_T_BYTES(size_t, _var, _expr)
-#define A1C_TRY_EXTRACT_R_STRING(_var, _expr) \
-    A1C_TRY_EXTRACT_T_STRING(size_t, _var, _expr)
-#define A1C_TRY_EXTRACT_R_MAP(_var, _expr) \
-    A1C_TRY_EXTRACT_T_MAP(size_t, _var, _expr)
-#define A1C_TRY_EXTRACT_R_ARRAY(_var, _expr) \
-    A1C_TRY_EXTRACT_T_ARRAY(size_t, _var, _expr)
-#define A1C_TRY_EXTRACT_R_SIMPLE(_var, _expr) \
-    A1C_TRY_EXTRACT_T_SIMPLE(size_t, _var, _expr)
-#define A1C_TRY_EXTRACT_R_TAG(_var, _expr) \
-    A1C_TRY_EXTRACT_T_TAG(size_t, _var, _expr)
-
 #define A1C_DECLARE_TRY_GET_T(_type, _member)        \
     A1C_DECLARE_TRY_GET_T_INNER(                     \
             ZS_MACRO_CONCAT(A1C_Item_tryGet, _type), \
@@ -270,9 +202,10 @@ ZL_INLINE ZL_RESULT_OF(A1C_ItemPtr)
     ZL_RESULT_DECLARE_TYPE(_item_type);                                  \
     ZL_INLINE ZL_RESULT_OF(_item_type) _name(const A1C_Item* const item) \
     {                                                                    \
-        ZL_RET_T_IF_NULL(_item_type, corruption, item);                  \
-        ZL_RET_T_IF_NE(_item_type, corruption, item->type, _enum_type);  \
-        return ZL_RESULT_WRAP_VALUE(_item_type, item->_union_member);    \
+        ZL_RESULT_DECLARE_SCOPE(_item_type, (ZL_OperationContext*)NULL); \
+        ZL_ERR_IF_NULL(item, corruption);                                \
+        ZL_ERR_IF_NE(item->type, _enum_type, corruption);                \
+        return ZL_WRAP_VALUE(item->_union_member);                       \
     }
 
 /**
@@ -311,16 +244,6 @@ A1C_DECLARE_TRY_GET_T(Tag, tag)
     ZL_TRY_LET_CONST(                                  \
             ZS_MACRO_CONCAT(A1C_, _a1c_type_suffix),   \
             _var,                                      \
-            ZS_MACRO_CONCAT(A1C_Item_tryGet, _a1c_type_suffix)((_expr)))
-
-#define A1C_TRY_EXTRACT_T(_a1c_type_suffix, _var, _expr) \
-    A1C_TRY_EXTRACT_TT(size_t, _a1c_type_suffix, _var, _expr)
-
-#define A1C_TRY_EXTRACT_TT(_return_type, _a1c_type_suffix, _var, _expr) \
-    ZL_TRY_LET_CONST_TT(                                                \
-            _return_type,                                               \
-            ZS_MACRO_CONCAT(A1C_, _a1c_type_suffix),                    \
-            _var,                                                       \
             ZS_MACRO_CONCAT(A1C_Item_tryGet, _a1c_type_suffix)((_expr)))
 
 ZL_END_C_DECLS

--- a/src/openzl/common/buffer_internal.h
+++ b/src/openzl/common/buffer_internal.h
@@ -59,11 +59,12 @@ ZL_INLINE ZL_RBuffer ZL_RBuffer_fromVector(VECTOR(uint8_t) const* vec)
  */
 ZL_INLINE ZL_Report ZL_WCursor_write(ZL_WCursor* wcp, ZL_RBuffer src)
 {
+    ZL_RESULT_DECLARE_SCOPE_REPORT((ZL_OperationContext*)NULL);
     ZL_ASSERT_NN(wcp);
     if (src.size)
         ZL_ASSERT_NN(src.start);
     if (wcp->pos + src.size > wcp->wb.capacity) {
-        ZL_RET_R_ERR(internalBuffer_tooSmall);
+        ZL_ERR(internalBuffer_tooSmall);
     }
     if (src.size) {
         ZL_memcpy((char*)wcp->wb.start + wcp->pos, src.start, src.size);
@@ -88,18 +89,16 @@ ZL_INLINE const void* ZL_RCursor_RPtr(ZL_RCursor rc)
 ZL_INLINE ZL_RESULT_OF(ZL_RBuffer)
         ZL_RBuffer_slice(ZL_RBuffer rb, size_t startPos, size_t length)
 {
-    ZL_RET_T_IF_LT(
-            ZL_RBuffer,
-            corruption,
-            startPos + length,
-            startPos); // ensure no overflow
-    ZL_RET_T_IF_GT(ZL_RBuffer, corruption, startPos + length, rb.size);
+    ZL_RESULT_DECLARE_SCOPE(ZL_RBuffer, (ZL_OperationContext*)NULL);
+    ZL_ERR_IF_LT(startPos + length, startPos,
+                 corruption); // ensure no overflow
+    ZL_ERR_IF_GT(startPos + length, rb.size, corruption);
     if (rb.start == NULL)
         ZL_ASSERT_EQ(startPos, 0);
     const void* const newStart =
             startPos ? (const char*)rb.start + startPos : rb.start;
     ZL_RBuffer ret = (ZL_RBuffer){ newStart, length };
-    return ZL_RESULT_WRAP_VALUE(ZL_RBuffer, ret);
+    return ZL_WRAP_VALUE(ret);
 }
 
 ZL_END_C_DECLS

--- a/src/openzl/common/cursor.h
+++ b/src/openzl/common/cursor.h
@@ -359,13 +359,14 @@ ZL_INLINE ZL_RESULT_OF(uint64_t) ZL_RC_popVarint(ZL_RC* rc)
 
 ZL_INLINE ZL_Report ZL_RC_popVarint32(ZL_RC* rc, uint32_t* valPtr)
 {
+    ZL_RESULT_DECLARE_SCOPE_REPORT((ZL_OperationContext*)NULL);
     ZL_RESULT_OF(uint64_t) res = ZL_varintDecode(&rc->_cur, rc->_end);
     if (ZL_RES_isError(res)) {
-        ZL_RET_R_ERR(GENERIC);
+        ZL_ERR(GENERIC);
     }
     uint64_t tmp = ZL_RES_value(res);
     if (tmp > UINT32_MAX) {
-        ZL_RET_R_ERR(GENERIC);
+        ZL_ERR(GENERIC);
     }
     *valPtr = (uint32_t)tmp;
     return ZL_returnSuccess();

--- a/src/openzl/common/errors.c
+++ b/src/openzl/common/errors.c
@@ -853,9 +853,10 @@ static ZL_Error ZL_E_addFrame_va(
     const ZL_ErrorCode code      = e._code;
     const ZL_StaticErrorInfo* st = ZL_E_st(e);
     ZL_DynamicErrorInfo* dy      = ZL_E_dy(e);
-    if (dy == NULL && scopeCtx != NULL) {
+    if (dy == NULL && scopeCtx != NULL && scopeCtx->opCtx != NULL) {
         // Existing error is missing context, add it.
-        dy      = ZL_OC_setError(scopeCtx->opCtx);
+        dy = ZL_OC_setError(scopeCtx->opCtx);
+        // NOTE: dy may still be NULL
         e._info = ZL_EI_fromDy(dy);
         if (st == NULL) {
             ZL_DEE_fill(
@@ -891,7 +892,7 @@ static ZL_Error ZL_E_addFrame_va(
                 ZL_DEE_internPrintf(dy, "Forwarding error: ");
         ZL_DEE_appendToMessage_va(dy, fmt, args);
         ZL_DEE_addFrame(dy, scopeCtx, file, func, line, messageOffset);
-    } else if (dy == NULL && st == NULL && scopeCtx == NULL) {
+    } else if (dy == NULL && st == NULL) {
         const ZL_ErrorCode backupCode = ZL_EE_code(backup);
         if (backupCode != ZL_ErrorCode_no_error
             && backupCode != ZL_ErrorCode_GENERIC) {
@@ -928,28 +929,10 @@ static ZL_Error ZL_E_addFrame_va(
     return e;
 }
 
-void ZL_E_addFrame(
-        ZL_ErrorContext const* scopeCtx,
-        ZL_Error* e,
-        const ZL_ErrorInfo backup,
-        const char* file,
-        const char* func,
-        int line,
-        const char* fmt,
-        ...)
-{
-    if (e == NULL) {
-        return;
-    }
-    va_list args;
-    va_start(args, fmt);
-    *e = ZL_E_addFrame_va(scopeCtx, *e, backup, file, func, line, fmt, args);
-    va_end(args);
-}
-
-ZL_Error ZL_E_addFrame_public(
+ZL_Error ZL_E_addFrame(
         ZL_ErrorContext const* scopeCtx,
         ZL_Error e,
+        const ZL_ErrorInfo backup,
         const char* file,
         const char* func,
         int line,
@@ -961,21 +944,27 @@ ZL_Error ZL_E_addFrame_public(
     }
     va_list args;
     va_start(args, fmt);
-    e = ZL_E_addFrame_va(scopeCtx, e, ZL_EE_EMPTY, file, func, line, fmt, args);
+    e = ZL_E_addFrame_va(scopeCtx, e, backup, file, func, line, fmt, args);
     va_end(args);
     return e;
 }
 #else  // !ZL_ERROR_ENABLE_STACKS
-ZL_Error ZL_E_addFrame_public(
-        ZL_ErrorContext const*,
+ZL_Error ZL_E_addFrame(
+        ZL_ErrorContext const* scopeCtx,
         ZL_Error e,
-        const ZL_ErrorInfo,
-        const char*,
-        const char*,
-        int,
-        const char*,
+        const ZL_ErrorInfo backup,
+        const char* file,
+        const char* func,
+        int line,
+        const char* fmt,
         ...)
 {
+    (void)scopeCtx;
+    (void)backup;
+    (void)file;
+    (void)func;
+    (void)line;
+    (void)fmt;
     return e;
 }
 #endif // ZL_ERROR_ENABLE_STACKS
@@ -1018,6 +1007,7 @@ ZL_Report ZL_reportError(
 
 ZL_Report ZL_returnError(ZL_ErrorCode err)
 {
+    ZL_RESULT_DECLARE_SCOPE_REPORT(NULL);
     // TODO : should control that err is within bounds
     return ZL_REPORT_ERROR_CODE(err);
 }

--- a/src/openzl/common/errors_internal.h
+++ b/src/openzl/common/errors_internal.h
@@ -187,22 +187,15 @@ ZL_INLINE ZL_ErrorInfo ZL_EI_fromSt(const ZL_StaticErrorInfo* const st)
 
 #define ZL_E_INNER(err, ...) \
     ZL_E_CODE_INNER(ZL_EXPAND_ERRCODE(err), __VA_ARGS__)
-#define ZL_E_CODE_INNER(code, ...)  \
-    ZL_E_create(                    \
-            NULL,                   \
-            ZL_GET_SCOPE_CONTEXT(), \
-            __FILE__,               \
-            __func__,               \
-            __LINE__,               \
-            code,                   \
+#define ZL_E_CODE_INNER(code, ...) \
+    ZL_E_create(                   \
+            NULL,                  \
+            &ZL__errorContext,     \
+            __FILE__,              \
+            __func__,              \
+            __LINE__,              \
+            code,                  \
             __VA_ARGS__)
-
-#if ZL_ERROR_ENABLE_STATIC_ERROR_INFO
-#    define ZL_EE_FROM_STATIC(name) \
-        ZL_EI_fromSt(ZL_E_POINTER_TO_STATIC_ERROR_INFO(name))
-#else
-#    define ZL_EE_FROM_STATIC(name) ZL_EE_EMPTY
-#endif
 
 /////////////////
 // Destruction //
@@ -286,7 +279,6 @@ char const* ZL_E_str(ZL_Error err);
                    #expr,                                             \
                    req_str);                                          \
             ZL_LOG_IFNONEMPTY(ALWAYS, "Context: ", __VA_ARGS__);      \
-            ZL_E_ADDFRAME(&_error, ZL_EE_EMPTY, "");                  \
             ZL_E_log(_error, ZL_LOG_LVL_ALWAYS);                      \
             ZL_ABORT();                                               \
         }                                                             \
@@ -306,47 +298,6 @@ ZL_DynamicErrorInfo* ZL_E_dy(ZL_Error err);
 // Get the static error info in the error. Returns nullptr if the error doesn't
 // contain an error or doesn't point at a static error.
 const ZL_StaticErrorInfo* ZL_E_st(ZL_Error err);
-
-// Append the current frame to the stack in the rich error.
-#define ZL_E_ADDFRAME(e, backup, ...) \
-    ZL_E_addFrame(                    \
-            ZL_GET_SCOPE_CONTEXT(),   \
-            e,                        \
-            backup,                   \
-            __FILE__,                 \
-            __func__,                 \
-            __LINE__,                 \
-            __VA_ARGS__)
-
-#if ZL_ERROR_ENABLE_STACKS
-void ZL_E_addFrame(
-        ZL_ErrorContext const* scopeCtx,
-        ZL_Error* e,
-        ZL_ErrorInfo backup,
-        const char* file,
-        const char* func,
-        int line,
-        char const* fmt,
-        ...);
-#else
-ZL_INLINE void ZL_E_addFrame(
-        ZL_ErrorContext const* scopeCtx,
-        ZL_Error* e,
-        ZL_ErrorInfo backup,
-        const char* file,
-        const char* func,
-        int line,
-        char const* fmt,
-        ...)
-{
-    (void)scopeCtx;
-    (void)file;
-    (void)func;
-    (void)line;
-    (void)fmt;
-    return e;
-}
-#endif // ZS_ENABLE_ERROR_STACKS
 
 void ZL_E_changeErrorCode(ZL_Error* err, ZL_ErrorCode code);
 
@@ -374,9 +325,9 @@ void ZL_E_changeErrorCode(ZL_Error* err, ZL_ErrorCode code);
             ZL_ErrorContext _scope_ctx = { .opCtx = _op_ctx };               \
             /* adding a frame will also trigger static -> dynamic error info \
              * conversion */                                                 \
-            ZL_E_addFrame(                                                   \
+            _error = ZL_E_addFrame(                                          \
                     &_scope_ctx,                                             \
-                    &_error,                                                 \
+                    _error,                                                  \
                     ZL_EE_EMPTY,                                             \
                     __FILE__,                                                \
                     __func__,                                                \
@@ -628,33 +579,39 @@ void ZL_EE_log(ZL_ErrorInfo ei, int level);
  * user-provided output buffer. If an internal call produces it, that's a logic
  * error, so we coerce it.
  */
-#define ZL_ERR_IF_ERR_COERCE_IMPL(expr, ...)                                \
-    do {                                                                    \
-        ZL__RetType _result = ZL_WRAP_ERROR_NO_FRAME(ZL_RES_error(expr));   \
-        if (ZL_UNLIKELY(ZL_RES_isError(_result))) {                         \
-            ZL_ASSERT_NE(                                                   \
-                    (int)ZL_E_code(ZL_RES_error(_result)),                  \
-                    (int)ZL_ErrorCode_dstCapacity_tooSmall,                 \
-                    "A call inside the zstrong internals produced "         \
-                    "dstCapacity_tooSmall, which should only be used at "   \
-                    "the end when interacting with the user-provided "      \
-                    "output buffer.");                                      \
-            if (ZL_E_code(ZL_RES_error(_result))                            \
-                == ZL_ErrorCode_dstCapacity_tooSmall) {                     \
-                ZL_E_changeErrorCode(                                       \
-                        &ZL_RES_error(_result), ZL_ErrorCode_logicError);   \
-                ZL_E_appendToMessage(                                       \
-                        ZL_RES_error(_result),                              \
-                        "A call inside the zstrong internals produced "     \
-                        "dstCapacity_tooSmall, which should only be used "  \
-                        "at the end when interacting with the "             \
-                        "user-provided output buffer. "                     \
-                        "Coerced to logicError.\n\t");                      \
-            }                                                               \
-            ZL_RES_error(_result) = ZL_E_ADDFRAME_PUBLIC(                   \
-                    &ZL__errorContext, ZL_RES_error(_result), __VA_ARGS__); \
-            return _result;                                                 \
-        }                                                                   \
+#define ZL_ERR_IF_ERR_COERCE_IMPL(expr, ...)                               \
+    do {                                                                   \
+        ZL__RetType _result = ZL_WRAP_ERROR_NO_FRAME(ZL_RES_error(expr));  \
+        if (ZL_UNLIKELY(ZL_RES_isError(_result))) {                        \
+            ZL_ASSERT_NE(                                                  \
+                    (int)ZL_E_code(ZL_RES_error(_result)),                 \
+                    (int)ZL_ErrorCode_dstCapacity_tooSmall,                \
+                    "A call inside the zstrong internals produced "        \
+                    "dstCapacity_tooSmall, which should only be used at "  \
+                    "the end when interacting with the user-provided "     \
+                    "output buffer.");                                     \
+            if (ZL_E_code(ZL_RES_error(_result))                           \
+                == ZL_ErrorCode_dstCapacity_tooSmall) {                    \
+                ZL_E_changeErrorCode(                                      \
+                        &ZL_RES_error(_result), ZL_ErrorCode_logicError);  \
+                ZL_E_appendToMessage(                                      \
+                        ZL_RES_error(_result),                             \
+                        "A call inside the zstrong internals produced "    \
+                        "dstCapacity_tooSmall, which should only be used " \
+                        "at the end when interacting with the "            \
+                        "user-provided output buffer. "                    \
+                        "Coerced to logicError.\n\t");                     \
+            }                                                              \
+            ZL_E_DECLARE_STATIC_ERROR_INFO(                                \
+                    __zl_static_error_info,                                \
+                    ZL_ErrorCode_GENERIC,                                  \
+                    "Forwarding error: " ZS_MACRO_1ST_ARG(__VA_ARGS__));   \
+            ZL_RES_error(_result) = ZL_E_ADDFRAME(                         \
+                    ZL_RES_error(_result),                                 \
+                    ZL_EE_FROM_STATIC(__zl_static_error_info),             \
+                    __VA_ARGS__);                                          \
+            return _result;                                                \
+        }                                                                  \
     } while (0)
 
 /**

--- a/src/openzl/common/opaque.c
+++ b/src/openzl/common/opaque.c
@@ -35,6 +35,7 @@ ZL_Report ZL_OpaquePtrRegistry_register(
         ZL_OpaquePtrRegistry* registry,
         ZL_OpaquePtr opaque)
 {
+    ZL_RESULT_DECLARE_SCOPE_REPORT(NULL);
     if (opaque.freeFn == NULL) {
         // Free is no-op => do not track
         return ZL_returnSuccess();
@@ -42,7 +43,7 @@ ZL_Report ZL_OpaquePtrRegistry_register(
     const bool success = VECTOR_PUSHBACK(registry->ptrs, opaque);
     if (!success) {
         ZL_OpaquePtr_free(opaque);
-        ZL_RET_R_ERR(allocation, "Failed to pushback to opaque vector");
+        ZL_ERR(allocation, "Failed to pushback to opaque vector");
     }
     return ZL_returnSuccess();
 }

--- a/src/openzl/common/refcount.c
+++ b/src/openzl/common/refcount.c
@@ -22,6 +22,7 @@ ZL_Report ZL_Refcount_init(
         ZL_Refcount_FreeFn freeFn,
         void* opaque)
 {
+    ZL_RESULT_DECLARE_SCOPE_REPORT(NULL);
     if (ctrlAlloc == NULL) {
         // just a reference, no ownership
         rc->_ref = NULL;
@@ -31,7 +32,7 @@ ZL_Report ZL_Refcount_init(
         ZL_ASSERT_NN(ctrlAlloc->sfree);
         struct ZS2_Refcount_Control* const ctrl =
                 ctrlAlloc->malloc(ctrlAlloc->opaque, sizeof(*ctrl));
-        ZL_RET_R_IF_NULL(allocation, ctrl);
+        ZL_ERR_IF_NULL(ctrl, allocation);
 
         ctrl->ptr           = ptr;
         ctrl->count         = 1;
@@ -74,9 +75,10 @@ ZL_Report ZL_Refcount_initMalloc(ZL_Refcount* rc, void* ptr)
 
 ZL_Report ZL_Refcount_initConstRef(ZL_Refcount* rc, const void* ptr)
 {
+    ZL_RESULT_DECLARE_SCOPE_REPORT(NULL);
     void* ptrMut;
     memcpy(&ptrMut, &ptr, sizeof(ptr));
-    ZL_RET_R_IF_ERR(ZL_Refcount_init(rc, ptrMut, NULL, NULL, NULL));
+    ZL_ERR_IF_ERR(ZL_Refcount_init(rc, ptrMut, NULL, NULL, NULL));
     rc->_mutable = false;
     ZL_ASSERT(!ZL_Refcount_mutable(rc));
     return ZL_returnSuccess();
@@ -84,7 +86,8 @@ ZL_Report ZL_Refcount_initConstRef(ZL_Refcount* rc, const void* ptr)
 
 ZL_Report ZL_Refcount_initMutRef(ZL_Refcount* rc, void* ptr)
 {
-    ZL_RET_R_IF_ERR(ZL_Refcount_init(rc, ptr, NULL, NULL, NULL));
+    ZL_RESULT_DECLARE_SCOPE_REPORT(NULL);
+    ZL_ERR_IF_ERR(ZL_Refcount_init(rc, ptr, NULL, NULL, NULL));
     rc->_mutable = true;
     ZL_ASSERT(ZL_Refcount_mutable(rc));
     return ZL_returnSuccess();

--- a/src/openzl/common/wire_format.c
+++ b/src/openzl/common/wire_format.c
@@ -9,7 +9,8 @@
 
 ZL_Report ZL_getFormatVersionFromFrame(void const* src, size_t srcSize)
 {
-    ZL_RET_R_IF_LT(srcSize_tooSmall, srcSize, 4);
+    ZL_RESULT_DECLARE_SCOPE_REPORT(NULL);
+    ZL_ERR_IF_LT(srcSize, 4, srcSize_tooSmall);
     uint32_t const magic = ZL_readCE32(src);
     return ZL_getFormatVersionFromMagic(magic);
 }
@@ -23,16 +24,17 @@ void ZL_writeMagicNumber(void* dst, size_t dstCapacity, uint32_t version)
 
 ZL_Report ZL_getFormatVersionFromMagic(uint32_t magic)
 {
+    ZL_RESULT_DECLARE_SCOPE_REPORT(NULL);
     // Detect invalid magic numbers - outside of the range of versions
     // we know about. Pad the top end of the range to handle versions added
     // after this library was shipped.
     if (magic < ZSTRONG_MAGIC_NUMBER_BASE || magic > ZS2_MAX_MAGIC + 16)
-        ZL_RET_R_ERR(header_unknown);
+        ZL_ERR(header_unknown);
 
     // Detect magic numbers we used for older versions that we no longer
     // support or newer versions we don't yet support.
-    ZL_RET_R_IF_LT(formatVersion_unsupported, magic, ZS2_MIN_MAGIC);
-    ZL_RET_R_IF_GT(formatVersion_unsupported, magic, ZS2_MAX_MAGIC);
+    ZL_ERR_IF_LT(magic, ZS2_MIN_MAGIC, formatVersion_unsupported);
+    ZL_ERR_IF_GT(magic, ZS2_MAX_MAGIC, formatVersion_unsupported);
 
     // Extract the supported version number.
     uint32_t const version = magic - ZSTRONG_MAGIC_NUMBER_BASE;

--- a/src/openzl/compress/cgraph.c
+++ b/src/openzl/compress/cgraph.c
@@ -756,7 +756,7 @@ ZL_Compressor_registerFunctionGraph2(
     ZL_DLOG(BLOCK,
             "ZL_Compressor_registerFunctionGraph '%s'",
             STR_REPLACE_NULL(desc->name));
-    ZL_ASSERT_NN(cgraph);
+    ZL_ASSERT_NN(compressor);
     if (desc->validate_f && !desc->validate_f(compressor, desc)) {
         ZL_OpaquePtr_free(desc->opaque);
         ZL_ERR(graph_invalid, "Validation failed");

--- a/src/openzl/compress/enc_interface.c
+++ b/src/openzl/compress/enc_interface.c
@@ -248,10 +248,9 @@ static ZL_Report ENC_runTransform_internal(
             CT_getTrName(trDesc),
             nodeid.nid,
             nbInStreams);
-    ZL_SCOPE_GRAPH_CONTEXT(
-            eictx,
-            { .transformID = trDesc->publicDesc.gd.CTid,
-              .name        = trDesc->publicDesc.name });
+    ZL_RESULT_SCOPE_ADD_GRAPH_CONTEXT(
+            (ZL_GraphContext){ .transformID = trDesc->publicDesc.gd.CTid,
+                               .name        = trDesc->publicDesc.name });
 
     eictx->privateParam             = trDesc->privateParam;
     eictx->opaquePtr                = trDesc->publicDesc.opaque.ptr;
@@ -273,7 +272,7 @@ static ZL_Report ENC_runTransform_internal(
             eictx, ZL_codemodDatasAsInputs(inStreams), nbInStreams));
     if (ZL_isError(codecExecResult)) {
         CWAYPOINT(on_codecEncode_end, eictx, NULL, 0, codecExecResult);
-        ZL_RET_R_IF_ERR_COERCE(
+        ZL_ERR_IF_ERR_COERCE(
                 codecExecResult, "transform %s failed", CT_getTrName(trDesc));
     }
     const RTGraph* rtgm       = CCTX_getRTGraph(eictx->cctx);

--- a/src/openzl/compress/enc_interface.c
+++ b/src/openzl/compress/enc_interface.c
@@ -103,6 +103,7 @@ void ZL_Encoder_sendCodecHeader(
         const void* trh,
         size_t trhSize)
 {
+    ZL_RESULT_DECLARE_SCOPE_REPORT(eictx);
     ZL_DLOG(SEQ, "ZL_Encoder_sendCodecHeader (%zu bytes)", trhSize);
     CWAYPOINT(on_ZL_Encoder_sendCodecHeader, eictx, trh, trhSize);
     ZL_ASSERT_NN(eictx);

--- a/src/openzl/compress/graphs/generic_clustering_graph.c
+++ b/src/openzl/compress/graphs/generic_clustering_graph.c
@@ -143,22 +143,22 @@ static ZL_Report cbor_serializeTypeSuccessor(
     A1C_MapBuilder typeSuccessorMapBuilder =
             A1C_Item_map_builder(parent, 4, arena);
     {
-        A1C_MAP_TRY_ADD_R(pair, typeSuccessorMapBuilder);
+        A1C_MAP_TRY_ADD(pair, typeSuccessorMapBuilder);
         A1C_Item_string_refCStr(&pair->key, "type");
         A1C_Item_int64(&pair->val, (A1C_Int64)typeSuccesor->type);
     }
     {
-        A1C_MAP_TRY_ADD_R(pair, typeSuccessorMapBuilder);
+        A1C_MAP_TRY_ADD(pair, typeSuccessorMapBuilder);
         A1C_Item_string_refCStr(&pair->key, "eltWidth");
         A1C_Item_int64(&pair->val, (A1C_Int64)typeSuccesor->eltWidth);
     }
     {
-        A1C_MAP_TRY_ADD_R(pair, typeSuccessorMapBuilder);
+        A1C_MAP_TRY_ADD(pair, typeSuccessorMapBuilder);
         A1C_Item_string_refCStr(&pair->key, "successorIdx");
         A1C_Item_int64(&pair->val, (A1C_Int64)typeSuccesor->successorIdx);
     }
     {
-        A1C_MAP_TRY_ADD_R(pair, typeSuccessorMapBuilder);
+        A1C_MAP_TRY_ADD(pair, typeSuccessorMapBuilder);
         A1C_Item_string_refCStr(&pair->key, "clusteringCodecIdx");
         A1C_Item_int64(&pair->val, (A1C_Int64)typeSuccesor->clusteringCodecIdx);
     }
@@ -178,7 +178,7 @@ ZL_Report ZL_Clustering_serializeClusteringConfig(
     ZL_ERR_IF_NULL(root, allocation);
     A1C_MapBuilder rootMapBuilder = A1C_Item_map_builder(root, 2, arena);
     {
-        A1C_MAP_TRY_ADD_R(pair, rootMapBuilder);
+        A1C_MAP_TRY_ADD(pair, rootMapBuilder);
         A1C_Item_string_refCStr(&pair->key, "clusters");
         A1C_Item* clusters =
                 A1C_Item_array(&pair->val, config->nbClusters, arena);
@@ -187,7 +187,7 @@ ZL_Report ZL_Clustering_serializeClusteringConfig(
             A1C_MapBuilder clustersMapBuilder =
                     A1C_Item_map_builder(&clusters[i], 2, arena);
             {
-                A1C_MAP_TRY_ADD_R(p, clustersMapBuilder);
+                A1C_MAP_TRY_ADD(p, clustersMapBuilder);
                 A1C_Item_string_refCStr(&p->key, "typeSuccessor");
                 ZL_ERR_IF_ERR(cbor_serializeTypeSuccessor(
                         errCtx,
@@ -196,7 +196,7 @@ ZL_Report ZL_Clustering_serializeClusteringConfig(
                         &config->clusters[i].typeSuccessor));
             }
             {
-                A1C_MAP_TRY_ADD_R(p, clustersMapBuilder);
+                A1C_MAP_TRY_ADD(p, clustersMapBuilder);
                 A1C_Item_string_refCStr(&p->key, "memberTags");
                 A1C_Item* memberTags = A1C_Item_array(
                         &p->val, config->clusters[i].nbMemberTags, arena);
@@ -210,7 +210,7 @@ ZL_Report ZL_Clustering_serializeClusteringConfig(
         }
     }
     {
-        A1C_MAP_TRY_ADD_R(pair, rootMapBuilder);
+        A1C_MAP_TRY_ADD(pair, rootMapBuilder);
         A1C_Item_string_refCStr(&pair->key, "typeDefaults");
         A1C_Item* typeDefaults =
                 A1C_Item_array(&pair->val, config->nbTypeDefaults, arena);
@@ -238,15 +238,15 @@ static ZL_Report cbor_deserializeTypeSuccessor(
         ZL_ClusteringConfig_TypeSuccessor* typeSuccessor)
 {
     ZL_RESULT_DECLARE_SCOPE_REPORT(errCtx);
-    A1C_TRY_EXTRACT_R_INT64(type, A1C_Map_get_cstr(typeSuccessorMap, "type"));
+    A1C_TRY_EXTRACT_INT64(type, A1C_Map_get_cstr(typeSuccessorMap, "type"));
     typeSuccessor->type = (ZL_Type)type;
-    A1C_TRY_EXTRACT_R_INT64(
+    A1C_TRY_EXTRACT_INT64(
             eltWidth, A1C_Map_get_cstr(typeSuccessorMap, "eltWidth"));
     typeSuccessor->eltWidth = (size_t)eltWidth;
-    A1C_TRY_EXTRACT_R_INT64(
+    A1C_TRY_EXTRACT_INT64(
             successorIdx, A1C_Map_get_cstr(typeSuccessorMap, "successorIdx"));
     typeSuccessor->successorIdx = (size_t)successorIdx;
-    A1C_TRY_EXTRACT_R_INT64(
+    A1C_TRY_EXTRACT_INT64(
             clusteringCodecIdx,
             A1C_Map_get_cstr(typeSuccessorMap, "clusteringCodecIdx"));
     typeSuccessor->clusteringCodecIdx = (size_t)clusteringCodecIdx;
@@ -271,12 +271,9 @@ ZL_Clustering_deserializeClusteringConfig(
                                  .rejectUnknownSimple = true };
     A1C_Decoder_init(&decoder, *arena, decoderConfig);
     const A1C_Item* root = A1C_Decoder_decode(&decoder, config, configSize);
-    A1C_TRY_EXTRACT_T_MAP(ZL_ClusteringConfig, rootMap, root);
+    A1C_TRY_EXTRACT_MAP(rootMap, root);
 
-    A1C_TRY_EXTRACT_T_ARRAY(
-            ZL_ClusteringConfig,
-            clustersItem,
-            A1C_Map_get_cstr(&rootMap, "clusters"));
+    A1C_TRY_EXTRACT_ARRAY(clustersItem, A1C_Map_get_cstr(&rootMap, "clusters"));
     dst.nbClusters = clustersItem.size;
     ZL_ERR_IF_GT(
             dst.nbClusters,
@@ -288,34 +285,27 @@ ZL_Clustering_deserializeClusteringConfig(
     ZL_ERR_IF_NULL(dst.clusters, allocation);
     for (size_t i = 0; i < dst.nbClusters; i++) {
         const A1C_Item* clusterItem = A1C_Array_get(&clustersItem, i);
-        A1C_TRY_EXTRACT_T_MAP(ZL_ClusteringConfig, clusterMap, clusterItem);
-        A1C_TRY_EXTRACT_T_MAP(
-                ZL_ClusteringConfig,
+        A1C_TRY_EXTRACT_MAP(clusterMap, clusterItem);
+        A1C_TRY_EXTRACT_MAP(
                 typeSuccessorMap,
                 A1C_Map_get_cstr(&clusterMap, "typeSuccessor"));
         ZL_ERR_IF_ERR(cbor_deserializeTypeSuccessor(
                 errCtx, &typeSuccessorMap, &dst.clusters[i].typeSuccessor));
-        A1C_TRY_EXTRACT_T_ARRAY(
-                ZL_ClusteringConfig,
-                memberTagsArray,
-                A1C_Map_get_cstr(&clusterMap, "memberTags"));
+        A1C_TRY_EXTRACT_ARRAY(
+                memberTagsArray, A1C_Map_get_cstr(&clusterMap, "memberTags"));
         dst.clusters[i].nbMemberTags = memberTagsArray.size;
         dst.clusters[i].memberTags   = arena->calloc(
                 arena->opaque, dst.clusters[i].nbMemberTags * sizeof(int));
         ZL_ERR_IF_NULL(dst.clusters[i].memberTags, allocation);
         for (size_t j = 0; j < dst.clusters[i].nbMemberTags; j++) {
-            A1C_TRY_EXTRACT_T_INT64(
-                    ZL_ClusteringConfig,
-                    memberTag,
-                    A1C_Array_get(&memberTagsArray, j));
+            A1C_TRY_EXTRACT_INT64(
+                    memberTag, A1C_Array_get(&memberTagsArray, j));
             ZL_ERR_IF_GT(memberTag, INT32_MAX, nodeParameter_invalidValue);
             dst.clusters[i].memberTags[j] = (int)memberTag;
         }
     }
-    A1C_TRY_EXTRACT_T_ARRAY(
-            ZL_ClusteringConfig,
-            typeDefaultsItem,
-            A1C_Map_get_cstr(&rootMap, "typeDefaults"));
+    A1C_TRY_EXTRACT_ARRAY(
+            typeDefaultsItem, A1C_Map_get_cstr(&rootMap, "typeDefaults"));
     dst.nbTypeDefaults = typeDefaultsItem.size;
     dst.typeDefaults   = arena->calloc(
             arena->opaque,
@@ -323,8 +313,7 @@ ZL_Clustering_deserializeClusteringConfig(
     ZL_ERR_IF_NULL(dst.typeDefaults, allocation);
     for (size_t i = 0; i < dst.nbTypeDefaults; i++) {
         const A1C_Item* typeDefaultItem = A1C_Array_get(&typeDefaultsItem, i);
-        A1C_TRY_EXTRACT_T_MAP(
-                ZL_ClusteringConfig, typeDefaultMap, typeDefaultItem);
+        A1C_TRY_EXTRACT_MAP(typeDefaultMap, typeDefaultItem);
         ZL_ERR_IF_ERR(cbor_deserializeTypeSuccessor(
                 errCtx, &typeDefaultMap, &dst.typeDefaults[i]));
     }

--- a/src/openzl/compress/graphs/sddl/simple_data_description_language.c
+++ b/src/openzl/compress/graphs/sddl/simple_data_description_language.c
@@ -3005,8 +3005,8 @@ ZL_SDDL_State_exec(
                 const ZL_SDDL_SourceLocationPrettyString pstr =
                         ZL_RES_value(pstr_res);
                 if (pstr.str.data != NULL) {
-                    ZL_E_ADDFRAME(
-                            &ZL_RES_error(result),
+                    ZL_RES_error(result) = ZL_E_ADDFRAME(
+                            ZL_RES_error(result),
                             ZL_EE_EMPTY,
                             "\nEncountered error at position %zu while processing:\n%.*s",
                             state->pos,

--- a/src/openzl/compress/segmenter.c
+++ b/src/openzl/compress/segmenter.c
@@ -96,6 +96,7 @@ ZL_Segmenter* SEGM_init(
  */
 ZL_Report SEGM_runSegmenter(ZL_Segmenter* segCtx)
 {
+    ZL_RESULT_DECLARE_SCOPE_REPORT(segCtx);
     ZL_ASSERT_NN(segCtx);
     ZL_SegmenterFn const segfn = segCtx->segDesc->segmenterFn;
     ZL_ASSERT_NN(segfn);
@@ -104,10 +105,10 @@ ZL_Report SEGM_runSegmenter(ZL_Segmenter* segCtx)
     // if successful, check that all inputs were consumed
     if (!ZL_isError(r)) {
         for (size_t n = 0; n < segCtx->nbInputs; n++) {
-            ZL_RET_R_IF_LT(
-                    segmenter_inputNotConsumed,
+            ZL_ERR_IF_LT(
                     segCtx->consumed[n],
                     ZL_Data_numElts(segCtx->inputs[n]),
+                    segmenter_inputNotConsumed,
                     "input %zu wasn't entirely consumed",
                     n);
         }

--- a/src/openzl/compress/segmenters/segmenter_numeric.c
+++ b/src/openzl/compress/segmenters/segmenter_numeric.c
@@ -6,6 +6,7 @@
 
 ZL_Report SEGM_numeric(ZL_Segmenter* sctx)
 {
+    ZL_RESULT_DECLARE_SCOPE_REPORT(sctx);
     size_t const numInputs = ZL_Segmenter_numInputs(sctx);
     ZL_ASSERT_EQ(numInputs, 1);
     const ZL_Input* const input = ZL_Segmenter_getInput(sctx, 0);
@@ -24,12 +25,12 @@ ZL_Report SEGM_numeric(ZL_Segmenter* sctx)
 
     size_t numElts = ZL_Input_numElts(input);
     while (numElts > chunkEltSizeMax) {
-        ZL_RET_R_IF_ERR(ZL_Segmenter_processChunk(
+        ZL_ERR_IF_ERR(ZL_Segmenter_processChunk(
                 sctx, &chunkEltSizeMax, 1, headGraph, NULL));
         numElts -= chunkEltSizeMax;
     }
     ZL_ASSERT_LE(numElts, chunkEltSizeMax);
-    ZL_RET_R_IF_ERR(
+    ZL_ERR_IF_ERR(
             ZL_Segmenter_processChunk(sctx, &numElts, 1, headGraph, NULL));
 
     return ZL_returnSuccess();

--- a/src/openzl/compress/selector.c
+++ b/src/openzl/compress/selector.c
@@ -71,7 +71,7 @@ ZL_Report ZL_Selector_setSuccessorParams(
         ALLOC_ARENA_MALLOC_CHECKED(
                 ZL_LocalParams, lparamsCopy, 1, selCtx->wkspArena);
         *lparamsCopy = *lparams;
-        ZL_RET_R_IF_ERR(LP_transferLocalParams(selCtx->wkspArena, lparamsCopy));
+        ZL_ERR_IF_ERR(LP_transferLocalParams(selCtx->wkspArena, lparamsCopy));
         SelectorSuccessorParams* p = selCtx->successorLParams;
         p->params                  = lparamsCopy;
     }

--- a/src/openzl/compress/selectors/ml/ml_selector_graph.c
+++ b/src/openzl/compress/selectors/ml/ml_selector_graph.c
@@ -99,27 +99,27 @@ static ZL_Report GBTModel_serializeNode(
     ZL_RESULT_DECLARE_SCOPE_REPORT(errCtx);
     A1C_MapBuilder nodeMapBuilder = A1C_Item_map_builder(parent, 5, a1cArena);
     {
-        A1C_MAP_TRY_ADD_R(pair, nodeMapBuilder);
+        A1C_MAP_TRY_ADD(pair, nodeMapBuilder);
         A1C_Item_string_refCStr(&pair->key, "featureIdx");
         A1C_Item_int64(&pair->val, (A1C_Int64)node->featureIdx);
     }
     {
-        A1C_MAP_TRY_ADD_R(pair, nodeMapBuilder);
+        A1C_MAP_TRY_ADD(pair, nodeMapBuilder);
         A1C_Item_string_refCStr(&pair->key, "value");
         A1C_Item_float64(&pair->val, node->value);
     }
     {
-        A1C_MAP_TRY_ADD_R(pair, nodeMapBuilder);
+        A1C_MAP_TRY_ADD(pair, nodeMapBuilder);
         A1C_Item_string_refCStr(&pair->key, "leftChildIdx");
         A1C_Item_int64(&pair->val, (A1C_Int64)node->leftChildIdx);
     }
     {
-        A1C_MAP_TRY_ADD_R(pair, nodeMapBuilder);
+        A1C_MAP_TRY_ADD(pair, nodeMapBuilder);
         A1C_Item_string_refCStr(&pair->key, "rightChildIdx");
         A1C_Item_int64(&pair->val, (A1C_Int64)node->rightChildIdx);
     }
     {
-        A1C_MAP_TRY_ADD_R(pair, nodeMapBuilder);
+        A1C_MAP_TRY_ADD(pair, nodeMapBuilder);
         A1C_Item_string_refCStr(&pair->key, "missingChildIdx");
         A1C_Item_int64(&pair->val, (A1C_Int64)node->missingChildIdx);
     }
@@ -135,12 +135,12 @@ static ZL_Report GBTModel_serializeTree(
     ZL_RESULT_DECLARE_SCOPE_REPORT(errCtx);
     A1C_MapBuilder treeMapBuilder = A1C_Item_map_builder(parent, 2, a1cArena);
     {
-        A1C_MAP_TRY_ADD_R(pair, treeMapBuilder);
+        A1C_MAP_TRY_ADD(pair, treeMapBuilder);
         A1C_Item_string_refCStr(&pair->key, "numNodes");
         A1C_Item_int64(&pair->val, (A1C_Int64)tree->numNodes);
     }
     {
-        A1C_MAP_TRY_ADD_R(pair, treeMapBuilder);
+        A1C_MAP_TRY_ADD(pair, treeMapBuilder);
         A1C_Item_string_refCStr(&pair->key, "nodes");
         A1C_Item* nodes = A1C_Item_array(&pair->val, tree->numNodes, a1cArena);
         ZL_ERR_IF_NULL(nodes, allocation);
@@ -161,12 +161,12 @@ static ZL_Report GBTModel_serializeForest(
     ZL_RESULT_DECLARE_SCOPE_REPORT(errCtx);
     A1C_MapBuilder forestMapBuilder = A1C_Item_map_builder(parent, 2, a1cArena);
     {
-        A1C_MAP_TRY_ADD_R(pair, forestMapBuilder);
+        A1C_MAP_TRY_ADD(pair, forestMapBuilder);
         A1C_Item_string_refCStr(&pair->key, "numTrees");
         A1C_Item_int64(&pair->val, (A1C_Int64)forest->numTrees);
     }
     {
-        A1C_MAP_TRY_ADD_R(pair, forestMapBuilder);
+        A1C_MAP_TRY_ADD(pair, forestMapBuilder);
         A1C_Item_string_refCStr(&pair->key, "trees");
         A1C_Item* trees =
                 A1C_Item_array(&pair->val, forest->numTrees, a1cArena);
@@ -189,12 +189,12 @@ static ZL_Report GBTModel_serializePredictor(
     A1C_MapBuilder predictorMapBuilder =
             A1C_Item_map_builder(parent, 2, a1cArena);
     {
-        A1C_MAP_TRY_ADD_R(pair, predictorMapBuilder);
+        A1C_MAP_TRY_ADD(pair, predictorMapBuilder);
         A1C_Item_string_refCStr(&pair->key, "numForests");
         A1C_Item_int64(&pair->val, (A1C_Int64)predictor->numForests);
     }
     {
-        A1C_MAP_TRY_ADD_R(pair, predictorMapBuilder);
+        A1C_MAP_TRY_ADD(pair, predictorMapBuilder);
         A1C_Item_string_refCStr(&pair->key, "forests");
         A1C_Item* forests =
                 A1C_Item_array(&pair->val, predictor->numForests, a1cArena);
@@ -232,7 +232,7 @@ static ZL_Report GBTModel_serialize(
 
     // Serialize predictor
     {
-        A1C_MAP_TRY_ADD_R(pair, rootMapBuilder);
+        A1C_MAP_TRY_ADD(pair, rootMapBuilder);
         A1C_Item_string_refCStr(&pair->key, "predictor");
         ZL_ERR_IF_ERR(GBTModel_serializePredictor(
                 errCtx, &pair->val, a1cArena, model->predictor));
@@ -242,28 +242,28 @@ static ZL_Report GBTModel_serialize(
         FeatureGenId fg = FeatureGen_getId(model->featureGenerator);
         ZL_ERR_IF_EQ(fg, FeatureGenId_Invalid, invalidName);
 
-        A1C_MAP_TRY_ADD_R(pair, rootMapBuilder);
+        A1C_MAP_TRY_ADD(pair, rootMapBuilder);
         A1C_Item_string_refCStr(&pair->key, "featureGenerator");
         A1C_Item_int64(&pair->val, (A1C_Int64)fg);
     }
 
     // Serialize nbSuccessors
     {
-        A1C_MAP_TRY_ADD_R(pair, rootMapBuilder);
+        A1C_MAP_TRY_ADD(pair, rootMapBuilder);
         A1C_Item_string_refCStr(&pair->key, "nbSuccessors");
         A1C_Item_int64(&pair->val, (A1C_Int64)model->nbSuccessors);
     }
 
     // Serialize nbFeatures
     {
-        A1C_MAP_TRY_ADD_R(pair, rootMapBuilder);
+        A1C_MAP_TRY_ADD(pair, rootMapBuilder);
         A1C_Item_string_refCStr(&pair->key, "nbFeatures");
         A1C_Item_int64(&pair->val, (A1C_Int64)model->nbFeatures);
     }
 
     // Serialize featureLabels array
     {
-        A1C_MAP_TRY_ADD_R(pair, rootMapBuilder);
+        A1C_MAP_TRY_ADD(pair, rootMapBuilder);
         A1C_Item_string_refCStr(&pair->key, "featureLabels");
         A1C_Item* labels =
                 A1C_Item_array(&pair->val, model->nbFeatures, a1cArena);
@@ -512,13 +512,13 @@ MLSelector_serializeMLSelectorConfig(
     // serialize model type
     A1C_MapBuilder rootMapBuilder = A1C_Item_map_builder(root, 2, arena);
     {
-        A1C_MAP_TRY_ADD_T(ZL_SerializedMLConfig, pair, rootMapBuilder);
+        A1C_MAP_TRY_ADD(pair, rootMapBuilder);
         A1C_Item_string_refCStr(&pair->key, "model");
         A1C_Item_int64(&pair->val, (A1C_Int64)config->model);
     }
     // Serialize predictor
     {
-        A1C_MAP_TRY_ADD_T(ZL_SerializedMLConfig, pair, rootMapBuilder);
+        A1C_MAP_TRY_ADD(pair, rootMapBuilder);
         A1C_Item_string_refCStr(&pair->key, "runtimeConfig");
         if (config->model == ZL_GBT) {
             ZL_ERR_IF_ERR(GBTModel_serialize(

--- a/src/openzl/decompress/gdparams.c
+++ b/src/openzl/decompress/gdparams.c
@@ -15,6 +15,7 @@ const GDParams GDParams_default = {
 ZL_Report
 GDParams_setParameter(GDParams* gdparams, ZL_DParam paramId, int value)
 {
+    ZL_RESULT_DECLARE_SCOPE_REPORT(NULL);
     ZL_ASSERT_NN(gdparams);
     switch (paramId) {
         case ZL_DParam_stickyParameters:
@@ -27,7 +28,7 @@ GDParams_setParameter(GDParams* gdparams, ZL_DParam paramId, int value)
             gdparams->checkContentChecksum = (ZL_TernaryParam)value;
             break;
         default:
-            ZL_RET_R_ERR(compressionParameter_invalid);
+            ZL_ERR(compressionParameter_invalid);
     }
     return ZL_returnSuccess();
 }

--- a/src/openzl/decompress/reflection.c
+++ b/src/openzl/decompress/reflection.c
@@ -116,8 +116,9 @@ void ZL_ReflectionCtx_registerMIDecoder(
 static ZL_Report
 copyStream(ZL_ReflectionCtx* rctx, const ZL_Data** dstPtr, const ZL_Data* src)
 {
+    ZL_RESULT_DECLARE_SCOPE_REPORT(rctx->dctx);
     ZL_Data* dst = STREAM_createInArena(rctx->arena, ZL_Data_id(src));
-    ZL_RET_R_IF_ERR(STREAM_copy(dst, src));
+    ZL_ERR_IF_ERR(STREAM_copy(dst, src));
     *dstPtr = dst;
     return ZL_returnSuccess();
 }
@@ -131,7 +132,7 @@ static ZL_Report fillStreamAndTransformInfo(
 {
     ZL_RESULT_DECLARE_SCOPE_REPORT(rctx->dctx);
     DFH_Struct const* dfh = DCtx_getFrameHeader(rctx->dctx);
-    ZL_RET_R_IF_NULL(GENERIC, dfh);
+    ZL_ERR_IF_NULL(dfh, GENERIC);
     const size_t nbStreams    = ZL_DCtx_getNumStreams(rctx->dctx);
     const size_t nbTransforms = dfh->nbDTransforms;
 
@@ -144,7 +145,7 @@ static ZL_Report fillStreamAndTransformInfo(
         info->index       = streamIdx;
         // Must copy out of the dctx, because the streams may reference the
         // source buffer.
-        ZL_RET_R_IF_ERR(copyStream(
+        ZL_ERR_IF_ERR(copyStream(
                 rctx,
                 &info->stream,
                 ZL_DCtx_getConstStream(rctx->dctx, (ZL_IDType)streamIdx)));
@@ -162,7 +163,8 @@ static ZL_Report fillStreamAndTransformInfo(
         // inputs  = regenerated streams of decoder
         const DFH_NodeInfo* node = &VECTOR_AT(dfh->nodes, transformIdx);
         const size_t nbInputs    = node->nbRegens;
-        ZL_TRY_LET_R(
+        ZL_TRY_LET(
+                size_t,
                 nbOutputs,
                 DCtx_getNbInputStreams(rctx->dctx, (ZL_IDType)transformIdx));
 
@@ -258,8 +260,9 @@ static ZL_Report fillExtraStreamInfo(
 static ZL_Report
 fillFrameInfo(ZL_ReflectionCtx* rctx, const void* src, size_t srcSize)
 {
+    ZL_RESULT_DECLARE_SCOPE_REPORT(rctx->dctx);
     DFH_Struct const* dfh = DCtx_getFrameHeader(rctx->dctx);
-    ZL_TRY_LET_R(frameHeaderSize, ZL_getHeaderSize(src, srcSize));
+    ZL_TRY_LET(size_t, frameHeaderSize, ZL_getHeaderSize(src, srcSize));
     rctx->frameFormatVersion       = dfh->formatVersion;
     rctx->frameHeaderSize          = frameHeaderSize;
     rctx->totalTransformHeaderSize = dfh->totalTHSize;
@@ -283,7 +286,7 @@ static ZL_Report ZL_ReflectionCtx_setCompressedFrame_impl(
     // Create the output stream storage in our arena.
     // We reference these streams, so they must live for the lifetime of the
     // ZL_ReflectionCtx.
-    ZL_TRY_LET_R(nbOutputs, ZL_FrameInfo_getNumOutputs(fi));
+    ZL_TRY_LET(size_t, nbOutputs, ZL_FrameInfo_getNumOutputs(fi));
     ALLOC_ARENA_CALLOC_CHECKED(
             ZL_TypedBuffer*, outputs, nbOutputs, rctx->arena);
     for (size_t i = 0; i < nbOutputs; ++i) {
@@ -293,12 +296,12 @@ static ZL_Report ZL_ReflectionCtx_setCompressedFrame_impl(
 
     // Run decompression
     DCTX_preserveStreams(rctx->dctx);
-    ZL_RET_R_IF_ERR(ZL_DCtx_decompressMultiTBuffer(
+    ZL_ERR_IF_ERR(ZL_DCtx_decompressMultiTBuffer(
             rctx->dctx, outputs, nbOutputs, src, srcSize));
 
-    ZL_RET_R_IF_ERR(fillFrameInfo(rctx, src, srcSize));
-    ZL_RET_R_IF_ERR(fillStreamAndTransformInfo(rctx, src));
-    ZL_RET_R_IF_ERR(fillExtraStreamInfo(rctx, nbOutputs));
+    ZL_ERR_IF_ERR(fillFrameInfo(rctx, src, srcSize));
+    ZL_ERR_IF_ERR(fillStreamAndTransformInfo(rctx, src));
+    ZL_ERR_IF_ERR(fillExtraStreamInfo(rctx, nbOutputs));
 
     return ZL_returnSuccess();
 }
@@ -308,13 +311,14 @@ ZL_Report ZL_ReflectionCtx_setCompressedFrame(
         void const* src,
         size_t srcSize)
 {
+    ZL_RESULT_DECLARE_SCOPE_REPORT(rctx->dctx);
     ZL_REQUIRE(
             !rctx->inputHasBeenSet,
             "Each reflection ctx can only be used for one input");
     rctx->inputHasBeenSet = true;
 
     ZL_FrameInfo* fi = ZL_FrameInfo_create(src, srcSize);
-    ZL_RET_R_IF_NULL(allocation, fi);
+    ZL_ERR_IF_NULL(fi, allocation);
     ZL_Report report =
             ZL_ReflectionCtx_setCompressedFrame_impl(rctx, fi, src, srcSize);
     ZL_FrameInfo_free(fi);

--- a/src/openzl/shared/clustering_common.c
+++ b/src/openzl/shared/clustering_common.c
@@ -6,16 +6,17 @@ ZL_Report ZL_ContextClustering_decode(
         ZL_ContextClustering* clustering,
         ZL_RC* src)
 {
+    ZL_RESULT_DECLARE_SCOPE_REPORT(NULL);
     //> Read the max symbol value
     if (ZL_RC_avail(src) < 1) {
-        ZL_RET_R_ERR(GENERIC);
+        ZL_ERR(GENERIC);
     }
     size_t const maxSymbol = ZL_RC_pop(src);
     clustering->maxSymbol  = maxSymbol;
 
     //> Read the contextToCluster map
     if (ZL_RC_avail(src) < maxSymbol + 1) {
-        ZL_RET_R_ERR(GENERIC);
+        ZL_ERR(GENERIC);
     }
     memcpy(clustering->contextToCluster, ZL_RC_ptr(src), maxSymbol + 1);
     ZL_RC_advance(src, maxSymbol + 1);

--- a/src/openzl/shared/clustering_compress.c
+++ b/src/openzl/shared/clustering_compress.c
@@ -12,9 +12,10 @@ ZL_Report ZL_ContextClustering_encode(
         ZL_WC* dst,
         ZL_ContextClustering const* clustering)
 {
+    ZL_RESULT_DECLARE_SCOPE_REPORT(NULL);
     size_t const size = 1 + clustering->maxSymbol + 1;
     if (ZL_WC_avail(dst) < size) {
-        ZL_RET_R_ERR(GENERIC);
+        ZL_ERR(GENERIC);
     }
 
     //> Write max symbol value
@@ -37,6 +38,7 @@ ZL_Report ZL_cluster(
         size_t maxClusters,
         ZL_ClusteringMode mode)
 {
+    ZL_RESULT_DECLARE_SCOPE_REPORT(NULL);
     switch (mode) {
         case ZL_ClusteringMode_identity:
             ZL_ContextClustering_identity(clustering, context);
@@ -50,10 +52,10 @@ ZL_Report ZL_cluster(
                     clustering, context, maxContext, maxClusters);
             break;
         default:
-            ZL_RET_R_ERR(GENERIC);
+            ZL_ERR(GENERIC);
     }
     if (clustering->numClusters > maxClusters)
-        ZL_RET_R_ERR(GENERIC);
+        ZL_ERR(GENERIC);
     return ZL_returnSuccess();
 }
 

--- a/src/openzl/shared/numeric_operations.c
+++ b/src/openzl/shared/numeric_operations.c
@@ -281,12 +281,13 @@ convertArray_2to4(uint32_t* dst32, const uint16_t* src16, size_t size)
 static ZL_Report
 convertArray_8to4(uint32_t* dst32, const uint64_t* src64, size_t size)
 {
+    ZL_RESULT_DECLARE_SCOPE_REPORT(NULL);
     for (size_t n = 0; n < size; n++) {
         // Note : need better overflow control
-        ZL_RET_R_IF_GE(
-                integerOverflow,
+        ZL_ERR_IF_GE(
                 src64[n],
                 (uint64_t)1 << 32,
+                integerOverflow,
                 "uint64_t value is too large for uint32_t");
         dst32[n] = (uint32_t)src64[n];
     }
@@ -299,6 +300,7 @@ ZL_Report NUMOP_write32_fromNumerics(
         const void* srcNum,
         size_t numWidth)
 {
+    ZL_RESULT_DECLARE_SCOPE_REPORT(NULL);
     if (!nbValues)
         return ZL_returnSuccess();
     ZL_ASSERT_NN(array);
@@ -315,7 +317,7 @@ ZL_Report NUMOP_write32_fromNumerics(
         case 8:
             return convertArray_8to4(array, (const uint64_t*)srcNum, nbValues);
         default:
-            ZL_RET_R_ERR(logicError, "only numeric width 1,2,4,8 are allowed");
+            ZL_ERR(logicError, "only numeric width 1,2,4,8 are allowed");
     }
 }
 

--- a/src/openzl/shared/varint.h
+++ b/src/openzl/shared/varint.h
@@ -125,6 +125,7 @@ ZL_RESULT_DECLARE_TYPE(uint64_t);
 ZL_INLINE ZL_RESULT_OF(uint64_t)
         ZL_varintDecode(const uint8_t** src, const uint8_t* end)
 {
+    ZL_RESULT_DECLARE_SCOPE(uint64_t, (ZL_OperationContext*)NULL);
     int8_t const* ptr  = (int8_t const*)*src;
     int8_t const* endi = (int8_t const*)end;
     uint64_t val       = 0;
@@ -181,7 +182,7 @@ ZL_INLINE ZL_RESULT_OF(uint64_t)
             if (b >= 0) {
                 break;
             }
-            ZL_RET_T_ERR(uint64_t, GENERIC);
+            ZL_ERR(GENERIC);
         } while (false);
     } else {
         int shift = 0;
@@ -190,12 +191,12 @@ ZL_INLINE ZL_RESULT_OF(uint64_t)
             shift += 7;
         }
         if (ptr == endi) {
-            ZL_RET_T_ERR(uint64_t, GENERIC);
+            ZL_ERR(GENERIC);
         }
         val |= (uint64_t)(*ptr++) << shift;
     }
     *src = (uint8_t const*)ptr;
-    return ZL_RESULT_WRAP_VALUE(uint64_t, val);
+    return ZL_WRAP_VALUE(val);
 }
 
 ZL_INLINE ZL_RESULT_OF(uint64_t) ZL_varintDecodeStrictImpl(
@@ -203,6 +204,7 @@ ZL_INLINE ZL_RESULT_OF(uint64_t) ZL_varintDecodeStrictImpl(
         const uint8_t* end,
         size_t kWidth)
 {
+    ZL_RESULT_DECLARE_SCOPE(uint64_t, (ZL_OperationContext*)NULL);
     int8_t const* ptr  = (int8_t const*)*src;
     int8_t const* endi = (int8_t const*)end;
     uint64_t val       = 0;
@@ -237,13 +239,12 @@ ZL_INLINE ZL_RESULT_OF(uint64_t) ZL_varintDecodeStrictImpl(
             val |= (uint64_t)(b & 0x7f) << 28;
             if (b >= 0) {
                 if (kWidth == 4 && (b & ~0xF) != 0) {
-                    ZL_RET_T_ERR(
-                            uint64_t, GENERIC, "Varint32 has too many bits!");
+                    ZL_ERR(GENERIC, "Varint32 has too many bits!");
                 }
                 break;
             }
             if (kWidth == 4) {
-                ZL_RET_T_ERR(uint64_t, GENERIC, "Varint32 has too many bytes!");
+                ZL_ERR(GENERIC, "Varint32 has too many bytes!");
             }
             b = *ptr++;
             val |= (uint64_t)(b & 0x7f) << 35;
@@ -269,17 +270,16 @@ ZL_INLINE ZL_RESULT_OF(uint64_t) ZL_varintDecodeStrictImpl(
             val |= (uint64_t)(b & 0x01) << 63;
             if (b >= 0) {
                 if ((b & ~0x01) != 0) {
-                    ZL_RET_T_ERR(
-                            uint64_t, GENERIC, "Varint64 has too many bits!");
+                    ZL_ERR(GENERIC, "Varint64 has too many bits!");
                 }
                 break;
             }
-            ZL_RET_T_ERR(uint64_t, GENERIC, "Varint64 has too many bytes!");
+            ZL_ERR(GENERIC, "Varint64 has too many bytes!");
         } while (false);
         // The last byte was zero means that the varint was encoded
         // inefficiently
         if (!zeroAllowed && b == 0x00) {
-            ZL_RET_T_ERR(uint64_t, GENERIC, "Varint has trailing 0x00 bytes");
+            ZL_ERR(GENERIC, "Varint has trailing 0x00 bytes");
         }
     } else {
         int iter = 0;
@@ -292,20 +292,20 @@ ZL_INLINE ZL_RESULT_OF(uint64_t) ZL_varintDecodeStrictImpl(
             ZL_ASSERT(!(kWidth == 8 && iter >= ZL_VARINT_LENGTH_64));
         }
         if (ptr == endi) {
-            ZL_RET_T_ERR(uint64_t, GENERIC, "Varint not finished!");
+            ZL_ERR(GENERIC, "Varint not finished!");
         }
         // Impossible because either the src is too small, or we would've
         // taken the other path.
         ZL_ASSERT(!(kWidth == 4 && iter >= ZL_VARINT_LENGTH_32 - 1));
         ZL_ASSERT(!(kWidth == 8 && iter >= ZL_VARINT_LENGTH_64 - 1));
         if (iter > 0 && *ptr == 0) {
-            ZL_RET_T_ERR(uint64_t, GENERIC, "Varint has trailing 0x00 bytes");
+            ZL_ERR(GENERIC, "Varint has trailing 0x00 bytes");
         }
 
         val |= (uint64_t)(*ptr++) << (iter * 7);
     }
     *src = (uint8_t const*)ptr;
-    return ZL_RESULT_WRAP_VALUE(uint64_t, val);
+    return ZL_WRAP_VALUE(val);
 }
 
 /**

--- a/tests/compress/test_gbt.cpp
+++ b/tests/compress/test_gbt.cpp
@@ -369,6 +369,7 @@ class GBTBinaryModelTest : public Test {
         auto featureGen_binaryModelTest = [](const ZL_Input* inputStream,
                                              VECTOR(LabeledFeature)
                                                      * features) -> ZL_Report {
+            ZL_RESULT_DECLARE_SCOPE_REPORT(nullptr);
             ZL_ASSERT(ZL_Input_type(inputStream) == ZL_Type_numeric);
 
             LabeledFeature meanFeature             = { "mean", 2.0f };
@@ -392,8 +393,7 @@ class GBTBinaryModelTest : public Test {
             badAlloc |= !VECTOR_PUSHBACK(*features, meanFeature);
             badAlloc |= !VECTOR_PUSHBACK(*features, varianceFeature);
 
-            ZL_RET_R_IF(
-                    allocation, badAlloc, "Failed to add features to vector");
+            ZL_ERR_IF(badAlloc, allocation, "Failed to add features to vector");
             return ZL_returnSuccess();
         };
 
@@ -488,6 +488,7 @@ class GBTMultiClassModelTest : public GBTMultiClassForestTest {
         auto featureGen_multiClassModelTest =
                 [](const ZL_Input* inputStream,
                    VECTOR(LabeledFeature) * features) -> ZL_Report {
+            ZL_RESULT_DECLARE_SCOPE_REPORT(nullptr);
             ZL_ASSERT(ZL_Input_type(inputStream) == ZL_Type_numeric);
 
             LabeledFeature meanFeature             = { "mean", 5.0f };
@@ -511,8 +512,7 @@ class GBTMultiClassModelTest : public GBTMultiClassForestTest {
             badAlloc |= !VECTOR_PUSHBACK(*features, meanFeature);
             badAlloc |= !VECTOR_PUSHBACK(*features, varianceFeature);
 
-            ZL_RET_R_IF(
-                    allocation, badAlloc, "Failed to add features to vector");
+            ZL_ERR_IF(badAlloc, allocation, "Failed to add features to vector");
             return ZL_returnSuccess();
         };
         model = { .predictor        = multiClassPredictor.get(),

--- a/tests/compress/test_zstrong_ml_core_models_generator.cpp
+++ b/tests/compress/test_zstrong_ml_core_models_generator.cpp
@@ -55,6 +55,7 @@ class ZstrongCoreBinaryMLTest : public Test {
             const ZL_Input* inputStream,
             VECTOR(LabeledFeature) * features)
     {
+        ZL_RESULT_DECLARE_SCOPE_REPORT(nullptr);
         ZL_ASSERT_EQ((int)ZL_Input_type(inputStream), (int)ZL_Type_numeric);
 
         ZL_ASSERT_EQ(ZL_Input_eltWidth(inputStream), 4);
@@ -67,7 +68,7 @@ class ZstrongCoreBinaryMLTest : public Test {
         badAlloc |= !VECTOR_PUSHBACK(*features, aFeature);
         badAlloc |= !VECTOR_PUSHBACK(*features, bFeature);
 
-        ZL_RET_R_IF(allocation, badAlloc, "Failed to add features to vector");
+        ZL_ERR_IF(badAlloc, allocation, "Failed to add features to vector");
         return ZL_returnSuccess();
     }
 
@@ -88,6 +89,7 @@ class ZstrongCoreMultiMLTest : public Test {
             const ZL_Input* inputStream,
             VECTOR(LabeledFeature) * features)
     {
+        ZL_RESULT_DECLARE_SCOPE_REPORT(nullptr);
         ZL_ASSERT_EQ((int)ZL_Input_type(inputStream), (int)ZL_Type_numeric);
 
         ZL_ASSERT_EQ(ZL_Input_eltWidth(inputStream), 4);
@@ -102,7 +104,7 @@ class ZstrongCoreMultiMLTest : public Test {
         badAlloc |= !VECTOR_PUSHBACK(*features, bFeature);
         badAlloc |= !VECTOR_PUSHBACK(*features, cFeature);
 
-        ZL_RET_R_IF(allocation, badAlloc, "Failed to add features to vector");
+        ZL_ERR_IF(badAlloc, allocation, "Failed to add features to vector");
         return ZL_returnSuccess();
     }
 

--- a/tests/datagen/structures/CompressorProducer.cpp
+++ b/tests/datagen/structures/CompressorProducer.cpp
@@ -296,8 +296,9 @@ std::vector<std::string> RandomCompressorMultiBuilder::register_split_node()
 {
     const auto name = make_unique_name("!tests.rand_graph.nodes.split.");
     const auto transform =
-            [](ZL_Encoder*, size_t[], const void*, size_t) noexcept {
-                ZL_RET_R_ERR(GENERIC, "Unimplemented! Can't actually run.");
+            [](ZL_Encoder* eictx, size_t[], const void*, size_t) noexcept {
+                ZL_RESULT_DECLARE_SCOPE_REPORT(eictx);
+                ZL_ERR(GENERIC, "Unimplemented! Can't actually run.");
             };
     const auto lp   = get_params();
     const auto desc = (ZL_SplitEncoderDesc){
@@ -321,8 +322,9 @@ std::vector<std::string> RandomCompressorMultiBuilder::register_typed_node(
         const TypeSpec ts)
 {
     const auto name      = make_unique_name("!tests.rand_graph.nodes.typed.");
-    const auto transform = [](ZL_Encoder*, const ZL_Input*) noexcept {
-        ZL_RET_R_ERR(GENERIC, "Unimplemented! Can't actually run.");
+    const auto transform = [](ZL_Encoder* eictx, const ZL_Input*) noexcept {
+        ZL_RESULT_DECLARE_SCOPE_REPORT(eictx);
+        ZL_ERR(GENERIC, "Unimplemented! Can't actually run.");
     };
     const auto lp        = get_params();
     const auto state_mgr = (ZL_CodecStateManager){
@@ -358,8 +360,9 @@ std::vector<std::string> RandomCompressorMultiBuilder::register_vo_node(
         const TypeSpec ts)
 {
     const auto name      = make_unique_name("!tests.rand_graph.nodes.vo.");
-    const auto transform = [](ZL_Encoder*, const ZL_Input*) noexcept {
-        ZL_RET_R_ERR(GENERIC, "Unimplemented! Can't actually run.");
+    const auto transform = [](ZL_Encoder* eictx, const ZL_Input*) noexcept {
+        ZL_RESULT_DECLARE_SCOPE_REPORT(eictx);
+        ZL_ERR(GENERIC, "Unimplemented! Can't actually run.");
     };
     const auto lp        = get_params();
     const auto state_mgr = (ZL_CodecStateManager){
@@ -396,10 +399,12 @@ std::vector<std::string> RandomCompressorMultiBuilder::register_vo_node(
 
 std::vector<std::string> RandomCompressorMultiBuilder::register_mi_node()
 {
-    const auto name      = make_unique_name("!tests.rand_graph.nodes.mi.");
-    const auto transform = [](ZL_Encoder*, const ZL_Input*[], size_t) noexcept {
-        ZL_RET_R_ERR(GENERIC, "Unimplemented! Can't actually run.");
-    };
+    const auto name = make_unique_name("!tests.rand_graph.nodes.mi.");
+    const auto transform =
+            [](ZL_Encoder* eictx, const ZL_Input*[], size_t) noexcept {
+                ZL_RESULT_DECLARE_SCOPE_REPORT(eictx);
+                ZL_ERR(GENERIC, "Unimplemented! Can't actually run.");
+            };
     const auto lp        = get_params();
     const auto state_mgr = (ZL_CodecStateManager){
         .stateAlloc      = NULL, // TODO?
@@ -782,8 +787,9 @@ std::vector<std::string> RandomCompressorMultiBuilder::make_multi_input_graph(
         size_t depth)
 {
     const auto name       = make_unique_name("!tests.rand_graph.graphs.multi.");
-    const auto graph_func = [](ZL_Graph*, ZL_Edge*[], size_t) noexcept {
-        ZL_RET_R_ERR(GENERIC, "Unimplemented! Can't actually run.");
+    const auto graph_func = [](ZL_Graph* gctx, ZL_Edge*[], size_t) noexcept {
+        ZL_RESULT_DECLARE_SCOPE_REPORT(gctx);
+        ZL_ERR(GENERIC, "Unimplemented! Can't actually run.");
     };
     const auto validate_func = [](const ZL_Compressor*,
                                   const ZL_FunctionGraphDesc*) noexcept {

--- a/tests/datagen/test_registry/CustomNodes.cpp
+++ b/tests/datagen/test_registry/CustomNodes.cpp
@@ -64,8 +64,9 @@ ZL_NodeID createCustomTokenizeNode(ZL_Compressor* cg)
 {
     auto tokenize = [](ZL_CustomTokenizeState* ctx,
                        ZL_Input const* input) -> ZL_Report {
+        ZL_RESULT_DECLARE_SCOPE_REPORT(nullptr);
         if (ZL_Input_eltWidth(input) != 4) {
-            ZL_RET_R_ERR(node_invalid_input);
+            ZL_ERR(node_invalid_input);
         }
 
         std::unordered_map<uint32_t, uint32_t> valueToIndex;
@@ -75,7 +76,7 @@ ZL_NodeID createCustomTokenizeNode(ZL_Compressor* cg)
         uint32_t* indices =
                 (uint32_t*)ZL_CustomTokenizeState_createIndexOutput(ctx, 4);
         if (indices == nullptr) {
-            ZL_RET_R_ERR(allocation);
+            ZL_ERR(allocation);
         }
 
         for (size_t i = 0; i < srcSize; ++i) {
@@ -87,7 +88,7 @@ ZL_NodeID createCustomTokenizeNode(ZL_Compressor* cg)
                 (uint32_t*)ZL_CustomTokenizeState_createAlphabetOutput(
                         ctx, valueToIndex.size());
         if (alphabet == nullptr) {
-            ZL_RET_R_ERR(allocation);
+            ZL_ERR(allocation);
         }
 
         for (auto [value, index] : valueToIndex) {

--- a/tests/integrationtest/CompressIntrospectionTest.cpp
+++ b/tests/integrationtest/CompressIntrospectionTest.cpp
@@ -252,6 +252,7 @@ TEST(CompressIntrospectionTest, EncoderSpecific)
     auto const encfn  = [](ZL_Encoder* eictx,
                           const ZL_Input* inputs[],
                           size_t) noexcept -> ZL_Report {
+        ZL_RESULT_DECLARE_SCOPE_REPORT(nullptr);
         auto so = ZL_Encoder_createTypedStream(
                 eictx,
                 0,

--- a/tests/integrationtest/GraphTest.cpp
+++ b/tests/integrationtest/GraphTest.cpp
@@ -254,7 +254,7 @@ TEST_F(GraphTest,
 
         // Run first encoder node without custom params (uses registered local
         // params)
-        ZL_TRY_LET_T(ZL_EdgeList, edges1, ZL_Edge_runNode(inputs[0], encNode));
+        ZL_TRY_LET(ZL_EdgeList, edges1, ZL_Edge_runNode(inputs[0], encNode));
         ZL_ERR_IF_NE(edges1.nbEdges, 1, GENERIC);
 
         // Get the opaque pointer which contains the params for the second call
@@ -284,7 +284,7 @@ TEST_F(GraphTest,
         };
 
         // Run second encoder node with custom params (override)
-        ZL_TRY_LET_T(
+        ZL_TRY_LET(
                 ZL_EdgeList,
                 edges2,
                 ZL_Edge_runNode_withParams(edges1.edges[0], encNode, &lp2));
@@ -809,7 +809,7 @@ TEST_F(GraphTest,
         ZL_ERR_IF_NULL(input, GENERIC);
 
         // Try the graph with runtime parameters
-        ZL_TRY_LET_T(
+        ZL_TRY_LET(
                 ZL_GraphPerformance,
                 perf,
                 ZL_Graph_tryGraph(graph, input, exfiltratingGraph, &rgp));

--- a/tests/unittest/common/test_errors.cpp
+++ b/tests/unittest/common/test_errors.cpp
@@ -45,6 +45,7 @@ TEST(ErrorsTest, errorCodeToString)
 
 TEST(ErrorsTest, errorCreation)
 {
+    ZL_RESULT_DECLARE_SCOPE_REPORT(nullptr);
     auto report = ZL_REPORT_ERROR(allocation, "fail! %d", 12345);
     ZL_E_print(ZL_RES_error(report));
     EXPECT_TRUE(ZL_isError(report));
@@ -58,6 +59,7 @@ TEST(ErrorsTest, errorCreation)
 
 TEST(ErrorsTest, requireChokeOnError)
 {
+    ZL_RESULT_DECLARE_SCOPE_REPORT(nullptr);
     auto report = ZL_REPORT_ERROR(allocation, "fail! %d", 12345);
     EXPECT_TRUE(ZL_isError(report));
     EXPECT_DEATH(ZL_REQUIRE_SUCCESS(report, "oops!"), "");
@@ -67,18 +69,19 @@ TEST(ErrorsTest, retIfs)
 {
     {
         auto f = [](int path) {
+            ZL_RESULT_DECLARE_SCOPE(Foo, nullptr);
             switch (path) {
                 case 0:
-                    ZL_RET_T_RES(Foo, ZL_RESULT_WRAP_VALUE(Foo, kFoo));
+                    return ZL_RESULT_WRAP_VALUE(Foo, kFoo);
                     break;
                 case 1:
-                    ZL_RET_T_ERR(Foo, GENERIC, "fail! %d", 1234);
+                    ZL_ERR(GENERIC, "fail! %d", 1234);
                     break;
                 case 2:
-                    ZL_RET_T_ERR(Foo, GENERIC, "fail!");
+                    ZL_ERR(GENERIC, "fail!");
                     break;
                 case 3:
-                    ZL_RET_T_ERR(Foo, GENERIC);
+                    ZL_ERR(GENERIC);
                     break;
                 default:
                     throw std::runtime_error("!");
@@ -91,9 +94,10 @@ TEST(ErrorsTest, retIfs)
     }
     {
         auto f = [](bool succeed) {
-            ZL_RET_T_IF(Foo, GENERIC, !succeed, "foo %d", 1234);
-            ZL_RET_T_IF(Foo, GENERIC, !succeed, "foo");
-            ZL_RET_T_IF(Foo, GENERIC, !succeed);
+            ZL_RESULT_DECLARE_SCOPE(Foo, nullptr);
+            ZL_ERR_IF(!succeed, GENERIC, "foo %d", 1234);
+            ZL_ERR_IF(!succeed, GENERIC, "foo");
+            ZL_ERR_IF(!succeed, GENERIC);
             return ZL_RESULT_WRAP_VALUE(Foo, kFoo);
         };
         EXPECT_FALSE(ZL_RES_isError(f(true)));
@@ -101,9 +105,10 @@ TEST(ErrorsTest, retIfs)
     }
     {
         auto f = [](bool succeed) {
-            ZL_RET_T_IF_NE(Foo, GENERIC, 1, 2 - (int)succeed, "foo %d", 1234);
-            ZL_RET_T_IF_NE(Foo, GENERIC, 1, 2 - (int)succeed, "foo");
-            ZL_RET_T_IF_NE(Foo, GENERIC, 1, 2 - (int)succeed);
+            ZL_RESULT_DECLARE_SCOPE(Foo, nullptr);
+            ZL_ERR_IF_NE(1, 2 - (int)succeed, GENERIC, "foo %d", 1234);
+            ZL_ERR_IF_NE(1, 2 - (int)succeed, GENERIC, "foo");
+            ZL_ERR_IF_NE(1, 2 - (int)succeed, GENERIC);
             return ZL_RESULT_WRAP_VALUE(Foo, kFoo);
         };
         EXPECT_FALSE(ZL_RES_isError(f(true)));
@@ -111,9 +116,10 @@ TEST(ErrorsTest, retIfs)
     }
     {
         auto f = [](bool succeed) {
-            ZL_RET_T_IF_EQ(Foo, GENERIC, 1, 1 + (int)succeed, "foo %d", 1234);
-            ZL_RET_T_IF_EQ(Foo, GENERIC, 1, 1 + (int)succeed, "foo");
-            ZL_RET_T_IF_EQ(Foo, GENERIC, 1, 1 + (int)succeed);
+            ZL_RESULT_DECLARE_SCOPE(Foo, nullptr);
+            ZL_ERR_IF_EQ(1, 1 + (int)succeed, GENERIC, "foo %d", 1234);
+            ZL_ERR_IF_EQ(1, 1 + (int)succeed, GENERIC, "foo");
+            ZL_ERR_IF_EQ(1, 1 + (int)succeed, GENERIC);
             return ZL_RESULT_WRAP_VALUE(Foo, kFoo);
         };
         EXPECT_FALSE(ZL_RES_isError(f(true)));
@@ -121,10 +127,10 @@ TEST(ErrorsTest, retIfs)
     }
     {
         auto f = [](bool succeed) {
-            ZL_RET_T_IF_GE(
-                    Foo, GENERIC, 2, 1 + (2 * (int)succeed), "foo %d", 1234);
-            ZL_RET_T_IF_GE(Foo, GENERIC, 2, 1 + (2 * (int)succeed), "foo");
-            ZL_RET_T_IF_GE(Foo, GENERIC, 2, 1 + (2 * (int)succeed));
+            ZL_RESULT_DECLARE_SCOPE(Foo, nullptr);
+            ZL_ERR_IF_GE(2, 1 + (2 * (int)succeed), GENERIC, "foo %d", 1234);
+            ZL_ERR_IF_GE(2, 1 + (2 * (int)succeed), GENERIC, "foo");
+            ZL_ERR_IF_GE(2, 1 + (2 * (int)succeed), GENERIC);
             return ZL_RESULT_WRAP_VALUE(Foo, kFoo);
         };
         EXPECT_FALSE(ZL_RES_isError(f(true)));
@@ -132,10 +138,10 @@ TEST(ErrorsTest, retIfs)
     }
     {
         auto f = [](bool succeed) {
-            ZL_RET_T_IF_LE(
-                    Foo, GENERIC, 1 + (2 * (int)succeed), 2, "foo %d", 1234);
-            ZL_RET_T_IF_LE(Foo, GENERIC, 1 + (2 * (int)succeed), 2, "foo");
-            ZL_RET_T_IF_LE(Foo, GENERIC, 1 + (2 * (int)succeed), 2);
+            ZL_RESULT_DECLARE_SCOPE(Foo, nullptr);
+            ZL_ERR_IF_LE(1 + (2 * (int)succeed), 2, GENERIC, "foo %d", 1234);
+            ZL_ERR_IF_LE(1 + (2 * (int)succeed), 2, GENERIC, "foo");
+            ZL_ERR_IF_LE(1 + (2 * (int)succeed), 2, GENERIC);
             return ZL_RESULT_WRAP_VALUE(Foo, kFoo);
         };
         EXPECT_FALSE(ZL_RES_isError(f(true)));
@@ -143,10 +149,10 @@ TEST(ErrorsTest, retIfs)
     }
     {
         auto f = [](bool succeed) {
-            ZL_RET_T_IF_GT(
-                    Foo, GENERIC, 2, 1 + (2 * (int)succeed), "foo %d", 1234);
-            ZL_RET_T_IF_GT(Foo, GENERIC, 2, 1 + (2 * (int)succeed), "foo");
-            ZL_RET_T_IF_GT(Foo, GENERIC, 2, 1 + (2 * (int)succeed));
+            ZL_RESULT_DECLARE_SCOPE(Foo, nullptr);
+            ZL_ERR_IF_GT(2, 1 + (2 * (int)succeed), GENERIC, "foo %d", 1234);
+            ZL_ERR_IF_GT(2, 1 + (2 * (int)succeed), GENERIC, "foo");
+            ZL_ERR_IF_GT(2, 1 + (2 * (int)succeed), GENERIC);
             return ZL_RESULT_WRAP_VALUE(Foo, kFoo);
         };
         EXPECT_FALSE(ZL_RES_isError(f(true)));
@@ -154,9 +160,10 @@ TEST(ErrorsTest, retIfs)
     }
     {
         auto f = [](bool succeed) {
-            ZL_RET_T_IF_AND(Foo, GENERIC, true, !succeed, "foo %d", 1234);
-            ZL_RET_T_IF_AND(Foo, GENERIC, true, !succeed, "foo");
-            ZL_RET_T_IF_AND(Foo, GENERIC, true, !succeed);
+            ZL_RESULT_DECLARE_SCOPE(Foo, nullptr);
+            ZL_ERR_IF_AND(true, !succeed, GENERIC, "foo %d", 1234);
+            ZL_ERR_IF_AND(true, !succeed, GENERIC, "foo");
+            ZL_ERR_IF_AND(true, !succeed, GENERIC);
             return ZL_RESULT_WRAP_VALUE(Foo, kFoo);
         };
         EXPECT_FALSE(ZL_RES_isError(f(true)));
@@ -164,9 +171,10 @@ TEST(ErrorsTest, retIfs)
     }
     {
         auto f = [](bool succeed) {
-            ZL_RET_T_IF_OR(Foo, GENERIC, false, !succeed, "foo %d", 1234);
-            ZL_RET_T_IF_OR(Foo, GENERIC, false, !succeed, "foo");
-            ZL_RET_T_IF_OR(Foo, GENERIC, false, !succeed);
+            ZL_RESULT_DECLARE_SCOPE(Foo, nullptr);
+            ZL_ERR_IF_OR(false, !succeed, GENERIC, "foo %d", 1234);
+            ZL_ERR_IF_OR(false, !succeed, GENERIC, "foo");
+            ZL_ERR_IF_OR(false, !succeed, GENERIC);
             return ZL_RESULT_WRAP_VALUE(Foo, kFoo);
         };
         EXPECT_FALSE(ZL_RES_isError(f(true)));
@@ -175,17 +183,17 @@ TEST(ErrorsTest, retIfs)
     {
         ZL_OperationContext opCtx{};
         ZL_OC_init(&opCtx);
-        ZL_ScopeContext ZL__scopeContext{ &opCtx, {} };
-        auto f = [&ZL__scopeContext](bool succeed) mutable {
+        auto f = [&](bool succeed) mutable {
+            ZL_RESULT_DECLARE_SCOPE(Foo, &opCtx);
             ZL_Report report;
             if (succeed) {
                 report = ZL_returnValue(1234);
             } else {
                 report = ZL_REPORT_ERROR(corruption, "foo %d", 1234);
             }
-            ZL_RET_T_IF_ERR(Foo, report, "bar %d", 5678);
-            ZL_RET_T_IF_ERR(Foo, report, "bar");
-            ZL_RET_T_IF_ERR(Foo, report);
+            ZL_ERR_IF_ERR(report, "bar %d", 5678);
+            ZL_ERR_IF_ERR(report, "bar");
+            ZL_ERR_IF_ERR(report);
             return ZL_RESULT_WRAP_VALUE(Foo, kFoo);
         };
         EXPECT_FALSE(ZL_RES_isError(f(true)));
@@ -200,10 +208,10 @@ TEST(ErrorsTest, retIfs)
     }
     {
         auto f = [](bool succeed) {
-            ZL_RET_T_IF_NULL(
-                    Foo, GENERIC, succeed ? "foo" : nullptr, "foo %d", 1234);
-            ZL_RET_T_IF_NULL(Foo, GENERIC, succeed ? "foo" : nullptr, "foo");
-            ZL_RET_T_IF_NULL(Foo, GENERIC, succeed ? "foo" : nullptr);
+            ZL_RESULT_DECLARE_SCOPE(Foo, nullptr);
+            ZL_ERR_IF_NULL(succeed ? "foo" : nullptr, GENERIC, "foo %d", 1234);
+            ZL_ERR_IF_NULL(succeed ? "foo" : nullptr, GENERIC, "foo");
+            ZL_ERR_IF_NULL(succeed ? "foo" : nullptr, GENERIC);
             return ZL_RESULT_WRAP_VALUE(Foo, kFoo);
         };
         EXPECT_FALSE(ZL_RES_isError(f(true)));
@@ -211,10 +219,10 @@ TEST(ErrorsTest, retIfs)
     }
     {
         auto f = [](bool succeed) {
-            ZL_RET_T_IF_NN(
-                    Foo, GENERIC, !succeed ? "foo" : nullptr, "foo %d", 1234);
-            ZL_RET_T_IF_NN(Foo, GENERIC, !succeed ? "foo" : nullptr, "foo");
-            ZL_RET_T_IF_NN(Foo, GENERIC, !succeed ? "foo" : nullptr);
+            ZL_RESULT_DECLARE_SCOPE(Foo, nullptr);
+            ZL_ERR_IF_NN(!succeed ? "foo" : nullptr, GENERIC, "foo %d", 1234);
+            ZL_ERR_IF_NN(!succeed ? "foo" : nullptr, GENERIC, "foo");
+            ZL_ERR_IF_NN(!succeed ? "foo" : nullptr, GENERIC);
             return ZL_RESULT_WRAP_VALUE(Foo, kFoo);
         };
         EXPECT_FALSE(ZL_RES_isError(f(true)));
@@ -229,20 +237,23 @@ TEST(ErrorsTest, errorForwardingTransportsSourceErrorInfo)
         ZL_OC_init(&opCtx);
 
         auto makeReportWithoutContext = []() {
+            ZL_RESULT_DECLARE_SCOPE_REPORT(nullptr);
             return ZL_REPORT_ERROR(corruption, "foo %d", 1234);
         };
         auto makeReportWithStContext = []() mutable {
-            ZL_RET_R_ERR(corruption, "foo %d", 1234);
+            ZL_RESULT_DECLARE_SCOPE_REPORT(nullptr);
+            ZL_ERR(corruption, "foo %d", 1234);
         };
         auto makeReportWithDyContext = [&opCtx]() mutable {
-            ZL_ScopeContext ZL__scopeContext{ &opCtx, {} };
+            ZL_RESULT_DECLARE_SCOPE_REPORT(&opCtx);
             return ZL_REPORT_ERROR(corruption, "foo %d", 1234);
         };
 
         auto addFrameWithoutContext =
                 [](auto result, std::string fmt, std::string msg) -> auto {
-            ZL_E_ADDFRAME(
-                    &ZL_RES_error(result),
+            ZL_RESULT_DECLARE_SCOPE_REPORT(nullptr);
+            ZL_RES_error(result) = ZL_E_ADDFRAME(
+                    ZL_RES_error(result),
                     ZL_EE_EMPTY,
                     fmt.c_str(),
                     msg.c_str());
@@ -250,9 +261,9 @@ TEST(ErrorsTest, errorForwardingTransportsSourceErrorInfo)
         };
         auto addFrameWithContext =
                 [&](auto result, std::string fmt, std::string msg) -> auto {
-            ZL_ScopeContext ZL__scopeContext{ &opCtx, {} };
-            ZL_E_ADDFRAME(
-                    &ZL_RES_error(result),
+            ZL_RESULT_DECLARE_SCOPE_REPORT(&opCtx);
+            ZL_RES_error(result) = ZL_E_ADDFRAME(
+                    ZL_RES_error(result),
                     ZL_EE_EMPTY,
                     fmt.c_str(),
                     msg.c_str());
@@ -260,16 +271,17 @@ TEST(ErrorsTest, errorForwardingTransportsSourceErrorInfo)
         };
 
         auto retIfErrWithoutContext = [](ZL_Report report) {
-            ZL_RET_R_IF_ERR(report, "bar %d", 5678);
-            ZL_RET_R_IF_ERR(report, "bar");
-            ZL_RET_R_IF_ERR(report);
+            ZL_RESULT_DECLARE_SCOPE_REPORT(nullptr);
+            ZL_ERR_IF_ERR(report, "bar %d", 5678);
+            ZL_ERR_IF_ERR(report, "bar");
+            ZL_ERR_IF_ERR(report);
             return ZL_returnValue(1234);
         };
         auto retIfErrWithContext = [&opCtx](ZL_Report report) mutable {
-            ZL_ScopeContext ZL__scopeContext{ &opCtx, {} };
-            ZL_RET_R_IF_ERR(report, "bar %d", 5678);
-            ZL_RET_R_IF_ERR(report, "bar");
-            ZL_RET_R_IF_ERR(report);
+            ZL_RESULT_DECLARE_SCOPE_REPORT(&opCtx);
+            ZL_ERR_IF_ERR(report, "bar %d", 5678);
+            ZL_ERR_IF_ERR(report, "bar");
+            ZL_ERR_IF_ERR(report);
             return ZL_returnValue(1234);
         };
 
@@ -569,7 +581,7 @@ TEST(ErrorsTest, ErrorInfoWorks)
     ZL_OperationContext opCtx{};
     ZL_OC_init(&opCtx);
     {
-        ZL_ScopeContext scopeCtx{ &opCtx, { .nodeID = { 5 } } };
+        ZL_ErrorContext scopeCtx{ &opCtx, { .nodeID = { 5 } } };
 
         // Create an error with a context
         auto error = ZL_E_create(
@@ -605,9 +617,9 @@ TEST(ErrorsTest, ErrorInfoWorks)
         scopeCtx.graphCtx.graphID.gid = 7;
         scopeCtx.graphCtx.transformID = 8;
 
-        ZL_E_addFrame(
+        error = ZL_E_addFrame(
                 &scopeCtx,
-                &error,
+                error,
                 {},
                 "MyFile2",
                 "MyFunc2",
@@ -685,9 +697,9 @@ TEST(ErrorsTest, ErrorInfoWorks)
         scopeCtx.graphCtx.graphID.gid = 0;
         scopeCtx.graphCtx.transformID = 0;
 
-        ZL_E_addFrame(
+        error = ZL_E_addFrame(
                 &scopeCtx,
-                &error,
+                error,
                 {},
                 "MyFile2",
                 "MyFile2",
@@ -717,19 +729,19 @@ TEST(ErrorsTest, ErrorInfoWorks)
         EXPECT_EQ(ZL_OC_numErrors(&opCtx), 0u);
 
         // Add a frame without a context
-        ZL_E_addFrame(
-                nullptr, &error, {}, "MyFile2", "MyFile2", 100, "MyFmtString2");
+        error = ZL_E_addFrame(
+                nullptr, error, {}, "MyFile2", "MyFile2", 100, "MyFmtString2");
 
         EXPECT_EQ(ZL_E_dy(error), nullptr);
         EXPECT_EQ(ZL_OC_numErrors(&opCtx), 0u);
 
         {
             // Add a frame with a context
-            ZL_ScopeContext scopeCtx{ &opCtx };
+            ZL_ErrorContext scopeCtx{ &opCtx };
 
-            // Add a frame without a context
-            ZL_E_addFrame(
-                    &scopeCtx, &error, {}, "MyFile3", "MyFile3", 300, "Fmt3");
+            // Add a frame with a context
+            error = ZL_E_addFrame(
+                    &scopeCtx, error, {}, "MyFile3", "MyFile3", 300, "Fmt3");
 
             EXPECT_NE(ZL_E_dy(error), nullptr);
             EXPECT_EQ(ZL_OC_numErrors(&opCtx), 1u);
@@ -744,7 +756,8 @@ TEST(ErrorsTest, ErrorInfoWorks)
         }
 
         // Add a frame without a context, but already in error
-        ZL_E_addFrame(nullptr, &error, {}, "MyFile4", "MyFile4", 400, "Fmt4");
+        error = ZL_E_addFrame(
+                nullptr, error, {}, "MyFile4", "MyFile4", 400, "Fmt4");
 
         EXPECT_NE(ZL_E_dy(error), nullptr);
         EXPECT_EQ(ZL_EE_code(error._info), ZL_ErrorCode_allocation);
@@ -789,10 +802,10 @@ static void testStaticErrorInfo(ZL_Error& e, const std::string& needle = "")
         ZL_OperationContext opCtx{};
         ZL_OC_init(&opCtx);
 
-        ZL_ScopeContext scopeCtx{ &opCtx, { .nodeID = { 5 } } };
+        ZL_ErrorContext scopeCtx{ &opCtx, { .nodeID = { 5 } } };
 
-        ZL_E_addFrame(
-                &scopeCtx, &e, {}, "MyFile", "MyFunc", 123, "MoarTxt %d", 1234);
+        e = ZL_E_addFrame(
+                &scopeCtx, e, {}, "MyFile", "MyFunc", 123, "MoarTxt %d", 1234);
 
         auto str = std::string(ZL_E_str(e));
         EXPECT_NE(str.find(needle), std::string::npos);
@@ -805,15 +818,16 @@ TEST(ErrorsTest, StaticErrorInfo)
 {
     {
         auto f = [](int path) {
+            ZL_RESULT_DECLARE_SCOPE(Foo, nullptr);
             switch (path) {
                 case 0:
-                    ZL_RET_T_ERR(Foo, corruption);
+                    ZL_ERR(corruption);
                     break;
                 case 1:
-                    ZL_RET_T_ERR(Foo, corruption, "BeepBeep!");
+                    ZL_ERR(corruption, "BeepBeep!");
                     break;
                 case 2:
-                    ZL_RET_T_ERR(Foo, corruption, "BeepBeep %d", 1234);
+                    ZL_ERR(corruption, "BeepBeep %d", 1234);
                     break;
                 default:
                     throw std::runtime_error("!");
@@ -829,7 +843,8 @@ TEST(ErrorsTest, StaticErrorInfo)
     }
     {
         auto f = [](bool succeed) {
-            ZL_RET_T_IF(Foo, corruption, !succeed, "BeepBeep!");
+            ZL_RESULT_DECLARE_SCOPE(Foo, nullptr);
+            ZL_ERR_IF(!succeed, corruption, "BeepBeep!");
             return ZL_RESULT_WRAP_VALUE(Foo, kFoo);
         };
 
@@ -840,20 +855,19 @@ TEST(ErrorsTest, StaticErrorInfo)
     }
     {
         auto f = [](int path) {
+            ZL_RESULT_DECLARE_SCOPE(Foo, nullptr);
             const auto condition_expression = true;
             switch (path) {
                 case 0:
-                    ZL_RET_T_IF(Foo, corruption, condition_expression);
+                    ZL_ERR_IF(condition_expression, corruption);
                     break;
                 case 1:
-                    ZL_RET_T_IF(
-                            Foo, corruption, condition_expression, "BeepBeep!");
+                    ZL_ERR_IF(condition_expression, corruption, "BeepBeep!");
                     break;
                 case 2:
-                    ZL_RET_T_IF(
-                            Foo,
-                            corruption,
+                    ZL_ERR_IF(
                             condition_expression,
+                            corruption,
                             "BeepBeep %d",
                             1234);
                     break;
@@ -871,18 +885,18 @@ TEST(ErrorsTest, StaticErrorInfo)
     }
     {
         auto f = [](int path) {
+            ZL_RESULT_DECLARE_SCOPE(Foo, nullptr);
             const auto val1 = 1;
             const auto val2 = 2;
             switch (path) {
                 case 0:
-                    ZL_RET_T_IF_NE(Foo, corruption, val1, val2);
+                    ZL_ERR_IF_NE(val1, val2, corruption);
                     break;
                 case 1:
-                    ZL_RET_T_IF_NE(Foo, corruption, val1, val2, "BeepBeep!");
+                    ZL_ERR_IF_NE(val1, val2, corruption, "BeepBeep!");
                     break;
                 case 2:
-                    ZL_RET_T_IF_NE(
-                            Foo, corruption, val1, val2, "BeepBeep %d", 1234);
+                    ZL_ERR_IF_NE(val1, val2, corruption, "BeepBeep %d", 1234);
                     break;
                 default:
                     throw std::runtime_error("!");
@@ -901,8 +915,9 @@ TEST(ErrorsTest, StaticErrorInfo)
 TEST(ErrorsTest, StaticInfoStringContainsPercentSymbol)
 {
     auto f = [](bool succeed) {
+        ZL_RESULT_DECLARE_SCOPE(Foo, nullptr);
         int x = !succeed;
-        ZL_RET_T_IF(Foo, corruption, x % 2);
+        ZL_ERR_IF(x % 2, corruption);
         return ZL_RESULT_WRAP_VALUE(Foo, kFoo);
     };
 
@@ -919,9 +934,9 @@ TEST(ErrorsTest, StaticInfoStringContainsPercentSymbol)
 
     ZL_OperationContext opCtx{};
     ZL_OC_init(&opCtx);
-    ZL_ScopeContext scopeCtx{ &opCtx, {} };
+    ZL_ErrorContext scopeCtx{ &opCtx, {} };
 
-    ZL_E_addFrame(&scopeCtx, &e, {}, "a", "b", 123, "c %d", 1234);
+    e = ZL_E_addFrame(&scopeCtx, e, {}, "a", "b", 123, "c %d", 1234);
 
     {
         auto str = std::string(ZL_E_str(e));
@@ -935,11 +950,11 @@ TEST(ErrorsTest, DynamicInfoStringContainsPercentSymbol)
 {
     ZL_OperationContext opCtx{};
     ZL_OC_init(&opCtx);
-    ZL_ScopeContext ZL__scopeContext{ &opCtx, {} };
 
     auto f = [&](bool succeed) mutable {
+        ZL_RESULT_DECLARE_SCOPE(Foo, &opCtx);
         int x = !succeed;
-        ZL_RET_T_IF(Foo, corruption, x % 2);
+        ZL_ERR_IF(x % 2, corruption);
         return ZL_RESULT_WRAP_VALUE(Foo, kFoo);
     };
 
@@ -959,12 +974,15 @@ TEST(ErrorsTest, CoerceInternalErrors)
 {
     ZL_OperationContext opCtx{};
     ZL_OC_init(&opCtx);
-    ZL_ScopeContext ZL__scopeContext{ &opCtx, {} };
 
-    auto f = [&]() mutable { ZL_RET_T_ERR(Foo, dstCapacity_tooSmall, "oops"); };
+    auto f = [&]() mutable {
+        ZL_RESULT_DECLARE_SCOPE(Foo, &opCtx);
+        ZL_ERR(dstCapacity_tooSmall, "oops");
+    };
 
     auto g = [&](ZL_RESULT_OF(Foo) & res) {
-        ZL_RET_T_IF_ERR_COERCE(Foo, res, "fail");
+        ZL_RESULT_DECLARE_SCOPE(Foo, &opCtx);
+        ZL_ERR_IF_ERR_COERCE(res, "fail");
         return res;
     };
 
@@ -986,7 +1004,10 @@ TEST(ErrorsTest, CoerceInternalErrors)
 
 TEST(ErrorsTest, LogicErrorGoesBoom)
 {
-    auto f = [&]() mutable { ZL_RET_T_ERR(Foo, logicError, "oops"); };
+    auto f = [&]() mutable {
+        ZL_RESULT_DECLARE_SCOPE(Foo, nullptr);
+        ZL_ERR(logicError, "oops");
+    };
     ZL_RESULT_OF(Foo) r;
 #if ZL_ENABLE_ASSERT
     ASSERT_DEATH({ r = f(); }, "oops");
@@ -1002,10 +1023,9 @@ TEST(ErrorsTest, BinaryTestArgTypesDeducedInC)
 
     ZL_OperationContext opCtx{};
     ZL_OC_init(&opCtx);
-    ZL_ScopeContext scopeCtx{ &opCtx, {} };
 
     ZL_Report report =
-            ZS2_test_errors_binary_arg_types_deduced_in_c_inner(scopeCtx);
+            ZS2_test_errors_binary_arg_types_deduced_in_c_inner(&opCtx);
     if (ZL_RES_isError(report)) {
         ZL_E_print(ZL_RES_error(report));
     }
@@ -1018,21 +1038,23 @@ TEST(ErrorsTest, BinaryTestArgTypesDeducedInC)
 TEST(ErrorsTest, TrySet)
 {
     const auto inner = [](bool succeed) -> ZL_RESULT_OF(Foo) {
-        ZL_RET_T_IF(Foo, GENERIC, !succeed);
+        ZL_RESULT_DECLARE_SCOPE(Foo, nullptr);
+        ZL_ERR_IF(!succeed, GENERIC);
         const Foo foo{
             .val = 1234,
         };
-        ZL_RET_T_VAL(Foo, foo);
+        return ZL_WRAP_VALUE(foo);
     };
 
     const auto outer = [&inner](bool succeed) -> ZL_RESULT_OF(Bar) {
+        ZL_RESULT_DECLARE_SCOPE(Bar, nullptr);
         Foo var;
-        ZL_TRY_SET_TT(Bar, Foo, var, inner(succeed));
+        ZL_TRY_SET(Foo, var, inner(succeed));
         EXPECT_TRUE(succeed);
         const Bar bar{
             .val = var.val,
         };
-        ZL_RET_T_VAL(Bar, bar);
+        return ZL_WRAP_VALUE(bar);
     };
 
     auto res = outer(false);
@@ -1046,21 +1068,23 @@ TEST(ErrorsTest, TrySet)
 TEST(ErrorsTest, TryLet)
 {
     const auto inner = [](bool succeed) -> ZL_RESULT_OF(Foo) {
-        ZL_RET_T_IF(Foo, GENERIC, !succeed);
+        ZL_RESULT_DECLARE_SCOPE(Foo, nullptr);
+        ZL_ERR_IF(!succeed, GENERIC);
         const Foo foo{
             .val = 1234,
         };
-        ZL_RET_T_VAL(Foo, foo);
+        return ZL_WRAP_VALUE(foo);
     };
 
     const auto outer = [&inner](bool succeed) -> ZL_RESULT_OF(Bar) {
-        ZL_TRY_LET_TT(Bar, Foo, var, inner(succeed));
+        ZL_RESULT_DECLARE_SCOPE(Bar, nullptr);
+        ZL_TRY_LET(Foo, var, inner(succeed));
         EXPECT_TRUE(succeed);
         var.val++;
         const Bar bar{
             .val = var.val,
         };
-        ZL_RET_T_VAL(Bar, bar);
+        return ZL_WRAP_VALUE(bar);
     };
 
     auto res = outer(false);
@@ -1074,20 +1098,22 @@ TEST(ErrorsTest, TryLet)
 TEST(ErrorsTest, TryLetConst)
 {
     const auto inner = [](bool succeed) -> ZL_RESULT_OF(Foo) {
-        ZL_RET_T_IF(Foo, GENERIC, !succeed);
+        ZL_RESULT_DECLARE_SCOPE(Foo, nullptr);
+        ZL_ERR_IF(!succeed, GENERIC);
         const Foo foo{
             .val = 1234,
         };
-        ZL_RET_T_VAL(Foo, foo);
+        return ZL_WRAP_VALUE(foo);
     };
 
     const auto outer = [&inner](bool succeed) -> ZL_RESULT_OF(Bar) {
-        ZL_TRY_LET_CONST_TT(Bar, Foo, var, inner(succeed));
+        ZL_RESULT_DECLARE_SCOPE(Bar, nullptr);
+        ZL_TRY_LET_CONST(Foo, var, inner(succeed));
         EXPECT_TRUE(succeed);
         const Bar bar{
             .val = var.val,
         };
-        ZL_RET_T_VAL(Bar, bar);
+        return ZL_WRAP_VALUE(bar);
     };
 
     auto res = outer(false);
@@ -1211,11 +1237,12 @@ TEST(ErrorsTest, EmptyDeclaredGetsDynInPassing)
 TEST(ErrorsTest, TrySetNew)
 {
     const auto inner = [](bool succeed) -> ZL_RESULT_OF(Foo) {
-        ZL_RET_T_IF(Foo, GENERIC, !succeed);
+        ZL_RESULT_DECLARE_SCOPE(Foo, nullptr);
+        ZL_ERR_IF(!succeed, GENERIC);
         const Foo foo{
             .val = 1234,
         };
-        ZL_RET_T_VAL(Foo, foo);
+        return ZL_WRAP_VALUE(foo);
     };
 
     const auto outer = [&inner](bool succeed) -> ZL_RESULT_OF(Bar) {
@@ -1240,11 +1267,12 @@ TEST(ErrorsTest, TrySetNew)
 TEST(ErrorsTest, TryLetNew)
 {
     const auto inner = [](bool succeed) -> ZL_RESULT_OF(Foo) {
-        ZL_RET_T_IF(Foo, GENERIC, !succeed);
+        ZL_RESULT_DECLARE_SCOPE(Foo, nullptr);
+        ZL_ERR_IF(!succeed, GENERIC);
         const Foo foo{
             .val = 1234,
         };
-        ZL_RET_T_VAL(Foo, foo);
+        return ZL_WRAP_VALUE(foo);
     };
 
     const auto outer = [&inner](bool succeed) -> ZL_RESULT_OF(Bar) {
@@ -1268,11 +1296,12 @@ TEST(ErrorsTest, TryLetNew)
 TEST(ErrorsTest, TryLetConstNew)
 {
     const auto inner = [](bool succeed) -> ZL_RESULT_OF(Foo) {
-        ZL_RET_T_IF(Foo, GENERIC, !succeed);
+        ZL_RESULT_DECLARE_SCOPE(Foo, nullptr);
+        ZL_ERR_IF(!succeed, GENERIC);
         const Foo foo{
             .val = 1234,
         };
-        ZL_RET_T_VAL(Foo, foo);
+        return ZL_WRAP_VALUE(foo);
     };
 
     const auto outer = [&inner](bool succeed) -> ZL_RESULT_OF(Bar) {

--- a/tests/unittest/common/test_errors_in_c.c
+++ b/tests/unittest/common/test_errors_in_c.c
@@ -13,36 +13,37 @@
 
 typedef enum { FOO, BAR } Foo;
 
-#define DEFINE_ERROR_MESSAGE_CONTAINS(type_name, type)              \
-    /* typename type type_name; */                                  \
-    static ZL_Report generate_error_message_##type_name(            \
-            ZL_ScopeContext ZL__scopeContext, type arg1, type arg2) \
-    {                                                               \
-        ZL_RET_R_IF_LT(GENERIC, arg1, arg2);                        \
-        return ZL_returnSuccess();                                  \
+#define DEFINE_ERROR_MESSAGE_CONTAINS(type_name, type)        \
+    /* typename type type_name; */                            \
+    static ZL_Report generate_error_message_##type_name(      \
+            ZL_OperationContext* opCtx, type arg1, type arg2) \
+    {                                                         \
+        ZL_RESULT_DECLARE_SCOPE_REPORT(opCtx);                \
+        ZL_ERR_IF_LT(arg1, arg2, GENERIC);                    \
+        return ZL_returnSuccess();                            \
     }
 
-#define EXPECT_ERROR_MESSAGE_CONTAINS(arg1, arg2, msg)                       \
-    do {                                                                     \
-        ZL_Report _report =                                                  \
-                generate_error_message_##arg1(ZL__scopeContext, arg1, arg2); \
-        ZL_RET_R_IF_NOT(                                                     \
-                GENERIC,                                                     \
-                ZL_RES_isError(_report),                                     \
-                "ZL_RET_R_IF_LT"                                             \
-                "(" #arg1 ", " #arg2 ") failed to fail.");                   \
-        ZL_E_ADDFRAME(&ZL_RES_error(_report), ZL_EE_EMPTY, "");              \
-        const char* _str = ZL_E_str(ZL_RES_error(_report));                  \
-        ZL_RET_R_IF_NULL(GENERIC, _str, "Error message is NULL!");           \
-        const char* _found = strstr(_str, msg);                              \
-        fprintf(stderr, "%s\n", _str);                                       \
-        fprintf(stderr, "%s\n", _found);                                     \
-        ZL_RET_R_IF_NULL(                                                    \
-                GENERIC,                                                     \
-                _found,                                                      \
-                "Message '%s' not found in error message '%s'",              \
-                msg,                                                         \
-                _str);                                                       \
+#define EXPECT_ERROR_MESSAGE_CONTAINS(arg1, arg2, msg)                        \
+    do {                                                                      \
+        ZL_Report _report = generate_error_message_##arg1(opCtx, arg1, arg2); \
+        ZL_ERR_IF_NOT(                                                        \
+                ZL_RES_isError(_report),                                      \
+                GENERIC,                                                      \
+                "ZL_ERR_IF_LT"                                                \
+                "(" #arg1 ", " #arg2 ") failed to fail.");                    \
+        ZL_RES_error(_report) =                                               \
+                ZL_E_ADDFRAME(ZL_RES_error(_report), ZL_EE_EMPTY, "");        \
+        const char* _str = ZL_E_str(ZL_RES_error(_report));                   \
+        ZL_ERR_IF_NULL(_str, GENERIC, "Error message is NULL!");              \
+        const char* _found = strstr(_str, msg);                               \
+        fprintf(stderr, "%s\n", _str);                                        \
+        fprintf(stderr, "%s\n", _found);                                      \
+        ZL_ERR_IF_NULL(                                                       \
+                _found,                                                       \
+                GENERIC,                                                      \
+                "Message '%s' not found in error message '%s'",               \
+                msg,                                                          \
+                _str);                                                        \
     } while (0)
 
 DEFINE_ERROR_MESSAGE_CONTAINS(c_1, char)
@@ -82,8 +83,10 @@ DEFINE_ERROR_MESSAGE_CONTAINS(pi_1, const int32_t*)
 DEFINE_ERROR_MESSAGE_CONTAINS(e_1, Foo)
 
 ZL_Report ZS2_test_errors_binary_arg_types_deduced_in_c_inner(
-        ZL_ScopeContext ZL__scopeContext)
+        ZL_OperationContext* opCtx)
 {
+    ZL_RESULT_DECLARE_SCOPE_REPORT(opCtx);
+
     const char c_1       = (char)1;
     const char c_2       = c_1 + 1;
     const short h_1      = c_1;
@@ -148,39 +151,39 @@ ZL_Report ZS2_test_errors_binary_arg_types_deduced_in_c_inner(
     const Foo e_1 = FOO;
     const Foo e_2 = BAR;
 
-    ZL_RET_R_IF_EQ(GENERIC, c_1, c_2);
-    ZL_RET_R_IF_EQ(GENERIC, h_1, h_2);
-    ZL_RET_R_IF_EQ(GENERIC, i_1, i_2);
-    ZL_RET_R_IF_EQ(GENERIC, l_1, l_2);
-    ZL_RET_R_IF_EQ(GENERIC, ll_1, ll_2);
+    ZL_ERR_IF_EQ(c_1, c_2, GENERIC);
+    ZL_ERR_IF_EQ(h_1, h_2, GENERIC);
+    ZL_ERR_IF_EQ(i_1, i_2, GENERIC);
+    ZL_ERR_IF_EQ(l_1, l_2, GENERIC);
+    ZL_ERR_IF_EQ(ll_1, ll_2, GENERIC);
 
-    ZL_RET_R_IF_EQ(GENERIC, sc_1, sc_2);
-    ZL_RET_R_IF_EQ(GENERIC, sh_1, sh_2);
-    ZL_RET_R_IF_EQ(GENERIC, si_1, si_2);
-    ZL_RET_R_IF_EQ(GENERIC, sl_1, sl_2);
-    ZL_RET_R_IF_EQ(GENERIC, sll_1, sll_2);
+    ZL_ERR_IF_EQ(sc_1, sc_2, GENERIC);
+    ZL_ERR_IF_EQ(sh_1, sh_2, GENERIC);
+    ZL_ERR_IF_EQ(si_1, si_2, GENERIC);
+    ZL_ERR_IF_EQ(sl_1, sl_2, GENERIC);
+    ZL_ERR_IF_EQ(sll_1, sll_2, GENERIC);
 
-    ZL_RET_R_IF_EQ(GENERIC, uc_1, uc_2);
-    ZL_RET_R_IF_EQ(GENERIC, uh_1, uh_2);
-    ZL_RET_R_IF_EQ(GENERIC, ui_1, ui_2);
-    ZL_RET_R_IF_EQ(GENERIC, ul_1, ul_2);
-    ZL_RET_R_IF_EQ(GENERIC, ull_1, ull_2);
+    ZL_ERR_IF_EQ(uc_1, uc_2, GENERIC);
+    ZL_ERR_IF_EQ(uh_1, uh_2, GENERIC);
+    ZL_ERR_IF_EQ(ui_1, ui_2, GENERIC);
+    ZL_ERR_IF_EQ(ul_1, ul_2, GENERIC);
+    ZL_ERR_IF_EQ(ull_1, ull_2, GENERIC);
 
-    ZL_RET_R_IF_EQ(GENERIC, i8_1, i8_2);
-    ZL_RET_R_IF_EQ(GENERIC, i16_1, i16_2);
-    ZL_RET_R_IF_EQ(GENERIC, i32_1, i32_2);
-    ZL_RET_R_IF_EQ(GENERIC, i64_1, i64_2);
+    ZL_ERR_IF_EQ(i8_1, i8_2, GENERIC);
+    ZL_ERR_IF_EQ(i16_1, i16_2, GENERIC);
+    ZL_ERR_IF_EQ(i32_1, i32_2, GENERIC);
+    ZL_ERR_IF_EQ(i64_1, i64_2, GENERIC);
 
-    ZL_RET_R_IF_EQ(GENERIC, u8_1, u8_2);
-    ZL_RET_R_IF_EQ(GENERIC, u16_1, u16_2);
-    ZL_RET_R_IF_EQ(GENERIC, u32_1, u32_2);
-    ZL_RET_R_IF_EQ(GENERIC, u64_1, u64_2);
+    ZL_ERR_IF_EQ(u8_1, u8_2, GENERIC);
+    ZL_ERR_IF_EQ(u16_1, u16_2, GENERIC);
+    ZL_ERR_IF_EQ(u32_1, u32_2, GENERIC);
+    ZL_ERR_IF_EQ(u64_1, u64_2, GENERIC);
 
-    ZL_RET_R_IF_GE(GENERIC, f_1, f_2);
-    ZL_RET_R_IF_GE(GENERIC, lf_1, lf_2);
-    ZL_RET_R_IF_GE(GENERIC, llf_1, llf_2);
+    ZL_ERR_IF_GE(f_1, f_2, GENERIC);
+    ZL_ERR_IF_GE(lf_1, lf_2, GENERIC);
+    ZL_ERR_IF_GE(llf_1, llf_2, GENERIC);
 
-    ZL_RET_R_IF_EQ(GENERIC, pi_1, pi_2);
+    ZL_ERR_IF_EQ(pi_1, pi_2, GENERIC);
 
     EXPECT_ERROR_MESSAGE_CONTAINS(c_1, c_2, "(int)"); // because promotion
     EXPECT_ERROR_MESSAGE_CONTAINS(h_1, h_2, "(int)"); // because promotion
@@ -226,22 +229,21 @@ ZL_Report ZS2_test_errors_binary_arg_types_deduced_in_c_inner(
     // - ARM64 may use either depending on ABI
     // Check for both possibilities explicitly
     {
-        ZL_Report _report =
-                generate_error_message_e_1(ZL__scopeContext, e_1, e_2);
-        ZL_RET_R_IF_NOT(
-                GENERIC,
+        ZL_Report _report = generate_error_message_e_1(opCtx, e_1, e_2);
+        ZL_ERR_IF_NOT(
                 ZL_RES_isError(_report),
-                "ZL_RET_R_IF_LT(e_1, e_2) failed to fail.");
-        ZL_E_ADDFRAME(&ZL_RES_error(_report), ZL_EE_EMPTY, "");
+                GENERIC,
+                "ZL_ERR_IF_LT(e_1, e_2) failed to fail.");
+        ZL_RES_error(_report) =
+                ZL_E_ADDFRAME(ZL_RES_error(_report), ZL_EE_EMPTY, "");
         const char* _str = ZL_E_str(ZL_RES_error(_report));
-        ZL_RET_R_IF_NULL(GENERIC, _str, "Error message is NULL!");
+        ZL_ERR_IF_NULL(_str, GENERIC, "Error message is NULL!");
         const char* _found_int  = strstr(_str, "(int)");
         const char* _found_uint = strstr(_str, "(unsigned int)");
         if (!_found_int && !_found_uint) {
-            ZL_RET_R_ERR(
-                    GENERIC,
-                    "Message '(int)' or '(unsigned int)' not found in error message '%s'",
-                    _str);
+            ZL_ERR(GENERIC,
+                   "Message '(int)' or '(unsigned int)' not found in error message '%s'",
+                   _str);
         }
     }
 

--- a/tests/unittest/common/test_errors_in_c.h
+++ b/tests/unittest/common/test_errors_in_c.h
@@ -2,13 +2,12 @@
 
 #pragma once
 
-#include "openzl/common/scope_context.h"
 #include "openzl/shared/portability.h"
 #include "openzl/zl_errors.h"
 
 ZL_BEGIN_C_DECLS
 
 ZL_Report ZS2_test_errors_binary_arg_types_deduced_in_c_inner(
-        ZL_ScopeContext scopeCtx);
+        ZL_OperationContext* opCtx);
 
 ZL_END_C_DECLS

--- a/tests/unittest/common/test_errors_public.cpp
+++ b/tests/unittest/common/test_errors_public.cpp
@@ -41,18 +41,19 @@ TEST(PublicErrorsTest, retIfs)
 {
     {
         auto f = [](int path) {
+            ZL_RESULT_DECLARE_SCOPE(Foo, nullptr);
             switch (path) {
                 case 0:
-                    ZL_RET_T_RES(Foo, ZL_RESULT_WRAP_VALUE(Foo, kFoo));
+                    return ZL_RESULT_WRAP_VALUE(Foo, kFoo);
                     break;
                 case 1:
-                    ZL_RET_T_ERR(Foo, GENERIC, "fail! %d", 1234);
+                    ZL_ERR(GENERIC, "fail! %d", 1234);
                     break;
                 case 2:
-                    ZL_RET_T_ERR(Foo, GENERIC, "fail!");
+                    ZL_ERR(GENERIC, "fail!");
                     break;
                 case 3:
-                    ZL_RET_T_ERR(Foo, GENERIC);
+                    ZL_ERR(GENERIC);
                     break;
                 default:
                     throw std::runtime_error("!");
@@ -65,9 +66,10 @@ TEST(PublicErrorsTest, retIfs)
     }
     {
         auto f = [](bool succeed) {
-            ZL_RET_T_IF(Foo, GENERIC, !succeed, "foo %d", 1234);
-            ZL_RET_T_IF(Foo, GENERIC, !succeed, "foo");
-            ZL_RET_T_IF(Foo, GENERIC, !succeed);
+            ZL_RESULT_DECLARE_SCOPE(Foo, nullptr);
+            ZL_ERR_IF(!succeed, GENERIC, "foo %d", 1234);
+            ZL_ERR_IF(!succeed, GENERIC, "foo");
+            ZL_ERR_IF(!succeed, GENERIC);
             return ZL_RESULT_WRAP_VALUE(Foo, kFoo);
         };
         EXPECT_FALSE(ZL_RES_isError(f(true)));
@@ -75,9 +77,10 @@ TEST(PublicErrorsTest, retIfs)
     }
     {
         auto f = [](bool succeed) {
-            ZL_RET_T_IF_NE(Foo, GENERIC, 1, 2 - (int)succeed, "foo %d", 1234);
-            ZL_RET_T_IF_NE(Foo, GENERIC, 1, 2 - (int)succeed, "foo");
-            ZL_RET_T_IF_NE(Foo, GENERIC, 1, 2 - (int)succeed);
+            ZL_RESULT_DECLARE_SCOPE(Foo, nullptr);
+            ZL_ERR_IF_NE(1, 2 - (int)succeed, GENERIC, "foo %d", 1234);
+            ZL_ERR_IF_NE(1, 2 - (int)succeed, GENERIC, "foo");
+            ZL_ERR_IF_NE(1, 2 - (int)succeed, GENERIC);
             return ZL_RESULT_WRAP_VALUE(Foo, kFoo);
         };
         EXPECT_FALSE(ZL_RES_isError(f(true)));
@@ -85,9 +88,10 @@ TEST(PublicErrorsTest, retIfs)
     }
     {
         auto f = [](bool succeed) {
-            ZL_RET_T_IF_EQ(Foo, GENERIC, 1, 1 + (int)succeed, "foo %d", 1234);
-            ZL_RET_T_IF_EQ(Foo, GENERIC, 1, 1 + (int)succeed, "foo");
-            ZL_RET_T_IF_EQ(Foo, GENERIC, 1, 1 + (int)succeed);
+            ZL_RESULT_DECLARE_SCOPE(Foo, nullptr);
+            ZL_ERR_IF_EQ(1, 1 + (int)succeed, GENERIC, "foo %d", 1234);
+            ZL_ERR_IF_EQ(1, 1 + (int)succeed, GENERIC, "foo");
+            ZL_ERR_IF_EQ(1, 1 + (int)succeed, GENERIC);
             return ZL_RESULT_WRAP_VALUE(Foo, kFoo);
         };
         EXPECT_FALSE(ZL_RES_isError(f(true)));
@@ -95,10 +99,10 @@ TEST(PublicErrorsTest, retIfs)
     }
     {
         auto f = [](bool succeed) {
-            ZL_RET_T_IF_GE(
-                    Foo, GENERIC, 2, 1 + (2 * (int)succeed), "foo %d", 1234);
-            ZL_RET_T_IF_GE(Foo, GENERIC, 2, 1 + (2 * (int)succeed), "foo");
-            ZL_RET_T_IF_GE(Foo, GENERIC, 2, 1 + (2 * (int)succeed));
+            ZL_RESULT_DECLARE_SCOPE(Foo, nullptr);
+            ZL_ERR_IF_GE(2, 1 + (2 * (int)succeed), GENERIC, "foo %d", 1234);
+            ZL_ERR_IF_GE(2, 1 + (2 * (int)succeed), GENERIC, "foo");
+            ZL_ERR_IF_GE(2, 1 + (2 * (int)succeed), GENERIC);
             return ZL_RESULT_WRAP_VALUE(Foo, kFoo);
         };
         EXPECT_FALSE(ZL_RES_isError(f(true)));
@@ -106,10 +110,10 @@ TEST(PublicErrorsTest, retIfs)
     }
     {
         auto f = [](bool succeed) {
-            ZL_RET_T_IF_LE(
-                    Foo, GENERIC, 1 + (2 * (int)succeed), 2, "foo %d", 1234);
-            ZL_RET_T_IF_LE(Foo, GENERIC, 1 + (2 * (int)succeed), 2, "foo");
-            ZL_RET_T_IF_LE(Foo, GENERIC, 1 + (2 * (int)succeed), 2);
+            ZL_RESULT_DECLARE_SCOPE(Foo, nullptr);
+            ZL_ERR_IF_LE(1 + (2 * (int)succeed), 2, GENERIC, "foo %d", 1234);
+            ZL_ERR_IF_LE(1 + (2 * (int)succeed), 2, GENERIC, "foo");
+            ZL_ERR_IF_LE(1 + (2 * (int)succeed), 2, GENERIC);
             return ZL_RESULT_WRAP_VALUE(Foo, kFoo);
         };
         EXPECT_FALSE(ZL_RES_isError(f(true)));
@@ -117,10 +121,10 @@ TEST(PublicErrorsTest, retIfs)
     }
     {
         auto f = [](bool succeed) {
-            ZL_RET_T_IF_GT(
-                    Foo, GENERIC, 2, 1 + (2 * (int)succeed), "foo %d", 1234);
-            ZL_RET_T_IF_GT(Foo, GENERIC, 2, 1 + (2 * (int)succeed), "foo");
-            ZL_RET_T_IF_GT(Foo, GENERIC, 2, 1 + (2 * (int)succeed));
+            ZL_RESULT_DECLARE_SCOPE(Foo, nullptr);
+            ZL_ERR_IF_GT(2, 1 + (2 * (int)succeed), GENERIC, "foo %d", 1234);
+            ZL_ERR_IF_GT(2, 1 + (2 * (int)succeed), GENERIC, "foo");
+            ZL_ERR_IF_GT(2, 1 + (2 * (int)succeed), GENERIC);
             return ZL_RESULT_WRAP_VALUE(Foo, kFoo);
         };
         EXPECT_FALSE(ZL_RES_isError(f(true)));
@@ -128,9 +132,10 @@ TEST(PublicErrorsTest, retIfs)
     }
     {
         auto f = [](bool succeed) {
-            ZL_RET_T_IF_AND(Foo, GENERIC, true, !succeed, "foo %d", 1234);
-            ZL_RET_T_IF_AND(Foo, GENERIC, true, !succeed, "foo");
-            ZL_RET_T_IF_AND(Foo, GENERIC, true, !succeed);
+            ZL_RESULT_DECLARE_SCOPE(Foo, nullptr);
+            ZL_ERR_IF_AND(true, !succeed, GENERIC, "foo %d", 1234);
+            ZL_ERR_IF_AND(true, !succeed, GENERIC, "foo");
+            ZL_ERR_IF_AND(true, !succeed, GENERIC);
             return ZL_RESULT_WRAP_VALUE(Foo, kFoo);
         };
         EXPECT_FALSE(ZL_RES_isError(f(true)));
@@ -138,9 +143,10 @@ TEST(PublicErrorsTest, retIfs)
     }
     {
         auto f = [](bool succeed) {
-            ZL_RET_T_IF_OR(Foo, GENERIC, false, !succeed, "foo %d", 1234);
-            ZL_RET_T_IF_OR(Foo, GENERIC, false, !succeed, "foo");
-            ZL_RET_T_IF_OR(Foo, GENERIC, false, !succeed);
+            ZL_RESULT_DECLARE_SCOPE(Foo, nullptr);
+            ZL_ERR_IF_OR(false, !succeed, GENERIC, "foo %d", 1234);
+            ZL_ERR_IF_OR(false, !succeed, GENERIC, "foo");
+            ZL_ERR_IF_OR(false, !succeed, GENERIC);
             return ZL_RESULT_WRAP_VALUE(Foo, kFoo);
         };
         EXPECT_FALSE(ZL_RES_isError(f(true)));
@@ -148,15 +154,16 @@ TEST(PublicErrorsTest, retIfs)
     }
     {
         auto f = [](bool succeed) {
+            ZL_RESULT_DECLARE_SCOPE(Foo, nullptr);
             ZL_Report report;
             if (succeed) {
                 report = ZL_returnValue(1234);
             } else {
                 report = ZL_REPORT_ERROR(corruption, "foo %d", 1234);
             }
-            ZL_RET_T_IF_ERR(Foo, report, "foo %d", 1234);
-            ZL_RET_T_IF_ERR(Foo, report, "foo");
-            ZL_RET_T_IF_ERR(Foo, report);
+            ZL_ERR_IF_ERR(report, "foo %d", 1234);
+            ZL_ERR_IF_ERR(report, "foo");
+            ZL_ERR_IF_ERR(report);
             return ZL_RESULT_WRAP_VALUE(Foo, kFoo);
         };
         EXPECT_FALSE(ZL_RES_isError(f(true)));
@@ -164,10 +171,10 @@ TEST(PublicErrorsTest, retIfs)
     }
     {
         auto f = [](bool succeed) {
-            ZL_RET_T_IF_NULL(
-                    Foo, GENERIC, succeed ? "foo" : nullptr, "foo %d", 1234);
-            ZL_RET_T_IF_NULL(Foo, GENERIC, succeed ? "foo" : nullptr, "foo");
-            ZL_RET_T_IF_NULL(Foo, GENERIC, succeed ? "foo" : nullptr);
+            ZL_RESULT_DECLARE_SCOPE(Foo, nullptr);
+            ZL_ERR_IF_NULL(succeed ? "foo" : nullptr, GENERIC, "foo %d", 1234);
+            ZL_ERR_IF_NULL(succeed ? "foo" : nullptr, GENERIC, "foo");
+            ZL_ERR_IF_NULL(succeed ? "foo" : nullptr, GENERIC);
             return ZL_RESULT_WRAP_VALUE(Foo, kFoo);
         };
         EXPECT_FALSE(ZL_RES_isError(f(true)));
@@ -175,10 +182,10 @@ TEST(PublicErrorsTest, retIfs)
     }
     {
         auto f = [](bool succeed) {
-            ZL_RET_T_IF_NN(
-                    Foo, GENERIC, !succeed ? "foo" : nullptr, "foo %d", 1234);
-            ZL_RET_T_IF_NN(Foo, GENERIC, !succeed ? "foo" : nullptr, "foo");
-            ZL_RET_T_IF_NN(Foo, GENERIC, !succeed ? "foo" : nullptr);
+            ZL_RESULT_DECLARE_SCOPE(Foo, nullptr);
+            ZL_ERR_IF_NN(!succeed ? "foo" : nullptr, GENERIC, "foo %d", 1234);
+            ZL_ERR_IF_NN(!succeed ? "foo" : nullptr, GENERIC, "foo");
+            ZL_ERR_IF_NN(!succeed ? "foo" : nullptr, GENERIC);
             return ZL_RESULT_WRAP_VALUE(Foo, kFoo);
         };
         EXPECT_FALSE(ZL_RES_isError(f(true)));

--- a/tests/unittest/common/test_operation_context.cpp
+++ b/tests/unittest/common/test_operation_context.cpp
@@ -206,8 +206,10 @@ TEST(OperationContextTest, Warnings)
 
     {
         // Coerce static info and convert into dynamic
-        auto e4 = ZL_RES_error(
-                []() { ZL_RET_R_ERR(corruption, "qwerty %d", 1234); }());
+        auto e4 = ZL_RES_error([]() {
+            ZL_RESULT_DECLARE_SCOPE_REPORT(nullptr);
+            ZL_ERR(corruption, "qwerty %d", 1234);
+        }());
 
         EXPECT_EQ(ZL_E_dy(e4), nullptr);
 

--- a/tests/unittest/compress/CompressorUnitTest.cpp
+++ b/tests/unittest/compress/CompressorUnitTest.cpp
@@ -1557,7 +1557,7 @@ TEST_F(CompressorTest, BaseGraphDynamic)
 {
     const auto name       = "!tests.graph.dyn.stub";
     const auto graph_func = [](ZL_Graph*, ZL_Edge*[], size_t) noexcept {
-        ZL_RET_R_ERR(GENERIC, "Unimplemented! Can't actually run.");
+        return ZL_REPORT_ERROR(GENERIC, "Unimplemented! Can't actually run.");
     };
     const auto validate_func = [](const ZL_Compressor*,
                                   const ZL_FunctionGraphDesc*) noexcept {
@@ -1630,7 +1630,7 @@ TEST_F(CompressorTest, CannotReplaceName)
         .name = "testParameterized",
     };
     const auto graph_func = [](ZL_Graph*, ZL_Edge*[], size_t) noexcept {
-        ZL_RET_R_ERR(GENERIC, "Unimplemented! Can't actually run.");
+        return ZL_REPORT_ERROR(GENERIC, "Unimplemented! Can't actually run.");
     };
     ZL_FunctionGraphDesc desc = {
         .name    = "testBase",
@@ -1652,7 +1652,7 @@ TEST_F(CompressorTest, CannotReplaceWhenGraphIsNotParameterized)
                        .nbCustomGraphs = 1,
     };
     const auto graph_func = [](ZL_Graph*, ZL_Edge*[], size_t) noexcept {
-        ZL_RET_R_ERR(GENERIC, "Unimplemented! Can't actually run.");
+        return ZL_REPORT_ERROR(GENERIC, "Unimplemented! Can't actually run.");
     };
     ZL_FunctionGraphDesc desc = {
         .name    = "testBase",
@@ -1675,7 +1675,7 @@ TEST_F(CompressorTest, CannotReplaceWhenGraphIsNotParameterized)
 TEST_F(CompressorTest, ReplaceGraphParamsOnlyWhenParamExists)
 {
     const auto graph_func = [](ZL_Graph*, ZL_Edge*[], size_t) noexcept {
-        ZL_RET_R_ERR(GENERIC, "Unimplemented! Can't actually run.");
+        return ZL_REPORT_ERROR(GENERIC, "Unimplemented! Can't actually run.");
     };
     ZL_GraphID customGraphs[1] = { ZL_GRAPH_ZSTD };
     ZL_NodeID customNodes[1]   = { ZL_NODE_ZIGZAG };

--- a/tests/unittest/compress/CompressorUnitTest.cpp
+++ b/tests/unittest/compress/CompressorUnitTest.cpp
@@ -1557,6 +1557,7 @@ TEST_F(CompressorTest, BaseGraphDynamic)
 {
     const auto name       = "!tests.graph.dyn.stub";
     const auto graph_func = [](ZL_Graph*, ZL_Edge*[], size_t) noexcept {
+        ZL_RESULT_DECLARE_SCOPE_REPORT(nullptr);
         return ZL_REPORT_ERROR(GENERIC, "Unimplemented! Can't actually run.");
     };
     const auto validate_func = [](const ZL_Compressor*,
@@ -1630,6 +1631,7 @@ TEST_F(CompressorTest, CannotReplaceName)
         .name = "testParameterized",
     };
     const auto graph_func = [](ZL_Graph*, ZL_Edge*[], size_t) noexcept {
+        ZL_RESULT_DECLARE_SCOPE_REPORT(nullptr);
         return ZL_REPORT_ERROR(GENERIC, "Unimplemented! Can't actually run.");
     };
     ZL_FunctionGraphDesc desc = {
@@ -1652,6 +1654,7 @@ TEST_F(CompressorTest, CannotReplaceWhenGraphIsNotParameterized)
                        .nbCustomGraphs = 1,
     };
     const auto graph_func = [](ZL_Graph*, ZL_Edge*[], size_t) noexcept {
+        ZL_RESULT_DECLARE_SCOPE_REPORT(nullptr);
         return ZL_REPORT_ERROR(GENERIC, "Unimplemented! Can't actually run.");
     };
     ZL_FunctionGraphDesc desc = {
@@ -1675,6 +1678,7 @@ TEST_F(CompressorTest, CannotReplaceWhenGraphIsNotParameterized)
 TEST_F(CompressorTest, ReplaceGraphParamsOnlyWhenParamExists)
 {
     const auto graph_func = [](ZL_Graph*, ZL_Edge*[], size_t) noexcept {
+        ZL_RESULT_DECLARE_SCOPE_REPORT(nullptr);
         return ZL_REPORT_ERROR(GENERIC, "Unimplemented! Can't actually run.");
     };
     ZL_GraphID customGraphs[1] = { ZL_GRAPH_ZSTD };

--- a/tests/zstrong/fuzz_compress_reuse.cpp
+++ b/tests/zstrong/fuzz_compress_reuse.cpp
@@ -29,13 +29,14 @@ constexpr ZL_TypedEncoderDesc kCTransform = {
     .gd = kGraphDesc,
     .transform_f =
             [](ZL_Encoder* eictx, ZL_Input const* in) noexcept {
+                ZL_RESULT_DECLARE_SCOPE_REPORT(eictx);
                 ZL_Output* out = ZL_Encoder_createTypedStream(
                         eictx, 0, ZL_Input_numElts(in), 1);
-                ZL_RET_R_IF_NULL(allocation, out);
+                ZL_ERR_IF_NULL(out, allocation);
                 memcpy(ZL_Output_ptr(out),
                        ZL_Input_ptr(in),
                        ZL_Input_numElts(in));
-                ZL_RET_R_IF_ERR(ZL_Output_commit(out, ZL_Input_numElts(in)));
+                ZL_ERR_IF_ERR(ZL_Output_commit(out, ZL_Input_numElts(in)));
                 return ZL_returnSuccess();
             },
 };
@@ -44,14 +45,14 @@ constexpr ZL_TypedDecoderDesc kDTransform = {
     .gd = kGraphDesc,
     .transform_f =
             [](ZL_Decoder* dictx, ZL_Input const* ins[]) noexcept {
+                ZL_RESULT_DECLARE_SCOPE_REPORT(dictx);
                 ZL_Output* out = ZL_Decoder_create1OutStream(
                         dictx, 0, ZL_Input_numElts(ins[0]));
-                ZL_RET_R_IF_NULL(allocation, out);
+                ZL_ERR_IF_NULL(out, allocation);
                 memcpy(ZL_Output_ptr(out),
                        ZL_Input_ptr(ins[0]),
                        ZL_Input_numElts(ins[0]));
-                ZL_RET_R_IF_ERR(
-                        ZL_Output_commit(out, ZL_Input_numElts(ins[0])));
+                ZL_ERR_IF_ERR(ZL_Output_commit(out, ZL_Input_numElts(ins[0])));
                 return ZL_returnSuccess();
             },
 };

--- a/tests/zstrong/fuzz_decompress_reuse.cpp
+++ b/tests/zstrong/fuzz_decompress_reuse.cpp
@@ -24,10 +24,11 @@ constexpr ZL_TypedDecoderDesc kTransform = {
         .nbOutStreams = kOutStreamTypes.size(),
     },
     .transform_f = [](ZL_Decoder* dictx, ZL_Input const* ins[]) noexcept {
+        ZL_RESULT_DECLARE_SCOPE_REPORT(dictx);
         ZL_Output* out = ZL_Decoder_create1OutStream(dictx, ZL_Input_numElts(ins[0]), 1);
-        ZL_RET_R_IF_NULL(allocation, out);
+        ZL_ERR_IF_NULL(out, allocation);
         memcpy(ZL_Output_ptr(out), ZL_Input_ptr(ins[0]), ZL_Input_numElts(ins[0]));
-        ZL_RET_R_IF_ERR(ZL_Output_commit(out, ZL_Input_numElts(ins[0])));
+        ZL_ERR_IF_ERR(ZL_Output_commit(out, ZL_Input_numElts(ins[0])));
         return ZL_returnSuccess();
     },
 };

--- a/tests/zstrong/test_fixed.cpp
+++ b/tests/zstrong/test_fixed.cpp
@@ -422,6 +422,7 @@ TEST_F(FixedTest, CustomTokenize4)
     int x         = 42;
     auto tokenize = [](ZL_CustomTokenizeState* ctx,
                        const ZL_Input* input) -> ZL_Report {
+        ZL_RESULT_DECLARE_SCOPE_REPORT(nullptr);
         EXPECT_EQ(
                 *(const int*)ZL_CustomTokenizeState_getOpaquePtr(ctx), int(42));
         EXPECT_EQ(ZL_Input_eltWidth(input), size_t(4));

--- a/tests/zstrong/test_graph_depth.cpp
+++ b/tests/zstrong/test_graph_depth.cpp
@@ -94,6 +94,7 @@ TEST_F(GraphDepthTest, FunctionGraphDepthAtRoot)
                 [](ZL_Graph* graph,
                    ZL_Edge* edges[],
                    size_t numEdges) noexcept {
+                    ZL_RESULT_DECLARE_SCOPE_REPORT(nullptr);
                     unsigned depth = ZL_Graph_getDepth(graph);
                     ZL_REQUIRE_EQ(depth, 1);
                     for (size_t i = 0; i < numEdges; ++i) {
@@ -120,6 +121,7 @@ TEST_F(GraphDepthTest, FunctionGraphDepthNested)
                 [](ZL_Graph* graph,
                    ZL_Edge* edges[],
                    size_t numEdges) noexcept {
+                    ZL_RESULT_DECLARE_SCOPE_REPORT(nullptr);
                     unsigned depth = ZL_Graph_getDepth(graph);
                     ZL_REQUIRE_EQ(depth, 2);
                     for (size_t i = 0; i < numEdges; ++i) {

--- a/tests/zstrong/test_opaque.cpp
+++ b/tests/zstrong/test_opaque.cpp
@@ -191,6 +191,7 @@ TEST_F(OpaqueTest, ValidFunctionGraph)
                 [](ZL_Graph* graph,
                    ZL_Edge* edges[],
                    size_t numEdges) noexcept {
+                    ZL_RESULT_DECLARE_SCOPE_REPORT(nullptr);
                     const char* opaque =
                             (const char*)ZL_Graph_getOpaquePtr(graph);
                     ZL_REQUIRE_NN(opaque);
@@ -222,6 +223,7 @@ TEST_F(OpaqueTest, InvalidFunctionGraph)
                 [](ZL_Graph* graph,
                    ZL_Edge* edges[],
                    size_t numEdges) noexcept {
+                    ZL_RESULT_DECLARE_SCOPE_REPORT(nullptr);
                     const char* opaque =
                             (const char*)ZL_Graph_getOpaquePtr(graph);
                     ZL_REQUIRE_NN(opaque);
@@ -258,6 +260,7 @@ static ZL_NodeID registerTypedEncoder(ZL_Compressor* compressor_)
         .gd = graphDesc,
         .transform_f =
                 [](ZL_Encoder* encoder, const ZL_Input* input) noexcept {
+                    ZL_RESULT_DECLARE_SCOPE_REPORT(nullptr);
                     const char* opaque =
                             (const char*)ZL_Encoder_getOpaquePtr(encoder);
                     ZL_REQUIRE_NN(opaque);
@@ -297,6 +300,7 @@ static void registerTypedDecoder(ZL_DCtx* dctx_)
         .gd = graphDesc,
         .transform_f =
                 [](ZL_Decoder* decoder, const ZL_Input* inputs[]) noexcept {
+                    ZL_RESULT_DECLARE_SCOPE_REPORT(nullptr);
                     const ZL_Input* input = inputs[0];
                     const char* opaque =
                             (const char*)ZL_Decoder_getOpaquePtr(decoder);
@@ -352,6 +356,7 @@ static void registerVODecoder(ZL_DCtx* dctx_)
                    size_t,
                    const ZL_Input* inputs[],
                    size_t numInputs) noexcept {
+                    ZL_RESULT_DECLARE_SCOPE_REPORT(nullptr);
                     const ZL_Input* input = inputs[0];
                     const char* opaque =
                             (const char*)ZL_Decoder_getOpaquePtr(decoder);
@@ -390,6 +395,7 @@ TEST_F(OpaqueTest, VariableOutputCodec)
         .gd = graphDesc,
         .transform_f =
                 [](ZL_Encoder* encoder, const ZL_Input* input) noexcept {
+                    ZL_RESULT_DECLARE_SCOPE_REPORT(nullptr);
                     const char* opaque =
                             (const char*)ZL_Encoder_getOpaquePtr(encoder);
                     ZL_REQUIRE_NN(opaque);
@@ -442,6 +448,7 @@ static void registerMIDecoder(ZL_DCtx* dctx_)
                    size_t numInputs,
                    const ZL_Input*[],
                    size_t) noexcept {
+                    ZL_RESULT_DECLARE_SCOPE_REPORT(nullptr);
                     const ZL_Input* input = inputs[0];
                     const char* opaque =
                             (const char*)ZL_Decoder_getOpaquePtr(decoder);
@@ -483,6 +490,7 @@ TEST_F(OpaqueTest, MultiInputCodec)
                 [](ZL_Encoder* encoder,
                    const ZL_Input* inputs[],
                    size_t numInputs) noexcept {
+                    ZL_RESULT_DECLARE_SCOPE_REPORT(nullptr);
                     const ZL_Input* input = inputs[0];
                     const char* opaque =
                             (const char*)ZL_Encoder_getOpaquePtr(encoder);

--- a/tests/zstrong/test_serialized.cpp
+++ b/tests/zstrong/test_serialized.cpp
@@ -314,6 +314,7 @@ ZL_Report splitOptimizationBackendGraph(
         size_t nbInputs,
         std::mt19937& gen)
 {
+    ZL_RESULT_DECLARE_SCOPE_REPORT(gctx);
     std::array<std::vector<ZL_Edge*>, 2> concats;
     std::uniform_int_distribution<size_t> destDist(0, 2);
     std::uniform_int_distribution<size_t> flushDist(0, 4);
@@ -326,29 +327,27 @@ ZL_Report splitOptimizationBackendGraph(
         if (ZL_Input_numElts(data) % 8 == 0) {
             std::uniform_int_distribution<size_t> convertDist(0, 2);
             if (convertDist(gen) == 0) {
-                ZL_TRY_LET_T(
+                ZL_TRY_LET(
                         ZL_EdgeList,
                         successors,
                         ZL_Edge_runNode(edge, ZL_NODE_INTERPRET_AS_LE64));
                 edge = successors.edges[0];
                 if (std::uniform_int_distribution<size_t>(0, 1)(gen) == 0) {
-                    ZL_RET_R_IF_ERR(
-                            ZL_Edge_setDestination(edge, ZL_GRAPH_STORE));
+                    ZL_ERR_IF_ERR(ZL_Edge_setDestination(edge, ZL_GRAPH_STORE));
                 } else {
-                    ZL_RET_R_IF_ERR(
-                            ZL_Edge_setDestination(edge, ZL_GRAPH_ZSTD));
+                    ZL_ERR_IF_ERR(ZL_Edge_setDestination(edge, ZL_GRAPH_ZSTD));
                 }
                 return ZL_returnSuccess();
             }
         }
         auto graph = graphs.graphids[graphDist(gen)];
-        ZL_RET_R_IF_ERR(ZL_Edge_setDestination(edge, graph));
+        ZL_ERR_IF_ERR(ZL_Edge_setDestination(edge, graph));
         return ZL_returnSuccess();
     };
 
     auto flush = [&](std::vector<ZL_Edge*>& concat) -> ZL_Report {
         if (!concat.empty()) {
-            ZL_TRY_LET_T(
+            ZL_TRY_LET(
                     ZL_EdgeList,
                     successors,
                     ZL_Edge_runMultiInputNode(
@@ -356,9 +355,9 @@ ZL_Report splitOptimizationBackendGraph(
                             concat.size(),
                             ZL_NODE_CONCAT_SERIAL));
             ZL_ASSERT_EQ(successors.nbEdges, 2);
-            ZL_RET_R_IF_ERR(ZL_Edge_setDestination(
+            ZL_ERR_IF_ERR(ZL_Edge_setDestination(
                     successors.edges[0], ZL_GRAPH_FIELD_LZ));
-            ZL_RET_R_IF_ERR(finish(successors.edges[1]));
+            ZL_ERR_IF_ERR(finish(successors.edges[1]));
         }
         concat.clear();
         return ZL_returnSuccess();
@@ -373,15 +372,15 @@ ZL_Report splitOptimizationBackendGraph(
             concats[dest].push_back(input);
 
             if (flushDist(gen) == 0) {
-                ZL_RET_R_IF_ERR(flush(concats[dest]));
+                ZL_ERR_IF_ERR(flush(concats[dest]));
             }
         } else {
-            ZL_RET_R_IF_ERR(finish(input));
+            ZL_ERR_IF_ERR(finish(input));
         }
     }
 
     for (auto& concat : concats) {
-        ZL_RET_R_IF_ERR(flush(concat));
+        ZL_ERR_IF_ERR(flush(concat));
     }
 
     return ZL_returnSuccess();
@@ -392,6 +391,7 @@ ZL_Report splitOptimizationGraph(
         ZL_Edge* inputs[],
         size_t nbInputs) noexcept
 {
+    ZL_RESULT_DECLARE_SCOPE_REPORT(gctx);
     const ZL_IntParam seed = ZL_Graph_getLocalIntParam(gctx, 0);
     std::mt19937 gen(seed.paramValue);
 
@@ -411,7 +411,7 @@ ZL_Report splitOptimizationGraph(
                 segmentSizes.push_back(segmentDist(gen));
                 remaining -= segmentSizes.back();
             }
-            ZL_TRY_LET_T(
+            ZL_TRY_LET(
                     ZL_EdgeList,
                     splitSuccessors,
                     ZL_Edge_runSplitNode(

--- a/tests/zstrong/test_zstrong_selector.cpp
+++ b/tests/zstrong/test_zstrong_selector.cpp
@@ -239,13 +239,14 @@ TEST_F(SelectorTest, TestSetSuccessorParams)
     const auto successorDgFn = [](ZL_Graph* gctx,
                                   ZL_Edge* inputs[],
                                   size_t nbIns) noexcept -> ZL_Report {
+        ZL_RESULT_DECLARE_SCOPE_REPORT(gctx);
         // verify passed params
         const auto p1 = ZL_Graph_getLocalIntParam(gctx, 1);
-        ZL_RET_R_IF_NE(GENERIC, p1.paramValue, 2);
+        ZL_ERR_IF_NE(p1.paramValue, 2, GENERIC);
         const auto p2 = ZL_Graph_getLocalIntParam(gctx, 2);
-        ZL_RET_R_IF_NE(GENERIC, p2.paramValue, 4);
+        ZL_ERR_IF_NE(p2.paramValue, 4, GENERIC);
         const auto p3 = ZL_Graph_getLocalIntParam(gctx, 3);
-        ZL_RET_R_IF_NE(GENERIC, p3.paramValue, 6);
+        ZL_ERR_IF_NE(p3.paramValue, 6, GENERIC);
         const auto p4 = ZL_Graph_getLocalRefParam(gctx, 4);
         if (std::string((const char*)p4.paramRef, 4) != std::string("I am")) {
             return ZL_returnError(ZL_ErrorCode_GENERIC);
@@ -254,7 +255,7 @@ TEST_F(SelectorTest, TestSetSuccessorParams)
         if (std::string((const char*)p5.paramRef, 4) != std::string(" the")) {
             return ZL_returnError(ZL_ErrorCode_GENERIC);
         }
-        ZL_RET_R_IF(graph_invalidNumInputs, nbIns != 1);
+        ZL_ERR_IF(nbIns != 1, graph_invalidNumInputs);
         ZL_Edge* input = inputs[0];
         ZL_REQUIRE_SUCCESS(ZL_Edge_setDestination(input, ZL_GRAPH_STORE));
         return ZL_returnSuccess();

--- a/tools/zstrong_cpp.cpp
+++ b/tools/zstrong_cpp.cpp
@@ -1011,9 +1011,10 @@ ZL_Report CustomTransform::encode(ZL_Encoder* eictx, ZL_Input const* input)
     return encode(eictx, &input, 1);
 }
 
-ZL_Report CustomTransform::decode(ZL_Decoder*, ZL_Input const*[]) const
+ZL_Report CustomTransform::decode(ZL_Decoder* dictx, ZL_Input const*[]) const
 {
-    ZL_RET_R_ERR(logicError);
+    ZL_RESULT_DECLARE_SCOPE_REPORT(dictx);
+    ZL_ERR(logicError);
 }
 
 ZL_Report CustomTransform::decode(


### PR DESCRIPTION
Summary:
This diff migrates `test_errors*` files, and to make tests pass has to cleanup and fix the `ZL_ERR_*` macros:

* Remove `ZL_E_ADDFRAME_PUBLIC` and move `ZL_E_ADDFRAME` to the public header while making it use `ZL__errorContext` rather than `ZL_GET_SCOPE_CONTEXT()`
* Update `ZL_ERR_IF_ERR_IMPL` to add static error info
* Update `ZL_E_addFrame_va` to handle the case where `scopeCtx != NULL && scopeCtx->opCtx == NULL`
* Update `ZL_E_CODE_INNER` to use `ZL__errorContext` rather than `ZL_GET_SCOPE_CONTEXT()`
* Remove `ZL_E_ADDFRAME` from `ZL_ASSERTION_SUCCESS_IMPL` so we don't require a error context for `ZL_REQUIRE_SUCCESS()` and `ZL_ASSERT_SUCCESS()`
* Fix callsites (all minor)

Reviewed By: felixhandte

Differential Revision: D98318703
