### PR TITLE
truncate stream preview size (#581)

### DIFF
--- a/cpp/src/openzl/cpp/experimental/trace/ChunkTraceCore.cpp
+++ b/cpp/src/openzl/cpp/experimental/trace/ChunkTraceCore.cpp
@@ -12,36 +12,45 @@ namespace openzl::visualizer {
 
 namespace {
 
+// Preview limits: save only enough data for the frontend to display ~4 lines.
+static constexpr size_t MAX_PREVIEW_BYTES         = 32;
+static constexpr size_t MAX_PREVIEW_NUMERIC_ELTS  = 100;
+static constexpr size_t MAX_PREVIEW_STRINGS_LINES = 4;
+
+static int64_t readNumericData(size_t eltWidth, const uint8_t* bytes, size_t i)
+{
+    int64_t val = 0;
+    switch (eltWidth) {
+        case 1:
+            val = reinterpret_cast<const int8_t*>(bytes)[i];
+            break;
+        case 2:
+            val = reinterpret_cast<const int16_t*>(bytes)[i];
+            break;
+        case 4:
+            val = reinterpret_cast<const int32_t*>(bytes)[i];
+            break;
+        case 8:
+            val = reinterpret_cast<const int64_t*>(bytes)[i];
+            break;
+        default:
+            throw std::runtime_error("Unexpected numeric eltWidth!");
+    }
+    return val;
+}
 std::vector<int64_t>
 getNumericData(const void* data, size_t eltWidth, size_t numElts)
 {
     if (data == nullptr || numElts == 0) {
         return {};
     }
-
+    const auto* bytes        = reinterpret_cast<const uint8_t*>(data);
+    const size_t previewElts = std::min(numElts, MAX_PREVIEW_NUMERIC_ELTS);
     std::vector<int64_t> numericData;
-    numericData.reserve(numElts);
+    numericData.reserve(previewElts);
 
-    const auto* bytes = reinterpret_cast<const uint8_t*>(data);
-    for (size_t i = 0; i < numElts; ++i) {
-        int64_t val = 0;
-        switch (eltWidth) {
-            case 1:
-                val = reinterpret_cast<const int8_t*>(bytes)[i];
-                break;
-            case 2:
-                val = reinterpret_cast<const int16_t*>(bytes)[i];
-                break;
-            case 4:
-                val = reinterpret_cast<const int32_t*>(bytes)[i];
-                break;
-            case 8:
-                val = reinterpret_cast<const int64_t*>(bytes)[i];
-                break;
-            default:
-                throw std::runtime_error("Unexpected numeric eltWidth!");
-        }
-        numericData.push_back(val);
+    for (size_t i = 0; i < previewElts; ++i) {
+        numericData.push_back(readNumericData(eltWidth, bytes, i));
     }
 
     return numericData;
@@ -60,7 +69,9 @@ getStringData(const void* data, size_t numStrings, const uint32_t* stringLens)
     const auto* bytes = reinterpret_cast<const char*>(data);
     size_t offset     = 0;
 
-    for (size_t i = 0; i < numStrings; ++i) {
+    const size_t previewStrings =
+            std::min(numStrings, MAX_PREVIEW_STRINGS_LINES);
+    for (size_t i = 0; i < previewStrings; ++i) {
         uint32_t len          = stringLens[i];
         std::string rawStr    = std::string(bytes + offset, len);
         std::string parsedStr = "";
@@ -100,9 +111,10 @@ std::vector<uint8_t> getSerialData(const void* data, size_t numBytes)
         return {};
     }
 
+    const size_t previewBytes = std::min(numBytes, MAX_PREVIEW_BYTES);
     std::vector<uint8_t> bytes;
     const auto* rawBytes = reinterpret_cast<const uint8_t*>(data);
-    bytes.assign(rawBytes, rawBytes + numBytes);
+    bytes.assign(rawBytes, rawBytes + previewBytes);
 
     return bytes;
 }

--- a/cpp/tests/experimental/trace/StreamdumpTest.cpp
+++ b/cpp/tests/experimental/trace/StreamdumpTest.cpp
@@ -63,26 +63,54 @@ static ZL_GraphID registerNumericChunkSegmenter(
     return ZL_Compressor_registerSegmenter(compressor, &numericChunkSegmenter);
 }
 
-TEST(StreamdumpTest, VerifyStreamdump)
-{
+class StreamdumpTest : public ::testing::Test {
+   protected:
+    void SetUp() override
+    {
+        compressor.setParameter(CParam::FormatVersion, ZL_MAX_FORMAT_VERSION);
+        compressor.selectStartingGraph(ZL_GRAPH_COMPRESS_GENERIC);
+    }
+
+    void generateAndCompressData(size_t sz = 1000, bool force_size = false)
+    {
+        auto dg = openzl::tests::datagen::DataGen();
+        data    = dg.template randVector<int64_t>("randVec", 0, 100, sz);
+        if (force_size) {
+            data.resize(sz);
+        }
+        auto input =
+                Input::refNumeric(data.data(), sizeof(int64_t), data.size());
+
+        compressData(input);
+    }
+
+    void compressData(Input& input)
+    {
+        cctx.refCompressor(compressor);
+        cctx.writeTraces(true, true);
+
+        auto compressed  = cctx.compressOne(input);
+        auto traceResult = cctx.getLatestTrace();
+
+        trace      = traceResult.first;
+        streamdump = traceResult.second;
+
+        EXPECT_FALSE(trace.empty());
+        EXPECT_FALSE(streamdump.empty());
+    }
+
+    std::string trace;
+    std::map<std::string, std::pair<poly::string_view, poly::string_view>>
+            streamdump;
+    std::vector<int64_t> data;
+
     Compressor compressor;
-    compressor.setParameter(CParam::FormatVersion, ZL_MAX_FORMAT_VERSION);
-    compressor.selectStartingGraph(ZL_GRAPH_COMPRESS_GENERIC);
-
-    auto dg         = openzl::tests::datagen::DataGen();
-    const auto data = dg.template randVector<int64_t>("randVec", 0, 100, 1000);
-
-    auto input = Input::refNumeric(data.data(), sizeof(int64_t), data.size());
     CCtx cctx;
-    cctx.refCompressor(compressor);
-    cctx.writeTraces(true);
+};
 
-    auto compressed = cctx.compressOne(input);
-
-    auto traceResult = cctx.getLatestTrace();
-    auto trace       = traceResult.first;
-    auto streamdump  = traceResult.second;
-
+TEST_F(StreamdumpTest, VerifyStreamdump)
+{
+    generateAndCompressData();
     EXPECT_FALSE(trace.empty());
     EXPECT_FALSE(streamdump.empty());
 
@@ -93,31 +121,11 @@ TEST(StreamdumpTest, VerifyStreamdump)
     }
 }
 
-TEST(StreamdumpTest, VerifyMultiChunkStreamdump)
+TEST_F(StreamdumpTest, VerifyMultiChunkStreamdump)
 {
-    Compressor compressor;
     ZL_GraphID segmenterId = registerNumericChunkSegmenter(compressor.get());
     compressor.selectStartingGraph(segmenterId);
-
-    auto dg   = openzl::tests::datagen::DataGen();
-    auto data = dg.template randVector<int64_t>("randVec", 0, 100, 1000);
-    data.resize(1000); // make sure we have 1000 elements to verify number
-                       // of chunks
-
-    auto input = Input::refNumeric(data.data(), sizeof(int64_t), data.size());
-    CCtx cctx;
-    cctx.refCompressor(compressor);
-    cctx.writeTraces(true);
-
-    auto compressed = cctx.compressOne(input);
-
-    auto traceResult = cctx.getLatestTrace();
-    auto trace       = traceResult.first;
-    auto streamdump  = traceResult.second;
-
-    EXPECT_FALSE(trace.empty());
-    EXPECT_FALSE(streamdump.empty());
-
+    generateAndCompressData(1000, true);
     int chunkSize = SMALL_CHUNK_SIZE / sizeof(int64_t);
     int numDataChunks =
             (data.size() + chunkSize - 1) / chunkSize; // ceiling division
@@ -151,5 +159,18 @@ TEST(StreamdumpTest, VerifyMultiChunkStreamdump)
                 << " streams, expected: " << expectedNumStreams;
     }
 }
+
+TEST_F(StreamdumpTest, TruncateStreamPreview)
+{
+    std::vector<int64_t> basicData(100000, 10);
+    auto input = Input::refNumeric(
+            basicData.data(), sizeof(int64_t), basicData.size());
+
+    compressData(input);
+
+    EXPECT_FALSE(trace.empty());
+    EXPECT_LE(trace.size(), 5000);
+}
+
 } // namespace openzl
 #endif // ZL_ALLOW_INTROSPECTION

--- a/tools/visualization_app/src/graphVisualization/views/EdgeView.tsx
+++ b/tools/visualization_app/src/graphVisualization/views/EdgeView.tsx
@@ -22,15 +22,15 @@ const MAX_STRING_LEN = 40;
 const HIGHLIGHT_COLOR = '#cfffafcb';
 
 // Format bytes as hex dump with highlighting for struct streams
-function formatSerialPreview(bytes: number[], eltWidth: number, isStruct: boolean): ReactNode {
+function formatSerialPreview(bytes: number[], eltWidth: number, isStruct: boolean, totalBytes: number): ReactNode {
   if (!bytes || bytes.length === 0) {
     return 'Stream Preview (0 bytes)';
   }
 
   const header = isStruct ? `Stream Preview (struct - eltWidth: ${eltWidth})` : 'Stream Preview (serial)';
 
-  const totalLines = Math.ceil(bytes.length / BYTES_PER_LINE);
-  const linesToShow = Math.min(MAX_LINES, totalLines);
+  const totalLines = Math.ceil(totalBytes / BYTES_PER_LINE);
+  const linesToShow = Math.min(MAX_LINES, Math.ceil(bytes.length / BYTES_PER_LINE));
 
   const lines: ReactNode[] = [];
 
@@ -130,51 +130,53 @@ function formatSerialPreview(bytes: number[], eltWidth: number, isStruct: boolea
 }
 
 // Format numeric values (for numeric streams)
-function formatNumericPreview(values: number[], eltWidth: number): ReactNode {
+function formatNumericPreview(values: number[], eltWidth: number, totalElts: number): ReactNode {
   if (!values || values.length === 0) {
     return 'Stream Preview (numeric - 0 elements)';
   }
 
-  let overflow = false;
   const lines: string[] = [];
   lines.push(`Stream Preview (numeric - eltWidth: ${eltWidth})`);
 
   let currentLine = '';
   let lineCount = 0;
-  // Store each line until max character length is reached, then start a new line
+  let shownElts = 0;
   for (let i = 0; i < values.length; i++) {
     currentLine += values[i] + ' ';
     if (currentLine.length >= MAX_STRING_LEN) {
       lines.push(currentLine);
       currentLine = '';
       lineCount++;
+      shownElts = i + 1;
     }
 
     if (lineCount >= MAX_LINES) {
-      const remaining = values.length - i - 1;
-      if (remaining > 0) {
-        lines.push('...(' + remaining + ' more numbers)');
-        overflow = true;
-      }
       break;
     }
   }
 
-  if (!overflow && currentLine.length !== 0) {
+  if (lineCount == 0 && currentLine.length !== 0) {
+    // Only show  partial lines if its the only line
     lines.push(currentLine);
+    shownElts = values.length;
+  }
+
+  const remaining = totalElts - shownElts;
+  if (remaining > 0) {
+    lines.push('...(' + remaining + ' more numbers)');
   }
 
   return <>{lines.join('\n')}</>;
 }
 
 // Format string values (for string streams)
-function formatStringPreview(strings: string[]): ReactNode {
+function formatStringPreview(strings: string[], totalElts: number): ReactNode {
   if (!strings || strings.length === 0) {
     return 'Stream Preview (string - empty)';
   }
 
   const lines: string[] = [];
-  lines.push(`Stream Preview (string - ${strings.length} elements)`);
+  lines.push(`Stream Preview (string - ${totalElts} elements)`);
 
   const stringsToShow = Math.min(MAX_LINES, strings.length);
 
@@ -188,8 +190,8 @@ function formatStringPreview(strings: string[]): ReactNode {
     lines.push(`[${i}]: "${currentLine}"`);
   }
 
-  if (strings.length > stringsToShow) {
-    lines.push(`... (${strings.length - stringsToShow} more strings)`);
+  if (totalElts > stringsToShow) {
+    lines.push(`... (${totalElts - stringsToShow} more strings)`);
   }
 
   return <>{lines.join('\n')}</>;
@@ -197,7 +199,7 @@ function formatStringPreview(strings: string[]): ReactNode {
 
 // Format preview based on stream type
 function formatPreview(edge: InternalEdge): ReactNode | null {
-  const {type, eltWidth, streamPreview} = edge;
+  const {type, eltWidth, numElts, streamPreview} = edge;
 
   if (!streamPreview || streamPreview.length === 0) {
     return null;
@@ -205,14 +207,14 @@ function formatPreview(edge: InternalEdge): ReactNode | null {
 
   switch (type) {
     case ZL_Type.ZL_Type_string:
-      return formatStringPreview(streamPreview as string[]);
+      return formatStringPreview(streamPreview as string[], numElts);
     case ZL_Type.ZL_Type_numeric:
-      return formatNumericPreview(streamPreview as number[], eltWidth);
+      return formatNumericPreview(streamPreview as number[], eltWidth, numElts);
     case ZL_Type.ZL_Type_struct:
-      return formatSerialPreview(streamPreview as number[], eltWidth, true);
+      return formatSerialPreview(streamPreview as number[], eltWidth, true, numElts);
     case ZL_Type.ZL_Type_serial:
     default:
-      return formatSerialPreview(streamPreview as number[], eltWidth, false);
+      return formatSerialPreview(streamPreview as number[], eltWidth, false, numElts);
   }
 }
 


### PR DESCRIPTION
Summary:

Update stream preview implementation to only save first n bytes of stream preview instead of saving entire preview.

Differential Revision: D98840581
