### PR TITLE
Fix xgboost Visual Studio build issue (#586)

### DIFF
--- a/.github/workflows/windows-ci.yml
+++ b/.github/workflows/windows-ci.yml
@@ -208,6 +208,8 @@ jobs:
           echo "=== Testing $CC $CXX ${{ matrix.msystem }} ==="
           CFLAGS=-Werror make lib V=1
           CFLAGS=-Werror CXXFLAGS=-Werror make test V=1
+          echo "=== Building with make -j ==="
+          make -j V=1
           echo "=== Build and test completed successfully ==="
 
 

--- a/.github/workflows/windows-ci.yml
+++ b/.github/workflows/windows-ci.yml
@@ -129,11 +129,20 @@ jobs:
           )
         shell: cmd
 
-      - name: Build
+      - name: Build openzl
         working-directory: ${{github.workspace}}/build
         run: |
-          echo "=== Building with clang-cl ==="
+          echo "=== Building openzl with clang-cl ==="
           cmake --build . --config ${{ matrix.config }} --target openzl --verbose
+          echo "=== Build completed ==="
+        shell: cmd
+
+      - name: Build all targets
+        if: matrix.arch == 'x64' && matrix.config == 'Release'
+        working-directory: ${{github.workspace}}/build
+        run: |
+          echo "=== Building all targets with clang-cl ==="
+          cmake --build . --config Release --verbose
           echo "=== Build completed ==="
         shell: cmd
 
@@ -211,7 +220,6 @@ jobs:
           echo "=== Building with make -j ==="
           make -j V=1
           echo "=== Build and test completed successfully ==="
-
 
 # =============================================================================
 # CHOCOLATEY MinGW-w64 (pure Windows, no MSYS2) — build with `make`

--- a/Makefile
+++ b/Makefile
@@ -491,8 +491,9 @@ XGBOOST_CMAKE_PLATFORM :=
 XGBOOST_LDFLAGS :=
 XGBOOST_LDLIBS :=
 ifneq (,$(filter $(SMALL_CMD_LINE),$(UNAME)))
-    # MinGW/MSYS: Link ws2_32 for Windows socket functions
-    XGBOOST_CMAKE_PLATFORM := -DCMAKE_CXX_STANDARD_LIBRARIES="-lws2_32" \
+    # MinGW/MSYS: Use Unix Makefiles generator and link ws2_32 for Windows socket functions
+    XGBOOST_CMAKE_PLATFORM := -G "Unix Makefiles" \
+        -DCMAKE_CXX_STANDARD_LIBRARIES="-lws2_32" \
         -DCMAKE_SHARED_LINKER_FLAGS="-lws2_32"
     XGBOOST_LDFLAGS += -L$(abspath $(XGBOOST_LIBDIR))
     XGBOOST_LDLIBS += -lws2_32
@@ -535,7 +536,11 @@ endif
 $(LIBXGBOOST_A) : MAKEOVERRIDES=
 $(LIBXGBOOST_A) : $(XGBOOST_HEADER)
 	$(MKDIR) -p $(XGBOOST_LIBDIR)
-	cd deps/xgboost && mkdir -p build && cd build && cmake .. -DBUILD_STATIC_LIB=ON -DUSE_OPENMP=OFF -DCMAKE_ARCHIVE_OUTPUT_DIRECTORY=$(abspath $(XGBOOST_LIBDIR)) && $(MAKE)
+	cd deps/xgboost && mkdir -p build && cd build && cmake .. -DBUILD_STATIC_LIB=ON -DUSE_OPENMP=OFF -DCMAKE_ARCHIVE_OUTPUT_DIRECTORY=$(abspath $(XGBOOST_LIBDIR)) $(XGBOOST_CMAKE_PLATFORM) && $(MAKE)
+	# xgboost's CMakeLists.txt strips the 'lib' prefix on Windows; rename to match expected name
+	@if [ -f $(XGBOOST_LIBDIR)/xgboost.a ] && [ ! -f $(XGBOOST_LIBDIR)/libxgboost.a ]; then \
+		mv $(XGBOOST_LIBDIR)/xgboost.a $(XGBOOST_LIBDIR)/libxgboost.a; \
+	fi
 
 # libdmlc.a is built as part of xgboost static build
 $(LIBDMLC_A): $(LIBXGBOOST_A)

--- a/build-scripts/cmake/OpenZLCompilerMSVC.cmake
+++ b/build-scripts/cmake/OpenZLCompilerMSVC.cmake
@@ -2,6 +2,9 @@
 
 # MSVC and clang-cl compiler configuration for OpenZL
 
+# Use static CRT (/MT) to match xgboost and other static dependencies
+set(CMAKE_MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>")
+
 # Detect ClangCL toolset (the standard way)
 set(USING_CLANG_CL FALSE)
 if (CMAKE_GENERATOR_TOOLSET STREQUAL "ClangCL")
@@ -23,7 +26,10 @@ set(OPENZL_CXX_COMPILE_DEFINITIONS ${OPENZL_COMMON_COMPILE_DEFINITIONS})
 # Define compile options for MSVC
 set(OPENZL_COMMON_COMPILE_OPTIONS)
 set(OPENZL_C_COMPILE_OPTIONS ${OPENZL_COMMON_COMPILE_OPTIONS})
-set(OPENZL_CXX_COMPILE_OPTIONS ${OPENZL_COMMON_COMPILE_OPTIONS})
+set(OPENZL_CXX_COMPILE_OPTIONS ${OPENZL_COMMON_COMPILE_OPTIONS} )
+
+# Add /Ehsc to enable excpetion handling (clang-cl disables by default)
+add_compile_options($<$<COMPILE_LANGUAGE:CXX>:/EHsc>)
 
 # Define warning options for MSVC
 set(OPENZL_COMMON_COMPILE_WARNINGS)

--- a/build-scripts/cmake/WINDOWS_BUILD.md
+++ b/build-scripts/cmake/WINDOWS_BUILD.md
@@ -56,6 +56,7 @@ cmake --build build --config Release
 ### MinGW-w64
 
 - Via MSYS2: `pacman -S mingw-w64-x86_64-gcc`
+  - For `zli` and test targets: also install `mingw-w64-x86_64-cmake`
 - Via w64devkit: Download from <https://github.com/skeeto/w64devkit>
 
 ## Examples

--- a/build-scripts/cmake/openzl-deps.cmake
+++ b/build-scripts/cmake/openzl-deps.cmake
@@ -93,6 +93,12 @@ endif()
 message(STATUS "zstd dependency resolved successfully")
 
 # Set zstd build options before making it available
+# Disable zstd shared library on MSVC-frontend compilers (MSVC and ClangCL).
+# ClangCL: rc.exe cannot find Clang's internal headers (e.g. __stddef_ptrdiff_t.h).
+# Plain MSVC: static CRT (/MT) is incompatible with a dynamically-linked zstd DLL.
+if(CMAKE_C_COMPILER_FRONTEND_VARIANT STREQUAL "MSVC")
+    set(ZSTD_BUILD_SHARED OFF CACHE BOOL "")
+endif()
 set(ZSTD_BUILD_PROGRAMS OFF CACHE BOOL "")
 set(ZSTD_BUILD_CONTRIB OFF CACHE BOOL "")
 set(ZSTD_BUILD_TESTS OFF CACHE BOOL "")

--- a/cpp/src/openzl/cpp/experimental/trace/CompressTracer.cpp
+++ b/cpp/src/openzl/cpp/experimental/trace/CompressTracer.cpp
@@ -12,6 +12,7 @@
 
 #include <cstdlib>
 #include <map>
+#include <stdexcept>
 #include <utility>
 #include <vector>
 

--- a/tools/ml_selector/CMakeLists.txt
+++ b/tools/ml_selector/CMakeLists.txt
@@ -11,9 +11,26 @@ if(OPENZL_BUILD_ML_SELECTOR)
     file(MAKE_DIRECTORY ${XGBOOST_INSTALL_DIR}/include)
     file(MAKE_DIRECTORY ${XGBOOST_LIB_DIR})
 
-    # Add XGBoost as external project due to vs build issues
-    # Turn logs on to prevent polluting stdout when building xgboost
-    # Disable DMLC stack trace to avoid dependency on execinfo.h
+    # On Windows/MSVC, static libraries don't have a "lib" prefix
+    if(MSVC)
+        set(XGBOOST_LIB_NAME "xgboost${CMAKE_STATIC_LIBRARY_SUFFIX}")
+        set(DMLC_LIB_NAME "dmlc${CMAKE_STATIC_LIBRARY_SUFFIX}")
+    else()
+        set(XGBOOST_LIB_NAME "libxgboost${CMAKE_STATIC_LIBRARY_SUFFIX}")
+        set(DMLC_LIB_NAME "libdmlc${CMAKE_STATIC_LIBRARY_SUFFIX}")
+    endif()
+
+    # Enable C++ exceptions for ClangCL.
+    if(MSVC)
+        set(XGBOOST_CXX_FLAGS
+            "-DDMLC_LOG_STACK_TRACE=0 /EHsc")
+    else()
+        set(XGBOOST_CXX_FLAGS
+            "-DDMLC_LOG_STACK_TRACE=0")
+    endif()
+
+    # Add XGBoost as external project
+    # Disable DMLC stack trace to avoid execinfo.h
     ExternalProject_Add(xgboost_external
         GIT_REPOSITORY https://github.com/dmlc/xgboost.git
         GIT_TAG        ccb511768e13d1670c10be07dea89d0edca138f3 # v3.1.0
@@ -24,17 +41,20 @@ if(OPENZL_BUILD_ML_SELECTOR)
             -DCMAKE_INSTALL_LIBDIR=lib
             -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}
             -DUSE_OPENMP=OFF
-            -DBUILD_TESTING=OFF
             -DUSE_CUDA=OFF
             -DUSE_NCCL=OFF
             -DCMAKE_POSITION_INDEPENDENT_CODE=ON
             -DBUILD_STATIC_LIB=ON
-            "-DCMAKE_C_FLAGS=-DDMLC_LOG_STACK_TRACE=0"
-            "-DCMAKE_CXX_FLAGS=-DDMLC_LOG_STACK_TRACE=0"
             ${XGBOOST_EXTRA_CMAKE_ARGS}
+        CMAKE_CACHE_ARGS
+            "-DCMAKE_C_FLAGS:STRING=-DDMLC_LOG_STACK_TRACE=0"
+            "-DCMAKE_CXX_FLAGS:STRING=${XGBOOST_CXX_FLAGS}"
+            "-DBUILD_TESTING:BOOL=OFF"
+            "-DCMAKE_POLICY_DEFAULT_CMP0091:STRING=NEW"
+            "-DCMAKE_MSVC_RUNTIME_LIBRARY:STRING=${CMAKE_MSVC_RUNTIME_LIBRARY}"
         BUILD_BYPRODUCTS
-            ${XGBOOST_LIB_DIR}/libxgboost${CMAKE_STATIC_LIBRARY_SUFFIX}
-            ${XGBOOST_LIB_DIR}/libdmlc${CMAKE_STATIC_LIBRARY_SUFFIX}
+            ${XGBOOST_LIB_DIR}/${XGBOOST_LIB_NAME}
+            ${XGBOOST_LIB_DIR}/${DMLC_LIB_NAME}
         LOG_DOWNLOAD ON
         LOG_CONFIGURE ON
         LOG_BUILD ON
@@ -45,7 +65,7 @@ if(OPENZL_BUILD_ML_SELECTOR)
     add_library(xgboost STATIC IMPORTED GLOBAL)
     set_target_properties(xgboost PROPERTIES
         IMPORTED_LOCATION
-            ${XGBOOST_LIB_DIR}/libxgboost${CMAKE_STATIC_LIBRARY_SUFFIX}
+            ${XGBOOST_LIB_DIR}/${XGBOOST_LIB_NAME}
         INTERFACE_INCLUDE_DIRECTORIES ${XGBOOST_INSTALL_DIR}/include
     )
     add_dependencies(xgboost xgboost_external)
@@ -58,7 +78,7 @@ if(OPENZL_BUILD_ML_SELECTOR)
     add_library(dmlc STATIC IMPORTED GLOBAL)
     set_target_properties(dmlc PROPERTIES
         IMPORTED_LOCATION
-            ${XGBOOST_LIB_DIR}/libdmlc${CMAKE_STATIC_LIBRARY_SUFFIX}
+            ${XGBOOST_LIB_DIR}/${DMLC_LIB_NAME}
         INTERFACE_INCLUDE_DIRECTORIES ${XGBOOST_INSTALL_DIR}/include
     )
     add_dependencies(dmlc xgboost_external)

--- a/tools/sddl2/assembler/main.cpp
+++ b/tools/sddl2/assembler/main.cpp
@@ -97,7 +97,7 @@ int main(int argc, char* argv[])
         if (!output && !input->name().empty()) {
             std::filesystem::path path{ std::string(input->name()) };
             output = std::make_shared<tools::io::OutputFile>(
-                    path.replace_extension("bin"));
+                    path.replace_extension("bin").string());
         }
         const auto assembler = sddl2::Assembler();
         const auto bytecode  = assembler.assemble(input->contents());

--- a/tools/sddl2/compiler/main.cpp
+++ b/tools/sddl2/compiler/main.cpp
@@ -68,7 +68,7 @@ int main(int argc, char* argv[])
         if (!output_file) {
             std::filesystem::path path{ std::string(input_file->name()) };
             output_file = std::make_shared<tools::io::OutputFile>(
-                    path.replace_extension("asm"));
+                    path.replace_extension("asm").string());
         }
         const auto compiler =
                 Compiler{ Compiler::Options{}.with_verbosity(verbosity) };

--- a/tools/training/clustering/compression_utils.cpp
+++ b/tools/training/clustering/compression_utils.cpp
@@ -198,9 +198,11 @@ std::future<SizeTimePair> CompressionUtils::tryCompress(
         };
         futures.emplace_back(threadPool_->run(task, configPtr, funcPtr));
     }
-    return threadPool_->run([futures = std::move(futures)]() mutable {
+    auto futuresPtr = std::make_shared<std::vector<std::future<SizeTimePair>>>(
+            std::move(futures));
+    return threadPool_->run([futuresPtr]() {
         SizeTimePair result{};
-        for (auto& future : futures) {
+        for (auto& future : *futuresPtr) {
             result = result + future.get();
         }
         return result;


### PR DESCRIPTION
Summary:

ClangCL disables C++ exception handling by default, enable exception handling by adding `/EHsc` flag for when MSVC/ClangCL is used.

Added CI and fixed other small issues with ClangCL

Github issue: #357

Differential Revision: D99160390


