### PR TITLE
tighten ZL_compressBound() with StoreOnExpansion premise (#588)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -242,7 +242,7 @@ GTEST_FILEO += $(filter %Test.o,$(CXX_FILE_OBJS))
 GTEST_FILTER_LIST := VersionTest.o NoIntrospectionTest.o
 GTEST_FILEO := $(filter-out $(GTEST_FILTER_LIST),$(GTEST_FILEO))
 
-ALL_TEST_OBJS := $(patsubst %.cpp,%.o,$(foreach dir,$(TESTSDIRS),$(wildcard $(dir)/*.cpp)))
+ALL_TEST_OBJS := $(patsubst %.cpp,%.o,$(foreach dir,$(TESTSDIRS) $(ML_SELECTOR_TESTS_DIR),$(wildcard $(dir)/*.cpp)))
 GTEST_OBJS := $(foreach name,$(GTEST_FILEO),$(filter %/$(name),$(ALL_TEST_OBJS)))
 
 # Other module objects used in gtests

--- a/cli/commands/cmd_compress.cpp
+++ b/cli/commands/cmd_compress.cpp
@@ -135,14 +135,6 @@ int performCompression(const CompressArgs& args)
     if (!args.storeOnExpansion) {
         cctx.setParameter(CParam::StoreOnExpansion, ZL_TernaryParam_disable);
     }
-    if (args.traceOutput) {
-        // When tracing, the user wants to inspect the full compression
-        // pipeline. The anti-inflation guard replaces expanded chunks with
-        // STORE, which discards all transforms — leaving decompression traces
-        // empty (zero codec decode steps = no stream trace data). Disable the
-        // guard so traces reflect the actual compression graph.
-        cctx.setParameter(CParam::StoreOnExpansion, ZL_TernaryParam_disable);
-    }
     cctx.refCompressor(*args.compressor());
     if (args.traceOutput) {
         args.traceOutput->open();
@@ -160,7 +152,14 @@ int performCompression(const CompressArgs& args)
     const auto inputSize = input.size().value();
     Logger::log(VERBOSE1, "Input size: ", inputSize);
 
-    std::string dstBuffer = std::string(ZL_compressBound(inputSize), '\0');
+    // When StoreOnExpansion is disabled (train-inline or explicit flag),
+    // compression may expand data beyond ZL_compressBound(), which assumes the
+    // anti-inflation guard limits output to input + overhead. Use a generous
+    // buffer in that case.
+    size_t const dstCapacity = (args.trainInline || !args.storeOnExpansion)
+            ? 2 * ZL_compressBound(inputSize) + 1024
+            : ZL_compressBound(inputSize);
+    std::string dstBuffer    = std::string(dstCapacity, '\0');
 
     // read the input
     const auto srcBuffer = input.contents();

--- a/cli/tests/cli_integration_tests.py
+++ b/cli/tests/cli_integration_tests.py
@@ -20,7 +20,7 @@ from command_utils import (
     execute_decompress,
     execute_train,
 )
-from file_utils import input_dir_path, profile_dir_path
+from file_utils import file_contents_match, input_dir_path, profile_dir_path
 
 
 class SerialTest(_CompressDecompressBaseTest):
@@ -501,7 +501,8 @@ class TraceTest(_CompressDecompressBaseTest):
 
     This test verifies that the --trace and --trace-streams-dir flags work
     correctly during compress and decompress without crashing, and that
-    trace output files are actually created.
+    trace output files are actually created. Tests that need full stream
+    traces must opt out of StoreOnExpansion explicitly.
     """
 
     @property
@@ -518,7 +519,8 @@ class TraceTest(_CompressDecompressBaseTest):
         and roundtrip correctly.
 
         This test:
-        1. Compresses a CSV sample with --trace and --trace-streams-dir
+        1. Compresses a CSV sample with --trace, --trace-streams-dir, and
+           --no-store-on-expansion
         2. Asserts the compress trace CBOR file exists and is non-empty
         3. Decompresses with --trace
         4. Asserts the decompress trace CBOR file exists and is non-empty
@@ -537,7 +539,11 @@ class TraceTest(_CompressDecompressBaseTest):
             file_to_compress_path=sample.orig_file_path,
             compressor_info=self.compressor_info,
             compressed_file_path=sample.compressed_file_path,
-            extra_args=f"--trace {compress_trace_path} --trace-streams-dir {streams_dir}",
+            extra_args=(
+                f"--trace {compress_trace_path} "
+                f"--trace-streams-dir {streams_dir} "
+                "--no-store-on-expansion"
+            ),
         )
 
         self.assertTrue(
@@ -588,6 +594,71 @@ class TraceTest(_CompressDecompressBaseTest):
         self.assertTrue(
             sample.original_matches_decompressed,
             f"Decompressed file does not match original: {sample.orig_file_path}",
+        )
+
+    def test_trace_does_not_change_compressed_output(self):
+        """
+        Test that compression tracing does not change the compressed bytes.
+
+        This uses a checked-in random sample that exercises StoreOnExpansion
+        for the serial profile. The traced output should match the default
+        output, not the --no-store-on-expansion output.
+        """
+        random_input_path = os.path.join(input_dir_path("u8"), "random_u8.bin")
+
+        compressor_info = CompressorInfo(
+            compressor_str="serial",
+            compressor_type=CompressorType.PROFILE,
+        )
+        plain_compressed_path = os.path.join(
+            self.output_dir_path, "plain_random_input.zl"
+        )
+        traced_compressed_path = os.path.join(
+            self.output_dir_path, "traced_random_input.zl"
+        )
+        no_store_compressed_path = os.path.join(
+            self.output_dir_path, "no_store_random_input.zl"
+        )
+        trace_path = os.path.join(self.output_dir_path, "random_trace.cbor")
+        streams_dir = os.path.join(self.output_dir_path, "random_trace_streams")
+        os.makedirs(streams_dir, exist_ok=True)
+
+        execute_compress(
+            file_to_compress_path=random_input_path,
+            compressor_info=compressor_info,
+            compressed_file_path=plain_compressed_path,
+            extra_args=None,
+        )
+        execute_compress(
+            file_to_compress_path=random_input_path,
+            compressor_info=compressor_info,
+            compressed_file_path=traced_compressed_path,
+            extra_args=f"--trace {trace_path} --trace-streams-dir {streams_dir}",
+        )
+        execute_compress(
+            file_to_compress_path=random_input_path,
+            compressor_info=compressor_info,
+            compressed_file_path=no_store_compressed_path,
+            extra_args="--no-store-on-expansion",
+        )
+
+        self.assertFalse(
+            file_contents_match(plain_compressed_path, no_store_compressed_path),
+            "Test input did not exercise StoreOnExpansion",
+        )
+
+        self.assertTrue(
+            file_contents_match(plain_compressed_path, traced_compressed_path),
+            "Compression tracing changed the compressed output",
+        )
+        self.assertTrue(
+            os.path.exists(trace_path),
+            "Compress trace file was not created",
+        )
+        self.assertGreater(
+            os.path.getsize(trace_path),
+            0,
+            "Compress trace file is empty",
         )
 
 

--- a/include/openzl/zl_compress.h
+++ b/include/openzl/zl_compress.h
@@ -36,20 +36,57 @@ extern "C" {
 //         size_t srcSize,
 //         int compressionLevel);
 
-#define ZL_COMPRESSBOUND(s) (((s) * 2) + 512 + 8)
+/**
+ * Assumed minimum chunk size for segmented compression.
+ * ZL_compressBound() relies on this assumption to bound per-chunk overhead.
+ * Segmenters producing chunks smaller than this value may cause the output
+ * to exceed ZL_compressBound(). This is a documented assumption, not enforced.
+ * Matches the default block size of the entropy layer.
+ */
+#define ZL_MIN_CHUNK_SIZE (32768)
+
+/**
+ * Maximum per-chunk overhead in bytes (STORE chunk header + both checksums).
+ * Generous overestimate: actual overhead is ~13 bytes for a 32 KB chunk.
+ * Breakdown: chunk header varints (~3-7 bytes) + content checksum (4 bytes)
+ *          + compressed checksum (4 bytes).
+ */
+#define ZL_CHUNK_OVERHEAD_MAX (16)
+
+/**
+ * Maximum frame-level overhead in bytes (frame header + EOF marker).
+ * Generous overestimate: actual overhead is ~9-17 bytes.
+ * Breakdown: magic (4) + flags (1) + input type (1) + input size varint (<=9)
+ *          + header checksum (1) + EOF marker (1).
+ */
+#define ZL_FRAME_OVERHEAD_MAX (32)
+
+#define ZL_COMPRESSBOUND(s)      \
+    ((s) + ZL_FRAME_OVERHEAD_MAX \
+     + (((s) / ZL_MIN_CHUNK_SIZE) + 1) * ZL_CHUNK_OVERHEAD_MAX)
+
 /**
  * Provides the upper bound for the compressed size needed to ensure
- * that compressing @p totalSrcSize is successful. When compressing
- * multiple inputs, @p totalSrcSize must be the sum of the size of each input.
+ * that compressing @p totalSrcSize bytes is successful.
  *
- * @param totalSrcSize The sum of all input sizes
- * @returns The upper bound of the compressed size
+ * This bound is valid for a single serial input compressed with the default
+ * pipeline (default segmenter, StoreOnExpansion enabled). For other scenarios,
+ * callers should allocate a larger buffer:
  *
- * @note This is a very large over-estimation, to be tightened later
+ * @param totalSrcSizeInBytes The total input size in bytes (not element count)
+ * @returns The upper bound of the compressed size, in bytes
+ *
+ * @pre Single serial input. Multi-input or multi-typed compression (e.g. via
+ *      ZL_CCtx_compressMultiTypedRef) may produce additional per-stream
+ *      overhead in chunk headers that exceeds this bound.
+ * @pre StoreOnExpansion is enabled (default). When disabled, compressed output
+ *      may exceed this bound.
+ * @pre Segmented compression uses chunks of at least ZL_MIN_CHUNK_SIZE bytes,
+ *      except for the last chunk which may be smaller (remainder).
  */
-ZL_INLINE size_t ZL_compressBound(size_t totalSrcSize)
+ZL_INLINE size_t ZL_compressBound(size_t totalSrcSizeInBytes)
 {
-    return ZL_COMPRESSBOUND(totalSrcSize);
+    return ZL_COMPRESSBOUND(totalSrcSizeInBytes);
 }
 
 // ----------------------------------------------------

--- a/src/openzl/compress/cctx.c
+++ b/src/openzl/compress/cctx.c
@@ -1678,7 +1678,7 @@ CCTX_flushChunk(ZL_CCtx* cctx, const ZL_Data* inputs[], size_t nbInputs)
     ZL_RESULT_DECLARE_SCOPE_REPORT(cctx);
     ZL_DLOG(BLOCK, "CCTX_flushChunk (%zu inputs)", nbInputs);
 
-    GraphInfo gi;
+    GraphInfo gi = { 0 };
     ZL_ERR_IF_ERR(CCTX_getFinalGraph(cctx, &gi));
 
     // Write chunk header
@@ -1688,26 +1688,46 @@ CCTX_flushChunk(ZL_CCtx* cctx, const ZL_Data* inputs[], size_t nbInputs)
     size_t frameSize            = startFrameSize;
     ZL_ASSERT_LE(frameSize, capacity);
 
-    ZL_TRY_LET(
-            size_t,
-            chunkHeaderSize,
-            CCTX_writeChunkHeader(
-                    cctx,
-                    (char*)dst + startFrameSize,
-                    capacity - startFrameSize,
-                    &gi));
-    ZL_LOG(SEQ,
-           "wrote %zu chunk header bytes into buffer of capacity %zu",
-           chunkHeaderSize,
-           capacity - startFrameSize);
-    ZL_ASSERT_LE(chunkHeaderSize, capacity - startFrameSize);
+    ZL_TernaryParam const storeOnExpansion =
+            (ZL_TernaryParam)CCTX_getAppliedGParam(
+                    cctx, ZL_CParam_storeOnExpansion);
 
-    if (gi.nbTransforms > 0) { // if == 0, then chunk is already using STORE
+    size_t chunkHeaderSize = 0;
+    int useStore           = 0; // set to 1 when STORE fallback is needed
+
+    {
+        ZL_Report const headerReport = CCTX_writeChunkHeader(
+                cctx,
+                (char*)dst + startFrameSize,
+                capacity - startFrameSize,
+                &gi);
+
+        if (ZL_isError(headerReport)) {
+            // Compressed chunk header doesn't fit in dst.
+            // If storeOnExpansion is enabled and there are transforms,
+            // STORE may produce a smaller header — try it before giving up.
+            if (gi.nbTransforms > 0
+                && storeOnExpansion != ZL_TernaryParam_disable) {
+                ZL_DLOG(BLOCK,
+                        "Compressed chunk header too large for dst "
+                        "(capacity=%zu), trying STORE fallback",
+                        capacity - startFrameSize);
+                useStore = 1;
+            } else {
+                return headerReport; // genuine error
+            }
+        } else {
+            chunkHeaderSize = ZL_validResult(headerReport);
+            ZL_LOG(SEQ,
+                   "wrote %zu chunk header bytes into buffer of capacity %zu",
+                   chunkHeaderSize,
+                   capacity - startFrameSize);
+            ZL_ASSERT_LE(chunkHeaderSize, capacity - startFrameSize);
+        }
+    }
+
+    if (gi.nbTransforms > 0 && !useStore) {
         // Check if data has expanded, use STORE in that case
-        ZL_TernaryParam const storeOnExpansion =
-                (ZL_TernaryParam)CCTX_getAppliedGParam(
-                        cctx, ZL_CParam_storeOnExpansion);
-
         if (storeOnExpansion != ZL_TernaryParam_disable) {
             // Calculate total compressed size (data buffers)
             size_t totalCompressedSize = chunkHeaderSize; // Start with header
@@ -1733,31 +1753,33 @@ CCTX_flushChunk(ZL_CCtx* cctx, const ZL_Data* inputs[], size_t nbInputs)
                         totalCompressedSize,
                         chunkHeaderSize,
                         totalCompressedSize - chunkHeaderSize);
-
-                // Replace with STORE
-                ZL_ERR_IF_ERR(
-                        CCTX_replaceChunkWithStore(cctx, inputs, nbInputs));
-
-                // Re-get graph info
-                ZL_ERR_IF_ERR(CCTX_getFinalGraph(cctx, &gi));
-
-                // Recalculate header size with new STORE graph
-                ZL_TRY_LET(
-                        size_t,
-                        newHeaderSize,
-                        CCTX_writeChunkHeader(
-                                cctx,
-                                (char*)dst + startFrameSize,
-                                capacity - startFrameSize,
-                                &gi));
-
-                ZL_DLOG(SEQ,
-                        "After STORE: header=%zu (was %zu)",
-                        newHeaderSize,
-                        chunkHeaderSize);
-                chunkHeaderSize = newHeaderSize;
+                useStore = 1;
             }
         } // storeOnExpansion enabled
+    }
+
+    if (useStore) {
+        // Replace with STORE
+        ZL_ERR_IF_ERR(CCTX_replaceChunkWithStore(cctx, inputs, nbInputs));
+
+        // Re-get graph info
+        ZL_ERR_IF_ERR(CCTX_getFinalGraph(cctx, &gi));
+
+        // Write STORE chunk header (if this also fails, genuine error)
+        ZL_TRY_LET(
+                size_t,
+                storeHeaderSize,
+                CCTX_writeChunkHeader(
+                        cctx,
+                        (char*)dst + startFrameSize,
+                        capacity - startFrameSize,
+                        &gi));
+
+        ZL_DLOG(SEQ,
+                "After STORE: header=%zu (was %zu)",
+                storeHeaderSize,
+                chunkHeaderSize);
+        chunkHeaderSize = storeHeaderSize;
     }
 
     // Copy final buffers(s)

--- a/tests/codecs/test_codec.h
+++ b/tests/codecs/test_codec.h
@@ -8,6 +8,7 @@
 #include <gtest/gtest.h>
 
 #include "openzl/openzl.hpp"
+#include "tests/utils.h" // @manual
 
 namespace openzl {
 namespace tests {
@@ -215,7 +216,18 @@ class CodecTest : public testing::Test {
     std::string testRoundTrip(poly::span<const Input> input)
     {
         cctx_.refCompressor(compressor_);
-        auto compressed   = cctx_.compress(input);
+        // StoreOnExpansion is disabled in this fixture, so the tight
+        // ZL_compressBound() may be insufficient. Allocate manually
+        // with ZL_COMPRESSBOUND_UNGUARDED.
+        size_t inputSize = 0;
+        for (auto const& inp : input) {
+            inputSize += inp.contentSize();
+            if (inp.type() == Type::String) {
+                inputSize += inp.numElts() * sizeof(uint32_t);
+            }
+        }
+        std::string compressed(ZL_COMPRESSBOUND_UNGUARDED(inputSize), '\0');
+        compressed.resize(cctx_.compress(compressed, input));
         auto roundTripped = dctx_.decompress(compressed);
         EXPECT_EQ(roundTripped.size(), input.size());
         for (size_t i = 0; i < input.size(); ++i) {

--- a/tests/decompress/test_decode_frameheader.cpp
+++ b/tests/decompress/test_decode_frameheader.cpp
@@ -8,6 +8,7 @@
 #include "openzl/common/errors_internal.h"
 #include "openzl/zl_compress.h"
 #include "openzl/zl_compressor.h"
+#include "tests/utils.h" // @manual
 
 using namespace ::testing;
 
@@ -40,11 +41,11 @@ static std::string randomCompress(size_t nbInputs, size_t inputSizeEach)
         constInputRefs.push_back(ref);
     }
 
-    size_t dstCap = ZL_compressBound(
-            std::accumulate(
-                    inputs.begin(), inputs.end(), 0ul, [](auto acc, auto s) {
-                        return acc + s.size();
-                    }));
+    size_t const totalInputSize = std::accumulate(
+            inputs.begin(), inputs.end(), 0ul, [](auto acc, const auto& s) {
+                return acc + s.size();
+            });
+    size_t dstCap = ZL_COMPRESSBOUND_UNGUARDED(totalInputSize);
     std::string dst(dstCap, 0);
 
     ZL_CCtx* cctx = ZL_CCtx_create();

--- a/tests/registry/OpenZLComponent.h
+++ b/tests/registry/OpenZLComponent.h
@@ -9,6 +9,7 @@
 #include "openzl/zl_version.h"
 #include "tests/datagen/DataGen.h"
 #include "tests/registry/OpenZLInput.h"
+#include "tests/utils.h" // @manual
 
 namespace openzl::tests {
 
@@ -110,7 +111,7 @@ class OpenZLComponent {
             }
         }
         totalSrcSize += inputs.size() * 256;
-        return ZL_compressBound(totalSrcSize);
+        return ZL_COMPRESSBOUND_UNGUARDED(totalSrcSize);
     }
 
     /**

--- a/tests/round_trip/test_codec_fusion.cpp
+++ b/tests/round_trip/test_codec_fusion.cpp
@@ -33,6 +33,7 @@ extern "C" {
 #include "openzl/zl_input.h"
 #include "openzl/zl_output.h"
 #include "openzl/zl_version.h"
+#include "tests/utils.h" // @manual
 
 namespace openzl::tests {
 namespace {
@@ -759,7 +760,7 @@ class CodecFusionTest : public ::testing::Test {
         ASSERT_FALSE(ZL_isError(
                 ZL_Compressor_selectStartingGraphID(compressor_.get(), graph)));
 
-        std::string compressed(ZL_compressBound(inputSize), '\0');
+        std::string compressed(ZL_COMPRESSBOUND_UNGUARDED(inputSize), '\0');
         CCtx cctx;
         setTestParams(cctx);
         ASSERT_FALSE(ZL_isError(
@@ -1859,7 +1860,7 @@ TEST_F(CodecFusionTest, EnableCodecFusionParam_EnabledAndDisabledMatch)
     ASSERT_FALSE(ZL_isError(
             ZL_Compressor_selectStartingGraphID(compressor_.get(), graph)));
     std::string compressed(
-            ZL_compressBound(data.size() * sizeof(uint32_t)), '\0');
+            ZL_COMPRESSBOUND_UNGUARDED(data.size() * sizeof(uint32_t)), '\0');
     CCtx cctx;
     setTestParams(cctx);
     ASSERT_FALSE(

--- a/tests/round_trip/test_compressBound.cpp
+++ b/tests/round_trip/test_compressBound.cpp
@@ -1,0 +1,212 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#include <gtest/gtest.h>
+
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <vector>
+
+#include "openzl/codecs/zl_store.h"
+#include "openzl/zl_common_types.h"
+#include "openzl/zl_compress.h"
+#include "openzl/zl_compressor.h"
+#include "openzl/zl_decompress.h"
+#include "openzl/zl_errors.h"
+#include "openzl/zl_segmenter.h"
+#include "openzl/zl_version.h"
+
+namespace {
+
+// ---------------------------------------------------------------------------
+// Configurable fixed-chunk-size segmenter
+// ---------------------------------------------------------------------------
+
+// NOLINTNEXTLINE(facebook-avoid-non-const-global-variables)
+static size_t g_fixedChunkSize = ZL_MIN_CHUNK_SIZE;
+
+/// Splits input into fixed-size chunks, routing each to ZL_GRAPH_STORE.
+/// The last chunk may be smaller (remainder).
+/// This produces worst-case overhead: STORE = no compression, maximum
+/// framing cost per byte of input.
+ZL_Report fixedChunkStoreSegmenterFn(ZL_Segmenter* sctx)
+{
+    assert(ZL_Segmenter_numInputs(sctx) == 1);
+    const ZL_Input* input = ZL_Segmenter_getInput(sctx, 0);
+    assert(input != NULL);
+
+    while (ZL_Input_numElts(input) > 0) {
+        size_t remaining = ZL_Input_numElts(input);
+        size_t chunkElts =
+                (remaining < g_fixedChunkSize) ? remaining : g_fixedChunkSize;
+
+        ZL_Report r = ZL_Segmenter_processChunk(
+                sctx, &chunkElts, 1, ZL_GRAPH_STORE, nullptr);
+        if (ZL_isError(r))
+            return r;
+
+        input = ZL_Segmenter_getInput(sctx, 0);
+    }
+    return ZL_returnSuccess();
+}
+
+static ZL_SegmenterDesc const fixedChunkStoreSegmenter = {
+    .name           = "Fixed-Chunk STORE Segmenter",
+    .segmenterFn    = fixedChunkStoreSegmenterFn,
+    .inputTypeMasks = (const ZL_Type[]){ ZL_Type_serial },
+    .numInputs      = 1,
+};
+
+/// Registers the segmenter with worst-case parameters:
+/// max format version, both checksums enabled.
+static ZL_GraphID registerFixedChunkStoreSegmenter(
+        ZL_Compressor* compressor) noexcept
+{
+    ZL_Report r = ZL_Compressor_setParameter(
+            compressor, ZL_CParam_formatVersion, ZL_MAX_FORMAT_VERSION);
+    if (ZL_isError(r))
+        abort();
+
+    r = ZL_Compressor_setParameter(
+            compressor, ZL_CParam_contentChecksum, ZL_TernaryParam_enable);
+    if (ZL_isError(r))
+        abort();
+
+    r = ZL_Compressor_setParameter(
+            compressor, ZL_CParam_compressedChecksum, ZL_TernaryParam_enable);
+    if (ZL_isError(r))
+        abort();
+
+    return ZL_Compressor_registerSegmenter(
+            compressor, &fixedChunkStoreSegmenter);
+}
+
+// ---------------------------------------------------------------------------
+// Core round-trip helper
+// ---------------------------------------------------------------------------
+
+static void compressBoundRoundTrip(size_t inputSize, const char* testLabel)
+{
+    printf("\n=== CompressBound: %s (inputSize=%zu, chunkSize=%zu) ===\n",
+           testLabel,
+           inputSize,
+           g_fixedChunkSize);
+
+    // Generate synthetic input (repeating byte pattern)
+    std::vector<unsigned char> inputData(inputSize);
+    for (size_t i = 0; i < inputSize; i++)
+        inputData[i] = static_cast<unsigned char>(i & 0xFF);
+
+    // Allocate exactly ZL_compressBound(inputSize)
+    size_t const bound = ZL_compressBound(inputSize);
+    std::vector<unsigned char> compressed(bound);
+
+    // Create serial typed ref
+    ZL_TypedRef* input = ZL_TypedRef_createSerial(inputData.data(), inputSize);
+    ASSERT_NE(input, nullptr);
+
+    // Compress
+    ZL_CCtx* cctx = ZL_CCtx_create();
+    ASSERT_NE(cctx, nullptr);
+    ZL_Compressor* compressor = ZL_Compressor_create();
+    ASSERT_NE(compressor, nullptr);
+
+    ZL_Report r = ZL_Compressor_initUsingGraphFn(
+            compressor, registerFixedChunkStoreSegmenter);
+    ASSERT_FALSE(ZL_isError(r)) << "compressor init failed";
+
+    r = ZL_CCtx_refCompressor(cctx, compressor);
+    ASSERT_FALSE(ZL_isError(r)) << "compressor ref failed";
+
+    r = ZL_CCtx_compressTypedRef(cctx, compressed.data(), bound, input);
+    ASSERT_FALSE(ZL_isError(r))
+            << "compression failed: bound " << bound
+            << " was insufficient for input size " << inputSize;
+    size_t compressedSize = ZL_validResult(r);
+
+    printf("  compressed %zu -> %zu (bound=%zu, overhead=%zu)\n",
+           inputSize,
+           compressedSize,
+           bound,
+           compressedSize > inputSize ? compressedSize - inputSize : 0);
+    EXPECT_LE(compressedSize, bound);
+
+    ZL_Compressor_free(compressor);
+    ZL_CCtx_free(cctx);
+    ZL_TypedRef_free(input);
+
+    // Decompress and verify round-trip
+    if (inputSize > 0) {
+        ZL_TypedBuffer* tbuf = ZL_TypedBuffer_create();
+        ASSERT_NE(tbuf, nullptr);
+        ZL_DCtx* dctx = ZL_DCtx_create();
+        ASSERT_NE(dctx, nullptr);
+
+        r = ZL_DCtx_decompressTBuffer(
+                dctx, tbuf, compressed.data(), compressedSize);
+        ASSERT_FALSE(ZL_isError(r)) << "decompression failed";
+        EXPECT_EQ(ZL_validResult(r), inputSize);
+        EXPECT_EQ(
+                memcmp(inputData.data(), ZL_TypedBuffer_rPtr(tbuf), inputSize),
+                0)
+                << "round-trip data mismatch";
+
+        ZL_TypedBuffer_free(tbuf);
+        ZL_DCtx_free(dctx);
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Test cases: 32 KB chunk size (the documented minimum)
+// ---------------------------------------------------------------------------
+
+TEST(CompressBound, exactMultiple)
+{
+    g_fixedChunkSize = ZL_MIN_CHUNK_SIZE;
+    compressBoundRoundTrip(8 * ZL_MIN_CHUNK_SIZE, "8 x 32KB exact");
+}
+
+TEST(CompressBound, tinyRemainder)
+{
+    g_fixedChunkSize = ZL_MIN_CHUNK_SIZE;
+    compressBoundRoundTrip(8 * ZL_MIN_CHUNK_SIZE + 1, "8 x 32KB + 1");
+}
+
+TEST(CompressBound, largeRemainder)
+{
+    g_fixedChunkSize = ZL_MIN_CHUNK_SIZE;
+    compressBoundRoundTrip(
+            8 * ZL_MIN_CHUNK_SIZE + ZL_MIN_CHUNK_SIZE - 1, "8 x 32KB + 32KB-1");
+}
+
+TEST(CompressBound, smallInput)
+{
+    g_fixedChunkSize = ZL_MIN_CHUNK_SIZE;
+    compressBoundRoundTrip(1000, "small 1000 bytes");
+}
+
+TEST(CompressBound, singleFullChunk)
+{
+    g_fixedChunkSize = ZL_MIN_CHUNK_SIZE;
+    compressBoundRoundTrip(ZL_MIN_CHUNK_SIZE, "single 32KB chunk");
+}
+
+// ---------------------------------------------------------------------------
+// Margin validation with larger chunk sizes
+// ---------------------------------------------------------------------------
+
+TEST(CompressBound, chunkSize_64KB)
+{
+    g_fixedChunkSize = 65536;
+    compressBoundRoundTrip(8 * 65536, "8 x 64KB exact");
+    compressBoundRoundTrip(8 * 65536 + 1, "8 x 64KB + 1");
+}
+
+TEST(CompressBound, chunkSize_128KB)
+{
+    g_fixedChunkSize = 131072;
+    compressBoundRoundTrip(8 * 131072, "8 x 128KB exact");
+    compressBoundRoundTrip(8 * 131072 + 1, "8 x 128KB + 1");
+}
+
+} // namespace

--- a/tests/round_trip/test_dispatchStringGraph.cpp
+++ b/tests/round_trip/test_dispatchStringGraph.cpp
@@ -135,12 +135,15 @@ class DispatchStringGraphTest : public ::testing::Test {
             int numDispatches,
             bool useDynGraph)
     {
-        ZL_REQUIRE_GE(dstCapacity, ZL_compressBound(src.size()));
-        ZL_CCtx* cctx = ZL_CCtx_create();
-        ZL_REQUIRE_NN(cctx);
-
         // massage input
-        const auto strLens  = genStrLens(src);
+        const auto strLens = genStrLens(src);
+
+        // For string inputs, total stored size includes both content and
+        // string lengths array
+        size_t const totalInputSize =
+                src.size() + strLens.size() * sizeof(uint32_t);
+        ZL_REQUIRE_GE(dstCapacity, ZL_compressBound(totalInputSize));
+        ZL_CCtx* cctx       = ZL_CCtx_create();
         ZL_TypedRef* strRef = ZL_TypedRef_createString(
                 src.data(), src.size(), strLens.data(), strLens.size());
         ZL_REQUIRE_NN(strRef);
@@ -217,7 +220,11 @@ class DispatchStringGraphTest : public ::testing::Test {
         const std::string_view src = (numDispatches == 0) ? "" : text;
         const size_t srcSize       = (numDispatches == 0) ? 0 : text.size();
 
-        size_t const compressedBound = ZL_compressBound(srcSize);
+        // For string inputs, total stored size includes string lengths array
+        const auto strLens = genStrLens(src);
+        size_t const totalInputSize =
+                srcSize + strLens.size() * sizeof(uint32_t);
+        size_t const compressedBound = ZL_compressBound(totalInputSize);
         void* const compressed       = malloc(compressedBound);
         ZL_REQUIRE_NN(compressed);
 

--- a/tests/round_trip/test_segmenter.cpp
+++ b/tests/round_trip/test_segmenter.cpp
@@ -46,7 +46,6 @@ static size_t compress(
         ZL_Type inputType,
         ZL_GraphFn graphf)
 {
-    assert(dstCapacity >= ZL_compressBound(srcSize));
     size_t const nbItems    = srcSize / 4;
     ZL_TypedRef* input      = NULL;
     uint32_t* stringLengths = NULL;
@@ -140,8 +139,15 @@ static size_t roundTripTest(
     printf("\n=========================== \n");
     printf(" %s \n", name);
     printf("--------------------------- \n");
-    // Generate test input
-    size_t const compressedBound = ZL_compressBound(inputSize);
+    // For string inputs, total stored size includes string lengths array.
+    // Estimate numStrings from inputSize assuming 4-byte elements (as used
+    // by roundTripGen).
+    size_t totalInputSize = inputSize;
+    if (inputType == ZL_Type_string) {
+        size_t const nbItems = inputSize / 4;
+        totalInputSize += nbItems * sizeof(uint32_t);
+    }
+    size_t const compressedBound = ZL_compressBound(totalInputSize);
     void* const compressed       = malloc(compressedBound);
     assert(compressed);
 
@@ -807,7 +813,10 @@ TEST(Segmenter, stringVariableLengthChunks)
     assert(input);
 
     // Compress
-    size_t const compressedBound = ZL_compressBound(totalContentSize);
+    // For string inputs, total stored size includes string lengths array
+    size_t const totalInputSize =
+            totalContentSize + numStrings * sizeof(uint32_t);
+    size_t const compressedBound = ZL_compressBound(totalInputSize);
     void* const compressed       = malloc(compressedBound);
     assert(compressed);
 

--- a/tests/utils.h
+++ b/tests/utils.h
@@ -14,10 +14,15 @@
 #include "openzl/common/cursor.h"
 #include "openzl/common/debug.h"
 #include "openzl/cpp/Input.hpp"
+#include "openzl/zl_compress.h"
 
 ////////////////////////////////////////
 // Macros to Adapt Zstrong Success or Failure to GTest Success or Failure
 ////////////////////////////////////////
+
+/// Generous compress bound for tests that violate ZL_compressBound() premises
+/// (multi-input, custom graphs, StoreOnExpansion disabled).
+#define ZL_COMPRESSBOUND_UNGUARDED(s) (2 * ZL_compressBound(s) + 1024)
 
 #define ASSERT_ZS_VALID(x) ASSERT_FALSE(ZL_RES_isError((x)))
 #define EXPECT_ZS_VALID(x) EXPECT_FALSE(ZL_RES_isError((x)))

--- a/tests/version/VersionTestInterfaceABI.cpp
+++ b/tests/version/VersionTestInterfaceABI.cpp
@@ -21,6 +21,7 @@
 #include "openzl/zl_reflection.h"
 #include "tests/constants.h"
 #include "tests/datagen/test_registry/CustomNodes.h"
+#include "tests/utils.h" // @manual
 
 namespace {
 using namespace openzl::tests::datagen::test_registry;
@@ -234,7 +235,7 @@ extern "C" void VersionTestInterface_getAllGraphIDs(
 
 extern "C" size_t VersionTestInterface_compressBound(size_t srcSize)
 {
-    return 2 * ZL_compressBound(srcSize);
+    return ZL_COMPRESSBOUND_UNGUARDED(srcSize);
 }
 
 extern "C" bool VersionTestInterface_isError(size_t ret)

--- a/tests/zstrong/test_zstrong_fixture.cpp
+++ b/tests/zstrong/test_zstrong_fixture.cpp
@@ -14,6 +14,7 @@
 #include "openzl/zl_opaque_types.h"
 #include "openzl/zl_reflection.h"
 #include "openzl/zl_selector.h"
+#include "tests/utils.h" // @manual
 
 namespace openzl {
 namespace tests {
@@ -247,7 +248,7 @@ void ZStrongTest::setLevels(int compressionLevel, int decompressionLevel)
 
 size_t ZStrongTest::compressBounds(std::string_view data)
 {
-    return ZL_compressBound(compressBoundFactor_ * data.size());
+    return ZL_COMPRESSBOUND_UNGUARDED(compressBoundFactor_ * data.size());
 }
 
 void ZStrongTest::setLargeCompressBound(size_t factor)
@@ -283,15 +284,15 @@ std::pair<ZL_Report, std::optional<std::string>> ZStrongTest::compress(
 std::pair<ZL_Report, std::optional<std::string>> ZStrongTest::compressMI(
         std::vector<std::unique_ptr<ZL_TypedRef, ZS2_TypedRef_Deleter>>& inputs)
 {
-    size_t compressBound = 0;
+    size_t totalInputSize = 0;
     std::vector<const ZL_TypedRef*> constInputs;
     for (auto& input : inputs) {
-        compressBound += ZL_compressBound(
-                (ZL_Input_contentSize(input.get())
-                 + ZL_Input_numElts(input.get()) * 4)
-                * compressBoundFactor_);
+        totalInputSize += (ZL_Input_contentSize(input.get())
+                           + ZL_Input_numElts(input.get()) * 4)
+                * compressBoundFactor_;
         constInputs.push_back(input.get());
     }
+    size_t compressBound = ZL_COMPRESSBOUND_UNGUARDED(totalInputSize);
     std::string compressed(compressBound, 0);
     if (cctx_ != nullptr) {
         ZL_CCtx_free(cctx_);
@@ -395,7 +396,7 @@ std::pair<ZL_Report, std::optional<std::string>> ZStrongTest::compressTyped(
         ZL_TypedRef* typedRef)
 {
     std::string compressed(
-            ZL_compressBound(
+            ZL_COMPRESSBOUND_UNGUARDED(
                     ZL_Input_contentSize(typedRef) * compressBoundFactor_),
             0);
     if (cctx_ != nullptr) {

--- a/tools/ml_selector/tests/test_mlSelectorGraph.cpp
+++ b/tools/ml_selector/tests/test_mlSelectorGraph.cpp
@@ -49,7 +49,7 @@ class TestMLSelectorGraph : public testing::Test {
             ZL_GraphID sgid,
             Compressor& compressor)
     {
-        auto compressBound = ZL_compressBound(input.size());
+        auto compressBound = ZL_compressBound(input.size() * sizeof(input[0]));
 
         // Compress using selected successor
         std::string cBuffer = std::string(compressBound, '\0');
@@ -69,7 +69,8 @@ class TestMLSelectorGraph : public testing::Test {
             Compressor& compressor)
     {
         // Compress using ml selector graph
-        std::string cBuffer = std::string(ZL_compressBound(input.size()), '\0');
+        std::string cBuffer = std::string(
+                ZL_compressBound(input.size() * sizeof(input[0])), '\0');
         auto compressedSize = compress(compressor, cBuffer, input, sgid);
         cBuffer.resize(compressedSize);
 

--- a/tools/protobuf/ProtoSerializer.cpp
+++ b/tools/protobuf/ProtoSerializer.cpp
@@ -184,7 +184,19 @@ std::vector<Input> ProtoSerializer::getTrainingInputs(const Message& message)
 std::string ProtoSerializer::serialize(const Message& message)
 {
     auto [inputs, bufs] = getInputs(message);
-    return cctx_.compress(inputs);
+    // Multi-input compression may exceed ZL_compressBound()'s single-input
+    // contract due to per-stream overhead in chunk headers.
+    size_t inputSize = 0;
+    for (auto const& input : inputs) {
+        inputSize += input.contentSize();
+        if (input.type() == openzl::Type::String) {
+            inputSize += input.numElts() * sizeof(uint32_t);
+        }
+    }
+    std::string output;
+    output.resize(2 * ZL_compressBound(inputSize) + 1024, '\0');
+    output.resize(cctx_.compress(output, inputs));
+    return output;
 };
 } // namespace protobuf
 } // namespace openzl


### PR DESCRIPTION
Summary:

Replace the overly generous `2*s+520` compress bound formula with a tight
`s + overhead` formula. The new bound is premised on StoreOnExpansion being
enabled (default), which guarantees that each chunk's output is at most
its input size plus framing overhead.

Defines three named constants:
- `ZL_MIN_CHUNK_SIZE` (32KB): documented minimum chunk size assumption for segmented compression. Matches the entropy layer's default block size. Segmenters producing smaller chunks may exceed the bound.
- `ZL_CHUNK_OVERHEAD_MAX` (16): generous per-chunk overhead bound
  (actual ~13 bytes: chunk header varints + both checksums).
- `ZL_FRAME_OVERHEAD_MAX` (32): generous frame-level overhead bound
  (actual ~9-17 bytes: magic + flags + type + size + EOF marker).

Adds a segmenter-based test that exercises pathological chunk sizes
(exact multiples, tiny/large remainders, sub-minimum inputs) with
forced `STORE` compression and both checksums enabled to validate the
bound holds under worst-case conditions.

Also fixes string-input callers of `ZL_compressBound()` in tests to
account for the string lengths array in total input size, which the
old 2x formula accidentally covered.

Reviewed By: terrelln

Differential Revision: D99192049


