### PR TITLE
Add bitsplit_bf16 codec for bfloat16 decomposition

### DIFF
--- a/cpp/include/openzl/cpp/codecs/Bitsplit.hpp
+++ b/cpp/include/openzl/cpp/codecs/Bitsplit.hpp
@@ -32,5 +32,17 @@ struct BitsplitFP : public SimplePipeNode<BitsplitFP> {
         .description = "Split IEEE 754 floats into sign, exponent, and mantissa"
     };
 };
+
+struct BitsplitBF16 : public SimplePipeNode<BitsplitBF16> {
+   public:
+    static constexpr NodeID node = ZL_NODE_BITSPLIT_BF16;
+
+    static constexpr NodeMetadata<1, 0, 1> metadata = {
+        .inputs          = { InputMetadata{ .type = Type::Numeric } },
+        .variableOutputs = { OutputMetadata{ .type = Type::Numeric,
+                                             .name = "bit_ranges" } },
+        .description     = "Split bfloat16 into sign, exponent, and mantissa"
+    };
+};
 } // namespace nodes
 } // namespace openzl

--- a/include/openzl/codecs/zl_bitsplit.h
+++ b/include/openzl/codecs/zl_bitsplit.h
@@ -23,6 +23,12 @@ extern "C" {
 // Supports IEEE 754 fp16, fp32, fp64.
 #define ZL_NODE_BITSPLIT_FP ZL_MAKE_NODE_ID(ZL_StandardNodeID_bitsplit_fp)
 
+// input  : 1 numeric stream (2-byte bfloat16 elements)
+// output : 1 variable output stream of 3 outputs
+//          (sign, exponent, mantissa)
+// bfloat16: sign (1 bit), exponent (8 bits), mantissa (7 bits).
+#define ZL_NODE_BITSPLIT_BF16 ZL_MAKE_NODE_ID(ZL_StandardNodeID_bitsplit_bf16)
+
 #if defined(__cplusplus)
 }
 #endif

--- a/include/openzl/zl_nodes.h
+++ b/include/openzl/zl_nodes.h
@@ -82,6 +82,7 @@ typedef enum {
 
     ZL_StandardNodeID_bitsplit_top8,
     ZL_StandardNodeID_bitsplit_fp,
+    ZL_StandardNodeID_bitsplit_bf16,
 
     ZL_StandardNodeID_partition,
 

--- a/src/openzl/codecs/bitSplit/encode_bitsplit_bf16_binding.c
+++ b/src/openzl/codecs/bitSplit/encode_bitsplit_bf16_binding.c
@@ -1,0 +1,34 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#include "openzl/codecs/bitSplit/encode_bitsplit_bf16_binding.h"
+#include "openzl/codecs/bitSplit/encode_bitSplit_binding.h" /* EI_bitSplit_withWidths */
+#include "openzl/common/assertion.h"                        /* ZL_ASSERT */
+#include "openzl/zl_data.h"                                 /* ZL_Input_type */
+#include "openzl/zl_errors.h"                               /* ZL_ERR_IF_NOT */
+#include "openzl/zl_input.h" /* ZL_Input_ptr, ZL_Input_eltWidth, ZL_Input_numElts */
+
+ZL_Report
+EI_bitsplit_bf16(ZL_Encoder* eictx, const ZL_Input* ins[], size_t nbIns)
+{
+    ZL_RESULT_DECLARE_SCOPE_REPORT(eictx);
+
+    ZL_ASSERT_NN(eictx);
+    ZL_ASSERT_EQ(nbIns, 1);
+    ZL_ASSERT_NN(ins);
+    const ZL_Input* in = ins[0];
+    ZL_ASSERT_NN(in);
+    ZL_ASSERT_EQ(ZL_Input_type(in), ZL_Type_numeric);
+    size_t const eltWidth = ZL_Input_eltWidth(in);
+    ZL_ERR_IF_NOT(
+            eltWidth == 2,
+            node_invalid_input,
+            "bitsplit_bf16 requires 2-byte elements (bfloat16)");
+
+    // bfloat16: [mantissa:7][exponent:8][sign:1] = 16 bits
+    uint8_t bitWidths[3];
+    bitWidths[0] = 7; // mantissa bits (LSB)
+    bitWidths[1] = 8; // exponent bits
+    bitWidths[2] = 1; // sign bit     (MSB)
+
+    return EI_bitSplit_withWidths(eictx, in, bitWidths, 3);
+}

--- a/src/openzl/codecs/bitSplit/encode_bitsplit_bf16_binding.h
+++ b/src/openzl/codecs/bitSplit/encode_bitsplit_bf16_binding.h
@@ -1,0 +1,43 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#ifndef OPENZL_CODECS_BITSPLIT_ENCODE_BITSPLIT_BF16_BINDING_H
+#define OPENZL_CODECS_BITSPLIT_ENCODE_BITSPLIT_BF16_BINDING_H
+
+#include "openzl/codecs/common/graph_vo.h" /* GRAPH_VO_NUM */
+#include "openzl/shared/portability.h"
+#include "openzl/zl_ctransform.h" /* ZL_Encoder */
+#include "openzl/zl_errors.h"     /* ZL_Report */
+#include "openzl/zl_opaque_types.h"
+
+ZL_BEGIN_C_DECLS
+
+/**
+ * bitsplit_bf16 encoder
+ *
+ * Decomposes bfloat16 values into 3 separate streams:
+ * sign (1 bit), exponent (8 bits), and mantissa (7 bits).
+ *
+ * bfloat16 layout (16 bits):
+ * - sign:     1 bit  (bit 15)
+ * - exponent: 8 bits (bits 7-14)
+ * - mantissa: 7 bits (bits 0-6)
+ *
+ * Input: 1 numeric stream (2-byte elements)
+ * Output: 1 variable output stream of 3 outputs
+ *         (mantissa, exponent, sign)
+ *
+ * Parameters: none (parameter-free node)
+ *
+ * Wire format: reuses bitSplit transform ID and codec header.
+ */
+ZL_Report
+EI_bitsplit_bf16(ZL_Encoder* eictx, const ZL_Input* ins[], size_t nbIns);
+
+#define EI_BITSPLIT_BF16(id)           \
+    { .gd          = GRAPH_VO_NUM(id), \
+      .transform_f = EI_bitsplit_bf16, \
+      .name        = "!zl.bitsplit_bf16" }
+
+ZL_END_C_DECLS
+
+#endif // OPENZL_CODECS_BITSPLIT_ENCODE_BITSPLIT_BF16_BINDING_H

--- a/src/openzl/codecs/encoder_registry.c
+++ b/src/openzl/codecs/encoder_registry.c
@@ -3,6 +3,7 @@
 #include "openzl/codecs/encoder_registry.h"
 
 #include "openzl/codecs/bitSplit/encode_bitSplit_binding.h"
+#include "openzl/codecs/bitSplit/encode_bitsplit_bf16_binding.h"
 #include "openzl/codecs/bitSplit/encode_bitsplit_fp_binding.h"
 #include "openzl/codecs/bitSplit/encode_bitsplit_top8_binding.h"
 #include "openzl/codecs/bitpack/encode_bitpack_binding.h"
@@ -112,6 +113,7 @@ const CNode ER_standardNodes[STANDARD_ENCODERS_NB] = {
     REGISTER_TRANSFORM(ZL_StandardNodeID_quantize_lengths, ZL_StandardTransformID_quantize_lengths, 3, EI_QUANTIZE_LENGTHS),
     REGISTER_TRANSFORM(ZL_StandardNodeID_bitsplit_top8, ZL_StandardTransformID_bitSplit, 24, EI_BITSPLIT_TOP8),
     REGISTER_TRANSFORM(ZL_StandardNodeID_bitsplit_fp, ZL_StandardTransformID_bitSplit, 24, EI_BITSPLIT_FP),
+    REGISTER_TRANSFORM(ZL_StandardNodeID_bitsplit_bf16, ZL_StandardTransformID_bitSplit, 24, EI_BITSPLIT_BF16),
     REGISTER_TRANSFORM(ZL_StandardNodeID_partition, ZL_StandardTransformID_partition, 24, EI_PARTITION),
     REGISTER_TRANSFORM(ZL_StandardNodeID_split_byrange, ZL_StandardTransformID_splitn_num, 24, EI_SPLIT_BYRANGE),
 

--- a/tests/codecs/test_bitsplit_bf16.cpp
+++ b/tests/codecs/test_bitsplit_bf16.cpp
@@ -1,0 +1,200 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#include <cstdint>
+#include <cstring>
+#include <vector>
+
+#include <gtest/gtest.h>
+
+#include "openzl/openzl.hpp"
+#include "tests/codecs/test_codec.h"
+
+namespace openzl {
+namespace tests {
+
+class BitsplitBF16Test : public CodecTest {
+   public:
+    /**
+     * Tests round-trip compression/decompression using bitsplit_bf16.
+     *
+     * @param input Numeric input data (2-byte bfloat16 elements as uint16_t)
+     */
+    void testBitsplitBF16RoundTrip(const std::vector<uint16_t>& input)
+    {
+        compressor_.setParameter(CParam::FormatVersion, ZL_MAX_FORMAT_VERSION);
+
+        auto graph = compressor_.buildStaticGraph(
+                ZL_NODE_BITSPLIT_BF16, { graphs::Compress{}() });
+        compressor_.selectStartingGraph(graph);
+
+        Input numericInput =
+                Input::refNumeric(poly::span<const uint16_t>{ input });
+        testRoundTrip(numericInput);
+    }
+};
+
+// =============================================================================
+// BF16 Round-Trip Tests
+// =============================================================================
+// bfloat16 layout: [sign:1][exponent:8][mantissa:7] = 16 bits
+// No native C++ type, so we use uint16_t with manually constructed bit
+// patterns.
+
+TEST_F(BitsplitBF16Test, BF16_RoundTrip)
+{
+    // Sweep through a range of normal bf16 values
+    std::vector<uint16_t> input(1000);
+    for (size_t i = 0; i < input.size(); i++) {
+        // Range from small positive normals to larger ones
+        // bf16 exponent field starts at bit 7, normal range [0x0080..0x7F7F]
+        input[i] = static_cast<uint16_t>(0x0080 + (i % 0x7F00));
+    }
+    testBitsplitBF16RoundTrip(input);
+}
+
+TEST_F(BitsplitBF16Test, BF16_AllZero)
+{
+    std::vector<uint16_t> input(1000, 0x0000);
+    testBitsplitBF16RoundTrip(input);
+}
+
+// =============================================================================
+// BF16 Edge Cases
+// =============================================================================
+
+TEST_F(BitsplitBF16Test, BF16_EmptyInput)
+{
+    std::vector<uint16_t> input;
+    testBitsplitBF16RoundTrip(input);
+}
+
+TEST_F(BitsplitBF16Test, BF16_SingleElement)
+{
+    // 0x4049 ~= 3.14 in bfloat16 (truncated from fp32 0x4048F5C3)
+    std::vector<uint16_t> input{ 0x4049 };
+    testBitsplitBF16RoundTrip(input);
+}
+
+TEST_F(BitsplitBF16Test, BF16_NaN)
+{
+    // bf16 quiet NaN: exponent all 1s (0xFF at bits 7-14), mantissa nonzero
+    std::vector<uint16_t> input{ 0x7FC0 };
+    testBitsplitBF16RoundTrip(input);
+}
+
+TEST_F(BitsplitBF16Test, BF16_NaNVariants)
+{
+    // Signaling NaN: exponent all 1s, mantissa nonzero with MSB=0
+    // Negative NaN: sign=1, exponent all 1s, mantissa nonzero
+    std::vector<uint16_t> input{
+        0x7F01, // positive signaling NaN
+        0xFF01, // negative signaling NaN
+        0xFFC0, // negative quiet NaN
+    };
+    testBitsplitBF16RoundTrip(input);
+}
+
+TEST_F(BitsplitBF16Test, BF16_Infinity)
+{
+    std::vector<uint16_t> input{
+        0x7F80, // +Inf (exponent all 1s, mantissa zero)
+        0xFF80, // -Inf
+    };
+    testBitsplitBF16RoundTrip(input);
+}
+
+TEST_F(BitsplitBF16Test, BF16_NegativeZero)
+{
+    std::vector<uint16_t> input{ 0x8000 };
+    testBitsplitBF16RoundTrip(input);
+}
+
+TEST_F(BitsplitBF16Test, BF16_MinMax)
+{
+    std::vector<uint16_t> input{
+        0x0080, // smallest normal (2^-126)
+        0x7F7F, // largest finite
+    };
+    testBitsplitBF16RoundTrip(input);
+}
+
+TEST_F(BitsplitBF16Test, BF16_Subnormals)
+{
+    // bf16 subnormals: exponent = 0, mantissa nonzero (bits 0-6)
+    std::vector<uint16_t> input(127);
+    for (size_t i = 0; i < input.size(); i++) {
+        // Subnormal mantissa range: 0x0001..0x007F
+        input[i] = static_cast<uint16_t>((i % 0x7F) + 1);
+    }
+    testBitsplitBF16RoundTrip(input);
+}
+
+TEST_F(BitsplitBF16Test, BF16_NegativeSubnormals)
+{
+    // bf16 negative subnormals: sign=1, exponent=0, mantissa nonzero (bits 0-6)
+    std::vector<uint16_t> input(127);
+    for (size_t i = 0; i < input.size(); i++) {
+        // Negative subnormal range: 0x8001..0x807F
+        input[i] = static_cast<uint16_t>(0x8000 | ((i % 0x7F) + 1));
+    }
+    testBitsplitBF16RoundTrip(input);
+}
+
+TEST_F(BitsplitBF16Test, BF16_AllBitsSet)
+{
+    // 0xFFFF = negative NaN with all mantissa bits set
+    std::vector<uint16_t> input{ 0xFFFF };
+    testBitsplitBF16RoundTrip(input);
+}
+
+TEST_F(BitsplitBF16Test, BF16_MixedValues)
+{
+    std::vector<uint16_t> input{
+        0x0000, // +0
+        0x8000, // -0
+        0x3F80, // 1.0
+        0xBF80, // -1.0
+        0x4049, // ~3.14
+        0x7F80, // +Inf
+        0xFF80, // -Inf
+        0x7FC0, // NaN
+        0x0001, // smallest subnormal
+        0x7F7F, // largest finite
+    };
+    testBitsplitBF16RoundTrip(input);
+}
+
+// =============================================================================
+// Split Order Case
+// =============================================================================
+
+TEST_F(BitsplitBF16Test, BF16_OutputOrder)
+{
+    // 0xC049 = negative ~3.14 in bfloat16
+    std::vector<uint16_t> input{ 0xC049 };
+
+    uint16_t rawBits;
+    std::memcpy(&rawBits, input.data(), sizeof(rawBits));
+    uint8_t mantissaVal = rawBits & 0x7F;        // bottom 7 bits
+    uint8_t exponentVal = (rawBits >> 7) & 0xFF; // next 8 bits
+    uint8_t signVal     = (rawBits >> 15) & 0x1; // top 1 bit
+
+    std::vector<uint8_t> expectedMantissa{ mantissaVal };
+    std::vector<uint8_t> expectedExponent{ exponentVal };
+    std::vector<uint8_t> expectedSign{ signVal };
+
+    Input inMantissa =
+            Input::refNumeric(poly::span<const uint8_t>{ expectedMantissa });
+    Input inExponent =
+            Input::refNumeric(poly::span<const uint8_t>{ expectedExponent });
+    Input inSign = Input::refNumeric(poly::span<const uint8_t>{ expectedSign });
+
+    Input numericInput = Input::refNumeric(poly::span<const uint16_t>{ input });
+    testCodecVO(
+            ZL_NODE_BITSPLIT_BF16,
+            numericInput,
+            { &inMantissa, &inExponent, &inSign },
+            24); // 24 is version where bitsplit codecs were added
+}
+} // namespace tests
+} // namespace openzl

--- a/tests/registry/OpenZLComponents.h
+++ b/tests/registry/OpenZLComponents.h
@@ -79,6 +79,7 @@ enum class OpenZLComponentID {
     SplitByExtParser,
     BitSplitFP,
     SplitByRange,
+    BitSplitBF16,
     // Must be last enum value
     NumComponents,
 };
@@ -144,6 +145,7 @@ std::unique_ptr<OpenZLComponent> makeSplitNumericByParamComponent();
 std::unique_ptr<OpenZLComponent> makeSplitByExtParserComponent();
 std::unique_ptr<OpenZLComponent> makeBitSplitFPComponent();
 std::unique_ptr<OpenZLComponent> makeSplitByRangeComponent();
+std::unique_ptr<OpenZLComponent> makeBitSplitBF16Component();
 
 } // namespace components
 
@@ -259,6 +261,8 @@ inline std::unique_ptr<OpenZLComponent> makeOpenZLComponent(
             return components::makeBitSplitFPComponent();
         case OpenZLComponentID::SplitByRange:
             return components::makeSplitByRangeComponent();
+        case OpenZLComponentID::BitSplitBF16:
+            return components::makeBitSplitBF16Component();
         case OpenZLComponentID::NumComponents:
         default:
             throw std::runtime_error("Invalid component");

--- a/tests/registry/components/BitSplit.cpp
+++ b/tests/registry/components/BitSplit.cpp
@@ -385,6 +385,84 @@ class BitSplitFPComponent : public OpenZLComponent {
     }
 };
 
+class BitSplitBF16Component : public OpenZLComponent {
+   public:
+    std::string name() const override
+    {
+        return "BitSplitBF16";
+    }
+
+    int minFormatVersion() const override
+    {
+        return 24;
+    }
+
+    std::vector<NodeID> predefinedNodes(Compressor& compressor) const override
+    {
+        return { nodes::BitsplitBF16{}.parameterize(compressor) };
+    }
+
+    std::vector<std::unique_ptr<OpenZLInput>> predefinedInputs() const override
+    {
+        std::vector<std::unique_ptr<OpenZLInput>> inputs;
+        // bf16 values (all 2-byte elements)
+        inputs.push_back(U16OpenZLInput::make(std::vector<uint16_t>{}));
+        inputs.push_back(U16OpenZLInput::make(std::vector<uint16_t>{ 0x0000 }));
+        inputs.push_back(
+                U16OpenZLInput::make(
+                        std::vector<uint16_t>{ 0x7FC0 })); // quiet NaN
+        inputs.push_back(
+                U16OpenZLInput::make(
+                        std::vector<uint16_t>{ 0x7F80, 0xFF80 })); // +-Inf
+        inputs.push_back(
+                U16OpenZLInput::make(std::vector<uint16_t>{ 0x8000 })); // -0
+        inputs.push_back(
+                U16OpenZLInput::make(
+                        std::vector<uint16_t>{
+                                0x0080, 0x7F7F })); // min normal, max finite
+        inputs.push_back(
+                U16OpenZLInput::make(
+                        std::vector<uint16_t>{ 0x0001 })); // smallest subnormal
+        inputs.push_back(
+                U16OpenZLInput::make(
+                        std::vector<uint16_t>{ 0x3F80, 0xBF80 })); // +-1.0
+        inputs.push_back(
+                U16OpenZLInput::make(
+                        std::vector<uint16_t>{ 0x8001 })); // negative subnormal
+        inputs.push_back(
+                U16OpenZLInput::make(
+                        std::vector<uint16_t>{
+                                0x7F01,
+                                0xFF01,
+                                0xFFC0 })); // signaling & negative NaN
+        inputs.push_back(
+                U16OpenZLInput::make(
+                        std::vector<uint16_t>{ 0xFFFF })); // all bits set
+        inputs.push_back(
+                U16OpenZLInput::make(std::vector<uint16_t>{ 0x4049 })); // ~3.14
+
+        return inputs;
+    }
+
+    std::vector<std::unique_ptr<OpenZLInput>> generateInputs(
+            datagen::DataGen& gen,
+            size_t num,
+            size_t maxInputSize,
+            const Compressor&,
+            GraphID) const override
+    {
+        std::vector<std::unique_ptr<OpenZLInput>> inputs;
+        inputs.reserve(num);
+        for (size_t i = 0; i < num; ++i) {
+            // bf16 always uses 2-byte elements
+            auto data =
+                    gen.randStringWithQuantizedLength("data", maxInputSize, 2);
+            inputs.push_back(makeNumericInput(data, 2));
+        }
+        return inputs;
+    }
+};
+
 } // namespace
 
 std::unique_ptr<OpenZLComponent> makeBitSplitComponent()
@@ -400,6 +478,11 @@ std::unique_ptr<OpenZLComponent> makeBitSplitTop8Component()
 std::unique_ptr<OpenZLComponent> makeBitSplitFPComponent()
 {
     return std::make_unique<BitSplitFPComponent>();
+}
+
+std::unique_ptr<OpenZLComponent> makeBitSplitBF16Component()
+{
+    return std::make_unique<BitSplitBF16Component>();
 }
 
 } // namespace openzl::tests::components

--- a/tools/training/ace/ace_compressors.cpp
+++ b/tools/training/ace/ace_compressors.cpp
@@ -91,6 +91,7 @@ std::vector<ACENode> makeAllNodes()
     n.push_back(buildNode(nodes::QuantizeLengths{}));
     n.push_back(buildNode(nodes::TransposeSplit{}));
     n.push_back(buildNode(nodes::BitsplitFP{}));
+    n.push_back(buildNode(nodes::BitsplitBF16{}));
     n.push_back(buildNode(nodes::BitsplitTop8{}));
     n.push_back(buildNode(nodes::Zigzag{}));
     n.push_back(buildNode(nodes::ConvertSerialToNum8{}));
@@ -157,6 +158,8 @@ std::vector<ACECompressor> makePrebuiltNumericCompressors()
     ACECompressor top8bitsEntropy(
             buildNode(nodes::BitsplitTop8{}), { entropy });
     ACECompressor fpBitsEntropy(buildNode(nodes::BitsplitFP{}), { entropy });
+    ACECompressor bf16BitsEntropy(
+            buildNode(nodes::BitsplitBF16{}), { entropy });
     ACECompressor fse(buildGraph(graphs::Fse{}));
     ACECompressor store(buildGraph(graphs::Store{}));
     ACECompressor quantizeOffsets(
@@ -177,6 +180,7 @@ std::vector<ACECompressor> makePrebuiltNumericCompressors()
         rangePackDeltaFieldLz,
         top8bitsEntropy,
         fpBitsEntropy,
+        bf16BitsEntropy,
         quantizeOffsets,
         quantizeLengths,
     };


### PR DESCRIPTION
Summary:
Add a dedicated `bitsplit_bf16` node that decomposes bfloat16 (2-byte) values
into 3 separate streams — mantissa (7 bits), exponent (8 bits), and sign (1 bit)
— for better downstream compression.

bfloat16 has the same element width (2 bytes) as IEEE 754 fp16, but a different
bit layout ({7, 8, 1} vs {10, 5, 1}), so it cannot share the existing
`bitsplit_fp` node which uses element width to infer bit widths.

The bf16 encode/decode kernel fast paths already existed (from D91787385). This
diff adds the node-level wiring so bf16 decomposition is accessible as a
first-class codec node (`ZL_NODE_BITSPLIT_BF16`) instead of requiring manual
parameterization through the generic `ZL_NODE_BITSPLIT`.

Changes:
- New encoder binding (`EI_bitsplit_bf16`) that hardcodes widths {7, 8, 1}
- New `ZL_StandardNodeID_bitsplit_bf16` enum and `ZL_NODE_BITSPLIT_BF16` macro
- C++ node wrapper (`nodes::BitsplitBF16`) for the graph API
- Registered in encoder registry at format version 24
- ACE integration: added to node universe + prebuilt `bf16BitsEntropy` compressor
- Registry test component (`BitSplitBF16Component`) for fuzz/property testing
- 14 new tests: round-trip, edge cases (NaN, signaling NaN, ±Inf, -0,
  subnormals, negative subnormals, min/max, all-bits-set, mixed values),
  and output order verification

Kernel benchmarks (10MB, `buck fbcode//mode/opt`, sandcastle OD):

| Operation | Throughput (MB/s) |
|-----------|-------------------|
| bf16 encode | 13,855 |
| bf16 decode | 29,964 |

Differential Revision: D99206240


