### PR TITLE
Fix fuzzing crash: catch formatVersion_unsupported in FuzzRoundTrip (#591)

### DIFF
--- a/tests/fuzz/OpenZLComponentFuzzer.cpp
+++ b/tests/fuzz/OpenZLComponentFuzzer.cpp
@@ -207,7 +207,19 @@ FUZZ(OpenZLComponentFuzzer, FuzzRoundTrip)
             break;
         }
         for (const auto& input : inputs) {
-            fuzzRoundTrip(*component, compressor, *input, graph, formatVersion);
+            try {
+                fuzzRoundTrip(
+                        *component, compressor, *input, graph, formatVersion);
+            } catch (const Exception& e) {
+                // The format version and graph are selected independently by
+                // the fuzzer. A graph may exceed the runtime limits (nodes,
+                // streams, inputs) of an older format version. This is not an
+                // input validity issue, so we allow it.
+                if (e.code() != ZL_ErrorCode_formatVersion_unsupported) {
+                    throw;
+                }
+                return;
+            }
         }
     }
 }


### PR DESCRIPTION
Summary:

The FuzzRoundTrip fuzzer selects a format version and graph independently.
A graph with many nodes/streams can exceed the runtime limits of an older format version, causing `ZL_ErrorCode_formatVersion_unsupported` (error 60) to be thrown from `CCtx::compress()`. This is not an input validity issue but a format version/graph incompatibility.

This is the same underlying issue as T258195820, where Lionhead found error 60 in FuzzCompress (bisected to D94530880, terrelln's SplitByParam component). terrelln's fix (D95604467) added `catch(...)` in `FuzzCompress` but did not address `FuzzRoundTrip`, which uses strict mode (`PermissiveCompression=0`) and had no exception handling. The crash resurfaced in T262320075 when D97624638 (`split_byrange`) expanded the graph space, making the format version/graph incompatibility more likely to trigger. Therefore D97624638 did not introduce the bug, but rather exposed a pre-existing gap in `FuzzRoundTrip`'s error handling.

Fix: catch `openzl::Exception` with error code `formatVersion_unsupported` in `FuzzRoundTrip` and return early, since the graph/formatVersion pair is fixed per invocation and all subsequent inputs would hit the same error.
All other exceptions are still re-thrown to maintain strict validation.

Fixes Lionhead crash 1438325060726444.

Differential Revision: D99376484


