### PR TITLE
introduce new materializer desc

### DIFF
--- a/include/openzl/zl_materializer.h
+++ b/include/openzl/zl_materializer.h
@@ -120,6 +120,74 @@ void* ZL_Materializer_allocate(ZL_Materializer* matCtx, size_t size);
  */
 void* ZL_Materializer_getScratchSpace(ZL_Materializer* matCtx, size_t size);
 
+// =================================================================
+// In-progress API
+// =================================================================
+/**
+ * @brief Descriptor for materializing and dematerializing dict objects.
+ *
+ * This structure defines functions to materialize an in-memory object from
+ * a raw source buffer and to dematerialize (free) that object.
+ */
+typedef struct {
+    /**
+     * Optionally an opaque pointer that can be queried with
+     * ZL_Materializer_getOpaquePtr().
+     * OpenZL unconditionally takes ownership of this pointer, even if
+     * registration fails, and it lives for the lifetime of the owning
+     * compressor/dict store.
+     */
+    ZL_OpaquePtr opaque;
+
+    /**
+     * @brief A custom function that materializes an in-memory object from a
+     * provided @p src buffer. Separate function interfaces are provided for
+     * compression-time and decompression-time materialization. These can be the
+     * same function or different functions, depending on the specific codec
+     * implementation.
+     *
+     * The generation MUST be deterministic and hermetic. Materialization shall
+     * not depend on variables other than the provided @p src buffer.
+     *
+     * Materialized object lifetimes will be managed by the @ref ZL_DictLoader
+     * or @ref ZL_Compressor on which the materialization scheme is registered.
+     *
+     * Do NOT rely on the materialization function being called at any specific
+     * time to do side-effect work. Doing so will result in undefined behavior.
+     *
+     * DO NOT attempt to modify the materialized object after creation, either
+     * directly or via API getters.
+     *
+     * @param matCtx A pointer to a materializer context object. The
+     * materialization function may use this to request managed memory as an
+     * alternative to managing allocations itself and via the dematerializeFn.
+     * @param src  A pointer to the buffer from which to materialize. The
+     * provided buffer has no lifetime guarantees past the invocation of this
+     * function. You may not hold references into @p src in the materialized
+     * object.
+     *
+     * @returns A ZL_RESULT containing a pointer to the materialized object on
+     * success, or an error. Returning NULL as a valid result (when there's
+     * nothing to materialize) should be wrapped in ZL_WRAP_VALUE(NULL). Ensure
+     * the function declares a result scope with ZL_RESULT_DECLARE_SCOPE or you
+     * will get a compiler error.
+     */
+    ZL_RESULT_OF(ZL_VoidPtr) (*materializeFn)(
+            ZL_Materializer* matCtx,
+            const void* src,
+            size_t srcSize)ZL_NOEXCEPT_FUNC_PTR;
+
+    /**
+     * @brief A custom function that destructs a materialized object.
+     *
+     * You should use this to deallocate all non-arena memory and free any held
+     * resources. As a convenience, if there are no resources or memory to free,
+     * you may use ZL_NOOP_DEMATERIALIZE as a placeholder.
+     */
+    void (*dematerializeFn)(ZL_Materializer* matCtx, void* materialized)
+            ZL_NOEXCEPT_FUNC_PTR;
+} ZL_MaterializerDesc2;
+
 #if defined(__cplusplus)
 } // extern "C"
 #endif

--- a/src/openzl/compress/materializer.c
+++ b/src/openzl/compress/materializer.c
@@ -16,9 +16,9 @@ ZL_Materializer* ZL_Materializer_create(
     if (mat == NULL) {
         return NULL;
     }
-    mat->allocator = allocator;
-    mat->matArena  = ALLOC_StackArena_create();
-    if (mat->matArena == NULL) {
+    mat->persistentArena = allocator;
+    mat->scratchArena    = ALLOC_StackArena_create();
+    if (mat->scratchArena == NULL) {
         ALLOC_Arena_free(allocator, mat);
         return NULL;
     }
@@ -31,24 +31,24 @@ void ZL_Materializer_free(ZL_Materializer* mat)
     if (mat == NULL) {
         return;
     }
-    ALLOC_Arena_freeArena(mat->matArena);
-    ALLOC_Arena_free(mat->allocator, mat);
+    ALLOC_Arena_freeArena(mat->scratchArena);
+    ALLOC_Arena_free(mat->persistentArena, mat);
 }
 
 void* ZL_Materializer_allocate(ZL_Materializer* mat, size_t size)
 {
-    if (mat == NULL || mat->allocator == NULL) {
+    if (mat == NULL || mat->persistentArena == NULL) {
         return NULL;
     }
-    return ALLOC_Arena_malloc(mat->allocator, size);
+    return ALLOC_Arena_malloc(mat->persistentArena, size);
 }
 
 void* ZL_Materializer_getScratchSpace(ZL_Materializer* mat, size_t size)
 {
-    if (mat == NULL || mat->matArena == NULL) {
+    if (mat == NULL || mat->scratchArena == NULL) {
         return NULL;
     }
-    return ALLOC_Arena_malloc(mat->matArena, size);
+    return ALLOC_Arena_malloc(mat->scratchArena, size);
 }
 
 void ZL_NOOP_DEMATERIALIZE(ZL_Materializer* matCtx, void* materialized)

--- a/src/openzl/compress/materializer.h
+++ b/src/openzl/compress/materializer.h
@@ -15,8 +15,8 @@ ZL_BEGIN_C_DECLS
 // ******************************************************************
 
 struct ZL_Materializer_s {
-    Arena* allocator;
-    Arena* matArena;
+    Arena* persistentArena;
+    Arena* scratchArena;
     const void* opaquePtr;
 } /* typedef'ed to ZL_Materializer in zl_opaque_types.h */;
 


### PR DESCRIPTION
Summary: For a number of timing reasons, the existing ZL_MaterializerDesc must be maintained while the new API is not ready.

Reviewed By: terrelln

Differential Revision: D98316768


