### PR TITLE
allow setting dictID on the encoder

### DIFF
--- a/include/openzl/zl_compressor.h
+++ b/include/openzl/zl_compressor.h
@@ -340,6 +340,9 @@ typedef struct {
     /// Optionally the new local params, if NULL then the parameters are not
     /// updated.
     const ZL_LocalParams* localParams;
+    /// Optionally, a new dict ID. If set to ZL_ID_NULL, then the dict ID is not
+    /// updated.
+    ZL_DictID dictID;
 } ZL_NodeParameters;
 
 /**
@@ -364,6 +367,9 @@ typedef struct {
     /// Optionally the new local params, if NULL then the parameters are not
     /// updated.
     const ZL_LocalParams* localParams;
+    /// Optionally, a new dict ID. If set to ZL_ID_NULL, then the dict ID is not
+    /// updated.
+    ZL_DictID dictID;
 } ZL_ParameterizedNodeDesc;
 
 /**

--- a/include/openzl/zl_ctransform.h
+++ b/include/openzl/zl_ctransform.h
@@ -343,6 +343,21 @@ typedef struct {
      * will be used to create materialized objects from local params.
      */
     ZL_MaterializerDesc materializer;
+
+    // New API. In progress.
+    /**
+     * Optional materializer descriptor for materialized dicts.
+     * If both materializeFn and dematerializeFn are non-null, the materializer
+     * will be used to create materialized objects. Create a node with
+     * materialization using ZL_Compressor_parameterizeNode().
+     */
+    ZL_MaterializerDesc2 dictMat;
+    /**
+     * Optional dictionary ID associated with this encoder.
+     * When set, identifies the dictionary that this encoder requires.
+     * A zero-initialized (null) value means no dictionary is associated.
+     */
+    ZL_DictID dictID;
 } ZL_MIEncoderDesc;
 
 /**

--- a/include/openzl/zl_materializer.h
+++ b/include/openzl/zl_materializer.h
@@ -120,6 +120,74 @@ void* ZL_Materializer_allocate(ZL_Materializer* matCtx, size_t size);
  */
 void* ZL_Materializer_getScratchSpace(ZL_Materializer* matCtx, size_t size);
 
+// =================================================================
+// In-progress API
+// =================================================================
+/**
+ * @brief Descriptor for materializing and dematerializing dict objects.
+ *
+ * This structure defines functions to materialize an in-memory object from
+ * a raw source buffer and to dematerialize (free) that object.
+ */
+typedef struct {
+    /**
+     * Optionally an opaque pointer that can be queried with
+     * ZL_Materializer_getOpaquePtr().
+     * OpenZL unconditionally takes ownership of this pointer, even if
+     * registration fails, and it lives for the lifetime of the owning
+     * compressor/dict store.
+     */
+    ZL_OpaquePtr opaque;
+
+    /**
+     * @brief A custom function that materializes an in-memory object from a
+     * provided @p src buffer. Separate function interfaces are provided for
+     * compression-time and decompression-time materialization. These can be the
+     * same function or different functions, depending on the specific codec
+     * implementation.
+     *
+     * The generation MUST be deterministic and hermetic. Materialization shall
+     * not depend on variables other than the provided @p src buffer.
+     *
+     * Materialized object lifetimes will be managed by the @ref ZL_DictLoader
+     * or @ref ZL_Compressor on which the materialization scheme is registered.
+     *
+     * Do NOT rely on the materialization function being called at any specific
+     * time to do side-effect work. Doing so will result in undefined behavior.
+     *
+     * DO NOT attempt to modify the materialized object after creation, either
+     * directly or via API getters.
+     *
+     * @param matCtx A pointer to a materializer context object. The
+     * materialization function may use this to request managed memory as an
+     * alternative to managing allocations itself and via the dematerializeFn.
+     * @param src  A pointer to the buffer from which to materialize. The
+     * provided buffer has no lifetime guarantees past the invocation of this
+     * function. You may not hold references into @p src in the materialized
+     * object.
+     *
+     * @returns A ZL_RESULT containing a pointer to the materialized object on
+     * success, or an error. Returning NULL as a valid result (when there's
+     * nothing to materialize) should be wrapped in ZL_WRAP_VALUE(NULL). Ensure
+     * the function declares a result scope with ZL_RESULT_DECLARE_SCOPE or you
+     * will get a compiler error.
+     */
+    ZL_RESULT_OF(ZL_VoidPtr) (*materializeFn)(
+            ZL_Materializer* matCtx,
+            const void* src,
+            size_t srcSize)ZL_NOEXCEPT_FUNC_PTR;
+
+    /**
+     * @brief A custom function that destructs a materialized object.
+     *
+     * You should use this to deallocate all non-arena memory and free any held
+     * resources. As a convenience, if there are no resources or memory to free,
+     * you may use ZL_NOOP_DEMATERIALIZE as a placeholder.
+     */
+    void (*dematerializeFn)(ZL_Materializer* matCtx, void* materialized)
+            ZL_NOEXCEPT_FUNC_PTR;
+} ZL_MaterializerDesc2;
+
 #if defined(__cplusplus)
 } // extern "C"
 #endif

--- a/include/openzl/zl_reflection.h
+++ b/include/openzl/zl_reflection.h
@@ -312,6 +312,13 @@ char const* ZL_Compressor_Node_getName(
 bool ZL_Compressor_Node_isStandard(ZL_Compressor const* cgraph, ZL_NodeID node);
 
 /**
+ * @returns The dict ID associated with the @p node.
+ */
+ZL_DictID ZL_Compressor_Node_getDictID(
+        ZL_Compressor const* cgraph,
+        ZL_NodeID node);
+
+/**
  * Reflection API for introspecting a compressed frame.
  *
  * 1. Create a reflection context with ZL_ReflectionCtx_create().

--- a/src/openzl/compress/cgraph.c
+++ b/src/openzl/compress/cgraph.c
@@ -414,6 +414,7 @@ ZL_Compressor_parameterizeNode(
         .name        = params->name,
         .node        = node,
         .localParams = params->localParams,
+        .dictID      = params->dictID,
     };
 
     return NM_parameterizeNode(&compressor->nmgr, &desc);
@@ -427,6 +428,7 @@ ZL_NodeID ZL_Compressor_registerParameterizedNode(
     ZL_NodeParameters params = {
         .name        = desc->name,
         .localParams = desc->localParams,
+        .dictID      = desc->dictID,
     };
     ZL_RESULT_OF(ZL_NodeID)
     nodeidResult =
@@ -1199,6 +1201,13 @@ char const* ZL_Compressor_Node_getName(
 bool ZL_Compressor_Node_isStandard(ZL_Compressor const* cgraph, ZL_NodeID node)
 {
     return CNODE_isTransformStandard(CGRAPH_getCNode(cgraph, node));
+}
+
+ZL_DictID ZL_Compressor_Node_getDictID(
+        ZL_Compressor const* cgraph,
+        ZL_NodeID node)
+{
+    return CNODE_getDictID(CGRAPH_getCNode(cgraph, node));
 }
 
 // ******************************************************************

--- a/src/openzl/compress/cnode.c
+++ b/src/openzl/compress/cnode.c
@@ -200,3 +200,10 @@ bool CNODE_isTransformStandard(CNode const* cnode)
 {
     return cnode->publicIDtype == trt_standard;
 }
+
+ZL_DictID CNODE_getDictID(CNode const* cnode)
+{
+    ZL_ASSERT_NN(cnode);
+    ZL_ASSERT_EQ(cnode->nodetype, node_internalTransform);
+    return cnode->transformDesc.publicDesc.dictID;
+}

--- a/src/openzl/compress/cnode.h
+++ b/src/openzl/compress/cnode.h
@@ -18,6 +18,11 @@ typedef struct {
     // Set to ZL_MAX_FORMAT_VERSION unless the node is deprecated.
     unsigned maxFormatVersion;
     InternalTransform_Desc transformDesc;
+    /// If a dictionary is specified in the transformDesc, this field is
+    /// populated with the offset of that dict within the compressor's bundle.
+    /// The "default" value is updated when ZL_Compressor_validate() is called,
+    /// before compression starts.
+    size_t maybeDictOffset /* defaults to SIZE_MAX */;
     /// Standard nodes leave this empty, all other nodes set this.
     /// When set ZL_Name_unique(&maybeName) == transformDesc.publicDesc.name.
     ZL_Name maybeName;
@@ -128,5 +133,9 @@ CNODE_FormatInfo CNODE_getFormatInfo(CNode const* cnode);
 
 // @returns the transformation type of the cnode
 bool CNODE_isTransformStandard(CNode const* cnode);
+
+/// @returns the dict ID associated with the @p cnode
+/// @pre cnode->nodetype == node_internalTransform
+ZL_DictID CNODE_getDictID(CNode const* cnode);
 
 #endif // OPENZL_COMPRESS_CNODE_H

--- a/src/openzl/compress/cnodes.c
+++ b/src/openzl/compress/cnodes.c
@@ -3,7 +3,8 @@
 #include "openzl/compress/cnodes.h"
 #include "openzl/common/allocation.h" // ALLOC_*, ZL_zeroes
 #include "openzl/common/assertion.h"
-#include "openzl/common/limits.h" // ZL_ENCODER_CUSTOM_NODE_LIMIT
+#include "openzl/common/limits.h"    // ZL_ENCODER_CUSTOM_NODE_LIMIT
+#include "openzl/common/unique_id.h" // ZL_UniqueID_isValid
 #include "openzl/common/vector.h"
 #include "openzl/common/wire_format.h" // trt_standard
 #include "openzl/compress/cnode.h"
@@ -336,6 +337,12 @@ CTM_parameterizeNode(
     clonedCNode.baseNodeID = desc->node;
     if (desc->localParams) {
         clonedCNode.transformDesc.publicDesc.localParams = *desc->localParams;
+    }
+    {
+        const ZL_UniqueID* uid = &desc->dictID.id;
+        if (ZL_UniqueID_isValid(uid)) {
+            clonedCNode.transformDesc.publicDesc.dictID = desc->dictID;
+        }
     }
     if (desc->name == NULL) {
         const ZL_Name name = CNODE_getNameObj(srcCNode);

--- a/src/openzl/compress/materializer.c
+++ b/src/openzl/compress/materializer.c
@@ -16,9 +16,9 @@ ZL_Materializer* ZL_Materializer_create(
     if (mat == NULL) {
         return NULL;
     }
-    mat->allocator = allocator;
-    mat->matArena  = ALLOC_StackArena_create();
-    if (mat->matArena == NULL) {
+    mat->persistentArena = allocator;
+    mat->scratchArena    = ALLOC_StackArena_create();
+    if (mat->scratchArena == NULL) {
         ALLOC_Arena_free(allocator, mat);
         return NULL;
     }
@@ -31,24 +31,24 @@ void ZL_Materializer_free(ZL_Materializer* mat)
     if (mat == NULL) {
         return;
     }
-    ALLOC_Arena_freeArena(mat->matArena);
-    ALLOC_Arena_free(mat->allocator, mat);
+    ALLOC_Arena_freeArena(mat->scratchArena);
+    ALLOC_Arena_free(mat->persistentArena, mat);
 }
 
 void* ZL_Materializer_allocate(ZL_Materializer* mat, size_t size)
 {
-    if (mat == NULL || mat->allocator == NULL) {
+    if (mat == NULL || mat->persistentArena == NULL) {
         return NULL;
     }
-    return ALLOC_Arena_malloc(mat->allocator, size);
+    return ALLOC_Arena_malloc(mat->persistentArena, size);
 }
 
 void* ZL_Materializer_getScratchSpace(ZL_Materializer* mat, size_t size)
 {
-    if (mat == NULL || mat->matArena == NULL) {
+    if (mat == NULL || mat->scratchArena == NULL) {
         return NULL;
     }
-    return ALLOC_Arena_malloc(mat->matArena, size);
+    return ALLOC_Arena_malloc(mat->scratchArena, size);
 }
 
 void ZL_NOOP_DEMATERIALIZE(ZL_Materializer* matCtx, void* materialized)

--- a/src/openzl/compress/materializer.h
+++ b/src/openzl/compress/materializer.h
@@ -15,8 +15,8 @@ ZL_BEGIN_C_DECLS
 // ******************************************************************
 
 struct ZL_Materializer_s {
-    Arena* allocator;
-    Arena* matArena;
+    Arena* persistentArena;
+    Arena* scratchArena;
     const void* opaquePtr;
 } /* typedef'ed to ZL_Materializer in zl_opaque_types.h */;
 

--- a/tests/integrationtest/CompressorIntegrationTest.cpp
+++ b/tests/integrationtest/CompressorIntegrationTest.cpp
@@ -2,15 +2,18 @@
 
 #include <gtest/gtest.h>
 
+#include <cstring>
+
 #include "openzl/cpp/CCtx.hpp"
 #include "openzl/cpp/CParam.hpp"
 #include "openzl/cpp/Compressor.hpp"
 #include "openzl/cpp/LocalParams.hpp"
 #include "openzl/cpp/poly/Span.hpp"
-#include "openzl/zl_compress.h"
+
 #include "openzl/zl_compressor.h"
 #include "openzl/zl_ctransform.h"
 #include "openzl/zl_graph_api.h"
+#include "openzl/zl_reflection.h"
 #include "openzl/zl_segmenter.h"
 #include "openzl/zl_selector.h"
 
@@ -716,6 +719,197 @@ TEST_F(CompressorIntegrationTest,
 
     compressData();
     EXPECT_EQ(str, str2);
+}
+
+TEST_F(CompressorIntegrationTest,
+       GIVENaNodeRegisteredWithDictIDWHENqueriedTHENdictIDIsReturned)
+{
+    const auto passthroughFn =
+            [](ZL_Encoder* eictx, const ZL_Input* inputs[], size_t nbInputs)
+                    ZL_NOEXCEPT_FUNC_PTR -> ZL_Report {
+        return passthrough(eictx, inputs, nbInputs);
+    };
+
+    ZL_DictID dictID;
+    memset(&dictID, 0, sizeof(dictID));
+    dictID.id.bytes[0] = 42;
+    dictID.id.bytes[1] = 123;
+
+    static ZL_Type typetype = ZL_Type_serial;
+    ZL_MIGraphDesc graphDesc{
+        .CTid                = nextCtid_++,
+        .inputTypes          = &typetype,
+        .nbInputs            = 1,
+        .lastInputIsVariable = false,
+        .soTypes             = &typetype,
+        .nbSOs               = 1,
+        .voTypes             = nullptr,
+        .nbVOs               = 0,
+    };
+
+    ZL_MIEncoderDesc encoderDesc{
+        .gd          = graphDesc,
+        .transform_f = passthroughFn,
+        .localParams = {},
+        .name        = "test_encoder_with_dictID",
+        .dictID      = dictID,
+    };
+
+    auto nodeid = compressor_.registerCustomEncoder(encoderDesc);
+    ASSERT_NE(nodeid.nid, ZL_NODE_ILLEGAL.nid);
+
+    ZL_DictID retrieved =
+            ZL_Compressor_Node_getDictID(compressor_.get(), nodeid);
+    EXPECT_EQ(retrieved.id.bytes[0], 42u);
+    EXPECT_EQ(retrieved.id.bytes[1], 123u);
+    EXPECT_EQ(retrieved.id.bytes[2], 0u);
+    EXPECT_EQ(retrieved.id.bytes[3], 0u);
+}
+
+TEST_F(CompressorIntegrationTest,
+       GIVENaParameterizedNodeWHENqueriedTHENdictIDIsPreservedFromBaseNode)
+{
+    const auto passthroughFn =
+            [](ZL_Encoder* eictx, const ZL_Input* inputs[], size_t nbInputs)
+                    ZL_NOEXCEPT_FUNC_PTR -> ZL_Report {
+        return passthrough(eictx, inputs, nbInputs);
+    };
+
+    ZL_DictID dictID;
+    memset(&dictID, 0, sizeof(dictID));
+    dictID.id.bytes[0] = 99;
+    dictID.id.bytes[1] = 200;
+    dictID.id.bytes[2] = 44;
+    dictID.id.bytes[3] = 144;
+
+    static ZL_Type typetype = ZL_Type_serial;
+    ZL_MIGraphDesc graphDesc{
+        .CTid                = nextCtid_++,
+        .inputTypes          = &typetype,
+        .nbInputs            = 1,
+        .lastInputIsVariable = false,
+        .soTypes             = &typetype,
+        .nbSOs               = 1,
+        .voTypes             = nullptr,
+        .nbVOs               = 0,
+    };
+
+    ZL_MIEncoderDesc encoderDesc{
+        .gd          = graphDesc,
+        .transform_f = passthroughFn,
+        .localParams = {},
+        .name        = "test_encoder_parameterized_dictID",
+        .dictID      = dictID,
+    };
+
+    auto baseNode = compressor_.registerCustomEncoder(encoderDesc);
+    ASSERT_NE(baseNode.nid, ZL_NODE_ILLEGAL.nid);
+
+    // Parameterize the node with new local params but no dictID override
+    ZL_IntParam ip = {
+        .paramId    = 1,
+        .paramValue = 42,
+    };
+    ZL_LocalParams lp = {
+        .intParams = {
+            .intParams   = &ip,
+            .nbIntParams = 1,
+        },
+    };
+    ZL_ParameterizedNodeDesc desc = {
+        .name        = nullptr,
+        .node        = baseNode,
+        .localParams = &lp,
+    };
+    ZL_NodeID paramNode =
+            ZL_Compressor_registerParameterizedNode(compressor_.get(), &desc);
+    ASSERT_NE(paramNode.nid, ZL_NODE_ILLEGAL.nid);
+
+    // The dictID should be carried over from the base node
+    ZL_DictID retrieved =
+            ZL_Compressor_Node_getDictID(compressor_.get(), paramNode);
+    EXPECT_EQ(retrieved.id.bytes[0], 99u);
+    EXPECT_EQ(retrieved.id.bytes[1], 200u);
+    EXPECT_EQ(retrieved.id.bytes[2], 44u);
+    EXPECT_EQ(retrieved.id.bytes[3], 144u);
+}
+
+TEST_F(CompressorIntegrationTest,
+       GIVENaParameterizedNodeWithNewDictIDWHENqueriedTHENnewDictIDIsUsed)
+{
+    const auto passthroughFn =
+            [](ZL_Encoder* eictx, const ZL_Input* inputs[], size_t nbInputs)
+                    ZL_NOEXCEPT_FUNC_PTR -> ZL_Report {
+        return passthrough(eictx, inputs, nbInputs);
+    };
+
+    // Register base node with an initial dictID
+    ZL_DictID originalDictID;
+    memset(&originalDictID, 0, sizeof(originalDictID));
+    originalDictID.id.bytes[0] = 10;
+    originalDictID.id.bytes[1] = 20;
+
+    static ZL_Type typetype = ZL_Type_serial;
+    ZL_MIGraphDesc graphDesc{
+        .CTid                = nextCtid_++,
+        .inputTypes          = &typetype,
+        .nbInputs            = 1,
+        .lastInputIsVariable = false,
+        .soTypes             = &typetype,
+        .nbSOs               = 1,
+        .voTypes             = nullptr,
+        .nbVOs               = 0,
+    };
+
+    ZL_MIEncoderDesc encoderDesc{
+        .gd          = graphDesc,
+        .transform_f = passthroughFn,
+        .localParams = {},
+        .name        = "test_encoder_override_dictID",
+        .dictID      = originalDictID,
+    };
+
+    auto baseNode = compressor_.registerCustomEncoder(encoderDesc);
+    ASSERT_NE(baseNode.nid, ZL_NODE_ILLEGAL.nid);
+
+    // Verify base node has the original dictID
+    ZL_DictID baseRetrieved =
+            ZL_Compressor_Node_getDictID(compressor_.get(), baseNode);
+    EXPECT_EQ(baseRetrieved.id.bytes[0], 10u);
+    EXPECT_EQ(baseRetrieved.id.bytes[1], 20u);
+
+    // Parameterize the node with a new dictID
+    ZL_DictID newDictID;
+    memset(&newDictID, 0, sizeof(newDictID));
+    newDictID.id.bytes[0] = 77;
+    newDictID.id.bytes[1] = 88;
+    newDictID.id.bytes[2] = 99;
+    newDictID.id.bytes[3] = 111;
+
+    ZL_NodeParameters params = {
+        .name        = nullptr,
+        .localParams = nullptr,
+        .dictID      = newDictID,
+    };
+    ZL_RESULT_OF(ZL_NodeID)
+    result = ZL_Compressor_parameterizeNode(
+            compressor_.get(), baseNode, &params);
+    ASSERT_FALSE(ZL_RES_isError(result));
+    ZL_NodeID paramNode = ZL_RES_value(result);
+    ASSERT_NE(paramNode.nid, ZL_NODE_ILLEGAL.nid);
+
+    // The parameterized node should have the new dictID
+    ZL_DictID retrieved =
+            ZL_Compressor_Node_getDictID(compressor_.get(), paramNode);
+    EXPECT_EQ(retrieved.id.bytes[0], 77u);
+    EXPECT_EQ(retrieved.id.bytes[1], 88u);
+    EXPECT_EQ(retrieved.id.bytes[2], 99u);
+    EXPECT_EQ(retrieved.id.bytes[3], 111u);
+
+    // The base node should still have the original dictID
+    baseRetrieved = ZL_Compressor_Node_getDictID(compressor_.get(), baseNode);
+    EXPECT_EQ(baseRetrieved.id.bytes[0], 10u);
+    EXPECT_EQ(baseRetrieved.id.bytes[1], 20u);
 }
 
 } // namespace openzl


### PR DESCRIPTION
Summary: Add a `dictID` member to the `CNode`, enabling encoder nodes to be associated with a specific dictionary. This threads the ZL_DictID through node registration/parameterization. Currently exposed via a new reflection API for testing.

Reviewed By: terrelln

Differential Revision: D98016824


