### PR TITLE
C++: Take Const Shared Pointers in Custom Component Registration Functions (#598)

### DIFF
--- a/cpp/include/openzl/cpp/Compressor.hpp
+++ b/cpp/include/openzl/cpp/Compressor.hpp
@@ -127,6 +127,8 @@ class Compressor {
 
     void selectStartingGraph(GraphID graph);
 
+    GraphID getStartingGraph() const;
+
     /// @returns a serialized representation of this compressor.
     ///
     /// @note consult zl_compressor_serialization.h for discussion of the

--- a/cpp/include/openzl/cpp/CustomDecoder.hpp
+++ b/cpp/include/openzl/cpp/CustomDecoder.hpp
@@ -65,7 +65,7 @@ class CustomDecoder {
 
     static void registerCustomDecoder(
             DCtx& dctx,
-            std::shared_ptr<CustomDecoder> decoder);
+            std::shared_ptr<const CustomDecoder> decoder);
 };
 
 } // namespace openzl

--- a/cpp/include/openzl/cpp/CustomEncoder.hpp
+++ b/cpp/include/openzl/cpp/CustomEncoder.hpp
@@ -86,7 +86,7 @@ class CustomEncoder {
 
     static NodeID registerCustomEncoder(
             Compressor& compressor,
-            std::shared_ptr<CustomEncoder> encoder);
+            std::shared_ptr<const CustomEncoder> encoder);
 };
 
 } // namespace openzl

--- a/cpp/include/openzl/cpp/FunctionGraph.hpp
+++ b/cpp/include/openzl/cpp/FunctionGraph.hpp
@@ -162,6 +162,6 @@ class FunctionGraph {
 
     static GraphID registerFunctionGraph(
             Compressor& compressor,
-            std::shared_ptr<FunctionGraph> functionGraph);
+            std::shared_ptr<const FunctionGraph> functionGraph);
 };
 } // namespace openzl

--- a/cpp/include/openzl/cpp/Selector.hpp
+++ b/cpp/include/openzl/cpp/Selector.hpp
@@ -92,7 +92,7 @@ class Selector : private FunctionGraph {
 
     static GraphID registerSelector(
             Compressor& compressor,
-            std::shared_ptr<Selector> selector);
+            std::shared_ptr<const Selector> selector);
 
    private:
     void graph(GraphState& state) const override;

--- a/cpp/src/openzl/cpp/Compressor.cpp
+++ b/cpp/src/openzl/cpp/Compressor.cpp
@@ -5,6 +5,7 @@
 #include "openzl/zl_compressor.h"
 #include "openzl/zl_compressor_serialization.h"
 #include "openzl/zl_ctransform.h"
+#include "openzl/zl_reflection.h"
 
 #include "openzl/cpp/CustomEncoder.hpp"
 #include "openzl/cpp/FunctionGraph.hpp"
@@ -162,6 +163,13 @@ poly::optional<GraphID> Compressor::getGraph(const char* name) const
 void Compressor::selectStartingGraph(GraphID graph)
 {
     unwrap(ZL_Compressor_selectStartingGraphID(get(), graph));
+}
+
+GraphID Compressor::getStartingGraph() const
+{
+    GraphID gid;
+    ZL_Compressor_getStartingGraphID(get(), &gid);
+    return gid;
 }
 
 std::string Compressor::serialize() const

--- a/cpp/src/openzl/cpp/CustomDecoder.cpp
+++ b/cpp/src/openzl/cpp/CustomDecoder.cpp
@@ -81,7 +81,7 @@ static ZL_Report decodeFn(
 
 /* static */ void CustomDecoder::registerCustomDecoder(
         DCtx& dctx,
-        std::shared_ptr<CustomDecoder> decoder)
+        std::shared_ptr<const CustomDecoder> decoder)
 {
     const auto& desc               = decoder->multiInputDescription();
     auto inputTypes                = typesToCTypes(desc.inputTypes);

--- a/cpp/src/openzl/cpp/CustomEncoder.cpp
+++ b/cpp/src/openzl/cpp/CustomEncoder.cpp
@@ -95,7 +95,7 @@ static ZL_Report encodeFn(
 
 /* static */ NodeID CustomEncoder::registerCustomEncoder(
         Compressor& compressor,
-        std::shared_ptr<CustomEncoder> encoder)
+        std::shared_ptr<const CustomEncoder> encoder)
 {
     const auto& desc               = encoder->multiInputDescription();
     auto inputTypes                = typesToCTypes(desc.inputTypes);

--- a/cpp/src/openzl/cpp/FunctionGraph.cpp
+++ b/cpp/src/openzl/cpp/FunctionGraph.cpp
@@ -204,7 +204,7 @@ graphFn(ZL_Graph* graph, ZL_Edge* edges[], size_t nbEdges) noexcept
 
 /* static */ GraphID FunctionGraph::registerFunctionGraph(
         Compressor& compressor,
-        std::shared_ptr<FunctionGraph> functionGraph)
+        std::shared_ptr<const FunctionGraph> functionGraph)
 {
     const auto& desc               = functionGraph->functionGraphDescription();
     auto inputTypeMasks            = typesMasksToCTypes(desc.inputTypeMasks);

--- a/cpp/src/openzl/cpp/Opaque.hpp
+++ b/cpp/src/openzl/cpp/Opaque.hpp
@@ -10,17 +10,18 @@
 namespace openzl {
 
 template <typename T>
-ZL_OpaquePtr moveToOpaquePtr(std::shared_ptr<T> ptr)
+ZL_OpaquePtr moveToOpaquePtr(std::shared_ptr<const T> ptr)
 {
     auto raw = ptr.get();
-    return ZL_OpaquePtr{ .ptr = raw,
+    return ZL_OpaquePtr{ .ptr = const_cast<void*>((const void*)raw),
                          .freeOpaquePtr =
-                                 new std::shared_ptr<T>(std::move(ptr)),
+                                 new std::shared_ptr<const T>(std::move(ptr)),
                          .freeFn = [](void* freeOpaquePtr,
                                       void* opaquePtr) noexcept {
                              assert(freeOpaquePtr != nullptr);
-                             auto sharedPtr = static_cast<std::shared_ptr<T>*>(
-                                     freeOpaquePtr);
+                             auto sharedPtr =
+                                     static_cast<std::shared_ptr<const T>*>(
+                                             freeOpaquePtr);
                              assert(sharedPtr->get() == opaquePtr);
                              sharedPtr->reset();
                              delete sharedPtr;

--- a/cpp/src/openzl/cpp/Selector.cpp
+++ b/cpp/src/openzl/cpp/Selector.cpp
@@ -10,12 +10,13 @@ namespace openzl {
 
 /* static */ GraphID Selector::registerSelector(
         Compressor& compressor,
-        std::shared_ptr<Selector> selector)
+        std::shared_ptr<const Selector> selector)
 {
     return FunctionGraph::registerFunctionGraph(
             compressor,
-            std::shared_ptr<FunctionGraph>(
-                    selector, static_cast<FunctionGraph*>(selector.get())));
+            std::shared_ptr<const FunctionGraph>(
+                    selector,
+                    static_cast<const FunctionGraph*>(selector.get())));
 }
 
 void Selector::graph(GraphState& state) const

--- a/cpp/tests/TestCompressor.cpp
+++ b/cpp/tests/TestCompressor.cpp
@@ -106,6 +106,7 @@ TEST_F(TestCompressor, buildStaticGraph)
     auto graph = compressor_.buildStaticGraph(
             ZL_NODE_DELTA_INT, { ZL_GRAPH_CONSTANT });
     compressor_.selectStartingGraph(graph);
+    ASSERT_EQ(compressor_.getStartingGraph(), graph);
 
     auto compressed = testRoundTrip(
             compressor_, Input::refNumeric(poly::span<const int>(data)));


### PR DESCRIPTION
Summary:

These objects are logically const. And in the new pattern we are setting up,
we make a single `constinit` instantiation of each custom component and then
point at that. So we don't have a non-const ref we can pass in.

This does mean converting the `moveToOpaquePtr()` helpers to take a const arg
which is a bit awkward because we then have to cast away the const to coerce
it to `void *`. But arguably `ZL_OpaquePtr` should just have a `const void*`
since the pointed-to object at minimum needs to be thread safe...

Reviewed By: kevinjzhang

Differential Revision: D98968843


