### PR TITLE
Skip graphs with no training samples (#600)

### DIFF
--- a/tools/protobuf/cli.cpp
+++ b/tools/protobuf/cli.cpp
@@ -18,7 +18,7 @@
 #include "tools/protobuf/ProtoDeserializer.h"
 #include "tools/protobuf/ProtoSerializer.h"
 #include "tools/protobuf/serialization_utils.h"
-#ifdef ZL_IS_FBCODE
+#if defined(ZL_IS_FBCODE) && (ZL_IS_FBCODE == 1)
 #    if ZL_FBCODE_IS_RELEASE
 #        include "openzl/prod/tools/protobuf/schema.pb.h"
 #    else

--- a/tools/training/ace/ace.cpp
+++ b/tools/training/ace/ace.cpp
@@ -118,8 +118,24 @@ std::vector<std::shared_ptr<const std::string_view>> ACETrainer::train(
     size_t graphIdx        = 0;
     const size_t numGraphs = autoBackendGraphs.size();
     for (const auto& backendGraph : autoBackendGraphs) {
+        ++graphIdx;
+        // Skip graphs with no training samples (e.g., optional fields that
+        // aren't present in the training data). These will use default
+        // compression.
+        if (samples[backendGraph].empty()) {
+            Logger::log(
+                    VERBOSE1,
+                    "Skipping ACE graph ",
+                    graphIdx,
+                    " / ",
+                    numGraphs,
+                    " (",
+                    backendGraph,
+                    "): no training samples");
+            continue;
+        }
         auto aceState = trainBackend(
-                samples[backendGraph], trainParams, ++graphIdx, numGraphs);
+                samples[backendGraph], trainParams, graphIdx, numGraphs);
         auto localParams = LocalParams();
         localParams.addCopyParam(
                 AutomatedCompressorExplorer::kAceStateParamId,


### PR DESCRIPTION
Summary:

When I run the protobuf training tool, if we have a proto field that's optional and all samples are missing it then since we iterate over all ACE graphs we will fail (no samples).

I think for optional/rarely-used fields, it's fine to skip and use default compression for those.

Also fixes a bug in the protobuf CLI class where we had `#ifdef ZL_IS_FBCODE`. This triggers even if `ZL_IS_FBCODE=0`, where we should actually check if it's true. This was causing compilation issues for me.

## Type of Change
Bug fix (non-breaking change which fixes an issue)


Test Plan: `protobuf_cli train --input training_data/ --output trained.zlc` where training_data has all samples missing some proto field

Reviewed By: daniellerozenblit

Differential Revision: D99707790

Pulled By: Cyan4973
