### PR TITLE
Add ~16MB auto-chunking segmenter to XLDB int graphs (#602)

### DIFF
--- a/tests/datagen/distributions/VecLengthDistribution.h
+++ b/tests/datagen/distributions/VecLengthDistribution.h
@@ -16,7 +16,7 @@ class VecLengthDistribution : public Distribution<size_t> {
     explicit VecLengthDistribution(
             std::shared_ptr<RandWrapper> generator,
             size_t min,
-            size_t max = kMaxVecLength)
+            size_t max = ((size_t)1u << 17))
             : Distribution<size_t>(generator), min_(min), max_(max)
     {
         if (min > max) {
@@ -57,8 +57,6 @@ class VecLengthDistribution : public Distribution<size_t> {
     }
 
    private:
-    static constexpr size_t kMaxVecLength = (size_t)1u << 17;
-
     const size_t min_;
     const size_t max_;
 };


### PR DESCRIPTION
Summary:

Add a segmenter to all XLDB numeric graphs (U8/U16/U32/U64/F32) that
auto-chunks input at ~16MB boundaries, aligned to element width. This
is implemented inside makeXldbGenericIntCGraphImpl so it applies to all
int/float graph variants automatically. Fallback (ZSTD) and Store graphs are not segmented.

There is an existing numeric segmenter standard graph, but we can't use it because it doesn't allow us to specify the chunk size or inner graph. The next diff in this stack will add support in the numeric segmenter. When a new OpenZL release is issued, we will migrate to the numeric segmenter.

Reviewed By: terrelln

Differential Revision: D99729801
