### PR TITLE
Add legacy SDDL1 documentation section

### DIFF
--- a/doc/mkdocs/doc/sddl/index.md
+++ b/doc/mkdocs/doc/sddl/index.md
@@ -13,3 +13,7 @@ The **target specification** for SDDL — the full language design we're buildin
 
 - [Full Documentation](north-star/index.md)
 - [SDDL for LLMs](north-star/sddl-for-llm.md) — Complete v0.6 spec optimized for AI assistants
+
+### [Legacy (SDDL1)](legacy/index.md)
+
+Documentation for the **original SDDL language** (v1), which uses a different syntax and compiles to a CBOR-based runtime. This version is deprecated in favor of SDDL2.

--- a/doc/mkdocs/doc/sddl/legacy/index.md
+++ b/doc/mkdocs/doc/sddl/legacy/index.md
@@ -1,0 +1,9 @@
+# SDDL1 — Legacy Language
+
+!!! warning "Deprecated"
+
+    This section documents the **original SDDL language** (v1), which uses a CBOR-based compiled representation and a different runtime engine. SDDL1 is deprecated in favor of the [current SDDL2 language](../getting-started.md).
+
+    New projects should use the current SDDL2 syntax. For the full planned feature set, see the [North Star (v0.6)](../north-star/index.md) specification.
+
+--8<-- "src/include/openzl/codecs/zl_sddl.md"

--- a/doc/mkdocs/mkdocs.yml
+++ b/doc/mkdocs/mkdocs.yml
@@ -48,6 +48,7 @@ nav:
         - Best Practices: sddl/north-star/best-practices.md
         - Quick Reference: sddl/north-star/reference.md
         - SDDL for LLMs: sddl/north-star/sddl-for-llm.md
+      - Legacy (SDDL1): sddl/legacy/index.md
   - API Reference:
     - C:
       - Compressor: api/c/compressor.md


### PR DESCRIPTION
Summary:
## Stack
The goal of this stack is to reorganize the SDDL documentation hub to clearly separate the current language (SDDL2), the north-star specification (v0.6), and the legacy language (SDDL1).

## Diff
Adds a legacy SDDL1 documentation section to preserve reference material for the original language.

Differential Revision: D100016132


