### PR TITLE
Add current-language documentation for supported SDDL2 features

### DIFF
--- a/doc/mkdocs/doc/sddl/conditional-fields.md
+++ b/doc/mkdocs/doc/sddl/conditional-fields.md
@@ -1,0 +1,65 @@
+# Conditional Fields
+
+## Conditional Fields with `when`
+
+Use `when` blocks to conditionally include fields based on a runtime value:
+
+```sddl
+Record Entry(has_extras) = {
+  id: UInt32LE,
+  value: Float64LE,
+  when has_extras == 1 {
+    extra1: UInt32LE,
+    extra2: UInt32LE
+  }
+}
+```
+
+The `when` block is only executed (and its fields only consumed) if the condition evaluates to a non-zero value.
+
+### Block Form
+
+The currently supported syntax uses braces to group conditional fields:
+
+```sddl
+when condition {
+  field1: Type1,
+  field2: Type2
+}
+```
+
+Multiple fields can appear inside a single `when` block.
+
+### Conditions
+
+Conditions can use any combination of variables, parameters, comparisons, and logical operators:
+
+```sddl
+Record FlexibleEntry(version, has_checksum) = {
+  id: UInt32LE,
+  data: UInt16LE,
+  when version >= 2 {
+    extended_data: UInt32LE
+  }
+  when has_checksum {
+    checksum: UInt32LE
+  }
+}
+```
+
+### Nesting
+
+`when` blocks can be nested:
+
+```sddl
+when version >= 2 {
+  extended: UInt32LE,
+  when has_extras == 1 {
+    bonus: UInt16LE
+  }
+}
+```
+
+### Important Restrictions
+
+- **Field references in conditions are not supported for member access.** You cannot reference fields consumed inside a `when` block from outside of it.

--- a/doc/mkdocs/doc/sddl/core-concepts.md
+++ b/doc/mkdocs/doc/sddl/core-concepts.md
@@ -1,0 +1,201 @@
+# Core Concepts
+
+This page explains the SDDL language features supported by the SDDL2 compiler today. For a compact lookup table of all syntax, see the [Quick Reference](reference.md).
+
+## Primitive Types
+
+SDDL provides integer, float, and byte-sequence types. Every multi-byte type requires an explicit endianness suffix: `LE` for little-endian, `BE` for big-endian. Single-byte types (`Byte`, `Int8`, `UInt8`) don't need one.
+
+For the complete list of all supported types and their sizes, see the [type tables in the Quick Reference](reference.md#types).
+
+### Integers
+
+Integer fields produce values that can be used in expressions — arithmetic, comparisons, array lengths, and conditions:
+
+```sddl
+count: UInt32LE
+offset = count * 4
+expect offset <= 1024
+data: Byte[offset]
+```
+
+### Floats
+
+Float types (`Float32LE`, `Float64LE`, `BFloat16BE`, etc.) describe how the engine should segment binary data, but their values **cannot be used in expressions**. You cannot do arithmetic or comparisons with float fields — they are type descriptors only.
+
+```sddl
+# OK: segmenting data as floats for better compression
+coordinates: Float64LE[100]
+
+# NOT allowed: using a float value in an expression
+# x: Float32LE
+# expect x > 0.0   # Error — float values can't be used in expressions
+```
+
+### Byte Sequences
+
+`Bytes(n)` consumes exactly `n` bytes as raw (untyped) data. The argument can be a literal or a variable:
+
+```sddl
+magic: Bytes(4)
+name: Bytes(name_length)
+```
+
+## Records
+
+Records group related fields into a named structure. They are the primary way to describe the layout of binary data.
+
+### Basic Records
+
+```sddl
+Record Header() = {
+  magic: UInt32LE,
+  version: UInt16LE,
+  flags: UInt16LE
+}
+```
+
+- Declared with `Record Name() = { ... }`
+- Fields are comma-separated `name: Type` pairs
+- Empty parentheses `()` are required even with no parameters
+
+### Parameterized Records
+
+Records can accept parameters that control their structure. This lets you define a single record that adapts to different variants of a format:
+
+```sddl
+Record DataBlock(element_count) = {
+  checksum: UInt32LE,
+  data: UInt16LE[element_count]
+}
+
+header: Header
+block: DataBlock(header.count)
+```
+
+Parameters can be used in array lengths, `when` conditions, and expressions within the record. When instantiating the record, you pass values (literals, variables, or field accesses) as arguments.
+
+### Nested Records
+
+Records can contain fields of other record types. Use dot notation to access nested fields:
+
+```sddl
+Record Point() = {
+  x: Int16LE,
+  y: Int16LE
+}
+
+Record Sprite() = {
+  id: UInt32LE,
+  position: Point
+}
+
+sprite: Sprite
+expect sprite.position.x >= 0
+```
+
+Chained access works to any depth: `outer.middle.inner.field`.
+
+### Anonymous (Inline) Records
+
+When you need a one-off record structure without defining a named type, use an anonymous record:
+
+```sddl
+: Record() {
+  id: Int32LE,
+  val: Int32LE
+}
+```
+
+This is useful for simple groupings where a named record would add unnecessary boilerplate.
+
+## Arrays
+
+### Fixed-Size Arrays
+
+Consume a type a specific number of times:
+
+```sddl
+values: UInt32LE[100]
+matrix: Float64LE[rows * cols]
+```
+
+The length can be a literal, a variable, or an arithmetic expression.
+
+### Auto-Sized Arrays
+
+Consume a type until the remaining input is exhausted:
+
+```sddl
+entries: StarEntry[]
+```
+
+Auto-sized arrays must appear at the end of the description, since they consume all remaining bytes.
+
+## Variables and Expressions
+
+### Variable Assignment
+
+Variables are created in two ways:
+
+**From consumption** — the `:` operator reads data and stores the result:
+```sddl
+header: Header
+```
+
+**From expressions** — the `=` operator computes a value:
+```sddl
+total_size = header.width * header.height
+num_rows = header.file_size / sizeof(Row)
+```
+
+Variables are **single-assignment** — once set, they cannot be reassigned.
+
+### Member Access
+
+Access fields of consumed records with dot notation:
+
+```sddl
+header: Header
+expect header.version == 1
+data: Byte[header.size]
+```
+
+Chained access works for nested records: `outer.inner.field`.
+
+### Operators
+
+SDDL supports arithmetic operators (`+`, `-`, `*`, `/`, `%`), unary negation (`-expr`), comparison operators (`==`, `!=`, `>`, `>=`, `<`, `<=`), and logical operators (`&&`, `||`, `!`). See the [operator tables in the Quick Reference](reference.md#operators) for the complete list.
+
+Use parentheses to control evaluation order:
+
+```sddl
+row_bytes = 4 * ((width + 3) / 4)
+```
+
+## Built-in Functions
+
+SDDL provides two built-in functions:
+
+**`sizeof`** returns the size in bytes of a type. Only works on types with statically known sizes:
+
+```sddl
+expect header.entry_size == sizeof(Row)
+expect sizeof(StarEntry(STNUM, MPROP, NMAG)) == header.NBENT
+```
+
+**`abs()`** returns the absolute value of an integer expression:
+
+```sddl
+count = abs(header.signed_count)
+magnitudes: Int16LE[abs(NMAG)]
+```
+
+## Comments
+
+Single-line comments start with `#`:
+
+```sddl
+# This is a comment
+magic: UInt32LE  # inline comment
+```

--- a/doc/mkdocs/doc/sddl/examples.md
+++ b/doc/mkdocs/doc/sddl/examples.md
@@ -1,0 +1,23 @@
+# Examples
+
+Complete SDDL descriptions for real binary formats.
+
+## SAO Star Catalog (Simplified)
+
+The [Silesia compression corpus](https://sun.aei.polsl.pl/~sdeor/index.php?page=silesia) includes a file from the SAO (Smithsonian Astronomical Observatory) star catalog. This simplified description treats every entry as having the same fixed layout — 28 bytes of coordinates, spectral type, magnitude, and proper motion:
+
+```sddl
+Record StarEntry() = {
+  SRA0:  Float64LE,     # Right Ascension (radians)
+  SDEC0: Float64LE,     # Declination (radians)
+  ISP:   Bytes(2),      # Spectral type
+  MAG:   Int16LE,       # Magnitude
+  XRPM:  Float32LE,     # R.A. proper motion
+  XDPM:  Float32LE      # Dec. proper motion
+}
+
+header: Byte[28]
+stars: StarEntry[]
+```
+
+This works well when the file uses a single fixed entry format. For the full SAO format with variable-layout entries, see the [Getting Started](getting-started.md#making-it-flexible) guide.

--- a/doc/mkdocs/doc/sddl/getting-started.md
+++ b/doc/mkdocs/doc/sddl/getting-started.md
@@ -1,0 +1,200 @@
+# Getting Started with SDDL
+
+This guide walks you through writing your first SDDL description, building up from a minimal example to a complete real-world format.
+
+## What is SDDL?
+
+SDDL (Simple Data Description Language) lets you describe binary file formats so that OpenZL can efficiently decompose them into typed streams for compression. You write a description of your format, the SDDL compiler translates it to bytecode, and the SDDL engine uses that bytecode to parse and split your data.
+
+Instead of treating a file as an opaque blob of bytes, SDDL lets you tell the compressor "these 8 bytes are a double-precision float, these 4 bytes are an unsigned integer, ..." — so it can group similar data together and compress it more effectively.
+
+## Your First Description
+
+The simplest useful description is a single field consumption:
+
+```sddl
+: Byte[]
+```
+
+This consumes the entire input as an array of bytes. Let's break this down:
+
+- `:` is the **consumption operator** — it reads bytes from the input and associates them with a type
+- `Byte` is a single-byte type
+- `[]` makes it an **auto-sized array** — it repeats until all input is consumed
+
+This doesn't do anything useful for compression (it's equivalent to treating the file as raw bytes), but it shows the basic mechanics.
+
+## Adding Structure
+
+We'll use a real format for the rest of this guide: the [SAO Star Catalog](http://tdc-www.harvard.edu/software/catalogs/catalogsb.html), which stores astronomical data as a flat array of fixed-size records.
+
+Each star entry is 28 bytes containing coordinates, spectral type, magnitude, and proper motion:
+
+```sddl
+Record StarEntry() = {
+  SRA0:  Float64LE,     # Right Ascension (radians, 8 bytes)
+  SDEC0: Float64LE,     # Declination (radians, 8 bytes)
+  ISP:   Bytes(2),      # Spectral type (2 bytes)
+  MAG:   Int16LE,       # Magnitude (2 bytes)
+  XRPM:  Float32LE,     # R.A. proper motion (4 bytes)
+  XDPM:  Float32LE      # Dec. proper motion (4 bytes)
+}
+```
+
+Key points:
+
+- **Records** are declared with `Record Name() = { ... }` and group related fields
+- Fields use `name: Type` syntax, separated by commas
+- **Endianness is always explicit** — `Float64LE` means 64-bit little-endian float, `Int16LE` means 16-bit little-endian signed integer
+- `Bytes(n)` consumes exactly `n` bytes as raw (untyped) data
+- Comments start with `#`
+
+## Describing the File
+
+The SAO file has a 28-byte header followed by star entries. For now, let's skip the header and just describe the repeating entries:
+
+```sddl
+Record StarEntry() = {
+  SRA0:  Float64LE,
+  SDEC0: Float64LE,
+  ISP:   Bytes(2),
+  MAG:   Int16LE,
+  XRPM:  Float32LE,
+  XDPM:  Float32LE
+}
+
+header: Byte[28]
+stars: StarEntry[]
+```
+
+- `header: Byte[28]` consumes 28 bytes and stores the result in a variable called `header`
+- `stars: StarEntry[]` consumes the remaining input as an auto-sized array of `StarEntry` records — the engine calculates how many entries fit in the remaining bytes
+
+This is already a working description — you could use it to compress the SAO file right now. But we can do better by parsing the header properly.
+
+## Parsing the Header
+
+Instead of treating the header as raw bytes, let's define its structure:
+
+```sddl
+Record CatalogHeader() = {
+  STAR0: Int32LE,   # Subtract from star number to get sequence number
+  STAR1: Int32LE,   # First star number in file
+  STARN: Int32LE,   # Number of stars in the file
+  STNUM: Int32LE,   # Star numbering scheme
+  MPROP: Int32LE,   # Proper motion info: 0=none, 1=included, 2=with velocity
+  NMAG:  Int32LE,   # Number of magnitude values per star
+  NBENT: Int32LE    # Bytes per star entry
+}
+
+Record StarEntry() = {
+  SRA0:  Float64LE,
+  SDEC0: Float64LE,
+  ISP:   Bytes(2),
+  MAG:   Int16LE,
+  XRPM:  Float32LE,
+  XDPM:  Float32LE
+}
+
+header: CatalogHeader
+stars: StarEntry[]
+```
+
+Now `header` is a structured variable. We can access its fields with **dot notation** — for example, `header.STARN` gives us the number of stars.
+
+## Adding Validation
+
+The `expect` statement lets you validate format constraints at parse time. If a condition is false, parsing fails with an error — catching corrupt or misidentified files early:
+
+```sddl
+header: CatalogHeader
+
+# Verify the entry size matches what we expect
+expect header.NBENT == sizeof(StarEntry)
+
+stars: StarEntry[]
+```
+
+- `sizeof` returns the size in bytes of a type (only works on types with statically known sizes)
+- If the header says entries are a different size than our `StarEntry` definition, something is wrong — `expect` catches this immediately
+
+## Making It Flexible
+
+The simplified description above assumes every star entry has the same fixed layout. But the full SAO format is more complex: depending on header flags, entries can include optional fields like catalog numbers, magnitude arrays, proper motion, radial velocity, and object names.
+
+SDDL handles this with **parameterized records** and **conditional fields**:
+
+```sddl
+Record CatalogHeader() = {
+  STAR0: Int32LE,   # Subtract from star number to get sequence number
+  STAR1: Int32LE,   # First star number in file
+  STARN: Int32LE,   # Number of stars; <0 → coordinates J2000
+  STNUM: Int32LE,   # ID scheme / name flag
+  MPROP: Int32LE,   # Motion info: 0=none, 1=proper, 2=radial
+  NMAG:  Int32LE,   # Number of magnitudes (0–10)
+  NBENT: Int32LE    # Bytes per star entry
+}
+
+Record StarEntry(STNUM, MPROP, NMAG) = {
+  when STNUM > 0 { XNO: Float32LE },               # Catalog number
+  SRA0:  Float64LE,                                # Right Ascension
+  SDEC0: Float64LE,                                # Declination
+  ISP:   Bytes(2),                                 # Spectral type
+  when abs(NMAG) > 0 { MAG: Int16LE[abs(NMAG)] },  # Magnitudes
+  when MPROP >= 1 {
+    XRPM: Float32LE,                               # R.A. proper motion
+    XDPM: Float32LE                                # Dec. proper motion
+  },
+  when MPROP == 2 { SVEL: Float64LE },             # Radial velocity
+  when STNUM < 0 { NAME: Bytes(-STNUM) }           # Object name
+}
+
+# File structure
+header: CatalogHeader
+
+# Parse the header to get the number of stars and entry parameters
+STNUM = header.STNUM
+MPROP = header.MPROP
+NMAG  = header.NMAG
+NBENT = header.NBENT
+record_count = abs(header.STARN)
+
+expect sizeof(StarEntry(STNUM, MPROP, NMAG)) == NBENT
+
+stars: StarEntry(STNUM, MPROP, NMAG)[record_count]
+```
+
+This description handles the full SAO format — both B1950 and J2000 coordinate systems, variable magnitude counts, optional motion data, and optional object names. Here's what's new:
+
+- **Parameterized records**: `Record StarEntry(STNUM, MPROP, NMAG)` accepts parameters that control which fields are included
+- **`when` blocks**: `when STNUM >= 0 { ... }` conditionally includes fields based on a runtime value
+- **Variable assignment**: `record_count = abs(header.STARN)` computes a value from an expression
+- **`abs()`**: Built-in function returning the absolute value of an integer
+- **`sizeof` with parameters**: `sizeof(StarEntry(...))` computes the size of a parameterized record with specific arguments
+- **Computed array length**: `StarEntry(...)[record_count]` uses a variable as the array size
+
+## Running Your Description
+
+### Using the CLI Profile
+
+```sh
+./zli compress --profile sddl2 --profile-arg desc.sddl --train-inline my_input -o my_input.zl
+```
+
+### Training Once, Compressing Many
+
+```sh
+./zli train --profile sddl2 --profile-arg desc.sddl input_dir/ -o trained.zlc
+
+for f in $(ls input_dir/); do
+  ./zli compress --compressor trained.zlc input_dir/$f -o output_dir/$f.zl
+done
+```
+
+## Next Steps
+
+- [Core Concepts](core-concepts.md) — detailed explanation of types, records, arrays, variables, and expressions
+- [Conditional Fields](conditional-fields.md) — `when` blocks in depth
+- [Validation](validation.md) — `expect` statements
+- [Examples](examples.md) — more complete format descriptions
+- [Quick Reference](reference.md) — all supported syntax at a glance

--- a/doc/mkdocs/doc/sddl/index.md
+++ b/doc/mkdocs/doc/sddl/index.md
@@ -4,8 +4,16 @@ SDDL is a domain-specific language for describing binary file formats. It enable
 
 ## Documentation Sections
 
+### [Current Language](getting-started.md)
 
+Documentation for the **currently supported** SDDL syntax — what you can use today with the SDDL2 compiler. Start here if you want to write SDDL descriptions that work now.
 
+- [Getting Started](getting-started.md) — Your first SDDL description
+- [Core Concepts](core-concepts.md) — Types, records, arrays, variables, and expressions
+- [Conditional Fields](conditional-fields.md) — `when` blocks
+- [Validation](validation.md) — `expect` statements
+- [Examples](examples.md) — Complete format descriptions
+- [Quick Reference](reference.md) — Supported syntax at a glance
 
 ### [North Star (v0.6)](north-star/index.md)
 

--- a/doc/mkdocs/doc/sddl/index.md
+++ b/doc/mkdocs/doc/sddl/index.md
@@ -13,3 +13,7 @@ The **target specification** for SDDL — the full language design we're buildin
 
 - [Full Documentation](north-star/index.md)
 - [SDDL for LLMs](north-star/sddl-for-llm.md) — Complete v0.6 spec optimized for AI assistants
+
+### [Legacy (SDDL1)](legacy/index.md)
+
+Documentation for the **original SDDL language** (v1), which uses a different syntax and compiles to a CBOR-based runtime. This version is deprecated in favor of SDDL2.

--- a/doc/mkdocs/doc/sddl/legacy/index.md
+++ b/doc/mkdocs/doc/sddl/legacy/index.md
@@ -1,0 +1,9 @@
+# SDDL1 — Legacy Language
+
+!!! warning "Deprecated"
+
+    This section documents the **original SDDL language** (v1), which uses a CBOR-based compiled representation and a different runtime engine. SDDL1 is deprecated in favor of the [current SDDL2 language](../getting-started.md).
+
+    New projects should use the current SDDL2 syntax. For the full planned feature set, see the [North Star (v0.6)](../north-star/index.md) specification.
+
+--8<-- "src/include/openzl/codecs/zl_sddl.md"

--- a/doc/mkdocs/doc/sddl/reference.md
+++ b/doc/mkdocs/doc/sddl/reference.md
@@ -1,0 +1,122 @@
+# Quick Reference
+
+A concise reference for all syntax currently supported by the SDDL2 compiler.
+
+## Types
+
+### Integer Types
+
+| Type | Size | Signed | Endianness |
+|------|------|--------|------------|
+| `Byte` | 1 | No | N/A |
+| `Int8` / `UInt8` | 1 | Yes / No | N/A |
+| `Int16LE` / `Int16BE` | 2 | Yes | Little / Big |
+| `UInt16LE` / `UInt16BE` | 2 | No | Little / Big |
+| `Int32LE` / `Int32BE` | 4 | Yes | Little / Big |
+| `UInt32LE` / `UInt32BE` | 4 | No | Little / Big |
+| `Int64LE` / `Int64BE` | 8 | Yes | Little / Big |
+| `UInt64LE` / `UInt64BE` | 8 | No | Little / Big |
+
+### Float Types (type descriptors only — cannot be used in expressions)
+
+| Type | Size | Endianness |
+|------|------|------------|
+| `Float16LE` / `Float16BE` | 2 | Little / Big |
+| `Float32LE` / `Float32BE` | 4 | Little / Big |
+| `Float64LE` / `Float64BE` | 8 | Little / Big |
+| `BFloat16LE` / `BFloat16BE` | 2 | Little / Big |
+
+### Byte Sequences
+
+| Syntax | Description |
+|--------|-------------|
+| `Bytes(n)` | Exactly `n` bytes as a serial field |
+
+## Syntax Quick Reference
+
+### Records
+
+```sddl
+Record Name() = { field: Type, ... }         # basic
+Record Name(PARAM1, PARAM2) = { ... }        # parameterized
+: Record() { field: Type, ... }              # anonymous/inline
+```
+
+### Arrays
+
+```sddl
+name: Type[length]     # fixed-size array
+name: Type[]           # auto-sized (consumes remaining input)
+```
+
+### Consumption
+
+```sddl
+: Type              # consume without storing
+name: Type          # consume and store in variable
+```
+
+### Variables
+
+```sddl
+name = expression           # assign from expression
+name: Type                  # assign from consumption
+name.field                  # member access
+name.inner.field            # chained member access
+```
+
+### Conditional Fields
+
+```sddl
+Record Name(COND) = {
+  when COND {
+    field1: Type1,
+    field2: Type2
+  },
+  field3: Type3
+}
+```
+
+### Validation
+
+```sddl
+expect condition
+```
+
+## Operators
+
+### Arithmetic
+
+| Op | Description |
+|----|-------------|
+| `+` `-` `*` `/` `%` | Add, subtract, multiply, divide, modulo |
+| `-expr` | Unary negation |
+
+### Comparison
+
+| Op | Description |
+|----|-------------|
+| `==` `!=` | Equal, not equal |
+| `>` `>=` `<` `<=` | Relational |
+
+### Logical
+
+| Op | Description |
+|----|-------------|
+| `&&` | AND |
+| `||` | OR |
+| `!` | NOT |
+
+## Builtin Functions
+
+| Function | Description |
+|----------|-------------|
+| `sizeof(Type)` | Size in bytes (static types only) |
+| `abs(expr)` | Absolute value |
+
+## Comments
+
+```sddl
+# single-line comment
+field: Type  # inline comment
+```

--- a/doc/mkdocs/doc/sddl/validation.md
+++ b/doc/mkdocs/doc/sddl/validation.md
@@ -1,0 +1,41 @@
+# Validation
+
+## Validation with `expect`
+
+Use `expect` to validate format constraints at parse time:
+
+```sddl
+header: Header
+expect header.magic == 0x42494E44
+expect header.version >= 1
+expect header.version <= 3
+expect header.entry_size == sizeof(DataEntry)
+```
+
+If an `expect` condition evaluates to zero (false), the SDDL engine reports a data error and parsing fails.
+
+## Common Patterns
+
+**Magic number validation:**
+```sddl
+header: FileHeader
+expect header.signature == 0x4D42  # "BM" for BMP files
+```
+
+**Size consistency checks:**
+```sddl
+header: Header
+expect header.entry_size == sizeof(Row)
+```
+
+**Range validation:**
+```sddl
+header: Header
+expect header.count >= 0
+expect header.count <= 1000000
+```
+
+**Combined conditions:**
+```sddl
+expect header.version >= 1 && header.version <= 3
+```

--- a/doc/mkdocs/mkdocs.yml
+++ b/doc/mkdocs/mkdocs.yml
@@ -34,6 +34,13 @@ nav:
     - Core Library Limitations: getting-started/library-limitations.md
   - SDDL:
       - Overview: sddl/index.md
+      - Current Language:
+        - Getting Started: sddl/getting-started.md
+        - Core Concepts: sddl/core-concepts.md
+        - Conditional Fields: sddl/conditional-fields.md
+        - Validation: sddl/validation.md
+        - Examples: sddl/examples.md
+        - Quick Reference: sddl/reference.md
       - North Star (v0.6):
         - Overview: sddl/north-star/index.md
         - Introduction & Motivation: sddl/north-star/introduction.md

--- a/doc/mkdocs/mkdocs.yml
+++ b/doc/mkdocs/mkdocs.yml
@@ -48,6 +48,7 @@ nav:
         - Best Practices: sddl/north-star/best-practices.md
         - Quick Reference: sddl/north-star/reference.md
         - SDDL for LLMs: sddl/north-star/sddl-for-llm.md
+      - Legacy (SDDL1): sddl/legacy/index.md
   - API Reference:
     - C:
       - Compressor: api/c/compressor.md


### PR DESCRIPTION
Summary:
## Stack
The goal of this stack is to reorganize the SDDL documentation hub to clearly separate the current language (SDDL2), the north-star specification (v0.6), and the legacy language (SDDL1).

## Diff
Adds current-language documentation for the SDDL features supported by the SDDL2 compiler today.

Differential Revision: D100056341


