### PR TITLE
Modify chunk size flag to take standard suffixes

### DIFF
--- a/cli/tests/cli_integration_tests.py
+++ b/cli/tests/cli_integration_tests.py
@@ -186,7 +186,7 @@ class CsvChunkedTest(_CsvBaseTest):
 
     @property
     def extra_args(self) -> str | None:
-        return "--chunk-size-mb 1"
+        return "--chunk-size 1M"
 
     def test_train_compress_decompress(self):
         """

--- a/cli/utils/compress_profiles.h
+++ b/cli/utils/compress_profiles.h
@@ -31,14 +31,14 @@ class ProfileArgs {
                 kChunkSize,
                 0,
                 true,
-                "The chunk size in MB for the input to be separated into. This reduces the memory usage to a multiplicative factor of the chunk size instead of the whole input. Defaults to 20MB if segmenter exists for profile.");
+                "The chunk size for the input to be separated into (e.g. 20M, 500K, 1G). Supports suffixes: K/KB (10^3), M/MB (10^6), G/GB (10^9), T/TB (10^12), and binary KiB (2^10), MiB (2^20), GiB (2^30), TiB (2^40). Plain numbers are treated as bytes. Defaults to 20M if segmenter exists for profile.");
     }
 
     explicit ProfileArgs(const arg::ParsedArgs& parsed)
     {
         auto chunkSize = parsed.globalFlag(kChunkSize);
         if (chunkSize.has_value()) {
-            chunkSize_ = std::stoull(chunkSize.value()) * 1000 * 1000;
+            chunkSize_ = parseSize(chunkSize.value());
         } else {
             chunkSize_ = poly::nullopt;
         }
@@ -86,8 +86,51 @@ class ProfileArgs {
     std::shared_ptr<Compressor> compressor_;
 
     inline static const std::string kProfileArg = "profile-arg";
-    inline static const std::string kChunkSize  = "chunk-size-mb";
+    inline static const std::string kChunkSize  = "chunk-size";
     inline static const std::string kProfile    = "profile";
+
+    static size_t suffixToMultiplier(const std::string& suffix)
+    {
+        if (suffix == "K" || suffix == "KB") {
+            return 1000ULL;
+        } else if (suffix == "M" || suffix == "MB") {
+            return 1000ULL * 1000;
+        } else if (suffix == "G" || suffix == "GB") {
+            return 1000ULL * 1000 * 1000;
+        } else if (suffix == "T" || suffix == "TB") {
+            return 1000ULL * 1000 * 1000 * 1000;
+        } else if (suffix == "KiB") {
+            return 1ULL << 10;
+        } else if (suffix == "MiB") {
+            return 1ULL << 20;
+        } else if (suffix == "GiB") {
+            return 1ULL << 30;
+        } else if (suffix == "TiB") {
+            return 1ULL << 40;
+        }
+        throw std::invalid_argument(
+                "Unknown size suffix '" + suffix
+                + "'. Use K/KB/KiB, M/MB/MiB, G/GB/GiB, or T/TB/TiB.");
+    }
+
+    static size_t parseSize(const std::string& str)
+    {
+        if (str.empty()) {
+            throw std::invalid_argument("Size string must not be empty.");
+        }
+        size_t pos   = 0;
+        size_t value = std::stoull(str, &pos);
+        if (pos < str.size()) {
+            std::string suffix = str.substr(pos);
+            size_t multiplier  = suffixToMultiplier(suffix);
+            if (value > SIZE_MAX / multiplier) {
+                throw std::overflow_error(
+                        "Size value overflows: '" + str + "'.");
+            }
+            value *= multiplier;
+        }
+        return value;
+    }
 
     poly::optional<std::string> name_;
     poly::optional<size_t> chunkSize_;


### PR DESCRIPTION
Summary: Modify chunk size flag to take as args K/M/G/T, KB/MB/GB/TB, and KiB/MiB/GiB/TiB suffixes.

Reviewed By: Victor-C-Zhang

Differential Revision: D99922468


