### PR TITLE
Add float deconstruct nodes as ACE prebuilt compressor presets

### DIFF
--- a/tools/training/ace/ace_compressors.cpp
+++ b/tools/training/ace/ace_compressors.cpp
@@ -162,6 +162,12 @@ std::vector<ACECompressor> makePrebuiltNumericCompressors()
             buildNode(nodes::BitsplitBF16{}), { entropy });
     ACECompressor fse(buildGraph(graphs::Fse{}));
     ACECompressor store(buildGraph(graphs::Store{}));
+    ACECompressor f32Decon(
+            buildNode(nodes::Float32Deconstruct{}), { store, entropy });
+    ACECompressor f16Decon(
+            buildNode(nodes::Float16Deconstruct{}), { store, entropy });
+    ACECompressor bf16Decon(
+            buildNode(nodes::BFloat16Deconstruct{}), { store, entropy });
     ACECompressor quantizeOffsets(
             buildNode(nodes::QuantizeOffsets{}), { fse, store });
     ACECompressor quantizeLengths(
@@ -181,6 +187,9 @@ std::vector<ACECompressor> makePrebuiltNumericCompressors()
         top8bitsEntropy,
         fpBitsEntropy,
         bf16BitsEntropy,
+        f32Decon,
+        f16Decon,
+        bf16Decon,
         quantizeOffsets,
         quantizeLengths,
     };


### PR DESCRIPTION
Summary:
Add Float32Deconstruct, Float16Deconstruct, and BFloat16Deconstruct as prebuilt ACE compressor presets in the numeric compressor list. Each preset sends sign+fraction output to store and exponent output to entropy.

ACE benchmarking (5 runs per config, 1MB data per float type, le-u16/le-u32 profiles) measures the impact of adding prebuilt seeds vs relying on ACE to discover float deconstruct graphs from scratch:

**Compression Ratio** (best compressor, median of 5 runs):
| Config | bf16 | fp16 | fp32 |
|--------|------|------|------|
| without prebuilts | 1.52 | 1.19 | 1.21 |
| with prebuilts | 1.51 | 1.19 | 1.21 |

Ratios are equivalent — prebuilts do not change the achievable compression ratio.

**Compression Speed** (MB/s, best compressor, median of 5 runs):
| Config | bf16 | fp16 | fp32 |
|--------|------|------|------|
| without prebuilts | 563 | 1280 | 965 |
| with prebuilts | **805** (1.4x) | 1273 | 910 |

**Decompression Speed** (MB/s, best compressor, median of 5 runs):
| Config | bf16 | fp16 | fp32 |
|--------|------|------|------|
| without prebuilts | 1047 | 2374 | 1634 |
| with prebuilts | **2504** (2.4x) | 2442 | 1673 |

For bf16, prebuilts yield faster best compressors (1.4x encode, 2.4x decode). For fp16 and fp32, speeds are comparable.

**FloatDeconstruct adoption in best compressor** (out of 5 runs):
| Config | bf16 | fp16 | fp32 |
|--------|------|------|------|
| without prebuilts | 1/5 | 3/5 | 0/5 |
| with prebuilts | **4/5** | **5/5** | **2/5** |

**FloatDeconstruct adoption across all Pareto compressors**:
| Config | bf16 | fp16 | fp32 |
|--------|------|------|------|
| without prebuilts | 18% | 43% | 0% |
| with prebuilts | **86%** | **86%** | **54%** |

Prebuilts dramatically increase float deconstruct node adoption across the Pareto frontier. Without prebuilts, ACE rarely discovers these graphs for bf16 (18%) and never for fp32 (0%). With prebuilts seeding the initial population, ACE builds on these known-useful starting points and the node appears in 54-86% of all Pareto-optimal compressors.

Differential Revision: D100067989


