### PR TITLE
plumb dicts from the ZL_Compressor to ZL_Encoder at compression time (#618)

### DIFF
--- a/include/openzl/detail/zl_error_context.h
+++ b/include/openzl/detail/zl_error_context.h
@@ -51,6 +51,8 @@ ZL_CONST_FN ZL_OperationContext* ZL_CompressorDeserializer_getOperationContext(
         ZL_CompressorDeserializer* ctx);
 ZL_CONST_FN ZL_OperationContext* ZL_Segmenter_getOperationContext(
         ZL_Segmenter* ctx);
+ZL_CONST_FN ZL_OperationContext* ZL_Materializer_getOperationContext(
+        ZL_Materializer* ctx);
 ZL_CONST_FN ZL_OperationContext* ZL_ErrorContext_getOperationContext(
         ZL_ErrorContext* ctx);
 ZL_CONST_FN ZL_OperationContext* ZL_NULL_getOperationContext(void* ctx);
@@ -109,6 +111,11 @@ ZL_INLINE ZL_CONST_FN ZL_OperationContext* ZL_getOperationContextImpl(
     return ZL_Segmenter_getOperationContext(ctx);
 }
 ZL_INLINE ZL_CONST_FN ZL_OperationContext* ZL_getOperationContextImpl(
+        ZL_Materializer* ctx)
+{
+    return ZL_Materializer_getOperationContext(ctx);
+}
+ZL_INLINE ZL_CONST_FN ZL_OperationContext* ZL_getOperationContextImpl(
         ZL_ErrorContext* ctx)
 {
     return ZL_ErrorContext_getOperationContext(ctx);
@@ -146,6 +153,8 @@ extern "C" {
                 ZL_CompressorDeserializer*: ZL_CompressorDeserializer_getOperationContext( \
                         (void*)(ctx)),                                                     \
                 ZL_Segmenter*: ZL_Segmenter_getOperationContext((void*)(ctx)),             \
+                ZL_Materializer*: ZL_Materializer_getOperationContext(                     \
+                        (void*)(ctx)),                                                     \
                 ZL_ErrorContext*: ZL_ErrorContext_getOperationContext(                     \
                         (void*)(ctx)),                                                     \
                 ZL_OperationContext*: (ctx),                                               \

--- a/include/openzl/zl_ctransform.h
+++ b/include/openzl/zl_ctransform.h
@@ -448,6 +448,12 @@ ZL_LocalIntParams ZL_Encoder_getLocalIntParams(const ZL_Encoder* eic);
  */
 const ZL_LocalParams* ZL_Encoder_getLocalParams(const ZL_Encoder* eic);
 
+/**
+ * @returns The materialized dictionary object associated with this node, if
+ * there is one. Otherwise NULL.
+ */
+const void* ZL_Encoder_getMaterializedDict(const ZL_Encoder* eictx);
+
 /* Scratch space allocation:
  * When the transform needs some buffer space for some local operation,
  * it can request such space from the Graph Engine. It is allowed to

--- a/src/openzl/compress/cdictmgr.c
+++ b/src/openzl/compress/cdictmgr.c
@@ -176,6 +176,7 @@ static ZL_RESULT_OF(ZL_DictConstPtr) CDictMgr_cacheDict(
         .persistentArena = mgr->arena,
         .scratchArena    = mgr->scratchArena,
         .opaquePtr       = matDesc->opaque.ptr,
+        .opCtx           = mgr->opCtx,
     };
 
     ZL_RESULT_OF(ZL_VoidPtr)

--- a/src/openzl/compress/cgraph.c
+++ b/src/openzl/compress/cgraph.c
@@ -1301,6 +1301,16 @@ ZL_Report ZL_Compressor_Node_getDictIndex(
     return ZL_returnValue(index);
 }
 
+const void* CGRAPH_getDictObj(const ZL_Compressor* cgraph, size_t dictOffset)
+{
+    ZL_ASSERT_NN(cgraph);
+    const ZL_DictBundle* bundle = cgraph->dictMgr.bundle;
+    if (bundle == NULL)
+        return NULL;
+    ZL_ASSERT_LT(dictOffset, bundle->info.numDicts);
+    return bundle->dicts[dictOffset]->dictObj;
+}
+
 const ZL_BundleID* ZL_Compressor_getDictBundleID(
         const ZL_Compressor* compressor)
 {

--- a/src/openzl/compress/cgraph.h
+++ b/src/openzl/compress/cgraph.h
@@ -74,6 +74,15 @@ ZL_NodeID CGraph_registerStandardMITransform(
         unsigned minFormatVersion,
         unsigned maxFormatVersion);
 
+/* =====   Dict accessors   ===== */
+
+/**
+ * @returns the materialized dictionary object at position @p dictOffset
+ * within the compressor's loaded bundle, or NULL if no bundle is loaded.
+ * @pre dictOffset < bundle->numDicts
+ */
+const void* CGRAPH_getDictObj(const ZL_Compressor* cgraph, size_t dictOffset);
+
 /* =====   Dict index resolution   ===== */
 
 /**

--- a/src/openzl/compress/enc_interface.c
+++ b/src/openzl/compress/enc_interface.c
@@ -7,11 +7,13 @@
 #include "openzl/common/introspection.h" // WAYPOINT, ZL_CompressIntrospectionHooks
 #include "openzl/common/limits.h"
 #include "openzl/common/operation_context.h"
-#include "openzl/compress/cctx.h" // CCTX_*
+#include "openzl/compress/cctx.h"   // CCTX_*
+#include "openzl/compress/cgraph.h" // CGRAPH_getDictObj
 #include "openzl/compress/cnode.h"
 #include "openzl/compress/localparams.h"
-#include "openzl/compress/trStates.h" // TRS_getState
-#include "openzl/zl_common_types.h"   // ZL_TernaryParam_disable
+#include "openzl/compress/trStates.h"   // TRS_getState
+#include "openzl/dict/dict_constants.h" // ZL_DICT_INDEX_NONE
+#include "openzl/zl_common_types.h"     // ZL_TernaryParam_disable
 #include "openzl/zl_compressor.h"
 #include "openzl/zl_data.h"
 
@@ -86,6 +88,17 @@ const ZL_LocalParams* ZL_Encoder_getLocalParams(const ZL_Encoder* eic)
 {
     ZL_ASSERT_NN(eic);
     return eic->lparams;
+}
+
+const void* ZL_Encoder_getMaterializedDict(const ZL_Encoder* eictx)
+{
+    ZL_ASSERT_NN(eictx);
+    if (eictx->cnode == NULL)
+        return NULL;
+    size_t offset = CNODE_getDictIndex(eictx->cnode);
+    if (offset == ZL_DICT_INDEX_NONE)
+        return NULL;
+    return CGRAPH_getDictObj(CCTX_getCGraph(eictx->cctx), offset);
 }
 
 const void* ENC_getPrivateParam(const ZL_Encoder* eictx)

--- a/src/openzl/compress/materializer.c
+++ b/src/openzl/compress/materializer.c
@@ -23,6 +23,7 @@ ZL_Materializer* ZL_Materializer_create(
         return NULL;
     }
     mat->opaquePtr = matDesc.opaque;
+    mat->opCtx     = NULL;
     return mat;
 }
 
@@ -33,6 +34,15 @@ void ZL_Materializer_free(ZL_Materializer* mat)
     }
     ALLOC_Arena_freeArena(mat->scratchArena);
     ALLOC_Arena_free(mat->persistentArena, mat);
+}
+
+ZL_CONST_FN
+ZL_OperationContext* ZL_Materializer_getOperationContext(ZL_Materializer* mat)
+{
+    if (mat == NULL) {
+        return NULL;
+    }
+    return mat->opCtx;
 }
 
 void* ZL_Materializer_allocate(ZL_Materializer* mat, size_t size)

--- a/src/openzl/compress/materializer.h
+++ b/src/openzl/compress/materializer.h
@@ -18,6 +18,7 @@ struct ZL_Materializer_s {
     Arena* persistentArena;
     Arena* scratchArena;
     const void* opaquePtr;
+    ZL_OperationContext* opCtx;
 } /* typedef'ed to ZL_Materializer in zl_opaque_types.h */;
 
 ZL_Materializer* ZL_Materializer_create(

--- a/tests/BUCK
+++ b/tests/BUCK
@@ -67,6 +67,7 @@ zs_unittest(
     supports_static_listing = False,
     deps = [
         "..:compress",
+        "..:dict",
         "../cpp:openzl_cpp",
         "datagen:datagen",
         "registry:openzl_components",

--- a/tests/integrationtest/CompressorIntegrationTest.cpp
+++ b/tests/integrationtest/CompressorIntegrationTest.cpp
@@ -3,6 +3,11 @@
 #include <gtest/gtest.h>
 
 #include <cstring>
+#include <vector>
+
+#include "openzl/dict/bundle.h"
+#include "openzl/dict/dict.h"
+#include "openzl/dict/dict_constants.h"
 
 #include "openzl/cpp/CCtx.hpp"
 #include "openzl/cpp/CParam.hpp"
@@ -719,6 +724,169 @@ TEST_F(CompressorIntegrationTest,
 
     compressData();
     EXPECT_EQ(str, str2);
+}
+
+static ZL_RESULT_OF(ZL_VoidPtr) copyDictMaterialize(
+        ZL_Materializer* matCtx,
+        const void* src,
+        size_t srcSize) ZL_NOEXCEPT_FUNC_PTR
+{
+    ZL_RESULT_DECLARE_SCOPE(ZL_VoidPtr, matCtx);
+    void* copy = ZL_Materializer_allocate(matCtx, srcSize);
+    ZL_ERR_IF_NULL(copy, allocation);
+    memcpy(copy, src, srcSize);
+    return ZL_WRAP_VALUE(copy);
+}
+
+TEST_F(CompressorIntegrationTest,
+       GIVENaFatBundleLoadedWHENencoderRunsTHENgetMaterializedDictReturnsDict)
+{
+    // -- Dict content that will be packed into the fat bundle --
+    const std::string dictContent = "test-dict-payload-12345";
+    ZL_DictID dictID;
+    memset(&dictID, 0, sizeof(dictID));
+    dictID.id.bytes[0] = 0xD1;
+    dictID.id.bytes[1] = 0xD2;
+
+    // -- Dict materializer (ZL_MaterializerDesc2): copies raw content --
+    ZL_MaterializerDesc2 dictMat{};
+    dictMat.materializeFn   = copyDictMaterialize;
+    dictMat.dematerializeFn = ZL_NOOP_DEMATERIALIZE;
+
+    // -- Register encoder first (CDictMgr needs the node to find materializer)
+    // --
+    const auto encoderCheckingDict =
+            [](ZL_Encoder* eictx, const ZL_Input* inputs[], size_t nbInputs)
+                    ZL_NOEXCEPT_FUNC_PTR -> ZL_Report {
+        ZL_RESULT_DECLARE_SCOPE_REPORT(eictx);
+
+        const void* dict = ZL_Encoder_getMaterializedDict(eictx);
+        ZL_ERR_IF_NULL(
+                dict,
+                GENERIC,
+                "Expected getMaterializedDict to return non-null");
+
+        // Verify content via ref param that holds expected size
+        auto rp = ZL_Encoder_getLocalParam(eictx, 1);
+        ZL_ERR_IF_NULL(rp.paramRef, GENERIC);
+        size_t expectedSize = *(const size_t*)rp.paramRef;
+
+        // The materialized dict should be a copy of the original content
+        ZL_ERR_IF_NE(
+                memcmp(dict,
+                       (const char*)rp.paramRef + sizeof(size_t),
+                       expectedSize),
+                0,
+                GENERIC,
+                "Dict content mismatch");
+
+        return passthrough(eictx, inputs, nbInputs);
+    };
+
+    const auto encoderNullDict =
+            [](ZL_Encoder* eictx, const ZL_Input* inputs[], size_t nbInputs)
+                    ZL_NOEXCEPT_FUNC_PTR -> ZL_Report {
+        ZL_RESULT_DECLARE_SCOPE_REPORT(eictx);
+
+        const void* dict = ZL_Encoder_getMaterializedDict(eictx);
+        ZL_ERR_IF_NN(
+                dict,
+                GENERIC,
+                "Expected getMaterializedDict to return NULL for node without dict");
+
+        return passthrough(eictx, inputs, nbInputs);
+    };
+
+    // Pack expected size + content into a buffer for the ref param
+    std::vector<uint8_t> verifyBuf(sizeof(size_t) + dictContent.size());
+    {
+        size_t sz = dictContent.size();
+        memcpy(verifyBuf.data(), &sz, sizeof(size_t));
+        memcpy(verifyBuf.data() + sizeof(size_t),
+               dictContent.data(),
+               dictContent.size());
+    }
+
+    ZL_RefParam rp = {
+        .paramId  = 1,
+        .paramRef = verifyBuf.data(),
+    };
+    ZL_LocalParams lp = {
+        .refParams = {
+            .refParams   = &rp,
+            .nbRefParams = 1,
+        },
+    };
+
+    static ZL_Type typetype = ZL_Type_serial;
+    ZL_MIGraphDesc graphDesc{
+        .CTid                = nextCtid_++,
+        .inputTypes          = &typetype,
+        .nbInputs            = 1,
+        .lastInputIsVariable = false,
+        .soTypes             = &typetype,
+        .nbSOs               = 1,
+        .voTypes             = nullptr,
+        .nbVOs               = 0,
+    };
+
+    ZL_MIEncoderDesc encoderDesc{
+        .gd          = graphDesc,
+        .transform_f = encoderCheckingDict,
+        .localParams = lp,
+        .name        = "test_encoder_getMaterializedDict",
+        .dictMat     = dictMat,
+        .dictID      = dictID,
+    };
+
+    auto nodeid = compressor_.registerCustomEncoder(encoderDesc);
+    ASSERT_NE(nodeid.nid, ZL_NODE_ILLEGAL.nid);
+
+    ZL_NodeID noDictNodeid =
+            registerNodeWithMaterialization(encoderNullDict, {}, nullptr);
+
+    // -- Build and load the fat bundle (after node registration) --
+    // Pack the dict wire buffer
+    std::vector<uint8_t> packedDict(
+            ZL_DICT_HEADER_SIZE + dictContent.size(), 0);
+    {
+        ZL_Report r = Dict_pack(
+                packedDict.data(),
+                packedDict.size(),
+                dictID,
+                /*materializingCodec=*/0,
+                trt_custom,
+                dictContent.data(),
+                dictContent.size());
+        ASSERT_FALSE(ZL_isError(r));
+        packedDict.resize(ZL_validResult(r));
+    }
+
+    // Pack into a fat bundle
+    const void* dictPtr = packedDict.data();
+    size_t dictSize     = packedDict.size();
+    size_t fatBufCapacity =
+            ZL_BUNDLE_HEADER_SIZE + sizeof(ZL_UniqueID) + packedDict.size();
+    std::vector<uint8_t> fatBuf(fatBufCapacity, 0);
+    {
+        ZL_Report r = ZL_DictBundle_packFatBundle(
+                fatBuf.data(), fatBuf.size(), &dictPtr, &dictSize, 1);
+        ASSERT_FALSE(ZL_isError(r));
+        fatBuf.resize(ZL_validResult(r));
+    }
+
+    // Load into compressor
+    {
+        ZL_Report r = ZL_Compressor_loadDictBundle(
+                compressor_.get(), fatBuf.data(), fatBuf.size());
+        ASSERT_FALSE(ZL_isError(r));
+    }
+
+    auto graphId1 = compressor_.buildStaticGraph(nodeid, { ZL_GRAPH_STORE });
+    auto graphId  = compressor_.buildStaticGraph(noDictNodeid, { graphId1 });
+    ASSERT_NE(graphId.gid, ZL_GRAPH_ILLEGAL.gid);
+    compressor_.selectStartingGraph(graphId);
+    compressData(); // will assert inside encoder if getMaterializedDict fails
 }
 
 TEST_F(CompressorIntegrationTest,


### PR DESCRIPTION
Summary:

Creates a new `ZL_Encoder_getCDict()` function to search the CDictMgr (within the ZL_Compressor) for the right dict object pointer.

Reviewed By: terrelln

Differential Revision: D98385368
