### PR TITLE
Add support for _rem intrinsic

### DIFF
--- a/tests/compress/graphs/sddl2/test_sddl2_code_execution.cpp
+++ b/tests/compress/graphs/sddl2/test_sddl2_code_execution.cpp
@@ -671,6 +671,75 @@ TEST_F(SDDL2CodeExecutionTest, AssignRuntimeValue)
     expect_success(prog, input, expected_sizes);
 }
 
+// ============================================================================
+// Intrinsics
+// ============================================================================
+
+TEST_F(SDDL2CodeExecutionTest, RemIntrinsicReturnsInputSize)
+{
+    const std::vector<size_t> expected_sizes = {};
+    std::vector<uint8_t> input               = {
+        0x01, 0x02, 0x03, 0x04, 0x05,
+    };
+
+    const auto prog = R"(
+        expect _rem == 5
+    )";
+
+    expect_success(prog, input, expected_sizes);
+}
+
+TEST_F(SDDL2CodeExecutionTest, RemIntrinsicDecrementsAfterConsume)
+{
+    const std::vector<size_t> expected_sizes = { 4 };
+    std::vector<uint8_t> input               = {
+        0x01, 0x00, 0x00, 0x00, // x = 1
+        0x05, 0x06,             // 2 remaining bytes
+    };
+
+    const auto prog = R"(
+        expect _rem == 6
+        x: Int32LE
+        expect _rem == 2
+    )";
+
+    expect_success(prog, input, expected_sizes);
+}
+
+TEST_F(SDDL2CodeExecutionTest, RemIntrinsicUsedInArrayLength)
+{
+    const std::vector<size_t> expected_sizes = { 2, 4 };
+    std::vector<uint8_t> input               = {
+        0x01, 0x02,             // header
+        0x03, 0x04, 0x05, 0x06, // remaining data
+    };
+
+    const auto prog = R"(
+        : Bytes(2)
+        : Bytes(_rem)
+    )";
+
+    expect_success(prog, input, expected_sizes);
+}
+
+TEST_F(SDDL2CodeExecutionTest, RemIntrinsicInWhenCondition)
+{
+    const std::vector<size_t> expected_sizes = { 4, 4 };
+    std::vector<uint8_t> input               = {
+        0x01, 0x00, 0x00, 0x00, // first
+        0x02, 0x00, 0x00, 0x00, // second
+    };
+
+    const auto prog = R"(
+        : Int32LE
+        when _rem > 0 {
+            : Int32LE
+        }
+    )";
+
+    expect_success(prog, input, expected_sizes);
+}
+
 } // namespace testing
 } // namespace sddl2
 } // namespace openzl

--- a/tools/sddl2/compiler/Syntax.cpp
+++ b/tools/sddl2/compiler/Syntax.cpp
@@ -220,4 +220,19 @@ poly::string_view sym_to_repr_str(Symbol sym)
                 + std::string{ sym_to_debug_str(sym) } + ")");
     }
 }
+
+static const std::vector<std::pair<poly::string_view, Intrinsic>>
+        strs_to_intrinsics{
+            { "_rem", Intrinsic::REM },
+        };
+
+poly::optional<Intrinsic> find_intrinsic(poly::string_view name)
+{
+    for (const auto& [str, intrinsic] : strs_to_intrinsics) {
+        if (str == name) {
+            return intrinsic;
+        }
+    }
+    return poly::nullopt;
+}
 } // namespace openzl::sddl2

--- a/tools/sddl2/compiler/Syntax.h
+++ b/tools/sddl2/compiler/Syntax.h
@@ -5,6 +5,7 @@
 #include <map>
 #include <vector>
 
+#include "openzl/cpp/poly/Optional.hpp"
 #include "openzl/cpp/poly/StringView.hpp"
 
 namespace openzl::sddl2 {
@@ -95,6 +96,17 @@ enum class Symbol {
     // Control Flow
     WHEN
 };
+
+/**
+ * Built-in intrinsic variables. These are pre-defined, read-only numeric
+ * values available in SDDL2 programs.
+ */
+enum class Intrinsic {
+    REM, // _rem: number of bytes remaining in the input
+};
+
+/// Returns the Intrinsic if `name` is a built-in intrinsic, or nullopt.
+poly::optional<Intrinsic> find_intrinsic(poly::string_view name);
 
 /// @returns a name string for a symbol.
 /// (E.g., Symbol::ADD -> "ADD")

--- a/tools/sddl2/compiler/codegen/CodeGenerator.cpp
+++ b/tools/sddl2/compiler/codegen/CodeGenerator.cpp
@@ -5,6 +5,7 @@
 #include <vector>
 
 #include "tools/sddl2/compiler/Exception.h"
+#include "tools/sddl2/compiler/Syntax.h"
 #include "tools/sddl2/compiler/codegen/AssemblyOutput.h"
 #include "tools/sddl2/compiler/codegen/CodeGenerator.h"
 #include "tools/sddl2/compiler/codegen/RegisterAllocator.h"
@@ -207,7 +208,12 @@ class CodeGeneratorImpl {
                 return output;
             }
             case ConvertedNodeType::VAR: {
-                auto var = node->as_var();
+                auto var       = node->as_var();
+                auto intrinsic = find_intrinsic(var->name());
+                if (intrinsic) {
+                    output += generateIntrinsic(var->loc(), *intrinsic);
+                    return output;
+                }
                 output += "push.i64 "
                         + std::to_string(registers_.get(var->name()));
                 output += "var.load";
@@ -489,6 +495,18 @@ class CodeGeneratorImpl {
 
     const detail::Logger& log_;
     size_t tag_ = 1;
+
+    static std::string generateIntrinsic(
+            const SourceLocation& loc,
+            const Intrinsic& intrinsic)
+    {
+        switch (intrinsic) {
+            case Intrinsic::REM:
+                return "push.remaining";
+            default:
+                throw CodegenError(loc, "Unsupported intrinsic!");
+        }
+    }
 
     // Register allocation
     RegisterAllocator registers_;

--- a/tools/sddl2/compiler/semantic_analyzer/SemanticAnalyzer.cpp
+++ b/tools/sddl2/compiler/semantic_analyzer/SemanticAnalyzer.cpp
@@ -5,6 +5,7 @@
 #include <unordered_set>
 
 #include "tools/sddl2/compiler/Exception.h"
+#include "tools/sddl2/compiler/Syntax.h"
 #include "tools/sddl2/compiler/parser/AST.h"
 #include "tools/sddl2/compiler/semantic_analyzer/SemanticAnalyzer.h"
 
@@ -84,6 +85,8 @@ class SemanticAnalyzerImpl {
    public:
     explicit SemanticAnalyzerImpl(const detail::Logger& logger) : log_(logger)
     {
+        // Pre-register built-in intrinsic variables
+        var_types_["_rem"] = Type{ TypeKind::NUMERIC };
     }
 
     void analyze(const ASTVec& ast)
@@ -272,6 +275,12 @@ class SemanticAnalyzerImpl {
     Type analyzeAssign(const ASTOp& op)
     {
         auto var = someVar(op.args()[0]);
+        if (find_intrinsic(var->name())) {
+            throw SemanticError(
+                    var->loc(),
+                    "Cannot assign to built-in variable '" + var->name()
+                            + "'.");
+        }
         if (var_types_.count(var->name()) > 0) {
             throw SemanticError(
                     var->loc(),
@@ -289,6 +298,12 @@ class SemanticAnalyzerImpl {
 
         // Assign the var to the assumed type
         auto var = someVar(op.args()[0]);
+        if (find_intrinsic(var->name())) {
+            throw SemanticError(
+                    var->loc(),
+                    "Cannot assign to built-in variable '" + var->name()
+                            + "'.");
+        }
         if (var_types_.count(var->name()) > 0) {
             throw SemanticError(
                     var->loc(),

--- a/tools/sddl2/compiler/tests/SemanticAnalyzerTest.cpp
+++ b/tools/sddl2/compiler/tests/SemanticAnalyzerTest.cpp
@@ -371,4 +371,28 @@ TEST_F(SemanticAnalyzerTest, MemberAccessOnNonConditionalField)
     expect_success(prog);
 }
 
+TEST_F(SemanticAnalyzerTest, IntrinsicRemIsNumeric)
+{
+    const auto prog = R"(
+        expect _rem >= 0
+    )";
+    expect_success(prog);
+}
+
+TEST_F(SemanticAnalyzerTest, IntrinsicRemCannotBeAssigned)
+{
+    const auto prog = R"(
+        _rem = 42
+    )";
+    expect_error(prog, "Cannot assign to built-in variable");
+}
+
+TEST_F(SemanticAnalyzerTest, IntrinsicRemCannotBeAssumed)
+{
+    const auto prog = R"(
+        _rem: Int32LE
+    )";
+    expect_error(prog, "Cannot assign to built-in variable");
+}
+
 } // namespace openzl::sddl2::tests


### PR DESCRIPTION
Summary: Implement the `_rem` intrinsic keyword for the SDDL2 compiler. `_rem` evaluates to the number of bytes remaining in the input buffer at runtime.

Differential Revision: D99906579


