### PR TITLE
Add MParam public usage API (#626)

### DIFF
--- a/include/openzl/zl_common_types.h
+++ b/include/openzl/zl_common_types.h
@@ -73,6 +73,7 @@ typedef struct {
  * with ZL_RESULT_DECLARE_SCOPE
  */
 typedef void* ZL_VoidPtr;
+typedef const void* ZL_ConstVoidPtr;
 
 #if defined(__cplusplus)
 } // extern "C"

--- a/include/openzl/zl_compressor.h
+++ b/include/openzl/zl_compressor.h
@@ -340,9 +340,11 @@ typedef struct {
     /// Optionally the new local params, if NULL then the parameters are not
     /// updated.
     const ZL_LocalParams* localParams;
-    /// Optionally, a new dict ID. If set to ZL_ID_NULL, then the dict ID is not
-    /// updated.
+    /// Optionally, a new dict ID. If set to ZL_DICT_ID_NULL, then the dict ID
+    /// is not updated.
     ZL_DictID dictID;
+    /// Optionally, a new MParam.
+    ZL_MParam mparam;
 } ZL_NodeParameters;
 
 /**
@@ -367,9 +369,11 @@ typedef struct {
     /// Optionally the new local params, if NULL then the parameters are not
     /// updated.
     const ZL_LocalParams* localParams;
-    /// Optionally, a new dict ID. If set to ZL_ID_NULL, then the dict ID is not
-    /// updated.
+    /// Optionally, a new dict ID. If set to ZL_DICT_ID_NULL, then the dict ID
+    /// is not updated.
     ZL_DictID dictID;
+    /// Optionally, a new MParam.
+    ZL_MParam mparam;
 } ZL_ParameterizedNodeDesc;
 
 /**

--- a/include/openzl/zl_ctransform.h
+++ b/include/openzl/zl_ctransform.h
@@ -16,7 +16,7 @@
 #include "openzl/zl_ctransform_legacy.h" // Pipe and Split transforms
 #include "openzl/zl_errors.h"            // ZL_Report
 #include "openzl/zl_input.h"
-#include "openzl/zl_materializer.h" // ZL_MaterializerDesc
+#include "openzl/zl_materializer.h" // ZL_MaterializerDesc, ZL_MParam
 #include "openzl/zl_opaque_types.h"
 #include "openzl/zl_output.h"
 #include "openzl/zl_portability.h" // ZL_NOEXCEPT_FUNC_PTR
@@ -355,9 +355,25 @@ typedef struct {
     /**
      * Optional dictionary ID associated with this encoder.
      * When set, identifies the dictionary that this encoder requires.
-     * A zero-initialized (null) value means no dictionary is associated.
+     * A zero-initialized value (ZL_DICT_ID_NULL) means no dictionary is
+     * associated.
      */
     ZL_DictID dictID;
+    /**
+     * Optional materializer for compression-only materialized parameters
+     *  (MParams). If materializeFn is non-null, it will be called during
+     *  compressor deserialization to create the materialized object from
+     *  the serialized MParam blob. Unlike dicts, MParams are NOT required
+     *  at decompression time.
+     */
+    ZL_MaterializerDesc2 mparamMat;
+    /**
+     * Optional MParam associated with this encoder. The provided content blob
+     * will be materialized as dictated by @p mparamMat . OpenZL will not take
+     * ownership of the content provided. The caller is free to free the buffer
+     * anytime after registering the MIEncoder.
+     */
+    ZL_MParam mparam;
 } ZL_MIEncoderDesc;
 
 /**
@@ -453,6 +469,13 @@ const ZL_LocalParams* ZL_Encoder_getLocalParams(const ZL_Encoder* eic);
  * there is one. Otherwise NULL.
  */
 const void* ZL_Encoder_getMaterializedDict(const ZL_Encoder* eictx);
+
+/**
+ * @returns The materialized MParam object associated with this node, if
+ * there is one. Otherwise NULL. MParams are compression-only resources
+ * that are not required at decompression time.
+ */
+const void* ZL_Encoder_getMParam(const ZL_Encoder* eictx);
 
 /* Scratch space allocation:
  * When the transform needs some buffer space for some local operation,

--- a/include/openzl/zl_errors.h
+++ b/include/openzl/zl_errors.h
@@ -13,7 +13,7 @@
 #include <assert.h>
 #include <stddef.h> // size_t
 
-#include "openzl/zl_common_types.h"  // ZL_VoidPtr
+#include "openzl/zl_common_types.h"  // ZL_VoidPtr, ZL_ConstVoidPtr
 #include "openzl/zl_errors_types.h"  // ZL_ErrorCode
 #include "openzl/zl_macro_helpers.h" // ZS_MACRO_PAD1 and friends
 #include "openzl/zl_opaque_types.h"  // ZL_GraphID, ZL_NodeID
@@ -197,6 +197,7 @@ extern "C" {
 ZL_RESULT_DECLARE_TYPE(ZL_GraphID);
 ZL_RESULT_DECLARE_TYPE(ZL_NodeID);
 ZL_RESULT_DECLARE_TYPE(ZL_VoidPtr);
+ZL_RESULT_DECLARE_TYPE(ZL_ConstVoidPtr);
 
 /*-*********************************************
  *  ZL_Report type

--- a/include/openzl/zl_materializer.h
+++ b/include/openzl/zl_materializer.h
@@ -124,21 +124,17 @@ void* ZL_Materializer_getScratchSpace(ZL_Materializer* matCtx, size_t size);
 // In-progress API
 // =================================================================
 /**
- * @brief Descriptor for materializing and dematerializing dict objects.
+ * @brief Descriptor for materializing and dematerializing resource objects
+ * (dicts and MParams).
  *
- * This structure defines functions to materialize an in-memory object from
- * a raw source buffer and to dematerialize (free) that object.
+ * Defines functions to create an in-memory object from a raw source buffer
+ * (materializeFn) and to free that object (dematerializeFn). Used for both
+ * dictionary objects (required at compression and decompression) and MParam
+ * objects (compression-only). Note that the registration APIs allow for
+ * different materializers for compression-time and decompression-time dict
+ * materialization.
  */
 typedef struct {
-    /**
-     * Optionally an opaque pointer that can be queried with
-     * ZL_Materializer_getOpaquePtr().
-     * OpenZL unconditionally takes ownership of this pointer, even if
-     * registration fails, and it lives for the lifetime of the owning
-     * compressor/dict store.
-     */
-    ZL_OpaquePtr opaque;
-
     /**
      * @brief A custom function that materializes an in-memory object from a
      * provided @p src buffer. Separate function interfaces are provided for
@@ -186,13 +182,24 @@ typedef struct {
      */
     void (*dematerializeFn)(ZL_Materializer* matCtx, void* materialized)
             ZL_NOEXCEPT_FUNC_PTR;
+
+    /**
+     * Optionally an opaque pointer that can be queried with
+     * ZL_Materializer_getOpaquePtr().
+     * OpenZL unconditionally takes ownership of this pointer, even if
+     * registration fails, and it lives for the lifetime of the owning
+     * compressor/dict store.
+     */
+    ZL_OpaquePtr opaque;
 } ZL_MaterializerDesc2;
 
 // MParam structure
 typedef struct {
-    ZL_MParamID mparamID;
     const void* content;
     size_t size;
+    /// For advanced use cases, you can specify a custom ID for this MParam. If
+    /// unset, a default ID will be assigned.
+    ZL_MParamID mparamID;
 } ZL_MParam;
 
 #if defined(__cplusplus)

--- a/include/openzl/zl_reflection.h
+++ b/include/openzl/zl_reflection.h
@@ -312,7 +312,8 @@ char const* ZL_Compressor_Node_getName(
 bool ZL_Compressor_Node_isStandard(ZL_Compressor const* cgraph, ZL_NodeID node);
 
 /**
- * @returns The dict ID associated with the @p node.
+ * @returns The dict ID associated with the @p node or ZL_DICT_ID_NULL if no
+ * dict is associated.
  */
 ZL_DictID ZL_Compressor_Node_getDictID(
         ZL_Compressor const* cgraph,
@@ -324,6 +325,22 @@ ZL_DictID ZL_Compressor_Node_getDictID(
  * @note Only valid after ZL_Compressor_validate() has been called.
  */
 ZL_Report ZL_Compressor_Node_getDictIndex(
+        ZL_Compressor const* cgraph,
+        ZL_NodeID node);
+
+/**
+ * @returns The MParam ID associated with the @p node or ZL_MPARAM_ID_NULL if no
+ * MParam is associated.
+ */
+ZL_MParamID ZL_Compressor_Node_getMParamID(
+        ZL_Compressor const* cgraph,
+        ZL_NodeID node);
+
+/**
+ * @returns The materialized Mparam object associated with the @p node or NULL
+ * if no MParam is associated.
+ */
+const void* ZL_Compressor_Node_getMParamObj(
         ZL_Compressor const* cgraph,
         ZL_NodeID node);
 

--- a/src/openzl/compress/cdictmgr.c
+++ b/src/openzl/compress/cdictmgr.c
@@ -157,7 +157,7 @@ static const ZL_MaterializerDesc2* CDictMgr_findMaterializer(
     return NULL;
 }
 
-static ZL_RESULT_OF(ZL_DictConstPtr) CDictMgr_cacheDict(
+static ZL_RESULT_OF(ZL_DictConstPtr) CDictMgr_cacheInternal(
         CDictMgr* mgr,
         const ZL_ParsedDict* parsed,
         const ZL_MaterializerDesc2* matDesc)
@@ -165,6 +165,8 @@ static ZL_RESULT_OF(ZL_DictConstPtr) CDictMgr_cacheDict(
     ZL_RESULT_DECLARE_SCOPE(ZL_DictConstPtr, mgr->opCtx);
     ZL_ASSERT_NN(matDesc);
     ZL_ASSERT_NN(matDesc->materializeFn);
+
+    // try to search in the cache for existing entries
     CDictMgr_DictKey lookupKey = {
         .id      = parsed->dictID.id,
         .matDesc = *matDesc,
@@ -175,14 +177,6 @@ static ZL_RESULT_OF(ZL_DictConstPtr) CDictMgr_cacheDict(
     if (existing != NULL) {
         return ZL_WRAP_VALUE(existing->val);
     }
-
-    ZL_Dict* dict = (ZL_Dict*)ALLOC_Arena_calloc(mgr->arena, sizeof(ZL_Dict));
-    ZL_ERR_IF_NULL(dict, allocation);
-
-    dict->dictID             = parsed->dictID;
-    dict->materializingCodec = parsed->materializingCodec;
-    dict->codecType          = parsed->codecType;
-    dict->packedSize         = parsed->packedSize;
 
     // We free all memory in the scratch allocator, so don't
     // pass an arena that's not cleared.
@@ -200,7 +194,15 @@ static ZL_RESULT_OF(ZL_DictConstPtr) CDictMgr_cacheDict(
 
     ALLOC_Arena_freeAll(mgr->scratchArena);
     ZL_ERR_IF_ERR(obj);
-    dict->dictObj = ZL_RES_value(obj);
+
+    // cache
+    ZL_Dict* dict = (ZL_Dict*)ALLOC_Arena_calloc(mgr->arena, sizeof(ZL_Dict));
+    ZL_ERR_IF_NULL(dict, allocation);
+    dict->dictID             = parsed->dictID;
+    dict->materializingCodec = parsed->materializingCodec;
+    dict->codecType          = parsed->codecType;
+    dict->packedSize         = parsed->packedSize;
+    dict->dictObj            = ZL_RES_value(obj);
 
     CDictMgr_DictMap_Entry entry = { .key = lookupKey, .val = dict };
     CDictMgr_DictMap_Insert ins =
@@ -316,7 +318,7 @@ CDictMgr_loadDict(CDictMgr* mgr, const void* serialBuffer, size_t bufferMaxSize)
             matDesc, noValidMaterialization, "no materializer found for dict");
 
     ZL_RESULT_OF(ZL_DictConstPtr)
-    dictRes = CDictMgr_cacheDict(mgr, &parsed, matDesc);
+    dictRes = CDictMgr_cacheInternal(mgr, &parsed, matDesc);
     ZL_ERR_IF_ERR(dictRes);
 
     const ZL_Dict* dict = ZL_RES_value(dictRes);
@@ -362,7 +364,7 @@ const ZL_BundleID* CDictMgr_getBundleID(const CDictMgr* mgr)
 
 /**
  * Store a raw MParam blob for later CBOR serialization. The blob data is
- * copied into the CDictMgr's arena.
+ * copied into the CDictMgr's arena. Duplicate blobs are de-duped.
  *
  * @param id   The MParam ID to associate with this blob.
  * @param data Raw serialized MParam blob (dict wire format).
@@ -377,6 +379,10 @@ static ZL_Report CDictMgr_storeMParamBlob(
     ZL_RESULT_DECLARE_SCOPE_REPORT(mgr->opCtx);
     ZL_ERR_IF_NULL(data, GENERIC, "MParam blob data must not be null");
     ZL_ERR_IF_EQ(size, 0, GENERIC, "MParam blob size must be > 0");
+
+    if (CDictMgr_MParamMap_find(&mgr->mparamBlobs, &id) != NULL) {
+        return ZL_returnSuccess();
+    }
 
     void* copy = ALLOC_Arena_malloc(mgr->arena, size);
     ZL_ERR_IF_NULL(copy, allocation);
@@ -400,4 +406,39 @@ const ZL_MParam* CDictMgr_getMParam(const CDictMgr* mgr, ZL_MParamID id)
     const CDictMgr_MParamMap_Entry* entry =
             CDictMgr_MParamMap_find(&mgr->mparamBlobs, &id);
     return (entry != NULL) ? &entry->val : NULL;
+}
+
+/* ================================================================
+ * CDictMgr_materializeMParam
+ * ================================================================ */
+
+ZL_RESULT_OF(ZL_ConstVoidPtr)
+CDictMgr_materializeMParam(
+        CDictMgr* mgr,
+        ZL_MParam mparam,
+        const ZL_MaterializerDesc2* matDesc)
+{
+    ZL_RESULT_DECLARE_SCOPE(ZL_ConstVoidPtr, mgr->opCtx);
+    ZL_ASSERT_NN(matDesc);
+    ZL_ASSERT_NN(matDesc->materializeFn);
+    ZL_ASSERT_NN(mparam.content);
+
+    ZL_ParsedDict toCache = {
+        .dictID             = (ZL_DictID){ mparam.mparamID.id },
+        .materializingCodec = 0, // not used by mparams
+        .codecType          = 0, // not used by mparams
+        .dictContent        = mparam.content,
+        .contentSize        = mparam.size,
+        .packedSize         = mparam.size,
+    };
+
+    ZL_RESULT_OF(ZL_DictConstPtr)
+    dictRes = CDictMgr_cacheInternal(mgr, &toCache, matDesc);
+    ZL_ERR_IF_ERR(dictRes);
+
+    // Store raw blob for CBOR serialization
+    ZL_ERR_IF_ERR(CDictMgr_storeMParamBlob(
+            mgr, mparam.mparamID, mparam.content, mparam.size));
+
+    return ZL_WRAP_VALUE(ZL_RES_value(dictRes)->dictObj);
 }

--- a/src/openzl/compress/cdictmgr.h
+++ b/src/openzl/compress/cdictmgr.h
@@ -52,7 +52,7 @@ bool CDictMgr_MParamMap_eq(const ZL_MParamID* lhs, const ZL_MParamID* rhs);
 
 ZL_DECLARE_CUSTOM_MAP_TYPE(CDictMgr_MParamMap, ZL_MParamID, ZL_MParam);
 
-typedef struct {
+typedef struct CDictMgr_s {
     ZL_BundleID bundleID;
     CDictMgr_DictMap dictsByID;
     ZL_DictBundle* bundle;
@@ -146,6 +146,21 @@ const ZL_BundleID* CDictMgr_getBundleID(const CDictMgr* mgr);
  * the given ID has been stored.
  */
 const ZL_MParam* CDictMgr_getMParam(const CDictMgr* mgr, ZL_MParamID id);
+
+/**
+ * Materialize a raw MParam content buffer. The raw content is passed directly
+ * to the materializer (no Dict_parse). The result is cached by
+ * (mparamID, matDesc) for dedup, and the raw blob is stored for CBOR
+ * serialization.
+ *
+ * @returns The materialized object pointer on success, or an error if
+ * materialization fails for any reason.
+ */
+ZL_RESULT_OF(ZL_ConstVoidPtr)
+CDictMgr_materializeMParam(
+        CDictMgr* mgr,
+        ZL_MParam mparam,
+        const ZL_MaterializerDesc2* matDesc);
 
 ZL_END_C_DECLS
 

--- a/src/openzl/compress/cgraph.c
+++ b/src/openzl/compress/cgraph.c
@@ -38,7 +38,7 @@ struct ZL_Compressor_s {
     ZL_GraphID starting_graph;
     GCParams gcparams;
     ZL_OperationContext opCtx; // for error logging
-    CDictMgr dictMgr;
+    CDictMgr cdictMgr;
 }; /* note typedef'd to ZL_Compressor in zl_compress.h */
 
 ZL_Compressor* ZL_Compressor_create(void)
@@ -59,10 +59,15 @@ ZL_Compressor* ZL_Compressor_create(void)
     }
     cgraph->starting_graph = (ZL_GraphID){ .gid = 0 }; // default
     if (ZL_isError(CDictMgr_init(
-                &cgraph->dictMgr, &cgraph->nmgr, cgraph->gm, &cgraph->opCtx))) {
+                &cgraph->cdictMgr,
+                &cgraph->nmgr,
+                cgraph->gm,
+                &cgraph->opCtx))) {
         ZL_Compressor_free(cgraph);
         return NULL;
     }
+    // Back-populate CDictMgr pointers
+    cgraph->nmgr.ctm.cdictMgr = &cgraph->cdictMgr;
 
 #if ZL_ENABLE_ASSERT
     // In debug mode, runtime check on the configuration of the Standard Graphs
@@ -76,7 +81,7 @@ void ZL_Compressor_free(ZL_Compressor* cgraph)
 {
     if (!cgraph)
         return;
-    CDictMgr_destroy(&cgraph->dictMgr);
+    CDictMgr_destroy(&cgraph->cdictMgr);
     ZL_OC_destroy(&cgraph->opCtx);
     GM_free(cgraph->gm);
     NM_destroy(&cgraph->nmgr);
@@ -452,6 +457,7 @@ ZL_Compressor_parameterizeNode(
         .node        = node,
         .localParams = params->localParams,
         .dictID      = params->dictID,
+        .mparam      = params->mparam,
     };
 
     return NM_parameterizeNode(&compressor->nmgr, &desc);
@@ -466,6 +472,7 @@ ZL_NodeID ZL_Compressor_registerParameterizedNode(
         .name        = desc->name,
         .localParams = desc->localParams,
         .dictID      = desc->dictID,
+        .mparam      = desc->mparam,
     };
     ZL_RESULT_OF(ZL_NodeID)
     nodeidResult =
@@ -1247,10 +1254,25 @@ ZL_DictID ZL_Compressor_Node_getDictID(
     return CNODE_getDictID(CGRAPH_getCNode(cgraph, node));
 }
 
+ZL_MParamID ZL_Compressor_Node_getMParamID(
+        ZL_Compressor const* cgraph,
+        ZL_NodeID node)
+{
+    const ZL_MParamID* id = CNODE_getMParamID(CGRAPH_getCNode(cgraph, node));
+    return *id;
+}
+
+const void* ZL_Compressor_Node_getMParamObj(
+        ZL_Compressor const* cgraph,
+        ZL_NodeID node)
+{
+    return CNODE_getMParamObj(CGRAPH_getCNode(cgraph, node));
+}
+
 ZL_Report CGraph_resolveDictIndices(ZL_Compressor* cgraph)
 {
     ZL_RESULT_DECLARE_SCOPE_REPORT(cgraph);
-    const ZL_DictBundle* bundle = cgraph->dictMgr.bundle;
+    const ZL_DictBundle* bundle = cgraph->cdictMgr.bundle;
     CNodes_manager* ctm         = &cgraph->nmgr.ctm;
     const ZL_IDType nbCNodes    = CTM_nbCNodes(ctm);
 
@@ -1304,7 +1326,7 @@ ZL_Report ZL_Compressor_Node_getDictIndex(
 const void* CGRAPH_getDictObj(const ZL_Compressor* cgraph, size_t dictOffset)
 {
     ZL_ASSERT_NN(cgraph);
-    const ZL_DictBundle* bundle = cgraph->dictMgr.bundle;
+    const ZL_DictBundle* bundle = cgraph->cdictMgr.bundle;
     if (bundle == NULL)
         return NULL;
     ZL_ASSERT_LT(dictOffset, bundle->info.numDicts);
@@ -1314,7 +1336,7 @@ const void* CGRAPH_getDictObj(const ZL_Compressor* cgraph, size_t dictOffset)
 const ZL_BundleID* ZL_Compressor_getDictBundleID(
         const ZL_Compressor* compressor)
 {
-    return CDictMgr_getBundleID(&compressor->dictMgr);
+    return CDictMgr_getBundleID(&compressor->cdictMgr);
 }
 
 ZL_Report ZL_Compressor_loadDictBundle(
@@ -1324,7 +1346,7 @@ ZL_Report ZL_Compressor_loadDictBundle(
 {
     ZL_RESULT_DECLARE_SCOPE_REPORT(compressor);
     ZL_ERR_IF_ERR(CDictMgr_loadFatBundle(
-            &compressor->dictMgr,
+            &compressor->cdictMgr,
             serializedDictBundle,
             serializedDictBundleSize));
     return ZL_returnSuccess();

--- a/src/openzl/compress/cnode.c
+++ b/src/openzl/compress/cnode.c
@@ -214,3 +214,17 @@ size_t CNODE_getDictIndex(CNode const* cnode)
     ZL_ASSERT_EQ(cnode->nodetype, node_internalTransform);
     return cnode->maybeDictIndex;
 }
+
+const void* CNODE_getMParamObj(CNode const* cnode)
+{
+    ZL_ASSERT_NN(cnode);
+    ZL_ASSERT_EQ(cnode->nodetype, node_internalTransform);
+    return cnode->mparamObj;
+}
+
+const ZL_MParamID* CNODE_getMParamID(CNode const* cnode)
+{
+    ZL_ASSERT_NN(cnode);
+    ZL_ASSERT_EQ(cnode->nodetype, node_internalTransform);
+    return &cnode->transformDesc.publicDesc.mparam.mparamID;
+}

--- a/src/openzl/compress/cnode.h
+++ b/src/openzl/compress/cnode.h
@@ -23,6 +23,11 @@ typedef struct {
     /// The "default" value is updated when ZL_Compressor_validate() is called,
     /// before compression starts.
     size_t maybeDictIndex /* defaults to ZL_DICT_INDEX_NONE */;
+    /// If an MParam is specified in the transformDesc, this field is populated
+    /// upon registration time with a pointer to the materialized object. The
+    /// CNode does not own the object, the ZL_Compressor owns it via the
+    /// CDictMgr.
+    const void* mparamObj;
     /// Standard nodes leave this empty, all other nodes set this.
     /// When set ZL_Name_unique(&maybeName) == transformDesc.publicDesc.name.
     ZL_Name maybeName;
@@ -142,5 +147,8 @@ ZL_DictID CNODE_getDictID(CNode const* cnode);
 /// or ZL_DICT_INDEX_NONE if no dictionary is associated.
 /// @pre cnode->nodetype == node_internalTransform
 size_t CNODE_getDictIndex(CNode const* cnode);
+
+const void* CNODE_getMParamObj(CNode const* cnode);
+const ZL_MParamID* CNODE_getMParamID(CNode const* cnode);
 
 #endif // OPENZL_COMPRESS_CNODE_H

--- a/src/openzl/compress/cnodes.c
+++ b/src/openzl/compress/cnodes.c
@@ -7,6 +7,7 @@
 #include "openzl/common/unique_id.h" // ZL_UniqueID_isValid
 #include "openzl/common/vector.h"
 #include "openzl/common/wire_format.h" // trt_standard
+#include "openzl/compress/cdictmgr.h"
 #include "openzl/compress/cnode.h"
 #include "openzl/compress/localparams.h"
 #include "openzl/compress/materializer.h" // ZL_Materializer functions
@@ -238,6 +239,49 @@ static ZL_RESULT_OF(CNodeID) CTM_registerCNode(
                         &trDesc->localParams,
                         &trDesc->materializer));
             }
+            // Materialize MParam if content and materializer are provided
+            if (trDesc->mparam.content != NULL || trDesc->mparam.size != 0) {
+                ZL_MParam mparam = trDesc->mparam;
+                // Ensure MParam is properly formed
+                ZL_ERR_IF_NULL(
+                        mparam.content,
+                        nodeParameter_invalid,
+                        "Passed MParam must have non-null content");
+                ZL_ERR_IF_EQ(
+                        mparam.size,
+                        0,
+                        nodeParameter_invalid,
+                        "Passed MParam must have non-zero size");
+
+                // Ensure there's a proper materializer
+                ZL_ERR_IF(
+                        trDesc->mparamMat.materializeFn == NULL
+                                && trDesc->mparamMat.dematerializeFn == NULL,
+                        nodeParameter_invalid,
+                        "MParam requested on a node without a materializer");
+                ZL_ERR_IF(
+                        trDesc->mparamMat.materializeFn == NULL
+                                || trDesc->mparamMat.dematerializeFn == NULL,
+                        nodeParameter_invalid,
+                        "MParam materializer must declare both a materialize and dematerialize function");
+
+                // If there's no ID, generate one
+                if (!ZL_UniqueID_isValid(&mparam.mparamID.id)) {
+                    mparam.mparamID.id = ZL_UniqueID_computeSHA256(
+                            mparam.content, mparam.size);
+                }
+
+                ZL_ASSERT_NN(ctm->cdictMgr);
+                ZL_RESULT_OF(ZL_ConstVoidPtr)
+                matRes = CDictMgr_materializeMParam(
+                        ctm->cdictMgr, mparam, &trDesc->mparamMat);
+                ZL_ERR_IF_ERR(matRes);
+                cnode->mparamObj = ZL_RES_value(matRes);
+                // Replace the CNode MParam with the cached version with
+                // guaranteed lifetime
+                trDesc->mparam =
+                        *CDictMgr_getMParam(ctm->cdictMgr, mparam.mparamID);
+            }
             // A valid transform must have at least one input
             ZL_ERR_IF_LT(
                     CNODE_getNbInputPorts(cnode),
@@ -293,6 +337,7 @@ CTM_registerCustomTransform(
                          .publicIDtype   = trt_custom,
                          .transformDesc  = *ctd,
                          .maybeDictIndex = ZL_DICT_INDEX_NONE,
+                         .mparamObj      = NULL,
                          .baseNodeID     = ZL_NODE_ILLEGAL };
     const char* name = ctd->publicDesc.name;
     // Registered => No need to free
@@ -341,11 +386,11 @@ CTM_parameterizeNode(
     if (desc->localParams) {
         clonedCNode.transformDesc.publicDesc.localParams = *desc->localParams;
     }
-    {
-        const ZL_UniqueID* uid = &desc->dictID.id;
-        if (ZL_UniqueID_isValid(uid)) {
-            clonedCNode.transformDesc.publicDesc.dictID = desc->dictID;
-        }
+    if (ZL_UniqueID_isValid(&desc->dictID.id)) {
+        clonedCNode.transformDesc.publicDesc.dictID = desc->dictID;
+    }
+    if (ZL_UniqueID_isValid(&desc->mparam.mparamID.id)) {
+        clonedCNode.transformDesc.publicDesc.mparam = desc->mparam;
     }
     if (desc->name == NULL) {
         const ZL_Name name = CNODE_getNameObj(srcCNode);

--- a/src/openzl/compress/cnodes.h
+++ b/src/openzl/compress/cnodes.h
@@ -20,10 +20,12 @@ ZL_RESULT_DECLARE_TYPE(CNodeID);
 
 DECLARE_VECTOR_TYPE(CNode)
 
+struct CDictMgr_s; // forward declaration
 typedef struct CNodes_manager_s {
     VECTOR(CNode) cnodes;
     ZL_OpaquePtrRegistry opaquePtrs;
     Arena* allocator;
+    struct CDictMgr_s* cdictMgr;
     MaterializedParamMap materializedParams;
     ZL_OperationContext* opCtx; // Non-owning pointer to error context
 } CNodes_manager;

--- a/src/openzl/compress/enc_interface.c
+++ b/src/openzl/compress/enc_interface.c
@@ -101,6 +101,14 @@ const void* ZL_Encoder_getMaterializedDict(const ZL_Encoder* eictx)
     return CGRAPH_getDictObj(CCTX_getCGraph(eictx->cctx), offset);
 }
 
+const void* ZL_Encoder_getMParam(const ZL_Encoder* eictx)
+{
+    ZL_ASSERT_NN(eictx);
+    if (eictx->cnode == NULL)
+        return NULL;
+    return CNODE_getMParamObj(eictx->cnode);
+}
+
 const void* ENC_getPrivateParam(const ZL_Encoder* eictx)
 {
     return eictx->privateParam;

--- a/tests/unittest/compress/CompressorUnitTest.cpp
+++ b/tests/unittest/compress/CompressorUnitTest.cpp
@@ -22,6 +22,7 @@
 #include "openzl/zl_reflection.h"
 #include "openzl/zl_selector.h"
 
+#include "tests/unittest/compress/CDictMgrTestHelpers.h"
 #include "tests/utils.h"
 
 using namespace ::testing;
@@ -417,6 +418,69 @@ class CompressorTest : public Test {
                 .nbIntParams = 1,
             },
         };
+    }
+
+    // ---- MParam sideloading helpers ----
+
+    static ZL_MParamID makeMParamID(uint8_t seed)
+    {
+        ZL_MParamID id = ZL_MPARAM_ID_NULL;
+        for (size_t i = 0; i < 32; i++) {
+            id.id.bytes[i] = static_cast<uint8_t>(seed + i);
+        }
+        return id;
+    }
+
+    static ZL_MaterializerDesc2 makeMParamMat()
+    {
+        return makeDefaultDictMaterializer();
+    }
+
+    ZL_NodeID registerNodeWithMParam(
+            ZL_MParamID mparamID,
+            ZL_MaterializerDesc2 mparamMat,
+            const void* content,
+            size_t contentSize)
+    {
+        static ZL_IDType nextMParamCtid = 5000;
+        static ZL_Type typetype         = ZL_Type_serial;
+        ZL_MIGraphDesc graphDesc{
+            .CTid                = nextMParamCtid++,
+            .inputTypes          = &typetype,
+            .nbInputs            = 1,
+            .lastInputIsVariable = false,
+            .soTypes             = &typetype,
+            .nbSOs               = 1,
+            .voTypes             = nullptr,
+            .nbVOs               = 0,
+        };
+
+        ZL_MParam mparam{
+            .content  = content,
+            .size     = contentSize,
+            .mparamID = mparamID,
+        };
+
+        ZL_MIEncoderDesc encoderDesc{
+            .gd          = graphDesc,
+            .transform_f = dummyEncoder,
+            .name        = "mparam_node",
+            .mparamMat   = mparamMat,
+            .mparam      = mparam,
+        };
+
+        return ZL_Compressor_registerMIEncoder(compressor_.get(), &encoderDesc);
+    }
+
+    ZL_NodeID parameterizeWithMParam(ZL_NodeID baseNode, ZL_MParam mparam)
+    {
+        ZL_ParameterizedNodeDesc paramDesc{
+            .name   = "mparam_param_node",
+            .node   = baseNode,
+            .mparam = mparam,
+        };
+        return ZL_Compressor_registerParameterizedNode(
+                compressor_.get(), &paramDesc);
     }
 
    protected:
@@ -1988,4 +2052,169 @@ TEST_F(CompressorTest,
     // Should not create a new materialized object for identical params
     EXPECT_EQ(materializeCount, 1)
             << "Should reuse materialized object when local params are identical";
+}
+
+// =============================================================================
+// MParam Registration Tests
+// =============================================================================
+
+TEST_F(CompressorTest, MParamRegistrationWithContent)
+{
+    auto mparamID  = makeMParamID(42);
+    auto mparamMat = makeMParamMat();
+    std::vector<uint8_t> rawContent(16, 0xCD);
+
+    auto node = registerNodeWithMParam(
+            mparamID, mparamMat, rawContent.data(), rawContent.size());
+    ASSERT_NE(node.nid, ZL_NODE_ILLEGAL.nid);
+
+    auto graphId = ZL_Compressor_registerStaticGraph_fromPipelineNodes1o(
+            compressor_.get(), &node, 1, ZL_GRAPH_STORE);
+    ASSERT_NE(graphId.gid, ZL_GRAPH_ILLEGAL.gid);
+
+    ASSERT_FALSE(
+            ZL_isError(ZL_Compressor_validate(compressor_.get(), graphId)));
+
+    ASSERT_NE(
+            ZL_Compressor_Node_getMParamObj(compressor_.get(), node), nullptr);
+}
+
+TEST_F(CompressorTest, MParamRegistrationMultipleMaterializations)
+{
+    auto mparamID   = makeMParamID(42);
+    auto mparamMat  = makeMParamMat();
+    auto mparamMat2 = mparamMat;
+    char dummy;
+    mparamMat2.opaque.ptr = (void*)&dummy;
+    std::vector<uint8_t> rawContent(16, 0xCD);
+
+    auto node1 = registerNodeWithMParam(
+            mparamID, mparamMat, rawContent.data(), rawContent.size());
+    ASSERT_NE(node1.nid, ZL_NODE_ILLEGAL.nid);
+
+    auto node2 = registerNodeWithMParam(
+            mparamID, mparamMat2, rawContent.data(), rawContent.size());
+    ASSERT_NE(node2.nid, ZL_NODE_ILLEGAL.nid);
+
+    auto graphId = ZL_Compressor_registerStaticGraph_fromPipelineNodes1o(
+            compressor_.get(), &node1, 1, ZL_GRAPH_STORE);
+    ASSERT_NE(graphId.gid, ZL_GRAPH_ILLEGAL.gid);
+
+    ASSERT_FALSE(
+            ZL_isError(ZL_Compressor_validate(compressor_.get(), graphId)));
+
+    ASSERT_NE(
+            ZL_Compressor_Node_getMParamObj(compressor_.get(), node1), nullptr);
+    ASSERT_NE(
+            ZL_Compressor_Node_getMParamObj(compressor_.get(), node2), nullptr);
+    // Different materializers should result in different materialized objects
+    ASSERT_NE(
+            ZL_Compressor_Node_getMParamObj(compressor_.get(), node1),
+            ZL_Compressor_Node_getMParamObj(compressor_.get(), node2));
+}
+
+TEST_F(CompressorTest, MParamRegistrationMultipleIDs)
+{
+    auto id1 = makeMParamID(10);
+    auto id2 = makeMParamID(20);
+    auto mat = makeMParamMat();
+    std::vector<uint8_t> content1(16, 0xAA);
+    std::vector<uint8_t> content2(16, 0xBB);
+
+    auto node1 =
+            registerNodeWithMParam(id1, mat, content1.data(), content1.size());
+    ASSERT_NE(node1.nid, ZL_NODE_ILLEGAL.nid);
+
+    auto node2 =
+            registerNodeWithMParam(id2, mat, content2.data(), content2.size());
+    ASSERT_NE(node2.nid, ZL_NODE_ILLEGAL.nid);
+
+    std::array<ZL_NodeID, 2> nodes = { node1, node2 };
+    auto graphId = ZL_Compressor_registerStaticGraph_fromPipelineNodes1o(
+            compressor_.get(), nodes.data(), nodes.size(), ZL_GRAPH_STORE);
+    ASSERT_NE(graphId.gid, ZL_GRAPH_ILLEGAL.gid);
+
+    ASSERT_FALSE(
+            ZL_isError(ZL_Compressor_validate(compressor_.get(), graphId)));
+
+    ASSERT_NE(
+            ZL_Compressor_Node_getMParamObj(compressor_.get(), node1), nullptr);
+    ASSERT_NE(
+            ZL_Compressor_Node_getMParamObj(compressor_.get(), node2), nullptr);
+    // Different IDs should result in different materialized objects
+    ASSERT_NE(
+            ZL_Compressor_Node_getMParamObj(compressor_.get(), node1),
+            ZL_Compressor_Node_getMParamObj(compressor_.get(), node2));
+}
+
+TEST_F(CompressorTest, WHENmparamRegisteredWithoutIDTHENoneIsAssigned)
+{
+    auto mat = makeMParamMat();
+    std::vector<uint8_t> content(16, 0xCD);
+
+    auto node = registerNodeWithMParam(
+            ZL_MPARAM_ID_NULL, mat, content.data(), content.size());
+    ASSERT_NE(node.nid, ZL_NODE_ILLEGAL.nid);
+
+    auto graphId = ZL_Compressor_registerStaticGraph_fromPipelineNodes1o(
+            compressor_.get(), &node, 1, ZL_GRAPH_STORE);
+    ASSERT_NE(graphId.gid, ZL_GRAPH_ILLEGAL.gid);
+
+    ASSERT_FALSE(
+            ZL_isError(ZL_Compressor_validate(compressor_.get(), graphId)));
+
+    ASSERT_NE(
+            ZL_Compressor_Node_getMParamObj(compressor_.get(), node), nullptr);
+    auto reflectedID = ZL_Compressor_Node_getMParamID(compressor_.get(), node);
+    ASSERT_TRUE(ZL_UniqueID_isValid(&reflectedID.id));
+}
+
+TEST_F(CompressorTest, WHENbadRegistrationTHENvalidationFails)
+{
+    auto idNeeded = makeMParamID(50);
+    auto mat      = makeMParamMat();
+    std::vector<uint8_t> content(16, 0xCD);
+
+    // Register with no content — validation should fail
+    auto node = registerNodeWithMParam(idNeeded, mat, nullptr, content.size());
+    ASSERT_EQ(node.nid, ZL_NODE_ILLEGAL.nid);
+
+    // Register with bad length - validation should fail
+    node = registerNodeWithMParam(idNeeded, mat, content.data(), 0);
+    ASSERT_EQ(node.nid, ZL_NODE_ILLEGAL.nid);
+
+    // Register without materializer — validation should fail
+    node = registerNodeWithMParam(idNeeded, {}, content.data(), content.size());
+    ASSERT_EQ(node.nid, ZL_NODE_ILLEGAL.nid);
+
+    // Register with bad materializer — validation should fail
+    auto badMat            = makeMParamMat();
+    badMat.dematerializeFn = nullptr;
+    node                   = registerNodeWithMParam(
+            idNeeded, badMat, content.data(), content.size());
+    ASSERT_EQ(node.nid, ZL_NODE_ILLEGAL.nid);
+}
+
+TEST_F(CompressorTest, MParamDedup)
+{
+    auto mparamID  = makeMParamID(42);
+    auto mparamMat = makeMParamMat();
+    std::vector<uint8_t> rawContent(16, 0xCD);
+
+    // Register two nodes with the same mparamID and same materializer
+    auto node1 = registerNodeWithMParam(
+            mparamID, mparamMat, rawContent.data(), rawContent.size());
+    ASSERT_NE(node1.nid, ZL_NODE_ILLEGAL.nid);
+
+    auto node2 = registerNodeWithMParam(
+            mparamID, mparamMat, rawContent.data(), rawContent.size());
+    ASSERT_NE(node2.nid, ZL_NODE_ILLEGAL.nid);
+
+    // Both should share the same materialized object (dedup by cache key)
+    const void* obj1 =
+            ZL_Compressor_Node_getMParamObj(compressor_.get(), node1);
+    const void* obj2 =
+            ZL_Compressor_Node_getMParamObj(compressor_.get(), node2);
+    ASSERT_NE(obj1, nullptr);
+    EXPECT_EQ(obj1, obj2) << "Same mparamID + same materializer should dedup";
 }


### PR DESCRIPTION
Summary:

Plumb the public API all the way through:
- Declare an encoder with `mparamMat` to indicate it supports materialization
- Register or parameterize with a mparamID to request
- Fetch the mparam with ZL_Encoder_getMParam()

Reviewed By: Cyan4973

Differential Revision: D99579815
