### PR TITLE
Fix docs for logical ops (#627)

### DIFF
--- a/src/openzl/compress/graphs/sddl2/sddl2_opcodes.def
+++ b/src/openzl/compress/graphs/sddl2/sddl2_opcodes.def
@@ -85,10 +85,10 @@
   cmp.ge    0x0006          "Pop two I64 values, push 1 if second >= first, 0 otherwise"
 
 @family LOGIC 0x0004 "Logical operations"
-  logic.and  0x0001          "Pop two I64 values, push their bitwise AND"
-  logic.or   0x0002          "Pop two I64 values, push their bitwise OR"
-  logic.xor  0x0003          "Pop two I64 values, push their bitwise XOR"
-  logic.not  0x0004          "Pop I64 value, push its bitwise NOT"
+  logic.and  0x0001          "Pop two I64 values, push 1 if both non-zero, 0 otherwise (logical AND)"
+  logic.or   0x0002          "Pop two I64 values, push 1 if either non-zero, 0 otherwise (logical OR)"
+  logic.xor  0x0003          "Pop two I64 values, push 1 if exactly one is non-zero, 0 otherwise (logical XOR)"
+  logic.not  0x0004          "Pop I64 value, push 1 if zero, 0 otherwise (logical NOT)"
 
 @family CONTROL 0x0005 "Control flow operations"
   halt         0x0001          "Stop VM execution"

--- a/tools/sddl2/assembler/Assembly_opcodes.md
+++ b/tools/sddl2/assembler/Assembly_opcodes.md
@@ -77,12 +77,12 @@ Comparison operations on signed I64 values
 ### LOGIC (0x0004)
 Logical operations
 
-| Mnemonic    | Opcode   | Params | Description                                |
-| ----------- | -------- | ------ | ------------------------------------------ |
-| `logic.and` | `0x0001` | `-`    | Pop two I64 values, push their bitwise AND |
-| `logic.or`  | `0x0002` | `-`    | Pop two I64 values, push their bitwise OR  |
-| `logic.xor` | `0x0003` | `-`    | Pop two I64 values, push their bitwise XOR |
-| `logic.not` | `0x0004` | `-`    | Pop I64 value, push its bitwise NOT        |
+| Mnemonic    | Opcode   | Params | Description                                                                      |
+| ----------- | -------- | ------ | -------------------------------------------------------------------------------- |
+| `logic.and` | `0x0001` | `-`    | Pop two I64 values, push 1 if both non-zero, 0 otherwise (logical AND)           |
+| `logic.or`  | `0x0002` | `-`    | Pop two I64 values, push 1 if either non-zero, 0 otherwise (logical OR)          |
+| `logic.xor` | `0x0003` | `-`    | Pop two I64 values, push 1 if exactly one is non-zero, 0 otherwise (logical XOR) |
+| `logic.not` | `0x0004` | `-`    | Pop I64 value, push 1 if zero, 0 otherwise (logical NOT)                         |
 
 ### CONTROL (0x0005)
 Control flow operations

--- a/tools/sddl2/assembler/Bytecode_spec.md
+++ b/tools/sddl2/assembler/Bytecode_spec.md
@@ -37,7 +37,7 @@ The VM instruction set is organized into families:
 | **PUSH** | Push constants and values onto stack | `push.zero`, `push.u32`, `push.i64`, `push.tag`, `push.remaining` |
 | **MATH** | Arithmetic operations on I64 values | `math.add`, `math.sub`, `math.mul`, `math.div`, `math.mod` |
 | **CMP** | Comparison operations | `cmp.eq`, `cmp.ne`, `cmp.lt`, `cmp.le`, `cmp.gt`, `cmp.ge` |
-| **LOGIC** | Bitwise logical operations | `logic.and`, `logic.or`, `logic.xor`, `logic.not` |
+| **LOGIC** | Logical (boolean) operations | `logic.and`, `logic.or`, `logic.xor`, `logic.not` |
 | **CONTROL** | Control flow | `halt`, `expect_true`, `trace.start` |
 | **LOAD** | Load values from input buffer | `load.u8`, `load.i8`, `load.u16le`, `load.i32be`, etc. |
 | **STACK** | Stack manipulation | `stack.dup`, `stack.drop`, `stack.swap`, `stack.rot` |

--- a/tools/sddl2/assembler/README.md
+++ b/tools/sddl2/assembler/README.md
@@ -83,7 +83,7 @@ At the time of this wrting, the instruction set is organized into these families
 **CMP (0x0003)** - Comparison operations
 - `cmp.eq`, `cmp.ne`, `cmp.lt`, `cmp.le`, `cmp.gt`, `cmp.ge`
 
-**LOGIC (0x0004)** - Bitwise/logical operations
+**LOGIC (0x0004)** - Logical operations
 - `logic.and`, `logic.or`, `logic.xor`, `logic.not`
 
 **LOAD (0x0006)** - Load from input buffer

--- a/tools/sddl2/compiler/semantic_analyzer/SemanticAnalyzer.cpp
+++ b/tools/sddl2/compiler/semantic_analyzer/SemanticAnalyzer.cpp
@@ -26,18 +26,18 @@ struct Type {
     const ASTNode* type_def = nullptr;
 };
 
-void expectNumeric(const Type& t)
+void expectNumeric(const SourceLocation& loc, const Type& t)
 {
     if (t.kind != TypeKind::NUMERIC) {
-        throw SemanticError("Expected a numeric expression.");
+        throw SemanticError(loc, "Expected a numeric expression.");
     }
 }
 
-void expectFieldType(const Type& t)
+void expectFieldType(const SourceLocation& loc, const Type& t)
 {
     if (!(t.kind == TypeKind::ARRAY || t.kind == TypeKind::RECORD
           || t.kind == TypeKind::BYTES || t.kind == TypeKind::BUILTIN_FIELD)) {
-        throw SemanticError("Expected a field type expression.");
+        throw SemanticError(loc, "Expected a field type expression.");
     }
 }
 
@@ -46,7 +46,7 @@ const ASTVar* someVar(const ASTPtr& node)
     if (auto var = node->as_var()) {
         return var;
     }
-    throw SemanticError("Expected a variable name.");
+    throw SemanticError(node->loc(), "Expected a variable name.");
 }
 
 bool hasLoadInstruction(Symbol sym)
@@ -125,7 +125,8 @@ class SemanticAnalyzerImpl {
             case ConvertedNodeType::OP:
                 return analyze(*node->as_op());
             default:
-                throw InvariantViolation("Unsupported AST node type.");
+                throw InvariantViolation(
+                        node->loc(), "Unsupported AST node type.");
         }
     }
 
@@ -141,15 +142,15 @@ class SemanticAnalyzerImpl {
 
     Type analyze(const ASTBytes& bytes)
     {
-        expectNumeric(analyzeNode(bytes.len()));
+        expectNumeric(bytes.loc(), analyzeNode(bytes.len()));
         return Type{ TypeKind::BYTES, &bytes };
     }
 
     Type analyze(const ASTArray& array)
     {
-        expectFieldType(analyzeNode(array.field()));
+        expectFieldType(array.field()->loc(), analyzeNode(array.field()));
         if (array.len()) {
-            expectNumeric(analyzeNode(array.len()));
+            expectNumeric(array.len()->loc(), analyzeNode(array.len()));
         }
         return Type{ TypeKind::ARRAY, &array };
     }
@@ -160,7 +161,7 @@ class SemanticAnalyzerImpl {
         if (!var) {
             throw SemanticError(field.loc(), "Field name must be a variable.");
         }
-        expectFieldType(analyzeNode(field.type()));
+        expectFieldType(field.type()->loc(), analyzeNode(field.type()));
         return Type{ TypeKind::NONE };
     }
 
@@ -214,7 +215,7 @@ class SemanticAnalyzerImpl {
 
         // Validate each argument is a numeric expression
         for (const auto& arg : call.args()) {
-            expectNumeric(analyzeNode(arg));
+            expectNumeric(arg->loc(), analyzeNode(arg));
         }
 
         return Type{ TypeKind::RECORD, target_type.type_def };
@@ -230,19 +231,19 @@ class SemanticAnalyzerImpl {
             case Op::MEMBER:
                 return analyzeMember(op);
             case Op::CONSUME:
-                expectFieldType(analyzeNode(op.args()[0]));
+                expectFieldType(op.args()[0]->loc(), analyzeNode(op.args()[0]));
                 return Type{ TypeKind::NONE };
             case Op::SIZEOF:
-                expectFieldType(analyzeNode(op.args()[0]));
+                expectFieldType(op.args()[0]->loc(), analyzeNode(op.args()[0]));
                 return Type{ TypeKind::NUMERIC };
             case Op::EXPECT:
-                expectNumeric(analyzeNode(op.args()[0]));
+                expectNumeric(op.args()[0]->loc(), analyzeNode(op.args()[0]));
                 return Type{ TypeKind::NONE };
             case Op::NEG:
             case Op::LOG_NOT:
             case Op::BIT_NOT:
             case Op::ABS:
-                expectNumeric(analyzeNode(op.args()[0]));
+                expectNumeric(op.args()[0]->loc(), analyzeNode(op.args()[0]));
                 return Type{ TypeKind::NUMERIC };
             case Op::ADD:
             case Op::SUB:
@@ -260,8 +261,8 @@ class SemanticAnalyzerImpl {
             case Op::BIT_XOR:
             case Op::LOG_AND:
             case Op::LOG_OR:
-                expectNumeric(analyzeNode(op.args()[0]));
-                expectNumeric(analyzeNode(op.args()[1]));
+                expectNumeric(op.args()[0]->loc(), analyzeNode(op.args()[0]));
+                expectNumeric(op.args()[1]->loc(), analyzeNode(op.args()[1]));
                 return Type{ TypeKind::NUMERIC };
             case Op::SEND:
             default:
@@ -285,7 +286,7 @@ class SemanticAnalyzerImpl {
     {
         // Check that the RHS is a valid field type
         auto field_type = analyzeNode(op.args()[1]);
-        expectFieldType(field_type);
+        expectFieldType(op.args()[1]->loc(), field_type);
 
         // Assign the var to the assumed type
         auto var = someVar(op.args()[0]);
@@ -353,7 +354,7 @@ class SemanticAnalyzerImpl {
 
     Type analyze(const ASTWhen& when)
     {
-        expectNumeric(analyzeNode(when.condition()));
+        expectNumeric(when.condition()->loc(), analyzeNode(when.condition()));
         for (const auto& stmt : when.body()) {
             analyzeNode(stmt);
         }


### PR DESCRIPTION
Summary:

The logic.* opcodes perform logical/boolean operations (returning 0 or 1 based on truthiness), not bitwise operations. Updated descriptions in:
- sddl2_opcodes.def
- Assembly_opcodes.md
- Bytecode_spec.md

Reviewed By: Cyan4973

Differential Revision: D100633850


