### PR TITLE
Add bitwise operators to VM (#628)

### DIFF
--- a/src/openzl/compress/graphs/sddl2/sddl2_disasm_generated.h
+++ b/src/openzl/compress/graphs/sddl2/sddl2_disasm_generated.h
@@ -3,7 +3,7 @@
 // AUTO-GENERATED FILE - DO NOT EDIT MANUALLY
 //
 // Generated from: src/openzl/compress/graphs/sddl2/sddl2_opcodes.def
-// Generated at: 2026-03-11 19:40:34 UTC
+// Generated at: 2026-04-13 19:23:35 UTC
 // Generator: generate_c_headers.py
 //
 // To regenerate: python3 src/openzl/compress/graphs/sddl2/generate_c_headers.py
@@ -117,6 +117,14 @@ static inline const char* SDDL2_instruction_name_impl(
                     return "math.abs";
                 case SDDL2_OP_MATH_NEG:
                     return "math.neg";
+                case SDDL2_OP_MATH_BIT_AND:
+                    return "math.bit_and";
+                case SDDL2_OP_MATH_BIT_OR:
+                    return "math.bit_or";
+                case SDDL2_OP_MATH_BIT_XOR:
+                    return "math.bit_xor";
+                case SDDL2_OP_MATH_BIT_NOT:
+                    return "math.bit_not";
                 default:
                     return "math.?";
             }

--- a/src/openzl/compress/graphs/sddl2/sddl2_interpreter.c
+++ b/src/openzl/compress/graphs/sddl2/sddl2_interpreter.c
@@ -34,14 +34,18 @@
     _func(SDDL2_OP_LOAD_I64LE, SDDL2_op_load_i64le) \
     _func(SDDL2_OP_LOAD_I64BE, SDDL2_op_load_i64be)
 
-#define FOR_EACH_MATH_OP(_func)              \
-    _func(SDDL2_OP_MATH_ADD, SDDL2_op_add)   \
-    _func(SDDL2_OP_MATH_SUB, SDDL2_op_sub)   \
-    _func(SDDL2_OP_MATH_MUL, SDDL2_op_mul)   \
-    _func(SDDL2_OP_MATH_DIV, SDDL2_op_div)   \
-    _func(SDDL2_OP_MATH_MOD, SDDL2_op_mod)   \
-    _func(SDDL2_OP_MATH_ABS, SDDL2_op_abs)   \
-    _func(SDDL2_OP_MATH_NEG, SDDL2_op_neg)
+#define FOR_EACH_MATH_OP(_func)                       \
+    _func(SDDL2_OP_MATH_ADD, SDDL2_op_add)            \
+    _func(SDDL2_OP_MATH_SUB, SDDL2_op_sub)            \
+    _func(SDDL2_OP_MATH_MUL, SDDL2_op_mul)            \
+    _func(SDDL2_OP_MATH_DIV, SDDL2_op_div)            \
+    _func(SDDL2_OP_MATH_MOD, SDDL2_op_mod)            \
+    _func(SDDL2_OP_MATH_ABS, SDDL2_op_abs)            \
+    _func(SDDL2_OP_MATH_NEG, SDDL2_op_neg)            \
+    _func(SDDL2_OP_MATH_BIT_AND, SDDL2_op_bit_and)    \
+    _func(SDDL2_OP_MATH_BIT_OR, SDDL2_op_bit_or)      \
+    _func(SDDL2_OP_MATH_BIT_XOR, SDDL2_op_bit_xor)    \
+    _func(SDDL2_OP_MATH_BIT_NOT, SDDL2_op_bit_not)
 
 #define FOR_EACH_CMP_OP(_func)             \
     _func(SDDL2_OP_CMP_EQ, SDDL2_op_eq)    \

--- a/src/openzl/compress/graphs/sddl2/sddl2_opcodes.def
+++ b/src/openzl/compress/graphs/sddl2/sddl2_opcodes.def
@@ -75,6 +75,10 @@
   math.mod  0x0005          "Pop two I64 values, push their remainder (second % first)"
   math.abs  0x0006          "Pop I64 value, push its absolute value"
   math.neg  0x0007          "Pop I64 value, push its negation"
+  math.bit_and  0x0008      "Pop two I64 values, push their bitwise AND"
+  math.bit_or   0x0009      "Pop two I64 values, push their bitwise OR"
+  math.bit_xor  0x000A      "Pop two I64 values, push their bitwise XOR"
+  math.bit_not  0x000B      "Pop I64 value, push its bitwise NOT"
 
 @family CMP 0x0003 "Comparison operations on signed I64 values"
   cmp.eq    0x0001          "Pop two I64 values, push 1 if equal, 0 otherwise"

--- a/src/openzl/compress/graphs/sddl2/sddl2_opcodes.def
+++ b/src/openzl/compress/graphs/sddl2/sddl2_opcodes.def
@@ -85,10 +85,10 @@
   cmp.ge    0x0006          "Pop two I64 values, push 1 if second >= first, 0 otherwise"
 
 @family LOGIC 0x0004 "Logical operations"
-  logic.and  0x0001          "Pop two I64 values, push their bitwise AND"
-  logic.or   0x0002          "Pop two I64 values, push their bitwise OR"
-  logic.xor  0x0003          "Pop two I64 values, push their bitwise XOR"
-  logic.not  0x0004          "Pop I64 value, push its bitwise NOT"
+  logic.and  0x0001          "Pop two I64 values, push 1 if both non-zero, 0 otherwise (logical AND)"
+  logic.or   0x0002          "Pop two I64 values, push 1 if either non-zero, 0 otherwise (logical OR)"
+  logic.xor  0x0003          "Pop two I64 values, push 1 if exactly one is non-zero, 0 otherwise (logical XOR)"
+  logic.not  0x0004          "Pop I64 value, push 1 if zero, 0 otherwise (logical NOT)"
 
 @family CONTROL 0x0005 "Control flow operations"
   halt         0x0001          "Stop VM execution"

--- a/src/openzl/compress/graphs/sddl2/sddl2_opcodes.h
+++ b/src/openzl/compress/graphs/sddl2/sddl2_opcodes.h
@@ -3,7 +3,7 @@
 // AUTO-GENERATED FILE - DO NOT EDIT MANUALLY
 //
 // Generated from: src/openzl/compress/graphs/sddl2/sddl2_opcodes.def
-// Generated at: 2026-03-11 19:40:34 UTC
+// Generated at: 2026-04-13 19:23:35 UTC
 // Generator: generate_c_headers.py
 //
 // To regenerate: python3 src/openzl/compress/graphs/sddl2/generate_c_headers.py
@@ -83,13 +83,17 @@ enum sddl2_opcode_push {
 
 /* MATH family (0x0002) - Arithmetic operations on I64 values */
 enum sddl2_opcode_math {
-    SDDL2_OP_MATH_ADD = 0x0001,
-    SDDL2_OP_MATH_SUB = 0x0002,
-    SDDL2_OP_MATH_MUL = 0x0003,
-    SDDL2_OP_MATH_DIV = 0x0004,
-    SDDL2_OP_MATH_MOD = 0x0005,
-    SDDL2_OP_MATH_ABS = 0x0006,
-    SDDL2_OP_MATH_NEG = 0x0007,
+    SDDL2_OP_MATH_ADD     = 0x0001,
+    SDDL2_OP_MATH_SUB     = 0x0002,
+    SDDL2_OP_MATH_MUL     = 0x0003,
+    SDDL2_OP_MATH_DIV     = 0x0004,
+    SDDL2_OP_MATH_MOD     = 0x0005,
+    SDDL2_OP_MATH_ABS     = 0x0006,
+    SDDL2_OP_MATH_NEG     = 0x0007,
+    SDDL2_OP_MATH_BIT_AND = 0x0008,
+    SDDL2_OP_MATH_BIT_OR  = 0x0009,
+    SDDL2_OP_MATH_BIT_XOR = 0x000A,
+    SDDL2_OP_MATH_BIT_NOT = 0x000B,
 };
 
 /* CMP family (0x0003) - Comparison operations on signed I64 values */

--- a/src/openzl/compress/graphs/sddl2/sddl2_vm.c
+++ b/src/openzl/compress/graphs/sddl2/sddl2_vm.c
@@ -700,6 +700,57 @@ SDDL2_op_ge(SDDL2_Stack* stack, SDDL2_Trace_buffer* trace, size_t pc)
 }
 
 /* ============================================================================
+ * Bitwise Operations (MATH Family - bitwise subset)
+ *
+ * Implements bitwise operations on I64 values:
+ * - bit_and: Bitwise AND
+ * - bit_or: Bitwise OR
+ * - bit_xor: Bitwise XOR
+ * - bit_not: Bitwise NOT (one's complement)
+ * All operations work on the full 64-bit representation.
+ * ========================================================================= */
+
+SDDL2_Error
+SDDL2_op_bit_and(SDDL2_Stack* stack, SDDL2_Trace_buffer* trace, size_t pc)
+{
+    int64_t a, b;
+    SDDL2_TRY(pop_binary_i64(stack, &a, &b));
+    int64_t result = (a & b);
+    SDDL2_log_binary_op("math.bit_and", "&", a, b, result, trace, pc);
+    return push_i64(stack, result);
+}
+
+SDDL2_Error
+SDDL2_op_bit_or(SDDL2_Stack* stack, SDDL2_Trace_buffer* trace, size_t pc)
+{
+    int64_t a, b;
+    SDDL2_TRY(pop_binary_i64(stack, &a, &b));
+    int64_t result = (a | b);
+    SDDL2_log_binary_op("math.bit_or", "|", a, b, result, trace, pc);
+    return push_i64(stack, result);
+}
+
+SDDL2_Error
+SDDL2_op_bit_xor(SDDL2_Stack* stack, SDDL2_Trace_buffer* trace, size_t pc)
+{
+    int64_t a, b;
+    SDDL2_TRY(pop_binary_i64(stack, &a, &b));
+    int64_t result = (a ^ b);
+    SDDL2_log_binary_op("math.bit_xor", "^", a, b, result, trace, pc);
+    return push_i64(stack, result);
+}
+
+SDDL2_Error
+SDDL2_op_bit_not(SDDL2_Stack* stack, SDDL2_Trace_buffer* trace, size_t pc)
+{
+    int64_t a;
+    SDDL2_TRY(pop_i64(stack, &a));
+    int64_t result = (~a);
+    SDDL2_log_unary_op("math.bit_not", "~", a, result, trace, pc);
+    return push_i64(stack, result);
+}
+
+/* ============================================================================
  * Logical Operations (LOGIC Family)
  *
  * Implements boolean/logical operations on I64 values:

--- a/src/openzl/compress/graphs/sddl2/sddl2_vm.h
+++ b/src/openzl/compress/graphs/sddl2/sddl2_vm.h
@@ -610,6 +610,22 @@ SDDL2_Error
 SDDL2_op_abs(SDDL2_Stack* stack, SDDL2_Trace_buffer* trace, size_t pc); // |a|
 SDDL2_Error
 SDDL2_op_neg(SDDL2_Stack* stack, SDDL2_Trace_buffer* trace, size_t pc); // -a
+SDDL2_Error SDDL2_op_bit_and(
+        SDDL2_Stack* stack,
+        SDDL2_Trace_buffer* trace,
+        size_t pc); // a & b
+SDDL2_Error SDDL2_op_bit_or(
+        SDDL2_Stack* stack,
+        SDDL2_Trace_buffer* trace,
+        size_t pc); // a | b
+SDDL2_Error SDDL2_op_bit_xor(
+        SDDL2_Stack* stack,
+        SDDL2_Trace_buffer* trace,
+        size_t pc); // a ^ b
+SDDL2_Error SDDL2_op_bit_not(
+        SDDL2_Stack* stack,
+        SDDL2_Trace_buffer* trace,
+        size_t pc); // ~a
 
 /* ============================================================================
  * Comparison Operations (CMP Family)
@@ -638,18 +654,24 @@ SDDL2_op_ge(SDDL2_Stack* stack, SDDL2_Trace_buffer* trace, size_t pc); // a >= b
  *
  * Binary operations: Stack: a:I64 b:I64 -> result:I64
  * Unary operation:   Stack: a:I64 -> result:I64
- * All operations perform bitwise operations on I64 values.
+ * All operations perform boolean logical operations on I64 values.
+ * Values are treated as boolean: 0 is false, non-zero is true.
+ * Results are always 0 or 1.
  * Errors: TypeMismatch
  * ========================================================================= */
 
+SDDL2_Error SDDL2_op_and(
+        SDDL2_Stack* stack,
+        SDDL2_Trace_buffer* trace,
+        size_t pc); // a && b
 SDDL2_Error
-SDDL2_op_and(SDDL2_Stack* stack, SDDL2_Trace_buffer* trace, size_t pc); // a & b
+SDDL2_op_or(SDDL2_Stack* stack, SDDL2_Trace_buffer* trace, size_t pc); // a || b
+SDDL2_Error SDDL2_op_xor(
+        SDDL2_Stack* stack,
+        SDDL2_Trace_buffer* trace,
+        size_t pc); // a ^^ b
 SDDL2_Error
-SDDL2_op_or(SDDL2_Stack* stack, SDDL2_Trace_buffer* trace, size_t pc); // a | b
-SDDL2_Error
-SDDL2_op_xor(SDDL2_Stack* stack, SDDL2_Trace_buffer* trace, size_t pc); // a ^ b
-SDDL2_Error
-SDDL2_op_not(SDDL2_Stack* stack, SDDL2_Trace_buffer* trace, size_t pc); // ~a
+SDDL2_op_not(SDDL2_Stack* stack, SDDL2_Trace_buffer* trace, size_t pc); // !a
 
 /* ============================================================================
  * Stack Manipulation Operations (STACK Family)

--- a/tests/compress/graphs/sddl2/test_sddl2_bitwise.cpp
+++ b/tests/compress/graphs/sddl2/test_sddl2_bitwise.cpp
@@ -1,0 +1,108 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#include "tests/compress/graphs/sddl2/utils.h"
+
+using namespace openzl::sddl2::testing;
+
+namespace {
+class SDDL2BitwiseTest : public SDDL2StackTest {};
+} // namespace
+
+// ============================================================================
+// Basic Operation Tests
+// ============================================================================
+
+TEST_F(SDDL2BitwiseTest, BitAndBasic)
+{
+    // 0xFF00 & 0x0FF0 = 0x0F00
+    ASSERT_EQ(SDDL2_Stack_push(stack_, SDDL2_Value_i64(0xFF00)), SDDL2_OK);
+    ASSERT_EQ(SDDL2_Stack_push(stack_, SDDL2_Value_i64(0x0FF0)), SDDL2_OK);
+    ASSERT_EQ(SDDL2_op_bit_and(stack_, NULL, 0), SDDL2_OK);
+    popAndVerifyI64(stack_, 0x0F00);
+}
+
+TEST_F(SDDL2BitwiseTest, BitOrBasic)
+{
+    // 0x00F0 | 0x0F00 = 0x0FF0
+    ASSERT_EQ(SDDL2_Stack_push(stack_, SDDL2_Value_i64(0x00F0)), SDDL2_OK);
+    ASSERT_EQ(SDDL2_Stack_push(stack_, SDDL2_Value_i64(0x0F00)), SDDL2_OK);
+    ASSERT_EQ(SDDL2_op_bit_or(stack_, NULL, 0), SDDL2_OK);
+    popAndVerifyI64(stack_, 0x0FF0);
+}
+
+TEST_F(SDDL2BitwiseTest, BitXorBasic)
+{
+    // 0xAAAA ^ 0x5555 = 0xFFFF
+    ASSERT_EQ(SDDL2_Stack_push(stack_, SDDL2_Value_i64(0xAAAA)), SDDL2_OK);
+    ASSERT_EQ(SDDL2_Stack_push(stack_, SDDL2_Value_i64(0x5555)), SDDL2_OK);
+    ASSERT_EQ(SDDL2_op_bit_xor(stack_, NULL, 0), SDDL2_OK);
+    popAndVerifyI64(stack_, 0xFFFF);
+}
+
+TEST_F(SDDL2BitwiseTest, BitNotBasic)
+{
+    // ~0 = -1 (all bits set)
+    ASSERT_EQ(SDDL2_Stack_push(stack_, SDDL2_Value_i64(0)), SDDL2_OK);
+    ASSERT_EQ(SDDL2_op_bit_not(stack_, NULL, 0), SDDL2_OK);
+    popAndVerifyI64(stack_, -1);
+}
+
+// ============================================================================
+// Type Mismatch Tests
+// ============================================================================
+
+TEST_F(SDDL2BitwiseTest, BitAndTypeMismatch)
+{
+    ASSERT_EQ(SDDL2_Stack_push(stack_, SDDL2_Value_i64(5)), SDDL2_OK);
+    ASSERT_EQ(SDDL2_Stack_push(stack_, SDDL2_Value_tag(100)), SDDL2_OK);
+    EXPECT_EQ(SDDL2_op_bit_and(stack_, NULL, 0), SDDL2_TYPE_MISMATCH);
+}
+
+TEST_F(SDDL2BitwiseTest, BitNotTypeMismatch)
+{
+    ASSERT_EQ(SDDL2_Stack_push(stack_, SDDL2_Value_tag(42)), SDDL2_OK);
+    EXPECT_EQ(SDDL2_op_bit_not(stack_, NULL, 0), SDDL2_TYPE_MISMATCH);
+}
+
+// ============================================================================
+// Stack Underflow Tests
+// ============================================================================
+
+TEST_F(SDDL2BitwiseTest, BitAndUnderflow)
+{
+    EXPECT_EQ(SDDL2_op_bit_and(stack_, NULL, 0), SDDL2_STACK_UNDERFLOW);
+
+    ASSERT_EQ(SDDL2_Stack_push(stack_, SDDL2_Value_i64(5)), SDDL2_OK);
+    EXPECT_EQ(SDDL2_op_bit_and(stack_, NULL, 0), SDDL2_STACK_UNDERFLOW);
+}
+
+TEST_F(SDDL2BitwiseTest, BitNotUnderflow)
+{
+    EXPECT_EQ(SDDL2_op_bit_not(stack_, NULL, 0), SDDL2_STACK_UNDERFLOW);
+}
+
+// ============================================================================
+// 64-bit Boundary Tests
+// ============================================================================
+
+TEST_F(SDDL2BitwiseTest, BitNotInt64MaxMin)
+{
+    // ~INT64_MAX = INT64_MIN
+    ASSERT_EQ(SDDL2_Stack_push(stack_, SDDL2_Value_i64(INT64_MAX)), SDDL2_OK);
+    ASSERT_EQ(SDDL2_op_bit_not(stack_, NULL, 0), SDDL2_OK);
+    popAndVerifyI64(stack_, INT64_MIN);
+
+    // ~INT64_MIN = INT64_MAX
+    ASSERT_EQ(SDDL2_Stack_push(stack_, SDDL2_Value_i64(INT64_MIN)), SDDL2_OK);
+    ASSERT_EQ(SDDL2_op_bit_not(stack_, NULL, 0), SDDL2_OK);
+    popAndVerifyI64(stack_, INT64_MAX);
+}
+
+TEST_F(SDDL2BitwiseTest, BitXorInt64MinMax)
+{
+    // INT64_MIN ^ INT64_MAX = -1
+    ASSERT_EQ(SDDL2_Stack_push(stack_, SDDL2_Value_i64(INT64_MIN)), SDDL2_OK);
+    ASSERT_EQ(SDDL2_Stack_push(stack_, SDDL2_Value_i64(INT64_MAX)), SDDL2_OK);
+    ASSERT_EQ(SDDL2_op_bit_xor(stack_, NULL, 0), SDDL2_OK);
+    popAndVerifyI64(stack_, -1);
+}

--- a/tests/compress/graphs/sddl2/test_sddl2_code_execution.cpp
+++ b/tests/compress/graphs/sddl2/test_sddl2_code_execution.cpp
@@ -671,6 +671,30 @@ TEST_F(SDDL2CodeExecutionTest, AssignRuntimeValue)
     expect_success(prog, input, expected_sizes);
 }
 
+// ============================================================================
+// Bitwise Operations
+// ============================================================================
+
+TEST_F(SDDL2CodeExecutionTest, BitwiseOperations)
+{
+    const std::vector<size_t> expected_sizes = { 4, 4 };
+    std::vector<uint8_t> input               = {
+        0xF0, 0x00, 0x00, 0x00, // a = 0x000000F0
+        0x0F, 0x00, 0x00, 0x00, // b = 0x0000000F
+    };
+
+    const auto prog = R"(
+        a: Int32LE
+        b: Int32LE
+        expect (a & b) == 0
+        expect (a | b) == 255
+        expect (a ^ b) == 255
+        expect (~0) == -1
+    )";
+
+    expect_success(prog, input, expected_sizes);
+}
+
 } // namespace testing
 } // namespace sddl2
 } // namespace openzl

--- a/tools/sddl2/assembler/Assembly_opcodes.md
+++ b/tools/sddl2/assembler/Assembly_opcodes.md
@@ -77,12 +77,12 @@ Comparison operations on signed I64 values
 ### LOGIC (0x0004)
 Logical operations
 
-| Mnemonic    | Opcode   | Params | Description                                |
-| ----------- | -------- | ------ | ------------------------------------------ |
-| `logic.and` | `0x0001` | `-`    | Pop two I64 values, push their bitwise AND |
-| `logic.or`  | `0x0002` | `-`    | Pop two I64 values, push their bitwise OR  |
-| `logic.xor` | `0x0003` | `-`    | Pop two I64 values, push their bitwise XOR |
-| `logic.not` | `0x0004` | `-`    | Pop I64 value, push its bitwise NOT        |
+| Mnemonic    | Opcode   | Params | Description                                                                      |
+| ----------- | -------- | ------ | -------------------------------------------------------------------------------- |
+| `logic.and` | `0x0001` | `-`    | Pop two I64 values, push 1 if both non-zero, 0 otherwise (logical AND)           |
+| `logic.or`  | `0x0002` | `-`    | Pop two I64 values, push 1 if either non-zero, 0 otherwise (logical OR)          |
+| `logic.xor` | `0x0003` | `-`    | Pop two I64 values, push 1 if exactly one is non-zero, 0 otherwise (logical XOR) |
+| `logic.not` | `0x0004` | `-`    | Pop I64 value, push 1 if zero, 0 otherwise (logical NOT)                         |
 
 ### CONTROL (0x0005)
 Control flow operations

--- a/tools/sddl2/assembler/Bytecode_spec.md
+++ b/tools/sddl2/assembler/Bytecode_spec.md
@@ -37,7 +37,7 @@ The VM instruction set is organized into families:
 | **PUSH** | Push constants and values onto stack | `push.zero`, `push.u32`, `push.i64`, `push.tag`, `push.remaining` |
 | **MATH** | Arithmetic operations on I64 values | `math.add`, `math.sub`, `math.mul`, `math.div`, `math.mod` |
 | **CMP** | Comparison operations | `cmp.eq`, `cmp.ne`, `cmp.lt`, `cmp.le`, `cmp.gt`, `cmp.ge` |
-| **LOGIC** | Bitwise logical operations | `logic.and`, `logic.or`, `logic.xor`, `logic.not` |
+| **LOGIC** | Logical (boolean) operations | `logic.and`, `logic.or`, `logic.xor`, `logic.not` |
 | **CONTROL** | Control flow | `halt`, `expect_true`, `trace.start` |
 | **LOAD** | Load values from input buffer | `load.u8`, `load.i8`, `load.u16le`, `load.i32be`, etc. |
 | **STACK** | Stack manipulation | `stack.dup`, `stack.drop`, `stack.swap`, `stack.rot` |

--- a/tools/sddl2/assembler/OpcodesGenerated.cpp
+++ b/tools/sddl2/assembler/OpcodesGenerated.cpp
@@ -3,7 +3,7 @@
 // AUTO-GENERATED FILE - DO NOT EDIT MANUALLY
 //
 // Generated from: src/openzl/compress/graphs/sddl2/sddl2_opcodes.def
-// Generated at: 2026-03-11 19:40:34 UTC
+// Generated at: 2026-04-13 19:23:40 UTC
 // Generator: generate_opcodes.py
 //
 // To regenerate: python3 generate_opcodes.py
@@ -129,6 +129,14 @@ const std::unordered_map<std::string, Instruction> INSTRUCTIONS = {
       Instruction{ Family::MATH, 0x0006, std::vector<ParamType>{} } },
     { "math.neg",
       Instruction{ Family::MATH, 0x0007, std::vector<ParamType>{} } },
+    { "math.bit_and",
+      Instruction{ Family::MATH, 0x0008, std::vector<ParamType>{} } },
+    { "math.bit_or",
+      Instruction{ Family::MATH, 0x0009, std::vector<ParamType>{} } },
+    { "math.bit_xor",
+      Instruction{ Family::MATH, 0x000A, std::vector<ParamType>{} } },
+    { "math.bit_not",
+      Instruction{ Family::MATH, 0x000B, std::vector<ParamType>{} } },
 
     // CMP family (0x0003)
     { "cmp.eq", Instruction{ Family::CMP, 0x0001, std::vector<ParamType>{} } },

--- a/tools/sddl2/assembler/OpcodesGenerated.h
+++ b/tools/sddl2/assembler/OpcodesGenerated.h
@@ -3,7 +3,7 @@
 // AUTO-GENERATED FILE - DO NOT EDIT MANUALLY
 //
 // Generated from: src/openzl/compress/graphs/sddl2/sddl2_opcodes.def
-// Generated at: 2026-03-11 19:40:34 UTC
+// Generated at: 2026-04-13 19:23:40 UTC
 // Generator: generate_opcodes.py
 //
 // To regenerate: python3 generate_opcodes.py

--- a/tools/sddl2/assembler/README.md
+++ b/tools/sddl2/assembler/README.md
@@ -83,7 +83,7 @@ At the time of this wrting, the instruction set is organized into these families
 **CMP (0x0003)** - Comparison operations
 - `cmp.eq`, `cmp.ne`, `cmp.lt`, `cmp.le`, `cmp.gt`, `cmp.ge`
 
-**LOGIC (0x0004)** - Bitwise/logical operations
+**LOGIC (0x0004)** - Logical operations
 - `logic.and`, `logic.or`, `logic.xor`, `logic.not`
 
 **LOAD (0x0006)** - Load from input buffer

--- a/tools/sddl2/assembler/tests/AssemblerTest.cpp
+++ b/tools/sddl2/assembler/tests/AssemblerTest.cpp
@@ -379,6 +379,28 @@ TEST_F(AssemblerTest, LogicOps)
     )");
 }
 
+TEST_F(AssemblerTest, BitOps)
+{
+    expect_success(R"(
+        push.i32 0xFF00
+        push.i32 0x0FF0
+        math.bit_and
+        stack.drop
+        push.i32 0x00F0
+        push.i32 0x0F00
+        math.bit_or
+        stack.drop
+        push.i32 0xAAAA
+        push.i32 0x5555
+        math.bit_xor
+        stack.drop
+        push.i32 0x0F0F
+        math.bit_not
+        stack.drop
+        halt
+    )");
+}
+
 TEST_F(AssemblerTest, LoadOps)
 {
     expect_success("load.u8\n     halt");

--- a/tools/sddl2/compiler/codegen/CodeGenerator.cpp
+++ b/tools/sddl2/compiler/codegen/CodeGenerator.cpp
@@ -22,20 +22,28 @@ const std::map<Op, std::string> op_to_asm = {
 
     { Op::SIZEOF, "type.sizeof" },
 
-    { Op::ADD, "math.add" },       { Op::SUB, "math.sub" },
-    { Op::MUL, "math.mul" },       { Op::DIV, "math.div" },
-    { Op::MOD, "math.mod" },       { Op::NEG, "math.neg" },
+    { Op::ADD, "math.add" },
+    { Op::SUB, "math.sub" },
+    { Op::MUL, "math.mul" },
+    { Op::DIV, "math.div" },
+    { Op::MOD, "math.mod" },
+    { Op::NEG, "math.neg" },
     { Op::ABS, "math.abs" },
+    { Op::BIT_AND, "math.bit_and" },
+    { Op::BIT_OR, "math.bit_or" },
+    { Op::BIT_XOR, "math.bit_xor" },
+    { Op::BIT_NOT, "math.bit_not" },
 
-    { Op::EQ, "cmp.eq" },          { Op::NE, "cmp.ne" },
-    { Op::GT, "cmp.gt" },          { Op::GE, "cmp.ge" },
-    { Op::LT, "cmp.lt" },          { Op::LE, "cmp.le" },
+    { Op::EQ, "cmp.eq" },
+    { Op::NE, "cmp.ne" },
+    { Op::GT, "cmp.gt" },
+    { Op::GE, "cmp.ge" },
+    { Op::LT, "cmp.lt" },
+    { Op::LE, "cmp.le" },
 
-    { Op::LOG_AND, "logic.and" },  { Op::LOG_OR, "logic.or" },
+    { Op::LOG_AND, "logic.and" },
+    { Op::LOG_OR, "logic.or" },
     { Op::LOG_NOT, "logic.not" },
-
-    { Op::BIT_AND, "logic.and" },  { Op::BIT_OR, "logic.or" },
-    { Op::BIT_XOR, "logic.xor" },  { Op::BIT_NOT, "logic.not" },
 };
 
 /**

--- a/tools/sddl2/compiler/semantic_analyzer/SemanticAnalyzer.cpp
+++ b/tools/sddl2/compiler/semantic_analyzer/SemanticAnalyzer.cpp
@@ -26,18 +26,18 @@ struct Type {
     const ASTNode* type_def = nullptr;
 };
 
-void expectNumeric(const Type& t)
+void expectNumeric(const SourceLocation& loc, const Type& t)
 {
     if (t.kind != TypeKind::NUMERIC) {
-        throw SemanticError("Expected a numeric expression.");
+        throw SemanticError(loc, "Expected a numeric expression.");
     }
 }
 
-void expectFieldType(const Type& t)
+void expectFieldType(const SourceLocation& loc, const Type& t)
 {
     if (!(t.kind == TypeKind::ARRAY || t.kind == TypeKind::RECORD
           || t.kind == TypeKind::BYTES || t.kind == TypeKind::BUILTIN_FIELD)) {
-        throw SemanticError("Expected a field type expression.");
+        throw SemanticError(loc, "Expected a field type expression.");
     }
 }
 
@@ -46,7 +46,7 @@ const ASTVar* someVar(const ASTPtr& node)
     if (auto var = node->as_var()) {
         return var;
     }
-    throw SemanticError("Expected a variable name.");
+    throw SemanticError(node->loc(), "Expected a variable name.");
 }
 
 bool hasLoadInstruction(Symbol sym)
@@ -125,7 +125,8 @@ class SemanticAnalyzerImpl {
             case ConvertedNodeType::OP:
                 return analyze(*node->as_op());
             default:
-                throw InvariantViolation("Unsupported AST node type.");
+                throw InvariantViolation(
+                        node->loc(), "Unsupported AST node type.");
         }
     }
 
@@ -141,15 +142,15 @@ class SemanticAnalyzerImpl {
 
     Type analyze(const ASTBytes& bytes)
     {
-        expectNumeric(analyzeNode(bytes.len()));
+        expectNumeric(bytes.loc(), analyzeNode(bytes.len()));
         return Type{ TypeKind::BYTES, &bytes };
     }
 
     Type analyze(const ASTArray& array)
     {
-        expectFieldType(analyzeNode(array.field()));
+        expectFieldType(array.field()->loc(), analyzeNode(array.field()));
         if (array.len()) {
-            expectNumeric(analyzeNode(array.len()));
+            expectNumeric(array.len()->loc(), analyzeNode(array.len()));
         }
         return Type{ TypeKind::ARRAY, &array };
     }
@@ -160,7 +161,7 @@ class SemanticAnalyzerImpl {
         if (!var) {
             throw SemanticError(field.loc(), "Field name must be a variable.");
         }
-        expectFieldType(analyzeNode(field.type()));
+        expectFieldType(field.type()->loc(), analyzeNode(field.type()));
         return Type{ TypeKind::NONE };
     }
 
@@ -214,7 +215,7 @@ class SemanticAnalyzerImpl {
 
         // Validate each argument is a numeric expression
         for (const auto& arg : call.args()) {
-            expectNumeric(analyzeNode(arg));
+            expectNumeric(arg->loc(), analyzeNode(arg));
         }
 
         return Type{ TypeKind::RECORD, target_type.type_def };
@@ -230,19 +231,19 @@ class SemanticAnalyzerImpl {
             case Op::MEMBER:
                 return analyzeMember(op);
             case Op::CONSUME:
-                expectFieldType(analyzeNode(op.args()[0]));
+                expectFieldType(op.args()[0]->loc(), analyzeNode(op.args()[0]));
                 return Type{ TypeKind::NONE };
             case Op::SIZEOF:
-                expectFieldType(analyzeNode(op.args()[0]));
+                expectFieldType(op.args()[0]->loc(), analyzeNode(op.args()[0]));
                 return Type{ TypeKind::NUMERIC };
             case Op::EXPECT:
-                expectNumeric(analyzeNode(op.args()[0]));
+                expectNumeric(op.args()[0]->loc(), analyzeNode(op.args()[0]));
                 return Type{ TypeKind::NONE };
             case Op::NEG:
             case Op::LOG_NOT:
             case Op::BIT_NOT:
             case Op::ABS:
-                expectNumeric(analyzeNode(op.args()[0]));
+                expectNumeric(op.args()[0]->loc(), analyzeNode(op.args()[0]));
                 return Type{ TypeKind::NUMERIC };
             case Op::ADD:
             case Op::SUB:
@@ -260,8 +261,8 @@ class SemanticAnalyzerImpl {
             case Op::BIT_XOR:
             case Op::LOG_AND:
             case Op::LOG_OR:
-                expectNumeric(analyzeNode(op.args()[0]));
-                expectNumeric(analyzeNode(op.args()[1]));
+                expectNumeric(op.args()[0]->loc(), analyzeNode(op.args()[0]));
+                expectNumeric(op.args()[1]->loc(), analyzeNode(op.args()[1]));
                 return Type{ TypeKind::NUMERIC };
             case Op::SEND:
             default:
@@ -285,7 +286,7 @@ class SemanticAnalyzerImpl {
     {
         // Check that the RHS is a valid field type
         auto field_type = analyzeNode(op.args()[1]);
-        expectFieldType(field_type);
+        expectFieldType(op.args()[1]->loc(), field_type);
 
         // Assign the var to the assumed type
         auto var = someVar(op.args()[0]);
@@ -353,7 +354,7 @@ class SemanticAnalyzerImpl {
 
     Type analyze(const ASTWhen& when)
     {
-        expectNumeric(analyzeNode(when.condition()));
+        expectNumeric(when.condition()->loc(), analyzeNode(when.condition()));
         for (const auto& stmt : when.body()) {
             analyzeNode(stmt);
         }


### PR DESCRIPTION
Summary:

Add bitwise operators (AND, OR, XOR, NOT) to the SDDL2 VM:
- `math.bit_and`: Bitwise AND of two I64 values
- `math.bit_or`: Bitwise OR of two I64 values
- `math.bit_xor`: Bitwise XOR of two I64 values
- `math.bit_not`: Bitwise NOT of an I64 value

These are distinct from the existing logical operators (`logic.and`, etc.) which perform boolean operations.

These are required for the SDDL2 bitwise operations in the syntax to actually execute the expected operation in the VM.

Reviewed By: Cyan4973

Differential Revision: D100654519


