### PR TITLE
Set up component benchmarks (#634)

### DIFF
--- a/benchmark/BUCK
+++ b/benchmark/BUCK
@@ -1,5 +1,6 @@
 # Copyright (c) Meta Platforms, Inc. and affiliates.
 
+load("@fbcode_macros//build_defs:cpp_binary.bzl", "cpp_binary")
 load("@fbcode_macros//build_defs:native_rules.bzl", "buck_filegroup")
 load("@fbsource//tools/build_defs:manifold.bzl", "manifold_get")
 load("../defs.bzl", "zs_cxxbinary")
@@ -28,9 +29,14 @@ zs_cxxbinary(
     srcs = [(
         src_file,
         SRC_FILE_FLAGS.get(src_file, []),
-    ) for src_file in glob([
-        "**/*.cpp",
-    ])],
+    ) for src_file in glob(
+        [
+            "**/*.cpp",
+        ],
+        exclude = [
+            "BenchmarkComponents.cpp",
+        ],
+    )],
     headers = glob([
         "**/*.h",
     ]),
@@ -54,6 +60,17 @@ zs_cxxbinary(
         "//folly:demangle",
         "//folly:dynamic",
         "//folly:json",
+    ],
+)
+
+cpp_binary(
+    # @autodeps-skip
+    name = "benchmark_components",
+    srcs = ["BenchmarkComponents.cpp"],
+    deps = [
+        "..:zstronglib",
+        "../tests/registry:openzl_components",
+        "fbsource//third-party/benchmark:benchmark",
     ],
 )
 

--- a/benchmark/BenchmarkComponents.cpp
+++ b/benchmark/BenchmarkComponents.cpp
@@ -1,0 +1,401 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#include <benchmark/benchmark.h>
+
+#include "openzl/cpp/CCtx.hpp"
+#include "openzl/cpp/Compressor.hpp"
+#include "openzl/cpp/DCtx.hpp"
+#include "openzl/cpp/FrameInfo.hpp"
+#include "tests/registry/OpenZLComponent.h"
+#include "tests/registry/OpenZLComponents.h"
+
+namespace {
+using namespace openzl;
+using namespace openzl::tests;
+
+bool detailedBenchmark(int* argc, char** argv)
+{
+    for (int i = 0; i < *argc; ++i) {
+        if (std::string_view{ argv[i] } == std::string_view{ "--detailed" }) {
+            for (int j = i; j < *argc - 1; ++j) {
+                argv[j] = argv[j + 1];
+            }
+            *argc -= 1;
+            return true;
+        }
+    }
+    return false;
+}
+
+class ComponentBenchmark {
+   public:
+    explicit ComponentBenchmark(const OpenZLComponent& component)
+            : component_(&component)
+    {
+        compressor_.selectStartingGraph(ZL_GRAPH_STORE);
+        component_->registerComponent(compressor_);
+        datagen::DataGen gen(0xdeadbeef);
+        benchmarks_ = component_->benchmarks(compressor_, gen);
+    }
+
+    static void registerCompressOverallBenchmark(
+            std::shared_ptr<ComponentBenchmark> self)
+    {
+        if (self->benchmarks_.empty()) {
+            return;
+        }
+        auto bench = [self](benchmark::State& state) {
+            self->benchCompressOverall(state);
+        };
+        benchmark::RegisterBenchmark(
+                ("Compress/Component:" + self->component_->name() + "/Overall")
+                        .c_str(),
+                std::move(bench));
+    }
+
+    static void registerCompressDetailedBenchmarks(
+            std::shared_ptr<ComponentBenchmark> self)
+    {
+        for (const auto& benchmark : self->benchmarks_) {
+            auto bench = [self, &benchmark](benchmark::State& state) {
+                self->benchCompressDetailed(state, benchmark);
+            };
+            benchmark::RegisterBenchmark(
+                    ("Compress/Component:" + self->component_->name()
+                     + "/Detailed/" + benchmark.name)
+                            .c_str(),
+                    std::move(bench));
+        }
+    }
+
+    static void registerDecompressOverallBenchmark(
+            std::shared_ptr<ComponentBenchmark> self)
+    {
+        if (self->benchmarks_.empty()) {
+            return;
+        }
+        auto bench = [self](benchmark::State& state) {
+            self->benchDecompressOverall(state);
+        };
+        benchmark::RegisterBenchmark(
+                ("Decompress/Component:" + self->component_->name()
+                 + "/Overall")
+                        .c_str(),
+                std::move(bench));
+    }
+
+    static void registerDecompressDetailedBenchmarks(
+            std::shared_ptr<ComponentBenchmark> self)
+    {
+        for (const auto& benchmark : self->benchmarks_) {
+            auto bench = [self, &benchmark](benchmark::State& state) {
+                self->benchDecompressDetailed(state, benchmark);
+            };
+            benchmark::RegisterBenchmark(
+                    ("Decompress/Component:" + self->component_->name()
+                     + "/Detailed/" + benchmark.name)
+                            .c_str(),
+                    std::move(bench));
+        }
+    }
+
+   private:
+    void setParameters(CCtx& cctx) const
+    {
+        cctx.refCompressor(compressor_);
+        cctx.setParameter(CParam::StickyParameters, true);
+        // Disable checksumming
+        cctx.setParameter(CParam::CompressedChecksum, ZL_TernaryParam_disable);
+        cctx.setParameter(CParam::ContentChecksum, ZL_TernaryParam_disable);
+        // Set format version (currently can only be max)
+        cctx.setParameter(CParam::FormatVersion, formatVersion_);
+    }
+
+    void benchCompressOverall(benchmark::State& state) const
+    {
+        CCtx cctx;
+        setParameters(cctx);
+
+        size_t compressBound = 0;
+        std::vector<std::vector<std::vector<Input>>> benchmarkInputs;
+        benchmarkInputs.reserve(benchmarks_.size());
+        size_t totalSrcSize = 0;
+        for (const auto& benchmark : benchmarks_) {
+            std::vector<std::vector<Input>> inputs;
+            inputs.reserve(benchmark.inputs.size());
+            for (const auto& input : benchmark.inputs) {
+                auto in = input->inputs();
+                compressBound =
+                        std::max(compressBound, component_->compressBound(in));
+                inputs.push_back(std::move(in));
+                totalSrcSize += input->sizeBytes();
+            }
+            benchmarkInputs.push_back(std::move(inputs));
+        }
+
+        std::string compressed(compressBound, '\0');
+        size_t totalCompressedSize = 0;
+        for (size_t i = 0; i < benchmarks_.size(); ++i) {
+            const auto& benchmark = benchmarks_[i];
+            for (const auto& input : benchmarkInputs[i]) {
+                cctx.selectStartingGraph(benchmark.graph);
+                const size_t cSize = cctx.compress(compressed, input);
+                totalCompressedSize += cSize;
+            }
+        }
+
+        for (auto _ : state) {
+            for (size_t i = 0; i < benchmarks_.size(); ++i) {
+                const auto& benchmark = benchmarks_[i];
+                for (const auto& input : benchmarkInputs[i]) {
+                    cctx.selectStartingGraph(benchmark.graph);
+                    cctx.compress(compressed, input);
+                    benchmark::DoNotOptimize(compressed);
+                    benchmark::ClobberMemory();
+                }
+            }
+        }
+
+        state.SetBytesProcessed((int64_t)(totalSrcSize * state.iterations()));
+        state.counters["CompressedSize"] = (double)totalCompressedSize;
+        state.counters["Size"]           = (double)totalSrcSize;
+        state.counters["CompressionRatio"] =
+                (double)totalSrcSize / totalCompressedSize;
+    }
+
+    void benchDecompressOverall(benchmark::State& state) const
+    {
+        CCtx cctx;
+        setParameters(cctx);
+        DCtx dctx;
+        component_->registerComponent(dctx);
+
+        size_t compressBound = 0;
+        size_t totalSrcSize  = 0;
+        std::vector<std::vector<std::vector<Input>>> benchmarkInputs;
+        benchmarkInputs.reserve(benchmarks_.size());
+        for (const auto& benchmark : benchmarks_) {
+            std::vector<std::vector<Input>> inputs;
+            inputs.reserve(benchmark.inputs.size());
+            for (const auto& input : benchmark.inputs) {
+                auto in = input->inputs();
+                compressBound =
+                        std::max(compressBound, component_->compressBound(in));
+                inputs.push_back(std::move(in));
+                totalSrcSize += input->sizeBytes();
+            }
+            benchmarkInputs.push_back(std::move(inputs));
+        }
+
+        // Compress all inputs and collect frame info
+        std::string compressBuffer(compressBound, '\0');
+        std::vector<CompressedFrame> frames;
+        for (size_t i = 0; i < benchmarks_.size(); ++i) {
+            for (const auto& input : benchmarkInputs[i]) {
+                frames.push_back(compressFrame(
+                        cctx, benchmarks_[i].graph, input, compressBuffer));
+            }
+        }
+        size_t totalCompressedSize = 0;
+        for (const auto& frame : frames) {
+            totalCompressedSize += frame.data.size();
+        }
+
+        std::vector<Output> outputs;
+        outputs.reserve(100);
+        for (auto _ : state) {
+            for (auto& frame : frames) {
+                outputs.clear();
+                for (size_t i = 0; i < frame.outputTypes.size(); ++i) {
+                    outputs.push_back(wrapOutput(
+                            frame.outputTypes[i],
+                            frame.outputEltWidths[i],
+                            frame.buffers[i]));
+                }
+                dctx.decompress(outputs, frame.data);
+                benchmark::DoNotOptimize(outputs);
+                benchmark::ClobberMemory();
+            }
+        }
+
+        state.SetBytesProcessed((int64_t)(totalSrcSize * state.iterations()));
+        state.counters["CompressedSize"] = (double)totalCompressedSize;
+        state.counters["Size"]           = (double)totalSrcSize;
+        state.counters["CompressionRatio"] =
+                (double)totalSrcSize / totalCompressedSize;
+    }
+
+    void benchCompressDetailed(
+            benchmark::State& state,
+            const OpenZLComponent::Benchmark& benchmark) const
+    {
+        CCtx cctx;
+        setParameters(cctx);
+
+        size_t compressBound = 0;
+        std::vector<std::vector<Input>> inputs;
+        inputs.reserve(benchmark.inputs.size());
+        size_t totalSrcSize = 0;
+        for (const auto& input : benchmark.inputs) {
+            auto in = input->inputs();
+            compressBound =
+                    std::max(compressBound, component_->compressBound(in));
+            inputs.push_back(std::move(in));
+            totalSrcSize += input->sizeBytes();
+        }
+
+        std::string compressed(compressBound, '\0');
+        size_t totalCompressedSize = 0;
+        for (const auto& input : inputs) {
+            cctx.selectStartingGraph(benchmark.graph);
+            const size_t cSize = cctx.compress(compressed, input);
+            totalCompressedSize += cSize;
+        }
+
+        for (auto _ : state) {
+            for (const auto& input : inputs) {
+                cctx.selectStartingGraph(benchmark.graph);
+                cctx.compress(compressed, input);
+            }
+        }
+
+        state.SetBytesProcessed((int64_t)(totalSrcSize * state.iterations()));
+        state.counters["CompressedSize"] = (double)totalCompressedSize;
+        state.counters["Size"]           = (double)totalSrcSize;
+        state.counters["CompressionRatio"] =
+                (double)totalSrcSize / totalCompressedSize;
+    }
+
+    void benchDecompressDetailed(
+            benchmark::State& state,
+            const OpenZLComponent::Benchmark& bm) const
+    {
+        CCtx cctx;
+        setParameters(cctx);
+        DCtx dctx;
+        component_->registerComponent(dctx);
+
+        size_t compressBound = 0;
+        std::vector<std::vector<Input>> inputs;
+        inputs.reserve(bm.inputs.size());
+        size_t totalSrcSize = 0;
+        for (const auto& input : bm.inputs) {
+            auto in = input->inputs();
+            compressBound =
+                    std::max(compressBound, component_->compressBound(in));
+            inputs.push_back(std::move(in));
+            totalSrcSize += input->sizeBytes();
+        }
+
+        // Compress all inputs and collect frame info
+        std::string compressBuffer(compressBound, '\0');
+        std::vector<CompressedFrame> frames;
+        frames.reserve(inputs.size());
+        for (const auto& input : inputs) {
+            frames.push_back(
+                    compressFrame(cctx, bm.graph, input, compressBuffer));
+        }
+        size_t totalCompressedSize = 0;
+        for (const auto& frame : frames) {
+            totalCompressedSize += frame.data.size();
+        }
+
+        std::vector<Output> outputs;
+        outputs.reserve(100);
+        for (auto _ : state) {
+            for (auto& frame : frames) {
+                outputs.clear();
+                for (size_t i = 0; i < frame.outputTypes.size(); ++i) {
+                    outputs.push_back(wrapOutput(
+                            frame.outputTypes[i],
+                            frame.outputEltWidths[i],
+                            frame.buffers[i]));
+                }
+                dctx.decompress(outputs, frame.data);
+                benchmark::DoNotOptimize(outputs);
+                benchmark::ClobberMemory();
+            }
+        }
+
+        state.SetBytesProcessed((int64_t)(totalSrcSize * state.iterations()));
+        state.counters["CompressedSize"] = (double)totalCompressedSize;
+        state.counters["Size"]           = (double)totalSrcSize;
+        state.counters["CompressionRatio"] =
+                (double)totalSrcSize / totalCompressedSize;
+    }
+
+    struct CompressedFrame {
+        std::string data;
+        std::vector<Type> outputTypes;
+        std::vector<size_t> outputEltWidths;
+        std::vector<std::vector<char>> buffers;
+    };
+
+    static CompressedFrame compressFrame(
+            CCtx& cctx,
+            GraphID graph,
+            poly::span<const Input> inputs,
+            std::string& compressBuffer)
+    {
+        cctx.selectStartingGraph(graph);
+        const size_t cSize = cctx.compress(compressBuffer, inputs);
+
+        CompressedFrame frame;
+        frame.data = compressBuffer.substr(0, cSize);
+        FrameInfo info(frame.data);
+        for (size_t i = 0; i < info.numOutputs(); ++i) {
+            frame.outputTypes.push_back(info.outputType(i));
+            frame.outputEltWidths.push_back(inputs[i].eltWidth());
+            if (info.outputType(i) != Type::String) {
+                frame.buffers.emplace_back(info.outputContentSize(i));
+            } else {
+                frame.buffers.emplace_back();
+            }
+        }
+        return frame;
+    }
+
+    static Output
+    wrapOutput(Type type, size_t eltWidth, std::vector<char>& buffer)
+    {
+        switch (type) {
+            case Type::Serial:
+                return Output::wrapSerial(buffer.data(), buffer.size());
+            case Type::Struct:
+                return Output::wrapStruct(
+                        buffer.data(), eltWidth, buffer.size() / eltWidth);
+            case Type::Numeric:
+                return Output::wrapNumeric(
+                        buffer.data(), eltWidth, buffer.size() / eltWidth);
+            case Type::String:
+                return Output();
+        }
+        return Output();
+    }
+
+    Compressor compressor_;
+    const OpenZLComponent* component_;
+    std::vector<OpenZLComponent::Benchmark> benchmarks_;
+    int formatVersion_ = ZL_MAX_FORMAT_VERSION;
+};
+
+} // namespace
+
+int main(int argc, char** argv)
+{
+    const bool detailed = detailedBenchmark(&argc, argv);
+
+    for (const auto& component : getAllOpenZLComponents()) {
+        auto bench = std::make_shared<ComponentBenchmark>(*component);
+        ComponentBenchmark::registerCompressOverallBenchmark(bench);
+        ComponentBenchmark::registerDecompressOverallBenchmark(bench);
+        if (detailed) {
+            ComponentBenchmark::registerCompressDetailedBenchmarks(bench);
+            ComponentBenchmark::registerDecompressDetailedBenchmarks(bench);
+        }
+    }
+
+    benchmark::Initialize(&argc, argv);
+    benchmark::RunSpecifiedBenchmarks();
+    benchmark::Shutdown();
+}

--- a/benchmark/CMakeLists.txt
+++ b/benchmark/CMakeLists.txt
@@ -25,6 +25,8 @@ file(
     "${CMAKE_CURRENT_LIST_DIR}/unitBench/**/*.c")
 list(FILTER openzl_benchmark_sources
      EXCLUDE REGEX "${CMAKE_CURRENT_LIST_DIR}/tools/.*$")
+list(FILTER openzl_benchmark_sources
+     EXCLUDE REGEX "${CMAKE_CURRENT_LIST_DIR}/BenchmarkComponents.cpp$")
 file(
     GLOB_RECURSE openzl_benchmark_headers
     CONFIGURE_DEPENDS

--- a/tests/registry/OpenZLComponent.h
+++ b/tests/registry/OpenZLComponent.h
@@ -211,6 +211,36 @@ class OpenZLComponent {
         return {};
     }
 
+    struct Benchmark {
+        std::string name;
+        GraphID graph;
+        std::vector<std::unique_ptr<OpenZLInput>> inputs;
+    };
+
+    /**
+     * @returns A list of benchmarks to run.
+     *
+     * These benchmarks will be run in two modes:
+     *
+     * - Overall mode: All the benchmarks will be combined into a single summary
+     *                 benchmark for the component.
+     * - Detailed Mode: Each benchmark will be run individually.
+     *
+     * It is recommended to make each benchmark approximately the same "weight"
+     * so that in summary mode they all contribute to the overall result. E.g.
+     * if one scenario processes 100 bytes, and another processes 1MB, the first
+     * scenario won't practically contribute to the summary result.
+     *
+     * These benchmarks should aim to be the minimal set that captures the
+     * interesting behavior of the component.
+     */
+    virtual std::vector<Benchmark> benchmarks(
+            Compressor& compressor,
+            datagen::DataGen& gen) const
+    {
+        return {};
+    }
+
     virtual ~OpenZLComponent() = default;
 
    private:

--- a/tests/registry/OpenZLInput.h
+++ b/tests/registry/OpenZLInput.h
@@ -23,6 +23,9 @@ class OpenZLInput {
    public:
     virtual std::vector<Input> inputs() const = 0;
 
+    /// @returns the size of the input in bytes
+    virtual size_t sizeBytes() const = 0;
+
     std::string serialize() const;
     static std::string serialize(poly::span<const Input> inputs);
     static std::unique_ptr<OpenZLInput> deserialize(std::string_view data);
@@ -47,6 +50,11 @@ class SerialOpenZLInput : public OpenZLInput {
         std::vector<Input> result;
         result.push_back(Input::refSerial(str_));
         return result;
+    }
+
+    size_t sizeBytes() const override
+    {
+        return str_.size();
     }
 
     ~SerialOpenZLInput() override = default;
@@ -92,6 +100,11 @@ class NumericOpenZLInput : public OpenZLInput {
         std::vector<Input> result;
         result.push_back(Input::refNumeric(poly::span<const T>(vec_)));
         return result;
+    }
+
+    size_t sizeBytes() const override
+    {
+        return vec_.size() * sizeof(T);
     }
 
     ~NumericOpenZLInput() override = default;
@@ -156,6 +169,11 @@ class StructOpenZLInput : public OpenZLInput {
         return result;
     }
 
+    size_t sizeBytes() const override
+    {
+        return data_.size();
+    }
+
     ~StructOpenZLInput() override = default;
 
    private:
@@ -195,6 +213,11 @@ class StringOpenZLInput : public OpenZLInput {
         return result;
     }
 
+    size_t sizeBytes() const override
+    {
+        return data_.size() + lens_.size() * sizeof(uint32_t);
+    }
+
     ~StringOpenZLInput() override = default;
 
    private:
@@ -228,6 +251,15 @@ class MultiOpenZLInput : public OpenZLInput {
             ins.push_back(std::move(inner[0]));
         }
         return ins;
+    }
+
+    size_t sizeBytes() const override
+    {
+        size_t size = 0;
+        for (const auto& input : inputs_) {
+            size += input->sizeBytes();
+        }
+        return size;
     }
 
     ~MultiOpenZLInput() override = default;


### PR DESCRIPTION
Summary:

Adds a new benchmark binary that generates benchmarks from the OpenZL Component registry. Its focus is on end-to-end benchmarking of a particular OpenZL component, which might be a single codec, or an entire graph.

* Why is this not in unit bench? Unit bench doesn't control the input that it is run on.
* Why is it not in the gbench? If we're happy with the component benchmark, I'd like to delete the previous gbench setup, and migrate to this one. With `unitBench` still providing microbenchmarks.

Reviewed By: Cyan4973

Differential Revision: D100054273


