### PR TITLE
Allow getting error context in function graphs (#637)

### DIFF
--- a/.claude/skills/openzl-codec-design/SKILL.md
+++ b/.claude/skills/openzl-codec-design/SKILL.md
@@ -1,0 +1,231 @@
+---
+name: openzl-codec-design
+description: Design patterns and requirements for OpenZL codecs (located under `src/openzl/codecs/`). **USE AUOMATICALLY** when creating, modifying, or reviewing codecs in OpenZL.
+---
+
+# Creating or Modifying an OpenZL Codec
+
+## Workflow for Creating a New Codec
+
+If the user provides an input to this skill, interpret it as an **informal specification** of the codec they want to create. Before writing any code:
+
+1. **Ask clarifying questions** about the format. Resolve ambiguities around input/output types, element widths, codec header layout, edge cases, error conditions, and whether the codec is public or private.
+2. **Write `spec.md` first.** ALWAYS generate the decoder wire format specification (`spec.md`) before any other file. Follow the conventions of existing specs in `src/openzl/codecs/` (inputs, codec header, decoding algorithm, outputs).
+3. **Ask the user to verify the spec.** Do NOT proceed with implementation until the user has reviewed and approved the `spec.md`. The spec is the contract — all code flows from it.
+
+## Security
+
+### Decoder MUST Be Safe to Malicious Inputs
+
+The decoder processes untrusted data from compressed frames. All assumptions MUST be validated, especially:
+- Bounds on sizes, counts, and offsets read from the frame header
+- Element widths and stream types
+- Buffer sizes before writing
+
+Never trust values from the compressed stream without verification. A malicious frame must not cause crashes, out-of-bounds access, or undefined behavior.
+
+### Encoder MUST Be Safe to Malicious Inputs
+
+The encoder is processing data that the user provides. Unless explicitly stated otherwise all assumptions MUST be validated. Typcially, this is less of an issue on the encoder side, but any assumptions the encoder makes about the input data (e.g. it doesn't contain the value 0) must be validated, otherwise the data could be corrupted.
+
+## Requirements
+
+### General
+
+- Codecs must work on big & little endian machines, and must not depend on endian-ness.
+- Prefer to use helpers that already exist in `src/openzl/shared/`, rather than re-implementing them.
+   - Especially `openzl/shared/mem.h`, `openzl/shared/bits.h`, and `openzl/shared/utils.h`.
+- All code MUST be portable across platforms. E.g. both ARM and x86-64, 32- and 64-bit systems, and both little- and big-endian.
+
+### Bumping ZL_MAX_FORMAT_VERSION
+
+When adding a new codec, or making a breaking change to a codec that requires bumping the format version, we need to make sure the development branch bumps the format version.
+If not adding a codec or making a format breaking change to a codec, then you can skip this section.
+
+Determine the production max format version from the `ZL_MAX_FORMAT_VERSION` macro in `fbcode/openzl/prod/include/openzl/zl_version.h`, call it `$prod_max_format_version`.
+Determine the development max format version from the `ZL_MAX_FORMAT_VERSION` macro in `fbcode/openzl/dev/include/openzl/zl_version.h`, call it `$dev_max_format_version`.
+If `$dev_max_format_version == $prod_max_format_version`, then the development `ZL_MAX_FORMAT_VERSION` in `fbcode/openzl/dev/include/openzl/zl_version.h` must be bumped.
+This needs to be done before hooking up the encoder and decoder registry so that the new max format version is used during registration.
+
+### Format Versioning
+
+Codecs MUST preserve forward and backward compatibility with all supported format versions from `ZL_MIN_FORMAT_VERSION` to `ZL_MAX_FORMAT_VERSION`.
+Codecs MAY change their format, with very careful consideration, but they MUST do it in way that preserves compatibility:
+
+- `ZL_MAX_FORMAT_VERSION` must be bumped in the dev branch (see above)
+- The `spec.md` file MUST be updated to reflect the variation based on the format version
+- The encoder MUST check the format version with `ZL_Encoder_getCParam(eictx, ZL_CParam_formatVersion)` and only emit the new format for the latest format version
+- The encoder MUST maintain the ability to emit the older format versions down to the minimum format version the codec supports
+- The decoder MUST check the format version with `DI_getFrameFormatVersion(dictx)` and correctly interpret the encoded data based on the format version
+
+While codecs are allowed to change their format, this is something that should only be done with extreme care, and done very rarely.
+It should NEVER be done on a whim to fix a small issue.
+Format versions will be supported for years, so every change compounds the maintainence burden of the code for years.
+
+### Encoder Parameters
+
+Parameters MUST be validated and cannot be trusted to match a particular format.
+Parameters can come from a serialized compressor, which means that an attacker could control the serialized compressor, so all assumptions about parameters MUST be validated.
+E.g. if a parameter is supposed to be an 8-byte uint64_t, then the size of the parameter MUST be validated to be equal to 8.
+
+## Directory Layout
+
+Each codec lives in `src/openzl/codecs/{codec_name}/`. A typical codec has these files:
+
+```
+{codec_name}/
+  encode_{codec}_binding.h     # Encoder binding API + registration macro (EI_CODEC)
+  encode_{codec}_binding.c     # Encoder binding implementation
+  encode_{codec}_kernel.h      # Encoder kernel API (transportable, no openzl deps)
+  encode_{codec}_kernel.c      # Encoder kernel implementation
+  decode_{codec}_binding.h     # Decoder binding API + registration macro (DI_CODEC)
+  decode_{codec}_binding.c     # Decoder binding implementation
+  decode_{codec}_kernel.h      # Decoder kernel API (transportable, no openzl deps)
+  decode_{codec}_kernel.c      # Decoder kernel implementation
+  graph_{codec}.h              # [optional] Graph descriptor (I/O stream types)
+  spec.md                      # [optional] Human-readable decoder wire format spec
+```
+
+### Kernel vs Binding Split
+
+**Kernel** = pure algorithm. Minimal deps (C standard library, `openzl/shared/`). No memory allocation. Must be independent of the OpenZL engine and transportable to other contexts. Publishes its own lean interface.
+
+**Binding** = glue between kernel and OpenZL engine. Implements `ZL_Encoder`/`ZL_Decoder` interfaces. Handles pre-condition checks, error reporting, memory allocation, and kernel orchestration.
+
+Simple codecs may skip the kernel and put everything in the binding. Complex codecs may have multiple kernel variants.
+
+See `README.md` for the full conventions.
+
+### Graph Descriptors
+
+Define I/O stream types. Common reusable graphs in `src/openzl/codecs/common/graph_pipe.h`:
+- `NUMPIPE_GRAPH(id)` — 1 numeric in, 1 numeric out (used by zigzag, delta, divide_by)
+- `PIPE_GRAPH(id)` — 1 serial in, 1 serial out (used by lz4, zstd, rolz)
+
+### spec.md
+
+A human-readable specification of the decoder wire format: inputs, codec header format, decoding algorithm, and outputs. Written from the decoder's perspective.
+
+## Encoder Binding Pattern
+
+The encoder binding header declares the encode function and a registration macro:
+
+```c
+ZL_Report EI_{codec}(ZL_Encoder* eictx, const ZL_Input* ins[], size_t nbIns);
+
+#define EI_CODEC(id)                    \
+    { .gd          = GRAPH_MACRO(id),   \
+      .transform_f = EI_{codec},        \
+      .name        = "!zl.{codec}" }
+```
+
+## Decoder Binding Pattern
+
+```c
+ZL_Report DI_{codec}(ZL_Decoder* dictx, const ZL_Input* in[]);
+
+#define DI_CODEC(id) { .transform_f = DI_{codec}, .name = "!zl.{codec}" }
+```
+
+## Adding the Wire Format ID
+
+In `src/openzl/common/wire_format.h`, add a new entry to the `ZL_StandardTransformID` enum before `ZL_StandardTransformID_end`. Use an available slot (look for gaps marked "available"). These IDs are serialized into compressed frames and must remain **stable forever**.
+
+## Adding the Encoder Node ID
+
+- **Public codecs**: Add to `ZL_StandardNodeID` in `include/openzl/zl_nodes.h` (before `ZL_StandardNodeID_public_end`)
+- **Private codecs**: Add to `ZL_PrivateStandardNodeID` in `src/openzl/compress/private_nodes.h` (before `ZL_PrivateStandardNodeID_end`)
+
+## Public C Header (`include/openzl/codecs/`)
+
+For public codecs, create `include/openzl/codecs/zl_{codec}.h`:
+
+1. Include `openzl/zl_nodes.h` (for nodes) or `openzl/zl_graphs.h` (for graphs)
+2. Wrap in `extern "C"` guards
+3. Add a comment block describing the codec's inputs, outputs, and behavior
+4. Define the public ID macro:
+   - Nodes: `#define ZL_NODE_{CODEC} ZL_MAKE_NODE_ID(ZL_StandardNodeID_{codec})`
+   - Graphs: `#define ZL_GRAPH_{CODEC} ZL_MAKE_GRAPH_ID(ZL_StandardGraphID_{codec})`
+5. Optionally define parameter IDs (`ZL_{CODEC}_PID`) and C API functions for parameterized codecs
+
+Then add `#include "openzl/codecs/zl_{codec}.h" // IWYU pragma: export` to `include/openzl/zl_public_nodes.h`.
+
+See existing headers in `include/openzl/codecs/` for examples (e.g., `zl_zigzag.h` for simple, `zl_partition.h` for complex).
+
+## C++ Binding (`cpp/include/openzl/cpp/codecs/`)
+
+Create `cpp/include/openzl/cpp/codecs/{Codec}.hpp`:
+
+1. Include the corresponding C header (`openzl/codecs/zl_{codec}.h`)
+2. Include C++ framework headers: `Compressor.hpp` and either `Node.hpp` or `Graph.hpp`, plus `Metadata.hpp`
+3. Define the class in `namespace openzl::nodes` (or `openzl::graphs`):
+   - For simple 1-in 1-out nodes: inherit `SimplePipeNode<{Codec}>`
+   - For simple graphs: inherit `SimpleGraph<{Codec}>`
+   - For complex codecs: inherit `Node` or `Graph` directly
+4. Declare `static constexpr NodeID node = ZL_NODE_{CODEC};` (or `GraphID graph = ZL_GRAPH_{CODEC};`)
+5. Declare `static constexpr auto metadata = NodeMetadata<nInputs, nSingletonOutputs>{...};` with input/output types, names, and description
+6. For parameterized codecs: add constructor taking config, override `parameters()`
+
+Then add `#include "openzl/cpp/codecs/{Codec}.hpp" // IWYU pragma: export` to `cpp/include/openzl/cpp/Codecs.hpp`.
+
+See `cpp/include/openzl/cpp/codecs/Zigzag.hpp` for a simple example, `cpp/include/openzl/cpp/codecs/Partition.hpp` for a complex one.
+
+## Hooking Up the Registries
+
+### Encoder Registry (`src/openzl/codecs/encoder_registry.c`)
+
+1. Add `#include "openzl/codecs/{codec}/encode_{codec}_binding.h"`
+2. Add entry to `ER_standardNodes[]`:
+```c
+REGISTER_TRANSFORM(ZL_StandardNodeID_{codec}, ZL_StandardTransformID_{codec}, ZL_MAX_FORMAT_VERSION, EI_CODEC),
+```
+
+NOTE: Do not use the macro `ZL_MAX_FORMAT_VERSION`, use the current value of that macro! This value tells OpenZL the minimum format version that is required to use this codec, which for new codecs is the current maximum format version.
+
+### Decoder Registry (`src/openzl/codecs/decoder_registry.c`)
+
+1. Add `#include "openzl/codecs/{codec}/decode_{codec}_binding.h"`
+2. Add entry to `SDecoders_array[]` using the appropriate macro:
+   - `REGISTER_TTRANSFORM_G` — fixed typed I/O (most common)
+   - `REGISTER_VOTRANSFORM_G` — variable number of outputs
+   - `REGISTER_MITRANSFORM_G` — variable number of inputs
+```c
+REGISTER_TTRANSFORM_G(ZL_StandardTransformID_{codec}, ZL_MAX_FORMAT_VERSION, DI_CODEC, GRAPH_MACRO),
+```
+
+NOTE: Do not use the macro `ZL_MAX_FORMAT_VERSION`, use the current value of that macro! This value tells OpenZL the minimum format version that is required to use this codec, which for new codecs is the current maximum format version.
+
+## Testing
+
+### Adding a Test Component
+
+See `tests/registry/README.md` and `tests/registry/OpenZLComponents.h` for instructions.
+
+Steps:
+1. Add enum value to `OpenZLComponentID` in `tests/registry/OpenZLComponents.h` (before `NumComponents`)
+2. Add factory declaration `make${Component}Component()` in the `components` namespace
+3. Add case to the `makeOpenZLComponent()` switch statement
+4. Create `tests/registry/components/${Component}.cpp` implementing `OpenZLComponent`
+
+Required overrides: `name()`, `minFormatVersion()`, `predefinedInputs()` (edge cases).
+Optional overrides: `predefinedNodes()`/`predefinedGraphs()`, `generateInputs()`, `generateNodes()`/`generateGraphs()`.
+
+Prefer using the C++ bindings (e.g., `nodes::Zigzag{}`, `graphs::Bitpack{}`) to create nodes and graphs in the test component rather than raw C API calls. Include from `openzl/cpp/codecs/{Codec}.hpp` and use `parameterize(compressor)` to build nodes/graphs.
+
+See `tests/registry/components/Zigzag.cpp` for a simple example.
+
+### Running Component Tests
+
+```bash
+buck test fbcode//openzl/dev/tests:integrationtest
+```
+
+### Running Component Fuzzers
+
+Run fuzzers only after all tests pass. Run all 3 in parallel with a 10-minute timeout:
+
+```bash
+arc lionhead bundle run Zstrong_OpenZLComponentFuzzer_FuzzRoundTrip --run-duration-secs 600
+arc lionhead bundle run Zstrong_OpenZLComponentFuzzer_FuzzCompress --run-duration-secs 600
+arc lionhead bundle run Zstrong_OpenZLComponentFuzzer_FuzzDecompress --run-duration-secs 600
+```

--- a/benchmark/BUCK
+++ b/benchmark/BUCK
@@ -1,5 +1,6 @@
 # Copyright (c) Meta Platforms, Inc. and affiliates.
 
+load("@fbcode_macros//build_defs:cpp_binary.bzl", "cpp_binary")
 load("@fbcode_macros//build_defs:native_rules.bzl", "buck_filegroup")
 load("@fbsource//tools/build_defs:manifold.bzl", "manifold_get")
 load("../defs.bzl", "zs_cxxbinary")
@@ -28,9 +29,14 @@ zs_cxxbinary(
     srcs = [(
         src_file,
         SRC_FILE_FLAGS.get(src_file, []),
-    ) for src_file in glob([
-        "**/*.cpp",
-    ])],
+    ) for src_file in glob(
+        [
+            "**/*.cpp",
+        ],
+        exclude = [
+            "BenchmarkComponents.cpp",
+        ],
+    )],
     headers = glob([
         "**/*.h",
     ]),
@@ -54,6 +60,17 @@ zs_cxxbinary(
         "//folly:demangle",
         "//folly:dynamic",
         "//folly:json",
+    ],
+)
+
+cpp_binary(
+    # @autodeps-skip
+    name = "benchmark_components",
+    srcs = ["BenchmarkComponents.cpp"],
+    deps = [
+        "..:zstronglib",
+        "../tests/registry:openzl_components",
+        "fbsource//third-party/benchmark:benchmark",
     ],
 )
 

--- a/benchmark/BenchmarkComponents.cpp
+++ b/benchmark/BenchmarkComponents.cpp
@@ -1,0 +1,401 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#include <benchmark/benchmark.h>
+
+#include "openzl/cpp/CCtx.hpp"
+#include "openzl/cpp/Compressor.hpp"
+#include "openzl/cpp/DCtx.hpp"
+#include "openzl/cpp/FrameInfo.hpp"
+#include "tests/registry/OpenZLComponent.h"
+#include "tests/registry/OpenZLComponents.h"
+
+namespace {
+using namespace openzl;
+using namespace openzl::tests;
+
+bool detailedBenchmark(int* argc, char** argv)
+{
+    for (int i = 0; i < *argc; ++i) {
+        if (std::string_view{ argv[i] } == std::string_view{ "--detailed" }) {
+            for (int j = i; j < *argc - 1; ++j) {
+                argv[j] = argv[j + 1];
+            }
+            *argc -= 1;
+            return true;
+        }
+    }
+    return false;
+}
+
+class ComponentBenchmark {
+   public:
+    explicit ComponentBenchmark(const OpenZLComponent& component)
+            : component_(&component)
+    {
+        compressor_.selectStartingGraph(ZL_GRAPH_STORE);
+        component_->registerComponent(compressor_);
+        datagen::DataGen gen(0xdeadbeef);
+        benchmarks_ = component_->benchmarks(compressor_, gen);
+    }
+
+    static void registerCompressOverallBenchmark(
+            std::shared_ptr<ComponentBenchmark> self)
+    {
+        if (self->benchmarks_.empty()) {
+            return;
+        }
+        auto bench = [self](benchmark::State& state) {
+            self->benchCompressOverall(state);
+        };
+        benchmark::RegisterBenchmark(
+                ("Compress/Component:" + self->component_->name() + "/Overall")
+                        .c_str(),
+                std::move(bench));
+    }
+
+    static void registerCompressDetailedBenchmarks(
+            std::shared_ptr<ComponentBenchmark> self)
+    {
+        for (const auto& benchmark : self->benchmarks_) {
+            auto bench = [self, &benchmark](benchmark::State& state) {
+                self->benchCompressDetailed(state, benchmark);
+            };
+            benchmark::RegisterBenchmark(
+                    ("Compress/Component:" + self->component_->name()
+                     + "/Detailed/" + benchmark.name)
+                            .c_str(),
+                    std::move(bench));
+        }
+    }
+
+    static void registerDecompressOverallBenchmark(
+            std::shared_ptr<ComponentBenchmark> self)
+    {
+        if (self->benchmarks_.empty()) {
+            return;
+        }
+        auto bench = [self](benchmark::State& state) {
+            self->benchDecompressOverall(state);
+        };
+        benchmark::RegisterBenchmark(
+                ("Decompress/Component:" + self->component_->name()
+                 + "/Overall")
+                        .c_str(),
+                std::move(bench));
+    }
+
+    static void registerDecompressDetailedBenchmarks(
+            std::shared_ptr<ComponentBenchmark> self)
+    {
+        for (const auto& benchmark : self->benchmarks_) {
+            auto bench = [self, &benchmark](benchmark::State& state) {
+                self->benchDecompressDetailed(state, benchmark);
+            };
+            benchmark::RegisterBenchmark(
+                    ("Decompress/Component:" + self->component_->name()
+                     + "/Detailed/" + benchmark.name)
+                            .c_str(),
+                    std::move(bench));
+        }
+    }
+
+   private:
+    void setParameters(CCtx& cctx) const
+    {
+        cctx.refCompressor(compressor_);
+        cctx.setParameter(CParam::StickyParameters, true);
+        // Disable checksumming
+        cctx.setParameter(CParam::CompressedChecksum, ZL_TernaryParam_disable);
+        cctx.setParameter(CParam::ContentChecksum, ZL_TernaryParam_disable);
+        // Set format version (currently can only be max)
+        cctx.setParameter(CParam::FormatVersion, formatVersion_);
+    }
+
+    void benchCompressOverall(benchmark::State& state) const
+    {
+        CCtx cctx;
+        setParameters(cctx);
+
+        size_t compressBound = 0;
+        std::vector<std::vector<std::vector<Input>>> benchmarkInputs;
+        benchmarkInputs.reserve(benchmarks_.size());
+        size_t totalSrcSize = 0;
+        for (const auto& benchmark : benchmarks_) {
+            std::vector<std::vector<Input>> inputs;
+            inputs.reserve(benchmark.inputs.size());
+            for (const auto& input : benchmark.inputs) {
+                auto in = input->inputs();
+                compressBound =
+                        std::max(compressBound, component_->compressBound(in));
+                inputs.push_back(std::move(in));
+                totalSrcSize += input->sizeBytes();
+            }
+            benchmarkInputs.push_back(std::move(inputs));
+        }
+
+        std::string compressed(compressBound, '\0');
+        size_t totalCompressedSize = 0;
+        for (size_t i = 0; i < benchmarks_.size(); ++i) {
+            const auto& benchmark = benchmarks_[i];
+            for (const auto& input : benchmarkInputs[i]) {
+                cctx.selectStartingGraph(benchmark.graph);
+                const size_t cSize = cctx.compress(compressed, input);
+                totalCompressedSize += cSize;
+            }
+        }
+
+        for (auto _ : state) {
+            for (size_t i = 0; i < benchmarks_.size(); ++i) {
+                const auto& benchmark = benchmarks_[i];
+                for (const auto& input : benchmarkInputs[i]) {
+                    cctx.selectStartingGraph(benchmark.graph);
+                    cctx.compress(compressed, input);
+                    benchmark::DoNotOptimize(compressed);
+                    benchmark::ClobberMemory();
+                }
+            }
+        }
+
+        state.SetBytesProcessed((int64_t)(totalSrcSize * state.iterations()));
+        state.counters["CompressedSize"] = (double)totalCompressedSize;
+        state.counters["Size"]           = (double)totalSrcSize;
+        state.counters["CompressionRatio"] =
+                (double)totalSrcSize / totalCompressedSize;
+    }
+
+    void benchDecompressOverall(benchmark::State& state) const
+    {
+        CCtx cctx;
+        setParameters(cctx);
+        DCtx dctx;
+        component_->registerComponent(dctx);
+
+        size_t compressBound = 0;
+        size_t totalSrcSize  = 0;
+        std::vector<std::vector<std::vector<Input>>> benchmarkInputs;
+        benchmarkInputs.reserve(benchmarks_.size());
+        for (const auto& benchmark : benchmarks_) {
+            std::vector<std::vector<Input>> inputs;
+            inputs.reserve(benchmark.inputs.size());
+            for (const auto& input : benchmark.inputs) {
+                auto in = input->inputs();
+                compressBound =
+                        std::max(compressBound, component_->compressBound(in));
+                inputs.push_back(std::move(in));
+                totalSrcSize += input->sizeBytes();
+            }
+            benchmarkInputs.push_back(std::move(inputs));
+        }
+
+        // Compress all inputs and collect frame info
+        std::string compressBuffer(compressBound, '\0');
+        std::vector<CompressedFrame> frames;
+        for (size_t i = 0; i < benchmarks_.size(); ++i) {
+            for (const auto& input : benchmarkInputs[i]) {
+                frames.push_back(compressFrame(
+                        cctx, benchmarks_[i].graph, input, compressBuffer));
+            }
+        }
+        size_t totalCompressedSize = 0;
+        for (const auto& frame : frames) {
+            totalCompressedSize += frame.data.size();
+        }
+
+        std::vector<Output> outputs;
+        outputs.reserve(100);
+        for (auto _ : state) {
+            for (auto& frame : frames) {
+                outputs.clear();
+                for (size_t i = 0; i < frame.outputTypes.size(); ++i) {
+                    outputs.push_back(wrapOutput(
+                            frame.outputTypes[i],
+                            frame.outputEltWidths[i],
+                            frame.buffers[i]));
+                }
+                dctx.decompress(outputs, frame.data);
+                benchmark::DoNotOptimize(outputs);
+                benchmark::ClobberMemory();
+            }
+        }
+
+        state.SetBytesProcessed((int64_t)(totalSrcSize * state.iterations()));
+        state.counters["CompressedSize"] = (double)totalCompressedSize;
+        state.counters["Size"]           = (double)totalSrcSize;
+        state.counters["CompressionRatio"] =
+                (double)totalSrcSize / totalCompressedSize;
+    }
+
+    void benchCompressDetailed(
+            benchmark::State& state,
+            const OpenZLComponent::Benchmark& benchmark) const
+    {
+        CCtx cctx;
+        setParameters(cctx);
+
+        size_t compressBound = 0;
+        std::vector<std::vector<Input>> inputs;
+        inputs.reserve(benchmark.inputs.size());
+        size_t totalSrcSize = 0;
+        for (const auto& input : benchmark.inputs) {
+            auto in = input->inputs();
+            compressBound =
+                    std::max(compressBound, component_->compressBound(in));
+            inputs.push_back(std::move(in));
+            totalSrcSize += input->sizeBytes();
+        }
+
+        std::string compressed(compressBound, '\0');
+        size_t totalCompressedSize = 0;
+        for (const auto& input : inputs) {
+            cctx.selectStartingGraph(benchmark.graph);
+            const size_t cSize = cctx.compress(compressed, input);
+            totalCompressedSize += cSize;
+        }
+
+        for (auto _ : state) {
+            for (const auto& input : inputs) {
+                cctx.selectStartingGraph(benchmark.graph);
+                cctx.compress(compressed, input);
+            }
+        }
+
+        state.SetBytesProcessed((int64_t)(totalSrcSize * state.iterations()));
+        state.counters["CompressedSize"] = (double)totalCompressedSize;
+        state.counters["Size"]           = (double)totalSrcSize;
+        state.counters["CompressionRatio"] =
+                (double)totalSrcSize / totalCompressedSize;
+    }
+
+    void benchDecompressDetailed(
+            benchmark::State& state,
+            const OpenZLComponent::Benchmark& bm) const
+    {
+        CCtx cctx;
+        setParameters(cctx);
+        DCtx dctx;
+        component_->registerComponent(dctx);
+
+        size_t compressBound = 0;
+        std::vector<std::vector<Input>> inputs;
+        inputs.reserve(bm.inputs.size());
+        size_t totalSrcSize = 0;
+        for (const auto& input : bm.inputs) {
+            auto in = input->inputs();
+            compressBound =
+                    std::max(compressBound, component_->compressBound(in));
+            inputs.push_back(std::move(in));
+            totalSrcSize += input->sizeBytes();
+        }
+
+        // Compress all inputs and collect frame info
+        std::string compressBuffer(compressBound, '\0');
+        std::vector<CompressedFrame> frames;
+        frames.reserve(inputs.size());
+        for (const auto& input : inputs) {
+            frames.push_back(
+                    compressFrame(cctx, bm.graph, input, compressBuffer));
+        }
+        size_t totalCompressedSize = 0;
+        for (const auto& frame : frames) {
+            totalCompressedSize += frame.data.size();
+        }
+
+        std::vector<Output> outputs;
+        outputs.reserve(100);
+        for (auto _ : state) {
+            for (auto& frame : frames) {
+                outputs.clear();
+                for (size_t i = 0; i < frame.outputTypes.size(); ++i) {
+                    outputs.push_back(wrapOutput(
+                            frame.outputTypes[i],
+                            frame.outputEltWidths[i],
+                            frame.buffers[i]));
+                }
+                dctx.decompress(outputs, frame.data);
+                benchmark::DoNotOptimize(outputs);
+                benchmark::ClobberMemory();
+            }
+        }
+
+        state.SetBytesProcessed((int64_t)(totalSrcSize * state.iterations()));
+        state.counters["CompressedSize"] = (double)totalCompressedSize;
+        state.counters["Size"]           = (double)totalSrcSize;
+        state.counters["CompressionRatio"] =
+                (double)totalSrcSize / totalCompressedSize;
+    }
+
+    struct CompressedFrame {
+        std::string data;
+        std::vector<Type> outputTypes;
+        std::vector<size_t> outputEltWidths;
+        std::vector<std::vector<char>> buffers;
+    };
+
+    static CompressedFrame compressFrame(
+            CCtx& cctx,
+            GraphID graph,
+            poly::span<const Input> inputs,
+            std::string& compressBuffer)
+    {
+        cctx.selectStartingGraph(graph);
+        const size_t cSize = cctx.compress(compressBuffer, inputs);
+
+        CompressedFrame frame;
+        frame.data = compressBuffer.substr(0, cSize);
+        FrameInfo info(frame.data);
+        for (size_t i = 0; i < info.numOutputs(); ++i) {
+            frame.outputTypes.push_back(info.outputType(i));
+            frame.outputEltWidths.push_back(inputs[i].eltWidth());
+            if (info.outputType(i) != Type::String) {
+                frame.buffers.emplace_back(info.outputContentSize(i));
+            } else {
+                frame.buffers.emplace_back();
+            }
+        }
+        return frame;
+    }
+
+    static Output
+    wrapOutput(Type type, size_t eltWidth, std::vector<char>& buffer)
+    {
+        switch (type) {
+            case Type::Serial:
+                return Output::wrapSerial(buffer.data(), buffer.size());
+            case Type::Struct:
+                return Output::wrapStruct(
+                        buffer.data(), eltWidth, buffer.size() / eltWidth);
+            case Type::Numeric:
+                return Output::wrapNumeric(
+                        buffer.data(), eltWidth, buffer.size() / eltWidth);
+            case Type::String:
+                return Output();
+        }
+        return Output();
+    }
+
+    Compressor compressor_;
+    const OpenZLComponent* component_;
+    std::vector<OpenZLComponent::Benchmark> benchmarks_;
+    int formatVersion_ = ZL_MAX_FORMAT_VERSION;
+};
+
+} // namespace
+
+int main(int argc, char** argv)
+{
+    const bool detailed = detailedBenchmark(&argc, argv);
+
+    for (const auto& component : getAllOpenZLComponents()) {
+        auto bench = std::make_shared<ComponentBenchmark>(*component);
+        ComponentBenchmark::registerCompressOverallBenchmark(bench);
+        ComponentBenchmark::registerDecompressOverallBenchmark(bench);
+        if (detailed) {
+            ComponentBenchmark::registerCompressDetailedBenchmarks(bench);
+            ComponentBenchmark::registerDecompressDetailedBenchmarks(bench);
+        }
+    }
+
+    benchmark::Initialize(&argc, argv);
+    benchmark::RunSpecifiedBenchmarks();
+    benchmark::Shutdown();
+}

--- a/benchmark/CMakeLists.txt
+++ b/benchmark/CMakeLists.txt
@@ -25,6 +25,8 @@ file(
     "${CMAKE_CURRENT_LIST_DIR}/unitBench/**/*.c")
 list(FILTER openzl_benchmark_sources
      EXCLUDE REGEX "${CMAKE_CURRENT_LIST_DIR}/tools/.*$")
+list(FILTER openzl_benchmark_sources
+     EXCLUDE REGEX "${CMAKE_CURRENT_LIST_DIR}/BenchmarkComponents.cpp$")
 file(
     GLOB_RECURSE openzl_benchmark_headers
     CONFIGURE_DEPENDS

--- a/cpp/include/openzl/cpp/Exception.hpp
+++ b/cpp/include/openzl/cpp/Exception.hpp
@@ -145,6 +145,10 @@ template <>
 ExceptionBuilder&& ExceptionBuilder::addErrorContext(
         const ZL_CompressorDeserializer* deserializer) && noexcept;
 
+template <>
+ExceptionBuilder&& ExceptionBuilder::addErrorContext(
+        const ZL_Graph* graph) && noexcept;
+
 /**
  * Helper free function to (possibly) convert a result into an exception and
  * throw it.

--- a/cpp/include/openzl/cpp/FunctionGraph.hpp
+++ b/cpp/include/openzl/cpp/FunctionGraph.hpp
@@ -119,6 +119,25 @@ class GraphState {
             const poly::optional<GraphParameters>& params =
                     poly::nullopt) const;
 
+    poly::string_view getErrorContextString(ZL_Error error) const;
+
+    template <typename ResultType>
+    poly::string_view getErrorContextString(ResultType result) const
+    {
+        return getErrorContextString(ZL_RES_error(result));
+    }
+
+    template <typename ResultType>
+    typename ResultType::ValueType unwrap(
+            ResultType result,
+            poly::string_view msg = {},
+            poly::source_location location =
+                    poly::source_location::current()) const
+    {
+        return openzl::unwrap(
+                result, std::move(msg), this, std::move(location));
+    }
+
    private:
     ZL_Graph* graph_;
     std::vector<Edge> edges_;

--- a/cpp/src/openzl/cpp/Exception.cpp
+++ b/cpp/src/openzl/cpp/Exception.cpp
@@ -134,6 +134,18 @@ ExceptionBuilder&& ExceptionBuilder::addErrorContext<ZL_CompressorDeserializer>(
     }
 }
 
+template <>
+ExceptionBuilder&& ExceptionBuilder::addErrorContext<ZL_Graph>(
+        ZL_Graph const* const ctx) && noexcept
+{
+    if (ctx != nullptr && error_.has_value()) {
+        return std::move(*this).withErrorContext(
+                ZL_Graph_getErrorContextString_fromError(ctx, error_.value()));
+    } else {
+        return std::move(*this);
+    }
+}
+
 Exception ExceptionBuilder::build() && noexcept
 {
     poly::optional<ZL_ErrorCode> code;

--- a/cpp/src/openzl/cpp/FunctionGraph.cpp
+++ b/cpp/src/openzl/cpp/FunctionGraph.cpp
@@ -226,4 +226,9 @@ graphFn(ZL_Graph* graph, ZL_Edge* edges[], size_t nbEdges) noexcept
     return compressor.registerFunctionGraph(graphDesc);
 }
 
+poly::string_view GraphState::getErrorContextString(ZL_Error error) const
+{
+    return ZL_Graph_getErrorContextString_fromError(get(), error);
+}
+
 } // namespace openzl

--- a/cpp/tests/TestException.cpp
+++ b/cpp/tests/TestException.cpp
@@ -18,6 +18,26 @@ ZL_RESULT_DECLARE_TYPE(Foo);
 class TestException : public testing::Test {
    public:
 };
+
+class ExceptionFunctionGraph : public FunctionGraph {
+   public:
+    FunctionGraphDescription functionGraphDescription() const override
+    {
+        return {
+            .name           = "unwrap_function_graph",
+            .inputTypeMasks = { TypeMask::Serial },
+        };
+    }
+
+    void graph(GraphState& state) const override
+    {
+        ZL_RESULT_DECLARE_SCOPE_REPORT(state.get());
+
+        const char* bar = "bar";
+        auto result     = ZL_REPORT_ERROR(GENERIC, "foo%s", bar);
+        state.unwrap(result);
+    }
+};
 } // namespace
 
 TEST_F(TestException, unwrapSuccess)
@@ -93,6 +113,25 @@ TEST_F(TestException, unwrapErrorCCtx)
     }
 }
 
+TEST_F(TestException, unwrapForGraphState)
+{
+    Compressor compressor;
+    compressor.selectStartingGraph(compressor.registerFunctionGraph(
+            std::make_shared<ExceptionFunctionGraph>()));
+    compressor.setParameter(CParam::FormatVersion, ZL_MAX_FORMAT_VERSION);
+    try {
+        CCtx cctx;
+        cctx.refCompressor(compressor);
+        cctx.compressSerial("hello world hello hello hello hello");
+        EXPECT_TRUE(false) << "should be unreachable";
+    } catch (const Exception& ex) {
+        const std::string what{ ex.what() };
+        EXPECT_NE(what.find("foobar"), std::string::npos) << what;
+    } catch (...) {
+        EXPECT_TRUE(false) << "shouldn't throw anything else!";
+    }
+}
+
 TEST_F(TestException, unwrapWithAllCtxTypes)
 {
     CCtx const* const cctx                                 = nullptr;
@@ -103,6 +142,7 @@ TEST_F(TestException, unwrapWithAllCtxTypes)
     ZL_Compressor const* const zl_compressor               = nullptr;
     ZL_CompressorSerializer const* const zl_serializer     = nullptr;
     ZL_CompressorDeserializer const* const zl_deserializer = nullptr;
+    ZL_Graph const* const zl_graph                         = nullptr;
 
     const auto result = ZL_RESULT_WRAP_VALUE(Foo, kFoo);
 
@@ -114,5 +154,6 @@ TEST_F(TestException, unwrapWithAllCtxTypes)
     unwrap(result, "", zl_compressor);
     unwrap(result, "", zl_serializer);
     unwrap(result, "", zl_deserializer);
+    unwrap(result, "", zl_graph);
 }
 } // namespace openzl::tests

--- a/include/openzl/zl_graph_api.h
+++ b/include/openzl/zl_graph_api.h
@@ -174,6 +174,31 @@ unsigned ZL_Graph_getDepth(const ZL_Graph* gctx);
 /* access the content of an Edge */
 const ZL_Input* ZL_Edge_getData(const ZL_Edge* sctx);
 
+/**
+ * Gets the error context for a given ZL_Report. This context is useful for
+ * debugging and for submitting bug reports to Zstrong developers.
+ *
+ * @param report The report to get the error context for
+ *
+ * @returns A verbose error string containing context about the error that
+ * occurred.
+ *
+ * @note: This string is stored within the @p graph and may only be valid for
+ * the lifetime of the @p graph.
+ */
+const char* ZL_Graph_getErrorContextString(
+        const ZL_Graph* graph,
+        ZL_Report report);
+
+/**
+ * See ZL_Graph_getErrorContextString()
+ *
+ * @param error: The error to get the context for
+ */
+const char* ZL_Graph_getErrorContextString_fromError(
+        const ZL_Graph* graph,
+        ZL_Error error);
+
 /* Actions */
 /* ------- */
 

--- a/src/openzl/codecs/partition/encode_partition_bitpack.c
+++ b/src/openzl/codecs/partition/encode_partition_bitpack.c
@@ -212,91 +212,174 @@ typedef struct {
     uint32_t* scratch;
 } PB_GreedyOpt;
 
+/// @returns The cost of a single partition [b, e) excluding the global
+/// bucketBits term (which is independent of the partition sizes).
+static uint32_t
+PB_singlePartitionCost(const uint32_t* cumHist, uint32_t b, uint32_t e)
+{
+    const uint32_t count   = cumHist[e] - cumHist[b];
+    const uint32_t offBits = (uint32_t)ZL_nextPow2(PB_bucketSize(b, e));
+    return PB_OVERHEAD_BITS + count * offBits;
+}
+
+/// @returns the end of partition @p i.
+static uint32_t PB_partitionEnd(
+        const uint32_t* partitions,
+        size_t numPartitions,
+        uint32_t histSize,
+        size_t i)
+{
+    return (i + 1 == numPartitions) ? histSize : partitions[i + 1];
+}
+
 /// @returns true iff the partition from [begin, end) is legal
 static bool PB_isLegalPartition(uint32_t begin, uint32_t end)
 {
     return begin < end && (end - begin) <= PB_idx2bucket(PB_MAX_BUCKET_SIZE);
 }
 
-/// @returns true iff the partitioning is legal
-static bool PB_isLegal(const PB_GreedyOpt* opt, const uint32_t* p, size_t n)
+/// Grows partition @p idx by doubling its size, and rounding all following
+/// partition sizes up to powers of two in @p out until a partition size is
+/// unchanged.
+/// @returns cascadeEnd: the first index NOT modified.
+static size_t PB_growPartitions(
+        const uint32_t* partitions,
+        size_t idx,
+        uint32_t* out,
+        size_t n)
 {
-    if (n == 0) {
-        return false;
-    }
-    if (p[n - 1] >= opt->histSize) {
-        return false;
-    }
-    for (size_t i = 0; i < n; ++i) {
-        const uint32_t begin = p[i];
-        const uint32_t end   = (i + 1 == n) ? opt->histSize : p[i + 1];
-        if (!PB_isLegalPartition(begin, end)) {
-            return false;
-        }
-    }
-    return true;
-}
-
-/// The cost of a partitioning, or UINT32_MAX if it is illegal
-static uint32_t PB_cost(const PB_GreedyOpt* opt, const uint32_t* p, size_t n)
-{
-    if (!PB_isLegal(opt, p, n)) {
-        return UINT32_MAX;
-    }
-    return PB_fixedBucketCost(
-            opt->cumHist, opt->histSize, p, n, opt->targetPartitions);
-}
-
-/// Grow the partition at @p n to the next power of two and fix up following
-/// partitions to all have power of two sizes.
-static void
-PB_growPartitions(PB_GreedyOpt* opt, size_t idx, uint32_t* out, size_t n)
-{
-    memcpy(out, opt->partitions, n * sizeof(uint32_t));
     if (idx + 1 == n) {
-        return;
+        return idx;
     }
-    uint32_t begin   = out[idx];
-    uint32_t end     = out[idx + 1];
+    uint32_t begin   = partitions[idx];
+    uint32_t end     = partitions[idx + 1];
     uint32_t sz      = end - begin;
     uint32_t newSize = 1u << ((unsigned)ZL_nextPow2(sz) + 1);
     out[idx + 1]     = begin + newSize;
 
     for (size_t j = idx + 1; j + 1 < n; ++j) {
-        begin        = out[j];
-        end          = out[j + 1];
-        sz           = end > begin ? end - begin : 1;
-        uint32_t alt = 1u << (unsigned)ZL_nextPow2(sz);
-        out[j + 1]   = begin + ZL_MAX(newSize, alt);
+        begin           = out[j];
+        end             = partitions[j + 1];
+        sz              = end > begin ? end - begin : 1;
+        uint32_t alt    = 1u << (unsigned)ZL_nextPow2(sz);
+        uint32_t newEnd = begin + ZL_MAX(newSize, alt);
+        if (newEnd == end) {
+            return j + 1;
+        }
+        out[j + 1] = newEnd;
     }
+    return n;
 }
 
-/// Shrink the partition at @p n to the previous power of two and fix up the
-/// following partitions to all have power of two sizes.
-static void
-PB_shrinkPartitions(PB_GreedyOpt* opt, size_t idx, uint32_t* out, size_t n)
+/// Shrinks partition @p idx by halving its size, and rounding all following
+/// partition sizes up to powers of two in @p out until a partition size is
+/// unchanged.
+/// @returns cascadeEnd: the first index NOT modified.
+static size_t PB_shrinkPartitions(
+        const uint32_t* partitions,
+        size_t idx,
+        uint32_t* out,
+        size_t n)
 {
-    memcpy(out, opt->partitions, n * sizeof(uint32_t));
     if (idx + 1 == n) {
-        return;
+        return idx;
     }
-    uint32_t begin = out[idx];
-    uint32_t end   = out[idx + 1];
+    uint32_t begin = partitions[idx];
+    uint32_t end   = partitions[idx + 1];
     uint32_t sz    = end - begin;
     if (sz <= 1) {
-        return;
+        return idx;
     }
     uint32_t newSize = 1u << ((unsigned)ZL_nextPow2(sz) - 1);
     out[idx + 1]     = begin + newSize;
 
     for (size_t j = idx + 1; j + 1 < n; ++j) {
         begin = out[j];
-        end   = out[j + 1];
+        end   = partitions[j + 1];
         sz    = end - begin;
         if (!ZL_isPow2(sz)) {
-            out[j + 1] = begin + (1u << ((unsigned)ZL_nextPow2(sz) - 1));
+            uint32_t newEnd = begin + (1u << ((unsigned)ZL_nextPow2(sz) - 1));
+            if (newEnd == end) {
+                return j + 1;
+            }
+            out[j + 1] = newEnd;
+        } else {
+            return j + 1;
         }
     }
+    return n;
+}
+
+/// Compute cost of modified partitions [from, to), where out contains the
+/// modified boundaries and partitions has the original values (used for the
+/// end of partition to-1 if to < n, and partition from's begin is unchanged).
+static uint32_t PB_modifiedRangeCost(
+        const uint32_t* cumHist,
+        const uint32_t* partitions,
+        const uint32_t* out,
+        size_t n,
+        uint32_t histSize,
+        size_t from,
+        size_t to)
+{
+    uint32_t cost = 0;
+    for (size_t i = from; i < to; ++i) {
+        const uint32_t b = (i == from) ? partitions[i] : out[i];
+        uint32_t e;
+        if (i + 1 == n) {
+            e = histSize;
+        } else if (i + 1 < to) {
+            e = out[i + 1];
+        } else {
+            e = partitions[i + 1];
+        }
+        if (e > histSize || !PB_isLegalPartition(b, e)) {
+            return UINT32_MAX;
+        }
+        cost += PB_singlePartitionCost(cumHist, b, e);
+    }
+    return cost;
+}
+
+/// Try applying a cascaded mutation from scratch and accept if it reduces cost.
+/// Returns true if the mutation was accepted.
+static bool PB_tryMutation(
+        PB_GreedyOpt* opt,
+        uint32_t* partCost,
+        uint32_t* currentCost,
+        size_t n,
+        size_t idx,
+        size_t cascadeEnd)
+{
+    uint32_t newRangeCost = PB_modifiedRangeCost(
+            opt->cumHist,
+            opt->partitions,
+            opt->scratch,
+            n,
+            opt->histSize,
+            idx,
+            cascadeEnd);
+    if (newRangeCost == UINT32_MAX) {
+        return false;
+    }
+    uint32_t oldRangeCost = 0;
+    for (size_t j = idx; j < cascadeEnd; ++j) {
+        oldRangeCost += partCost[j];
+    }
+    if (newRangeCost >= oldRangeCost) {
+        return false;
+    }
+    for (size_t j = idx + 1; j < cascadeEnd && j < n; ++j) {
+        opt->partitions[j] = opt->scratch[j];
+    }
+    *currentCost = *currentCost - oldRangeCost + newRangeCost;
+    for (size_t j = idx; j < cascadeEnd; ++j) {
+        const uint32_t b = opt->partitions[j];
+        const uint32_t e =
+                PB_partitionEnd(opt->partitions, n, opt->histSize, j);
+        partCost[j] = PB_singlePartitionCost(opt->cumHist, b, e);
+    }
+    return true;
 }
 
 /**
@@ -310,25 +393,37 @@ PB_shrinkPartitions(PB_GreedyOpt* opt, size_t idx, uint32_t* out, size_t n)
 static void PB_iterativeImprovement(PB_GreedyOpt* opt)
 {
     const size_t n = opt->numPartitions;
+    if (n < 2) {
+        return;
+    }
+
+    uint32_t partCost[PB_MAX_PARTITIONS];
+    uint32_t sumCost = 0;
+    for (size_t i = 0; i < n; ++i) {
+        const uint32_t b = opt->partitions[i];
+        const uint32_t e =
+                PB_partitionEnd(opt->partitions, n, opt->histSize, i);
+        partCost[i] = PB_singlePartitionCost(opt->cumHist, b, e);
+        sumCost += partCost[i];
+    }
+
+    const uint32_t totalCount = opt->cumHist[opt->histSize];
+    const uint32_t bucketBits = (uint32_t)ZL_nextPow2(opt->targetPartitions);
+    const uint32_t baseCost   = totalCount * bucketBits;
+    uint32_t currentCost      = baseCost + sumCost;
+
     for (;;) {
-        const uint32_t startCost = PB_cost(opt, opt->partitions, n);
-        uint32_t currentCost     = startCost;
-        for (size_t idx = 0; idx + 1 < n;) {
-            PB_growPartitions(opt, idx, opt->scratch, n);
-            uint32_t newCost = PB_cost(opt, opt->scratch, n);
-            if (newCost < currentCost) {
-                memcpy(opt->partitions, opt->scratch, n * sizeof(uint32_t));
-                currentCost = newCost;
-                break;
+        const uint32_t startCost = currentCost;
+        for (size_t idx = 0; idx + 1 < n; ++idx) {
+            size_t cascadeEnd =
+                    PB_growPartitions(opt->partitions, idx, opt->scratch, n);
+            if (PB_tryMutation(
+                        opt, partCost, &currentCost, n, idx, cascadeEnd)) {
+                continue;
             }
-            PB_shrinkPartitions(opt, idx, opt->scratch, n);
-            newCost = PB_cost(opt, opt->scratch, n);
-            if (newCost < currentCost) {
-                memcpy(opt->partitions, opt->scratch, n * sizeof(uint32_t));
-                currentCost = newCost;
-                break;
-            }
-            ++idx;
+            cascadeEnd =
+                    PB_shrinkPartitions(opt->partitions, idx, opt->scratch, n);
+            PB_tryMutation(opt, partCost, &currentCost, n, idx, cascadeEnd);
         }
         if (currentCost == startCost) {
             break;
@@ -343,9 +438,9 @@ static void PB_iterativeImprovement(PB_GreedyOpt* opt)
 static void
 PB_dividePartitionAt(const PB_GreedyOpt* opt, uint32_t* out, size_t i)
 {
-    const uint32_t begin   = opt->partitions[i];
-    const uint32_t end     = (i + 1 == opt->numPartitions) ? opt->histSize
-                                                           : opt->partitions[i + 1];
+    const uint32_t begin = opt->partitions[i];
+    const uint32_t end   = PB_partitionEnd(
+            opt->partitions, opt->numPartitions, opt->histSize, i);
     const uint32_t sz      = end - begin;
     const uint32_t newSize = 1u << ((unsigned)ZL_nextPow2(sz) - 1);
 
@@ -359,45 +454,88 @@ PB_dividePartitionAt(const PB_GreedyOpt* opt, uint32_t* out, size_t i)
     out[i + 1] = begin + newSize;
 }
 
-/**
- * Divide a single partition into two using PB_dividePartitionAt(). The selected
- * partition is either:
- * - The first illegal partition (if any)
- * - The partition with the highest gain from dividing it
- */
-static bool PB_dividePartition(PB_GreedyOpt* opt)
+/// @returns the gain from splitting partition [begin, end) into two where the
+/// first partition is the largest power of two smaller than the current size.
+static int32_t
+PB_splitGain(const uint32_t* cumHist, uint32_t begin, uint32_t end)
 {
-    const size_t n     = opt->numPartitions;
-    const size_t start = opt->prefixSize > 0 ? opt->prefixSize - 1 : 0;
-    uint32_t bestCost  = UINT32_MAX;
-    size_t bestIdx     = (size_t)-1;
+    assert(end - begin > 1);
+    assert(PB_isLegalPartition(begin, end));
+    const uint32_t oldCost   = PB_singlePartitionCost(cumHist, begin, end);
+    const uint32_t sz        = end - begin;
+    const uint32_t newSize   = 1u << ((unsigned)ZL_nextPow2(sz) - 1);
+    const uint32_t mid       = begin + newSize;
+    const uint32_t leftCost  = PB_singlePartitionCost(cumHist, begin, mid);
+    const uint32_t rightCost = PB_singlePartitionCost(cumHist, mid, end);
+    return (int32_t)oldCost - (int32_t)(leftCost + rightCost);
+}
 
-    for (size_t i = start; i < n; ++i) {
-        const uint32_t begin = opt->partitions[i];
-        const uint32_t end =
-                (i + 1 == n) ? opt->histSize : opt->partitions[i + 1];
-        if (end - begin == 1) {
-            continue;
+/**
+ * Greedily divide the partition that is either illegal or provides the biggest
+ * gain from division until we hit @p targetPartitions.
+ * Run in O(targetPartitions^2) time.
+ */
+static void PB_dividePartitions(PB_GreedyOpt* opt, size_t targetPartitions)
+{
+    // Cache split gains to avoid O(N^2) rescanning.
+    // gains[i] = gain from splitting partition i; INT32_MIN = unsplittable.
+    int32_t gains[PB_MAX_PARTITIONS];
+    {
+        const size_t n     = opt->numPartitions;
+        const size_t start = opt->prefixSize > 0 ? opt->prefixSize - 1 : 0;
+        for (size_t i = 0; i < start; ++i) {
+            gains[i] = INT32_MIN;
         }
-        if (!PB_isLegalPartition(begin, end)) {
-            // Prioritize fixing illegal partitions
-            PB_dividePartitionAt(opt, opt->partitions, i);
-            ++opt->numPartitions;
-            return true;
-        }
-        PB_dividePartitionAt(opt, opt->scratch, i);
-        const uint32_t cost = PB_cost(opt, opt->scratch, n + 1);
-        if (cost < bestCost) {
-            bestCost = cost;
-            bestIdx  = i;
+        for (size_t i = start; i < n; ++i) {
+            const uint32_t b = opt->partitions[i];
+            const uint32_t e =
+                    PB_partitionEnd(opt->partitions, n, opt->histSize, i);
+            gains[i] = (e - b <= 1) ? INT32_MIN
+                    : !PB_isLegalPartition(b, e)
+                    ? INT32_MAX
+                    : PB_splitGain(opt->cumHist, b, e);
         }
     }
-    if (bestIdx == (size_t)-1) {
-        return false;
+
+    while (opt->numPartitions < targetPartitions) {
+        const size_t n   = opt->numPartitions;
+        int32_t bestGain = INT32_MIN;
+        size_t bestIdx   = (size_t)-1;
+        for (size_t i = 0; i < n; ++i) {
+            if (gains[i] == INT32_MAX) {
+                // Illegal partition - must split immediately
+                bestIdx = i;
+                break;
+            }
+            if (gains[i] > bestGain) {
+                bestGain = gains[i];
+                bestIdx  = i;
+            }
+        }
+        if (bestIdx == (size_t)-1) {
+            break;
+        }
+
+        PB_dividePartitionAt(opt, opt->partitions, bestIdx);
+        ++opt->numPartitions;
+
+        // Shift gains right for indices after bestIdx
+        for (size_t j = opt->numPartitions - 1; j > bestIdx + 1; --j) {
+            gains[j] = gains[j - 1];
+        }
+
+        // Recompute gains for the two new partitions at bestIdx and bestIdx+1
+        for (size_t j = bestIdx; j <= bestIdx + 1 && j < opt->numPartitions;
+             ++j) {
+            const uint32_t b = opt->partitions[j];
+            const uint32_t e = PB_partitionEnd(
+                    opt->partitions, opt->numPartitions, opt->histSize, j);
+            gains[j] = (e - b <= 1) ? INT32_MIN
+                    : !PB_isLegalPartition(b, e)
+                    ? INT32_MAX
+                    : PB_splitGain(opt->cumHist, b, e);
+        }
     }
-    PB_dividePartitionAt(opt, opt->partitions, bestIdx);
-    ++opt->numPartitions;
-    return true;
 }
 
 /// Run the greedy optimizer.
@@ -436,17 +574,17 @@ static size_t PB_greedyOptimize(
         opt.prefixSize    = prefixSize;
     }
 
-    // Greedily sub-divide the partition that gets the most gain until we have
-    // enough partitions.
-    while (opt.numPartitions < targetPartitions) {
-        if (!PB_dividePartition(&opt)) {
-            break;
-        }
-    }
+    // Greedily divide the current partitions until we have targetPartitions or
+    // can't divide further.
+    PB_dividePartitions(&opt, targetPartitions);
 
-    // Iteratively improve the partition boundries one at a time until we reach
-    // a local minima.
-    PB_iterativeImprovement(&opt);
+    // If there are at least 10K elements in the histogram, run the iterative
+    // improvement pass. Otherwise, it is too expensive.
+    if (cumHist.cumHist[cumHist.histSize] >= 10000) {
+        // Iteratively improve the partition boundries one at a time until we
+        // reach a local minima.
+        PB_iterativeImprovement(&opt);
+    }
 
     return opt.numPartitions;
 }

--- a/src/openzl/compress/dyngraph_interface.c
+++ b/src/openzl/compress/dyngraph_interface.c
@@ -481,3 +481,17 @@ ZL_Graph_tryGraph(
 {
     return ZL_Graph_tryMultiInputGraph(gctx, &input, 1, graphID, params);
 }
+
+const char* ZL_Graph_getErrorContextString(
+        const ZL_Graph* graph,
+        ZL_Report report)
+{
+    return ZL_CCtx_getErrorContextString(graph->cctx, report);
+}
+
+const char* ZL_Graph_getErrorContextString_fromError(
+        const ZL_Graph* graph,
+        ZL_Error error)
+{
+    return ZL_CCtx_getErrorContextString_fromError(graph->cctx, error);
+}

--- a/tests/datagen/distributions/ConstantDistribution.h
+++ b/tests/datagen/distributions/ConstantDistribution.h
@@ -9,7 +9,10 @@ namespace openzl::tests::datagen {
 template <typename RetType>
 class ConstantDistribution : public Distribution<RetType> {
    public:
-    explicit ConstantDistribution(RetType value) : value_(value) {}
+    explicit ConstantDistribution(RetType value)
+            : Distribution<RetType>(nullptr), value_(value)
+    {
+    }
 
     RetType operator()(RandWrapper::NameType) override
     {

--- a/tests/datagen/distributions/LogUniformDistribution.h
+++ b/tests/datagen/distributions/LogUniformDistribution.h
@@ -1,0 +1,52 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#pragma once
+
+#include "tests/datagen/distributions/Distribution.h"
+
+#include <cmath>
+
+namespace openzl::tests::datagen {
+
+/// Used to generate values that look like offsets in LZ, which typically follow
+/// a log-uniform distribution.
+/// See https://en.wikipedia.org/wiki/Reciprocal_distribution
+template <typename RetType>
+class LogUniformDistribution : public Distribution<RetType> {
+   public:
+    static_assert(std::is_integral<RetType>::value);
+    static_assert(std::is_unsigned<RetType>::value);
+
+    explicit LogUniformDistribution(
+            std::shared_ptr<RandWrapper> rw,
+            RetType min = 1,
+            RetType max = std::numeric_limits<RetType>::max())
+            : Distribution<RetType>(std::move(rw)),
+              min_(min),
+              max_(max),
+              logMin_(std::log(min_)),
+              logAMinusB_(std::log(max_) - std::log(min_))
+    {
+    }
+
+    RetType operator()(RandWrapper::NameType) override
+    {
+        return (RetType)std::round(
+                std::exp(
+                        logMin_
+                        + this->rw_->f32_range("float", 0, 1) * logAMinusB_));
+    }
+
+    void print(std::ostream& os) const override
+    {
+        os << "LogUniformDistribution(" << min_ << "," << max_ << ")";
+    }
+
+   private:
+    RetType min_;
+    RetType max_;
+    float logMin_;
+    float logAMinusB_;
+};
+
+} // namespace openzl::tests::datagen

--- a/tests/registry/BUCK
+++ b/tests/registry/BUCK
@@ -33,6 +33,7 @@ zs_cxxlibrary(
     ]),
     headers = ["OpenZLComponents.h"],
     deps = [
+        "../datagen:datagen",
         "fbsource//third-party/zstd:zstd",
     ],
     exported_deps = [

--- a/tests/registry/OpenZLComponent.h
+++ b/tests/registry/OpenZLComponent.h
@@ -211,6 +211,36 @@ class OpenZLComponent {
         return {};
     }
 
+    struct Benchmark {
+        std::string name;
+        GraphID graph;
+        std::vector<std::unique_ptr<OpenZLInput>> inputs;
+    };
+
+    /**
+     * @returns A list of benchmarks to run.
+     *
+     * These benchmarks will be run in two modes:
+     *
+     * - Overall mode: All the benchmarks will be combined into a single summary
+     *                 benchmark for the component.
+     * - Detailed Mode: Each benchmark will be run individually.
+     *
+     * It is recommended to make each benchmark approximately the same "weight"
+     * so that in summary mode they all contribute to the overall result. E.g.
+     * if one scenario processes 100 bytes, and another processes 1MB, the first
+     * scenario won't practically contribute to the summary result.
+     *
+     * These benchmarks should aim to be the minimal set that captures the
+     * interesting behavior of the component.
+     */
+    virtual std::vector<Benchmark> benchmarks(
+            Compressor& compressor,
+            datagen::DataGen& gen) const
+    {
+        return {};
+    }
+
     virtual ~OpenZLComponent() = default;
 
    private:

--- a/tests/registry/OpenZLInput.h
+++ b/tests/registry/OpenZLInput.h
@@ -23,6 +23,9 @@ class OpenZLInput {
    public:
     virtual std::vector<Input> inputs() const = 0;
 
+    /// @returns the size of the input in bytes
+    virtual size_t sizeBytes() const = 0;
+
     std::string serialize() const;
     static std::string serialize(poly::span<const Input> inputs);
     static std::unique_ptr<OpenZLInput> deserialize(std::string_view data);
@@ -47,6 +50,11 @@ class SerialOpenZLInput : public OpenZLInput {
         std::vector<Input> result;
         result.push_back(Input::refSerial(str_));
         return result;
+    }
+
+    size_t sizeBytes() const override
+    {
+        return str_.size();
     }
 
     ~SerialOpenZLInput() override = default;
@@ -92,6 +100,11 @@ class NumericOpenZLInput : public OpenZLInput {
         std::vector<Input> result;
         result.push_back(Input::refNumeric(poly::span<const T>(vec_)));
         return result;
+    }
+
+    size_t sizeBytes() const override
+    {
+        return vec_.size() * sizeof(T);
     }
 
     ~NumericOpenZLInput() override = default;
@@ -156,6 +169,11 @@ class StructOpenZLInput : public OpenZLInput {
         return result;
     }
 
+    size_t sizeBytes() const override
+    {
+        return data_.size();
+    }
+
     ~StructOpenZLInput() override = default;
 
    private:
@@ -195,6 +213,11 @@ class StringOpenZLInput : public OpenZLInput {
         return result;
     }
 
+    size_t sizeBytes() const override
+    {
+        return data_.size() + lens_.size() * sizeof(uint32_t);
+    }
+
     ~StringOpenZLInput() override = default;
 
    private:
@@ -228,6 +251,15 @@ class MultiOpenZLInput : public OpenZLInput {
             ins.push_back(std::move(inner[0]));
         }
         return ins;
+    }
+
+    size_t sizeBytes() const override
+    {
+        size_t size = 0;
+        for (const auto& input : inputs_) {
+            size += input->sizeBytes();
+        }
+        return size;
     }
 
     ~MultiOpenZLInput() override = default;

--- a/tests/registry/components/PartitionBitpack.cpp
+++ b/tests/registry/components/PartitionBitpack.cpp
@@ -2,8 +2,14 @@
 
 #include "openzl/codecs/zl_partition.h"
 #include "openzl/cpp/codecs/Partition.hpp"
+#include "tests/datagen/distributions/ConstantDistribution.h"
+#include "tests/datagen/distributions/LogUniformDistribution.h"
+#include "tests/datagen/distributions/UniformDistribution.h"
+#include "tests/datagen/structures/VectorProducer.h"
 #include "tests/registry/OpenZLComponents.h"
 #include "tests/registry/OpenZLInput.h"
+
+#include "openzl/shared/bits.h"
 
 namespace openzl::tests::components {
 namespace {
@@ -103,6 +109,30 @@ class PartitionBitpackComponent : public OpenZLComponent {
         return inputs;
     }
 
+    std::unique_ptr<OpenZLInput> generateLogUniformInput(
+            datagen::DataGen& gen,
+            size_t inputSize) const
+    {
+        datagen::VectorProducer<uint16_t> dist(
+                std::make_unique<datagen::LogUniformDistribution<uint16_t>>(
+                        gen.getRandWrapper()),
+                std::make_unique<datagen::ConstantDistribution<size_t>>(
+                        inputSize));
+        return NumericOpenZLInput<uint16_t>::make(dist("vector"));
+    }
+
+    std::unique_ptr<OpenZLInput> generateUniformInput(
+            datagen::DataGen& gen,
+            size_t inputSize) const
+    {
+        datagen::VectorProducer<uint16_t> dist(
+                std::make_unique<datagen::UniformDistribution<uint16_t>>(
+                        gen.getRandWrapper()),
+                std::make_unique<datagen::ConstantDistribution<size_t>>(
+                        inputSize));
+        return NumericOpenZLInput<uint16_t>::make(dist("vector"));
+    }
+
     std::vector<std::unique_ptr<OpenZLInput>> generateInputs(
             datagen::DataGen& gen,
             size_t num,
@@ -113,14 +143,50 @@ class PartitionBitpackComponent : public OpenZLComponent {
         std::vector<std::unique_ptr<OpenZLInput>> inputs;
         inputs.reserve(num);
         for (size_t i = 0; i < num; ++i) {
-            auto maxElts = maxInputSize / sizeof(uint16_t);
-            auto minVal  = gen.u16_range("min_val", 0, UINT16_MAX);
-            auto maxVal  = gen.u16_range("max_val", minVal, UINT16_MAX);
-            inputs.push_back(
-                    U16OpenZLInput::make(gen.randVector<uint16_t>(
-                            "values", minVal, maxVal, maxElts)));
+            auto numElts = gen.usize_range(
+                    "num_elts", 0, maxInputSize / sizeof(uint16_t));
+            if (gen.coin("log_uniform", 0.5)) {
+                inputs.push_back(generateLogUniformInput(gen, numElts));
+            } else {
+                inputs.push_back(generateUniformInput(gen, numElts));
+            }
         }
         return inputs;
+    }
+
+    std::vector<Benchmark> benchmarks(
+            Compressor& compressor,
+            datagen::DataGen& gen) const override
+    {
+        struct BenchmarkParams {
+            size_t inputSize;
+            size_t numInputs;
+        };
+        // Tuned so that each benchmark takes approximately the same amount
+        // of compression time, so each scenario is approximately evenly
+        // weighted.
+        std::array<BenchmarkParams, 3> kParams = {
+            BenchmarkParams{ 1000, 20 },
+            BenchmarkParams{ 10000, 20 },
+            BenchmarkParams{ 100000, 10 },
+        };
+        std::vector<Benchmark> benchmarks;
+        benchmarks.reserve(kParams.size());
+        for (auto param : kParams) {
+            std::vector<std::unique_ptr<OpenZLInput>> inputs;
+            inputs.reserve(param.numInputs);
+            for (size_t i = 0; i < param.numInputs; ++i) {
+                inputs.push_back(generateLogUniformInput(gen, param.inputSize));
+            }
+            benchmarks.push_back(
+                    Benchmark{
+                            .name = "InputSize:"
+                                    + std::to_string(param.inputSize),
+                            .graph  = ZL_GRAPH_PARTITION_BITPACK,
+                            .inputs = std::move(inputs),
+                    });
+        }
+        return benchmarks;
     }
 };
 


### PR DESCRIPTION
Summary:

Allow unwrapping exceptions with a `openzl::GraphState` so that the rich error message from the C code is included in the C++ exception message.

Reviewed By: Victor-C-Zhang

Differential Revision: D99142650


