### PR TITLE
Add sentinel codec (#638)

### DIFF
--- a/cpp/include/openzl/cpp/Codecs.hpp
+++ b/cpp/include/openzl/cpp/Codecs.hpp
@@ -29,6 +29,7 @@
 #include "openzl/cpp/codecs/RangePack.hpp"        // IWYU pragma: export
 #include "openzl/cpp/codecs/SDDL.hpp"             // IWYU pragma: export
 #include "openzl/cpp/codecs/SDDL2.hpp"            // IWYU pragma: export
+#include "openzl/cpp/codecs/Sentinel.hpp"         // IWYU pragma: export
 #include "openzl/cpp/codecs/Split.hpp"            // IWYU pragma: export
 #include "openzl/cpp/codecs/SplitByStruct.hpp"    // IWYU pragma: export
 #include "openzl/cpp/codecs/Store.hpp"            // IWYU pragma: export

--- a/cpp/include/openzl/cpp/codecs/Sentinel.hpp
+++ b/cpp/include/openzl/cpp/codecs/Sentinel.hpp
@@ -1,0 +1,122 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#pragma once
+
+#include "openzl/codecs/zl_sentinel.h"
+#include "openzl/codecs/zl_store.h"
+#include "openzl/cpp/Compressor.hpp"
+#include "openzl/cpp/codecs/Metadata.hpp"
+#include "openzl/cpp/codecs/Node.hpp"
+
+#include <vector>
+
+namespace openzl {
+namespace nodes {
+
+/**
+ * Sentinel-byte node: narrows values < 255 to 1 byte, stores values >= 255
+ * in a full-width exceptions stream with sentinel marker 255.
+ */
+struct SentinelByte : public Node {
+    static constexpr NodeID node = ZL_NODE_SENTINEL_BYTE;
+
+    static constexpr NodeMetadata<1, 2> metadata = {
+        .inputs           = { InputMetadata{ .type = Type::Numeric } },
+        .singletonOutputs = { OutputMetadata{ .type = Type::Numeric,
+                                              .name = "values" },
+                              OutputMetadata{ .type = Type::Numeric,
+                                              .name = "exceptions" } },
+        .description =
+                "Narrow values < 255 to 1 byte, route exceptions at full width",
+    };
+
+    NodeID baseNode() const override
+    {
+        return node;
+    }
+
+    GraphID
+    operator()(Compressor& compressor, GraphID values, GraphID exceptions) const
+    {
+        return buildGraph(
+                compressor,
+                std::initializer_list<GraphID>{ values, exceptions });
+    }
+
+    ~SentinelByte() override = default;
+};
+
+/**
+ * General sentinel node: marks designated exception positions with a sentinel
+ * value and routes original values to an exceptions stream.
+ *
+ * This node requires local params (exception indices + sentinel value) and
+ * is intended to be invoked via run() within a function graph.
+ */
+class Sentinel : public Node {
+   public:
+    explicit Sentinel(
+            poly::span<const size_t> exceptionIndices,
+            poly::optional<uint64_t> sentinel = poly::nullopt)
+            : exceptionIndices_(exceptionIndices), sentinel_(sentinel)
+    {
+    }
+
+    static constexpr NodeID node = ZL_NODE_SENTINEL_NUM;
+
+    static constexpr NodeMetadata<1, 2> metadata = {
+        .inputs           = { InputMetadata{ .type = Type::Numeric } },
+        .singletonOutputs = { OutputMetadata{ .type = Type::Numeric,
+                                              .name = "values" },
+                              OutputMetadata{ .type = Type::Numeric,
+                                              .name = "exceptions" } },
+        .description =
+                "Replace values at exception indices with a sentinel marker",
+    };
+
+    NodeID baseNode() const override
+    {
+        return node;
+    }
+
+    poly::optional<NodeParameters> parameters() const override
+    {
+        // Use copy params instead of ref params. When using in runNode copy
+        // params aren't actually copied, but when using this at graph
+        // construction time they are (and have to be).
+        LocalParams params;
+        params.addCopyParam(
+                ZL_SENTINEL_INDICES_PID,
+                exceptionIndices_.data(),
+                exceptionIndices_.size_bytes());
+        if (sentinel_.has_value()) {
+            params.addCopyParam(
+                    ZL_SENTINEL_VALUE_PID,
+                    &sentinel_.value(),
+                    sizeof(uint64_t));
+        }
+        return NodeParameters{ .localParams = std::move(params) };
+    }
+
+    Edge::RunNodeResult run(Edge& edge) const override
+    {
+        return edge.runNode(baseNode(), parameters());
+    }
+
+    GraphID
+    operator()(Compressor& compressor, GraphID values, GraphID exceptions) const
+    {
+        return buildGraph(
+                compressor,
+                std::initializer_list<GraphID>{ values, exceptions });
+    }
+
+    ~Sentinel() override = default;
+
+   private:
+    poly::span<const size_t> exceptionIndices_;
+    poly::optional<uint64_t> sentinel_;
+};
+
+} // namespace nodes
+} // namespace openzl

--- a/include/openzl/codecs/zl_sentinel.h
+++ b/include/openzl/codecs/zl_sentinel.h
@@ -1,0 +1,83 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#ifndef OPENZL_CODECS_ZL_SENTINEL_H
+#define OPENZL_CODECS_ZL_SENTINEL_H
+
+#include <stddef.h>
+#include <stdint.h>
+
+#include "openzl/zl_errors.h"
+#include "openzl/zl_graph_api.h"
+#include "openzl/zl_nodes.h"
+
+#if defined(__cplusplus)
+extern "C" {
+#endif
+
+/**
+ * Sentinel-byte node.
+ *
+ * Encodes each numeric input element into a 1-byte values stream and a
+ * full-width exceptions stream. Values < 255 are stored directly as a
+ * single byte; values >= 255 are replaced by the sentinel 255 in the values
+ * stream and stored at the original width in the exceptions stream.
+ *
+ * Input:    1 numeric stream (width >= 2)
+ * Output 0: numeric stream of 1-byte values (sentinel or narrowed value)
+ * Output 1: numeric stream of exceptions at the original input width
+ */
+#define ZL_NODE_SENTINEL_BYTE ZL_MAKE_NODE_ID(ZL_StandardNodeID_sentinel_byte)
+
+/**
+ * General sentinel node.
+ *
+ * Encodes a numeric input by writing a sentinel marker at designated
+ * exception positions and moving the original values to an exceptions
+ * stream. The values stream retains the same element width as the input.
+ *
+ * This node is intended to be invoked within a function graph via
+ * ZL_Edge_runSentinelNode() or ZL_Edge_runNode_withParams().
+ *
+ * Local parameters:
+ *   ZL_SENTINEL_INDICES_PID (ref): sorted array of size_t exception indices
+ *   ZL_SENTINEL_VALUE_PID   (ref): pointer to uint64_t sentinel value
+ *                                  (optional, defaults to max for elem width)
+ *
+ * Input:    1 numeric stream
+ * Output 0: numeric stream of values (same width, sentinel at exception pos)
+ * Output 1: numeric stream of exceptions (same width as input)
+ */
+#define ZL_NODE_SENTINEL_NUM ZL_MAKE_NODE_ID(ZL_StandardNodeID_sentinel_num)
+
+/// Ref/Copy param ID for the sorted array of exception indices (size_t[]).
+#define ZL_SENTINEL_INDICES_PID 130
+
+/// Ref/Copy param ID for the sentinel value (uint64_t) which will be masked to
+/// the element width.
+/// Optional: defaults to max value for the element width if absent.
+#define ZL_SENTINEL_VALUE_PID 131
+
+/**
+ * Run the general sentinel node on @p input within a function graph.
+ *
+ * Convenience wrapper around ZL_Edge_runNode_withParams() that packages
+ * exception indices and sentinel value as local params.
+ *
+ * @param input            The input edge to process
+ * @param exceptionIndices Sorted array of indices to move to exceptions
+ * @param numExceptions    Number of exception indices
+ * @param sentinel         The sentinel value to use
+ * @returns An EdgeList with 2 edges: [0] = values, [1] = exceptions
+ */
+ZL_RESULT_OF(ZL_EdgeList)
+ZL_Edge_runSentinelNode(
+        ZL_Edge* input,
+        const size_t* exceptionIndices,
+        size_t numExceptions,
+        uint64_t sentinel);
+
+#if defined(__cplusplus)
+}
+#endif
+
+#endif

--- a/include/openzl/zl_nodes.h
+++ b/include/openzl/zl_nodes.h
@@ -88,6 +88,9 @@ typedef enum {
 
     ZL_StandardNodeID_split_byrange,
 
+    ZL_StandardNodeID_sentinel_byte,
+    ZL_StandardNodeID_sentinel_num,
+
     ZL_StandardNodeID_public_end // last id, used to detect end of public range
 } ZL_StandardNodeID;
 

--- a/include/openzl/zl_public_nodes.h
+++ b/include/openzl/zl_public_nodes.h
@@ -38,6 +38,7 @@
 #include "openzl/codecs/zl_quantize.h"             // IWYU pragma: export
 #include "openzl/codecs/zl_range_pack.h"           // IWYU pragma: export
 #include "openzl/codecs/zl_sddl.h"                 // IWYU pragma: export
+#include "openzl/codecs/zl_sentinel.h"             // IWYU pragma: export
 #include "openzl/codecs/zl_split.h"                // IWYU pragma: export
 #include "openzl/codecs/zl_split_by_struct.h"      // IWYU pragma: export
 #include "openzl/codecs/zl_store.h"                // IWYU pragma: export

--- a/src/openzl/codecs/decoder_registry.c
+++ b/src/openzl/codecs/decoder_registry.c
@@ -29,6 +29,7 @@
 #include "openzl/codecs/quantize/decode_quantize_binding.h"
 #include "openzl/codecs/range_pack/decode_range_pack_binding.h"
 #include "openzl/codecs/rolz/decode_rolz_binding.h"
+#include "openzl/codecs/sentinel/decode_sentinel_binding.h"
 #include "openzl/codecs/splitByStruct/decode_splitByStruct_binding.h"
 #include "openzl/codecs/splitN/decode_splitN_binding.h"
 #include "openzl/codecs/tokenize/decode_tokenize_binding.h"
@@ -130,6 +131,7 @@ const StandardDTransform SDecoders_array[ZL_StandardTransformID_end] = {
     REGISTER_TTRANSFORM(ZL_StandardTransformID_parse_int, 19, PARSE_INT),
     REGISTER_TTRANSFORM_G(ZL_StandardTransformID_lz4, 23, DI_LZ4, PIPE_GRAPH),
     REGISTER_TTRANSFORM_G(ZL_StandardTransformID_partition, 24, DI_PARTITION, PARTITION_GRAPH),
+    REGISTER_TTRANSFORM_G(ZL_StandardTransformID_sentinel, 24, DI_SENTINEL, SENTINEL_GRAPH),
 
     REGISTER_VOTRANSFORM_G(ZL_StandardTransformID_splitn, 9, DI_SPLITN, GRAPH_VO_SERIAL),
     REGISTER_VOTRANSFORM_G(ZL_StandardTransformID_splitn_struct, 14, DI_SPLITN_STRUCT, GRAPH_VO_STRUCT),

--- a/src/openzl/codecs/encoder_registry.c
+++ b/src/openzl/codecs/encoder_registry.c
@@ -29,6 +29,7 @@
 #include "openzl/codecs/quantize/encode_quantize_binding.h"
 #include "openzl/codecs/range_pack/encode_range_pack_binding.h"
 #include "openzl/codecs/rolz/encode_rolz_binding.h"
+#include "openzl/codecs/sentinel/encode_sentinel_binding.h"
 #include "openzl/codecs/splitByStruct/encode_splitByStruct_binding.h"
 #include "openzl/codecs/splitN/encode_splitN_binding.h"
 #include "openzl/codecs/splitN/encode_split_byrange_binding.h"
@@ -116,6 +117,8 @@ const CNode ER_standardNodes[STANDARD_ENCODERS_NB] = {
     REGISTER_TRANSFORM(ZL_StandardNodeID_bitsplit_bf16, ZL_StandardTransformID_bitSplit, 24, EI_BITSPLIT_BF16),
     REGISTER_TRANSFORM(ZL_StandardNodeID_partition, ZL_StandardTransformID_partition, 24, EI_PARTITION),
     REGISTER_TRANSFORM(ZL_StandardNodeID_split_byrange, ZL_StandardTransformID_splitn_num, 24, EI_SPLIT_BYRANGE),
+    REGISTER_TRANSFORM(ZL_StandardNodeID_sentinel_byte, ZL_StandardTransformID_sentinel, 24, EI_SENTINEL_BYTE),
+    REGISTER_TRANSFORM(ZL_StandardNodeID_sentinel_num, ZL_StandardTransformID_sentinel, 24, EI_SENTINEL),
 
     // Private Nodes
     REGISTER_TRANSFORM(ZL_PrivateStandardNodeID_set_string_lens,           ZL_StandardTransformID_convert_serial_string, 10, EI_SETSTRINGLENS),

--- a/src/openzl/codecs/sentinel/decode_sentinel_binding.c
+++ b/src/openzl/codecs/sentinel/decode_sentinel_binding.c
@@ -1,0 +1,62 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+#include "openzl/codecs/sentinel/decode_sentinel_binding.h"
+
+#include "openzl/codecs/sentinel/decode_sentinel_kernel.h"
+#include "openzl/common/assertion.h"
+#include "openzl/shared/utils.h"
+#include "openzl/shared/varint.h"
+#include "openzl/zl_dtransform.h"
+
+ZL_Report DI_sentinel(ZL_Decoder* dictx, const ZL_Input* ins[])
+{
+    ZL_RESULT_DECLARE_SCOPE_REPORT(dictx);
+    ZL_ASSERT_NN(dictx);
+    ZL_ASSERT_NN(ins);
+
+    const ZL_Input* const valuesIn     = ins[0];
+    const ZL_Input* const exceptionsIn = ins[1];
+
+    ZL_ASSERT_EQ(ZL_Input_type(valuesIn), ZL_Type_numeric);
+    ZL_ASSERT_EQ(ZL_Input_type(exceptionsIn), ZL_Type_numeric);
+
+    const size_t valWidth      = ZL_Input_eltWidth(valuesIn);
+    const size_t outWidth      = ZL_Input_eltWidth(exceptionsIn);
+    const size_t numElts       = ZL_Input_numElts(valuesIn);
+    const size_t numExceptions = ZL_Input_numElts(exceptionsIn);
+
+    ZL_ERR_IF_GT(valWidth, outWidth, corruption, "values width > output width");
+
+    /* Read codec header to determine sentinel */
+    const ZL_RBuffer header = ZL_Decoder_getCodecHeader(dictx);
+
+    const uint64_t maxVal = ZL_maxValueForWidth(valWidth);
+    uint64_t sentinel     = maxVal;
+
+    if (header.size > 0) {
+        const uint8_t* hdr = (const uint8_t*)header.start;
+        ZL_TRY_LET(uint64_t, decoded, ZL_varintDecode(&hdr, hdr + header.size));
+        sentinel = decoded;
+        ZL_ERR_IF_GT(
+                sentinel, maxVal, corruption, "sentinel exceeds values width");
+    }
+
+    /* Create output stream at outWidth */
+    ZL_Output* const out =
+            ZL_Decoder_create1OutStream(dictx, numElts, outWidth);
+    ZL_ERR_IF_NULL(out, allocation);
+
+    const int rc = ZL_sentinelDecode(
+            ZL_Output_ptr(out),
+            ZL_Input_ptr(valuesIn),
+            ZL_Input_ptr(exceptionsIn),
+            numElts,
+            numExceptions,
+            valWidth,
+            outWidth,
+            sentinel);
+    ZL_ERR_IF_NE(rc, 0, corruption, "sentinel decode failed");
+
+    ZL_ERR_IF_ERR(ZL_Output_commit(out, numElts));
+
+    return ZL_returnSuccess();
+}

--- a/src/openzl/codecs/sentinel/decode_sentinel_binding.h
+++ b/src/openzl/codecs/sentinel/decode_sentinel_binding.h
@@ -1,0 +1,22 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+#ifndef OPENZL_CODECS_SENTINEL_DECODE_SENTINEL_BINDING_H
+#define OPENZL_CODECS_SENTINEL_DECODE_SENTINEL_BINDING_H
+
+#include "openzl/codecs/sentinel/graph_sentinel.h"
+#include "openzl/shared/portability.h"
+#include "openzl/zl_dtransform.h"
+
+ZL_BEGIN_C_DECLS
+
+/// Decoder binding for the sentinel transform.
+/// Reads the codec header to determine the sentinel value, then decodes
+/// values + exceptions back into the original input.
+ZL_Report DI_sentinel(ZL_Decoder* dictx, const ZL_Input* ins[]);
+
+/// Macro to register the sentinel decoder transform.
+#define DI_SENTINEL(id) \
+    { .transform_f = DI_sentinel, .name = "!zl.sentinel_num" }
+
+ZL_END_C_DECLS
+
+#endif

--- a/src/openzl/codecs/sentinel/decode_sentinel_kernel.c
+++ b/src/openzl/codecs/sentinel/decode_sentinel_kernel.c
@@ -1,0 +1,148 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+#include "openzl/codecs/sentinel/decode_sentinel_kernel.h"
+
+#include <assert.h>
+
+#include "openzl/shared/mem.h"
+
+ZL_FORCE_INLINE int ZL_sentinelDecode_impl(
+        void* output,
+        const void* values,
+        const void* exceptions,
+        size_t numElts,
+        size_t numExceptions,
+        size_t kValWidth,
+        size_t kOutWidth,
+        uint64_t sentinel)
+{
+    const uint8_t* const valPtr = (const uint8_t*)values;
+    const uint8_t* const excPtr = (const uint8_t*)exceptions;
+    uint8_t* const outPtr       = (uint8_t*)output;
+
+    size_t excIdx = 0;
+    for (size_t i = 0; i < numElts; ++i) {
+        const uint64_t v = ZL_readN(valPtr + i * kValWidth, kValWidth);
+        if (ZL_LIKELY(v != sentinel)) {
+            /* zero-extend from valWidth to outWidth */
+            ZL_writeN(outPtr + i * kOutWidth, v, kOutWidth);
+        } else {
+            if (excIdx >= numExceptions) {
+                return 1; /* corruption: not enough exceptions */
+            }
+            const uint64_t exc =
+                    ZL_readN(excPtr + excIdx * kOutWidth, kOutWidth);
+            ZL_writeN(outPtr + i * kOutWidth, exc, kOutWidth);
+            ++excIdx;
+        }
+    }
+
+    if (excIdx != numExceptions) {
+        return 2; /* corruption: unconsumed exceptions */
+    }
+
+    return 0;
+}
+
+static int ZL_sentinelDecode_generic(
+        void* output,
+        const void* values,
+        const void* exceptions,
+        size_t numElts,
+        size_t numExceptions,
+        size_t valWidth,
+        size_t outWidth,
+        uint64_t sentinel)
+{
+    return ZL_sentinelDecode_impl(
+            output,
+            values,
+            exceptions,
+            numElts,
+            numExceptions,
+            valWidth,
+            outWidth,
+            sentinel);
+}
+
+#define ZL_GEN_SENTINEL_DECODE_IMPL(v, o)   \
+    static int ZL_sentinelDecode_##v##_##o( \
+            void* output,                   \
+            const void* values,             \
+            const void* exceptions,         \
+            size_t numElts,                 \
+            size_t numExceptions,           \
+            uint64_t sentinel)              \
+    {                                       \
+        return ZL_sentinelDecode_impl(      \
+                output,                     \
+                values,                     \
+                exceptions,                 \
+                numElts,                    \
+                numExceptions,              \
+                v,                          \
+                o,                          \
+                sentinel);                  \
+    }
+
+ZL_GEN_SENTINEL_DECODE_IMPL(1, 2)
+ZL_GEN_SENTINEL_DECODE_IMPL(1, 4)
+ZL_GEN_SENTINEL_DECODE_IMPL(1, 8)
+
+ZL_GEN_SENTINEL_DECODE_IMPL(1, 1)
+ZL_GEN_SENTINEL_DECODE_IMPL(2, 2)
+ZL_GEN_SENTINEL_DECODE_IMPL(4, 4)
+ZL_GEN_SENTINEL_DECODE_IMPL(8, 8)
+
+int ZL_sentinelDecode(
+        void* output,
+        const void* values,
+        const void* exceptions,
+        size_t numElts,
+        size_t numExceptions,
+        size_t valWidth,
+        size_t outWidth,
+        uint64_t sentinel)
+{
+    assert(valWidth == 1 || valWidth == 2 || valWidth == 4 || valWidth == 8);
+    assert(outWidth == 1 || outWidth == 2 || outWidth == 4 || outWidth == 8);
+    assert(valWidth <= outWidth);
+
+#define ZL_SENTINEL_DECODE_IMPL(v, o) \
+    ZL_sentinelDecode_##v##_##o(      \
+            output, values, exceptions, numElts, numExceptions, sentinel)
+
+    if (valWidth == 1 && outWidth > 1) {
+        switch (outWidth) {
+            case 2:
+                return ZL_SENTINEL_DECODE_IMPL(1, 2);
+            case 4:
+                return ZL_SENTINEL_DECODE_IMPL(1, 4);
+            case 8:
+                return ZL_SENTINEL_DECODE_IMPL(1, 8);
+        }
+        assert(false);
+    } else if (valWidth == outWidth) {
+        switch (valWidth) {
+            case 1:
+                return ZL_SENTINEL_DECODE_IMPL(1, 1);
+            case 2:
+                return ZL_SENTINEL_DECODE_IMPL(2, 2);
+            case 4:
+                return ZL_SENTINEL_DECODE_IMPL(4, 4);
+            case 8:
+                return ZL_SENTINEL_DECODE_IMPL(8, 8);
+        }
+        assert(false);
+    }
+    return ZL_sentinelDecode_generic(
+            output,
+            values,
+            exceptions,
+            numElts,
+            numExceptions,
+            valWidth,
+            outWidth,
+            sentinel);
+
+#undef ZL_SENTINEL_DECODE_IMPL
+}

--- a/src/openzl/codecs/sentinel/decode_sentinel_kernel.h
+++ b/src/openzl/codecs/sentinel/decode_sentinel_kernel.h
@@ -1,0 +1,42 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+#ifndef OPENZL_CODECS_SENTINEL_DECODE_SENTINEL_KERNEL_H
+#define OPENZL_CODECS_SENTINEL_DECODE_SENTINEL_KERNEL_H
+
+#include <stddef.h>
+#include <stdint.h>
+
+#if defined(__cplusplus)
+extern "C" {
+#endif
+
+/**
+ * Decode sentinel-encoded data.
+ *
+ * Values equal to @p sentinel are replaced by the next exception.
+ * Non-sentinel values are zero-extended from @p valWidth to @p outWidth.
+ *
+ * @param output         Output buffer (outWidth * numElts bytes)
+ * @param values         Values stream (valWidth bytes per element)
+ * @param exceptions     Exceptions stream (outWidth bytes per element)
+ * @param numElts        Number of elements in the values stream
+ * @param numExceptions  Number of elements in the exceptions stream
+ * @param valWidth       Element width of the values stream (bytes)
+ * @param outWidth       Element width of the output/exceptions stream (bytes)
+ * @param sentinel       The sentinel value (compared at valWidth)
+ * @returns 0 on success, non-zero on error
+ */
+int ZL_sentinelDecode(
+        void* output,
+        const void* values,
+        const void* exceptions,
+        size_t numElts,
+        size_t numExceptions,
+        size_t valWidth,
+        size_t outWidth,
+        uint64_t sentinel);
+
+#if defined(__cplusplus)
+}
+#endif
+
+#endif

--- a/src/openzl/codecs/sentinel/encode_sentinel_binding.c
+++ b/src/openzl/codecs/sentinel/encode_sentinel_binding.c
@@ -1,0 +1,151 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+#include "openzl/codecs/sentinel/encode_sentinel_binding.h"
+
+#include "openzl/codecs/sentinel/encode_sentinel_kernel.h"
+#include "openzl/codecs/zl_sentinel.h"
+#include "openzl/common/assertion.h"
+#include "openzl/shared/utils.h"
+#include "openzl/shared/varint.h"
+#include "openzl/zl_ctransform.h"
+
+/// Send the codec header. Empty if sentinel == max value for valWidth,
+/// otherwise varint-encoded sentinel.
+static void
+sendSentinelHeader(ZL_Encoder* eictx, uint64_t sentinel, size_t valWidth)
+{
+    if (sentinel == ZL_maxValueForWidth(valWidth)) {
+        // Default sentinel: empty header
+        return;
+    }
+    uint8_t buf[ZL_VARINT_LENGTH_64];
+    const size_t size = ZL_varintEncode(sentinel, buf);
+    ZL_Encoder_sendCodecHeader(eictx, buf, size);
+}
+
+ZL_Report
+EI_sentinel_byte(ZL_Encoder* eictx, const ZL_Input* ins[], size_t nbIns)
+{
+    ZL_RESULT_DECLARE_SCOPE_REPORT(eictx);
+    ZL_ASSERT_EQ(nbIns, 1);
+    ZL_ASSERT_NN(ins);
+    const ZL_Input* const in = ins[0];
+    ZL_ASSERT_EQ(ZL_Input_type(in), ZL_Type_numeric);
+
+    const size_t eltWidth = ZL_Input_eltWidth(in);
+    const size_t numElts  = ZL_Input_numElts(in);
+
+    ZL_ERR_IF_EQ(
+            eltWidth,
+            1,
+            node_invalid_input,
+            "sentinel_byte does not accept 1-byte inputs");
+
+    /* Output 0: values at 1 byte per element */
+    ZL_Output* const valuesOut =
+            ZL_Encoder_createTypedStream(eictx, 0, numElts, 1);
+    ZL_ERR_IF_NULL(valuesOut, allocation);
+
+    /* Output 1: exceptions at original width (worst case: all elements) */
+    ZL_Output* const exceptionsOut =
+            ZL_Encoder_createTypedStream(eictx, 1, numElts, eltWidth);
+    ZL_ERR_IF_NULL(exceptionsOut, allocation);
+
+    const size_t numExceptions = ZL_sentinelByteEncode(
+            (uint8_t*)ZL_Output_ptr(valuesOut),
+            ZL_Output_ptr(exceptionsOut),
+            ZL_Input_ptr(in),
+            numElts,
+            eltWidth);
+
+    ZL_ERR_IF_ERR(ZL_Output_commit(valuesOut, numElts));
+    ZL_ERR_IF_ERR(ZL_Output_commit(exceptionsOut, numExceptions));
+
+    return ZL_returnSuccess();
+}
+
+ZL_Report EI_sentinel(ZL_Encoder* eictx, const ZL_Input* ins[], size_t nbIns)
+{
+    ZL_RESULT_DECLARE_SCOPE_REPORT(eictx);
+    ZL_ASSERT_EQ(nbIns, 1);
+    ZL_ASSERT_NN(ins);
+    const ZL_Input* const in = ins[0];
+    ZL_ASSERT_EQ(ZL_Input_type(in), ZL_Type_numeric);
+
+    const size_t eltWidth = ZL_Input_eltWidth(in);
+    const size_t numElts  = ZL_Input_numElts(in);
+
+    /* Read exception indices from ref param */
+    const ZL_RefParam indicesParam =
+            ZL_Encoder_getLocalParam(eictx, ZL_SENTINEL_INDICES_PID);
+    ZL_ERR_IF_NE(
+            indicesParam.paramId,
+            ZL_SENTINEL_INDICES_PID,
+            nodeParameter_invalid,
+            "Missing indices");
+    const size_t* const exceptionIndices = (const size_t*)indicesParam.paramRef;
+    const size_t numExceptions = indicesParam.paramSize / sizeof(size_t);
+
+    /* Read sentinel from ref param (optional, defaults to max for width) */
+    const uint64_t maxVal = ZL_maxValueForWidth(eltWidth);
+    uint64_t sentinel     = maxVal;
+    const ZL_RefParam sentinelParam =
+            ZL_Encoder_getLocalParam(eictx, ZL_SENTINEL_VALUE_PID);
+    if (sentinelParam.paramRef != NULL) {
+        ZL_ERR_IF_NE(
+                sentinelParam.paramSize,
+                sizeof(uint64_t),
+                nodeParameter_invalid,
+                "Sentinel value must be 64 bits");
+        memcpy(&sentinel, sentinelParam.paramRef, sizeof(uint64_t));
+    }
+    // Mask the sentinel to the width of the input to allow for signed types
+    // passed as uint64_t.
+    sentinel &= maxVal;
+
+    /* Output 0: values at same width */
+    ZL_Output* const valuesOut =
+            ZL_Encoder_createTypedStream(eictx, 0, numElts, eltWidth);
+    ZL_ERR_IF_NULL(valuesOut, allocation);
+
+    /* Output 1: exceptions at same width */
+    ZL_Output* const exceptionsOut =
+            ZL_Encoder_createTypedStream(eictx, 1, numExceptions, eltWidth);
+    ZL_ERR_IF_NULL(exceptionsOut, allocation);
+
+    const int rc = ZL_sentinelEncode(
+            ZL_Output_ptr(valuesOut),
+            ZL_Output_ptr(exceptionsOut),
+            ZL_Input_ptr(in),
+            numElts,
+            eltWidth,
+            exceptionIndices,
+            numExceptions,
+            sentinel);
+    ZL_ERR_IF_NE(rc, 0, GENERIC, "Sentinel encode validation failed");
+
+    sendSentinelHeader(eictx, sentinel, eltWidth);
+
+    ZL_ERR_IF_ERR(ZL_Output_commit(valuesOut, numElts));
+    ZL_ERR_IF_ERR(ZL_Output_commit(exceptionsOut, numExceptions));
+
+    return ZL_returnSuccess();
+}
+
+ZL_RESULT_OF(ZL_EdgeList)
+ZL_Edge_runSentinelNode(
+        ZL_Edge* input,
+        const size_t* exceptionIndices,
+        size_t numExceptions,
+        uint64_t sentinel)
+{
+    const ZL_RefParam refParams[2] = {
+        { ZL_SENTINEL_INDICES_PID,
+          exceptionIndices,
+          numExceptions * sizeof(size_t) },
+        { ZL_SENTINEL_VALUE_PID, &sentinel, sizeof(uint64_t) },
+    };
+    const ZL_LocalParams lp = {
+        .refParams = { refParams, 2 },
+    };
+    return ZL_Edge_runNode_withParams(input, ZL_NODE_SENTINEL_NUM, &lp);
+}

--- a/src/openzl/codecs/sentinel/encode_sentinel_binding.h
+++ b/src/openzl/codecs/sentinel/encode_sentinel_binding.h
@@ -1,0 +1,34 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+#ifndef OPENZL_CODECS_SENTINEL_ENCODE_SENTINEL_BINDING_H
+#define OPENZL_CODECS_SENTINEL_ENCODE_SENTINEL_BINDING_H
+
+#include "openzl/codecs/sentinel/graph_sentinel.h"
+#include "openzl/shared/portability.h"
+#include "openzl/zl_ctransform.h"
+
+ZL_BEGIN_C_DECLS
+
+/// Encoder binding for sentinel_byte: narrows values < 255 to 1 byte,
+/// exceptions (>= 255) stored at original width. Sentinel = 255.
+ZL_Report
+EI_sentinel_byte(ZL_Encoder* eictx, const ZL_Input* ins[], size_t nbIns);
+
+/// Encoder binding for general sentinel: exception indices and sentinel value
+/// are read from local params.
+ZL_Report EI_sentinel(ZL_Encoder* eictx, const ZL_Input* ins[], size_t nbIns);
+
+/// Macro to register the sentinel_byte encoder transform.
+#define EI_SENTINEL_BYTE(id)             \
+    { .gd          = SENTINEL_GRAPH(id), \
+      .transform_f = EI_sentinel_byte,   \
+      .name        = "!zl.sentinel_byte" }
+
+/// Macro to register the general sentinel encoder transform.
+#define EI_SENTINEL(id)                  \
+    { .gd          = SENTINEL_GRAPH(id), \
+      .transform_f = EI_sentinel,        \
+      .name        = "!zl.sentinel_num" }
+
+ZL_END_C_DECLS
+
+#endif

--- a/src/openzl/codecs/sentinel/encode_sentinel_kernel.c
+++ b/src/openzl/codecs/sentinel/encode_sentinel_kernel.c
@@ -1,0 +1,96 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+#include "openzl/codecs/sentinel/encode_sentinel_kernel.h"
+
+#include <assert.h>
+
+#include "openzl/shared/mem.h"
+#include "openzl/shared/portability.h"
+#include "openzl/shared/utils.h"
+
+ZL_FORCE_INLINE size_t ZL_sentinelByteEncode_impl(
+        uint8_t* values,
+        void* exceptions,
+        const void* input,
+        size_t numElts,
+        size_t kEltWidth)
+{
+    const uint8_t* const inPtr = (const uint8_t*)input;
+    uint8_t* const excPtr      = (uint8_t*)exceptions;
+
+    size_t numExceptions = 0;
+    for (size_t i = 0; i < numElts; ++i) {
+        const uint64_t v = ZL_readN(inPtr + i * kEltWidth, kEltWidth);
+        if (ZL_LIKELY(v < 255)) {
+            values[i] = (uint8_t)v;
+        } else {
+            values[i] = 255;
+            ZL_writeN(excPtr + numExceptions * kEltWidth, v, kEltWidth);
+            ++numExceptions;
+        }
+    }
+    return numExceptions;
+}
+
+size_t ZL_sentinelByteEncode(
+        uint8_t* values,
+        void* exceptions,
+        const void* input,
+        size_t numElts,
+        size_t eltWidth)
+{
+    assert(eltWidth == 2 || eltWidth == 4 || eltWidth == 8);
+    switch (eltWidth) {
+        case 2:
+            return ZL_sentinelByteEncode_impl(
+                    values, exceptions, input, numElts, 2);
+        case 4:
+            return ZL_sentinelByteEncode_impl(
+                    values, exceptions, input, numElts, 4);
+        case 8:
+            return ZL_sentinelByteEncode_impl(
+                    values, exceptions, input, numElts, 8);
+    }
+    assert(false);
+    return 0;
+}
+
+int ZL_sentinelEncode(
+        void* values,
+        void* exceptions,
+        const void* input,
+        size_t numElts,
+        size_t eltWidth,
+        const size_t* exceptionIndices,
+        size_t numExceptions,
+        uint64_t sentinel)
+{
+    assert(eltWidth == 1 || eltWidth == 2 || eltWidth == 4 || eltWidth == 8);
+    assert((sentinel & ZL_maxValueForWidth(eltWidth)) == sentinel);
+
+    const uint8_t* const inPtr = (const uint8_t*)input;
+    uint8_t* const valPtr      = (uint8_t*)values;
+    uint8_t* const excPtr      = (uint8_t*)exceptions;
+
+    size_t excIdx = 0;
+    for (size_t i = 0; i < numElts; ++i) {
+        const uint64_t v = ZL_readN(inPtr + i * eltWidth, eltWidth);
+        if (excIdx < numExceptions && exceptionIndices[excIdx] == i) {
+            ZL_writeN(valPtr + i * eltWidth, sentinel, eltWidth);
+            ZL_writeN(excPtr + excIdx * eltWidth, v, eltWidth);
+            ++excIdx;
+        } else {
+            if (v == sentinel) {
+                return 1; /* validation failure: sentinel in non-exception
+                             position */
+            }
+            ZL_writeN(valPtr + i * eltWidth, v, eltWidth);
+        }
+    }
+
+    /* All exception indices must have been consumed */
+    if (excIdx != numExceptions) {
+        return 2; /* validation failure: out-of-range indices */
+    }
+
+    return 0;
+}

--- a/src/openzl/codecs/sentinel/encode_sentinel_kernel.h
+++ b/src/openzl/codecs/sentinel/encode_sentinel_kernel.h
@@ -1,0 +1,63 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+#ifndef OPENZL_CODECS_SENTINEL_ENCODE_SENTINEL_KERNEL_H
+#define OPENZL_CODECS_SENTINEL_ENCODE_SENTINEL_KERNEL_H
+
+#include <stddef.h>
+#include <stdint.h>
+
+#if defined(__cplusplus)
+extern "C" {
+#endif
+
+/**
+ * Sentinel-byte encode: values < 255 are stored as 1 byte in @p values,
+ * values >= 255 are stored at full width in @p exceptions with sentinel 255
+ * placed into @p values.
+ *
+ * @param values           Output: 1 byte per element (sentinel or narrowed
+ *                         value)
+ * @param exceptions       Output: full-width exceptions (eltWidth bytes each)
+ * @param input            Input elements (eltWidth bytes each)
+ * @param numElts          Number of input elements
+ * @param eltWidth         Width of each input element in bytes (2, 4, or 8).
+ *                         Must be > 1 (1-byte inputs make no sense for
+ *                         byte-narrowing).
+ * @returns Number of exceptions written
+ */
+size_t ZL_sentinelByteEncode(
+        uint8_t* values,
+        void* exceptions,
+        const void* input,
+        size_t numElts,
+        size_t eltWidth);
+
+/**
+ * General sentinel encode: places sentinel at exception positions and copies
+ * non-exception values to the values stream at the same width. Exception
+ * values are copied to the exceptions stream.
+ *
+ * @param values           Output values (eltWidth bytes per element, numElts)
+ * @param exceptions       Output exceptions (eltWidth bytes per element)
+ * @param input            Input elements (eltWidth bytes per element)
+ * @param numElts          Number of input elements
+ * @param eltWidth         Width of each element in bytes (1, 2, 4, or 8)
+ * @param exceptionIndices Sorted array of exception indices
+ * @param numExceptions    Number of exception indices
+ * @param sentinel         The sentinel value (must fit in eltWidth)
+ * @returns 0 on success, non-zero on validation failure
+ */
+int ZL_sentinelEncode(
+        void* values,
+        void* exceptions,
+        const void* input,
+        size_t numElts,
+        size_t eltWidth,
+        const size_t* exceptionIndices,
+        size_t numExceptions,
+        uint64_t sentinel);
+
+#if defined(__cplusplus)
+}
+#endif
+
+#endif

--- a/src/openzl/codecs/sentinel/graph_sentinel.h
+++ b/src/openzl/codecs/sentinel/graph_sentinel.h
@@ -1,0 +1,19 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+#ifndef OPENZL_CODECS_SENTINEL_GRAPH_SENTINEL_H
+#define OPENZL_CODECS_SENTINEL_GRAPH_SENTINEL_H
+
+/// Graph definition for the sentinel transform
+/// used by both the encoder and decoder side.
+///
+/// Input: 1 numeric stream (any width)
+/// Output 0: numeric stream of values (possibly narrower width)
+/// Output 1: numeric stream of exceptions (same width as input)
+
+#define SENTINEL_GRAPH(id)                                                 \
+    {                                                                      \
+        .CTid       = id,                                                  \
+        .inputTypes = ZL_STREAMTYPELIST(ZL_Type_numeric),                  \
+        .soTypes    = ZL_STREAMTYPELIST(ZL_Type_numeric, ZL_Type_numeric), \
+    }
+
+#endif

--- a/src/openzl/codecs/sentinel/spec.md
+++ b/src/openzl/codecs/sentinel/spec.md
@@ -1,0 +1,86 @@
+# Sentinel Codec — Decoder Wire Format Specification
+
+## Overview
+
+The sentinel codec replaces values at designated positions with a sentinel
+marker and moves the original values to a separate exceptions stream. On the
+decoder side the sentinel marker signals that the next value should be read
+from the exceptions stream instead of being taken from the values stream.
+
+Multiple encoders share this single decoder.
+
+## Inputs
+
+| Index | Name       | Type    | Description |
+|-------|------------|---------|-------------|
+| 0     | values     | Numeric | One element per original input element. Elements at exception positions contain the sentinel value; all other elements are the original values (potentially narrowed to a smaller width). Width W_v. |
+| 1     | exceptions | Numeric | The original values for positions that were replaced by the sentinel. Width W_e, where W_e equals the width of the original unencoded input. |
+
+### Constraints
+
+* W_v <= W_e (the values stream may be narrower than the exceptions stream,
+  but not wider).
+* Each element in the values stream is interpreted as an unsigned integer of
+  width W_v.
+* Each element in the exceptions stream is interpreted as an unsigned integer
+  of width W_e.
+
+## Output
+
+| Name   | Type    | Description |
+|--------|---------|-------------|
+| output | Numeric | The reconstructed original input. Width W_e, element count equals the element count of the values stream. |
+
+## Codec Header
+
+| Condition                        | Header contents  |
+|----------------------------------|------------------|
+| sentinel == 2^(8 * W_v) - 1      | Empty (0 bytes)  |
+| sentinel != 2^(8 * W_v) - 1      | varint(sentinel) |
+
+When the sentinel value is `2^(8 * W_v) - 1` (i.e. all bits set), no header bytes
+are needed because this is the default. Otherwise the sentinel value is
+encoded as a single varint.
+
+## Decoding Algorithm
+
+```
+
+W_v = element_width(values)
+W_e = element_width(exceptions)
+N   = element_count(values)
+M   = element_count(exceptions)
+
+sentinel_v = 2^(8 * W_v) - 1                # default
+if codec_header is not empty:
+    sentinel_v = varint_decode(codec_header)
+    VALIDATE sentinel_v < 2^(8 * W_v)
+
+VALIDATE W_v <= W_e
+
+allocate output[N] at width W_e
+
+exception_index = 0
+for i in 0 .. N-1:
+    v = read_element(values, i, W_v)       # unsigned, W_v bytes
+    if v == sentinel_v:
+        VALIDATE exception_index < M
+        output[i] = read_element(exceptions, exception_index, W_e)
+        exception_index += 1
+    else:
+        output[i] = zero_extend(v, W_v, W_e)
+
+VALIDATE exception_index == M              # all exceptions consumed
+
+return output
+```
+
+### Security Notes (malicious input handling)
+
+* If `W_v > W_e`, return a corruption error.
+* If a sentinel match is encountered but `exception_index >= M`, return a
+  corruption error (not enough exceptions).
+* If `exception_index != M` after processing all values, return a corruption
+  error (unconsumed exceptions).
+* If the codec header is non-empty but fails varint decoding, return a
+  corruption error.

--- a/src/openzl/common/wire_format.h
+++ b/src/openzl/common/wire_format.h
@@ -233,7 +233,8 @@ typedef enum {
     ZL_StandardTransformID_fse_deprecated           = 15,
     ZL_StandardTransformID_huffman_deprecated       = 16,
     ZL_StandardTransformID_huffman_fixed_deprecated = 17,
-    // 18-19 : available
+    ZL_StandardTransformID_sentinel                 = 18,
+    // 19 : available
     ZL_StandardTransformID_rolz       = 20,
     ZL_StandardTransformID_fastlz     = 21,
     ZL_StandardTransformID_zstd       = 22,

--- a/src/openzl/shared/utils.h
+++ b/src/openzl/shared/utils.h
@@ -70,6 +70,18 @@ ZL_INLINE size_t ZL_isLegalIntegerWidth(size_t width)
     return width == 1 || width == 2 || width == 4 || width == 8;
 }
 
+/**
+ * @returns The maximum unsigned value for an element of @p width bytes.
+ */
+ZL_INLINE uint64_t ZL_maxValueForWidth(size_t width)
+{
+    ZL_ASSERT(ZL_isLegalIntegerWidth(width));
+    if (width == 8) {
+        return UINT64_MAX;
+    }
+    return ((uint64_t)1 << (width * 8)) - 1;
+}
+
 ZL_END_C_DECLS
 
 #endif // ZS_COMMON_UTILS_H

--- a/tests/registry/OpenZLComponents.h
+++ b/tests/registry/OpenZLComponents.h
@@ -83,6 +83,8 @@ enum class OpenZLComponentID {
     PartitionBitpack,
     SegmentNumeric,
     SegmentNumFromSerial,
+    SentinelByte,
+    SentinelNum,
     // Must be last enum value
     NumComponents,
 };
@@ -152,6 +154,8 @@ std::unique_ptr<OpenZLComponent> makeBitSplitBF16Component();
 std::unique_ptr<OpenZLComponent> makePartitionBitpackComponent();
 std::unique_ptr<OpenZLComponent> makeSegmentNumericComponent();
 std::unique_ptr<OpenZLComponent> makeSegmentNumFromSerialComponent();
+std::unique_ptr<OpenZLComponent> makeSentinelByteComponent();
+std::unique_ptr<OpenZLComponent> makeSentinelNumComponent();
 
 } // namespace components
 
@@ -275,6 +279,10 @@ inline std::unique_ptr<OpenZLComponent> makeOpenZLComponent(
             return components::makeSegmentNumericComponent();
         case OpenZLComponentID::SegmentNumFromSerial:
             return components::makeSegmentNumFromSerialComponent();
+        case OpenZLComponentID::SentinelByte:
+            return components::makeSentinelByteComponent();
+        case OpenZLComponentID::SentinelNum:
+            return components::makeSentinelNumComponent();
         case OpenZLComponentID::NumComponents:
         default:
             throw std::runtime_error("Invalid component");

--- a/tests/registry/components/Sentinel.cpp
+++ b/tests/registry/components/Sentinel.cpp
@@ -1,0 +1,230 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#include <algorithm>
+
+#include "openzl/codecs/zl_sentinel.h"
+#include "openzl/codecs/zl_store.h"
+#include "openzl/cpp/codecs/Sentinel.hpp"
+#include "openzl/shared/utils.h"
+#include "openzl/zl_reflection.h"
+#include "tests/registry/OpenZLComponents.h"
+#include "tests/registry/OpenZLInput.h"
+
+namespace openzl::tests::components {
+namespace {
+
+class SentinelNumComponent : public OpenZLComponent {
+   public:
+    std::string name() const override
+    {
+        return "SentinelNum";
+    }
+
+    int minFormatVersion() const override
+    {
+        return 24;
+    }
+
+    std::vector<GraphID> predefinedGraphs(Compressor& compressor) const override
+    {
+        std::vector<size_t> noIdx;
+        std::vector<size_t> idx_0123 = { 0, 1, 2, 3 };
+        std::vector<size_t> idx_13   = { 1, 3 };
+        std::vector<size_t> idx_0    = { 0 };
+        std::vector<size_t> idx_3    = { 3 };
+        std::vector<size_t> idx_12   = { 1, 2 };
+        return {
+            nodes::Sentinel{ noIdx, UINT64_MAX }(
+                    compressor, ZL_GRAPH_STORE, ZL_GRAPH_STORE),
+            nodes::Sentinel{ idx_0123, 42 }(
+                    compressor, ZL_GRAPH_STORE, ZL_GRAPH_STORE),
+            nodes::Sentinel{ idx_13, 0 }(
+                    compressor, ZL_GRAPH_STORE, ZL_GRAPH_STORE),
+            nodes::Sentinel{ idx_0, 100 }(
+                    compressor, ZL_GRAPH_STORE, ZL_GRAPH_STORE),
+            nodes::Sentinel{ idx_3, UINT64_MAX }(
+                    compressor, ZL_GRAPH_STORE, ZL_GRAPH_STORE),
+            nodes::Sentinel{ idx_12, 1 }(
+                    compressor, ZL_GRAPH_STORE, ZL_GRAPH_STORE),
+        };
+    }
+
+    std::vector<GraphID> generateGraphs(
+            Compressor& compressor,
+            datagen::DataGen& gen,
+            size_t num) const override
+    {
+        std::vector<GraphID> result;
+        result.reserve(num);
+        for (size_t i = 0; i < num; ++i) {
+            size_t numElts       = gen.usize_range("numElts", 1, 256);
+            size_t numExceptions = gen.usize_range("numExceptions", 0, numElts);
+
+            // Generate sorted unique exception indices
+            std::vector<size_t> indices;
+            indices.reserve(numExceptions);
+            for (size_t j = 0; j < numExceptions; ++j) {
+                size_t idx = gen.usize_range("index", 0, numElts - 1);
+                indices.push_back(idx);
+            }
+            std::sort(indices.begin(), indices.end());
+            indices.erase(
+                    std::unique(indices.begin(), indices.end()), indices.end());
+
+            // Pick a sentinel value
+            bool useDefault = gen.boolean("useDefaultSentinel");
+            poly::optional<uint64_t> sentinel;
+            if (!useDefault) {
+                sentinel = gen.u64("sentinel");
+            }
+
+            result.push_back(
+                    nodes::Sentinel{ indices, sentinel }(
+                            compressor, ZL_GRAPH_STORE, ZL_GRAPH_STORE));
+        }
+        return result;
+    }
+
+    std::vector<std::unique_ptr<OpenZLInput>> predefinedInputs() const override
+    {
+        return {};
+    }
+
+    /// Extract sentinel parameters from a graph via the reflection API.
+    void getSentinelParams(
+            const Compressor& compressor,
+            GraphID graphID,
+            std::vector<size_t>& indices,
+            uint64_t& sentinel) const
+    {
+        auto node = ZL_Compressor_Graph_getHeadNode(compressor.get(), graphID);
+        auto localParams =
+                ZL_Compressor_Node_getLocalParams(compressor.get(), node);
+
+        indices.clear();
+        sentinel = UINT64_MAX;
+        for (size_t i = 0; i < localParams.copyParams.nbCopyParams; ++i) {
+            const auto& cp = localParams.copyParams.copyParams[i];
+            if (cp.paramId == ZL_SENTINEL_INDICES_PID) {
+                auto* data   = static_cast<const size_t*>(cp.paramPtr);
+                size_t count = cp.paramSize / sizeof(size_t);
+                indices.assign(data, data + count);
+            } else if (cp.paramId == ZL_SENTINEL_VALUE_PID) {
+                sentinel = *static_cast<const uint64_t*>(cp.paramPtr);
+            }
+        }
+    }
+
+    std::vector<std::unique_ptr<OpenZLInput>> generateInputs(
+            datagen::DataGen& gen,
+            size_t num,
+            size_t maxInputSize,
+            const Compressor& compressor,
+            GraphID graphID) const override
+    {
+        std::vector<size_t> indices;
+        uint64_t sentinelBase;
+        getSentinelParams(compressor, graphID, indices, sentinelBase);
+
+        size_t minElts = indices.empty() ? 0 : indices.back() + 1;
+
+        std::vector<std::unique_ptr<OpenZLInput>> inputs;
+        inputs.reserve(num);
+        for (size_t i = 0; i < num; ++i) {
+            auto width     = gen.choices<size_t>("width", { 1, 2, 4, 8 });
+            size_t maxElts = maxInputSize / width;
+            if (maxElts < minElts) {
+                maxElts = minElts;
+            }
+            size_t numElts = gen.usize_range("numElts", minElts, maxElts);
+
+            // Compute sentinel masked to this width
+            uint64_t maxVal   = ZL_maxValueForWidth(width);
+            uint64_t sentinel = sentinelBase & maxVal;
+
+            // Build a set of exception positions for fast lookup
+            auto isException = [&](size_t idx) {
+                return std::binary_search(indices.begin(), indices.end(), idx);
+            };
+
+            // Generate values: non-exception positions must not contain
+            // sentinel
+            switch (width) {
+                case 1: {
+                    std::vector<uint8_t> vec(numElts);
+                    uint8_t s8 = static_cast<uint8_t>(sentinel);
+                    for (size_t j = 0; j < numElts; ++j) {
+                        if (isException(j)) {
+                            vec[j] = gen.u8_range("exc", 0, UINT8_MAX);
+                        } else {
+                            // Avoid sentinel value
+                            vec[j] = gen.u8_range("val", 0, UINT8_MAX);
+                            if (vec[j] == s8) {
+                                ++vec[j];
+                            }
+                        }
+                    }
+                    inputs.push_back(U8OpenZLInput::make(std::move(vec)));
+                    break;
+                }
+                case 2: {
+                    std::vector<uint16_t> vec(numElts);
+                    uint16_t s16 = static_cast<uint16_t>(sentinel);
+                    for (size_t j = 0; j < numElts; ++j) {
+                        if (isException(j)) {
+                            vec[j] = gen.u16_range("exc", 0, UINT16_MAX);
+                        } else {
+                            vec[j] = gen.u16_range("val", 0, UINT16_MAX);
+                            if (vec[j] == s16) {
+                                ++vec[j];
+                            }
+                        }
+                    }
+                    inputs.push_back(U16OpenZLInput::make(std::move(vec)));
+                    break;
+                }
+                case 4: {
+                    std::vector<uint32_t> vec(numElts);
+                    uint32_t s32 = static_cast<uint32_t>(sentinel);
+                    for (size_t j = 0; j < numElts; ++j) {
+                        if (isException(j)) {
+                            vec[j] = gen.u32_range("exc", 0, UINT32_MAX);
+                        } else {
+                            vec[j] = gen.u32_range("val", 0, UINT32_MAX);
+                            if (vec[j] == s32) {
+                                ++vec[j];
+                            }
+                        }
+                    }
+                    inputs.push_back(U32OpenZLInput::make(std::move(vec)));
+                    break;
+                }
+                case 8: {
+                    std::vector<uint64_t> vec(numElts);
+                    for (size_t j = 0; j < numElts; ++j) {
+                        if (isException(j)) {
+                            vec[j] = gen.u64_range("exc", 0, UINT64_MAX);
+                        } else {
+                            vec[j] = gen.u64_range("val", 0, UINT64_MAX);
+                            if (vec[j] == sentinel) {
+                                ++vec[j];
+                            }
+                        }
+                    }
+                    inputs.push_back(U64OpenZLInput::make(std::move(vec)));
+                    break;
+                }
+            }
+        }
+        return inputs;
+    }
+};
+
+} // namespace
+
+std::unique_ptr<OpenZLComponent> makeSentinelNumComponent()
+{
+    return std::make_unique<SentinelNumComponent>();
+}
+
+} // namespace openzl::tests::components

--- a/tests/registry/components/SentinelByte.cpp
+++ b/tests/registry/components/SentinelByte.cpp
@@ -1,0 +1,150 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#include "openzl/cpp/codecs/Sentinel.hpp"
+#include "tests/registry/OpenZLComponents.h"
+#include "tests/registry/OpenZLInput.h"
+
+namespace openzl::tests::components {
+namespace {
+
+class SentinelByteComponent : public OpenZLComponent {
+   public:
+    std::string name() const override
+    {
+        return "SentinelByte";
+    }
+
+    int minFormatVersion() const override
+    {
+        return 24;
+    }
+
+    std::vector<GraphID> predefinedGraphs(Compressor& compressor) const override
+    {
+        return {
+            nodes::SentinelByte{}(compressor, ZL_GRAPH_STORE, ZL_GRAPH_STORE),
+        };
+    }
+
+    std::vector<std::unique_ptr<OpenZLInput>> predefinedInputs() const override
+    {
+        std::vector<std::unique_ptr<OpenZLInput>> inputs;
+        // Empty inputs (sentinel_byte rejects 1-byte inputs, so no U8)
+        inputs.push_back(U16OpenZLInput::make(std::vector<uint16_t>{}));
+        inputs.push_back(U32OpenZLInput::make(std::vector<uint32_t>{}));
+        inputs.push_back(U64OpenZLInput::make(std::vector<uint64_t>{}));
+
+        // All values < 255 (no exceptions)
+        inputs.push_back(
+                U32OpenZLInput::make(std::vector<uint32_t>{ 0, 1, 42, 254 }));
+        // All values >= 255 (all exceptions)
+        inputs.push_back(
+                U32OpenZLInput::make(
+                        std::vector<uint32_t>{ 255, 256, 1000, UINT32_MAX }));
+        // Mix of small and large values
+        inputs.push_back(
+                U32OpenZLInput::make(
+                        std::vector<uint32_t>{ 0, 255, 1, 256, 254, 1000 }));
+        // Single element < 255
+        inputs.push_back(U16OpenZLInput::make(std::vector<uint16_t>{ 42 }));
+        // Single element == 255
+        inputs.push_back(U16OpenZLInput::make(std::vector<uint16_t>{ 255 }));
+        // Width 8 with large values
+        inputs.push_back(
+                U64OpenZLInput::make(
+                        std::vector<uint64_t>{ 0, 254, 255, 256, UINT64_MAX }));
+
+        return inputs;
+    }
+
+    template <typename T>
+    std::unique_ptr<OpenZLInput>
+    makeInput(datagen::DataGen& gen, size_t inputSize, float smallProb) const
+    {
+        std::vector<T> input;
+        input.reserve(inputSize);
+        for (size_t i = 0; i < inputSize; ++i) {
+            if (gen.coin("small", smallProb)) {
+                input.push_back(
+                        gen.getRandWrapper()->range("small_val", T(0), T(254)));
+            } else {
+                input.push_back(gen.getRandWrapper()->range<T>(
+                        "large_val", T(255), std::numeric_limits<T>::max()));
+            }
+        }
+        return NumericOpenZLInput<T>::make(std::move(input));
+    }
+
+    std::vector<std::unique_ptr<OpenZLInput>> generateInputs(
+            datagen::DataGen& gen,
+            size_t num,
+            size_t maxInputSize,
+            const Compressor&,
+            GraphID) const override
+    {
+        std::vector<std::unique_ptr<OpenZLInput>> inputs;
+        inputs.reserve(num);
+        for (size_t i = 0; i < num; ++i) {
+            // Only widths >= 2 (sentinel_byte rejects 1-byte inputs)
+            const auto widthChoice = gen.usize_range("width", 0, 2);
+            const auto smallProb   = gen.f32_range("small_prob", 0.0, 1.0);
+            auto inputSize = gen.usize_range("input_size", 0, maxInputSize);
+            switch (widthChoice) {
+                case 0:
+                    inputs.push_back(
+                            makeInput<uint16_t>(gen, inputSize, smallProb));
+                    break;
+                case 1:
+                    inputs.push_back(
+                            makeInput<uint32_t>(gen, inputSize, smallProb));
+                    break;
+                case 2:
+                    inputs.push_back(
+                            makeInput<uint64_t>(gen, inputSize, smallProb));
+            }
+        }
+        return inputs;
+    }
+
+    std::vector<Benchmark> benchmarks(
+            Compressor& compressor,
+            datagen::DataGen& gen) const override
+    {
+        constexpr size_t kInputSize = 10000;
+        constexpr size_t kNumInputs = 10;
+
+        std::array<int, 5> smallProbs = { 5, 25, 50, 75, 95 };
+
+        std::vector<Benchmark> benchmarks;
+        benchmarks.reserve(smallProbs.size());
+
+        auto graph = nodes::SentinelByte{}(
+                compressor, ZL_GRAPH_STORE, ZL_GRAPH_STORE);
+
+        for (auto smallProb : smallProbs) {
+            std::vector<std::unique_ptr<OpenZLInput>> inputs;
+            inputs.reserve(kNumInputs);
+            for (size_t i = 0; i < kNumInputs; ++i) {
+                inputs.push_back(
+                        makeInput<uint16_t>(
+                                gen, kInputSize, smallProb / 100.0));
+            }
+            benchmarks.push_back(
+                    Benchmark{
+                            .name   = "SmallProb:" + std::to_string(smallProb),
+                            .graph  = graph,
+                            .inputs = std::move(inputs),
+                    });
+        }
+        return benchmarks;
+    }
+};
+
+} // namespace
+
+std::unique_ptr<OpenZLComponent> makeSentinelByteComponent()
+{
+    return std::make_unique<SentinelByteComponent>();
+}
+
+} // namespace openzl::tests::components


### PR DESCRIPTION
Summary:

Adds the `sentinel` codec, whose decoder takes two inputs (`values`, `exceptions`). It reads the `sentinel` value from the header. The output is `values`, except where `values[i] == sentinel`, in which case the value is taken from `exceptions`. The `values` stream may be a smaller width than the `exceptions` stream. See `spec.md` for a formal spec.

Adds two encoders for the `sentinel` codec:
* `ZL_NODE_SENTINEL_BYTE`: sentinel == 255, exceptions are values >= 255. The `values` stream width is 1-byte.
* `ZL_NODE_SENTINEL_NUM`: Takes the `sentinel` values as a parameter, along with a list of exception indices that should be replaced with the `sentinel`. This is mainly present for testing, but can be used for user-defined sentinel codecs.

I envision at least one more encoder in the future:
* `ZL_NODE_SENTINEL_NUM_TOPK`: The top `K` (set via parameter) most frequent values are preserved, and the remainder are replaced with the sentinel. This can be combined with `ZL_NODE_TOKENIZE_NUM` to implement a partial tokenization, where only the most frequent values are tokenized. It can use a Count-Min Sketch to estimate the top `K` values using `O(K)` space.

Reviewed By: Cyan4973

Differential Revision: D99101575


