### PR TITLE
Add doxygen dependency to mkdocstrings-zstd tests

### DIFF
--- a/doc/mkdocs/mkdocstrings-zstd/tests/BUCK
+++ b/doc/mkdocs/mkdocstrings-zstd/tests/BUCK
@@ -37,8 +37,12 @@ python_pytest(
         "test_doxygen.py",
         "test_handler.py",
     ],
+    env = {
+        "DOXYGEN_PATH": "$(location fbsource//third-party/doxygen:doxygen)",
+    },
     deps = [
         "../src:mkdocstrings-zstd",
+        "fbsource//third-party/doxygen:doxygen",  # @manual
         "fbsource//third-party/pypi/markdown:markdown",
         "fbsource//third-party/pypi/mkdocs:mkdocs",
         "fbsource//third-party/pypi/mkdocs-material:mkdocs-material",  # @manual


### PR DESCRIPTION
Summary:
The python_pytest target was missing the doxygen binary dependency,
causing tests to fail with `PermissionError: [Errno 13] Permission
denied: 'doxygen'`.

The handler resolves the doxygen path via
`os.environ.get("DOXYGEN_PATH", "doxygen")`, but neither the env var
was set nor was the binary available in the test sandbox.

Added `DOXYGEN_PATH` env var and `fbsource//third-party/doxygen:doxygen`
dep, mirroring the existing `static_docs_test` target in the parent
mkdocs BUCK file.

Differential Revision: D101063866


