### PR TITLE
Modify directed selector to be serializable

### DIFF
--- a/custom_transforms/thrift/directed_selector.c
+++ b/custom_transforms/thrift/directed_selector.c
@@ -3,6 +3,7 @@
 #include "custom_transforms/thrift/directed_selector.h" // @manual
 
 #include "openzl/zl_data.h"
+#include "openzl/zl_selector.h"
 
 static ZL_GraphID directed_selector_impl(
         const ZL_Selector* selCtx,
@@ -26,18 +27,36 @@ static ZL_GraphID directed_selector_impl(
     return customGraphs[idx];
 }
 
-ZL_SelectorDesc buildDirectedSelectorDesc(
-        ZL_Type type,
+ZL_GraphID registerDirectedSelectorBaseGraph(ZL_Compressor* compressor)
+{
+    ZL_GraphID baseGraph =
+            ZL_Compressor_getGraph(compressor, "zl_custom.directed_selector");
+    if (baseGraph.gid != ZL_GRAPH_ILLEGAL.gid) {
+        return baseGraph;
+    }
+
+    ZL_SelectorDesc const baseDesc = {
+        .selector_f     = directed_selector_impl,
+        .inStreamType   = ZL_Type_any,
+        .customGraphs   = NULL,
+        .nbCustomGraphs = 0,
+        .localParams    = {},
+        .name           = "!zl_custom.directed_selector",
+    };
+    return ZL_Compressor_registerSelectorGraph(compressor, &baseDesc);
+}
+
+ZL_GraphID registerDirectedSelectorGraph(
+        ZL_Compressor* compressor,
         const ZL_GraphID* successors,
         size_t nbSuccessors)
 {
-    return (ZL_SelectorDesc){
-        .selector_f     = directed_selector_impl,
-        .inStreamType   = type,
+    ZL_GraphID baseGraph = registerDirectedSelectorBaseGraph(compressor);
+
+    ZL_ParameterizedGraphDesc const paramDesc = {
+        .graph          = baseGraph,
         .customGraphs   = successors,
         .nbCustomGraphs = nbSuccessors,
-        .localParams = { .intParams  = { .intParams = NULL, .nbIntParams = 0 },
-                         .copyParams = { .copyParams   = NULL,
-                                         .nbCopyParams = 0 } },
     };
+    return ZL_Compressor_registerParameterizedGraph(compressor, &paramDesc);
 }

--- a/custom_transforms/thrift/directed_selector.h
+++ b/custom_transforms/thrift/directed_selector.h
@@ -2,7 +2,7 @@
 
 #pragma once
 
-#include "openzl/zl_selector.h"
+#include "openzl/zl_compressor.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -15,12 +15,31 @@ extern "C" {
 static const int kDirectedSelectorMetadataID = 0;
 
 /**
- * A selector that does what it's told. The selector expects to receive
- * direction as to which successor to select in the form of an integer metadata
- * on the input stream (at kDirectedSelectorMetadataID).
+ * Registers the base directed selector graph if not already registered.
+ * The base graph is serializable and can be parameterized with successors.
+ *
+ * @param compressor The compressor to register the graph with.
+ * @return The base graph ID, or ZL_GRAPH_ILLEGAL on error.
  */
-ZL_SelectorDesc buildDirectedSelectorDesc(
-        ZL_Type type,
+ZL_GraphID registerDirectedSelectorBaseGraph(ZL_Compressor* compressor);
+
+/**
+ * A directed selector graph that selects a successor based on integer metadata.
+ * The selector expects to receive direction as to which successor to select
+ * in the form of an integer metadata on the input stream (at
+ * kDirectedSelectorMetadataID).
+ *
+ * This function registers a base graph (if not already registered) and returns
+ * a parameterized graph with the provided successors. The base graph is
+ * serializable.
+ *
+ * @param compressor The compressor to register the graph with.
+ * @param successors Array of successor graph IDs to select from.
+ * @param nbSuccessors Number of successors in the array.
+ * @return The parameterized graph ID, or ZL_GRAPH_ILLEGAL on error.
+ */
+ZL_GraphID registerDirectedSelectorGraph(
+        ZL_Compressor* compressor,
         const ZL_GraphID* successors,
         size_t nbSuccessors);
 

--- a/custom_transforms/thrift/tests/util.cpp
+++ b/custom_transforms/thrift/tests/util.cpp
@@ -215,14 +215,11 @@ std::string thriftSplitCompress(
         const std::vector<ZL_GraphID> directedSelectorSuccessors{
             { ZL_GRAPH_STORE }
         };
-        const ZL_SelectorDesc directed_selector_desc =
-                buildDirectedSelectorDesc(
-                        type,
+        const ZL_GraphID directedSelectorGraphID =
+                registerDirectedSelectorGraph(
+                        cgraph.get(),
                         directedSelectorSuccessors.data(),
                         directedSelectorSuccessors.size());
-        const ZL_GraphID directedSelectorGraphID =
-                ZL_Compressor_registerSelectorGraph(
-                        cgraph.get(), &directed_selector_desc);
         assert(directedSelectorGraphID.gid != ZL_GRAPH_ILLEGAL.gid);
         const std::vector<ZL_GraphID> emptyInputSelectorSuccessors{
             { ZL_GRAPH_STORE, directedSelectorGraphID }

--- a/tools/zstrong_cpp.cpp
+++ b/tools/zstrong_cpp.cpp
@@ -446,10 +446,9 @@ class DirectedSelector : public Selector {
             std::span<ZL_GraphID const> successors,
             ZL_LocalParams const& localParams) const override
     {
-        auto desc = buildDirectedSelectorDesc(
-                ZL_Type_any, successors.data(), successors.size());
-        desc.localParams = localParams;
-        return ZL_Compressor_registerSelectorGraph(&cgraph, &desc);
+        (void)localParams; // TODO: support localParams if needed
+        return registerDirectedSelectorGraph(
+                &cgraph, successors.data(), successors.size());
     }
 
     ZL_Type inputType() const override


### PR DESCRIPTION
Summary:
Modifies the directed selector component used in the thrift graph is serializable. The other possible approach is to keep a duplicate copy of this component, or directly integrate this new component into the thrift graph.

Also patches the changes to prod branch.

Compatibility:
- Both new compressors trained on old library versions and old compressors trained on new library versions are unaffected due to the component not being serialized in any manner, and no modifications have been done to to serialized configs.

Differences
- The selector now accepts an any typed input

Reviewed By: terrelln

Differential Revision: D97001848


