### PR TITLE
Add base graphs/node for empty input selector and thrift node

### DIFF
--- a/custom_transforms/thrift/directed_selector.c
+++ b/custom_transforms/thrift/directed_selector.c
@@ -3,6 +3,7 @@
 #include "custom_transforms/thrift/directed_selector.h" // @manual
 
 #include "openzl/zl_data.h"
+#include "openzl/zl_selector.h"
 
 static ZL_GraphID directed_selector_impl(
         const ZL_Selector* selCtx,
@@ -26,18 +27,36 @@ static ZL_GraphID directed_selector_impl(
     return customGraphs[idx];
 }
 
-ZL_SelectorDesc buildDirectedSelectorDesc(
-        ZL_Type type,
+ZL_GraphID registerDirectedSelectorBaseGraph(ZL_Compressor* compressor)
+{
+    ZL_GraphID baseGraph =
+            ZL_Compressor_getGraph(compressor, "zl_custom.directed_selector");
+    if (baseGraph.gid != ZL_GRAPH_ILLEGAL.gid) {
+        return baseGraph;
+    }
+
+    ZL_SelectorDesc const baseDesc = {
+        .selector_f     = directed_selector_impl,
+        .inStreamType   = ZL_Type_any,
+        .customGraphs   = NULL,
+        .nbCustomGraphs = 0,
+        .localParams    = {},
+        .name           = "!zl_custom.directed_selector",
+    };
+    return ZL_Compressor_registerSelectorGraph(compressor, &baseDesc);
+}
+
+ZL_GraphID registerDirectedSelectorGraph(
+        ZL_Compressor* compressor,
         const ZL_GraphID* successors,
         size_t nbSuccessors)
 {
-    return (ZL_SelectorDesc){
-        .selector_f     = directed_selector_impl,
-        .inStreamType   = type,
+    ZL_GraphID baseGraph = registerDirectedSelectorBaseGraph(compressor);
+
+    ZL_ParameterizedGraphDesc const paramDesc = {
+        .graph          = baseGraph,
         .customGraphs   = successors,
         .nbCustomGraphs = nbSuccessors,
-        .localParams = { .intParams  = { .intParams = NULL, .nbIntParams = 0 },
-                         .copyParams = { .copyParams   = NULL,
-                                         .nbCopyParams = 0 } },
     };
+    return ZL_Compressor_registerParameterizedGraph(compressor, &paramDesc);
 }

--- a/custom_transforms/thrift/directed_selector.h
+++ b/custom_transforms/thrift/directed_selector.h
@@ -2,7 +2,7 @@
 
 #pragma once
 
-#include "openzl/zl_selector.h"
+#include "openzl/zl_compressor.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -15,12 +15,31 @@ extern "C" {
 static const int kDirectedSelectorMetadataID = 0;
 
 /**
- * A selector that does what it's told. The selector expects to receive
- * direction as to which successor to select in the form of an integer metadata
- * on the input stream (at kDirectedSelectorMetadataID).
+ * Registers the base directed selector graph if not already registered.
+ * The base graph is serializable and can be parameterized with successors.
+ *
+ * @param compressor The compressor to register the graph with.
+ * @return The base graph ID, or ZL_GRAPH_ILLEGAL on error.
  */
-ZL_SelectorDesc buildDirectedSelectorDesc(
-        ZL_Type type,
+ZL_GraphID registerDirectedSelectorBaseGraph(ZL_Compressor* compressor);
+
+/**
+ * A directed selector graph that selects a successor based on integer metadata.
+ * The selector expects to receive direction as to which successor to select
+ * in the form of an integer metadata on the input stream (at
+ * kDirectedSelectorMetadataID).
+ *
+ * This function registers a base graph (if not already registered) and returns
+ * a parameterized graph with the provided successors. The base graph is
+ * serializable.
+ *
+ * @param compressor The compressor to register the graph with.
+ * @param successors Array of successor graph IDs to select from.
+ * @param nbSuccessors Number of successors in the array.
+ * @return The parameterized graph ID, or ZL_GRAPH_ILLEGAL on error.
+ */
+ZL_GraphID registerDirectedSelectorGraph(
+        ZL_Compressor* compressor,
         const ZL_GraphID* successors,
         size_t nbSuccessors);
 

--- a/custom_transforms/thrift/empty_input_selector.c
+++ b/custom_transforms/thrift/empty_input_selector.c
@@ -11,8 +11,6 @@ static ZL_GraphID empty_input_selector_impl(
         size_t nbCustomGraphs)
 {
     (void)selCtx;
-    assert(customGraphs != NULL);
-    assert(nbCustomGraphs == 2);
     if (customGraphs == NULL || nbCustomGraphs != 2) {
         return (ZL_GraphID){
             0
@@ -36,4 +34,40 @@ ZL_SelectorDesc buildEmptyInputSelectorDesc(
                          .copyParams = { .copyParams   = NULL,
                                          .nbCopyParams = 0 } },
     };
+}
+
+ZL_GraphID registerEmptyInputSelectorBaseGraph(ZL_Compressor* compressor)
+{
+    ZL_GraphID baseGraph = ZL_Compressor_getGraph(
+            compressor, "zl_custom.empty_input_selector");
+    if (baseGraph.gid != ZL_GRAPH_ILLEGAL.gid) {
+        return baseGraph;
+    }
+
+    ZL_SelectorDesc const baseDesc = {
+        .selector_f     = empty_input_selector_impl,
+        .inStreamType   = ZL_Type_any,
+        .customGraphs   = NULL,
+        .nbCustomGraphs = 0,
+        .localParams = { .intParams  = { .intParams = NULL, .nbIntParams = 0 },
+                         .copyParams = { .copyParams   = NULL,
+                                         .nbCopyParams = 0 } },
+        .name        = "!zl_custom.empty_input_selector",
+    };
+    return ZL_Compressor_registerSelectorGraph(compressor, &baseDesc);
+}
+
+ZL_GraphID registerEmptyInputSelectorGraph(
+        ZL_Compressor* compressor,
+        const ZL_GraphID* successors,
+        size_t nbSuccessors)
+{
+    ZL_GraphID baseGraph = registerEmptyInputSelectorBaseGraph(compressor);
+
+    ZL_ParameterizedGraphDesc const paramDesc = {
+        .graph          = baseGraph,
+        .customGraphs   = successors,
+        .nbCustomGraphs = nbSuccessors,
+    };
+    return ZL_Compressor_registerParameterizedGraph(compressor, &paramDesc);
 }

--- a/custom_transforms/thrift/empty_input_selector.h
+++ b/custom_transforms/thrift/empty_input_selector.h
@@ -2,6 +2,7 @@
 
 #pragma once
 
+#include "openzl/zl_compressor.h"
 #include "openzl/zl_selector.h"
 
 #ifdef __cplusplus
@@ -19,6 +20,24 @@ extern "C" {
  */
 ZL_SelectorDesc buildEmptyInputSelectorDesc(
         ZL_Type type,
+        const ZL_GraphID* successors,
+        size_t nbSuccessors);
+
+/**
+ * Registers the base empty input selector graph if not already registered.
+ */
+ZL_GraphID registerEmptyInputSelectorBaseGraph(ZL_Compressor* compressor);
+
+/**
+ * Registers a serializable empty input selector graph.
+ * The base graph is registered as a named anchor, and the successors
+ * are captured in a parameterized graph layer (serializable).
+ *
+ * @param successors Array of exactly 2 graph IDs: [empty, non-empty].
+ * @param nbSuccessors Must be 2.
+ */
+ZL_GraphID registerEmptyInputSelectorGraph(
+        ZL_Compressor* compressor,
         const ZL_GraphID* successors,
         size_t nbSuccessors);
 

--- a/custom_transforms/thrift/tests/util.cpp
+++ b/custom_transforms/thrift/tests/util.cpp
@@ -215,14 +215,11 @@ std::string thriftSplitCompress(
         const std::vector<ZL_GraphID> directedSelectorSuccessors{
             { ZL_GRAPH_STORE }
         };
-        const ZL_SelectorDesc directed_selector_desc =
-                buildDirectedSelectorDesc(
-                        type,
+        const ZL_GraphID directedSelectorGraphID =
+                registerDirectedSelectorGraph(
+                        cgraph.get(),
                         directedSelectorSuccessors.data(),
                         directedSelectorSuccessors.size());
-        const ZL_GraphID directedSelectorGraphID =
-                ZL_Compressor_registerSelectorGraph(
-                        cgraph.get(), &directed_selector_desc);
         assert(directedSelectorGraphID.gid != ZL_GRAPH_ILLEGAL.gid);
         const std::vector<ZL_GraphID> emptyInputSelectorSuccessors{
             { ZL_GRAPH_STORE, directedSelectorGraphID }

--- a/custom_transforms/thrift/thrift_parsers.cpp
+++ b/custom_transforms/thrift/thrift_parsers.cpp
@@ -663,25 +663,25 @@ ZL_VOGraphDesc const thriftBinaryConfigurableGd = {
 ZL_VOEncoderDesc const thriftCompactConfigurableSplitter = {
     .gd          = thriftCompactConfigurableGd,
     .transform_f = configurableEncodeCompact,
-    .name        = "Thrift Compact Encode",
+    .name        = "!zl_custom.thrift_compact_encode",
 };
 
 ZL_VODecoderDesc const thriftCompactConfigurableUnSplitter = {
     .gd          = thriftCompactConfigurableGd,
     .transform_f = configurableDecodeCompact,
-    .name        = "Thrift Compact Decode",
+    .name        = "zl_custom.thrift_compact_decode",
 };
 
 ZL_VOEncoderDesc const thriftBinaryConfigurableSplitter = {
     .gd          = thriftBinaryConfigurableGd,
     .transform_f = configurableEncodeBinary,
-    .name        = "Thrift Binary Encode",
+    .name        = "!zl_custom.thrift_binary_encode",
 };
 
 ZL_VODecoderDesc const thriftBinaryConfigurableUnSplitter = {
     .gd          = thriftBinaryConfigurableGd,
     .transform_f = configurableDecodeBinary,
-    .name        = "Thrift Binary Decode",
+    .name        = "zl_custom.thrift_binary_decode",
 };
 
 ZL_Report registerCustomTransforms(ZL_DCtx* dctx)
@@ -698,7 +698,12 @@ ZL_NodeID registerCompactTransform(ZL_Compressor* cgraph, ZL_IDType id)
 {
     auto desc    = thriftCompactConfigurableSplitter;
     desc.gd.CTid = id;
-    return ZL_Compressor_registerVOEncoder(cgraph, &desc);
+    auto compactEncode =
+            ZL_Compressor_getNode(cgraph, "zl_custom.thrift_compact_encode");
+    if (compactEncode.nid == ZL_NODE_ILLEGAL.nid) {
+        return ZL_Compressor_registerVOEncoder(cgraph, &desc);
+    }
+    return compactEncode;
 }
 
 ZL_Report registerCompactTransform(ZL_DCtx* dctx, ZL_IDType id)
@@ -712,7 +717,12 @@ ZL_NodeID registerBinaryTransform(ZL_Compressor* cgraph, ZL_IDType id)
 {
     auto desc    = thriftBinaryConfigurableSplitter;
     desc.gd.CTid = id;
-    return ZL_Compressor_registerVOEncoder(cgraph, &desc);
+    auto binaryEncode =
+            ZL_Compressor_getNode(cgraph, "zl_custom.thrift_binary_encode");
+    if (binaryEncode.nid == ZL_NODE_ILLEGAL.nid) {
+        return ZL_Compressor_registerVOEncoder(cgraph, &desc);
+    }
+    return binaryEncode;
 }
 
 ZL_Report registerBinaryTransform(ZL_DCtx* dctx, ZL_IDType id)

--- a/tools/zstrong_cpp.cpp
+++ b/tools/zstrong_cpp.cpp
@@ -446,10 +446,9 @@ class DirectedSelector : public Selector {
             std::span<ZL_GraphID const> successors,
             ZL_LocalParams const& localParams) const override
     {
-        auto desc = buildDirectedSelectorDesc(
-                ZL_Type_any, successors.data(), successors.size());
-        desc.localParams = localParams;
-        return ZL_Compressor_registerSelectorGraph(&cgraph, &desc);
+        (void)localParams; // TODO: support localParams if needed
+        return registerDirectedSelectorGraph(
+                &cgraph, successors.data(), successors.size());
     }
 
     ZL_Type inputType() const override


### PR DESCRIPTION
Summary: Adds serializable registration functions for the empty input selector and thrift node component in both dev and prod.

Reviewed By: terrelln

Differential Revision: D99504682


