### PR TITLE
Add parsing error as a category of OpenZL Errors (#653)

### DIFF
--- a/custom_transforms/thrift/binary_splitter.h
+++ b/custom_transforms/thrift/binary_splitter.h
@@ -6,6 +6,7 @@
 #include "custom_transforms/thrift/parse_config.h"   // @manual
 #include "custom_transforms/thrift/split_helpers.h"  // @manual
 #include "custom_transforms/thrift/splitter.h"       // @manual
+#include "custom_transforms/thrift/thrift_errors.h"  // @manual
 #include "custom_transforms/thrift/thrift_parsers.h" // @manual
 #include "custom_transforms/thrift/thrift_types.h"   // @manual
 
@@ -72,7 +73,7 @@ BinaryParser::parseListHeader(const BinaryParser::PT::Iterator& current)
 {
     const auto elemType = (TType)readValue<uint8_t>();
     if (elemType > TType::T_FLOAT) {
-        throw std::runtime_error("Illegal list element type!");
+        throw ThriftMalformedInputError("Illegal list element type!");
     }
     writeType(elemType);
 
@@ -88,7 +89,7 @@ DBinaryParser::unparseListHeader(const DBinaryParser::PT::Iterator& current)
 {
     const auto elemType = readType();
     if (elemType > TType::T_FLOAT) {
-        throw std::runtime_error("Illegal list element type!");
+        throw ThriftMalformedInputError("Illegal list element type!");
     }
     writeValue((uint8_t)elemType);
 
@@ -108,10 +109,10 @@ BinaryParser::parseMapHeader(const BinaryParser::PT::Iterator& current)
     const auto keyType   = (TType)readValue<uint8_t>();
     const auto valueType = (TType)readValue<uint8_t>();
     if (keyType > TType::T_FLOAT) {
-        throw std::runtime_error("Illegal map key type!");
+        throw ThriftMalformedInputError("Illegal map key type!");
     }
     if (valueType > TType::T_FLOAT) {
-        throw std::runtime_error("Illegal map value type!");
+        throw ThriftMalformedInputError("Illegal map value type!");
     }
     writeType(keyType);
     writeType(valueType);
@@ -134,10 +135,10 @@ DBinaryParser::unparseMapHeader(const DBinaryParser::PT::Iterator& current)
     const auto keyType   = readType();
     const auto valueType = readType();
     if (keyType > TType::T_FLOAT) {
-        throw std::runtime_error("Illegal map key type!");
+        throw ThriftMalformedInputError("Illegal map key type!");
     }
     if (valueType > TType::T_FLOAT) {
-        throw std::runtime_error("Illegal map value type!");
+        throw ThriftMalformedInputError("Illegal map value type!");
     }
     writeValue((uint8_t)keyType);
     writeValue((uint8_t)valueType);
@@ -158,7 +159,7 @@ ZL_FORCE_INLINE_ATTR BinaryParser::PT::Iterator BinaryParser::parseFieldHeader(
 {
     const auto type = (TType)readValue<uint8_t>();
     if (type > TType::T_FLOAT) {
-        throw std::runtime_error("Illegal type!");
+        throw ThriftMalformedInputError("Illegal type!");
     }
     writeType(type);
 
@@ -188,7 +189,7 @@ DBinaryParser::unparseFieldHeader(
     // Get the type
     const auto type = readType();
     if (type > TType::T_FLOAT) {
-        throw std::runtime_error("Illegal type!");
+        throw ThriftMalformedInputError("Illegal type!");
     }
     writeValue((uint8_t)type);
 
@@ -291,7 +292,7 @@ void BinaryParser::advance(const BinaryParser::PT::Iterator& current)
         case TType::T_UTF16:
         case TType::T_STREAM:
         default: {
-            throw std::runtime_error(
+            throw ThriftMalformedInputError(
                     "Unexpected thrift type: " + thriftTypeToString(type));
         }
     }
@@ -378,7 +379,7 @@ void DBinaryParser::advance(const DBinaryParser::PT::Iterator& current)
         case TType::T_UTF16:
         case TType::T_STREAM:
         default: {
-            throw std::runtime_error(
+            throw ThriftMalformedInputError(
                     "Unexpected thrift type: " + thriftTypeToString(type));
         }
     }
@@ -386,7 +387,7 @@ void DBinaryParser::advance(const DBinaryParser::PT::Iterator& current)
 
 void BinaryParser::parseTulipV2Header(const PT::Iterator&)
 {
-    throw std::runtime_error{
+    throw InvalidConfigError{
         "TulipV2 mode is not compatible with binary protocol!"
     };
 }

--- a/custom_transforms/thrift/compact_splitter.h
+++ b/custom_transforms/thrift/compact_splitter.h
@@ -6,6 +6,7 @@
 #include "custom_transforms/thrift/parse_config.h"   // @manual
 #include "custom_transforms/thrift/split_helpers.h"  // @manual
 #include "custom_transforms/thrift/splitter.h"       // @manual
+#include "custom_transforms/thrift/thrift_errors.h"  // @manual
 #include "custom_transforms/thrift/thrift_parsers.h" // @manual
 #include "custom_transforms/thrift/thrift_types.h"   // @manual
 
@@ -87,7 +88,7 @@ ZL_FORCE_INLINE_ATTR constexpr uint8_t CompactParser::parseBool(uint8_t byte)
     if (byte == trueVal || byte == falseVal) {
         return byte == trueVal;
     }
-    throw std::runtime_error{ "Invalid boolean value!" };
+    throw ThriftMalformedInputError{ "Invalid boolean value!" };
 }
 
 ZL_FORCE_INLINE_ATTR constexpr uint8_t DCompactParser::unparseBool(uint8_t byte)
@@ -96,7 +97,7 @@ ZL_FORCE_INLINE_ATTR constexpr uint8_t DCompactParser::unparseBool(uint8_t byte)
         return (uint8_t)(byte == 1 ? CType::CT_BOOLEAN_TRUE
                                    : CType::CT_BOOLEAN_FALSE);
     }
-    throw std::runtime_error{ "Invalid boolean value!" };
+    throw ThriftMalformedInputError{ "Invalid boolean value!" };
 }
 
 ZL_FORCE_INLINE_ATTR constexpr TType CompactParser::parseType(
@@ -106,13 +107,13 @@ ZL_FORCE_INLINE_ATTR constexpr TType CompactParser::parseType(
     if (interp == TypeParse::kForCollection
         && rawType == 2 /* CT_BOOL_FALSE */) {
         // Reject non-canonical Thrift
-        throw std::runtime_error{
+        throw ThriftUnhandledInputError{
             "CT_BOOL_FALSE is not expected in collection headers"
         };
     }
     TType const type = CTypeToTType.at(rawType);
     if (type == TType::T_VOID) {
-        throw std::runtime_error{ "T_VOID is not a valid wire value!" };
+        throw ThriftMalformedInputError{ "T_VOID is not a valid wire value!" };
     }
     return type;
 }
@@ -123,7 +124,7 @@ ZL_FORCE_INLINE_ATTR constexpr uint8_t DCompactParser::unparseType(TType type)
     static_assert(sizeof(CType) == sizeof(uint8_t));
     const CType rawType = TTypeToCType.at(static_cast<uint8_t>(type));
     if (rawType == CType::CT_VOID) {
-        throw std::runtime_error{ fmt::format(
+        throw ThriftMalformedInputError{ fmt::format(
                 "Type value {} from the wire doesn't map to CType enum!",
                 static_cast<uint8_t>(type)) };
     }
@@ -178,7 +179,7 @@ CompactParser::parseListHeader(const CompactParser::PT::Iterator& current)
         size = readValue<uint32_t>();
         if (size < 15) {
             // Reject non-canonical Thrift
-            throw std::runtime_error{
+            throw ThriftUnhandledInputError{
                 "Invalid list header: size < 15 but varint is present"
             };
         }
@@ -291,7 +292,7 @@ CompactParser::parseFieldHeader(
     if (type == TType::T_STOP) {
         if (byte != 0) {
             // Reject non-canonical Thrift
-            throw std::runtime_error{
+            throw ThriftUnhandledInputError{
                 "Invalid field header: non-zero stop byte"
             };
         }
@@ -319,7 +320,7 @@ CompactParser::parseFieldHeader(
 
     // Reject non-canonical Thrift
     if (rawIdDelta >= 1 && rawIdDelta <= 15 && deltaNibble == 0) {
-        throw std::runtime_error{
+        throw ThriftUnhandledInputError{
             "Invalid field header: delta is small but varint is present"
         };
     }
@@ -466,7 +467,7 @@ void CompactParser::advance(const CompactParser::PT::Iterator& current)
         case TType::T_UTF16:
         case TType::T_STREAM:
         default: {
-            throw std::runtime_error(
+            throw ThriftMalformedInputError(
                     "Unexpected thrift type: " + thriftTypeToString(type));
         }
     }
@@ -543,7 +544,7 @@ bool DCompactParser::advanceIfTrivial(
         case TType::T_UTF16:
         case TType::T_STREAM:
         default: {
-            throw std::runtime_error(
+            throw ThriftMalformedInputError(
                     "Unexpected thrift type: " + thriftTypeToString(type));
         }
     }
@@ -633,7 +634,7 @@ void CompactParser::parseTulipV2Header(const PT::Iterator& current)
     headerSize++;
 
     if (byte0 != uint8_t(0x80) || byte1 != uint8_t(0x00)) {
-        throw std::runtime_error("Bad TulipV2 header");
+        throw ThriftMalformedInputError("Bad TulipV2 header");
     }
 
     writeValue<uint32_t>(it.lengths(), folly::to<uint32_t>(headerSize));

--- a/custom_transforms/thrift/path_tracker-inl.h
+++ b/custom_transforms/thrift/path_tracker-inl.h
@@ -2,6 +2,8 @@
 
 #pragma once
 
+#include "custom_transforms/thrift/thrift_errors.h" // @manual
+
 namespace zstrong::thrift {
 namespace detail {
 constexpr std::string_view kOldStyleVsfErrorMsg =
@@ -191,7 +193,7 @@ void PathTracker<StreamSetType>::Node::checkType(TType t) const
 {
     t = coerceType(t);
     if (t != type()) {
-        throw std::runtime_error(
+        throw ThriftParserUserError(
                 fmt::format(
                         "Node (id {}) has type {} ({}) but is being accessed with type {} ({})!",
                         id(),

--- a/custom_transforms/thrift/path_tracker.h
+++ b/custom_transforms/thrift/path_tracker.h
@@ -58,7 +58,7 @@ class PathTracker {
                   depth_(depth)
         {
             if (depth_ > kMaxThriftDepth) {
-                throw std::runtime_error(
+                throw ThriftUnhandledInputError(
                         "Exceeded maximum thrift recursion depth!");
             }
         }

--- a/custom_transforms/thrift/split_helpers.h
+++ b/custom_transforms/thrift/split_helpers.h
@@ -4,11 +4,12 @@
 
 #include "custom_transforms/thrift/constants.h" // @manual
 #include "custom_transforms/thrift/debug.h"
-#include "custom_transforms/thrift/parse_config.h" // @manual
-#include "custom_transforms/thrift/thrift_types.h" // @manual
-#include "openzl/codecs/common/copy.h"             // @manual
-#include "openzl/common/errors_internal.h"         // @manual
-#include "openzl/shared/varint.h"                  // @manual
+#include "custom_transforms/thrift/parse_config.h"  // @manual
+#include "custom_transforms/thrift/thrift_errors.h" // @manual
+#include "custom_transforms/thrift/thrift_types.h"  // @manual
+#include "openzl/codecs/common/copy.h"              // @manual
+#include "openzl/common/errors_internal.h"          // @manual
+#include "openzl/shared/varint.h"                   // @manual
 
 #include <folly/Portability.h>
 #include <folly/Range.h>
@@ -204,7 +205,9 @@ class WriteStream : public detail::BaseWriteStream<WriteStream> {
               type_(type)
     {
         if (width() == 0) {
-            throw std::runtime_error{ fmt::format(
+            // Note: It is not possible to create an EncoderConfig that throws
+            // here with the provided construction API.
+            throw InvalidConfigError{ fmt::format(
                     "Invalid WriteStream type {}", type_) };
         }
     }

--- a/custom_transforms/thrift/splitter.h
+++ b/custom_transforms/thrift/splitter.h
@@ -5,6 +5,7 @@
 #include "custom_transforms/thrift/parse_config.h"
 #include "custom_transforms/thrift/path_tracker.h"
 #include "custom_transforms/thrift/split_helpers.h"
+#include "custom_transforms/thrift/thrift_errors.h"
 #include "openzl/zl_errors.h"
 
 #include <type_traits>
@@ -61,6 +62,11 @@ class BaseParser {
                     // Note: parser.advance() always makes forward progress
                     break;
                 }
+            } catch (const ThriftParserUserError& ex) {
+                throw ThriftParserUserError{ fmt::format(
+                        "Thrift parser failed at position {}: {}",
+                        rs_.pos(),
+                        ex.what()) };
             } catch (const std::exception& ex) {
                 throw std::runtime_error{ fmt::format(
                         "Thrift parser failed at position {}: {}",
@@ -318,6 +324,11 @@ class DBaseParser {
                     break;
                 }
                 assert(ws_.nbytes() <= kMaxExpansionFactor * rss_.nbytes());
+            } catch (const ThriftParserUserError& ex) {
+                throw ThriftParserUserError{ fmt::format(
+                        "Thrift parser failed at position {}: {}",
+                        ws_.nbytes(),
+                        ex.what()) };
             } catch (const std::exception& ex) {
                 throw std::runtime_error{ fmt::format(
                         "Thrift parser failed at position {}: {}",

--- a/custom_transforms/thrift/thrift_errors.h
+++ b/custom_transforms/thrift/thrift_errors.h
@@ -1,0 +1,36 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#pragma once
+
+#include <stdexcept>
+
+namespace zstrong::thrift {
+
+/// Thrown when the parser encounters an error that should be classified as a
+/// user error.
+class ThriftParserUserError : public std::runtime_error {
+   public:
+    using std::runtime_error::runtime_error;
+};
+
+/// Thrown when the parser encounters malformed input data (e.g. illegal type
+/// values that violate the protocol specification).
+class ThriftMalformedInputError : public ThriftParserUserError {
+   public:
+    using ThriftParserUserError::ThriftParserUserError;
+};
+
+/// Thrown when the parser encounters valid thrift but unhandled input (e.g. a
+/// type that is recognized but not supported by this parser implementation).
+class ThriftUnhandledInputError : public std::runtime_error {
+   public:
+    using std::runtime_error::runtime_error;
+};
+
+/// Thrown when the configuration is incompatible with the input getting parsed.
+class InvalidConfigError : public std::runtime_error {
+   public:
+    using std::runtime_error::runtime_error;
+};
+
+} // namespace zstrong::thrift

--- a/custom_transforms/thrift/thrift_parsers.cpp
+++ b/custom_transforms/thrift/thrift_parsers.cpp
@@ -373,6 +373,10 @@ ZL_Report configurableEncode(ZL_Encoder* eictx, const ZL_Input* in)
         Parser parser{ config, srcStream, dstStreamSet, formatVersion };
         try {
             parser.parse();
+        } catch (const ThriftParserUserError& ex) {
+            ZL_ERR(graph_parser_malformedInput,
+                   "Thrift kernel failed inside core parser: %s",
+                   ex.what());
         } catch (const std::exception& ex) {
             ZL_ERR(GENERIC,
                    "Thrift kernel failed inside core parser: %s",

--- a/include/openzl/detail/zl_errors_detail.h
+++ b/include/openzl/detail/zl_errors_detail.h
@@ -89,6 +89,10 @@ extern "C" {
 #define ZL_ErrorCode_graph_nonserializable__desc_str \
     "Graph incompatible with serialization"
 #define ZL_ErrorCode_graph_invalidNumInputs__desc_str "Graph invalid nb inputs"
+#define ZL_ErrorCode_graph_parser_malformedInput__desc_str \
+    "Parser encountered malformed input"
+#define ZL_ErrorCode_graph_parser_unhandledInput__desc_str \
+    "Parser encountered unhandled input"
 #define ZL_ErrorCode_successor_invalid__desc_str \
     "Selected an invalid Successor Graph"
 #define ZL_ErrorCode_successor_alreadySet__desc_str \

--- a/include/openzl/zl_errors_types.h
+++ b/include/openzl/zl_errors_types.h
@@ -65,10 +65,12 @@ typedef enum {
     ZL_ErrorCode_outputNotReserved                    = 25,
     ZL_ErrorCode_segmenter_inputNotConsumed           = 26,
     /* graph stage errors */
-    ZL_ErrorCode_graph_invalid          = 30,
-    ZL_ErrorCode_graph_nonserializable  = 31,
-    ZL_ErrorCode_invalidTransform       = 32,
-    ZL_ErrorCode_graph_invalidNumInputs = 33,
+    ZL_ErrorCode_graph_invalid               = 30,
+    ZL_ErrorCode_graph_nonserializable       = 31,
+    ZL_ErrorCode_invalidTransform            = 32,
+    ZL_ErrorCode_graph_invalidNumInputs      = 33,
+    ZL_ErrorCode_graph_parser_malformedInput = 34,
+    ZL_ErrorCode_graph_parser_unhandledInput = 35,
     /* runtime compression errors */
     ZL_ErrorCode_successor_invalid          = 40,
     ZL_ErrorCode_successor_alreadySet       = 41,

--- a/src/openzl/common/errors.c
+++ b/src/openzl/common/errors.c
@@ -54,6 +54,10 @@ const char* ZL_ErrorCode_toString(ZL_ErrorCode code)
             return ZL_ErrorCode_graph_nonserializable__desc_str;
         case ZL_ErrorCode_graph_invalidNumInputs:
             return ZL_ErrorCode_graph_invalidNumInputs__desc_str;
+        case ZL_ErrorCode_graph_parser_malformedInput:
+            return ZL_ErrorCode_graph_parser_malformedInput__desc_str;
+        case ZL_ErrorCode_graph_parser_unhandledInput:
+            return ZL_ErrorCode_graph_parser_unhandledInput__desc_str;
         case ZL_ErrorCode_successor_invalid:
             return ZL_ErrorCode_successor_invalid__desc_str;
         case ZL_ErrorCode_successor_alreadySet:

--- a/src/openzl/common/errors_internal.h
+++ b/src/openzl/common/errors_internal.h
@@ -81,6 +81,10 @@ ZL_BEGIN_C_DECLS
 #define ZL_ErrorCode_graph_nonserializable__desc_str \
     "Graph incompatible with serialization"
 #define ZL_ErrorCode_graph_invalidNumInputs__desc_str "Graph invalid nb inputs"
+#define ZL_ErrorCode_graph_parser_malformedInput__desc_str \
+    "Parser encountered malformed input"
+#define ZL_ErrorCode_graph_parser_unhandledInput__desc_str \
+    "Parser encountered unhandled input"
 #define ZL_ErrorCode_successor_invalid__desc_str \
     "Selected an invalid Successor Graph"
 #define ZL_ErrorCode_successor_alreadySet__desc_str \


### PR DESCRIPTION
Summary:

Add a category of errors "parseError" to OpenZL graphs. Also, for anything that fails in the thift parser use the error code.

Reviewed By: felixhandte

Differential Revision: D101210010


