### PR TITLE
Require parentheses for sizeof

### DIFF
--- a/tools/sddl2/compiler/Syntax.md
+++ b/tools/sddl2/compiler/Syntax.md
@@ -175,7 +175,7 @@ Op        | Syntax        | Types         | Effect
 --------- | ------------- | ------------- | ------
 `expect`  | `expect <A>`  | I -> N        | Fails the run if `A` evaluates to 0.
 `consume` | `[L] : <R>`   | V?, FL -> IS? | Consumes the field provided as `R`, stores the result into an optional variable `L`. The expression as a whole also evaluates to that result value.
-`sizeof`  | `sizeof <A>`  | F -> I        | Evaluates to the size in bytes of the given field `A`. Fails the run if invoked on anything other than a static field.
+`sizeof`  | `sizeof(<A>)` | F -> I        | Evaluates to the size in bytes of the given field `A`. Fails the run if invoked on anything other than a static field.
 `assign`  | `<L> = <R>`   | V, * -> *     | Stores the resolved value of the expression in `R` and stores it in the variable `L`. The assignment expression also evaluates as a whole to that resolved value.
 `member`  | `<L>.<R>`     | S, V -> *     | Retrieves the value held by the variable `R` in the scope `L`. Cannot be used as the left-hand argument of assignment.
 `bind`    | `<L>(<R...>)` | L, T -> L     | Binds the first `n` args of function `L` to the `n` comma-separated args `R`, returning a new function with `n` fewer unbound arguments.

--- a/tools/sddl2/compiler/parser/Grammar.cpp
+++ b/tools/sddl2/compiler/parser/Grammar.cpp
@@ -561,13 +561,14 @@ class WhenRule : public GrammarRule {
     }
 };
 
-class AbsRule : public GrammarRule {
+class BuiltinFuncRule : public GrammarRule {
    public:
-    explicit AbsRule()
+    explicit BuiltinFuncRule(Symbol sym, Op result_op)
             : GrammarRule(
-                      Symbol::ABS,
+                      sym,
                       Precedence::ACCESS,
-                      std::vector<ArgType>({ ArgType::LIST_PAREN }))
+                      std::vector<ArgType>({ ArgType::LIST_PAREN })),
+              result_op_(result_op)
     {
     }
 
@@ -577,18 +578,25 @@ class AbsRule : public GrammarRule {
         auto& paren_list = args.at(0);
         const auto* list = some(paren_list).as_list();
         if (list == nullptr) {
-            throw ParseError(some(op).loc(), "abs() requires a paren list.");
+            throw ParseError(
+                    some(op).loc(),
+                    std::string{ sym_to_repr_str(this->sym()) }
+                            + "() requires a paren list.");
         }
 
         const auto& inner_args = list->nodes();
         if (inner_args.size() != 1) {
             throw ParseError(
-                    some(op).loc(), "abs() requires exactly 1 argument.");
+                    some(op).loc(),
+                    std::string{ sym_to_repr_str(this->sym()) }
+                            + "() requires exactly 1 argument.");
         }
 
         return std::make_shared<ASTOp>(
-                op->loc(), Op::ABS, ArgsVec{ inner_args.at(0) });
+                op->loc(), result_op_, ArgsVec{ inner_args.at(0) });
     }
+
+    const Op result_op_;
 };
 
 template <typename RuleT, typename... Args>
@@ -614,9 +622,9 @@ const std::vector<std::unique_ptr<const GrammarRule>> grammar_rules{ []() {
 
     // Ops
     add_rule<UnaryOpRule>(r, Symbol::EXPECT, Precedence::ASSIGNMENT);
-    add_rule<UnaryOpRule>(r, Symbol::SIZEOF);
+    add_rule<BuiltinFuncRule>(r, Symbol::SIZEOF, Op::SIZEOF);
     add_rule<WhenRule>(r);
-    add_rule<AbsRule>(r);
+    add_rule<BuiltinFuncRule>(r, Symbol::ABS, Op::ABS);
 
     add_rule<BinaryOpRule>(r, Symbol::ASSIGN, Precedence::ASSIGNMENT);
     add_rule<BinaryOpRule>(r, Symbol::ASSUME, Precedence::ASSIGNMENT);


### PR DESCRIPTION
Summary:
sizeof now requires parentheses: `sizeof(Type)` instead of `sizeof Type`. This makes the syntax consistent with the north star vision, as well as with `abs()` and other builtin functions.

Refactored `AbsRule` into a shared `BuiltinFuncRule` class parameterized by symbol and op, used by both `sizeof()` and `abs()`.

Reviewed By: felixhandte

Differential Revision: D101647381


