### PR TITLE
Encode v24 dict bundle metadata and enforce dict-backed frame requirements (#656)

### DIFF
--- a/include/openzl/zl_compress.h
+++ b/include/openzl/zl_compress.h
@@ -55,11 +55,11 @@ extern "C" {
 
 /**
  * Maximum frame-level overhead in bytes (frame header + EOF marker).
- * Generous overestimate: actual overhead is ~9-17 bytes.
+ * Generous overestimate: actual overhead is ~9-17 bytes without dict bundle.
  * Breakdown: magic (4) + flags (1) + input type (1) + input size varint (<=9)
- *          + header checksum (1) + EOF marker (1).
+ *          + bundleID (<=33) + header checksum (1) + EOF marker (1).
  */
-#define ZL_FRAME_OVERHEAD_MAX (32)
+#define ZL_FRAME_OVERHEAD_MAX (64)
 
 #define ZL_COMPRESSBOUND(s)      \
     ((s) + ZL_FRAME_OVERHEAD_MAX \

--- a/include/openzl/zl_ctransform.h
+++ b/include/openzl/zl_ctransform.h
@@ -467,7 +467,8 @@ const ZL_LocalParams* ZL_Encoder_getLocalParams(const ZL_Encoder* eic);
 
 /**
  * @returns The materialized dictionary object associated with this node, if
- * there is one. Otherwise NULL.
+ * there is one. Returns NULL if there is no dict or if the frame format is
+ * less than ZL_MATERIALIZED_DICT_VERSION_MIN.
  */
 const void* ZL_Encoder_getMaterializedDict(const ZL_Encoder* eictx);
 

--- a/include/openzl/zl_decompress.h
+++ b/include/openzl/zl_decompress.h
@@ -369,6 +369,14 @@ ZL_RESULT_DECLARE_TYPE(ZL_Comment);
  */
 ZL_RESULT_OF(ZL_Comment) ZL_FrameInfo_getComment(const ZL_FrameInfo* zfi);
 
+/**
+ * @brief Gets the dict bundle ID referenced by the frame, if any.
+ *
+ * @returns A pointer to the bundle ID stored in @p zfi, or NULL if the frame
+ * does not reference a dict bundle.
+ */
+const ZL_BundleID* ZL_FrameInfo_getBundleID(const ZL_FrameInfo* zfi);
+
 // ----------------------------------------------------
 // Decompression of Typed content
 // ----------------------------------------------------

--- a/include/openzl/zl_dictloader.h
+++ b/include/openzl/zl_dictloader.h
@@ -74,8 +74,9 @@ void* ZL_DictLoader_getOpaque(const ZL_DictLoader* loader);
  * serialization.
  *
  * Codecs that support dictionaries may fetch the materialized object (if any)
- * at both compression time and decompression time using ZL_Encoder_getDict()
- * and ZL_Decoder_getDict() respectively.
+ * at both compression time and decompression time using
+ * ZL_Encoder_getMaterializedDict() and
+ * ZL_Decoder_getMaterializedDict() respectively.
  *
  * The loader takes unconditional ownership of the materializer opaque pointer
  * and will free it upon destruction or failed registrations.

--- a/include/openzl/zl_dtransform.h
+++ b/include/openzl/zl_dtransform.h
@@ -322,6 +322,16 @@ const void* ZL_Decoder_getOpaquePtr(const ZL_Decoder* dictx);
  */
 void* ZL_Decoder_getState(const ZL_Decoder* dictx);
 
+/**
+ * @returns The materialized dictionary object resolved for this node from the
+ *          dict loader attached to the active DCtx, if there is one, otherwise
+ *          NULL.
+ *
+ * NOTE: If the frame format < ZL_MATERIALIZED_DICT_VERSION_MIN, this will
+ * necessarily return NULL.
+ */
+const void* ZL_Decoder_getMaterializedDict(const ZL_Decoder* dictx);
+
 #if defined(__cplusplus)
 } // extern "C"
 #endif

--- a/include/openzl/zl_unique_id.h
+++ b/include/openzl/zl_unique_id.h
@@ -48,6 +48,16 @@ bool ZL_UniqueID_eq(const ZL_UniqueID* lhs, const ZL_UniqueID* rhs);
  */
 ZL_UniqueID ZL_UniqueID_computeSHA256(const void* data, size_t size);
 
+/**
+ * @returns The number of significant leading bytes in @p id . Returns 0 if @p
+ * id is all zeros.
+ *
+ * Example: for an ID whose bytes 0, 1, and 4 are non-zero and bytes 5-31 are
+ * zero, this returns 5. This is useful for variable-length serialization where
+ * trailing zero bytes can be omitted.
+ */
+size_t ZL_UniqueID_significantBytes(const ZL_UniqueID* id);
+
 #if defined(__cplusplus)
 } // extern "C"
 #endif

--- a/include/openzl/zl_version.h
+++ b/include/openzl/zl_version.h
@@ -62,6 +62,9 @@ extern "C" {
 /// Minimum wire format version required to support typed input.
 #define ZL_TYPED_INPUT_VERSION_MIN (14)
 
+/// Minimum wire format version required to expose per-node materialized dicts.
+#define ZL_MATERIALIZED_DICT_VERSION_MIN (24)
+
 /**
  * @returns The current encoding version number.
  * This version number is used when the version

--- a/src/openzl/codecs/encoder_registry.c
+++ b/src/openzl/codecs/encoder_registry.c
@@ -40,6 +40,7 @@
 #include "openzl/codecs/zstd/encode_zstd_binding.h"
 #include "openzl/common/assertion.h"
 #include "openzl/compress/private_nodes.h"
+#include "openzl/dict/dict_constants.h"
 #include "openzl/shared/utils.h"
 #include "openzl/zl_version.h"
 
@@ -71,6 +72,7 @@
     .minFormatVersion = (_minFormatVersion),                        \
     .maxFormatVersion = (_maxFormatVersion),                        \
     .minLibraryVersion = (_reqLibVersion),                          \
+    .maybeDictIndex = ZL_DICT_INDEX_NONE,                           \
     .transformDesc = {                                              \
         .publicDesc = _macro(_strid),                               \
     },                                                              \

--- a/src/openzl/common/unique_id.c
+++ b/src/openzl/common/unique_id.c
@@ -60,3 +60,13 @@ ZL_UniqueID ZL_UniqueID_computeSHA256(const void* data, size_t size)
     ZL_sha256(data, size, result.bytes);
     return result;
 }
+
+size_t ZL_UniqueID_significantBytes(const ZL_UniqueID* id)
+{
+    for (size_t i = sizeof(id->bytes); i > 0; i--) {
+        if (id->bytes[i - 1] != 0) {
+            return i;
+        }
+    }
+    return 0;
+}

--- a/src/openzl/common/wire_format.h
+++ b/src/openzl/common/wire_format.h
@@ -21,6 +21,9 @@
  *   + bit0: checksum of decoded data
  *   + bit1: checksum of encoded data (also control frame header checksum)
  *   + bit2: presence of a comment field
+ *   + bit3: v24+: presence of a dict bundle ID
+ * - v24+: if bit3 set: 1-byte ID size + variable-length dict bundle ID (up to
+ * 32 bytes)
  * - Input Type :
  *   + v13-: 0-byte , 1 Input assumed to be Serial
  *   + v14 : 1-byte, single Input, selectable type
@@ -102,6 +105,11 @@
  * - V16+ : Array of nbRegens
  *   + bit-packed flags separate 1-regen decoders from 2+ ones
  *   + 2+ regens values are shifted (-2) then varint encoded
+ * - V24+ : Array of dictIdx (dict bundle offsets)
+ *   + has-dict flags are bit-packed (1 = has dict, 0 = no dict)
+ *   + if any has-dict flag is set:
+ *     1-byte nbBits = ceil(log2(maxDictIdx + 1))
+ *     non-zero dict indices are bitpacked using nbBits bits each
  * - Array of streamID distances is bitpacked,
  *   with nbBits depending on graph's size.
  *   There is 1 distance per regenerated stream.
@@ -194,6 +202,7 @@ typedef struct {
     bool hasContentChecksum;
     bool hasCompressedChecksum;
     bool hasComment;
+    bool hasBundleID;
 } ZL_FrameProperties;
 
 typedef enum { trt_standard, trt_custom } TransformType_e;

--- a/src/openzl/compress/cctx.c
+++ b/src/openzl/compress/cctx.c
@@ -26,6 +26,7 @@
 #include "openzl/compress/rtgraphs.h"            // RTGraph, RTStreamID
 #include "openzl/compress/segmenter.h"           // SEGM_*
 #include "openzl/compress/trStates.h"            // TrStates
+#include "openzl/dict/dict_constants.h"          // ZL_DICT_INDEX_NONE
 #include "openzl/zl_buffer.h"                    // ZL_RBuffer
 #include "openzl/zl_compress.h"
 #include "openzl/zl_compressor.h"
@@ -1629,6 +1630,11 @@ static ZL_Report CCTX_writeChunkHeader(
         .hasCompressedChecksum =
                 CCTX_getAppliedGParam(cctx, ZL_CParam_compressedChecksum)
                 != ZL_TernaryParam_disable,
+        .hasBundleID =
+                (formatVersion >= ZL_MATERIALIZED_DICT_VERSION_MIN
+                 && CCTX_getCGraph(cctx) != NULL
+                 && ZL_Compressor_getDictBundleID(CCTX_getCGraph(cctx))
+                         != NULL),
     };
     return EFH_writeChunkHeader(dst, dstCapacity, &info, gi, formatVersion);
 }
@@ -1897,6 +1903,8 @@ ZL_Report CCTX_getFinalGraph(ZL_CCtx* cctx, GraphInfo* gip)
     ALLOC_ARENA_MALLOC_CHECKED(size_t, nbVOs, nbTransforms, cctx->chunkArena);
     ALLOC_ARENA_MALLOC_CHECKED(
             size_t, nbTrInputs, nbTransforms, cctx->chunkArena);
+    ALLOC_ARENA_MALLOC_CHECKED(
+            uint32_t, dictIdxs, nbTransforms, cctx->chunkArena);
     ALLOC_ARENA_CALLOC_CHECKED(
             ZL_RBuffer, buffs, nbStreamsMax, cctx->chunkArena);
     ALLOC_ARENA_MALLOC_CHECKED(
@@ -1906,6 +1914,7 @@ ZL_Report CCTX_getFinalGraph(ZL_CCtx* cctx, GraphInfo* gip)
     gip->trHSizes    = trHSizes;
     gip->nbVOs       = nbVOs;
     gip->nbTrInputs  = nbTrInputs;
+    gip->dictIdxs    = dictIdxs;
     gip->storedBuffs = buffs;
     gip->inputDescs  = inputDescs;
 
@@ -1935,6 +1944,7 @@ ZL_Report CCTX_getFinalGraph(ZL_CCtx* cctx, GraphInfo* gip)
         nbVOs[n] = RTGM_getNbOutStreams(&cctx->rtgraph, rtnid)
                 - CNODE_getNbOut1s(cnode);
         nbTrInputs[n] = RTGM_getNbInStreams(&cctx->rtgraph, rtnid);
+        dictIdxs[n]   = CNODE_getDictIndex(cnode);
         nbDistances += nbTrInputs[n];
         ZL_DLOG(BLOCK,
                 "CCTX_getFinalGraph: stage %u uses Transform ID %u ",

--- a/src/openzl/compress/cgraph.c
+++ b/src/openzl/compress/cgraph.c
@@ -1329,8 +1329,10 @@ ZL_Report CGraph_resolveDictIndices(ZL_Compressor* cgraph)
             continue;
 
         const ZL_UniqueID* dictUID = &cnode->transformDesc.publicDesc.dictID.id;
-        if (!ZL_UniqueID_isValid(dictUID))
+        if (!ZL_UniqueID_isValid(dictUID)) {
+            CTM_setDictIndex(ctm, cnodeID, ZL_DICT_INDEX_NONE);
             continue;
+        }
 
         // This CNode requires a dictionary — resolve its bundle index
         ZL_ERR_IF_NULL(
@@ -1340,7 +1342,7 @@ ZL_Report CGraph_resolveDictIndices(ZL_Compressor* cgraph)
                 CNODE_getName(cnode));
 
         bool found = false;
-        for (size_t j = 0; j < bundle->info.numDicts; ++j) {
+        for (uint32_t j = 0; j < bundle->info.numDicts; ++j) {
             if (ZL_UniqueID_eq(dictUID, &bundle->info.dictIDs[j].id)) {
                 CTM_setDictIndex(ctm, cnodeID, j);
                 found = true;
@@ -1360,7 +1362,7 @@ ZL_Report ZL_Compressor_Node_getDictIndex(
         ZL_Compressor const* cgraph,
         ZL_NodeID node)
 {
-    size_t index = CNODE_getDictIndex(CGRAPH_getCNode(cgraph, node));
+    uint32_t index = CNODE_getDictIndex(CGRAPH_getCNode(cgraph, node));
     if (index == ZL_DICT_INDEX_NONE) {
         return ZL_returnError(ZL_ErrorCode_dictNoRecord);
     }

--- a/src/openzl/compress/cnode.c
+++ b/src/openzl/compress/cnode.c
@@ -208,7 +208,7 @@ ZL_DictID CNODE_getDictID(CNode const* cnode)
     return cnode->transformDesc.publicDesc.dictID;
 }
 
-size_t CNODE_getDictIndex(CNode const* cnode)
+uint32_t CNODE_getDictIndex(CNode const* cnode)
 {
     ZL_ASSERT_NN(cnode);
     ZL_ASSERT_EQ(cnode->nodetype, node_internalTransform);

--- a/src/openzl/compress/cnode.h
+++ b/src/openzl/compress/cnode.h
@@ -22,7 +22,7 @@ typedef struct {
     /// populated with the index of that dict within the compressor's bundle.
     /// The "default" value is updated when ZL_Compressor_validate() is called,
     /// before compression starts.
-    size_t maybeDictIndex /* defaults to ZL_DICT_INDEX_NONE */;
+    uint32_t maybeDictIndex /* defaults to ZL_DICT_INDEX_NONE */;
     /// If an MParam is specified in the transformDesc, this field is populated
     /// upon registration time with a pointer to the materialized object. The
     /// CNode does not own the object, the ZL_Compressor owns it via the
@@ -150,7 +150,7 @@ ZL_DictID CNODE_getDictID(CNode const* cnode);
 /// @returns the dict index within the compressor's bundle for the @p cnode,
 /// or ZL_DICT_INDEX_NONE if no dictionary is associated.
 /// @pre cnode->nodetype == node_internalTransform
-size_t CNODE_getDictIndex(CNode const* cnode);
+uint32_t CNODE_getDictIndex(CNode const* cnode);
 
 const void* CNODE_getMParamObj(CNode const* cnode);
 const ZL_MParamID* CNODE_getMParamID(CNode const* cnode);

--- a/src/openzl/compress/cnodes.c
+++ b/src/openzl/compress/cnodes.c
@@ -433,7 +433,7 @@ ZL_IDType CTM_nbCNodes(const CNodes_manager* ctm)
     return (ZL_IDType)VECTOR_SIZE(ctm->cnodes);
 }
 
-void CTM_setDictIndex(CNodes_manager* ctm, CNodeID id, size_t index)
+void CTM_setDictIndex(CNodes_manager* ctm, CNodeID id, uint32_t index)
 {
     ZL_ASSERT_NN(ctm);
     ZL_ASSERT_LT(id.cnid, VECTOR_SIZE(ctm->cnodes));

--- a/src/openzl/compress/cnodes.h
+++ b/src/openzl/compress/cnodes.h
@@ -79,7 +79,7 @@ CTM_registerStandardTransform(
 
 /// Sets the dict index for a CNode. Used during validation to resolve
 /// the dict's position within the compressor's bundle.
-void CTM_setDictIndex(CNodes_manager* ctm, CNodeID id, size_t index);
+void CTM_setDictIndex(CNodes_manager* ctm, CNodeID id, uint32_t index);
 
 /**
  * Rolls back the registration of @p id

--- a/src/openzl/compress/compress2.c
+++ b/src/openzl/compress/compress2.c
@@ -15,7 +15,8 @@
 #include "openzl/shared/mem.h"                  // writeLE32
 #include "openzl/shared/xxhash.h"               // XXH3_64bits
 #include "openzl/zl_common_types.h" // ZL_TernaryParam_enable, ZL_TernaryParam_disable
-#include "openzl/zl_compress.h" // ZS2_compress_*
+#include "openzl/zl_compress.h"   // ZS2_compress_*
+#include "openzl/zl_compressor.h" // ZL_Compressor_getDictBundleID
 #include "openzl/zl_data.h"
 #include "openzl/zl_errors.h"
 
@@ -61,7 +62,11 @@ static ZL_Report writeFrameHeader(
         inputDescs[n].numElts  = ZL_Data_numElts(inputs[n]);
     }
 
-    ZL_Comment comment = CCTX_getHeaderComment(cctx);
+    ZL_Comment comment          = CCTX_getHeaderComment(cctx);
+    const ZL_BundleID* bundleID = CCTX_getCGraph(cctx)
+            ? ZL_Compressor_getDictBundleID(CCTX_getCGraph(cctx))
+            : NULL;
+
     // Requested frame properties (checksum)
     ZL_FrameProperties const fprop = {
         .hasContentChecksum =
@@ -71,6 +76,9 @@ static ZL_Report writeFrameHeader(
                 CCTX_getAppliedGParam(cctx, ZL_CParam_compressedChecksum)
                 != ZL_TernaryParam_disable,
         .hasComment = (comment.size != 0),
+        .hasBundleID =
+                (formatVersion >= ZL_MATERIALIZED_DICT_VERSION_MIN
+                 && bundleID != NULL),
     };
 
     EFH_FrameInfo const fi = {
@@ -78,6 +86,7 @@ static ZL_Report writeFrameHeader(
         .numInputs  = numInputs,
         .fprop      = &fprop,
         .comment    = comment,
+        .bundleID   = bundleID,
     };
 
     ZL_Report const r =

--- a/src/openzl/compress/enc_interface.c
+++ b/src/openzl/compress/enc_interface.c
@@ -16,6 +16,7 @@
 #include "openzl/zl_common_types.h"     // ZL_TernaryParam_disable
 #include "openzl/zl_compressor.h"
 #include "openzl/zl_data.h"
+#include "openzl/zl_version.h"
 
 ZL_Report ENC_initEICtx(
         ZL_Encoder* eictx,
@@ -95,7 +96,12 @@ const void* ZL_Encoder_getMaterializedDict(const ZL_Encoder* eictx)
     ZL_ASSERT_NN(eictx);
     if (eictx->cnode == NULL)
         return NULL;
-    size_t offset = CNODE_getDictIndex(eictx->cnode);
+    if ((unsigned)CCTX_getAppliedGParam(eictx->cctx, ZL_CParam_formatVersion)
+        < ZL_MATERIALIZED_DICT_VERSION_MIN) {
+        ZL_ASSERT_EQ(CNODE_getDictIndex(eictx->cnode), ZL_DICT_INDEX_NONE);
+        return NULL;
+    }
+    uint32_t offset = CNODE_getDictIndex(eictx->cnode);
     if (offset == ZL_DICT_INDEX_NONE)
         return NULL;
     return CGRAPH_getDictObj(CCTX_getCGraph(eictx->cctx), offset);
@@ -375,6 +381,17 @@ ZL_Report ENC_runTransform(
             lparams);
     if (lparams == NULL)
         lparams = CNODE_getLocalParams(cnode);
+    if (cnode->maybeDictIndex != ZL_DICT_INDEX_NONE
+        && CCTX_getAppliedGParam(cctx, ZL_CParam_formatVersion)
+                < ZL_MATERIALIZED_DICT_VERSION_MIN) {
+        char const* const nodeName = CNODE_getName(cnode);
+        ZL_ERR(formatVersion_unsupported,
+               "Frame format version %u does not support dict-backed transforms. "
+               "Node `%s` requires a dictionary; use format version >= %u.",
+               CCTX_getAppliedGParam(cctx, ZL_CParam_formatVersion),
+               nodeName == NULL ? "<unnamed>" : nodeName,
+               ZL_MATERIALIZED_DICT_VERSION_MIN);
+    }
     ZL_Encoder eiState;
     ZL_ERR_IF_ERR(ENC_initEICtx(
             &eiState, cctx, wkspArena, &rtnodeid, cnode, lparams, trstates));

--- a/src/openzl/compress/encode_frameheader.c
+++ b/src/openzl/compress/encode_frameheader.c
@@ -13,11 +13,13 @@
 #include "openzl/common/limits.h"
 #include "openzl/common/logging.h"     // ZL_LOG
 #include "openzl/common/wire_format.h" // ZSTRONG_MAGIC_NUMBER, ZL_FrameProperties
-#include "openzl/shared/mem.h"         // writeLE32
-#include "openzl/shared/varint.h"      // ZL_varintEncode
-#include "openzl/shared/xxhash.h"      // XXH3_64bits
-#include "openzl/zl_data.h"            // ZL_Type
+#include "openzl/dict/dict_constants.h" // ZL_DICT_INDEX_NONE, ZL_UNIQUE_ID_SIZE
+#include "openzl/shared/mem.h"          // writeLE32
+#include "openzl/shared/varint.h"       // ZL_varintEncode
+#include "openzl/shared/xxhash.h"       // XXH3_64bits
+#include "openzl/zl_data.h"             // ZL_Type
 #include "openzl/zl_errors.h"
+#include "openzl/zl_unique_id.h" // ZL_UniqueID_significantBytes
 #include "openzl/zl_version.h"
 
 // computeFHsize() :
@@ -49,7 +51,8 @@ static ZL_Report computeFHBound(
 
     const size_t bound = 4 + (numInputs * 5) + ZL_varintSize(nbTransforms)
             + ZL_varintSize(nbBuffs - 1) + (nbBuffs * 4) + (nbTransforms * 22)
-            + (nbRegens * 4) + 4 + 4;
+            + (nbRegens * 4) + 4 + 4 + ((nbTransforms + 7) / 8) + 1
+            + (nbTransforms * 3);
     return ZL_returnValue(bound);
 }
 
@@ -323,6 +326,44 @@ static void compressNumInputs(
     }
 }
 
+// Compress per-codec dict bundle offsets (v24+)
+// - Bitmap encode has-dict flags (1 = has dict, 0 = no dict)
+// - Bitpack encode raw dict indices for has-dict entries
+static void compressDictIdxs(
+        ZL_WC* out,
+        const uint32_t dictIdxs[],
+        size_t nbCodecs,
+        uint32_t* wksp0,
+        uint32_t* wksp1)
+{
+    // Build bitmap and collect non-zero values
+    size_t nbNonZero = 0;
+    for (size_t n = 0; n < nbCodecs; n++) {
+        if (dictIdxs[n] != ZL_DICT_INDEX_NONE) {
+            wksp0[n]           = 1;
+            wksp1[nbNonZero++] = dictIdxs[n];
+        } else {
+            wksp0[n] = 0;
+        }
+    }
+
+    // bitpack has-dict flags
+    ZL_WC_bitpackEncode32(out, wksp0, nbCodecs, 1);
+
+    // bitpack non-empty values
+    if (nbNonZero > 0) {
+        uint32_t maxVal = 0;
+        for (size_t u = 0; u < nbNonZero; u++) {
+            if (wksp1[u] > maxVal)
+                maxVal = wksp1[u];
+        }
+        int const nbBits = ZL_nextPow2(maxVal + 1);
+        ZL_ASSERT_LE(nbBits, 16);
+        ZL_WC_push(out, (uint8_t)nbBits);
+        ZL_WC_bitpackEncode32(out, wksp1, nbNonZero, nbBits);
+    }
+}
+
 // Compress Stream Distances information
 // Values are bitpacked. nbBits is determined by Graph's size (bound)
 // Ideas for the future (@Cyan):
@@ -455,6 +496,11 @@ static ZL_Report writeFrameHeader_internal(
     ZL_TRY_LET(size_t, hsBound, computeFHBound(fip->numInputs, 0, 0, 0));
     // Add comment bytes relaxing header bound
     hsBound += fip->comment.size ? 4 + fip->comment.size : 0;
+    // Add bundleID bytes (v24+): 1 size byte + up to 32 ID bytes
+    if (encoder->formatVersion >= ZL_MATERIALIZED_DICT_VERSION_MIN
+        && fip->fprop->hasBundleID) {
+        hsBound += 1 + ZL_UNIQUE_ID_SIZE;
+    }
     ZL_DLOG(FRAME,
             "writeFrameHeader_internal (nbInputs=%zu, maxBound=%zu bytes)",
             fip->numInputs,
@@ -478,7 +524,23 @@ static ZL_Report writeFrameHeader_internal(
         if (encoder->formatVersion >= ZL_COMMENT_VERSION_MIN
             && fip->fprop->hasComment)
             flags |= 1 << 2;
+        if (encoder->formatVersion >= ZL_MATERIALIZED_DICT_VERSION_MIN
+            && fip->fprop->hasBundleID)
+            flags |= 1 << 3;
         ZL_WC_push(&out, flags);
+    }
+
+    // Store dict bundle ID (v24+): 1-byte size + variable-length ID
+    if (encoder->formatVersion >= ZL_MATERIALIZED_DICT_VERSION_MIN
+        && fip->fprop->hasBundleID) {
+        ZL_ASSERT_NN(fip->bundleID);
+        size_t const sigBytes =
+                ZL_UniqueID_significantBytes(&fip->bundleID->id);
+        ZL_ERR_IF_EQ(
+                sigBytes, 0, nodeParameter_invalid, "invalid (zero) bundle ID");
+        uint8_t const encLen = (uint8_t)sigBytes;
+        ZL_WC_push(&out, encLen);
+        ZL_WC_shove(&out, fip->bundleID->id.bytes, encLen);
     }
 
     // Nb of Inputs and their types
@@ -817,6 +879,14 @@ static ZL_Report writeChunkHeaderV8_internal(
                     "Version %u encoding format does not support Transforms featuring 2+ inputs",
                     encoder->formatVersion);
         }
+    }
+
+    /* Encode per-codec dict indices (v24+ only, when bundle is present)
+     */
+    if (encoder->formatVersion >= ZL_MATERIALIZED_DICT_VERSION_MIN
+        && fprop->hasBundleID) {
+        compressDictIdxs(
+                &out, gip->dictIdxs, nbCodecs, wksp->scratch0, wksp->scratch1);
     }
 
     /* Encode Regen Distances */

--- a/src/openzl/compress/encode_frameheader.h
+++ b/src/openzl/compress/encode_frameheader.h
@@ -31,6 +31,8 @@ typedef struct {
     const InputDesc* inputDescs; /**< Array of input stream's properties */
     size_t numInputs;
     ZL_Comment comment;
+    const ZL_BundleID* bundleID; /**< vZL_MATERIALIZED_DICT_VERSION_MIN+:
+                                    dict bundle ID, or NULL */
 } EFH_FrameInfo;
 
 /**
@@ -65,6 +67,7 @@ typedef struct {
     const size_t* trHSizes;   /**< Array of transform header sizes (bytes) */
     const size_t* nbVOs;      /**< Array of output counts per transform */
     const size_t* nbTrInputs; /**< Array of input counts per transform */
+    const uint32_t* dictIdxs; /**< Array of dict bundle offsets per transform */
     const uint32_t*
             distances;  /**< Array of dependency distances between transforms */
     size_t nbDistances; /**< Number of dependency distance entries */

--- a/src/openzl/decompress/dctx2.h
+++ b/src/openzl/decompress/dctx2.h
@@ -3,7 +3,6 @@
 #ifndef ZSTRONG_DECOMPRESS_DCTX2_H
 #define ZSTRONG_DECOMPRESS_DCTX2_H
 
-#include "openzl/common/wire_format.h"            // PublicTransformInfo
 #include "openzl/decompress/decode_frameheader.h" // DFH_Struct
 #include "openzl/shared/portability.h"
 #include "openzl/zl_data.h"         // ZL_Type

--- a/src/openzl/decompress/decode_frameheader.c
+++ b/src/openzl/decompress/decode_frameheader.c
@@ -12,15 +12,17 @@
 #include "openzl/common/assertion.h"  // ZS_ASSERT_*
 #include "openzl/common/cursor.h"     // ZL_RC
 #include "openzl/common/limits.h"
-#include "openzl/common/wire_format.h" // ZL_StandardTransformID_numBits
-#include "openzl/fse/fse.h"            // FSE_getErrorName
-#include "openzl/fse/hist.h"           // HIST_count_simple
+#include "openzl/common/wire_format.h"  // ZL_StandardTransformID_numBits
+#include "openzl/dict/dict_constants.h" // ZL_MAX_DICTS_PER_BUNDLE
+#include "openzl/fse/fse.h"             // FSE_getErrorName
+#include "openzl/fse/hist.h"            // HIST_count_simple
 #include "openzl/shared/bits.h"
 #include "openzl/shared/mem.h"    // ZL_readLE32, etc.
 #include "openzl/shared/xxhash.h" // XXH3_64bits
 #include "openzl/zl_data.h"
 #include "openzl/zl_decompress.h" // ZS2_* public methods
 #include "openzl/zl_errors.h"     // ZL_Report
+#include "openzl/zl_unique_id.h"
 #include "openzl/zl_version.h"
 
 // -------------------------------------------------
@@ -36,6 +38,7 @@ struct ZL_FrameInfo {
     size_t frameHeaderSize;
     void* comment;
     size_t commentSize;
+    ZL_BundleID bundleID; // v24+: dict bundle ID
 };
 
 static ZL_Type decodeType(uint8_t et)
@@ -151,7 +154,8 @@ static ZL_Report DFH_decoderOutputTypes(
         size_t done = 0;
         if (nbOutputs <= 14) {
             // First 2 output types stored in first byte
-            uint8_t const token1 = ((const uint8_t*)cSrc)[5];
+            // (the same byte that DFH_decodeNbOutputs already consumed)
+            uint8_t const token1 = ((const uint8_t*)cSrc)[*consumedPtr - 1];
             size_t const max     = ZL_MIN(2, nbOutputs);
             for (size_t n = 0; n < max; n++) {
                 size_t const shift = n * 2 + 4;
@@ -290,6 +294,29 @@ static ZL_Report DFH_FrameInfo_decodeFrameHeader(
         zfi->properties.hasContentChecksum    = ((flags & (1 << 0)) != 0);
         zfi->properties.hasCompressedChecksum = ((flags & (1 << 1)) != 0);
         zfi->properties.hasComment            = ((flags & (1 << 2)) != 0);
+        zfi->properties.hasBundleID =
+                (formatVersion >= ZL_MATERIALIZED_DICT_VERSION_MIN)
+                && ((flags & (1 << 3)) != 0);
+    }
+
+    // Decode dict bundle ID (v24+): 1-byte size + variable-length ID
+    if (zfi->properties.hasBundleID) {
+        ZL_ERR_IF_LE(cSize, consumed, corruption);
+        uint8_t const encLen = ptr[consumed++];
+        ZL_ERR_IF_EQ(
+                encLen,
+                0,
+                corruption,
+                "bundleID size byte is 0 but flag is set");
+        ZL_ERR_IF_GT(
+                encLen,
+                ZL_UNIQUE_ID_SIZE,
+                corruption,
+                "bundleID size too large");
+        ZL_ERR_IF_LT(cSize, consumed + encLen, corruption);
+        memset(zfi->bundleID.id.bytes, 0, ZL_UNIQUE_ID_SIZE);
+        memcpy(zfi->bundleID.id.bytes, ptr + consumed, encLen);
+        consumed += encLen;
     }
 
     /* nb of outputs */
@@ -499,6 +526,12 @@ ZL_RESULT_OF(ZL_Comment) ZL_FrameInfo_getComment(const ZL_FrameInfo* zfi)
     return ZL_WRAP_VALUE(comment);
 }
 
+const ZL_BundleID* ZL_FrameInfo_getBundleID(const ZL_FrameInfo* zfi)
+{
+    ZL_ASSERT_NN(zfi);
+    return ZL_UniqueID_isValid(&zfi->bundleID.id) ? &zfi->bundleID : NULL;
+}
+
 // --------------------------
 // Header parsing
 // --------------------------
@@ -607,7 +640,19 @@ ZL_Report ZL_getOutputType(ZL_Type* typePtr, const void* cSrc, size_t cSize)
         *typePtr = decodeType(typeEncoded);
     } else { // formatVersion >= ZL_CHUNK_VERSION_MIN
         ZL_ERR_IF_LT(cSize, 6, srcSize_tooSmall);
-        uint8_t const typeEncoded = ((const uint8_t*)cSrc)[5];
+        uint8_t const flags = ((const uint8_t*)cSrc)[4];
+        int const hasBundleID =
+                (formatVersion >= ZL_MATERIALIZED_DICT_VERSION_MIN)
+                && ((flags & (1 << 3)) != 0);
+        // Skip: flags(1) + [sizebyte(1) + bundleID(sizeByte)] if present
+        size_t bundleIDFieldLen = 0;
+        if (hasBundleID) {
+            uint8_t const idLen = ((const uint8_t*)cSrc)[5];
+            bundleIDFieldLen    = 1 + idLen;
+        }
+        size_t const tokenOffset = 5 + bundleIDFieldLen;
+        ZL_ERR_IF_LT(cSize, tokenOffset + 1, srcSize_tooSmall);
+        uint8_t const typeEncoded = ((const uint8_t*)cSrc)[tokenOffset];
         ZL_ERR_IF_NE(typeEncoded & 15, 1, invalidRequest_singleOutputFrameOnly);
         *typePtr = decodeType((typeEncoded >> 4) & 3);
     }
@@ -845,6 +890,60 @@ static ZL_Report decompressNbRegens(
                     corruption);
         } else {
             nbRegens[u] = 1;
+        }
+    }
+
+    return ZL_returnSuccess();
+}
+
+// Decompress per-codec dict bundle offsets
+// (v24+)
+// has-dict flags are bitpacked
+// non-zero dict indices are bitpacked
+static ZL_Report decompressDictIdxs(
+        uint32_t dictIdxs[],
+        size_t nbTransforms,
+        ZL_RC* src,
+        uint32_t* valuesWksp)
+{
+    ZL_RESULT_DECLARE_SCOPE_REPORT(NULL);
+    // Decode bitmap into dictIdxs (0 = no dict, 1 = has dict)
+    ZL_ERR_IF_ERR(checkedBitpackDecode32(dictIdxs, nbTransforms, src, 1));
+
+    // Count non-zero entries
+    size_t nbNonZero = 0;
+    for (size_t u = 0; u < nbTransforms; u++) {
+        if (dictIdxs[u] != 0)
+            nbNonZero++;
+    }
+
+    if (nbNonZero > 0) {
+        // Read nbBits
+        ZL_ERR_IF_LT(ZL_RC_avail(src), 1, srcSize_tooSmall);
+        uint8_t const nbBits = ZL_RC_pop(src);
+        ZL_ERR_IF_GT(nbBits, 16, corruption, "dictIdx nbBits too large");
+
+        // Decode bitpacked values into separate workspace
+        ZL_ERR_IF_ERR(
+                checkedBitpackDecode32(valuesWksp, nbNonZero, src, nbBits));
+
+        // Merge: walk forward, overwriting bitmap flags with actual values
+        size_t idx = 0;
+        for (size_t u = 0; u < nbTransforms; u++) {
+            if (dictIdxs[u]) {
+                ZL_ERR_IF_GT(
+                        valuesWksp[idx],
+                        ZL_MAX_DICTS_PER_BUNDLE,
+                        corruption,
+                        "dictIdx value above allowed range");
+                dictIdxs[u] = valuesWksp[idx++];
+            } else {
+                dictIdxs[u] = ZL_DICT_INDEX_NONE;
+            }
+        }
+    } else {
+        for (size_t u = 0; u < nbTransforms; u++) {
+            dictIdxs[u] = ZL_DICT_INDEX_NONE;
         }
     }
 
@@ -1119,6 +1218,22 @@ static ZL_Report decodeChunkHeader_internal(
         totalNbRegens = nbDecoders;
     }
 
+    // Decode per-codec dict indices if a bundle is declared
+    // (v24+ only)
+    if (decoder->formatVersion >= ZL_MATERIALIZED_DICT_VERSION_MIN
+        && dfh->frameinfo->properties.hasBundleID) {
+        uint32_t* const dictIdxs = wksp.scratch0;
+        ZL_ERR_IF_ERR(
+                decompressDictIdxs(dictIdxs, nbDecoders, &in, wksp.scratch1));
+        for (unsigned u = 0; u < nbDecoders; u++) {
+            nodes[u].dictIdx = dictIdxs[u];
+        }
+    } else {
+        for (unsigned u = 0; u < nbDecoders; u++) {
+            nodes[u].dictIdx = ZL_DICT_INDEX_NONE;
+        }
+    }
+
     // Decode regen stream id distance (1 per Transform)
     ZL_DLOG(SEQ, "totalNbRegens = %zu", totalNbRegens);
     ZL_ERR_IF_NE(
@@ -1188,12 +1303,25 @@ static ZL_Report getDecompressedSizeV3orMore(
 {
     ZL_RESULT_DECLARE_SCOPE_REPORT(NULL);
     ZL_DLOG(FRAME, "getDecompressedSizeV3orMore (from srcSize=%zu)", srcSize);
+    ZL_ERR_IF_LT(srcSize, 5, srcSize_tooSmall);
+    uint8_t const flags = ((const uint8_t*)src)[4];
+    int const hasBundleID =
+            (decoder->formatVersion >= ZL_MATERIALIZED_DICT_VERSION_MIN)
+            && ((flags & (1 << 3)) != 0);
+    size_t bundleIDFieldLen = 0;
+    if (hasBundleID) {
+        ZL_ERR_IF_LT(srcSize, 6, srcSize_tooSmall);
+        uint8_t const idLen = ((const uint8_t*)src)[5];
+        bundleIDFieldLen    = 1 + idLen;
+    }
     size_t const hSize = (size_t)4 + (decoder->formatVersion > 13)
-            + (decoder->formatVersion >= ZL_CHUNK_VERSION_MIN);
+            + (decoder->formatVersion >= ZL_CHUNK_VERSION_MIN)
+            + bundleIDFieldLen;
     ZL_ERR_IF_LT(srcSize, hSize + 4, srcSize_tooSmall);
     if (decoder->formatVersion > 14) {
         uint8_t token1 = ((const uint8_t*)src)
-                [4 + (decoder->formatVersion >= ZL_CHUNK_VERSION_MIN)];
+                [4ul + (decoder->formatVersion >= ZL_CHUNK_VERSION_MIN)
+                 + bundleIDFieldLen];
         ZL_ERR_IF_GE(
                 token1,
                 64,

--- a/src/openzl/decompress/decode_frameheader.h
+++ b/src/openzl/decompress/decode_frameheader.h
@@ -41,6 +41,10 @@ typedef struct {
      */
     uint32_t numInputStreams;
     /**
+     * Dict bundle offset from chunk header (ZL_DICT_INDEX_NONE if unset)
+     */
+    uint32_t dictIdx;
+    /**
      * If this node is fused, a pointer to the fusion descriptor.
      * @note Set by the dctx after decoding the frame header.
      */

--- a/src/openzl/decompress/decoder_fusion.c
+++ b/src/openzl/decompress/decoder_fusion.c
@@ -294,7 +294,9 @@ ZL_DecoderFusion_runCodec(ZL_DecoderFusion* state, size_t idx)
     ZL_ERR_IF_GE(idx, state->numCodecs, logicError);
     const DFH_NodeInfo* nodeInfo = state->nodeInfos[idx];
     ZL_ERR_IF_ERR(DCTX_runDecoder(
-            state->dctx, nodeInfo, /* withinFusedDecoder */ true));
+            state->dctx,
+            nodeInfo,
+            /* withinFusedDecoder */ true));
 
     const ZL_IDType inputEndIdx =
             nodeInfo->inputStreamBaseIdx + nodeInfo->numInputStreams;

--- a/src/openzl/decompress/decompress2.c
+++ b/src/openzl/decompress/decompress2.c
@@ -19,14 +19,18 @@
 #include "openzl/decompress/dictx.h"       // struct ZL_Decoder_s
 #include "openzl/decompress/dtransforms.h" // DTransforms_manager, TransformID
 #include "openzl/decompress/gdparams.h"
-#include "openzl/shared/mem.h"    // ZL_readLE32, etc.
-#include "openzl/shared/xxhash.h" // XXH3_64bits
-#include "openzl/zl_buffer.h"     // ZL_RBuffer
+#include "openzl/dict/dict_constants.h" // ZL_DICT_INDEX_NONE
+#include "openzl/dict/dictloader.h"     // struct ZL_DictLoader_s
+#include "openzl/shared/mem.h"          // ZL_readLE32, etc.
+#include "openzl/shared/xxhash.h"       // XXH3_64bits
+#include "openzl/zl_buffer.h"           // ZL_RBuffer
 #include "openzl/zl_data.h"
 #include "openzl/zl_decompress.h" // ZL_TypedDecoderDesc
+#include "openzl/zl_dict.h"       // ZL_Dict, ZL_DictBundle
 #include "openzl/zl_dtransform.h" //
 #include "openzl/zl_errors.h"
 #include "openzl/zl_opaque_types.h" // ZL_IDType
+#include "openzl/zl_unique_id.h"
 #include "openzl/zl_version.h"
 
 // --------------------------
@@ -86,9 +90,10 @@ struct ZL_DCtx_s {
     Arena* fusionWkspArena;
     Arena* streamArena;
     ZL_OperationContext opCtx;
-    GDParams requestedGDParams; // As user-selected at DCtx level
-    GDParams appliedGDParams;   // Used at decompression time; DCtx > default
-    ZL_DictLoader* dictLoader;  // Referenced, not owned
+    GDParams requestedGDParams;  // As user-selected at DCtx level
+    GDParams appliedGDParams;    // Used at decompression time; DCtx > default
+    ZL_DictLoader* dictLoader;   // Referenced, not owned
+    const ZL_DictBundle* bundle; // Current frame's resolved bundle, or NULL
 }; // typedef'd to ZL_DCtx within zs2_decompress.h
 
 // --------------------------
@@ -1520,6 +1525,26 @@ ZL_Report DCTX_runDecoder(
             trName,
             dt->miGraphDesc.CTid,
             nodeInfo->nbRegens);
+
+    uint32_t const dictIdx = nodeInfo->dictIdx;
+    const void* ddict      = NULL;
+    /* Resolve dict from bundle if this transform uses a dictionary */
+    if (dictIdx != ZL_DICT_INDEX_NONE) {
+        ZL_ASSERT_NN(dctx->bundle);
+        ZL_ERR_IF(
+                dictIdx >= dctx->bundle->info.numDicts,
+                corruption,
+                "dictIdx %u out of range (bundle has %zu dicts)",
+                (unsigned)dictIdx,
+                dctx->bundle->info.numDicts);
+        ZL_ERR_IF_NULL(
+                dctx->bundle->dicts[dictIdx]->dictObj,
+                dict_materialization,
+                "Dict at index %u has not been materialized",
+                (unsigned)dictIdx);
+        ddict = dctx->bundle->dicts[dictIdx]->dictObj;
+    }
+
     struct ZL_Decoder_s diState = {
         .dctx           = dctx,
         .dt             = dt,
@@ -1528,6 +1553,7 @@ ZL_Report DCTX_runDecoder(
         .regensID       = regensID,
         .nbRegens       = nodeInfo->nbRegens,
         .thContent      = thContent,
+        .ddict          = ddict,
     };
     ZL_ERR_IF_NULL(
             diState.statePtr,
@@ -1931,6 +1957,22 @@ ZL_Report ZL_DCtx_decompressMultiTBuffer(
             consumed,
             decodeFrameHeader(dctx, framePtr, frameSize, nbOutputs));
     ZL_DLOG(SEQ, "decoded frame header, of size %zu bytes", consumed);
+    dctx->bundle = NULL;
+    {
+        const ZL_BundleID* const bundleID =
+                ZL_FrameInfo_getBundleID(dctx->dfh.frameinfo);
+        if (bundleID != NULL) {
+            ZL_ERR_IF_NULL(
+                    dctx->dictLoader,
+                    dictNoRecord,
+                    "Frame references a dict bundle but no dict loader is attached");
+            dctx->bundle = DictLoader_getDictBundle(dctx->dictLoader, bundleID);
+            ZL_ERR_IF_NULL(
+                    dctx->bundle,
+                    dictNoRecord,
+                    "Could not fetch dict bundle required by the frame");
+        }
+    }
 
     // check buffers in outputs objects
     for (size_t n = 0; n < nbOutputs; n++) {

--- a/src/openzl/decompress/dictx.c
+++ b/src/openzl/decompress/dictx.c
@@ -6,6 +6,7 @@
 #include "openzl/common/operation_context.h" // ZL_OperationContext
 #include "openzl/decompress/dctx2.h"         // DCTX_* declarations
 #include "openzl/zl_data.h"
+#include "openzl/zl_version.h"
 
 ZL_Decoder* DI_createDICtx(ZL_DCtx* dctx)
 {
@@ -209,6 +210,16 @@ void* ZL_Decoder_getState(const ZL_Decoder* dictx)
 size_t DI_getNbRegens(const ZL_Decoder* dictx)
 {
     return dictx->nbRegens;
+}
+
+const void* ZL_Decoder_getMaterializedDict(const ZL_Decoder* dictx)
+{
+    ZL_ASSERT_NN(dictx);
+    if (DI_getFrameFormatVersion(dictx) < ZL_MATERIALIZED_DICT_VERSION_MIN) {
+        ZL_ASSERT_NULL(dictx->ddict);
+        return NULL;
+    }
+    return dictx->ddict;
 }
 
 void* ZL_Decoder_getScratchSpace(ZL_Decoder* di, size_t size)

--- a/src/openzl/decompress/dictx.h
+++ b/src/openzl/decompress/dictx.h
@@ -48,6 +48,7 @@ struct ZL_Decoder_s {
     const ZL_IDType* regensID;
     size_t nbRegens;
     ZL_RBuffer thContent;
+    const void* ddict; // materialized dict object (NULL if none)
 }; // typedef'd to ZL_Decoder within "zs2_dtransform.h"
 
 ZL_Decoder* DI_createDICtx(ZL_DCtx* dctx);

--- a/src/openzl/dict/dict_constants.h
+++ b/src/openzl/dict/dict_constants.h
@@ -3,7 +3,7 @@
 #ifndef OPENZL_DICT_DICT_CONSTANTS_H
 #define OPENZL_DICT_DICT_CONSTANTS_H
 
-#include <stddef.h> /* size_t */
+#include <stdint.h> /* uint32_t */
 
 /**
  * Shared wire-format constants for dict and bundle serialization.
@@ -26,6 +26,6 @@
 
 #define ZL_MAX_BUNDLES_PER_FATBUNDLE_LOADER 128
 
-#define ZL_DICT_INDEX_NONE (SIZE_MAX) /* no dict associated */
+#define ZL_DICT_INDEX_NONE (UINT32_MAX) /* no dict associated */
 
 #endif /* OPENZL_DICT_DICT_CONSTANTS_H */


### PR DESCRIPTION
Summary:

This diff finishes the v24 dictionary metadata path for custom codecs.

It adds frame-level bundle IDs and chunk-level per-transform dictIdx entries to the wire format, threads that metadata through frame/chunk encode-decode, and resolves materialized dictionaries for decoders through the attached dict loader. The public transform APIs now expose only materialized dict objects, not raw bundle offsets.

It also adds codec runtime enforcement that dict-backed transforms cannot be written with formatVersion < 24, using the applied CCtx format version so CCtx overrides cannot silently produce an invalid frame.

Concretely, the diff:

  - adds a `hasBundleID` flag to the v24 frame header
  - adds bundleID to the v24 frame header and dictIdx to the v24 chunk header, only when required
  - updates wire-format docs and encode/decode logic for both fields
  - adds the decoder accessor ZL_Decoder_getMaterializedDict() and keeps dictIdx internal
  - adds ZL_FrameInfo_getBundleID() and uses it to fetch the required bundle before chunk decompression
  - fetches and passes the resolved bundle into chunk decoder execution so transforms receive the right materialized dict
  - returns NULL from encoder/decoder materialized-dict getters for pre-v24 formats
  - rejects dict-backed compression when the effective frame format version is below 24

Reviewed By: terrelln

Differential Revision: D98749325


