### PR TITLE
Add content hash to ZL_Dict for dedup verification (#658)

### DIFF
--- a/include/openzl/zl_common_types.h
+++ b/include/openzl/zl_common_types.h
@@ -73,6 +73,7 @@ typedef struct {
  * with ZL_RESULT_DECLARE_SCOPE
  */
 typedef void* ZL_VoidPtr;
+typedef const void* ZL_ConstVoidPtr;
 
 #if defined(__cplusplus)
 } // extern "C"

--- a/include/openzl/zl_compressor.h
+++ b/include/openzl/zl_compressor.h
@@ -340,9 +340,11 @@ typedef struct {
     /// Optionally the new local params, if NULL then the parameters are not
     /// updated.
     const ZL_LocalParams* localParams;
-    /// Optionally, a new dict ID. If set to ZL_ID_NULL, then the dict ID is not
-    /// updated.
+    /// Optionally, a new dict ID. If set to ZL_DICT_ID_NULL, then the dict ID
+    /// is not updated.
     ZL_DictID dictID;
+    /// Optionally, a new MParam.
+    ZL_MParam mparam;
 } ZL_NodeParameters;
 
 /**
@@ -367,9 +369,11 @@ typedef struct {
     /// Optionally the new local params, if NULL then the parameters are not
     /// updated.
     const ZL_LocalParams* localParams;
-    /// Optionally, a new dict ID. If set to ZL_ID_NULL, then the dict ID is not
-    /// updated.
+    /// Optionally, a new dict ID. If set to ZL_DICT_ID_NULL, then the dict ID
+    /// is not updated.
     ZL_DictID dictID;
+    /// Optionally, a new MParam.
+    ZL_MParam mparam;
 } ZL_ParameterizedNodeDesc;
 
 /**

--- a/include/openzl/zl_ctransform.h
+++ b/include/openzl/zl_ctransform.h
@@ -16,7 +16,7 @@
 #include "openzl/zl_ctransform_legacy.h" // Pipe and Split transforms
 #include "openzl/zl_errors.h"            // ZL_Report
 #include "openzl/zl_input.h"
-#include "openzl/zl_materializer.h" // ZL_MaterializerDesc
+#include "openzl/zl_materializer.h" // ZL_MaterializerDesc, ZL_MParam
 #include "openzl/zl_opaque_types.h"
 #include "openzl/zl_output.h"
 #include "openzl/zl_portability.h" // ZL_NOEXCEPT_FUNC_PTR
@@ -355,9 +355,25 @@ typedef struct {
     /**
      * Optional dictionary ID associated with this encoder.
      * When set, identifies the dictionary that this encoder requires.
-     * A zero-initialized (null) value means no dictionary is associated.
+     * A zero-initialized value (ZL_DICT_ID_NULL) means no dictionary is
+     * associated.
      */
     ZL_DictID dictID;
+    /**
+     * Optional materializer for compression-only materialized parameters
+     *  (MParams). If materializeFn is non-null, it will be called during
+     *  compressor deserialization to create the materialized object from
+     *  the serialized MParam blob. Unlike dicts, MParams are NOT required
+     *  at decompression time.
+     */
+    ZL_MaterializerDesc2 mparamMat;
+    /**
+     * Optional MParam associated with this encoder. The provided content blob
+     * will be materialized as dictated by @p mparamMat . OpenZL will not take
+     * ownership of the content provided. The caller is free to free the buffer
+     * anytime after registering the MIEncoder.
+     */
+    ZL_MParam mparam;
 } ZL_MIEncoderDesc;
 
 /**
@@ -453,6 +469,13 @@ const ZL_LocalParams* ZL_Encoder_getLocalParams(const ZL_Encoder* eic);
  * there is one. Otherwise NULL.
  */
 const void* ZL_Encoder_getMaterializedDict(const ZL_Encoder* eictx);
+
+/**
+ * @returns The materialized MParam object associated with this node, if
+ * there is one. Otherwise NULL. MParams are compression-only resources
+ * that are not required at decompression time.
+ */
+const void* ZL_Encoder_getMParam(const ZL_Encoder* eictx);
 
 /* Scratch space allocation:
  * When the transform needs some buffer space for some local operation,

--- a/include/openzl/zl_ctransform.h
+++ b/include/openzl/zl_ctransform.h
@@ -371,7 +371,8 @@ typedef struct {
      * Optional MParam associated with this encoder. The provided content blob
      * will be materialized as dictated by @p mparamMat . OpenZL will not take
      * ownership of the content provided. The caller is free to free the buffer
-     * anytime after registering the MIEncoder.
+     * anytime after registering the MIEncoder with
+     * ZL_Compressor_registerMIEncoder().
      */
     ZL_MParam mparam;
 } ZL_MIEncoderDesc;

--- a/include/openzl/zl_errors.h
+++ b/include/openzl/zl_errors.h
@@ -13,7 +13,7 @@
 #include <assert.h>
 #include <stddef.h> // size_t
 
-#include "openzl/zl_common_types.h"  // ZL_VoidPtr
+#include "openzl/zl_common_types.h"  // ZL_VoidPtr, ZL_ConstVoidPtr
 #include "openzl/zl_errors_types.h"  // ZL_ErrorCode
 #include "openzl/zl_macro_helpers.h" // ZS_MACRO_PAD1 and friends
 #include "openzl/zl_opaque_types.h"  // ZL_GraphID, ZL_NodeID
@@ -197,6 +197,7 @@ extern "C" {
 ZL_RESULT_DECLARE_TYPE(ZL_GraphID);
 ZL_RESULT_DECLARE_TYPE(ZL_NodeID);
 ZL_RESULT_DECLARE_TYPE(ZL_VoidPtr);
+ZL_RESULT_DECLARE_TYPE(ZL_ConstVoidPtr);
 
 /*-*********************************************
  *  ZL_Report type

--- a/include/openzl/zl_materializer.h
+++ b/include/openzl/zl_materializer.h
@@ -102,21 +102,25 @@ void ZL_NOOP_DEMATERIALIZE(ZL_Materializer* matCtx, void* materialized)
         ZL_NOEXCEPT_FUNC_PTR;
 
 /**
- * Managed space allocation:
+ * Managed space allocation (Materializers ONLY):
  * Materialization may request arena space to hold materialized objects. It is
  * allowed to request multiple buffers of any size. Returned buffers are not
  * initialized, and cannot be freed individually. All buffers are
- * automatically released at end of the owning @ref ZL_Compressor 's lifetime.
+ * automatically released at end of the owning @ref ZL_Compressor's lifetime.
+ *
+ * @note Always returns NULL during dematerialization.
  */
 void* ZL_Materializer_allocate(ZL_Materializer* matCtx, size_t size);
 
 /**
- * Scratch space allocation:
+ * Scratch space allocation (Materializers ONLY):
  * When the materializer needs some buffer space for some local operation,
  * it can request such space from the engine. It is allowed to
  * request multiple buffers of any size. Returned buffers are not
  * initialized, and cannot be freed individually. All scratch buffers are
  * automatically released at the end of the materializer's execution.
+ *
+ * @note Always returns NULL during dematerialization.
  */
 void* ZL_Materializer_getScratchSpace(ZL_Materializer* matCtx, size_t size);
 

--- a/include/openzl/zl_materializer.h
+++ b/include/openzl/zl_materializer.h
@@ -202,6 +202,11 @@ typedef struct {
     ZL_MParamID mparamID;
 } ZL_MParam;
 
+/**
+ * @returns true if @p id is non-NULL and not ZL_MPARAM_ID_NULL.
+ */
+bool ZL_MParamID_hasValue(const ZL_MParamID* id);
+
 #if defined(__cplusplus)
 } // extern "C"
 #endif

--- a/include/openzl/zl_materializer.h
+++ b/include/openzl/zl_materializer.h
@@ -124,21 +124,17 @@ void* ZL_Materializer_getScratchSpace(ZL_Materializer* matCtx, size_t size);
 // In-progress API
 // =================================================================
 /**
- * @brief Descriptor for materializing and dematerializing dict objects.
+ * @brief Descriptor for materializing and dematerializing resource objects
+ * (dicts and MParams).
  *
- * This structure defines functions to materialize an in-memory object from
- * a raw source buffer and to dematerialize (free) that object.
+ * Defines functions to create an in-memory object from a raw source buffer
+ * (materializeFn) and to free that object (dematerializeFn). Used for both
+ * dictionary objects (required at compression and decompression) and MParam
+ * objects (compression-only). Note that the registration APIs allow for
+ * different materializers for compression-time and decompression-time dict
+ * materialization.
  */
 typedef struct {
-    /**
-     * Optionally an opaque pointer that can be queried with
-     * ZL_Materializer_getOpaquePtr().
-     * OpenZL unconditionally takes ownership of this pointer, even if
-     * registration fails, and it lives for the lifetime of the owning
-     * compressor/dict store.
-     */
-    ZL_OpaquePtr opaque;
-
     /**
      * @brief A custom function that materializes an in-memory object from a
      * provided @p src buffer. Separate function interfaces are provided for
@@ -186,13 +182,24 @@ typedef struct {
      */
     void (*dematerializeFn)(ZL_Materializer* matCtx, void* materialized)
             ZL_NOEXCEPT_FUNC_PTR;
+
+    /**
+     * Optionally an opaque pointer that can be queried with
+     * ZL_Materializer_getOpaquePtr().
+     * OpenZL unconditionally takes ownership of this pointer, even if
+     * registration fails, and it lives for the lifetime of the owning
+     * compressor/dict store.
+     */
+    ZL_OpaquePtr opaque;
 } ZL_MaterializerDesc2;
 
 // MParam structure
 typedef struct {
-    ZL_MParamID mparamID;
     const void* content;
     size_t size;
+    /// For advanced use cases, you can specify a custom ID for this MParam. If
+    /// unset, a default ID will be assigned.
+    ZL_MParamID mparamID;
 } ZL_MParam;
 
 #if defined(__cplusplus)

--- a/include/openzl/zl_reflection.h
+++ b/include/openzl/zl_reflection.h
@@ -312,7 +312,8 @@ char const* ZL_Compressor_Node_getName(
 bool ZL_Compressor_Node_isStandard(ZL_Compressor const* cgraph, ZL_NodeID node);
 
 /**
- * @returns The dict ID associated with the @p node.
+ * @returns The dict ID associated with the @p node or ZL_DICT_ID_NULL if no
+ * dict is associated.
  */
 ZL_DictID ZL_Compressor_Node_getDictID(
         ZL_Compressor const* cgraph,
@@ -324,6 +325,22 @@ ZL_DictID ZL_Compressor_Node_getDictID(
  * @note Only valid after ZL_Compressor_validate() has been called.
  */
 ZL_Report ZL_Compressor_Node_getDictIndex(
+        ZL_Compressor const* cgraph,
+        ZL_NodeID node);
+
+/**
+ * @returns The MParam ID associated with the @p node or ZL_MPARAM_ID_NULL if no
+ * MParam is associated.
+ */
+ZL_MParamID ZL_Compressor_Node_getMParamID(
+        ZL_Compressor const* cgraph,
+        ZL_NodeID node);
+
+/**
+ * @returns The materialized Mparam object associated with the @p node or NULL
+ * if no MParam is associated.
+ */
+const void* ZL_Compressor_Node_getMParamObj(
         ZL_Compressor const* cgraph,
         ZL_NodeID node);
 

--- a/include/openzl/zl_reflection.h
+++ b/include/openzl/zl_reflection.h
@@ -337,12 +337,39 @@ ZL_MParamID ZL_Compressor_Node_getMParamID(
         ZL_NodeID node);
 
 /**
- * @returns The materialized Mparam object associated with the @p node or NULL
+ * @returns A pointer to the *unmaterialized* MParam associated with the @p
+ * node, or NULL if no MParam is associated.
+ */
+const ZL_MParam* ZL_Compressor_Node_getMParam(
+        ZL_Compressor const* cgraph,
+        ZL_NodeID node);
+
+/**
+ * @returns The *materialized* Mparam object associated with the @p node or NULL
  * if no MParam is associated.
  */
 const void* ZL_Compressor_Node_getMParamObj(
         ZL_Compressor const* cgraph,
         ZL_NodeID node);
+
+/**
+ * @returns The number of unique MParam blobs stored in the @p compressor.
+ */
+size_t ZL_Compressor_numMParams(const ZL_Compressor* compressor);
+
+typedef ZL_Report (*ZL_Compressor_ForEachMParamCallback)(
+        void* opaque,
+        const ZL_MParam* mparam) ZL_NOEXCEPT_FUNC_PTR;
+
+/**
+ * Calls @p callback on every unique MParam stored in the @p compressor.
+ * If @p callback returns an error, short-circuit and return that error.
+ * @returns Success if all callbacks succeed, or the first error.
+ */
+ZL_Report ZL_Compressor_forEachMParam(
+        const ZL_Compressor* compressor,
+        ZL_Compressor_ForEachMParamCallback callback,
+        void* opaque);
 
 /**
  * Reflection API for introspecting a compressed frame.

--- a/src/openzl/compress/cctx.c
+++ b/src/openzl/compress/cctx.c
@@ -139,10 +139,11 @@ struct ZL_CCtx_s {
     CCTX_TransformHeaders trHeaders;
     /* These Arenas presume single-thread execution.
      * For parallel execution, it will have to be replaced by Arena Pools */
-    Arena* codecArena;   // Codec lifetime
-    Arena* graphArena;   // Graph Lifetime
-    Arena* chunkArena;   // Chunk Lifetime
-    Arena* sessionArena; // Entire compression lifetime
+    Arena* codecArena;      // Codec lifetime
+    Arena* graphArena;      // Graph Lifetime
+    Arena* chunkArena;      // Chunk Lifetime
+    Arena* sessionArena;    // Entire compression lifetime
+    Arena* matScratchArena; // Scratch space for materializers
     const ZL_TypedRef** inputs;
     unsigned nbInputs;
     int numSegments;         // number of segments in the current frame
@@ -160,13 +161,15 @@ static ZL_Report CCTX_init(ZL_CCtx* cctx)
 
     ZL_OC_init(&cctx->opCtx);
 
-    cctx->codecArena   = ALLOC_StackArena_create();
-    cctx->graphArena   = ALLOC_StackArena_create();
-    cctx->chunkArena   = ALLOC_StackArena_create();
-    cctx->sessionArena = ALLOC_StackArena_create();
+    cctx->codecArena      = ALLOC_StackArena_create();
+    cctx->graphArena      = ALLOC_StackArena_create();
+    cctx->chunkArena      = ALLOC_StackArena_create();
+    cctx->sessionArena    = ALLOC_StackArena_create();
+    cctx->matScratchArena = ALLOC_StackArena_create();
     ZL_ERR_IF(
             cctx->graphArena == NULL || cctx->codecArena == NULL
-                    || cctx->chunkArena == NULL || cctx->sessionArena == NULL,
+                    || cctx->chunkArena == NULL || cctx->sessionArena == NULL
+                    || cctx->matScratchArena == NULL,
             allocation);
 
     ZL_ERR_IF_ERR(RTGM_init(&cctx->rtgraph));
@@ -219,6 +222,7 @@ void CCTX_free(ZL_CCtx* cctx)
     ALLOC_Arena_freeArena(cctx->codecArena);
     ALLOC_Arena_freeArena(cctx->graphArena);
     ALLOC_Arena_freeArena(cctx->chunkArena);
+    ALLOC_Arena_freeArena(cctx->matScratchArena);
     ALLOC_Arena_freeArena(cctx->sessionArena);
     ZL_OC_destroy(&cctx->opCtx);
     ZL_free(cctx);
@@ -504,6 +508,7 @@ static ZL_Report CCTX_runCNode_wParams(
             ZL_RESULT_OF(OneshotMaterializationResult)
             res = MPM_materializeOneshot(
                     cctx->sessionArena,
+                    cctx->matScratchArena,
                     ZL_CCtx_getOperationContext(cctx),
                     lparams,
                     &cnode->transformDesc.publicDesc.materializer);
@@ -967,6 +972,7 @@ static ZL_Report CCTX_runSegmenter(
                 ZL_RESULT_OF(OneshotMaterializationResult)
                 res = MPM_materializeOneshot(
                         cctx->sessionArena,
+                        cctx->matScratchArena,
                         ZL_CCtx_getOperationContext(cctx),
                         rgp->localParams,
                         &segDesc->materializer);
@@ -1151,6 +1157,7 @@ static ZL_Report CCTX_runSupervisedGraphID_internal(
                 ZL_RESULT_OF(OneshotMaterializationResult)
                 res = MPM_materializeOneshot(
                         cctx->sessionArena,
+                        cctx->matScratchArena,
                         ZL_CCtx_getOperationContext(cctx),
                         rgp->localParams,
                         &dstGd->materializer);

--- a/src/openzl/compress/cdictmgr.c
+++ b/src/openzl/compress/cdictmgr.c
@@ -175,6 +175,13 @@ static ZL_RESULT_OF(ZL_DictConstPtr) CDictMgr_cacheInternal(
     const CDictMgr_DictMap_Entry* existing =
             CDictMgr_DictMap_find(&mgr->dictsByID, &lookupKey);
     if (existing != NULL) {
+        // Verify we aren't trying to materialize a different buffer with the
+        // same ID
+        ZL_ERR_IF_NOT(
+                ZL_UniqueID_eq(
+                        &existing->val->contentHash, &parsed->contentHash),
+                nodeParameter_invalid,
+                "Two different materialized objects cannot have the same ID. IDs must be unique!");
         return ZL_WRAP_VALUE(existing->val);
     }
 
@@ -199,6 +206,7 @@ static ZL_RESULT_OF(ZL_DictConstPtr) CDictMgr_cacheInternal(
     ZL_Dict* dict = (ZL_Dict*)ALLOC_Arena_calloc(mgr->arena, sizeof(ZL_Dict));
     ZL_ERR_IF_NULL(dict, allocation);
     dict->dictID             = parsed->dictID;
+    dict->contentHash        = parsed->contentHash;
     dict->materializingCodec = parsed->materializingCodec;
     dict->codecType          = parsed->codecType;
     dict->packedSize         = parsed->packedSize;
@@ -424,7 +432,8 @@ CDictMgr_materializeMParam(
     ZL_ASSERT_NN(mparam.content);
 
     ZL_ParsedDict toCache = {
-        .dictID             = (ZL_DictID){ mparam.mparamID.id },
+        .dictID      = (ZL_DictID){ mparam.mparamID.id },
+        .contentHash = ZL_UniqueID_computeSHA256(mparam.content, mparam.size),
         .materializingCodec = 0, // not used by mparams
         .codecType          = 0, // not used by mparams
         .dictContent        = mparam.content,

--- a/src/openzl/compress/cdictmgr.c
+++ b/src/openzl/compress/cdictmgr.c
@@ -157,7 +157,7 @@ static const ZL_MaterializerDesc2* CDictMgr_findMaterializer(
     return NULL;
 }
 
-static ZL_RESULT_OF(ZL_DictConstPtr) CDictMgr_cacheDict(
+static ZL_RESULT_OF(ZL_DictConstPtr) CDictMgr_cacheInternal(
         CDictMgr* mgr,
         const ZL_ParsedDict* parsed,
         const ZL_MaterializerDesc2* matDesc)
@@ -165,6 +165,8 @@ static ZL_RESULT_OF(ZL_DictConstPtr) CDictMgr_cacheDict(
     ZL_RESULT_DECLARE_SCOPE(ZL_DictConstPtr, mgr->opCtx);
     ZL_ASSERT_NN(matDesc);
     ZL_ASSERT_NN(matDesc->materializeFn);
+
+    // try to search in the cache for existing entries
     CDictMgr_DictKey lookupKey = {
         .id      = parsed->dictID.id,
         .matDesc = *matDesc,
@@ -175,14 +177,6 @@ static ZL_RESULT_OF(ZL_DictConstPtr) CDictMgr_cacheDict(
     if (existing != NULL) {
         return ZL_WRAP_VALUE(existing->val);
     }
-
-    ZL_Dict* dict = (ZL_Dict*)ALLOC_Arena_calloc(mgr->arena, sizeof(ZL_Dict));
-    ZL_ERR_IF_NULL(dict, allocation);
-
-    dict->dictID             = parsed->dictID;
-    dict->materializingCodec = parsed->materializingCodec;
-    dict->codecType          = parsed->codecType;
-    dict->packedSize         = parsed->packedSize;
 
     // We free all memory in the scratch allocator, so don't
     // pass an arena that's not cleared.
@@ -200,7 +194,15 @@ static ZL_RESULT_OF(ZL_DictConstPtr) CDictMgr_cacheDict(
 
     ALLOC_Arena_freeAll(mgr->scratchArena);
     ZL_ERR_IF_ERR(obj);
-    dict->dictObj = ZL_RES_value(obj);
+
+    // cache
+    ZL_Dict* dict = (ZL_Dict*)ALLOC_Arena_calloc(mgr->arena, sizeof(ZL_Dict));
+    ZL_ERR_IF_NULL(dict, allocation);
+    dict->dictID             = parsed->dictID;
+    dict->materializingCodec = parsed->materializingCodec;
+    dict->codecType          = parsed->codecType;
+    dict->packedSize         = parsed->packedSize;
+    dict->dictObj            = ZL_RES_value(obj);
 
     CDictMgr_DictMap_Entry entry = { .key = lookupKey, .val = dict };
     CDictMgr_DictMap_Insert ins =
@@ -316,7 +318,7 @@ CDictMgr_loadDict(CDictMgr* mgr, const void* serialBuffer, size_t bufferMaxSize)
             matDesc, noValidMaterialization, "no materializer found for dict");
 
     ZL_RESULT_OF(ZL_DictConstPtr)
-    dictRes = CDictMgr_cacheDict(mgr, &parsed, matDesc);
+    dictRes = CDictMgr_cacheInternal(mgr, &parsed, matDesc);
     ZL_ERR_IF_ERR(dictRes);
 
     const ZL_Dict* dict = ZL_RES_value(dictRes);
@@ -362,7 +364,7 @@ const ZL_BundleID* CDictMgr_getBundleID(const CDictMgr* mgr)
 
 /**
  * Store a raw MParam blob for later CBOR serialization. The blob data is
- * copied into the CDictMgr's arena.
+ * copied into the CDictMgr's arena. Duplicate blobs are de-duped.
  *
  * @param id   The MParam ID to associate with this blob.
  * @param data Raw serialized MParam blob (dict wire format).
@@ -377,6 +379,10 @@ static ZL_Report CDictMgr_storeMParamBlob(
     ZL_RESULT_DECLARE_SCOPE_REPORT(mgr->opCtx);
     ZL_ERR_IF_NULL(data, GENERIC, "MParam blob data must not be null");
     ZL_ERR_IF_EQ(size, 0, GENERIC, "MParam blob size must be > 0");
+
+    if (CDictMgr_MParamMap_find(&mgr->mparamBlobs, &id) != NULL) {
+        return ZL_returnSuccess();
+    }
 
     void* copy = ALLOC_Arena_malloc(mgr->arena, size);
     ZL_ERR_IF_NULL(copy, allocation);
@@ -400,4 +406,39 @@ const ZL_MParam* CDictMgr_getMParam(const CDictMgr* mgr, ZL_MParamID id)
     const CDictMgr_MParamMap_Entry* entry =
             CDictMgr_MParamMap_find(&mgr->mparamBlobs, &id);
     return (entry != NULL) ? &entry->val : NULL;
+}
+
+/* ================================================================
+ * CDictMgr_materializeMParam
+ * ================================================================ */
+
+ZL_RESULT_OF(ZL_ConstVoidPtr)
+CDictMgr_materializeMParam(
+        CDictMgr* mgr,
+        ZL_MParam mparam,
+        const ZL_MaterializerDesc2* matDesc)
+{
+    ZL_RESULT_DECLARE_SCOPE(ZL_ConstVoidPtr, mgr->opCtx);
+    ZL_ASSERT_NN(matDesc);
+    ZL_ASSERT_NN(matDesc->materializeFn);
+    ZL_ASSERT_NN(mparam.content);
+
+    ZL_ParsedDict toCache = {
+        .dictID             = (ZL_DictID){ mparam.mparamID.id },
+        .materializingCodec = 0, // not used by mparams
+        .codecType          = 0, // not used by mparams
+        .dictContent        = mparam.content,
+        .contentSize        = mparam.size,
+        .packedSize         = mparam.size,
+    };
+
+    ZL_RESULT_OF(ZL_DictConstPtr)
+    dictRes = CDictMgr_cacheInternal(mgr, &toCache, matDesc);
+    ZL_ERR_IF_ERR(dictRes);
+
+    // Store raw blob for CBOR serialization
+    ZL_ERR_IF_ERR(CDictMgr_storeMParamBlob(
+            mgr, mparam.mparamID, mparam.content, mparam.size));
+
+    return ZL_WRAP_VALUE(ZL_RES_value(dictRes)->dictObj);
 }

--- a/src/openzl/compress/cdictmgr.h
+++ b/src/openzl/compress/cdictmgr.h
@@ -52,7 +52,7 @@ bool CDictMgr_MParamMap_eq(const ZL_MParamID* lhs, const ZL_MParamID* rhs);
 
 ZL_DECLARE_CUSTOM_MAP_TYPE(CDictMgr_MParamMap, ZL_MParamID, ZL_MParam);
 
-typedef struct {
+typedef struct CDictMgr_s {
     ZL_BundleID bundleID;
     CDictMgr_DictMap dictsByID;
     ZL_DictBundle* bundle;
@@ -146,6 +146,21 @@ const ZL_BundleID* CDictMgr_getBundleID(const CDictMgr* mgr);
  * the given ID has been stored.
  */
 const ZL_MParam* CDictMgr_getMParam(const CDictMgr* mgr, ZL_MParamID id);
+
+/**
+ * Materialize a raw MParam content buffer. The raw content is passed directly
+ * to the materializer (no Dict_parse). The result is cached by
+ * (mparamID, matDesc) for dedup, and the raw blob is stored for CBOR
+ * serialization.
+ *
+ * @returns The materialized object pointer on success, or an error if
+ * materialization fails for any reason.
+ */
+ZL_RESULT_OF(ZL_ConstVoidPtr)
+CDictMgr_materializeMParam(
+        CDictMgr* mgr,
+        ZL_MParam mparam,
+        const ZL_MaterializerDesc2* matDesc);
 
 ZL_END_C_DECLS
 

--- a/src/openzl/compress/cgraph.c
+++ b/src/openzl/compress/cgraph.c
@@ -38,7 +38,7 @@ struct ZL_Compressor_s {
     ZL_GraphID starting_graph;
     GCParams gcparams;
     ZL_OperationContext opCtx; // for error logging
-    CDictMgr dictMgr;
+    CDictMgr cdictMgr;
 }; /* note typedef'd to ZL_Compressor in zl_compress.h */
 
 ZL_Compressor* ZL_Compressor_create(void)
@@ -59,10 +59,15 @@ ZL_Compressor* ZL_Compressor_create(void)
     }
     cgraph->starting_graph = (ZL_GraphID){ .gid = 0 }; // default
     if (ZL_isError(CDictMgr_init(
-                &cgraph->dictMgr, &cgraph->nmgr, cgraph->gm, &cgraph->opCtx))) {
+                &cgraph->cdictMgr,
+                &cgraph->nmgr,
+                cgraph->gm,
+                &cgraph->opCtx))) {
         ZL_Compressor_free(cgraph);
         return NULL;
     }
+    // Back-populate CDictMgr pointers
+    cgraph->nmgr.ctm.cdictMgr = &cgraph->cdictMgr;
 
 #if ZL_ENABLE_ASSERT
     // In debug mode, runtime check on the configuration of the Standard Graphs
@@ -76,7 +81,7 @@ void ZL_Compressor_free(ZL_Compressor* cgraph)
 {
     if (!cgraph)
         return;
-    CDictMgr_destroy(&cgraph->dictMgr);
+    CDictMgr_destroy(&cgraph->cdictMgr);
     ZL_OC_destroy(&cgraph->opCtx);
     GM_free(cgraph->gm);
     NM_destroy(&cgraph->nmgr);
@@ -452,6 +457,7 @@ ZL_Compressor_parameterizeNode(
         .node        = node,
         .localParams = params->localParams,
         .dictID      = params->dictID,
+        .mparam      = params->mparam,
     };
 
     return NM_parameterizeNode(&compressor->nmgr, &desc);
@@ -466,6 +472,7 @@ ZL_NodeID ZL_Compressor_registerParameterizedNode(
         .name        = desc->name,
         .localParams = desc->localParams,
         .dictID      = desc->dictID,
+        .mparam      = desc->mparam,
     };
     ZL_RESULT_OF(ZL_NodeID)
     nodeidResult =
@@ -1247,10 +1254,25 @@ ZL_DictID ZL_Compressor_Node_getDictID(
     return CNODE_getDictID(CGRAPH_getCNode(cgraph, node));
 }
 
+ZL_MParamID ZL_Compressor_Node_getMParamID(
+        ZL_Compressor const* cgraph,
+        ZL_NodeID node)
+{
+    const ZL_MParamID* id = CNODE_getMParamID(CGRAPH_getCNode(cgraph, node));
+    return *id;
+}
+
+const void* ZL_Compressor_Node_getMParamObj(
+        ZL_Compressor const* cgraph,
+        ZL_NodeID node)
+{
+    return CNODE_getMParamObj(CGRAPH_getCNode(cgraph, node));
+}
+
 ZL_Report CGraph_resolveDictIndices(ZL_Compressor* cgraph)
 {
     ZL_RESULT_DECLARE_SCOPE_REPORT(cgraph);
-    const ZL_DictBundle* bundle = cgraph->dictMgr.bundle;
+    const ZL_DictBundle* bundle = cgraph->cdictMgr.bundle;
     CNodes_manager* ctm         = &cgraph->nmgr.ctm;
     const ZL_IDType nbCNodes    = CTM_nbCNodes(ctm);
 
@@ -1304,7 +1326,7 @@ ZL_Report ZL_Compressor_Node_getDictIndex(
 const void* CGRAPH_getDictObj(const ZL_Compressor* cgraph, size_t dictOffset)
 {
     ZL_ASSERT_NN(cgraph);
-    const ZL_DictBundle* bundle = cgraph->dictMgr.bundle;
+    const ZL_DictBundle* bundle = cgraph->cdictMgr.bundle;
     if (bundle == NULL)
         return NULL;
     ZL_ASSERT_LT(dictOffset, bundle->info.numDicts);
@@ -1314,7 +1336,7 @@ const void* CGRAPH_getDictObj(const ZL_Compressor* cgraph, size_t dictOffset)
 const ZL_BundleID* ZL_Compressor_getDictBundleID(
         const ZL_Compressor* compressor)
 {
-    return CDictMgr_getBundleID(&compressor->dictMgr);
+    return CDictMgr_getBundleID(&compressor->cdictMgr);
 }
 
 ZL_Report ZL_Compressor_loadDictBundle(
@@ -1324,7 +1346,7 @@ ZL_Report ZL_Compressor_loadDictBundle(
 {
     ZL_RESULT_DECLARE_SCOPE_REPORT(compressor);
     ZL_ERR_IF_ERR(CDictMgr_loadFatBundle(
-            &compressor->dictMgr,
+            &compressor->cdictMgr,
             serializedDictBundle,
             serializedDictBundleSize));
     return ZL_returnSuccess();

--- a/src/openzl/compress/cgraph.c
+++ b/src/openzl/compress/cgraph.c
@@ -1262,11 +1262,44 @@ ZL_MParamID ZL_Compressor_Node_getMParamID(
     return *id;
 }
 
+const ZL_MParam* ZL_Compressor_Node_getMParam(
+        ZL_Compressor const* cgraph,
+        ZL_NodeID node)
+{
+    const CNode* cnode = CGRAPH_getCNode(cgraph, node);
+    if (cnode == NULL)
+        return NULL;
+    const ZL_MParam* mp = &cnode->transformDesc.publicDesc.mparam;
+    if (!ZL_UniqueID_isValid(&mp->mparamID.id))
+        return NULL;
+    return mp;
+}
+
 const void* ZL_Compressor_Node_getMParamObj(
         ZL_Compressor const* cgraph,
         ZL_NodeID node)
 {
     return CNODE_getMParamObj(CGRAPH_getCNode(cgraph, node));
+}
+
+size_t ZL_Compressor_numMParams(const ZL_Compressor* compressor)
+{
+    return CDictMgr_MParamMap_size(&compressor->cdictMgr.mparamBlobs);
+}
+
+ZL_Report ZL_Compressor_forEachMParam(
+        const ZL_Compressor* compressor,
+        ZL_Compressor_ForEachMParamCallback callback,
+        void* opaque)
+{
+    ZL_RESULT_DECLARE_SCOPE_REPORT(NULL);
+    CDictMgr_MParamMap_Iter it =
+            CDictMgr_MParamMap_iter(&compressor->cdictMgr.mparamBlobs);
+    const CDictMgr_MParamMap_Entry* entry;
+    while ((entry = CDictMgr_MParamMap_Iter_next(&it)) != NULL) {
+        ZL_ERR_IF_ERR(callback(opaque, &entry->val));
+    }
+    return ZL_returnSuccess();
 }
 
 ZL_Report CGraph_resolveDictIndices(ZL_Compressor* cgraph)

--- a/src/openzl/compress/cnode.c
+++ b/src/openzl/compress/cnode.c
@@ -214,3 +214,17 @@ size_t CNODE_getDictIndex(CNode const* cnode)
     ZL_ASSERT_EQ(cnode->nodetype, node_internalTransform);
     return cnode->maybeDictIndex;
 }
+
+const void* CNODE_getMParamObj(CNode const* cnode)
+{
+    ZL_ASSERT_NN(cnode);
+    ZL_ASSERT_EQ(cnode->nodetype, node_internalTransform);
+    return cnode->mparamObj;
+}
+
+const ZL_MParamID* CNODE_getMParamID(CNode const* cnode)
+{
+    ZL_ASSERT_NN(cnode);
+    ZL_ASSERT_EQ(cnode->nodetype, node_internalTransform);
+    return &cnode->transformDesc.publicDesc.mparam.mparamID;
+}

--- a/src/openzl/compress/cnode.h
+++ b/src/openzl/compress/cnode.h
@@ -23,6 +23,11 @@ typedef struct {
     /// The "default" value is updated when ZL_Compressor_validate() is called,
     /// before compression starts.
     size_t maybeDictIndex /* defaults to ZL_DICT_INDEX_NONE */;
+    /// If an MParam is specified in the transformDesc, this field is populated
+    /// upon registration time with a pointer to the materialized object. The
+    /// CNode does not own the object, the ZL_Compressor owns it via the
+    /// CDictMgr.
+    const void* mparamObj;
     /// Standard nodes leave this empty, all other nodes set this.
     /// When set ZL_Name_unique(&maybeName) == transformDesc.publicDesc.name.
     ZL_Name maybeName;
@@ -142,5 +147,8 @@ ZL_DictID CNODE_getDictID(CNode const* cnode);
 /// or ZL_DICT_INDEX_NONE if no dictionary is associated.
 /// @pre cnode->nodetype == node_internalTransform
 size_t CNODE_getDictIndex(CNode const* cnode);
+
+const void* CNODE_getMParamObj(CNode const* cnode);
+const ZL_MParamID* CNODE_getMParamID(CNode const* cnode);
 
 #endif // OPENZL_COMPRESS_CNODE_H

--- a/src/openzl/compress/cnodes.c
+++ b/src/openzl/compress/cnodes.c
@@ -7,6 +7,7 @@
 #include "openzl/common/unique_id.h" // ZL_UniqueID_isValid
 #include "openzl/common/vector.h"
 #include "openzl/common/wire_format.h" // trt_standard
+#include "openzl/compress/cdictmgr.h"
 #include "openzl/compress/cnode.h"
 #include "openzl/compress/localparams.h"
 #include "openzl/compress/materializer.h" // ZL_Materializer functions
@@ -238,6 +239,49 @@ static ZL_RESULT_OF(CNodeID) CTM_registerCNode(
                         &trDesc->localParams,
                         &trDesc->materializer));
             }
+            // Materialize MParam if content and materializer are provided
+            if (trDesc->mparam.content != NULL || trDesc->mparam.size != 0) {
+                ZL_MParam mparam = trDesc->mparam;
+                // Ensure MParam is properly formed
+                ZL_ERR_IF_NULL(
+                        mparam.content,
+                        nodeParameter_invalid,
+                        "Passed MParam must have non-null content");
+                ZL_ERR_IF_EQ(
+                        mparam.size,
+                        0,
+                        nodeParameter_invalid,
+                        "Passed MParam must have non-zero size");
+
+                // Ensure there's a proper materializer
+                ZL_ERR_IF(
+                        trDesc->mparamMat.materializeFn == NULL
+                                && trDesc->mparamMat.dematerializeFn == NULL,
+                        nodeParameter_invalid,
+                        "MParam requested on a node without a materializer");
+                ZL_ERR_IF(
+                        trDesc->mparamMat.materializeFn == NULL
+                                || trDesc->mparamMat.dematerializeFn == NULL,
+                        nodeParameter_invalid,
+                        "MParam materializer must declare both a materialize and dematerialize function");
+
+                // If there's no ID, generate one
+                if (!ZL_UniqueID_isValid(&mparam.mparamID.id)) {
+                    mparam.mparamID.id = ZL_UniqueID_computeSHA256(
+                            mparam.content, mparam.size);
+                }
+
+                ZL_ASSERT_NN(ctm->cdictMgr);
+                ZL_RESULT_OF(ZL_ConstVoidPtr)
+                matRes = CDictMgr_materializeMParam(
+                        ctm->cdictMgr, mparam, &trDesc->mparamMat);
+                ZL_ERR_IF_ERR(matRes);
+                cnode->mparamObj = ZL_RES_value(matRes);
+                // Replace the CNode MParam with the cached version with
+                // guaranteed lifetime
+                trDesc->mparam =
+                        *CDictMgr_getMParam(ctm->cdictMgr, mparam.mparamID);
+            }
             // A valid transform must have at least one input
             ZL_ERR_IF_LT(
                     CNODE_getNbInputPorts(cnode),
@@ -293,6 +337,7 @@ CTM_registerCustomTransform(
                          .publicIDtype   = trt_custom,
                          .transformDesc  = *ctd,
                          .maybeDictIndex = ZL_DICT_INDEX_NONE,
+                         .mparamObj      = NULL,
                          .baseNodeID     = ZL_NODE_ILLEGAL };
     const char* name = ctd->publicDesc.name;
     // Registered => No need to free
@@ -341,11 +386,11 @@ CTM_parameterizeNode(
     if (desc->localParams) {
         clonedCNode.transformDesc.publicDesc.localParams = *desc->localParams;
     }
-    {
-        const ZL_UniqueID* uid = &desc->dictID.id;
-        if (ZL_UniqueID_isValid(uid)) {
-            clonedCNode.transformDesc.publicDesc.dictID = desc->dictID;
-        }
+    if (ZL_UniqueID_isValid(&desc->dictID.id)) {
+        clonedCNode.transformDesc.publicDesc.dictID = desc->dictID;
+    }
+    if (ZL_UniqueID_isValid(&desc->mparam.mparamID.id)) {
+        clonedCNode.transformDesc.publicDesc.mparam = desc->mparam;
     }
     if (desc->name == NULL) {
         const ZL_Name name = CNODE_getNameObj(srcCNode);

--- a/src/openzl/compress/cnodes.c
+++ b/src/openzl/compress/cnodes.c
@@ -76,6 +76,11 @@ ZL_Report CTM_init(CNodes_manager* ctm, ZL_OperationContext* opCtx)
     // Note 2: this is why this init function can fail
     ctm->allocator = ALLOC_HeapArena_create();
     ZL_ERR_IF_NULL(ctm->allocator, allocation);
+    ctm->scratchAllocator = ALLOC_StackArena_create();
+    if (ctm->scratchAllocator == NULL) {
+        ALLOC_Arena_freeArena(ctm->allocator);
+        ZL_ERR(allocation);
+    }
     return ZL_returnSuccess();
 }
 
@@ -85,10 +90,11 @@ void CTM_destroy(CNodes_manager* ctm)
     ZL_ASSERT_NN(ctm);
     // Dematerialize all materialized params before freeing any corresponding
     // CNodes
-    MPM_dematerializeAllParams(&ctm->materializedParams, ctm->allocator);
+    MPM_dematerializeAllParams(&ctm->materializedParams);
     MaterializedParamMap_destroy(&ctm->materializedParams);
     ZL_OpaquePtrRegistry_destroy(&ctm->opaquePtrs);
     VECTOR_DESTROY(ctm->cnodes);
+    ALLOC_Arena_freeArena(ctm->scratchAllocator);
     ALLOC_Arena_freeArena(ctm->allocator);
     ZL_zeroes(ctm, sizeof(*ctm));
 }
@@ -105,14 +111,14 @@ void CTM_reset(CNodes_manager* ctm)
     while ((entry = MaterializedParamMap_Iter_next(&iter)) != NULL) {
         if (entry->val.materializedParam != NULL
             && entry->key.matDesc.dematerializeFn != NULL) {
-            ZL_Materializer* mat =
-                    ZL_Materializer_create(ctm->allocator, entry->key.matDesc);
-            if (mat == NULL) {
-                continue;
-            }
+            ZL_Materializer mat = {
+                // dematerializers aren't allowed to allocate
+                .persistentArena = NULL,
+                .scratchArena    = NULL,
+                .opaquePtr       = entry->key.matDesc.opaque,
+            };
             entry->key.matDesc.dematerializeFn(
-                    mat, entry->val.materializedParam);
-            ZL_Materializer_free(mat);
+                    &mat, entry->val.materializedParam);
         }
     }
     MaterializedParamMap_clear(&ctm->materializedParams);
@@ -234,6 +240,7 @@ static ZL_RESULT_OF(CNodeID) CTM_registerCNode(
                 // Add the materialized object to refParams
                 ZL_ERR_IF_ERR(MPM_addOrReuseMaterializedParam(
                         ctm->allocator,
+                        ctm->scratchAllocator,
                         &ctm->materializedParams,
                         ctm->opCtx,
                         &trDesc->localParams,

--- a/src/openzl/compress/cnodes.h
+++ b/src/openzl/compress/cnodes.h
@@ -25,6 +25,7 @@ typedef struct CNodes_manager_s {
     VECTOR(CNode) cnodes;
     ZL_OpaquePtrRegistry opaquePtrs;
     Arena* allocator;
+    Arena* scratchAllocator;
     struct CDictMgr_s* cdictMgr;
     MaterializedParamMap materializedParams;
     ZL_OperationContext* opCtx; // Non-owning pointer to error context

--- a/src/openzl/compress/cnodes.h
+++ b/src/openzl/compress/cnodes.h
@@ -20,10 +20,12 @@ ZL_RESULT_DECLARE_TYPE(CNodeID);
 
 DECLARE_VECTOR_TYPE(CNode)
 
+struct CDictMgr_s; // forward declaration
 typedef struct CNodes_manager_s {
     VECTOR(CNode) cnodes;
     ZL_OpaquePtrRegistry opaquePtrs;
     Arena* allocator;
+    struct CDictMgr_s* cdictMgr;
     MaterializedParamMap materializedParams;
     ZL_OperationContext* opCtx; // Non-owning pointer to error context
 } CNodes_manager;

--- a/src/openzl/compress/compressor_serialization.c
+++ b/src/openzl/compress/compressor_serialization.c
@@ -16,9 +16,65 @@
 #include "openzl/common/operation_context.h"
 #include "openzl/common/vector.h"
 
-#include "openzl/compress/cgraph.h"
 #include "openzl/compress/localparams.h"
 #include "openzl/compress/private_nodes.h"
+
+#include "openzl/zl_materializer.h"
+
+static ZL_RESULT_OF(StringView)
+        cs_hexEncodeMParamID(Arena* const arena, const ZL_MParamID* id)
+{
+    ZL_RESULT_DECLARE_SCOPE(StringView, NULL);
+    const size_t encSize = sizeof(id->id.bytes) * 2;
+    char* buf            = ALLOC_Arena_malloc(arena, encSize + 1);
+    ZL_ERR_IF_NULL(buf, allocation);
+    for (size_t i = 0; i < sizeof(id->id.bytes); i++) {
+        const uint8_t byte = id->id.bytes[i];
+        buf[i * 2]         = "0123456789abcdef"[byte >> 4];
+        buf[i * 2 + 1]     = "0123456789abcdef"[byte & 0x0f];
+    }
+    buf[encSize] = '\0';
+    return ZL_WRAP_VALUE(StringView_init(buf, encSize));
+}
+
+ZL_RESULT_DECLARE_TYPE(ZL_MParamID);
+
+static ZL_RESULT_OF(ZL_MParamID) cs_hexDecodeMParamID(const StringView sv)
+{
+    ZL_RESULT_DECLARE_SCOPE(ZL_MParamID, NULL);
+    ZL_MParamID decoded;
+    memset(&decoded, 0, sizeof(decoded));
+    ZL_ERR_IF_NE(
+            sv.size,
+            sizeof(decoded.id.bytes) * 2,
+            corruption,
+            "Failed to hex-decode mparam ID: wrong length");
+    for (size_t i = 0; i < sizeof(decoded.id.bytes); i++) {
+        const char hi = sv.data[i * 2];
+        const char lo = sv.data[i * 2 + 1];
+        uint8_t nib_hi, nib_lo;
+        if (hi >= '0' && hi <= '9') {
+            nib_hi = (uint8_t)(hi - '0');
+        } else if (hi >= 'a' && hi <= 'f') {
+            nib_hi = (uint8_t)(hi - 'a' + 10);
+        } else if (hi >= 'A' && hi <= 'F') {
+            nib_hi = (uint8_t)(hi - 'A' + 10);
+        } else {
+            ZL_ERR(corruption, "Invalid hex char in mparam ID");
+        }
+        if (lo >= '0' && lo <= '9') {
+            nib_lo = (uint8_t)(lo - '0');
+        } else if (lo >= 'a' && lo <= 'f') {
+            nib_lo = (uint8_t)(lo - 'a' + 10);
+        } else if (lo >= 'A' && lo <= 'F') {
+            nib_lo = (uint8_t)(lo - 'A' + 10);
+        } else {
+            ZL_ERR(corruption, "Invalid hex char in mparam ID");
+        }
+        decoded.id.bytes[i] = (uint8_t)((nib_hi << 4) | nib_lo);
+    }
+    return ZL_WRAP_VALUE(decoded);
+}
 
 ////////////////////////////////////////
 // Misc Utilities
@@ -280,6 +336,11 @@ ZL_DECLARE_PREDEF_MAP_TYPE(
         ZL_LocalParams,
         StringView);
 
+ZL_DECLARE_PREDEF_MAP_TYPE(
+        CompressorSerializer_MParamMap,
+        StringView,
+        ZL_MParam);
+
 ////////////////////////////////////////
 // Intermediate Node Representation
 ////////////////////////////////////////
@@ -288,6 +349,7 @@ typedef struct {
     StringView node_name;
     StringView base_node_name;
     StringView param_set_name;
+    StringView mparam_id;
 } CompressorSerializer_Node;
 
 ////////////////////////////////////////
@@ -357,6 +419,7 @@ struct ZL_CompressorSerializer_s {
     // finally the serialized CBOR.
     CompressorSerializer_ParamSetCanonicalizationMap param_names;
     CompressorSerializer_ParamSetMap params;
+    CompressorSerializer_MParamMap mparams;
     CompressorSerializer_NodeMap nodes;
     CompressorSerializer_GraphMap graphs;
 
@@ -368,6 +431,7 @@ struct ZL_CompressorSerializer_s {
 
     // First-level nodes in the serialized tree.
     A1C_Item* params_root;
+    A1C_Item* mparams_root;
     A1C_Item* nodes_root;
     A1C_Item* graphs_root;
 };
@@ -397,6 +461,7 @@ static void ZL_CompressorSerializer_destroy(
         CompressorSerializer_ParamSet_destroy(&param_set_entry->val);
     }
     CompressorSerializer_ParamSetMap_destroy(&state->params);
+    CompressorSerializer_MParamMap_destroy(&state->mparams);
     CompressorSerializer_ParamSetCanonicalizationMap_destroy(
             &state->param_names);
     ZL_OC_destroy(&state->opCtx);
@@ -425,6 +490,8 @@ static ZL_Report ZL_CompressorSerializer_init(
     state->params = CompressorSerializer_ParamSetMap_create(
             ZL_COMPRESSOR_SERIALIZATION_PARAM_SET_LIMIT);
     state->nodes = CompressorSerializer_NodeMap_create(
+            ZL_COMPRESSOR_SERIALIZATION_NODE_COUNT_LIMIT);
+    state->mparams = CompressorSerializer_MParamMap_create(
             ZL_COMPRESSOR_SERIALIZATION_NODE_COUNT_LIMIT);
     state->graphs =
             CompressorSerializer_GraphMap_create(ZL_ENCODER_GRAPH_LIMIT);
@@ -857,6 +924,27 @@ static ZL_Report CompressorSerializer_serializeNode_cb(
     info.param_set_name = param_set_name;
 
     {
+        ZL_MParamID mid = ZL_Compressor_Node_getMParamID(c, nid);
+        if (ZL_MParamID_hasValue(&mid)) {
+            ZL_TRY_LET_CONST(
+                    StringView,
+                    mparam_id_sv,
+                    cs_hexEncodeMParamID(state->arena, &mid));
+            ZL_ERR_IF_NULL(
+                    CompressorSerializer_MParamMap_find(
+                            &state->mparams, &mparam_id_sv),
+                    logicError,
+                    "Node '%.*s' references mparam ID '%.*s' which was not "
+                    "recorded in the mparams map",
+                    (int)info.node_name.size,
+                    info.node_name.data,
+                    (int)mparam_id_sv.size,
+                    mparam_id_sv.data);
+            info.mparam_id = mparam_id_sv;
+        }
+    }
+
+    {
         const CompressorSerializer_NodeMap_Entry entry =
                 (CompressorSerializer_NodeMap_Entry){
                     .key = info.node_name,
@@ -1024,7 +1112,7 @@ static ZL_Report ZL_CompressorSerializer_encodeNode(
 
     A1C_Item_string_refStringView(node_key_item, entry->key);
     const A1C_MapBuilder node_builder =
-            A1C_Item_map_builder(node_val_item, 2, &state->a1c_arena);
+            A1C_Item_map_builder(node_val_item, 3, &state->a1c_arena);
 
     {
         A1C_MAP_TRY_ADD(pair, node_builder);
@@ -1036,6 +1124,12 @@ static ZL_Report ZL_CompressorSerializer_encodeNode(
         A1C_MAP_TRY_ADD(pair, node_builder);
         A1C_Item_string_refCStr(&pair->key, "params");
         A1C_Item_string_refStringView(&pair->val, info->param_set_name);
+    }
+
+    if (info->mparam_id.size > 0) {
+        A1C_MAP_TRY_ADD(pair, node_builder);
+        A1C_Item_string_refCStr(&pair->key, "mparam");
+        A1C_Item_string_refStringView(&pair->val, info->mparam_id);
     }
 
     return ZL_returnSuccess();
@@ -1211,6 +1305,61 @@ static ZL_Report ZL_CompressorSerializer_encodeGraphs(
     return ZL_returnSuccess();
 }
 
+static ZL_Report recordMParam_cb(void* opaque, const ZL_MParam* mparam)
+{
+    ZL_CompressorSerializer* const state = (ZL_CompressorSerializer*)opaque;
+    ZL_RESULT_DECLARE_SCOPE_REPORT(state);
+
+    ZL_TRY_LET_CONST(
+            StringView,
+            key,
+            cs_hexEncodeMParamID(state->arena, &mparam->mparamID));
+
+    const CompressorSerializer_MParamMap_Entry entry =
+            (CompressorSerializer_MParamMap_Entry){
+                .key = key,
+                .val = *mparam,
+            };
+    const CompressorSerializer_MParamMap_Insert insert =
+            CompressorSerializer_MParamMap_insert(&state->mparams, &entry);
+    ZL_ERR_IF(insert.badAlloc, allocation);
+    return ZL_returnSuccess();
+}
+
+static ZL_Report ZL_CompressorSerializer_recordMParams(
+        ZL_CompressorSerializer* const state,
+        const ZL_Compressor* const compressor)
+{
+    ZL_RESULT_DECLARE_SCOPE_REPORT(state);
+    ZL_ERR_IF_ERR(
+            ZL_Compressor_forEachMParam(compressor, recordMParam_cb, state));
+    return ZL_returnSuccess();
+}
+
+static ZL_Report ZL_CompressorSerializer_encodeMParams(
+        ZL_CompressorSerializer* const state)
+{
+    ZL_RESULT_DECLARE_SCOPE_REPORT(state);
+    const size_t numBlobs =
+            CompressorSerializer_MParamMap_size(&state->mparams);
+    A1C_MapBuilder builder = A1C_Item_map_builder(
+            state->mparams_root, numBlobs, &state->a1c_arena);
+
+    CompressorSerializer_MParamMap_Iter it =
+            CompressorSerializer_MParamMap_iter(&state->mparams);
+    const CompressorSerializer_MParamMap_Entry* entry;
+    while ((entry = CompressorSerializer_MParamMap_Iter_next(&it)) != NULL) {
+        A1C_MAP_TRY_ADD(pair, builder);
+        ZL_ERR_IF_NULL(pair, allocation);
+        A1C_Item_string_refStringView(&pair->key, entry->key);
+        A1C_Item_bytes_ref(
+                &pair->val,
+                (const uint8_t*)entry->val.content,
+                entry->val.size);
+    }
+    return ZL_returnSuccess();
+}
+
 static ZL_Report ZL_CompressorSerializer_setStartingGraph(
         ZL_CompressorSerializer* const state,
         const ZL_Compressor* const compressor,
@@ -1378,6 +1527,9 @@ static ZL_Report ZL_CompressorSerializer_serializeInner(
 
     // Extract info about components from compressor
 
+    // MParams
+    ZL_ERR_IF_ERR(ZL_CompressorSerializer_recordMParams(state, c));
+
     // Nodes
     ZL_ERR_IF_ERR(ZL_Compressor_forEachNode(
             c, CompressorSerializer_serializeNode_cb, state));
@@ -1398,7 +1550,7 @@ static ZL_Report ZL_CompressorSerializer_serializeInner(
     A1C_Item* global_params;
     {
         const A1C_MapBuilder root_map_builder =
-                A1C_Item_map_builder(state->root, 6, &state->a1c_arena);
+                A1C_Item_map_builder(state->root, 7, &state->a1c_arena);
         {
             A1C_MAP_TRY_ADD(pair, root_map_builder);
             A1C_Item_string_refCStr(&pair->key, "version");
@@ -1408,6 +1560,11 @@ static ZL_Report ZL_CompressorSerializer_serializeInner(
             A1C_MAP_TRY_ADD(pair, root_map_builder);
             A1C_Item_string_refCStr(&pair->key, "params");
             state->params_root = &pair->val;
+        }
+        {
+            A1C_MAP_TRY_ADD(pair, root_map_builder);
+            A1C_Item_string_refCStr(&pair->key, "mparams");
+            state->mparams_root = &pair->val;
         }
         {
             A1C_MAP_TRY_ADD(pair, root_map_builder);
@@ -1440,6 +1597,9 @@ static ZL_Report ZL_CompressorSerializer_serializeInner(
 
     // Write Params
     ZL_ERR_IF_ERR(ZL_CompressorSerializer_encodeParams(state));
+
+    // Write MParams
+    ZL_ERR_IF_ERR(ZL_CompressorSerializer_encodeMParams(state));
 
     // Write Nodes
     ZL_ERR_IF_ERR(ZL_CompressorSerializer_encodeNodes(state));
@@ -1533,6 +1693,11 @@ ZL_DECLARE_PREDEF_MAP_TYPE(
         StringView,
         ZL_LocalParams);
 
+ZL_DECLARE_PREDEF_MAP_TYPE(
+        CompressorDeserializer_MParamMap,
+        StringView,
+        ZL_MParam);
+
 // typedef'ed in the header
 struct ZL_CompressorDeserializer_s {
     // May be NULL!
@@ -1563,6 +1728,7 @@ struct ZL_CompressorDeserializer_s {
     CompressorDeserializer_NameMap graph_names;
 
     CompressorDeserializer_ParamMap cached_params;
+    CompressorDeserializer_MParamMap mparams_map;
 };
 
 static void ZL_CompressorDeserializer_destroy(
@@ -1573,6 +1739,7 @@ static void ZL_CompressorDeserializer_destroy(
     }
 
     CompressorDeserializer_ParamMap_destroy(&state->cached_params);
+    CompressorDeserializer_MParamMap_destroy(&state->mparams_map);
 
     CompressorDeserializer_NameMap_destroy(&state->graph_names);
     CompressorDeserializer_NameMap_destroy(&state->node_names);
@@ -1608,6 +1775,9 @@ static ZL_Report ZL_CompressorDeserializer_init(
 
     state->cached_params =
             CompressorDeserializer_ParamMap_create(ZL_ENCODER_GRAPH_LIMIT);
+
+    state->mparams_map = CompressorDeserializer_MParamMap_create(
+            ZL_COMPRESSOR_SERIALIZATION_NODE_COUNT_LIMIT);
 
     return ZL_returnSuccess();
 }
@@ -2195,11 +2365,30 @@ static ZL_Report ZL_CompressorDeserializer_tryBuildNode(
                     &base_local_params,
                     NULL));
 
+    // Read optional "mparam" field (hex string key) and look up the
+    // corresponding entry from the pre-parsed mparams map.
+    ZL_MParam mparam            = { .mparamID = ZL_MPARAM_ID_NULL };
+    const A1C_Item* mparam_item = A1C_Map_get_cstr(&val_map, "mparam");
+    if (mparam_item != NULL) {
+        A1C_TRY_EXTRACT_STRING(mparam_key_str, mparam_item);
+        const StringView mparam_key_sv = StringView_initFromA1C(mparam_key_str);
+
+        const CompressorDeserializer_MParamMap_Entry* const mp_entry =
+                CompressorDeserializer_MParamMap_find(
+                        &state->mparams_map, &mparam_key_sv);
+        ZL_ERR_IF_NULL(
+                mp_entry,
+                corruption,
+                "Node references mparam ID not found in mparams section");
+        mparam = mp_entry->val;
+    }
+
     const ZL_NodeID node_id = ZL_Compressor_registerParameterizedNode(
             compressor,
             &(const ZL_ParameterizedNodeDesc){
                     .node        = base_nid,
                     .localParams = &local_params,
+                    .mparam      = mparam,
             });
     ZL_ERR_IF_EQ(node_id.nid, ZL_NODE_ILLEGAL.nid, corruption);
 
@@ -3049,6 +3238,50 @@ static ZL_Report ZL_CompressorDeserializer_setupGraphs(
     return ZL_returnSuccess();
 }
 
+static ZL_Report ZL_CompressorDeserializer_setupMParams(
+        ZL_CompressorDeserializer* const state)
+{
+    ZL_RESULT_DECLARE_SCOPE_REPORT(state);
+    A1C_TRY_EXTRACT_MAP(root_map, state->root);
+    const A1C_Item* const mparams = A1C_Map_get_cstr(&root_map, "mparams");
+    if (mparams == NULL) {
+        return ZL_returnSuccess();
+    }
+    ZL_ERR_IF_NE(
+            mparams->type,
+            A1C_ItemType_map,
+            corruption,
+            "'mparams' field must be a map");
+    const A1C_Map* const mparams_map = &mparams->map;
+
+    for (size_t i = 0; i < mparams_map->size; i++) {
+        const A1C_Pair* const pair = &mparams_map->items[i];
+        A1C_TRY_EXTRACT_STRING(key_str, &pair->key);
+        const StringView key_sv = StringView_initFromA1C(key_str);
+
+        ZL_TRY_LET_CONST(ZL_MParamID, decoded_id, cs_hexDecodeMParamID(key_sv));
+
+        A1C_TRY_EXTRACT_BYTES(blob, &pair->val);
+
+        const ZL_MParam mp = {
+            .mparamID = decoded_id,
+            .content  = blob.data,
+            .size     = blob.size,
+        };
+
+        const CompressorDeserializer_MParamMap_Entry mp_entry =
+                (CompressorDeserializer_MParamMap_Entry){
+                    .key = key_sv,
+                    .val = mp,
+                };
+        const CompressorDeserializer_MParamMap_Insert mp_insert =
+                CompressorDeserializer_MParamMap_insert(
+                        &state->mparams_map, &mp_entry);
+        ZL_ERR_IF(mp_insert.badAlloc, allocation);
+    }
+    return ZL_returnSuccess();
+}
+
 static ZL_Report ZL_CompressorDeserializer_setStartingGraph(
         ZL_CompressorDeserializer* const state,
         ZL_Compressor* const compressor)
@@ -3147,6 +3380,8 @@ ZL_Report ZL_CompressorDeserializer_deserialize(
     ZL_ERR_IF_ERR(ZL_CompressorDeserializer_checkVersion(state));
 
     ZL_ERR_IF_ERR(ZL_CompressorDeserializer_setupParams(state));
+
+    ZL_ERR_IF_ERR(ZL_CompressorDeserializer_setupMParams(state));
 
     ZL_ERR_IF_ERR(ZL_CompressorDeserializer_setupNodes(
             state, ZL_CompressorDeserializer_tryBuildNode));

--- a/src/openzl/compress/enc_interface.c
+++ b/src/openzl/compress/enc_interface.c
@@ -101,6 +101,14 @@ const void* ZL_Encoder_getMaterializedDict(const ZL_Encoder* eictx)
     return CGRAPH_getDictObj(CCTX_getCGraph(eictx->cctx), offset);
 }
 
+const void* ZL_Encoder_getMParam(const ZL_Encoder* eictx)
+{
+    ZL_ASSERT_NN(eictx);
+    if (eictx->cnode == NULL)
+        return NULL;
+    return CNODE_getMParamObj(eictx->cnode);
+}
+
 const void* ENC_getPrivateParam(const ZL_Encoder* eictx)
 {
     return eictx->privateParam;

--- a/src/openzl/compress/graphmgr.c
+++ b/src/openzl/compress/graphmgr.c
@@ -30,6 +30,7 @@ struct GraphsMgr_s {
     /// Contains a map from name -> graph for all standard & custom graphs
     GraphMap nameMap;
     Arena* allocator;
+    Arena* scratchAllocator;
     const Nodes_manager* nmgr;
     ZL_OpaquePtrRegistry opaquePtrs;
     MaterializedParamMap materializedParams;
@@ -72,6 +73,11 @@ GraphsMgr* GM_create(const Nodes_manager* nmgr)
         GM_free(gm);
         return NULL;
     }
+    gm->scratchAllocator = ALLOC_StackArena_create();
+    if (gm->scratchAllocator == NULL) {
+        GM_free(gm);
+        return NULL;
+    }
     gm->materializedParams =
             MaterializedParamMap_create(ZL_ENCODER_GRAPH_LIMIT);
     VECTOR_INIT(gm->gdv, ZL_ENCODER_GRAPH_LIMIT);
@@ -88,11 +94,12 @@ void GM_free(GraphsMgr* gm)
 {
     if (gm == NULL)
         return;
-    MPM_dematerializeAllParams(&gm->materializedParams, gm->allocator);
+    MPM_dematerializeAllParams(&gm->materializedParams);
     MaterializedParamMap_destroy(&gm->materializedParams);
     ZL_OpaquePtrRegistry_destroy(&gm->opaquePtrs);
     VECTOR_DESTROY(gm->gdv);
     GraphMap_destroy(&gm->nameMap);
+    ALLOC_Arena_freeArena(gm->scratchAllocator);
     ALLOC_Arena_freeArena(gm->allocator);
     ZL_free(gm);
 }
@@ -321,6 +328,7 @@ static ZL_RESULT_OF(ZL_GraphID) GM_registerInternalGraph(
         // Add the materialized object to refParams
         ZL_ERR_IF_ERR(MPM_addOrReuseMaterializedParam(
                 gm->allocator,
+                gm->scratchAllocator,
                 &gm->materializedParams,
                 gm->opCtx,
                 &gdi.migd.localParams,
@@ -719,6 +727,7 @@ static ZL_RESULT_OF(ZL_GraphID) GM_registerSegmenter_internal(
         // Add the materialized object to refParams
         ZL_ERR_IF_ERR(MPM_addOrReuseMaterializedParam(
                 gm->allocator,
+                gm->scratchAllocator,
                 &gm->materializedParams,
                 gm->opCtx,
                 &gdi.segDesc.localParams,

--- a/src/openzl/compress/materializer.c
+++ b/src/openzl/compress/materializer.c
@@ -2,6 +2,7 @@
 
 #include "openzl/compress/materializer.h"
 #include "openzl/common/allocation.h" // ALLOC_*
+#include "openzl/common/unique_id.h"  // ZL_UniqueID_isValid
 #include "openzl/compress/localparams.h" // LP_getLocalRefParam, LP_getLocalIntParam
 
 // ******************************************************************
@@ -67,6 +68,14 @@ void ZL_NOOP_DEMATERIALIZE(ZL_Materializer* matCtx, void* materialized)
     (void)matCtx;
     (void)materialized;
     return;
+}
+
+bool ZL_MParamID_hasValue(const ZL_MParamID* id)
+{
+    if (id == NULL) {
+        return false;
+    }
+    return ZL_UniqueID_isValid(&id->id);
 }
 
 // ******************************************************************

--- a/src/openzl/compress/materializer.c
+++ b/src/openzl/compress/materializer.c
@@ -6,79 +6,6 @@
 #include "openzl/compress/localparams.h" // LP_getLocalRefParam, LP_getLocalIntParam
 
 // ******************************************************************
-// ZL_Materializer
-// ******************************************************************
-
-ZL_Materializer* ZL_Materializer_create(
-        Arena* allocator,
-        ZL_MaterializerDesc matDesc)
-{
-    ZL_Materializer* mat = ALLOC_Arena_malloc(allocator, sizeof(*mat));
-    if (mat == NULL) {
-        return NULL;
-    }
-    mat->persistentArena = allocator;
-    mat->scratchArena    = ALLOC_StackArena_create();
-    if (mat->scratchArena == NULL) {
-        ALLOC_Arena_free(allocator, mat);
-        return NULL;
-    }
-    mat->opaquePtr = matDesc.opaque;
-    mat->opCtx     = NULL;
-    return mat;
-}
-
-void ZL_Materializer_free(ZL_Materializer* mat)
-{
-    if (mat == NULL) {
-        return;
-    }
-    ALLOC_Arena_freeArena(mat->scratchArena);
-    ALLOC_Arena_free(mat->persistentArena, mat);
-}
-
-ZL_CONST_FN
-ZL_OperationContext* ZL_Materializer_getOperationContext(ZL_Materializer* mat)
-{
-    if (mat == NULL) {
-        return NULL;
-    }
-    return mat->opCtx;
-}
-
-void* ZL_Materializer_allocate(ZL_Materializer* mat, size_t size)
-{
-    if (mat == NULL || mat->persistentArena == NULL) {
-        return NULL;
-    }
-    return ALLOC_Arena_malloc(mat->persistentArena, size);
-}
-
-void* ZL_Materializer_getScratchSpace(ZL_Materializer* mat, size_t size)
-{
-    if (mat == NULL || mat->scratchArena == NULL) {
-        return NULL;
-    }
-    return ALLOC_Arena_malloc(mat->scratchArena, size);
-}
-
-void ZL_NOOP_DEMATERIALIZE(ZL_Materializer* matCtx, void* materialized)
-        ZL_NOEXCEPT_FUNC_PTR
-{
-    (void)matCtx;
-    (void)materialized;
-    return;
-}
-
-bool ZL_MParamID_hasValue(const ZL_MParamID* id)
-{
-    if (id == NULL) {
-        return false;
-    }
-    return ZL_UniqueID_isValid(&id->id);
-}
-
-// ******************************************************************
 // MaterializedParamMap
 // ******************************************************************
 
@@ -150,6 +77,7 @@ ZL_Report MPM_addMaterializedRefParam(
 
 ZL_Report MPM_addOrReuseMaterializedParam(
         Arena* allocator,
+        Arena* scratchAllocator,
         MaterializedParamMap* materializedParams,
         ZL_OperationContext* opCtx,
         ZL_LocalParams* lp,
@@ -183,10 +111,13 @@ ZL_Report MPM_addOrReuseMaterializedParam(
     }
 
     // Not found, create new materialized param
-    ZL_Materializer* mat = ZL_Materializer_create(allocator, *matDesc);
-    ZL_ERR_IF_NULL(mat, allocation);
-    ZL_RESULT_OF(ZL_VoidPtr) matResult = matDesc->materializeFn(mat, lp);
-    ZL_Materializer_free(mat);
+    ZL_Materializer mat = {
+        .persistentArena = allocator,
+        .scratchArena    = scratchAllocator,
+        .opaquePtr       = matDesc->opaque,
+    };
+    ZL_RESULT_OF(ZL_VoidPtr) matResult = matDesc->materializeFn(&mat, lp);
+    ALLOC_Arena_freeAll(scratchAllocator);
     ZL_ERR_IF_ERR(matResult);
 
     void* materialized = ZL_RES_value(matResult);
@@ -203,10 +134,13 @@ ZL_Report MPM_addOrReuseMaterializedParam(
     MaterializedParamMap_Insert insertResult =
             MaterializedParamMap_insert(materializedParams, &entryToInsert);
     if (insertResult.badAlloc) {
-        ZL_Materializer* mat2 = ZL_Materializer_create(allocator, *matDesc);
-        ZL_ERR_IF_NULL(mat2, allocation);
-        matDesc->dematerializeFn(mat2, materialized);
-        ZL_Materializer_free(mat2);
+        ZL_Materializer mat2 = {
+            // dematerializers aren't allowed to allocate
+            .persistentArena = NULL,
+            .scratchArena    = NULL,
+            .opaquePtr       = matDesc->opaque,
+        };
+        matDesc->dematerializeFn(&mat2, materialized);
         ZL_ERR(allocation, "Failed to insert materialized param into map");
     }
 
@@ -214,9 +148,7 @@ ZL_Report MPM_addOrReuseMaterializedParam(
             allocator, opCtx, lp, matDesc->paramId, materialized);
 }
 
-void MPM_dematerializeAllParams(
-        MaterializedParamMap* materializedParams,
-        Arena* allocator)
+void MPM_dematerializeAllParams(MaterializedParamMap* materializedParams)
 {
     MaterializedParamMap_Iter iter =
             MaterializedParamMap_iter(materializedParams);
@@ -224,14 +156,14 @@ void MPM_dematerializeAllParams(
     while ((entry = MaterializedParamMap_Iter_next(&iter)) != NULL) {
         if (entry->val.materializedParam != NULL) {
             ZL_ASSERT_NN(entry->key.matDesc.dematerializeFn);
-            ZL_Materializer* mat =
-                    ZL_Materializer_create(allocator, entry->key.matDesc);
-            if (mat == NULL) {
-                continue;
-            }
+            ZL_Materializer mat = {
+                // dematerializers aren't allowed to allocate
+                .persistentArena = NULL,
+                .scratchArena    = NULL,
+                .opaquePtr       = entry->key.matDesc.opaque,
+            };
             entry->key.matDesc.dematerializeFn(
-                    mat, entry->val.materializedParam);
-            ZL_Materializer_free(mat);
+                    &mat, entry->val.materializedParam);
         }
     }
 }
@@ -243,6 +175,7 @@ void MPM_dematerializeAllParams(
 ZL_RESULT_OF(OneshotMaterializationResult)
 MPM_materializeOneshot(
         Arena* allocator,
+        Arena* scratchAllocator,
         ZL_OperationContext* opCtx,
         const ZL_LocalParams* runtimeParams,
         const ZL_MaterializerDesc* matDesc)
@@ -262,11 +195,14 @@ MPM_materializeOneshot(
     ZL_ERR_IF_ERR(
             MPM_validateMaterializedParamId(runtimeParams, matDesc->paramId));
 
-    ZL_Materializer* mat = ZL_Materializer_create(allocator, *matDesc);
-    ZL_ERR_IF_NULL(mat, allocation);
+    ZL_Materializer mat = {
+        .persistentArena = allocator,
+        .scratchArena    = scratchAllocator,
+        .opaquePtr       = matDesc->opaque,
+    };
     ZL_RESULT_OF(ZL_VoidPtr)
-    matResult = matDesc->materializeFn(mat, runtimeParams);
-    ZL_Materializer_free(mat);
+    matResult = matDesc->materializeFn(&mat, runtimeParams);
+    ALLOC_Arena_freeAll(scratchAllocator);
     ZL_ERR_IF_ERR(matResult);
     void* materialized = ZL_RES_value(matResult);
 
@@ -285,11 +221,13 @@ MPM_materializeOneshot(
 
     if (ZL_isError(addResult)) {
         // Clean up materialized object
-        ZL_Materializer* mat2 = ZL_Materializer_create(allocator, *matDesc);
-        if (mat2 != NULL) {
-            matDesc->dematerializeFn(mat2, materialized);
-            ZL_Materializer_free(mat2);
-        }
+        ZL_Materializer mat2 = {
+            // dematerializers aren't allowed to allocate
+            .persistentArena = NULL,
+            .scratchArena    = NULL,
+            .opaquePtr       = matDesc->opaque,
+        };
+        matDesc->dematerializeFn(&mat2, materialized);
         ZL_ERR_IF_ERR(addResult);
     }
 
@@ -312,10 +250,11 @@ void MPM_dematerializeOneshot(
     // validity of the materializer in MPM_materializeOneshot
     ZL_ASSERT_NN(matResult->matDesc.dematerializeFn);
 
-    ZL_Materializer* mat =
-            ZL_Materializer_create(allocator, matResult->matDesc);
-    if (mat != NULL) {
-        matResult->matDesc.dematerializeFn(mat, matResult->materializedObj);
-        ZL_Materializer_free(mat);
-    }
+    ZL_Materializer mat = {
+        // dematerializers aren't allowed to allocate
+        .persistentArena = NULL,
+        .scratchArena    = NULL,
+        .opaquePtr       = matResult->matDesc.opaque,
+    };
+    matResult->matDesc.dematerializeFn(&mat, matResult->materializedObj);
 }

--- a/src/openzl/compress/materializer.h
+++ b/src/openzl/compress/materializer.h
@@ -5,27 +5,11 @@
 
 #include "openzl/common/allocation.h" // Arena
 #include "openzl/common/map.h"
+#include "openzl/dict/materializer_ctx.h" // struct ZL_Materializer_s
 #include "openzl/shared/portability.h"
 #include "openzl/zl_errors.h" // ZL_RESULT_DECLARE_TYPE_IMPL, ZL_RESULT_OF
 
 ZL_BEGIN_C_DECLS
-
-// ******************************************************************
-// ZL_Materializer
-// ******************************************************************
-
-struct ZL_Materializer_s {
-    Arena* persistentArena;
-    Arena* scratchArena;
-    const void* opaquePtr;
-    ZL_OperationContext* opCtx;
-} /* typedef'ed to ZL_Materializer in zl_opaque_types.h */;
-
-ZL_Materializer* ZL_Materializer_create(
-        Arena* allocator,
-        ZL_MaterializerDesc matDesc);
-
-void ZL_Materializer_free(ZL_Materializer* mat);
 
 // ******************************************************************
 // MaterializedParamMap
@@ -79,6 +63,7 @@ ZL_Report MPM_addMaterializedRefParam(
  */
 ZL_Report MPM_addOrReuseMaterializedParam(
         Arena* allocator,
+        Arena* scratchAllocator,
         MaterializedParamMap* materializedParams,
         ZL_OperationContext* opCtx,
         ZL_LocalParams* lp,
@@ -88,9 +73,7 @@ ZL_Report MPM_addOrReuseMaterializedParam(
  * Function called before MaterializedParamMap_destroy() to free all non-arena
  * memory allocated by materializers.
  */
-void MPM_dematerializeAllParams(
-        MaterializedParamMap* materializedParams,
-        Arena* allocator);
+void MPM_dematerializeAllParams(MaterializedParamMap* materializedParams);
 
 // ******************************************************************
 // MaterializedParamMap: Static functions
@@ -123,6 +106,7 @@ ZL_RESULT_DECLARE_TYPE(OneshotMaterializationResult);
 ZL_RESULT_OF(OneshotMaterializationResult)
 MPM_materializeOneshot(
         Arena* allocator,
+        Arena* scratchAllocator,
         ZL_OperationContext* opCtx,
         const ZL_LocalParams* runtimeParams,
         const ZL_MaterializerDesc* matDesc);

--- a/src/openzl/dict/dict.c
+++ b/src/openzl/dict/dict.c
@@ -58,6 +58,7 @@ ZL_RESULT_OF(ZL_ParsedDict) Dict_parse(const void* dictBuffer, size_t dictSize)
     result.contentSize = contentSize;
     result.packedSize  = ZL_DICT_HEADER_SIZE + (size_t)contentSize;
     result.dictContent = (const void*)p;
+    result.contentHash = ZL_UniqueID_computeSHA256(p, contentSize);
 
     return ZL_RESULT_WRAP_VALUE(ZL_ParsedDict, result);
 }

--- a/src/openzl/dict/dict.h
+++ b/src/openzl/dict/dict.h
@@ -28,6 +28,7 @@ extern "C" {
 
 struct ZL_Dict_s {
     ZL_DictID dictID;
+    ZL_UniqueID contentHash; // SHA-256 of raw dict content
     ZL_IDType materializingCodec;
     TransformType_e codecType;
     void* dictObj;
@@ -38,6 +39,7 @@ ZL_RESULT_DECLARE_TYPE(ZL_DictConstPtr);
 
 typedef struct {
     ZL_DictID dictID;
+    ZL_UniqueID contentHash; // SHA-256 of raw dict content
     ZL_IDType materializingCodec;
     TransformType_e codecType;
     const void* dictContent;

--- a/src/openzl/dict/materializer_ctx.c
+++ b/src/openzl/dict/materializer_ctx.c
@@ -1,0 +1,48 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#include "openzl/dict/materializer_ctx.h"
+
+#include "openzl/common/allocation.h"
+#include "openzl/common/unique_id.h"
+#include "openzl/zl_materializer.h"
+
+ZL_CONST_FN
+ZL_OperationContext* ZL_Materializer_getOperationContext(ZL_Materializer* mat)
+{
+    if (mat == NULL) {
+        return NULL;
+    }
+    return mat->opCtx;
+}
+
+void* ZL_Materializer_allocate(ZL_Materializer* mat, size_t size)
+{
+    if (mat == NULL || mat->persistentArena == NULL) {
+        return NULL;
+    }
+    return ALLOC_Arena_malloc(mat->persistentArena, size);
+}
+
+void* ZL_Materializer_getScratchSpace(ZL_Materializer* mat, size_t size)
+{
+    if (mat == NULL || mat->scratchArena == NULL) {
+        return NULL;
+    }
+    return ALLOC_Arena_malloc(mat->scratchArena, size);
+}
+
+void ZL_NOOP_DEMATERIALIZE(ZL_Materializer* matCtx, void* materialized)
+        ZL_NOEXCEPT_FUNC_PTR
+{
+    (void)matCtx;
+    (void)materialized;
+    return;
+}
+
+bool ZL_MParamID_hasValue(const ZL_MParamID* id)
+{
+    if (id == NULL) {
+        return false;
+    }
+    return ZL_UniqueID_isValid(&id->id);
+}

--- a/src/openzl/dict/materializer_ctx.h
+++ b/src/openzl/dict/materializer_ctx.h
@@ -1,0 +1,29 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#ifndef OPENZL_DICT_MATERIALIZER_CTX_H
+#define OPENZL_DICT_MATERIALIZER_CTX_H
+
+#include "openzl/common/allocation.h"       // Arena
+#include "openzl/detail/zl_error_context.h" // ZL_OperationContext
+
+#if defined(__cplusplus)
+extern "C" {
+#endif
+
+/**
+ * Concrete definition of the ZL_Materializer context struct.
+ * Forward-declared in zl_opaque_types.h as `struct ZL_Materializer_s`.
+ * Both :dict and :compress need visibility into this layout.
+ */
+struct ZL_Materializer_s {
+    Arena* persistentArena;
+    Arena* scratchArena;
+    const void* opaquePtr;
+    ZL_OperationContext* opCtx;
+} /* typedef'ed to ZL_Materializer in zl_opaque_types.h */;
+
+#if defined(__cplusplus)
+} // extern "C"
+#endif
+
+#endif // OPENZL_DICT_MATERIALIZER_CTX_H

--- a/tests/integrationtest/CompressorIntegrationTest.cpp
+++ b/tests/integrationtest/CompressorIntegrationTest.cpp
@@ -16,6 +16,7 @@
 #include "openzl/cpp/poly/Span.hpp"
 
 #include "openzl/zl_compressor.h"
+#include "openzl/zl_compressor_serialization.h"
 #include "openzl/zl_ctransform.h"
 #include "openzl/zl_graph_api.h"
 #include "openzl/zl_reflection.h"
@@ -1078,6 +1079,282 @@ TEST_F(CompressorIntegrationTest,
     baseRetrieved = ZL_Compressor_Node_getDictID(compressor_.get(), baseNode);
     EXPECT_EQ(baseRetrieved.id.bytes[0], 10u);
     EXPECT_EQ(baseRetrieved.id.bytes[1], 20u);
+}
+
+// This test exercises MParams thoroughly
+// 1. Create materializers and encoders that take materialized params
+// 2. Register nodes onto compressor (MParams materialize at registration time)
+// 3. Compress
+// 4. Serialize + Deserialize
+// 5. Compress again (must match artifact in step 3)
+TEST_F(CompressorIntegrationTest,
+       GIVENmparamsLoadedWHENserializedAndDeserializedTHENcompressedOutputMatches)
+{
+    // --- MParam content blobs ---
+    const std::string mparam1_content = "mparam-blob-for-node-A-original";
+    const std::string mparam2_content = "mparam-blob-for-node-B-different-mat";
+    const std::string mparam3_content =
+            "mparam-blob-for-node-A-parameterized-1";
+    const std::string mparam4_content =
+            "mparam-blob-for-node-A-parameterized-2";
+
+    // --- MParam IDs ---
+    ZL_MParamID id1 = ZL_MPARAM_ID_NULL;
+    id1.id.bytes[0] = 0x01;
+    ZL_MParamID id2 = ZL_MPARAM_ID_NULL;
+    id2.id.bytes[0] = 0x02;
+    ZL_MParamID id3 = ZL_MPARAM_ID_NULL;
+    id3.id.bytes[0] = 0x03;
+    ZL_MParamID id4 = ZL_MPARAM_ID_NULL;
+    id4.id.bytes[0] = 0x04;
+
+    // --- Two different materializers ---
+    ZL_MaterializerDesc2 matA{};
+    matA.materializeFn   = copyDictMaterialize;
+    matA.dematerializeFn = ZL_NOOP_DEMATERIALIZE;
+
+    ZL_MaterializerDesc2 matB{};
+    matB.materializeFn   = copyDictMaterialize;
+    matB.dematerializeFn = ZL_NOOP_DEMATERIALIZE;
+    matB.opaque          = { .ptr = (void*)0xBEEF };
+
+    // --- Encoder that verifies MParam content against CopyParam ---
+    const auto encoderVerifyingMParam =
+            [](ZL_Encoder* eictx, const ZL_Input* inputs[], size_t nbInputs)
+                    ZL_NOEXCEPT_FUNC_PTR -> ZL_Report {
+        ZL_RESULT_DECLARE_SCOPE_REPORT(eictx);
+
+        const void* mparam = ZL_Encoder_getMParam(eictx);
+        ZL_ERR_IF_NULL(mparam, GENERIC, "Expected getMParam non-null");
+
+        auto cp = ZL_Encoder_getLocalCopyParam(eictx, 1);
+        ZL_ERR_IF_NULL(cp.paramPtr, GENERIC, "Expected CopyParam(1) non-null");
+        ZL_ERR_IF_NE(
+                memcmp(mparam, cp.paramPtr, cp.paramSize),
+                0,
+                GENERIC,
+                "MParam content mismatch with expected CopyParam");
+
+        return passthrough(eictx, inputs, nbInputs);
+    };
+
+    // --- Encoder that verifies MParam is NULL ---
+    const auto encoderNoMParam =
+            [](ZL_Encoder* eictx, const ZL_Input* inputs[], size_t nbInputs)
+                    ZL_NOEXCEPT_FUNC_PTR -> ZL_Report {
+        ZL_RESULT_DECLARE_SCOPE_REPORT(eictx);
+
+        const void* mparam = ZL_Encoder_getMParam(eictx);
+        ZL_ERR_IF_NN(
+                mparam,
+                GENERIC,
+                "Expected getMParam NULL for node without mparam");
+
+        return passthrough(eictx, inputs, nbInputs);
+    };
+
+    // --- Register nodes ---
+    static ZL_Type typetype = ZL_Type_serial;
+
+    auto makeGraphDesc = [&]() -> ZL_MIGraphDesc {
+        return ZL_MIGraphDesc{
+            .CTid                = nextCtid_++,
+            .inputTypes          = &typetype,
+            .nbInputs            = 1,
+            .lastInputIsVariable = false,
+            .soTypes             = &typetype,
+            .nbSOs               = 1,
+            .voTypes             = nullptr,
+            .nbVOs               = 0,
+        };
+    };
+
+    // Node A: matA + id1, CopyParam holds expected mparam1_content
+    ZL_CopyParam cpA = {
+        .paramId   = 1,
+        .paramPtr  = mparam1_content.data(),
+        .paramSize = mparam1_content.size(),
+    };
+    ZL_LocalParams lpA = {
+        .copyParams = {
+            .copyParams   = &cpA,
+            .nbCopyParams = 1,
+        },
+    };
+    ZL_MIEncoderDesc descA{
+        .gd          = makeGraphDesc(),
+        .transform_f = encoderVerifyingMParam,
+        .localParams = lpA,
+        .name        = "!encoder_mparam_A",
+        .mparamMat   = matA,
+        .mparam      = {
+            .content  = mparam1_content.data(),
+            .size     = mparam1_content.size(),
+            .mparamID = id1,
+        },
+    };
+    auto nodeA = compressor_.registerCustomEncoder(descA);
+    ASSERT_NE(nodeA.nid, ZL_NODE_ILLEGAL.nid);
+
+    // Node B: matB + id2 (different materializer)
+    ZL_CopyParam cpB = {
+        .paramId   = 1,
+        .paramPtr  = mparam2_content.data(),
+        .paramSize = mparam2_content.size(),
+    };
+    ZL_LocalParams lpB = {
+        .copyParams = {
+            .copyParams   = &cpB,
+            .nbCopyParams = 1,
+        },
+    };
+    ZL_MIEncoderDesc descB{
+        .gd          = makeGraphDesc(),
+        .transform_f = encoderVerifyingMParam,
+        .localParams = lpB,
+        .name        = "!encoder_mparam_B",
+        .mparamMat   = matB,
+        .mparam      = {
+            .content  = mparam2_content.data(),
+            .size     = mparam2_content.size(),
+            .mparamID = id2,
+        },
+    };
+    auto nodeB = compressor_.registerCustomEncoder(descB);
+    ASSERT_NE(nodeB.nid, ZL_NODE_ILLEGAL.nid);
+
+    // Node C: no mparam
+    ZL_MIEncoderDesc descC{
+        .gd          = makeGraphDesc(),
+        .transform_f = encoderNoMParam,
+        .name        = "!encoder_no_mparam",
+    };
+    auto nodeC = compressor_.registerCustomEncoder(descC);
+    ASSERT_NE(nodeC.nid, ZL_NODE_ILLEGAL.nid);
+
+    // Parameterize nodeA with id3 (same materializer, different MParam)
+    ZL_CopyParam cp3 = {
+        .paramId   = 1,
+        .paramPtr  = mparam3_content.data(),
+        .paramSize = mparam3_content.size(),
+    };
+    ZL_LocalParams lp3 = {
+        .copyParams = {
+            .copyParams   = &cp3,
+            .nbCopyParams = 1,
+        },
+    };
+    ZL_NodeParameters params3{
+        .localParams = &lp3,
+        .mparam      = {
+            .content  = mparam3_content.data(),
+            .size     = mparam3_content.size(),
+            .mparamID = id3,
+        },
+    };
+    auto result3 =
+            ZL_Compressor_parameterizeNode(compressor_.get(), nodeA, &params3);
+    ASSERT_FALSE(ZL_RES_isError(result3));
+    auto nodeA_param1 = ZL_RES_value(result3);
+
+    // Parameterize nodeA again with id4
+    ZL_CopyParam cp4 = {
+        .paramId   = 1,
+        .paramPtr  = mparam4_content.data(),
+        .paramSize = mparam4_content.size(),
+    };
+    ZL_LocalParams lp4 = {
+        .copyParams = {
+            .copyParams   = &cp4,
+            .nbCopyParams = 1,
+        },
+    };
+    ZL_NodeParameters params4{
+        .localParams = &lp4,
+        .mparam      = {
+            .content  = mparam4_content.data(),
+            .size     = mparam4_content.size(),
+            .mparamID = id4,
+        },
+    };
+    auto result4 =
+            ZL_Compressor_parameterizeNode(compressor_.get(), nodeA, &params4);
+    ASSERT_FALSE(ZL_RES_isError(result4));
+    auto nodeA_param2 = ZL_RES_value(result4);
+
+    // --- Build graph: nodeA → nodeB → nodeC → nodeA_param1 → nodeA_param2 →
+    // STORE ---
+    std::array<ZL_NodeID, 5> nodes = {
+        nodeA, nodeB, nodeC, nodeA_param1, nodeA_param2
+    };
+    auto graphId = ZL_Compressor_registerStaticGraph_fromPipelineNodes1o(
+            compressor_.get(), nodes.data(), nodes.size(), ZL_GRAPH_STORE);
+    ASSERT_NE(graphId.gid, ZL_GRAPH_ILLEGAL.gid);
+
+    compressor_.selectStartingGraph(graphId);
+
+    // --- First compress: verify MParam content ---
+    cctx_.refCompressor(compressor_);
+    cctx_.setParameter(CParam::FormatVersion, ZL_MAX_FORMAT_VERSION);
+
+    std::string src =
+            "Let me think. That's just inherently very difficult. What are we doing?";
+    std::vector<char> dst(1000);
+    size_t compressedSize =
+            cctx_.compressSerial(poly::span<char>(dst.data(), dst.size()), src);
+    ASSERT_GT(compressedSize, 0u);
+
+    // --- Serialize the compressor ---
+    ZL_CompressorSerializer* serializer = ZL_CompressorSerializer_create();
+    ASSERT_NE(serializer, nullptr);
+
+    void* serialized      = nullptr;
+    size_t serializedSize = 0;
+    {
+        ZL_Report r = ZL_CompressorSerializer_serialize(
+                serializer, compressor_.get(), &serialized, &serializedSize);
+        ASSERT_FALSE(ZL_isError(r));
+    }
+
+    std::vector<uint8_t> serializedCopy(
+            (const uint8_t*)serialized,
+            (const uint8_t*)serialized + serializedSize);
+    ZL_CompressorSerializer_free(serializer);
+
+    // --- Deserialize into a new compressor ---
+    openzl::Compressor compressor2;
+
+    // Pre-register the same custom nodes
+    compressor2.registerCustomEncoder(descA);
+    compressor2.registerCustomEncoder(descB);
+    compressor2.registerCustomEncoder(descC);
+
+    // Deserialize — MParams should be auto-materialized from the CBOR
+    ZL_CompressorDeserializer* deserializer =
+            ZL_CompressorDeserializer_create();
+    ASSERT_NE(deserializer, nullptr);
+    {
+        ZL_Report r = ZL_CompressorDeserializer_deserialize(
+                deserializer,
+                compressor2.get(),
+                serializedCopy.data(),
+                serializedCopy.size());
+        ASSERT_FALSE(ZL_isError(r));
+    }
+    ZL_CompressorDeserializer_free(deserializer);
+
+    // --- Second compress with deserialized compressor ---
+    openzl::CCtx cctx2;
+    cctx2.refCompressor(compressor2);
+    cctx2.setParameter(CParam::FormatVersion, ZL_MAX_FORMAT_VERSION);
+
+    std::vector<char> dst2(1000);
+    size_t compressedSize2 = cctx2.compressSerial(
+            poly::span<char>(dst2.data(), dst2.size()), src);
+    ASSERT_EQ(compressedSize, compressedSize2);
+    ASSERT_EQ(
+            std::string(dst.data(), compressedSize),
+            std::string(dst2.data(), compressedSize));
 }
 
 } // namespace openzl

--- a/tests/unittest/compress/CompressorUnitTest.cpp
+++ b/tests/unittest/compress/CompressorUnitTest.cpp
@@ -22,6 +22,7 @@
 #include "openzl/zl_reflection.h"
 #include "openzl/zl_selector.h"
 
+#include "tests/unittest/compress/CDictMgrTestHelpers.h"
 #include "tests/utils.h"
 
 using namespace ::testing;
@@ -417,6 +418,69 @@ class CompressorTest : public Test {
                 .nbIntParams = 1,
             },
         };
+    }
+
+    // ---- MParam sideloading helpers ----
+
+    static ZL_MParamID makeMParamID(uint8_t seed)
+    {
+        ZL_MParamID id = ZL_MPARAM_ID_NULL;
+        for (size_t i = 0; i < 32; i++) {
+            id.id.bytes[i] = static_cast<uint8_t>(seed + i);
+        }
+        return id;
+    }
+
+    static ZL_MaterializerDesc2 makeMParamMat()
+    {
+        return makeDefaultDictMaterializer();
+    }
+
+    ZL_NodeID registerNodeWithMParam(
+            ZL_MParamID mparamID,
+            ZL_MaterializerDesc2 mparamMat,
+            const void* content,
+            size_t contentSize)
+    {
+        static ZL_IDType nextMParamCtid = 5000;
+        static ZL_Type typetype         = ZL_Type_serial;
+        ZL_MIGraphDesc graphDesc{
+            .CTid                = nextMParamCtid++,
+            .inputTypes          = &typetype,
+            .nbInputs            = 1,
+            .lastInputIsVariable = false,
+            .soTypes             = &typetype,
+            .nbSOs               = 1,
+            .voTypes             = nullptr,
+            .nbVOs               = 0,
+        };
+
+        ZL_MParam mparam{
+            .content  = content,
+            .size     = contentSize,
+            .mparamID = mparamID,
+        };
+
+        ZL_MIEncoderDesc encoderDesc{
+            .gd          = graphDesc,
+            .transform_f = dummyEncoder,
+            .name        = "mparam_node",
+            .mparamMat   = mparamMat,
+            .mparam      = mparam,
+        };
+
+        return ZL_Compressor_registerMIEncoder(compressor_.get(), &encoderDesc);
+    }
+
+    ZL_NodeID parameterizeWithMParam(ZL_NodeID baseNode, ZL_MParam mparam)
+    {
+        ZL_ParameterizedNodeDesc paramDesc{
+            .name   = "mparam_param_node",
+            .node   = baseNode,
+            .mparam = mparam,
+        };
+        return ZL_Compressor_registerParameterizedNode(
+                compressor_.get(), &paramDesc);
     }
 
    protected:
@@ -1988,4 +2052,169 @@ TEST_F(CompressorTest,
     // Should not create a new materialized object for identical params
     EXPECT_EQ(materializeCount, 1)
             << "Should reuse materialized object when local params are identical";
+}
+
+// =============================================================================
+// MParam Registration Tests
+// =============================================================================
+
+TEST_F(CompressorTest, MParamRegistrationWithContent)
+{
+    auto mparamID  = makeMParamID(42);
+    auto mparamMat = makeMParamMat();
+    std::vector<uint8_t> rawContent(16, 0xCD);
+
+    auto node = registerNodeWithMParam(
+            mparamID, mparamMat, rawContent.data(), rawContent.size());
+    ASSERT_NE(node.nid, ZL_NODE_ILLEGAL.nid);
+
+    auto graphId = ZL_Compressor_registerStaticGraph_fromPipelineNodes1o(
+            compressor_.get(), &node, 1, ZL_GRAPH_STORE);
+    ASSERT_NE(graphId.gid, ZL_GRAPH_ILLEGAL.gid);
+
+    ASSERT_FALSE(
+            ZL_isError(ZL_Compressor_validate(compressor_.get(), graphId)));
+
+    ASSERT_NE(
+            ZL_Compressor_Node_getMParamObj(compressor_.get(), node), nullptr);
+}
+
+TEST_F(CompressorTest, MParamRegistrationMultipleMaterializations)
+{
+    auto mparamID   = makeMParamID(42);
+    auto mparamMat  = makeMParamMat();
+    auto mparamMat2 = mparamMat;
+    char dummy;
+    mparamMat2.opaque.ptr = (void*)&dummy;
+    std::vector<uint8_t> rawContent(16, 0xCD);
+
+    auto node1 = registerNodeWithMParam(
+            mparamID, mparamMat, rawContent.data(), rawContent.size());
+    ASSERT_NE(node1.nid, ZL_NODE_ILLEGAL.nid);
+
+    auto node2 = registerNodeWithMParam(
+            mparamID, mparamMat2, rawContent.data(), rawContent.size());
+    ASSERT_NE(node2.nid, ZL_NODE_ILLEGAL.nid);
+
+    auto graphId = ZL_Compressor_registerStaticGraph_fromPipelineNodes1o(
+            compressor_.get(), &node1, 1, ZL_GRAPH_STORE);
+    ASSERT_NE(graphId.gid, ZL_GRAPH_ILLEGAL.gid);
+
+    ASSERT_FALSE(
+            ZL_isError(ZL_Compressor_validate(compressor_.get(), graphId)));
+
+    ASSERT_NE(
+            ZL_Compressor_Node_getMParamObj(compressor_.get(), node1), nullptr);
+    ASSERT_NE(
+            ZL_Compressor_Node_getMParamObj(compressor_.get(), node2), nullptr);
+    // Different materializers should result in different materialized objects
+    ASSERT_NE(
+            ZL_Compressor_Node_getMParamObj(compressor_.get(), node1),
+            ZL_Compressor_Node_getMParamObj(compressor_.get(), node2));
+}
+
+TEST_F(CompressorTest, MParamRegistrationMultipleIDs)
+{
+    auto id1 = makeMParamID(10);
+    auto id2 = makeMParamID(20);
+    auto mat = makeMParamMat();
+    std::vector<uint8_t> content1(16, 0xAA);
+    std::vector<uint8_t> content2(16, 0xBB);
+
+    auto node1 =
+            registerNodeWithMParam(id1, mat, content1.data(), content1.size());
+    ASSERT_NE(node1.nid, ZL_NODE_ILLEGAL.nid);
+
+    auto node2 =
+            registerNodeWithMParam(id2, mat, content2.data(), content2.size());
+    ASSERT_NE(node2.nid, ZL_NODE_ILLEGAL.nid);
+
+    std::array<ZL_NodeID, 2> nodes = { node1, node2 };
+    auto graphId = ZL_Compressor_registerStaticGraph_fromPipelineNodes1o(
+            compressor_.get(), nodes.data(), nodes.size(), ZL_GRAPH_STORE);
+    ASSERT_NE(graphId.gid, ZL_GRAPH_ILLEGAL.gid);
+
+    ASSERT_FALSE(
+            ZL_isError(ZL_Compressor_validate(compressor_.get(), graphId)));
+
+    ASSERT_NE(
+            ZL_Compressor_Node_getMParamObj(compressor_.get(), node1), nullptr);
+    ASSERT_NE(
+            ZL_Compressor_Node_getMParamObj(compressor_.get(), node2), nullptr);
+    // Different IDs should result in different materialized objects
+    ASSERT_NE(
+            ZL_Compressor_Node_getMParamObj(compressor_.get(), node1),
+            ZL_Compressor_Node_getMParamObj(compressor_.get(), node2));
+}
+
+TEST_F(CompressorTest, WHENmparamRegisteredWithoutIDTHENoneIsAssigned)
+{
+    auto mat = makeMParamMat();
+    std::vector<uint8_t> content(16, 0xCD);
+
+    auto node = registerNodeWithMParam(
+            ZL_MPARAM_ID_NULL, mat, content.data(), content.size());
+    ASSERT_NE(node.nid, ZL_NODE_ILLEGAL.nid);
+
+    auto graphId = ZL_Compressor_registerStaticGraph_fromPipelineNodes1o(
+            compressor_.get(), &node, 1, ZL_GRAPH_STORE);
+    ASSERT_NE(graphId.gid, ZL_GRAPH_ILLEGAL.gid);
+
+    ASSERT_FALSE(
+            ZL_isError(ZL_Compressor_validate(compressor_.get(), graphId)));
+
+    ASSERT_NE(
+            ZL_Compressor_Node_getMParamObj(compressor_.get(), node), nullptr);
+    auto reflectedID = ZL_Compressor_Node_getMParamID(compressor_.get(), node);
+    ASSERT_TRUE(ZL_UniqueID_isValid(&reflectedID.id));
+}
+
+TEST_F(CompressorTest, WHENbadRegistrationTHENvalidationFails)
+{
+    auto idNeeded = makeMParamID(50);
+    auto mat      = makeMParamMat();
+    std::vector<uint8_t> content(16, 0xCD);
+
+    // Register with no content — validation should fail
+    auto node = registerNodeWithMParam(idNeeded, mat, nullptr, content.size());
+    ASSERT_EQ(node.nid, ZL_NODE_ILLEGAL.nid);
+
+    // Register with bad length - validation should fail
+    node = registerNodeWithMParam(idNeeded, mat, content.data(), 0);
+    ASSERT_EQ(node.nid, ZL_NODE_ILLEGAL.nid);
+
+    // Register without materializer — validation should fail
+    node = registerNodeWithMParam(idNeeded, {}, content.data(), content.size());
+    ASSERT_EQ(node.nid, ZL_NODE_ILLEGAL.nid);
+
+    // Register with bad materializer — validation should fail
+    auto badMat            = makeMParamMat();
+    badMat.dematerializeFn = nullptr;
+    node                   = registerNodeWithMParam(
+            idNeeded, badMat, content.data(), content.size());
+    ASSERT_EQ(node.nid, ZL_NODE_ILLEGAL.nid);
+}
+
+TEST_F(CompressorTest, MParamDedup)
+{
+    auto mparamID  = makeMParamID(42);
+    auto mparamMat = makeMParamMat();
+    std::vector<uint8_t> rawContent(16, 0xCD);
+
+    // Register two nodes with the same mparamID and same materializer
+    auto node1 = registerNodeWithMParam(
+            mparamID, mparamMat, rawContent.data(), rawContent.size());
+    ASSERT_NE(node1.nid, ZL_NODE_ILLEGAL.nid);
+
+    auto node2 = registerNodeWithMParam(
+            mparamID, mparamMat, rawContent.data(), rawContent.size());
+    ASSERT_NE(node2.nid, ZL_NODE_ILLEGAL.nid);
+
+    // Both should share the same materialized object (dedup by cache key)
+    const void* obj1 =
+            ZL_Compressor_Node_getMParamObj(compressor_.get(), node1);
+    const void* obj2 =
+            ZL_Compressor_Node_getMParamObj(compressor_.get(), node2);
+    ASSERT_NE(obj1, nullptr);
+    EXPECT_EQ(obj1, obj2) << "Same mparamID + same materializer should dedup";
 }


### PR DESCRIPTION
Summary:

Add a ZL_UniqueID contentHash field (SHA-256 of raw dict content) to both
ZL_Dict_s and ZL_ParsedDict. Dict_parse now computes the hash at parse time.

This enables the FatBundleDictLoader (next diff) to verify that two dicts
loaded with the same ID actually have the same content, catching ID collisions.

Reviewed By: terrelln

Differential Revision: D100242067
