### PR TITLE
LZ Codec

### DIFF
--- a/.claude/skills/openzl-component-registry/SKILL.md
+++ b/.claude/skills/openzl-component-registry/SKILL.md
@@ -1,0 +1,6 @@
+---
+name: openzl-component-registry
+description: Design documentation for the OpenZL component registry located under tests/registry. **USE AUTOMATICALLY** whenever editing files under tests/registry/.
+---
+
+@../../../tests/registry/README.md

--- a/cpp/include/openzl/cpp/Codecs.hpp
+++ b/cpp/include/openzl/cpp/Codecs.hpp
@@ -20,6 +20,7 @@
 #include "openzl/cpp/codecs/Flatpack.hpp"         // IWYU pragma: export
 #include "openzl/cpp/codecs/FloatDeconstruct.hpp" // IWYU pragma: export
 #include "openzl/cpp/codecs/Illegal.hpp"          // IWYU pragma: export
+#include "openzl/cpp/codecs/Lz.hpp"               // IWYU pragma: export
 #include "openzl/cpp/codecs/Lz4.hpp"              // IWYU pragma: export
 #include "openzl/cpp/codecs/MergeSorted.hpp"      // IWYU pragma: export
 #include "openzl/cpp/codecs/ParseInt.hpp"         // IWYU pragma: export

--- a/cpp/include/openzl/cpp/codecs/Lz.hpp
+++ b/cpp/include/openzl/cpp/codecs/Lz.hpp
@@ -1,0 +1,39 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#pragma once
+
+#include "openzl/codecs/zl_lz.h"
+#include "openzl/cpp/Compressor.hpp"
+#include "openzl/cpp/codecs/Metadata.hpp"
+#include "openzl/cpp/codecs/Node.hpp"
+
+namespace openzl {
+namespace nodes {
+struct Lz : public Node {
+   public:
+    static constexpr NodeID node = ZL_NODE_LZ;
+
+    static constexpr NodeMetadata<1, 4> metadata = {
+        .inputs           = { InputMetadata{ .type = Type::Serial } },
+        .singletonOutputs = { OutputMetadata{ .type = Type::Serial,
+                                              .name = "literals" },
+                              OutputMetadata{ .type = Type::Numeric,
+                                              .name = "offsets" },
+                              OutputMetadata{ .type = Type::Numeric,
+                                              .name = "literal lengths" },
+                              OutputMetadata{ .type = Type::Numeric,
+                                              .name = "match lengths" } },
+        .description      = "LZ77 compress a serial byte stream",
+    };
+
+    Lz() {}
+
+    NodeID baseNode() const override
+    {
+        return node;
+    }
+
+    ~Lz() override = default;
+};
+} // namespace nodes
+} // namespace openzl

--- a/include/openzl/codecs/zl_lz.h
+++ b/include/openzl/codecs/zl_lz.h
@@ -1,0 +1,30 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#ifndef OPENZL_CODECS_LZ_H
+#define OPENZL_CODECS_LZ_H
+
+#include "openzl/zl_nodes.h"
+
+#if defined(__cplusplus)
+extern "C" {
+#endif
+
+// LZ compresses a serial byte stream using LZ77 matching,
+// decomposing it into four output streams.
+//
+// Input: A serial byte stream.
+// Output 1: Literals: A serial stream of unmatched bytes.
+// Output 2: Offsets: A numeric stream of match distances.
+// Output 3: Literal Lengths: A numeric stream of literal run lengths.
+// Output 4: Match Lengths: A numeric stream of match lengths.
+#define ZL_NODE_LZ ZL_MAKE_NODE_ID(ZL_StandardNodeID_lz)
+
+/// The LZ encoder sets the metadata on this ID to the minimum possible
+/// match length emitted by the encoder.
+#define ZL_LZ_MIN_MATCH_LENGTH_METADATA_ID 77
+
+#if defined(__cplusplus)
+}
+#endif
+
+#endif

--- a/include/openzl/zl_nodes.h
+++ b/include/openzl/zl_nodes.h
@@ -91,6 +91,8 @@ typedef enum {
     ZL_StandardNodeID_sentinel_byte,
     ZL_StandardNodeID_sentinel_num,
 
+    ZL_StandardNodeID_lz,
+
     ZL_StandardNodeID_public_end // last id, used to detect end of public range
 } ZL_StandardNodeID;
 

--- a/include/openzl/zl_public_nodes.h
+++ b/include/openzl/zl_public_nodes.h
@@ -30,6 +30,7 @@
 #include "openzl/codecs/zl_generic.h"              // IWYU pragma: export
 #include "openzl/codecs/zl_illegal.h"              // IWYU pragma: export
 #include "openzl/codecs/zl_interleave.h"           // IWYU pragma: export
+#include "openzl/codecs/zl_lz.h"                   // IWYU pragma: export
 #include "openzl/codecs/zl_lz4.h"                  // IWYU pragma: export
 #include "openzl/codecs/zl_merge_sorted.h"         // IWYU pragma: export
 #include "openzl/codecs/zl_mlselector.h"           // IWYU pragma: export

--- a/src/openzl/codecs/decoder_registry.c
+++ b/src/openzl/codecs/decoder_registry.c
@@ -132,6 +132,7 @@ const StandardDTransform SDecoders_array[ZL_StandardTransformID_end] = {
     REGISTER_TTRANSFORM_G(ZL_StandardTransformID_lz4, 23, DI_LZ4, PIPE_GRAPH),
     REGISTER_TTRANSFORM_G(ZL_StandardTransformID_partition, 24, DI_PARTITION, PARTITION_GRAPH),
     REGISTER_TTRANSFORM_G(ZL_StandardTransformID_sentinel, 24, DI_SENTINEL, SENTINEL_GRAPH),
+    REGISTER_TTRANSFORM_G(ZL_StandardTransformID_lz, 24, DI_LZ, LZ_GRAPH),
 
     REGISTER_VOTRANSFORM_G(ZL_StandardTransformID_splitn, 9, DI_SPLITN, GRAPH_VO_SERIAL),
     REGISTER_VOTRANSFORM_G(ZL_StandardTransformID_splitn_struct, 14, DI_SPLITN_STRUCT, GRAPH_VO_STRUCT),

--- a/src/openzl/codecs/encoder_registry.c
+++ b/src/openzl/codecs/encoder_registry.c
@@ -119,6 +119,7 @@ const CNode ER_standardNodes[STANDARD_ENCODERS_NB] = {
     REGISTER_TRANSFORM(ZL_StandardNodeID_split_byrange, ZL_StandardTransformID_splitn_num, 24, EI_SPLIT_BYRANGE),
     REGISTER_TRANSFORM(ZL_StandardNodeID_sentinel_byte, ZL_StandardTransformID_sentinel, 24, EI_SENTINEL_BYTE),
     REGISTER_TRANSFORM(ZL_StandardNodeID_sentinel_num, ZL_StandardTransformID_sentinel, 24, EI_SENTINEL),
+    REGISTER_TRANSFORM(ZL_StandardNodeID_lz, ZL_StandardTransformID_lz, 24, EI_LZ),
 
     // Private Nodes
     REGISTER_TRANSFORM(ZL_PrivateStandardNodeID_set_string_lens,           ZL_StandardTransformID_convert_serial_string, 10, EI_SETSTRINGLENS),

--- a/src/openzl/codecs/lz/decode_lz_binding.c
+++ b/src/openzl/codecs/lz/decode_lz_binding.c
@@ -3,6 +3,7 @@
 #include "openzl/codecs/lz/decode_lz_binding.h"
 
 #include "openzl/codecs/lz/common_field_lz.h"
+#include "openzl/codecs/lz/decode_lz_kernel.h"
 #include "openzl/common/assertion.h"
 #include "openzl/shared/utils.h"
 #include "openzl/shared/varint.h"
@@ -101,4 +102,60 @@ ZL_Report DI_fieldLz(ZL_Decoder* dictx, const ZL_Input* ins[])
     ZL_ERR_IF_ERR(ZL_Output_commit(dst, ZL_validResult(dstSize)));
 
     return ZL_returnValue(1);
+}
+
+ZL_Report DI_lz(ZL_Decoder* dictx, const ZL_Input* ins[])
+{
+    ZL_RESULT_DECLARE_SCOPE_REPORT(dictx);
+
+    ZL_Input const* const literals    = ins[0];
+    ZL_Input const* const offsets     = ins[1];
+    ZL_Input const* const literalLens = ins[2];
+    ZL_Input const* const matchLens   = ins[3];
+
+    size_t const offsetsEltWidth     = ZL_Input_eltWidth(offsets);
+    size_t const literalLensEltWidth = ZL_Input_eltWidth(literalLens);
+    size_t const matchLensEltWidth   = ZL_Input_eltWidth(matchLens);
+
+    size_t const numSequences = ZL_Input_numElts(offsets);
+    ZL_ERR_IF_NE(
+            numSequences,
+            ZL_Input_numElts(literalLens),
+            corruption,
+            "LZ: offsets and literal_lengths must have same count");
+    ZL_ERR_IF_NE(
+            numSequences,
+            ZL_Input_numElts(matchLens),
+            corruption,
+            "LZ: offsets and match_lengths must have same count");
+
+    ZL_RBuffer const header        = ZL_Decoder_getCodecHeader(dictx);
+    uint8_t const* headerStart     = (uint8_t const*)header.start;
+    uint8_t const* const headerEnd = headerStart + header.size;
+    ZL_TRY_LET_CONST(
+            uint64_t, dstSize, ZL_varintDecode(&headerStart, headerEnd));
+    ZL_ERR_IF_NE(
+            headerStart, headerEnd, corruption, "LZ: header leftover bytes");
+
+    ZL_Output* dst = ZL_Decoder_create1OutStream(dictx, dstSize, 1);
+    ZL_ERR_IF_NULL(dst, allocation);
+
+    ZL_Lz_InSequences const src = {
+        .literals               = (const uint8_t*)ZL_Input_ptr(literals),
+        .numLiterals            = ZL_Input_numElts(literals),
+        .offsets                = ZL_Input_ptr(offsets),
+        .offsetsEltWidth        = offsetsEltWidth,
+        .literalLengths         = ZL_Input_ptr(literalLens),
+        .literalLengthsEltWidth = literalLensEltWidth,
+        .matchLengths           = ZL_Input_ptr(matchLens),
+        .matchLengthsEltWidth   = matchLensEltWidth,
+        .numSequences           = numSequences,
+    };
+    ZL_LzError const err =
+            ZL_Lz_decode((uint8_t*)ZL_Output_ptr(dst), (size_t)dstSize, &src);
+    ZL_ERR_IF_NE(err, ZL_LzError_ok, corruption, "LZ decode failed");
+
+    ZL_ERR_IF_ERR(ZL_Output_commit(dst, (size_t)dstSize));
+
+    return ZL_returnSuccess();
 }

--- a/src/openzl/codecs/lz/decode_lz_binding.h
+++ b/src/openzl/codecs/lz/decode_lz_binding.h
@@ -10,8 +10,10 @@
 ZL_BEGIN_C_DECLS
 
 ZL_Report DI_fieldLz(ZL_Decoder* dictx, const ZL_Input* ins[]);
+ZL_Report DI_lz(ZL_Decoder* dictx, const ZL_Input* ins[]);
 
 #define DI_FIELD_LZ(id) { .transform_f = DI_fieldLz, .name = "field lz" }
+#define DI_LZ(id) { .transform_f = DI_lz, .name = "!zl.lz" }
 
 ZL_END_C_DECLS
 

--- a/src/openzl/codecs/lz/decode_lz_kernel.c
+++ b/src/openzl/codecs/lz/decode_lz_kernel.c
@@ -1,0 +1,685 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#include "openzl/codecs/lz/decode_lz_kernel.h"
+
+#include <string.h>
+
+#include "openzl/codecs/common/copy.h"
+#include "openzl/shared/mem.h"
+#include "openzl/shared/portability.h"
+#include "openzl/shared/utils.h"
+
+enum {
+    // The loop is not currently unrolled, but leave kUnroll in place so it can
+    // be easily unrolled in the future, and make sure all logic takes kUnroll
+    // into account.
+    ZL_Lz_kUnroll = 1,
+
+    // Each sequences always copies 32-bytes of literals and match, and copies
+    // in chunks of 32-bytes. So the loop needs to ensure that it is always safe
+    // to copy up to roundUp(litLength, 32) and roundUp(matchLength, 32) bytes.
+    ZL_Lz_kLitCopyLen   = 32,
+    ZL_Lz_kMatchCopyLen = 32,
+
+    // The amount of remaining literals the fast decoding loop needs to execute
+    // one
+    // iteration.
+    ZL_Lz_kLitSlop = ZL_Lz_kUnroll * ZL_Lz_kLitCopyLen,
+
+    // The amount of remaining output space the fast decoding loop needs to
+    // execute one iteration.
+    ZL_Lz_kOutSlop = ZL_Lz_kLitSlop + (ZL_Lz_kUnroll * ZL_Lz_kMatchCopyLen)
+};
+
+/**
+ * Logically:
+ *
+ * ```
+ * char tmp[kLength];
+ * memcpy(tmp, src, kLength);
+ * memcpy(dst, tmp, kLength);
+ * ```
+ *
+ * Unlike `memcpy()` @p src and @p dst are allowed to overlap, and we guarantee
+ * that the copy happens as-if they were not overlapped.
+ */
+ZL_FORCE_INLINE void
+copyNonOverlapping(uint8_t* dst, const uint8_t* src, size_t kLength)
+{
+#if ZL_HAS_SSSE3
+    if (kLength == 16) {
+        const __m128i v = _mm_lddqu_si128((const __m128i_u*)src);
+        _mm_storeu_si128((__m128i_u*)dst, v);
+        return;
+    }
+#endif
+
+#if ZL_HAS_AVX2
+    if (kLength == 32) {
+        const __m256i v = _mm256_lddqu_si256((const __m256i_u*)src);
+        _mm256_storeu_si256((__m256i_u*)dst, v);
+        return;
+    } else if (kLength == 64) {
+        const __m256i v0 = _mm256_lddqu_si256((const __m256i_u*)src);
+        const __m256i v1 = _mm256_lddqu_si256((const __m256i_u*)(src + 32));
+        _mm256_storeu_si256((__m256i_u*)dst, v0);
+        _mm256_storeu_si256((__m256i_u*)(dst + 32), v1);
+        return;
+    }
+#endif
+
+    assert(kLength <= 64);
+    char tmp[64];
+    memcpy(tmp, src, kLength);
+    memcpy(dst, tmp, kLength);
+}
+
+/**
+ * Helper macro to copy @p kCopyLength bytes and sink a bounds check @p
+ * shouldExit to only run if @p length > @p kCopyLength. And finally
+ * copy @p length bytes @p kCopyLength bytes at a time. It uses the
+ * @p copy function or function-like-macro to do the copy.
+ *
+ * Sinking the bounds check behind the unlikely long length check avoids
+ * the bounds check in the majority of cases.
+ */
+#define ZL_LZ_COPY_LOOP(copy, kCopyLength, length, shouldExit) \
+    do {                                                       \
+        copy(0, kCopyLength);                                  \
+        if (ZL_UNLIKELY(length > kCopyLength)) {               \
+            if (ZL_UNLIKELY(shouldExit)) {                     \
+                goto _exit;                                    \
+            }                                                  \
+            ptrdiff_t copied = kCopyLength;                    \
+            do {                                               \
+                copy(copied, kCopyLength);                     \
+                copied += kCopyLength;                         \
+            } while (copied < length);                         \
+        }                                                      \
+    } while (0)
+
+#define ZL_LZ_COPY_LITERALS_IMPL(copied, kCopyLength) \
+    copyNonOverlapping(                               \
+            out + outPos + copied, lits + litPos + copied, kCopyLength)
+
+/**
+ * Copies @p length literals from `lit + litPos` to `out + outPos`
+ * `ZL_Lz_kLitCopyLen` bytes at a time. Uses the bounds check @p shouldExit
+ * for lengths longer than `ZL_Lz_kLitCopyLen` to `goto _exit` when it is true.
+ */
+#define ZL_LZ_COPY_LITERALS(length, shouldExit) \
+    ZL_LZ_COPY_LOOP(                            \
+            ZL_LZ_COPY_LITERALS_IMPL, ZL_Lz_kLitCopyLen, length, shouldExit)
+
+#define ZL_LZ_COPY_MATCH_NON_OVERLAPPING_IMPL(copied, kCopyLength) \
+    copyNonOverlapping(                                            \
+            out + outMatch + copied, out + match + copied, kCopyLength)
+
+/**
+ * Copies @p length bytes from `out + match` to `out + outMatch` @p kCopyLength
+ * bytes at a time. Uses the bounds check @p shouldExit for lengths longer than
+ * @p kCopyLen to `goto _exit` when it is true.
+ *
+ * @pre `offset >= kCopyLength || offset >= length`
+ */
+#define ZL_LZ_COPY_MATCH_NON_OVERLAPPING(length, kCopyLength, shouldExit) \
+    assert(offset >= kCopyLength || offset >= length);                    \
+    ZL_LZ_COPY_LOOP(                                                      \
+            ZL_LZ_COPY_MATCH_NON_OVERLAPPING_IMPL,                        \
+            kCopyLength,                                                  \
+            length,                                                       \
+            shouldExit)
+
+#if ZL_HAS_AVX2
+// clang-format off
+// LUT for generating an initial 16-byte pattern from the first `offset` bytes.
+// Entry [offset][pos] = pos % offset, used as a shuffle mask for _mm_shuffle_epi8.
+// Entry [0] is unused (offset=0 is invalid) and zeroed out via 0x80.
+static const uint8_t ZL_ALIGNED(16)
+kPatternGeneration[17][16] = {
+    {0x80,0x80,0x80,0x80,0x80,0x80,0x80,0x80,0x80,0x80,0x80,0x80,0x80,0x80,0x80,0x80}, // offset 0 (unused)
+    {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},       // offset 1
+    {0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1},       // offset 2
+    {0, 1, 2, 0, 1, 2, 0, 1, 2, 0, 1, 2, 0, 1, 2, 0},       // offset 3
+    {0, 1, 2, 3, 0, 1, 2, 3, 0, 1, 2, 3, 0, 1, 2, 3},       // offset 4
+    {0, 1, 2, 3, 4, 0, 1, 2, 3, 4, 0, 1, 2, 3, 4, 0},       // offset 5
+    {0, 1, 2, 3, 4, 5, 0, 1, 2, 3, 4, 5, 0, 1, 2, 3},       // offset 6
+    {0, 1, 2, 3, 4, 5, 6, 0, 1, 2, 3, 4, 5, 6, 0, 1},       // offset 7
+    {0, 1, 2, 3, 4, 5, 6, 7, 0, 1, 2, 3, 4, 5, 6, 7},       // offset 8
+    {0, 1, 2, 3, 4, 5, 6, 7, 8, 0, 1, 2, 3, 4, 5, 6},       // offset 9
+    {0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 0, 1, 2, 3, 4, 5},       // offset 10
+    {0, 1, 2, 3, 4, 5, 6, 7, 8, 9,10, 0, 1, 2, 3, 4},       // offset 11
+    {0, 1, 2, 3, 4, 5, 6, 7, 8, 9,10,11, 0, 1, 2, 3},       // offset 12
+    {0, 1, 2, 3, 4, 5, 6, 7, 8, 9,10,11,12, 0, 1, 2},       // offset 13
+    {0, 1, 2, 3, 4, 5, 6, 7, 8, 9,10,11,12,13, 0, 1},       // offset 14
+    {0, 1, 2, 3, 4, 5, 6, 7, 8, 9,10,11,12,13,14, 0},       // offset 15
+    {0, 1, 2, 3, 4, 5, 6, 7, 8, 9,10,11,12,13,14,15},       // offset 16
+};
+
+// LUT for reshuffling a pattern to advance by 16 positions.
+// Entry [offset][pos] = (16 + pos) % offset, used to rotate the pattern
+// for the next 16-byte store when offset is not a power of 2.
+static const uint8_t ZL_ALIGNED(16)
+kPatternReshuffle[17][16] = {
+    {0x80,0x80,0x80,0x80,0x80,0x80,0x80,0x80,0x80,0x80,0x80,0x80,0x80,0x80,0x80,0x80}, // offset 0 (unused)
+    {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},       // offset 1
+    {0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1},       // offset 2
+    {1, 2, 0, 1, 2, 0, 1, 2, 0, 1, 2, 0, 1, 2, 0, 1},       // offset 3
+    {0, 1, 2, 3, 0, 1, 2, 3, 0, 1, 2, 3, 0, 1, 2, 3},       // offset 4
+    {1, 2, 3, 4, 0, 1, 2, 3, 4, 0, 1, 2, 3, 4, 0, 1},       // offset 5
+    {4, 5, 0, 1, 2, 3, 4, 5, 0, 1, 2, 3, 4, 5, 0, 1},       // offset 6
+    {2, 3, 4, 5, 6, 0, 1, 2, 3, 4, 5, 6, 0, 1, 2, 3},       // offset 7
+    {0, 1, 2, 3, 4, 5, 6, 7, 0, 1, 2, 3, 4, 5, 6, 7},       // offset 8
+    {7, 8, 0, 1, 2, 3, 4, 5, 6, 7, 8, 0, 1, 2, 3, 4},       // offset 9
+    {6, 7, 8, 9, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 0, 1},       // offset 10
+    {5, 6, 7, 8, 9,10, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9},       // offset 11
+    {4, 5, 6, 7, 8, 9,10,11, 0, 1, 2, 3, 4, 5, 6, 7},       // offset 12
+    {3, 4, 5, 6, 7, 8, 9,10,11,12, 0, 1, 2, 3, 4, 5},       // offset 13
+    {2, 3, 4, 5, 6, 7, 8, 9,10,11,12,13, 0, 1, 2, 3},       // offset 14
+    {1, 2, 3, 4, 5, 6, 7, 8, 9,10,11,12,13,14, 0, 1},       // offset 15
+    {0, 1, 2, 3, 4, 5, 6, 7, 8, 9,10,11,12,13,14,15},       // offset 16
+};
+// clang-format on
+
+/// Loads the pattern for copying 16 bytes from @p src when the offset is @p
+/// offset, accounting for overlapping matches.
+/// @pre offset <= 16
+/// @note Defines offset == 0 to memset(0)
+ZL_FORCE_INLINE __m128i loadPattern(const uint8_t* src, ptrdiff_t offset)
+{
+    assert(offset >= 0 && offset <= 16);
+    __m128i generation =
+            _mm_load_si128((const __m128i*)kPatternGeneration[offset]);
+    __m128i data = _mm_lddqu_si128((const __m128i_u*)src);
+    return _mm_shuffle_epi8(data, generation);
+}
+
+/// Loads the reshuffle mask for the pattern. This is used to rotate the pattern
+/// after each 16-byte copy. For example, if the offset is 5, then the original
+/// pattern is:
+///
+/// 0123401234012340
+///
+/// And after copying 16 bytes it needs to be reshuffled to start with 1
+///
+/// 1234012340123401
+ZL_FORCE_INLINE __m128i loadReshuffle(ptrdiff_t offset)
+{
+    return _mm_load_si128((const __m128i*)kPatternReshuffle[offset]);
+}
+
+/// Store @p pattern to @p dst
+ZL_FORCE_INLINE void copyPattern32(uint8_t* dst, __m256i pattern)
+{
+    _mm256_storeu_si256((__m256i_u*)dst, pattern);
+}
+
+/// Store @p pattern to @p dst twice
+ZL_FORCE_INLINE void copyPattern2x16(uint8_t* dst, __m128i pattern)
+{
+    _mm_storeu_si128((__m128i_u*)dst, pattern);
+    _mm_storeu_si128((__m128i_u*)(dst + 16), pattern);
+}
+
+/// Store @p pattern to @p dst twice and uses @p reshuffle to shuffle the mask
+/// after each store.
+/// @returns The shuffled pattern
+ZL_FORCE_INLINE __m128i
+copyPatternWithReshuffle2x16(uint8_t* dst, __m128i pattern, __m128i reshuffle)
+{
+    _mm_storeu_si128((__m128i_u*)dst, pattern);
+    pattern = _mm_shuffle_epi8(pattern, reshuffle);
+    _mm_storeu_si128((__m128i_u*)(dst + 16), pattern);
+    pattern = _mm_shuffle_epi8(pattern, reshuffle);
+    return pattern;
+}
+
+#    define ZL_LZ_COPY_MATCH_OVERLAPPING_OFFSET_1_IMPL(copied, kCopyLength) \
+        copyPattern32(out + outMatch + copied, pattern)
+
+/**
+ * Copies @p length bytes from `out + match` to `out + outMatch` @p kCopyLength
+ * bytes at a time. Uses the bounds check @p shouldExit for lengths longer than
+ * @p kCopyLen to `goto _exit` when it is true.
+ *
+ * @pre `offset == 1`
+ */
+#    define ZL_LZ_COPY_MATCH_OVERLAPPING_OFFSET_1(length, shouldExit)   \
+        do {                                                            \
+            assert(offset == 1);                                        \
+            assert(ZL_Lz_kMatchCopyLen >= 32);                          \
+            const __m256i pattern = _mm256_set1_epi8((char)out[match]); \
+            ZL_LZ_COPY_LOOP(                                            \
+                    ZL_LZ_COPY_MATCH_OVERLAPPING_OFFSET_1_IMPL,         \
+                    32,                                                 \
+                    length,                                             \
+                    shouldExit);                                        \
+        } while (0)
+
+#    define ZL_LZ_COPY_MATCH_OVERLAPPING_POW2_IMPL(copied, kCopyLength) \
+        copyPattern2x16(out + outMatch + copied, pattern)
+
+/**
+ * Copies @p length bytes from `out + match` to `out + outMatch` @p kCopyLength
+ * bytes at a time. Uses the bounds check @p shouldExit for lengths longer than
+ * @p kCopyLen to `goto _exit` when it is true.
+ *
+ * @pre `ZL_isPow2(offset)`
+ */
+#    define ZL_LZ_COPY_MATCH_OVERLAPPING_POW2(length, shouldExit)     \
+        do {                                                          \
+            assert(ZL_isPow2((uint64_t)offset));                      \
+            assert(ZL_Lz_kMatchCopyLen >= 32);                        \
+            const __m128i pattern = loadPattern(out + match, offset); \
+            ZL_LZ_COPY_LOOP(                                          \
+                    ZL_LZ_COPY_MATCH_OVERLAPPING_POW2_IMPL,           \
+                    32,                                               \
+                    length,                                           \
+                    shouldExit);                                      \
+        } while (0)
+
+#    define ZL_LZ_COPY_MATCH_OVERLAPPING_NON_POW2_IMPL(copied, kCopyLength) \
+        do {                                                                \
+            pattern = copyPatternWithReshuffle2x16(                         \
+                    out + outMatch + copied, pattern, reshuffle);           \
+        } while (0)
+
+/**
+ * Copies @p length bytes from `out + match` to `out + outMatch` @p kCopyLength
+ * bytes at a time. Uses the bounds check @p shouldExit for lengths longer than
+ * @p kCopyLen to `goto _exit` when it is true.
+ *
+ * @pre `offset <= 16`
+ */
+#    define ZL_LZ_COPY_MATCH_OVERLAPPING_NON_POW2(length, shouldExit)   \
+        do {                                                            \
+            assert(offset <= 16);                                       \
+            assert(ZL_Lz_kMatchCopyLen >= 32);                          \
+            __m128i pattern         = loadPattern(out + match, offset); \
+            const __m128i reshuffle = loadReshuffle(offset);            \
+            ZL_LZ_COPY_LOOP(                                            \
+                    ZL_LZ_COPY_MATCH_OVERLAPPING_NON_POW2_IMPL,         \
+                    32,                                                 \
+                    length,                                             \
+                    shouldExit);                                        \
+        } while (0)
+
+/**
+ * Copies @p length bytes from `out + match` to `out + outMatch` @p kCopyLength
+ * bytes at a time. Uses the bounds check @p shouldExit for lengths longer than
+ * @p kCopyLen to `goto _exit` when it is true.
+ *
+ * @note Handles the case when `offset < length`
+ */
+#    define ZL_LZ_COPY_MATCH_OVERLAPPING(length, shouldExit)                 \
+        do {                                                                 \
+            if (offset == 1) {                                               \
+                ZL_LZ_COPY_MATCH_OVERLAPPING_OFFSET_1(matchLen, shouldExit); \
+            } else if (                                                      \
+                    offset == 2 || offset == 4 || offset == 8                \
+                    || offset == 16) {                                       \
+                ZL_LZ_COPY_MATCH_OVERLAPPING_POW2(matchLen, shouldExit);     \
+            } else if (offset <= 16) {                                       \
+                ZL_LZ_COPY_MATCH_OVERLAPPING_NON_POW2(matchLen, shouldExit); \
+            } else {                                                         \
+                ZL_LZ_COPY_MATCH_NON_OVERLAPPING(matchLen, 16, shouldExit);  \
+            }                                                                \
+        } while (0)
+#else
+
+/**
+ * Copies @p length bytes from `out + match` to `out + outMatch` @p kCopyLength
+ * bytes at a time. Uses the bounds check @p shouldExit for lengths longer than
+ * @p kCopyLen to `goto _exit` when it is true.
+ *
+ * @note Handles the case when `offset < length`
+ */
+#    define ZL_LZ_COPY_MATCH_OVERLAPPING(length, shouldExit)       \
+        do {                                                       \
+            assert(ZL_Lz_kMatchCopyLen >= ZS_WILDCOPY_OVERLENGTH); \
+            if (shouldExit) {                                      \
+                goto _exit;                                        \
+            }                                                      \
+            ZS_wildcopy(                                           \
+                    out + outMatch,                                \
+                    out + match,                                   \
+                    length,                                        \
+                    ZS_wo_src_before_dst);                         \
+        } while (0)
+#endif
+
+/**
+ * Decodes a single LZ sequences and updates @p outPos and @p litPos
+ */
+static ZL_LzError ZL_Lz_decode_sequence(
+        uint8_t* dst,
+        size_t dstSize,
+        const ZL_Lz_InSequences* src,
+        ptrdiff_t seq,
+        ptrdiff_t* outPos,
+        ptrdiff_t* litPos)
+{
+    const uint8_t* const literals    = src->literals;
+    ptrdiff_t const numLiterals      = (ptrdiff_t)src->numLiterals;
+    const void* const offsets        = src->offsets;
+    ptrdiff_t const offsetsEltWidth  = (ptrdiff_t)src->offsetsEltWidth;
+    const void* const literalLengths = src->literalLengths;
+    ptrdiff_t const literalLengthsEltWidth =
+            (ptrdiff_t)src->literalLengthsEltWidth;
+    const void* const matchLengths       = src->matchLengths;
+    ptrdiff_t const matchLengthsEltWidth = (ptrdiff_t)src->matchLengthsEltWidth;
+
+    assert((size_t)seq < src->numSequences);
+    assert((size_t)*outPos <= dstSize);
+    assert(*litPos <= numLiterals);
+
+    ptrdiff_t const litLen = (ptrdiff_t)ZL_readN(
+            (const uint8_t*)literalLengths + seq * literalLengthsEltWidth,
+            (size_t)literalLengthsEltWidth);
+    ptrdiff_t const offset = (ptrdiff_t)ZL_readN(
+            (const uint8_t*)offsets + seq * offsetsEltWidth,
+            (size_t)offsetsEltWidth);
+    ptrdiff_t const matchLen = (ptrdiff_t)ZL_readN(
+            (const uint8_t*)matchLengths + seq * matchLengthsEltWidth,
+            (size_t)matchLengthsEltWidth);
+
+    // Copy literals
+    if (*litPos + litLen > numLiterals) {
+        return ZL_LzError_notEnoughLiterals;
+    }
+    if (*outPos + litLen > (ptrdiff_t)dstSize) {
+        return ZL_LzError_literalLengthTooLarge;
+    }
+    if (litLen > 0) {
+        memcpy(dst + *outPos, literals + *litPos, (size_t)litLen);
+    }
+    *outPos += litLen;
+    *litPos += litLen;
+
+    // Validate offset
+    if (offset == 0) {
+        return ZL_LzError_offsetZero;
+    }
+    if (offset > *outPos) {
+        return ZL_LzError_offsetTooLarge;
+    }
+
+    // Copy match (byte-by-byte to handle overlapping matches)
+    if (*outPos + matchLen > (ptrdiff_t)dstSize) {
+        return ZL_LzError_matchLengthTooLarge;
+    }
+    for (ptrdiff_t i = 0; i < matchLen; ++i) {
+        dst[*outPos + i] = dst[*outPos + i - offset];
+    }
+    *outPos += matchLen;
+    return ZL_LzError_ok;
+}
+
+/**
+ * Decodes the remaining literals in the literals buffer after all sequences
+ * have been executed.
+ */
+static ZL_LzError ZL_Lz_decode_lastLiterals(
+        uint8_t* dst,
+        size_t dstSize,
+        const ZL_Lz_InSequences* src,
+        ptrdiff_t outPos,
+        ptrdiff_t litPos)
+{
+    const uint8_t* const literals = src->literals;
+    ptrdiff_t const numLiterals   = (ptrdiff_t)src->numLiterals;
+
+    if (litPos > numLiterals) {
+        // This can happen when using the temporary literal buffer.
+        // It is okay, however, because we are just reading zeros.
+        assert(litPos - numLiterals <= ZL_Lz_kLitSlop);
+        return ZL_LzError_notEnoughLiterals;
+    }
+
+    assert(outPos <= (ptrdiff_t)dstSize);
+
+    if (litPos < numLiterals) {
+        const ptrdiff_t lastLits = numLiterals - litPos;
+        if (outPos + lastLits > (ptrdiff_t)dstSize) {
+            return ZL_LzError_literalsTooLarge;
+        }
+        memcpy(dst + outPos, literals + litPos, (size_t)lastLits);
+        outPos += lastLits;
+    }
+
+    if (outPos != (ptrdiff_t)dstSize) {
+        return ZL_LzError_dstSizeTooLarge;
+    }
+
+    return ZL_LzError_ok;
+}
+
+/// The fallback LZ decoder that works on all numeric widths but is slow
+static ZL_LzError
+ZL_Lz_decode_generic(uint8_t* dst, size_t dstSize, const ZL_Lz_InSequences* src)
+{
+    ptrdiff_t seq    = 0;
+    ptrdiff_t outPos = 0;
+    ptrdiff_t litPos = 0;
+
+    ptrdiff_t const numSequences = (ptrdiff_t)src->numSequences;
+    for (; seq < numSequences; seq++) {
+        const ZL_LzError err =
+                ZL_Lz_decode_sequence(dst, dstSize, src, seq, &outPos, &litPos);
+        if (err != ZL_LzError_ok) {
+            return err;
+        }
+    }
+
+    return ZL_Lz_decode_lastLiterals(dst, dstSize, src, outPos, litPos);
+}
+
+typedef struct {
+    ZL_Lz_InSequences src;
+    ptrdiff_t seq;
+    ptrdiff_t outPos;
+    ptrdiff_t litPos;
+    ptrdiff_t litLimit;
+} ZL_Lz_DecodeState;
+
+/**
+ * The hot LZ decoding loop.
+ *
+ * @pre state->seq <= state->src.numSequences - ZL_Lz_kUnroll
+ * @pre state->outPos <= dstSize - ZL_Lz_kOutSlop
+ * @pre state->litPos <= state->litLimit
+ *
+ * NOTE: This is force outlined because the loop is tight on registers. If there
+ * is a function call in the loop body, then the compiler has to worry about
+ * callee saved registers, and spills more variables to the stack. So force
+ * outline the hot loop and also ensure that every function it calls is force
+ * inlined.
+ *
+ * NOTE: This kernel uses ptrdiff_t rather than pointers to avoid UB with
+ * pointers, which are only valid within the buffer and one past the end.
+ */
+ZL_FORCE_NOINLINE ZL_LzError ZL_Lz_decode_u16Loop(
+        uint8_t* const dst,
+        size_t dstSize,
+        ZL_Lz_DecodeState* state)
+{
+    uint8_t* const out              = dst;
+    const size_t numSeqs            = state->src.numSequences;
+    const uint8_t* const lits       = state->src.literals;
+    const uint16_t* const offs      = state->src.offsets;
+    const uint16_t* const litLens   = state->src.literalLengths;
+    const uint16_t* const matchLens = state->src.matchLengths;
+
+    ptrdiff_t outPos         = state->outPos;
+    const ptrdiff_t outLimit = (ptrdiff_t)dstSize - ZL_Lz_kOutSlop;
+
+    ptrdiff_t litPos         = state->litPos;
+    const ptrdiff_t litLimit = state->litLimit;
+
+    ptrdiff_t seq            = state->seq;
+    const ptrdiff_t seqLimit = (ptrdiff_t)numSeqs - ZL_Lz_kUnroll;
+
+    do {
+        assert(seq <= seqLimit);
+        assert(litPos <= litLimit);
+        assert(outPos <= outLimit);
+#ifdef __clang__
+#    pragma clang loop unroll(full)
+#endif
+        for (size_t u = 0; u < ZL_Lz_kUnroll; ++u) {
+            assert((size_t)seq < numSeqs);
+            assert((size_t)litPos <= state->src.numLiterals);
+            assert((size_t)outPos <= dstSize);
+
+            const ptrdiff_t litLen   = litLens[seq];
+            const ptrdiff_t matchLen = matchLens[seq];
+            const ptrdiff_t offset   = offs[seq];
+
+            const ptrdiff_t outMatch = outPos + litLen;
+            const ptrdiff_t outNext  = outMatch + matchLen;
+            const ptrdiff_t litNext  = litPos + litLen;
+
+            // Copies literals and breaks if the literals go beyond litLimit or
+            // the sequences goes beyond outLimit. Check outNext rather than
+            // outMatch so that if the literals are long, we don't need to
+            // re-copy the literals if the match will exit.
+            //
+            // The bounds check only needs to be executed when
+            // litLen > ZL_Lz_kLitCopyLen because we guarantee there is enough
+            // space to copy short literals.
+            ZL_LZ_COPY_LITERALS(
+                    litLen, (litNext > litLimit || outNext > outLimit));
+
+            const ptrdiff_t match = outMatch - offset;
+            if (ZL_UNLIKELY(match < 0)) {
+                return ZL_LzError_offsetTooLarge;
+            }
+
+            // Copies the match using different strategies for the common case
+            // where the match doesn't overlap, and for when the match does
+            // overlap.
+            //
+            // The bounds check only needs to be executed when
+            // matchLen > ZL_Lz_kMatchCopyLen because we guarantee there is
+            // enough space to copy short matches.
+            if (ZL_UNLIKELY(offset < matchLen)) {
+                ZL_LZ_COPY_MATCH_OVERLAPPING(matchLen, (outNext > outLimit));
+            } else {
+                ZL_LZ_COPY_MATCH_NON_OVERLAPPING(
+                        matchLen, ZL_Lz_kMatchCopyLen, (outNext > outLimit));
+            }
+
+            // Only update the state at the end of the loop because either the
+            // literal or match copy may reach a limit, and we will need to
+            // reprocess the current sequence.
+            outPos = outNext;
+            litPos = litNext;
+            ++seq;
+        }
+    } while (seq <= seqLimit && outPos <= outLimit && litPos <= litLimit);
+
+_exit:
+    state->seq    = seq;
+    state->outPos = outPos;
+    state->litPos = litPos;
+
+    return ZL_LzError_ok;
+}
+
+static ZL_LzError ZL_Lz_decode_u16(
+        uint8_t* const dst,
+        size_t dstSize,
+        const ZL_Lz_InSequences* src)
+{
+    ZL_Lz_DecodeState state = {
+        .src      = *src,
+        .seq      = 0,
+        .outPos   = 0,
+        .litPos   = 0,
+        .litLimit = (ptrdiff_t)state.src.numLiterals - ZL_Lz_kLitSlop,
+    };
+
+    const ptrdiff_t numSeqs  = (ptrdiff_t)state.src.numSequences;
+    const ptrdiff_t outLimit = (ptrdiff_t)dstSize - ZL_Lz_kOutSlop;
+    const ptrdiff_t seqLimit =
+            (ptrdiff_t)state.src.numSequences - ZL_Lz_kUnroll;
+
+    uint8_t litBuffer[2 * ZL_Lz_kLitSlop] = { 0 };
+
+    for (; state.seq < numSeqs;) {
+        // Transfer the literals to a temporary buffer that is guaranteed to
+        // have enough slop space when close to the end. This avoids pessimizing
+        // the edge case where there are many sequences remaining but very few
+        // literals remaining.
+        if (state.litPos > state.litLimit) {
+            if (state.src.literals != src->literals) {
+                // We've already transferred the literals
+                assert(state.litPos <= (ptrdiff_t)sizeof(litBuffer));
+                // Implies not enough literals
+                return ZL_LzError_notEnoughLiterals;
+            }
+            assert(state.litPos <= (ptrdiff_t)state.src.numLiterals);
+            const size_t remainingLiterals =
+                    state.src.numLiterals - (size_t)state.litPos;
+            assert(remainingLiterals <= ZL_Lz_kLitSlop);
+            if (remainingLiterals > 0) {
+                memcpy(litBuffer,
+                       state.src.literals + state.litPos,
+                       remainingLiterals);
+            }
+            state.src.literals    = litBuffer;
+            state.src.numLiterals = remainingLiterals;
+            state.litPos          = 0;
+            state.litLimit        = (ptrdiff_t)remainingLiterals;
+        }
+        if (state.outPos <= outLimit && state.litPos <= state.litLimit
+            && state.seq <= seqLimit) {
+            const ZL_LzError err = ZL_Lz_decode_u16Loop(dst, dstSize, &state);
+            if (err != ZL_LzError_ok) {
+                return err;
+            }
+        }
+
+        if (state.seq < numSeqs) {
+            // Execute a single sequence. We need to do it here because
+            // ZL_Lz_decode_u16Loop may be exactly one sequence short of hitting
+            // a limit, so we need to execute one before transferring the
+            // literals (if that was the limiting factor), otherwise we will
+            // infinite loop.
+            //
+            // Then, after transferring literals, this code also handles the
+            // trailing sequences.
+            const ZL_LzError err = ZL_Lz_decode_sequence(
+                    dst,
+                    dstSize,
+                    &state.src,
+                    state.seq,
+                    &state.outPos,
+                    &state.litPos);
+            if (err != ZL_LzError_ok) {
+                return err;
+            }
+            ++state.seq;
+        }
+    }
+
+    // Copy the remaining literals
+    return ZL_Lz_decode_lastLiterals(
+            dst, dstSize, &state.src, state.outPos, state.litPos);
+}
+
+ZL_LzError
+ZL_Lz_decode(uint8_t* dst, size_t dstSize, const ZL_Lz_InSequences* src)
+{
+    // Optimize for cases that the encoder actually produces
+    if (src->offsetsEltWidth == 2 && src->literalLengthsEltWidth == 2
+        && src->matchLengthsEltWidth == 2) {
+        return ZL_Lz_decode_u16(dst, dstSize, src);
+    }
+
+    // Generic fallback to handle any width to allow us to update the encoder
+    // without guaranteeing 100% of decoders are updated. If the encoder is
+    // updated, a new specialization should be added, but then we only need to
+    // wait for most decoders to be updated, rather than 100% of decoders.
+    return ZL_Lz_decode_generic(dst, dstSize, src);
+}

--- a/src/openzl/codecs/lz/decode_lz_kernel.h
+++ b/src/openzl/codecs/lz/decode_lz_kernel.h
@@ -1,0 +1,51 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#ifndef ZS_DECODE_LZ_KERNEL_H
+#define ZS_DECODE_LZ_KERNEL_H
+
+#include <stddef.h>
+#include <stdint.h>
+
+typedef struct {
+    const uint8_t* literals;
+    size_t numLiterals;
+
+    const void* offsets;
+    size_t offsetsEltWidth;
+
+    const void* literalLengths;
+    size_t literalLengthsEltWidth;
+
+    const void* matchLengths;
+    size_t matchLengthsEltWidth;
+
+    size_t numSequences;
+} ZL_Lz_InSequences;
+
+/// Detailed error codes for LZ decoding.
+typedef enum {
+    ZL_LzError_ok = 0,
+    ZL_LzError_literalLengthTooLarge,
+    ZL_LzError_notEnoughLiterals,
+    ZL_LzError_offsetZero,
+    ZL_LzError_offsetTooLarge,
+    ZL_LzError_matchLengthTooLarge,
+    ZL_LzError_literalsTooLarge,
+    ZL_LzError_dstSizeTooLarge,
+} ZL_LzError;
+
+/**
+ * Decodes LZ sequences back into the original byte stream.
+ *
+ * dst must have capacity for at least dstSize bytes.
+ * Exactly dstSize bytes must be produced, otherwise an error is returned.
+ *
+ * The three numeric streams (offsets, literalLengths, matchLengths) may
+ * have any element width (1, 2, 4, or 8 bytes), specified independently.
+ *
+ * @returns ZL_LzError_ok on success, or an error code upon corruption.
+ */
+ZL_LzError
+ZL_Lz_decode(uint8_t* dst, size_t dstSize, const ZL_Lz_InSequences* src);
+
+#endif

--- a/src/openzl/codecs/lz/encode_lz_binding.c
+++ b/src/openzl/codecs/lz/encode_lz_binding.c
@@ -2,21 +2,22 @@
 
 #include "openzl/codecs/lz/encode_lz_binding.h"
 
+#include "openzl/codecs/common/fast_table.h"
 #include "openzl/codecs/lz/common_field_lz.h"
 #include "openzl/codecs/lz/encode_field_lz_literals_selector.h"
-#include "openzl/compress/private_nodes.h"
+#include "openzl/codecs/lz/encode_lz_kernel.h"
+#include "openzl/codecs/zl_lz.h"
 #include "openzl/shared/utils.h"
 #include "openzl/shared/varint.h"
 #include "openzl/zl_ctransform.h"
 #include "openzl/zl_data.h"
 #include "openzl/zl_graph_api.h"
-#include "openzl/zl_reflection.h"
 
 /**
  * Set the maximum bytes to process to 4B to avoid overflow in the match finder.
  * It could likely be higher, but this is close enough to 2^32-1.
  */
-static const size_t kFieldLzContentSizeBytes = 4000000000u;
+static const size_t kLzContentSizeBytes = 4000000000u;
 
 static void* allocEICtx(void* opaque, size_t size)
 {
@@ -47,7 +48,7 @@ ZL_Report EI_fieldLz(ZL_Encoder* eictx, const ZL_Input* ins[], size_t nbIns)
     }
     ZL_ERR_IF_GT(
             ZL_Input_contentSize(in),
-            kFieldLzContentSizeBytes,
+            kLzContentSizeBytes,
             temporaryLibraryLimitation,
             "FieldLZ only supports up to 4B of input due to 32-bit overflow in the match finder");
 
@@ -125,6 +126,75 @@ ZL_Report EI_fieldLz(ZL_Encoder* eictx, const ZL_Input* ins[], size_t nbIns)
     ZL_LOG(TRANSFORM, "#extraMatchLengths = %zu", dst.nbExtraMatchLengths);
 
     return ZL_returnValue(5);
+}
+
+ZL_Report EI_lz(ZL_Encoder* eictx, const ZL_Input* ins[], size_t nbIns)
+{
+    ZL_RESULT_DECLARE_SCOPE_REPORT(eictx);
+
+    ZL_ASSERT_EQ(nbIns, 1);
+    ZL_ASSERT_NN(ins);
+    const ZL_Input* in   = ins[0];
+    size_t const srcSize = ZL_Input_numElts(in);
+
+    ZL_ASSERT_EQ(ZL_Input_type(in), ZL_Type_serial);
+    ZL_ERR_IF_GT(
+            srcSize,
+            kLzContentSizeBytes,
+            temporaryLibraryLimitation,
+            "LZ only supports up to 4B of input");
+
+    size_t const maxNumSeq = ZL_Lz_maxNumSequences(srcSize);
+
+    // Create output streams
+    size_t const literalsCapacity = srcSize + ZL_LZ_LIT_OVER_LENGTH;
+    ZL_Output* const literals =
+            ZL_Encoder_createTypedStream(eictx, 0, literalsCapacity, 1);
+    ZL_Output* const offsets =
+            ZL_Encoder_createTypedStream(eictx, 1, maxNumSeq, 2);
+    ZL_Output* const literalLengths =
+            ZL_Encoder_createTypedStream(eictx, 2, maxNumSeq, 2);
+    ZL_Output* const matchLengths =
+            ZL_Encoder_createTypedStream(eictx, 3, maxNumSeq, 2);
+
+    ZL_ERR_IF_NULL(literals, allocation);
+    ZL_ERR_IF_NULL(offsets, allocation);
+    ZL_ERR_IF_NULL(literalLengths, allocation);
+    ZL_ERR_IF_NULL(matchLengths, allocation);
+
+    // Allocate hash table from scratch space
+    size_t const hashTableSize = ZS_FastTable_tableSize(ZL_LZ_TABLE_LOG);
+    void* hashTableMem = ZL_Encoder_getScratchSpace(eictx, hashTableSize);
+    ZL_ERR_IF_NULL(hashTableMem, allocation);
+
+    ZL_Lz_OutSequences dst = {
+        .literals         = (uint8_t*)ZL_Output_ptr(literals),
+        .literalsCapacity = literalsCapacity,
+        .numLiterals      = 0,
+
+        .offsets           = (uint16_t*)ZL_Output_ptr(offsets),
+        .literalLengths    = (uint16_t*)ZL_Output_ptr(literalLengths),
+        .matchLengths      = (uint16_t*)ZL_Output_ptr(matchLengths),
+        .sequencesCapacity = maxNumSeq,
+        .numSequences      = 0,
+    };
+
+    ZL_Lz_encode(&dst, (const uint8_t*)ZL_Input_ptr(in), srcSize, hashTableMem);
+
+    // Write the original size as a varint codec header
+    uint8_t header[ZL_VARINT_LENGTH_64];
+    size_t const headerSize = ZL_varintEncode(srcSize, header);
+    ZL_Encoder_sendCodecHeader(eictx, header, headerSize);
+
+    ZL_ERR_IF_ERR(ZL_Output_commit(literals, dst.numLiterals));
+    ZL_ERR_IF_ERR(ZL_Output_commit(offsets, dst.numSequences));
+    ZL_ERR_IF_ERR(ZL_Output_commit(literalLengths, dst.numSequences));
+    ZL_ERR_IF_ERR(ZL_Output_commit(matchLengths, dst.numSequences));
+
+    ZL_ERR_IF_ERR(ZL_Output_setIntMetadata(
+            matchLengths, ZL_LZ_MIN_MATCH_LENGTH_METADATA_ID, ZL_LZ_MIN_MATCH));
+
+    return ZL_returnSuccess();
 }
 
 static ZL_Report tokensDynGraph(ZL_Graph* gctx, ZL_Edge* tokens)

--- a/src/openzl/codecs/lz/encode_lz_binding.h
+++ b/src/openzl/codecs/lz/encode_lz_binding.h
@@ -11,6 +11,7 @@
 ZL_BEGIN_C_DECLS
 
 ZL_Report EI_fieldLz(ZL_Encoder* eictx, const ZL_Input* ins[], size_t nbIns);
+ZL_Report EI_lz(ZL_Encoder* eictx, const ZL_Input* ins[], size_t nbIns);
 
 /**
  * Dynamic graph backing ZL_GRAPH_FIELD_LZ
@@ -38,6 +39,13 @@ ZL_GraphID SI_fieldLzLiteralsChannelSelector(
         .gd          = FIELD_LZ_GRAPH(id), \
         .transform_f = EI_fieldLz,         \
         .name        = "!zl.field_lz",     \
+    }
+
+#define EI_LZ(id)                    \
+    {                                \
+        .gd          = LZ_GRAPH(id), \
+        .transform_f = EI_lz,        \
+        .name        = "!zl.lz",     \
     }
 
 ZL_END_C_DECLS

--- a/src/openzl/codecs/lz/encode_lz_kernel.c
+++ b/src/openzl/codecs/lz/encode_lz_kernel.c
@@ -1,0 +1,208 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#include "openzl/codecs/lz/encode_lz_kernel.h"
+
+#include <string.h>
+
+#include "openzl/codecs/common/copy.h"
+#include "openzl/codecs/common/fast_table.h"
+#include "openzl/shared/mem.h"
+#include "openzl/shared/simd_wrapper.h"
+
+#define ZL_LZ_HASH_LEN 7
+
+#define ZL_LZ_MATCH_OVER_LENGTH 16
+#define ZL_LZ_SEARCH_STRENGTH 8
+
+static ptrdiff_t matchLength(
+        uint8_t const* const in,
+        ptrdiff_t inPos,
+        ptrdiff_t matchPos,
+        ptrdiff_t inEnd)
+{
+    {
+        ZL_ASSERT_LE(inPos + 16, inEnd);
+        const ZL_Vec128 matchVec = ZL_Vec128_read(in + matchPos);
+        const ZL_Vec128 ipVec    = ZL_Vec128_read(in + inPos);
+        const ZL_Vec128 maskVec  = ZL_Vec128_cmp8(matchVec, ipVec);
+        const uint32_t mask      = ZL_Vec128_mask8(maskVec);
+        const uint32_t len       = (uint32_t)ZL_ctz32(~mask);
+        if (ZL_LIKELY(len < 16)) {
+            return len;
+        }
+    }
+    ptrdiff_t totalLength   = 16;
+    const ptrdiff_t inLimit = inEnd - 16;
+    while (inPos + totalLength < inLimit) {
+        const ZL_Vec128 matchVec = ZL_Vec128_read(in + matchPos + totalLength);
+        const ZL_Vec128 ipVec    = ZL_Vec128_read(in + inPos + totalLength);
+        const ZL_Vec128 maskVec  = ZL_Vec128_cmp8(matchVec, ipVec);
+        const uint32_t mask      = ZL_Vec128_mask8(maskVec);
+        const uint32_t length    = (uint32_t)ZL_ctz32(~mask);
+        if (length < 16) {
+            return totalLength + length;
+        }
+        totalLength += 16;
+        if (ZL_UNLIKELY(totalLength > UINT16_MAX)) {
+            return UINT16_MAX;
+        }
+    }
+
+    while (inPos + totalLength < inEnd
+           && in[inPos + totalLength] == in[matchPos + totalLength]) {
+        ++totalLength;
+    }
+    return totalLength;
+}
+
+size_t ZL_Lz_maxNumSequences(size_t srcSize)
+{
+    if (srcSize == 0) {
+        return 0;
+    }
+    // Each real match sequence consumes at least MIN_MATCH bytes.
+    // Each overflow no-op sequence consumes UINT16_MAX literal bytes.
+    // Add 2 for the trailing literal sequence and rounding.
+    return srcSize / ZL_LZ_MIN_MATCH + srcSize / UINT16_MAX + 2;
+}
+
+/**
+ * Match finding algorithm that runs the equivalent of the ZSTD_fast strategy.
+ *
+ * NOTE: This kernel uses ptrdiff_t rather than pointers to avoid UB with
+ * pointers, which are only valid within the buffer and one past the end.
+ */
+void ZL_Lz_encode(
+        ZL_Lz_OutSequences* dst,
+        const uint8_t* const src,
+        size_t srcSize,
+        void* hashTableMem)
+{
+    if (srcSize == 0) {
+        dst->numLiterals  = 0;
+        dst->numSequences = 0;
+        return;
+    }
+
+    assert(dst->literalsCapacity >= srcSize + ZL_LZ_LIT_OVER_LENGTH);
+    assert(dst->sequencesCapacity >= ZL_Lz_maxNumSequences(srcSize));
+
+    ZS_FastTable table = { 0, 0, 0 };
+    ZS_FastTable_init(&table, hashTableMem, ZL_LZ_TABLE_LOG, ZL_LZ_HASH_LEN);
+
+    const ptrdiff_t kSrcOverLength =
+            ZL_MAX(ZL_LZ_LIT_OVER_LENGTH, ZL_LZ_MATCH_OVER_LENGTH);
+
+    const uint8_t* const in = src;
+    const ptrdiff_t inEnd   = (ptrdiff_t)srcSize;
+    ptrdiff_t inLitStart    = 0;
+    ptrdiff_t inPos         = 1;
+    ptrdiff_t inLimit       = (ptrdiff_t)srcSize - kSrcOverLength;
+
+    // Cache output pointers locally to avoid reloading through dst
+    uint8_t* lits             = dst->literals;
+    uint16_t* const litLens   = dst->literalLengths;
+    uint16_t* const matchLens = dst->matchLengths;
+    uint16_t* const offsets   = dst->offsets;
+
+    size_t seq = 0;
+
+    const ptrdiff_t kStepIncr = 1 << ZL_LZ_SEARCH_STRENGTH;
+    ptrdiff_t step            = 1;
+    ptrdiff_t nextStep        = inPos + kStepIncr;
+
+    while (inPos <= inLimit) {
+        const uint8_t* const inPtr = in + inPos;
+        ptrdiff_t match            = ZS_FastTable_getAndUpdateT(
+                &table, inPtr, (uint32_t)inPos, ZL_LZ_HASH_LEN);
+        const ptrdiff_t distance = inPos - match;
+        if (ZL_read32(in + match) == ZL_read32(inPtr)
+            && distance <= ZL_LZ_MAX_OFFSET) {
+            ptrdiff_t ml = 4 + matchLength(in, inPos + 4, match + 4, inEnd);
+
+            // Walk the match backwards
+            while (match > 0 && inPos > inLitStart
+                   && in[match - 1] == in[inPos - 1]) {
+                --match;
+                --inPos;
+                ++ml;
+            }
+
+            // Truncate match to fit in a uint16_t
+            if (ZL_UNLIKELY(ml > UINT16_MAX)) {
+                ml = UINT16_MAX;
+            }
+
+            // Copy literals
+            size_t ll = (size_t)(inPos - inLitStart);
+            assert(inPos + ZL_LZ_LIT_OVER_LENGTH <= (ptrdiff_t)srcSize);
+            memcpy(lits, in + inLitStart, 16);
+            if (ZL_UNLIKELY(ll > 16)) {
+                assert(ZL_LZ_LIT_OVER_LENGTH >= ZS_WILDCOPY_OVERLENGTH);
+                ZS_wildcopy(
+                        lits, in + inLitStart, (ptrdiff_t)ll, ZS_wo_no_overlap);
+            }
+            lits += ll;
+
+            // Store the sequence
+            if (ZL_LIKELY(ll <= UINT16_MAX)) {
+                litLens[seq] = (uint16_t)ll;
+            } else {
+                // If the literal length is too large, split it into multiple
+                // sequences with match length 0 and offset 1.
+                while (ll > UINT16_MAX) {
+                    litLens[seq]   = UINT16_MAX;
+                    matchLens[seq] = 0;
+                    offsets[seq]   = 1;
+                    ++seq;
+                    ll -= UINT16_MAX;
+                }
+                litLens[seq] = (uint16_t)ll;
+            }
+            matchLens[seq] = (uint16_t)ml;
+            offsets[seq]   = (uint16_t)distance;
+            ++seq;
+
+            // Update the hash table with positions at the start and end of the
+            // match.
+            // NOTE: Taken from zstd_fast.c
+            ZS_FastTable_putT(
+                    &table,
+                    in + inPos + 2,
+                    (uint32_t)(inPos + 2),
+                    ZL_LZ_HASH_LEN);
+            inPos += ml;
+            if (inPos <= inLimit) {
+                ZS_FastTable_putT(
+                        &table,
+                        in + inPos - 2,
+                        (uint32_t)(inPos - 2),
+                        ZL_LZ_HASH_LEN);
+            }
+            inLitStart = inPos;
+            step       = 1;
+            nextStep   = inPos + kStepIncr;
+        } else {
+            inPos += step;
+
+            // This logic helps skip over incompressible data quickly by
+            // progresssively speeding up every kStepIncr bytes and resetting
+            // when a match is found.
+            if (inPos >= nextStep) {
+                ++step;
+                nextStep += kStepIncr;
+            }
+        }
+    }
+
+    // Handle trailing literals
+    const size_t lastLits = srcSize - (size_t)inLitStart;
+    memcpy(lits, in + inLitStart, lastLits);
+    lits += lastLits;
+
+    dst->numLiterals  = (size_t)(lits - dst->literals);
+    dst->numSequences = seq;
+
+    assert(dst->numLiterals + ZL_LZ_LIT_OVER_LENGTH <= dst->literalsCapacity);
+    assert(dst->numSequences <= dst->sequencesCapacity);
+}

--- a/src/openzl/codecs/lz/encode_lz_kernel.h
+++ b/src/openzl/codecs/lz/encode_lz_kernel.h
@@ -1,0 +1,52 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#ifndef ZS_ENCODE_LZ_KERNEL_H
+#define ZS_ENCODE_LZ_KERNEL_H
+
+#include <stddef.h>
+#include <stdint.h>
+
+#define ZL_LZ_LIT_OVER_LENGTH 32
+#define ZL_LZ_MIN_MATCH 4
+#define ZL_LZ_TABLE_LOG 14
+#define ZL_LZ_MAX_OFFSET UINT16_MAX
+
+typedef struct {
+    uint8_t* literals;
+    size_t literalsCapacity;
+    size_t numLiterals;
+
+    uint16_t* offsets;
+    uint16_t* literalLengths;
+    uint16_t* matchLengths;
+    size_t sequencesCapacity;
+    size_t numSequences;
+} ZL_Lz_OutSequences;
+
+/**
+ * Returns the maximum number of sequences that the encoder can produce
+ * for an input of srcSize bytes.
+ */
+size_t ZL_Lz_maxNumSequences(size_t srcSize);
+
+/**
+ * Encodes src[0..srcSize) into LZ sequences.
+ *
+ * All output buffers in dst must be pre-allocated by the caller:
+ *   - dst->literals: at least srcSize bytes
+ *   - dst->offsets, dst->literalLengths, dst->matchLengths:
+ *     at least ZL_Lz_maxNumSequences(srcSize) elements each
+ *
+ * hashTableMem must point to at least
+ * ZS_FastTable_tableSize(ZL_LZ_TABLE_LOG) bytes of writable memory.
+ *
+ * dst->numLiterals and dst->numSequences are set to the number of
+ * output literals and sequences respectively.
+ */
+void ZL_Lz_encode(
+        ZL_Lz_OutSequences* dst,
+        const uint8_t* src,
+        size_t srcSize,
+        void* hashTableMem);
+
+#endif

--- a/src/openzl/codecs/lz/graph_lz.h
+++ b/src/openzl/codecs/lz/graph_lz.h
@@ -24,4 +24,22 @@
                 ZL_Type_numeric),                     \
     }
 
+/// Graph definition for the LZ codec.
+/// Input: 1 serial stream
+/// Output streams are:
+/// 1. Literals (serial)
+/// 2. Offsets (numeric)
+/// 3. Literal lengths (numeric)
+/// 4. Match lengths (numeric)
+#define LZ_GRAPH(id)                                     \
+    {                                                    \
+        .CTid       = id,                                \
+        .inputTypes = ZL_STREAMTYPELIST(ZL_Type_serial), \
+        .soTypes    = ZL_STREAMTYPELIST(                 \
+                ZL_Type_serial,                       \
+                ZL_Type_numeric,                      \
+                ZL_Type_numeric,                      \
+                ZL_Type_numeric),                     \
+    }
+
 #endif

--- a/src/openzl/codecs/lz/spec_lz.md
+++ b/src/openzl/codecs/lz/spec_lz.md
@@ -1,0 +1,56 @@
+# LZ Codec
+
+## Overview
+
+The LZ codec implements LZ77 matching on a byte-level serial input stream,
+decomposing it into four output streams: literals, offsets, literal lengths, and
+match lengths.
+
+## Inputs
+
+| Stream | Type   | Element Width | Description              |
+|--------|--------|---------------|--------------------------|
+| input  | Serial | 1             | Input byte stream        |
+
+## Outputs
+
+| Index | Stream          | Type    | Element Width | Description                                   |
+|-------|-----------------|---------|---------------|-----------------------------------------------|
+| 0     | literals        | Serial  | 1             | Literal bytes not part of matches             |
+| 1     | offsets         | Numeric | Any           | Distance back to start of match               |
+| 2     | literal_lengths | Numeric | Any           | Number of literal bytes before each match     |
+| 3     | match_lengths   | Numeric | Any           | Number of bytes to copy from the match        |
+
+The decoder MUST accept any element width for the three numeric streams.
+However, the decoder MAY only optimize for certain widths, e.g. 2-byte and 4-byte.
+
+## Codec Header
+
+A single varint encoding the decompressed (original) size in bytes.
+
+## Decoding Algorithm
+
+```python
+def decode(literals, offsets, literal_lengths, match_lengths):
+    assert len(offsets) == len(literal_lengths) == len(match_lengths)
+
+    output = []
+    lit_pos = 0
+    for offset, lit_len, match_len in zip(offsets, literal_lengths, match_lengths):
+        # Copy literals
+        assert lit_pos + lit_len <= len(literals)
+        output.extend(literals[lit_pos : lit_pos + lit_len])
+        lit_pos += lit_len
+
+        # Copy match
+        # NOTE: match_len may be larger than offset
+        assert offset != 0
+        assert offset <= len(output)
+        for i in range(match_len):
+            output.append(output[-offset])
+
+    # Copy remaining literals
+    output.extend(literals[lit_pos:])
+
+    return output
+```

--- a/src/openzl/common/wire_format.h
+++ b/src/openzl/common/wire_format.h
@@ -234,12 +234,12 @@ typedef enum {
     ZL_StandardTransformID_huffman_deprecated       = 16,
     ZL_StandardTransformID_huffman_fixed_deprecated = 17,
     ZL_StandardTransformID_sentinel                 = 18,
-    // 19 : available
-    ZL_StandardTransformID_rolz       = 20,
-    ZL_StandardTransformID_fastlz     = 21,
-    ZL_StandardTransformID_zstd       = 22,
-    ZL_StandardTransformID_zstd_fixed = 23,
-    ZL_StandardTransformID_field_lz   = 24,
+    ZL_StandardTransformID_lz                       = 19,
+    ZL_StandardTransformID_rolz                     = 20,
+    ZL_StandardTransformID_fastlz                   = 21,
+    ZL_StandardTransformID_zstd                     = 22,
+    ZL_StandardTransformID_zstd_fixed               = 23,
+    ZL_StandardTransformID_field_lz                 = 24,
 
     // TODO: Use local parameters to select quantization mode dynamically
     // instead of specialization for offsets / lengths.

--- a/src/openzl/compress/graph_registry.c
+++ b/src/openzl/compress/graph_registry.c
@@ -16,6 +16,7 @@
 #include "openzl/compress/graphs/generic_clustering_graph.h" // MIGRAPH_CLUSTERING
 #include "openzl/compress/graphs/sddl/simple_data_description_language.h" // ZL_SDDL_dynGraph
 #include "openzl/compress/graphs/sddl2/sddl2.h" // SDDL2_parse
+#include "openzl/compress/graphs/small_lengths_graph.h"
 #include "openzl/compress/graphs/split_graph.h" // ZL_splitFnGraph
 #include "openzl/compress/implicit_conversion.h" // ICONV_isCompatible for type checking
 #include "openzl/compress/private_nodes.h" // ZL_PrivateStandardGraphID_end, private node ID definitions
@@ -199,6 +200,8 @@ const InternalGraphDesc GR_standardGraphs[ZL_PrivateStandardGraphID_end] = {
     REGISTER_DYNAMIC_GRAPH(ZL_PrivateStandardGraphID_split_string, "!zl.private.split_string", ZL_Type_string, ZL_splitFnGraph),
 
     REGISTER_MIGRAPH(ZL_PrivateStandardGraphID_n_to_n, MIGRAPH_N_TO_N),
+    
+    REGISTER_DYNAMIC_GRAPH(ZL_PrivateStandardGraphID_compress_small_lengths, "!zl.compress_small_lengths", ZL_Type_numeric, ZL_compressSmallLengthsGraph),
 };
 // clang-format on
 

--- a/src/openzl/compress/graphs/small_lengths_graph.c
+++ b/src/openzl/compress/graphs/small_lengths_graph.c
@@ -1,0 +1,80 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#include "openzl/compress/graphs/small_lengths_graph.h"
+
+#include "openzl/codecs/zl_entropy.h"
+#include "openzl/codecs/zl_generic.h"
+#include "openzl/codecs/zl_partition.h"
+#include "openzl/codecs/zl_quantize.h"
+#include "openzl/codecs/zl_sentinel.h"
+#include "openzl/codecs/zl_store.h"
+#include "openzl/common/assertion.h"
+
+static const size_t kInputStoreThreshold = 50;
+static const size_t kLargeStoreThreshold = 100;
+
+ZL_Report ZL_compressSmallLengthsGraph(
+        ZL_Graph* graph,
+        ZL_Edge** inputs,
+        size_t numInputs)
+{
+    ZL_RESULT_DECLARE_SCOPE_REPORT(graph);
+    ZL_ASSERT_EQ(numInputs, 1);
+    ZL_Edge* const edge         = inputs[0];
+    const ZL_Input* const input = ZL_Edge_getData(edge);
+
+    if (ZL_Input_numElts(input) < kInputStoreThreshold) {
+        return ZL_Edge_setDestination(edge, ZL_GRAPH_STORE);
+    }
+
+    if (ZL_Input_eltWidth(input) == 1) {
+        // 1-byte values go directly to Huffman
+        return ZL_Edge_setDestination(edge, ZL_GRAPH_HUFFMAN);
+    }
+
+    if (!ZL_Graph_isNodeSupported(graph, ZL_NODE_SENTINEL_BYTE)) {
+        // Older format versions fallback to generic compression
+        return ZL_Edge_setDestination(edge, ZL_GRAPH_COMPRESS_GENERIC);
+    }
+
+    // All values < 255 go into small stream
+    // Other values push 255 into small stream and go into large stream
+    ZL_TRY_LET(
+            ZL_EdgeList, edges, ZL_Edge_runNode(edge, ZL_NODE_SENTINEL_BYTE));
+    ZL_ASSERT_EQ(edges.nbEdges, 2);
+
+    ZL_Edge* const smallEdge = edges.edges[0];
+    ZL_Edge* const largeEdge = edges.edges[1];
+
+    // Small values go to Huffman (they are U8)
+    ZL_ERR_IF_ERR(ZL_Edge_setDestination(smallEdge, ZL_GRAPH_HUFFMAN));
+
+    const ZL_Input* const largeInput = ZL_Edge_getData(largeEdge);
+
+    const size_t largeEltWidth = ZL_Input_eltWidth(largeInput);
+    if (ZL_Input_numElts(largeInput) < kLargeStoreThreshold) {
+        ZL_ERR_IF_ERR(ZL_Edge_setDestination(largeEdge, ZL_GRAPH_STORE));
+    } else if (
+            largeEltWidth == 2
+            && ZL_Graph_isNodeSupported(graph, ZL_NODE_PARTITION)) {
+        // For 2-byte values send the lengths to partition+bitpack
+        ZL_ERR_IF_ERR(
+                ZL_Edge_setDestination(largeEdge, ZL_GRAPH_PARTITION_BITPACK));
+    } else if (largeEltWidth == 4) {
+        // TODO(T264089692): Use partition for quantize lengths once it is
+        // optimized
+        ZL_TRY_SET(
+                ZL_EdgeList,
+                edges,
+                ZL_Edge_runNode(largeEdge, ZL_NODE_QUANTIZE_LENGTHS));
+        ZL_ERR_IF_ERR(ZL_Edge_setDestination(edges.edges[0], ZL_GRAPH_FSE));
+        ZL_ERR_IF_ERR(ZL_Edge_setDestination(edges.edges[1], ZL_GRAPH_STORE));
+    } else {
+        // Don't have a good graph prepared yet, or the format version doesn't
+        // support it, just use generic compression
+        ZL_ERR_IF_ERR(
+                ZL_Edge_setDestination(largeEdge, ZL_GRAPH_COMPRESS_GENERIC));
+    }
+
+    return ZL_returnSuccess();
+}

--- a/src/openzl/compress/graphs/small_lengths_graph.h
+++ b/src/openzl/compress/graphs/small_lengths_graph.h
@@ -1,0 +1,16 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#ifndef OPENZL_COMPRESS_GRAPHS_SMALL_LENGTHS_GRAPH_H
+#define OPENZL_COMPRESS_GRAPHS_SMALL_LENGTHS_GRAPH_H
+
+#include "openzl/zl_graph_api.h"
+
+/**
+ * Backend for ZL_GRAPH_COMPRESS_SMALL_LENGTHS
+ */
+ZL_Report ZL_compressSmallLengthsGraph(
+        ZL_Graph* graph,
+        ZL_Edge** inputs,
+        size_t numInputs);
+
+#endif

--- a/src/openzl/compress/private_nodes.h
+++ b/src/openzl/compress/private_nodes.h
@@ -215,6 +215,8 @@ typedef enum {
     ZL_PrivateStandardGraphID_interpret_num32_compress,
     ZL_PrivateStandardGraphID_interpret_num64_compress,
 
+    ZL_PrivateStandardGraphID_compress_small_lengths,
+
     ZL_PrivateStandardGraphID_end // last id, used to detect out-of-bound enum
                                   // values
 } ZL_PrivateStandardGraphID;
@@ -296,6 +298,12 @@ typedef enum {
 #define ZL_GRAPH_INTERPRET_NUM16_COMPRESS (ZL_GraphID){ZL_PrivateStandardGraphID_interpret_num16_compress}
 #define ZL_GRAPH_INTERPRET_NUM32_COMPRESS (ZL_GraphID){ZL_PrivateStandardGraphID_interpret_num32_compress}
 #define ZL_GRAPH_INTERPRET_NUM64_COMPRESS (ZL_GraphID){ZL_PrivateStandardGraphID_interpret_num64_compress}
+
+/**
+ * Specializes in compressing small lengths that are mostly < 255.
+ * For example: literal & match lengths from LZ.
+ */
+#define ZL_GRAPH_COMPRESS_SMALL_LENGTHS (ZL_GraphID){ZL_PrivateStandardGraphID_compress_small_lengths}
 
 /**
  * This graph selects between the merge sorted transform and a backup graph

--- a/tests/registry/OpenZLComponents.h
+++ b/tests/registry/OpenZLComponents.h
@@ -85,6 +85,7 @@ enum class OpenZLComponentID {
     SegmentNumFromSerial,
     SentinelByte,
     SentinelNum,
+    CompressSmallLengths,
     // Must be last enum value
     NumComponents,
 };
@@ -156,6 +157,7 @@ std::unique_ptr<OpenZLComponent> makeSegmentNumericComponent();
 std::unique_ptr<OpenZLComponent> makeSegmentNumFromSerialComponent();
 std::unique_ptr<OpenZLComponent> makeSentinelByteComponent();
 std::unique_ptr<OpenZLComponent> makeSentinelNumComponent();
+std::unique_ptr<OpenZLComponent> makeCompressSmallLengthsComponent();
 
 } // namespace components
 
@@ -283,6 +285,8 @@ inline std::unique_ptr<OpenZLComponent> makeOpenZLComponent(
             return components::makeSentinelByteComponent();
         case OpenZLComponentID::SentinelNum:
             return components::makeSentinelNumComponent();
+        case OpenZLComponentID::CompressSmallLengths:
+            return components::makeCompressSmallLengthsComponent();
         case OpenZLComponentID::NumComponents:
         default:
             throw std::runtime_error("Invalid component");

--- a/tests/registry/OpenZLComponents.h
+++ b/tests/registry/OpenZLComponents.h
@@ -86,6 +86,7 @@ enum class OpenZLComponentID {
     SentinelByte,
     SentinelNum,
     CompressSmallLengths,
+    Lz,
     // Must be last enum value
     NumComponents,
 };
@@ -158,6 +159,7 @@ std::unique_ptr<OpenZLComponent> makeSegmentNumFromSerialComponent();
 std::unique_ptr<OpenZLComponent> makeSentinelByteComponent();
 std::unique_ptr<OpenZLComponent> makeSentinelNumComponent();
 std::unique_ptr<OpenZLComponent> makeCompressSmallLengthsComponent();
+std::unique_ptr<OpenZLComponent> makeLzComponent();
 
 } // namespace components
 
@@ -287,6 +289,8 @@ inline std::unique_ptr<OpenZLComponent> makeOpenZLComponent(
             return components::makeSentinelNumComponent();
         case OpenZLComponentID::CompressSmallLengths:
             return components::makeCompressSmallLengthsComponent();
+        case OpenZLComponentID::Lz:
+            return components::makeLzComponent();
         case OpenZLComponentID::NumComponents:
         default:
             throw std::runtime_error("Invalid component");

--- a/tests/registry/components/CompressSmallLengths.cpp
+++ b/tests/registry/components/CompressSmallLengths.cpp
@@ -1,0 +1,208 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#include "openzl/compress/private_nodes.h"
+#include "tests/datagen/distributions/ConstantDistribution.h"
+#include "tests/datagen/distributions/LogUniformDistribution.h"
+#include "tests/datagen/structures/VectorProducer.h"
+#include "tests/registry/OpenZLComponents.h"
+#include "tests/registry/OpenZLInput.h"
+
+namespace openzl::tests::components {
+namespace {
+
+class CompressSmallLengthsComponent : public OpenZLComponent {
+   public:
+    std::string name() const override
+    {
+        return "CompressSmallLengths";
+    }
+
+    int minFormatVersion() const override
+    {
+        return ZL_MIN_FORMAT_VERSION;
+    }
+
+    std::vector<GraphID> predefinedGraphs(Compressor& compressor) const override
+    {
+        compressor.selectStartingGraph(ZL_GRAPH_COMPRESS_SMALL_LENGTHS);
+        return { ZL_GRAPH_COMPRESS_SMALL_LENGTHS };
+    }
+
+    std::vector<std::unique_ptr<OpenZLInput>> predefinedInputs() const override
+    {
+        std::vector<std::unique_ptr<OpenZLInput>> inputs;
+
+        // Empty inputs at each width
+        inputs.push_back(U8OpenZLInput::make(std::vector<uint8_t>{}));
+        inputs.push_back(U16OpenZLInput::make(std::vector<uint16_t>{}));
+        inputs.push_back(U32OpenZLInput::make(std::vector<uint32_t>{}));
+        inputs.push_back(U64OpenZLInput::make(std::vector<uint64_t>{}));
+
+        // Small input (< 50 elements, triggers store fallback) at each width
+        inputs.push_back(
+                U8OpenZLInput::make(std::vector<uint8_t>{ 0, 1, 254, 255 }));
+        inputs.push_back(
+                U16OpenZLInput::make(std::vector<uint16_t>{ 0, 1, 254, 500 }));
+        inputs.push_back(
+                U32OpenZLInput::make(std::vector<uint32_t>{ 0, 1, 254, 500 }));
+        inputs.push_back(
+                U64OpenZLInput::make(std::vector<uint64_t>{ 0, 1, 254, 500 }));
+
+        // All values < 255 (no exceptions in sentinel_byte)
+        {
+            std::vector<uint8_t> v(254);
+            std::iota(v.begin(), v.end(), 0);
+            inputs.push_back(U8OpenZLInput::make(std::move(v)));
+        }
+        {
+            std::vector<uint16_t> v(254);
+            std::iota(v.begin(), v.end(), 0);
+            inputs.push_back(U16OpenZLInput::make(std::move(v)));
+        }
+        {
+            std::vector<uint32_t> v(254);
+            std::iota(v.begin(), v.end(), 0);
+            inputs.push_back(U32OpenZLInput::make(std::move(v)));
+        }
+        {
+            std::vector<uint64_t> v(254);
+            std::iota(v.begin(), v.end(), 0);
+            inputs.push_back(U64OpenZLInput::make(std::move(v)));
+        }
+
+        // All values >= 255 (all exceptions in sentinel_byte)
+        {
+            std::vector<uint8_t> v(1000, 255);
+            inputs.push_back(U8OpenZLInput::make(std::move(v)));
+        }
+        {
+            std::vector<uint16_t> v(1000);
+            std::iota(v.begin(), v.end(), 255);
+            inputs.push_back(U16OpenZLInput::make(std::move(v)));
+        }
+        {
+            std::vector<uint32_t> v(1000);
+            std::iota(v.begin(), v.end(), 255);
+            inputs.push_back(U32OpenZLInput::make(std::move(v)));
+        }
+        {
+            std::vector<uint64_t> v(1000);
+            std::iota(v.begin(), v.end(), 255);
+            inputs.push_back(U64OpenZLInput::make(std::move(v)));
+        }
+
+        // Mix of small and large values
+        {
+            std::vector<uint8_t> v(1000, 255);
+            for (size_t i = 0; i < v.size(); i += 2) {
+                v[i] = (uint8_t)(i % 255);
+            }
+            inputs.push_back(U8OpenZLInput::make(std::move(v)));
+        }
+        {
+            std::vector<uint16_t> v(1000);
+            for (size_t i = 0; i < v.size(); i += 2) {
+                v[i]     = (uint16_t)(i % 255);
+                v[i + 1] = 255 + i;
+            }
+            inputs.push_back(U16OpenZLInput::make(std::move(v)));
+        }
+        {
+            std::vector<uint32_t> v(1000);
+            for (size_t i = 0; i < v.size(); i += 2) {
+                v[i]     = (uint32_t)(i % 255);
+                v[i + 1] = 255 + i;
+            }
+            inputs.push_back(U32OpenZLInput::make(std::move(v)));
+        }
+        {
+            std::vector<uint64_t> v(1000);
+            for (size_t i = 0; i < v.size(); i += 2) {
+                v[i]     = (uint64_t)(i % 255);
+                v[i + 1] = 255 + i;
+            }
+            inputs.push_back(U64OpenZLInput::make(std::move(v)));
+        }
+
+        return inputs;
+    }
+
+    template <typename T>
+    std::unique_ptr<OpenZLInput> makeInput(
+            datagen::DataGen& gen,
+            size_t inputSize) const
+    {
+        datagen::VectorProducer<T> dist(
+                std::make_unique<datagen::LogUniformDistribution<T>>(
+                        gen.getRandWrapper(),
+                        1,
+                        std::min<size_t>(500, std::numeric_limits<T>::max())),
+                std::make_unique<datagen::ConstantDistribution<size_t>>(
+                        inputSize));
+        return NumericOpenZLInput<T>::make(dist("vector"));
+    }
+
+    std::vector<std::unique_ptr<OpenZLInput>> generateInputs(
+            datagen::DataGen& gen,
+            size_t num,
+            size_t maxInputSize,
+            const Compressor&,
+            GraphID) const override
+    {
+        std::vector<std::unique_ptr<OpenZLInput>> inputs;
+        inputs.reserve(num);
+        for (size_t i = 0; i < num; ++i) {
+            // Widths >= 2 (sentinel_byte rejects 1-byte inputs)
+            const auto widthChoice = gen.usize_range("width", 0, 3);
+            auto inputSize = gen.usize_range("input_size", 0, maxInputSize);
+            switch (widthChoice) {
+                case 0:
+                    inputs.push_back(makeInput<uint8_t>(gen, inputSize));
+                    break;
+                case 1:
+                    inputs.push_back(makeInput<uint16_t>(gen, inputSize));
+                    break;
+                case 2:
+                    inputs.push_back(makeInput<uint32_t>(gen, inputSize));
+                    break;
+                case 3:
+                    inputs.push_back(makeInput<uint64_t>(gen, inputSize));
+                    break;
+            }
+        }
+        return inputs;
+    }
+
+    std::vector<Benchmark> benchmarks(
+            Compressor& compressor,
+            datagen::DataGen& gen) const override
+    {
+        constexpr size_t kInputBytes = 1000000;
+
+        std::vector<Benchmark> benchmarks;
+
+        for (auto inputSize : { 1000, 10000, 100000 }) {
+            size_t numInputs = kInputBytes / inputSize;
+            std::vector<std::unique_ptr<OpenZLInput>> inputs;
+            inputs.reserve(numInputs);
+            for (size_t i = 0; i < numInputs; ++i) {
+                inputs.push_back(makeInput<uint16_t>(gen, inputSize));
+            }
+            benchmarks.push_back(
+                    Benchmark{
+                            .name   = "InputSize:" + std::to_string(inputSize),
+                            .graph  = ZL_GRAPH_COMPRESS_SMALL_LENGTHS,
+                            .inputs = std::move(inputs),
+                    });
+        }
+        return benchmarks;
+    }
+};
+
+} // namespace
+
+std::unique_ptr<OpenZLComponent> makeCompressSmallLengthsComponent()
+{
+    return std::make_unique<CompressSmallLengthsComponent>();
+}
+} // namespace openzl::tests::components

--- a/tests/registry/components/Lz.cpp
+++ b/tests/registry/components/Lz.cpp
@@ -1,0 +1,82 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#include "openzl/codecs/zl_lz.h"
+#include "tests/datagen/structures/CompressibleStringProducer.h"
+#include "tests/registry/OpenZLComponents.h"
+#include "tests/registry/OpenZLInput.h"
+#include "tests/utils.h"
+
+namespace openzl::tests::components {
+namespace {
+class LzComponent : public OpenZLComponent {
+   public:
+    std::string name() const override
+    {
+        return "Lz";
+    }
+
+    int minFormatVersion() const override
+    {
+        return 24;
+    }
+
+    std::vector<NodeID> predefinedNodes(Compressor& compressor) const override
+    {
+        (void)compressor;
+        return { ZL_NODE_LZ };
+    }
+
+    std::vector<std::unique_ptr<OpenZLInput>> predefinedInputs() const override
+    {
+        std::vector<std::unique_ptr<OpenZLInput>> inputs;
+        // Empty input
+        inputs.push_back(std::make_unique<SerialOpenZLInput>(""));
+        // Single byte
+        inputs.push_back(std::make_unique<SerialOpenZLInput>("x"));
+        // Short input (shorter than minimum match length)
+        inputs.push_back(std::make_unique<SerialOpenZLInput>("abc"));
+        // Repeated bytes (should produce matches)
+        inputs.push_back(
+                std::make_unique<SerialOpenZLInput>(std::string(1000, 'x')));
+        // Input with repeating pattern (good for LZ matching)
+        {
+            std::string pattern;
+            for (int i = 0; i < 100; ++i) {
+                pattern += "Hello World! ";
+            }
+            inputs.push_back(std::make_unique<SerialOpenZLInput>(pattern));
+        }
+        // Standard test data
+        inputs.push_back(std::make_unique<SerialOpenZLInput>(kLoremTestInput));
+        inputs.push_back(
+                std::make_unique<SerialOpenZLInput>(kAudioPCMS32LETestInput));
+        return inputs;
+    }
+
+    std::vector<std::unique_ptr<OpenZLInput>> generateInputs(
+            datagen::DataGen& gen,
+            size_t num,
+            size_t maxInputSize,
+            const Compressor&,
+            GraphID) const override
+    {
+        std::vector<std::unique_ptr<OpenZLInput>> inputs;
+        inputs.reserve(num);
+        for (size_t i = 0; i < num; ++i) {
+            datagen::CompressibleStringProducer producer(
+                    gen.getRandWrapper(),
+                    gen.usize_range("input_size", 0, maxInputSize),
+                    gen.u32_range("match_prob", 0, 100) / 100.0);
+            inputs.push_back(
+                    std::make_unique<SerialOpenZLInput>(producer("input")));
+        }
+        return inputs;
+    }
+};
+} // namespace
+
+std::unique_ptr<OpenZLComponent> makeLzComponent()
+{
+    return std::make_unique<LzComponent>();
+}
+} // namespace openzl::tests::components


### PR DESCRIPTION
Summary:
Adds the LZ codec to OpenZL.

* The decoder supports any width for the three numeric inputs (offsets, literal lengths, match lengths)
* The encoder only emits 2-byte numeric fields for all three numeric outputs
* The decoder is optimized for 2-byte numeric fields
* The encoder currently only supports the equivalent of the Zstd level 1 match finder. More match finders will be added in future diffs

NOTE: A future diff in the stack will create `ZL_GRAPH_LZ` which sets the default successors.

Reviewed By: Cyan4973

Differential Revision: D99344108


