### PR TITLE
Wire --chunk-size through to parquet profile (#663)

### DIFF
--- a/cli/tests/BUCK
+++ b/cli/tests/BUCK
@@ -135,6 +135,20 @@ custom_unittest(
 )
 
 custom_unittest(
+    name = "parquet_chunked_test",
+    command = [
+        "$(location :integration_test_bin)",
+        "$(location ..:zli)",
+        "ParquetChunkedTest.test_chunk_size_affects_output",
+    ],
+    type = "simple",
+    deps = [
+        "..:zli",
+        ":integration_test_bin",
+    ],
+)
+
+custom_unittest(
     name = "parquet_test",
     command = [
         "$(location :integration_test_bin)",

--- a/cli/tests/cli_integration_tests.py
+++ b/cli/tests/cli_integration_tests.py
@@ -473,6 +473,70 @@ class ParquetTest(_TrainBaseTest):
         self.train_compress_decompress()
 
 
+class ParquetChunkedTest(ParquetTest):
+    """
+    Verify that --chunk-size is wired through to the parquet profile.
+
+    Trains twice — once with the default chunk size and once with an explicit
+    --chunk-size 2M — then checks that the serialized compressors differ
+    (the chunk size is baked into the profile) and that both round-trip
+    correctly.
+    """
+
+    def test_chunk_size_affects_output(self):
+        profile = CompressorInfo(
+            compressor_str=self.compressor_profile_name,
+            compressor_type=CompressorType.PROFILE,
+        )
+
+        default_trained = os.path.join(self.output_dir_path, "default.zlc")
+        execute_train(
+            compressor_info=profile,
+            uncompressed_dir=input_dir_path(self.input_dir_name),
+            trained_compressor_path=default_trained,
+        )
+
+        chunked_trained = os.path.join(self.output_dir_path, "chunked.zlc")
+        execute_train(
+            compressor_info=profile,
+            uncompressed_dir=input_dir_path(self.input_dir_name),
+            trained_compressor_path=chunked_trained,
+            extra_args="--chunk-size 2M",
+        )
+
+        self.assertNotEqual(
+            os.path.getsize(default_trained),
+            os.path.getsize(chunked_trained),
+            "Trained compressors should differ when --chunk-size is changed",
+        )
+
+        sample = self.input_samples[0]
+        for trained_path, label in [
+            (default_trained, "default"),
+            (chunked_trained, "chunked"),
+        ]:
+            trained = CompressorInfo(
+                compressor_str=trained_path,
+                compressor_type=CompressorType.FILE,
+            )
+            compressed = sample.compressed_file_path + f".{label}"
+            execute_compress(
+                file_to_compress_path=sample.orig_file_path,
+                compressor_info=trained,
+                compressed_file_path=compressed,
+                extra_args=None,
+            )
+            decompressed = compressed + ".out"
+            execute_decompress(
+                compressed_file_path=compressed,
+                decompressed_file_path=decompressed,
+            )
+            self.assertTrue(
+                file_contents_match(sample.orig_file_path, decompressed),
+                f"Round-trip failed for {label} path",
+            )
+
+
 class U16TrainInlineTest(_TrainInlineBaseTest):
     @property
     def input_file_name(self) -> str:

--- a/cli/utils/compress_profiles.cpp
+++ b/cli/utils/compress_profiles.cpp
@@ -5,6 +5,8 @@
 
 #include <string.h>
 
+#include <limits>
+
 #include "openzl/codecs/zl_conversion.h"
 #include "openzl/codecs/zl_mlselector.h"
 #include "openzl/codecs/zl_sddl2.h"
@@ -333,13 +335,23 @@ compressProfiles()
         mp[kParquetName]         = std::make_shared<CompressProfile>(
                 kParquetName,
                 "Parquet in the canonical format (no compression, plain encoding)",
-                [](ZL_Compressor* comp, void*, const ProfileArgs&) {
+                [](ZL_Compressor* comp, void*, const ProfileArgs& args) {
                     auto clustering = ZS2_createGraph_genericClustering(comp);
-                    return ZL_Parquet_registerGraph_withChunkSize(
-                            comp,
-                            clustering,
+                    const size_t chunkSize = args.chunkSize().value_or(
                             custom_parsers::kDefaultChunkSize);
-                });
+                    if (chunkSize > static_cast<size_t>(
+                                std::numeric_limits<int>::max())) {
+                        throw InvalidArgsException(
+                                "--chunk-size for the parquet profile must be at most "
+                                + std::to_string(
+                                        std::numeric_limits<int>::max())
+                                + " bytes.");
+                    }
+                    return ZL_Parquet_registerGraph_withChunkSize(
+                            comp, clustering, static_cast<int>(chunkSize));
+                },
+                nullptr,
+                true);
 
         std::string kSDDLName = "sddl";
         mp[kSDDLName]         = std::make_shared<CompressProfile>(


### PR DESCRIPTION
Summary:

The parquet profile already used `ZL_Parquet_registerGraph_withChunkSize` 
but hardcoded `kDefaultChunkSize`, ignoring the CLI `--chunk-size` flag. 

This `diff` reads `args.chunkSize()` like the CSV and SDDL2 profiles already do, 
and marks the profile as `supportsChunkSize = true` so the CLI no longer warns that parquet ignores the flag.

The change itself is trivial (2 lines in `compress_profiles.cpp`), most of the code in this `diff` is for tests.

Reviewed By: daniellerozenblit

Differential Revision: D101880416


