### PR TITLE
Return SDDL2_Error from SDDL2_kind_size and SDDL2_Type_size (#666)

### DIFF
--- a/src/openzl/compress/graphs/sddl2/sddl2.c
+++ b/src/openzl/compress/graphs/sddl2/sddl2.c
@@ -264,16 +264,13 @@ static ZL_Report sddl2_flatten_field_sizes(
                     graph, type.struct_data->members[i], field_sizes, index));
         }
     } else {
-        // Primitive type: calculate size and append
-        size_t field_size = SDDL2_Type_size(type);
-
-        // Skip zero-sized fields (invalid types)
-        if (field_size == 0) {
-            ZL_DLOG(BLOCK,
-                    "Skipping field with zero size (type kind %d)",
-                    (int)type.kind);
-            return ZL_returnSuccess();
-        }
+        size_t field_size;
+        ZL_ERR_IF_NE(
+                SDDL2_Type_size(type, &field_size),
+                SDDL2_OK,
+                GENERIC,
+                "Failed to compute size for type kind %d",
+                (int)type.kind);
 
         field_sizes[(*index)++] = field_size;
     }
@@ -667,12 +664,12 @@ static ZL_Report sddl2_apply_type_conversion(
 
     // Determine primitive element size in bytes (not including width)
     // For array types, we convert the base element, not the full array
-    size_t element_size = SDDL2_kind_size(type.kind);
-    ZL_ERR_IF_EQ(
-            element_size,
-            0,
+    size_t element_size;
+    ZL_ERR_IF_NE(
+            SDDL2_kind_size(type.kind, &element_size),
+            SDDL2_OK,
             GENERIC,
-            "Invalid SDDL2 type kind %d for segment (unsupported or zero-sized type)",
+            "Invalid SDDL2 type kind %d for segment (unsupported type)",
             (int)type.kind);
 
     // Determine endianness
@@ -1154,10 +1151,10 @@ static ZL_Report sddl2_get_chunk_split_unit_size(
 
     // Primitive kinds, including BYTES, split on their element size.
     // BYTES intentionally uses 1-byte units so raw byte spans can chunk.
-    size_t const unitBytes = SDDL2_kind_size(type.kind);
-    ZL_ERR_IF_EQ(
-            unitBytes,
-            0,
+    size_t unitBytes;
+    ZL_ERR_IF_NE(
+            SDDL2_kind_size(type.kind, &unitBytes),
+            SDDL2_OK,
             GENERIC,
             "Failed to derive a split unit size for SDDL2 segment chunking");
     return ZL_returnValue(unitBytes);

--- a/src/openzl/compress/graphs/sddl2/sddl2_vm.c
+++ b/src/openzl/compress/graphs/sddl2/sddl2_vm.c
@@ -93,13 +93,15 @@ void sddl2_fallback_free(void* ptr)
  * Handles both primitive types and complex structures.
  * ========================================================================= */
 
-size_t SDDL2_kind_size(SDDL2_Type_kind kind)
+SDDL2_Error SDDL2_kind_size(SDDL2_Type_kind kind, size_t* out_size)
 {
+    *out_size = (size_t)-1; // Initialize to invalid value
     switch (kind) {
         case SDDL2_TYPE_U8:
         case SDDL2_TYPE_I8:
         case SDDL2_TYPE_F8:
-            return 1;
+            *out_size = 1;
+            return SDDL2_OK;
         case SDDL2_TYPE_U16LE:
         case SDDL2_TYPE_U16BE:
         case SDDL2_TYPE_I16LE:
@@ -108,51 +110,48 @@ size_t SDDL2_kind_size(SDDL2_Type_kind kind)
         case SDDL2_TYPE_F16BE:
         case SDDL2_TYPE_BF16LE:
         case SDDL2_TYPE_BF16BE:
-            return 2;
+            *out_size = 2;
+            return SDDL2_OK;
         case SDDL2_TYPE_U32LE:
         case SDDL2_TYPE_U32BE:
         case SDDL2_TYPE_I32LE:
         case SDDL2_TYPE_I32BE:
         case SDDL2_TYPE_F32LE:
         case SDDL2_TYPE_F32BE:
-            return 4;
+            *out_size = 4;
+            return SDDL2_OK;
         case SDDL2_TYPE_U64LE:
         case SDDL2_TYPE_U64BE:
         case SDDL2_TYPE_I64LE:
         case SDDL2_TYPE_I64BE:
         case SDDL2_TYPE_F64LE:
         case SDDL2_TYPE_F64BE:
-            return 8;
+            *out_size = 8;
+            return SDDL2_OK;
         case SDDL2_TYPE_BYTES:
-            return 1; // Raw bytes, unit size is 1 byte
+            *out_size = 1;
+            return SDDL2_OK;
         case SDDL2_TYPE_STRUCTURE:
-            return 0; // Structures don't have a fixed kind size (use
-                      // struct_data)
+            return SDDL2_TYPE_MISMATCH;
         default:
-            return 0; // Unknown type
+            return SDDL2_TYPE_MISMATCH;
     }
 }
 
-size_t SDDL2_Type_size(SDDL2_Type type)
+SDDL2_Error SDDL2_Type_size(SDDL2_Type type, size_t* out_size)
 {
-    // Handle structures specially
     if (type.kind == SDDL2_TYPE_STRUCTURE) {
-        assert(type.struct_data != NULL);
         if (type.struct_data == NULL) {
-            // Should not happen
-            return 0;
+            return SDDL2_TYPE_MISMATCH;
         }
-        return type.struct_data->total_size_bytes * type.width;
+        *out_size = type.struct_data->total_size_bytes * type.width;
+        return SDDL2_OK;
     }
 
-    // For primitives, use kind size
-    size_t kind_size = SDDL2_kind_size(type.kind);
-    assert(kind_size > 0);
-    if (kind_size == 0) {
-        // Unknown type kind: should not happen
-        return 0;
-    }
-    return kind_size * type.width;
+    size_t ks;
+    SDDL2_TRY(SDDL2_kind_size(type.kind, &ks));
+    *out_size = ks * type.width;
+    return SDDL2_OK;
 }
 
 /* ============================================================================
@@ -391,7 +390,12 @@ SDDL2_Error SDDL2_op_type_structure(
 
     // Compute total size by summing all member sizes
     for (size_t i = 0; i < member_count; i++) {
-        size_t member_size = SDDL2_Type_size(struct_data->members[i]);
+        size_t member_size;
+        if (SDDL2_Type_size(struct_data->members[i], &member_size)
+            != SDDL2_OK) {
+            sddl2_free(struct_data, alloc_fn);
+            return SDDL2_TYPE_MISMATCH;
+        }
 
         // Check for size overflow when adding member_size
         if (ZL_overflowAddST(
@@ -419,10 +423,8 @@ SDDL2_Error SDDL2_op_type_sizeof(SDDL2_Stack* stack)
     SDDL2_Type type;
     SDDL2_TRY(pop_type(stack, &type));
 
-    // Get the size of the type
-    size_t size = SDDL2_Type_size(type);
-
-    // Push the size as I64
+    size_t size;
+    SDDL2_TRY(SDDL2_Type_size(type, &size));
     return push_i64(stack, (int64_t)size);
 }
 
@@ -1322,10 +1324,8 @@ static SDDL2_Error segment_create_internal(
     // Calculate actual size in bytes
     // total_type_size = size of one instance of the type (including width)
     // segment_size = element_count × total_type_size
-    size_t total_type_size = SDDL2_Type_size(type);
-    if (total_type_size == 0) {
-        return SDDL2_TYPE_MISMATCH; // Unknown or invalid type
-    }
+    size_t total_type_size;
+    SDDL2_TRY(SDDL2_Type_size(type, &total_type_size));
 
     // Check for overflow in element_count * total_type_size multiplication
     size_t size_bytes;

--- a/src/openzl/compress/graphs/sddl2/sddl2_vm.h
+++ b/src/openzl/compress/graphs/sddl2/sddl2_vm.h
@@ -481,16 +481,16 @@ SDDL2_Value SDDL2_Value_type(SDDL2_Type type);
 /**
  * Get the size in bytes of a single element of the given type kind (primitive
  * size). Returns 1 for BYTES (raw bytes with no known interpretation).
- * Returns 0 for unknown/invalid types.
+ * Returns SDDL2_TYPE_MISMATCH for unknown/invalid type kinds and for STRUCTURE.
  */
-size_t SDDL2_kind_size(SDDL2_Type_kind kind);
+SDDL2_Error SDDL2_kind_size(SDDL2_Type_kind kind, size_t* out_size);
 
 /**
  * Get the total size in bytes of a type (including width).
- * Calculates: SDDL2_kind_size(type.kind) × type.width
- * Returns 0 if error, like type.kind is unknown.
+ * Calculates: element_size × type.width
+ * Returns SDDL2_TYPE_MISMATCH for invalid types.
  */
-size_t SDDL2_Type_size(SDDL2_Type type);
+SDDL2_Error SDDL2_Type_size(SDDL2_Type type, size_t* out_size);
 
 /* ============================================================================
  * Type Operations

--- a/tests/compress/graphs/sddl2/test_sddl2_field_extraction.cpp
+++ b/tests/compress/graphs/sddl2/test_sddl2_field_extraction.cpp
@@ -25,7 +25,7 @@ SDDL2_Type createStructureType(SDDL2_Type* members, size_t member_count)
 {
     size_t total_size = 0;
     for (size_t i = 0; i < member_count; i++) {
-        total_size += SDDL2_Type_size(members[i]);
+        total_size += getTypeSize(members[i]);
     }
 
     size_t alloc_size =
@@ -78,9 +78,9 @@ TEST_F(SDDL2FieldExtractionTest, SimpleFlatStructure)
     EXPECT_EQ(data->member_count, 3u);
     EXPECT_EQ(data->total_size_bytes, 7u);
 
-    EXPECT_EQ(SDDL2_Type_size(data->members[0]), 1u);
-    EXPECT_EQ(SDDL2_Type_size(data->members[1]), 2u);
-    EXPECT_EQ(SDDL2_Type_size(data->members[2]), 4u);
+    EXPECT_EQ(getTypeSize(data->members[0]), 1u);
+    EXPECT_EQ(getTypeSize(data->members[1]), 2u);
+    EXPECT_EQ(getTypeSize(data->members[2]), 4u);
 
     free(data);
 }
@@ -101,9 +101,9 @@ TEST_F(SDDL2FieldExtractionTest, StructureWithArrayField)
     EXPECT_EQ(data->member_count, 3u);
     EXPECT_EQ(data->total_size_bytes, 43u);
 
-    EXPECT_EQ(SDDL2_Type_size(data->members[0]), 1u);
-    EXPECT_EQ(SDDL2_Type_size(data->members[1]), 40u);
-    EXPECT_EQ(SDDL2_Type_size(data->members[2]), 2u);
+    EXPECT_EQ(getTypeSize(data->members[0]), 1u);
+    EXPECT_EQ(getTypeSize(data->members[1]), 40u);
+    EXPECT_EQ(getTypeSize(data->members[2]), 2u);
 
     free(data);
 }
@@ -125,7 +125,7 @@ TEST_F(SDDL2FieldExtractionTest, AllPrimitiveTypes)
 
     size_t expected_sizes[] = { 1, 2, 4, 8 };
     for (size_t i = 0; i < 4; i++) {
-        EXPECT_EQ(SDDL2_Type_size(data->members[i]), expected_sizes[i]);
+        EXPECT_EQ(getTypeSize(data->members[i]), expected_sizes[i]);
     }
 
     free(data);
@@ -177,10 +177,10 @@ TEST_F(SDDL2FieldExtractionTest, TypeSizeFunction)
     };
 
     SDDL2_Type struct_type = createStructureType(members, 2);
-    EXPECT_EQ(SDDL2_Type_size(struct_type), 5u); // 1 + 4
+    EXPECT_EQ(getTypeSize(struct_type), 5u); // 1 + 4
 
     struct_type.width = 10;
-    EXPECT_EQ(SDDL2_Type_size(struct_type), 50u); // 5 × 10
+    EXPECT_EQ(getTypeSize(struct_type), 50u); // 5 × 10
 
     free(struct_type.struct_data);
 }
@@ -237,7 +237,7 @@ TEST_F(SDDL2FieldExtractionTest, NestedStructure3Levels)
     };
     SDDL2_Type level3 = createStructureType(level3_members, 2);
 
-    EXPECT_EQ(SDDL2_Type_size(level3), 15u);
+    EXPECT_EQ(getTypeSize(level3), 15u);
 
     free(level1.struct_data);
     free(level2.struct_data);
@@ -261,7 +261,7 @@ TEST_F(SDDL2FieldExtractionTest, NestedStructureWithArrays)
     };
     SDDL2_Type outer = createStructureType(outer_members, 3);
 
-    EXPECT_EQ(SDDL2_Type_size(outer), 31u);
+    EXPECT_EQ(getTypeSize(outer), 31u);
 
     free(inner.struct_data);
     free(outer.struct_data);
@@ -291,7 +291,7 @@ TEST_F(SDDL2FieldExtractionTest, MultipleNestedStructures)
     };
     SDDL2_Type outer = createStructureType(outer_members, 3);
 
-    EXPECT_EQ(SDDL2_Type_size(outer), 19u);
+    EXPECT_EQ(getTypeSize(outer), 19u);
 
     free(structA.struct_data);
     free(structB.struct_data);
@@ -405,7 +405,7 @@ TEST_F(SDDL2FieldExtractionTest, FieldTypesSizesAlignment)
     ASSERT_EQ(type_index, 4u);
     for (size_t i = 0; i < 4; i++) {
         EXPECT_EQ(field_types[i], expected_types[i]);
-        EXPECT_EQ(SDDL2_kind_size(field_types[i]), expected_sizes[i]);
+        EXPECT_EQ(getKindSize(field_types[i]), expected_sizes[i]);
     }
 
     free(inner.struct_data);

--- a/tests/compress/graphs/sddl2/test_sddl2_structure_split_integration.cpp
+++ b/tests/compress/graphs/sddl2/test_sddl2_structure_split_integration.cpp
@@ -60,9 +60,9 @@ TEST_F(SDDL2StructureSplitIntegrationTest, FlatStructureSplit)
     EXPECT_EQ(struct_data->member_count, 3u);
     EXPECT_EQ(struct_data->total_size_bytes, 7u);
 
-    EXPECT_EQ(SDDL2_Type_size(struct_data->members[0]), 1u); // U8
-    EXPECT_EQ(SDDL2_Type_size(struct_data->members[1]), 2u); // I16LE
-    EXPECT_EQ(SDDL2_Type_size(struct_data->members[2]), 4u); // I32LE
+    EXPECT_EQ(getTypeSize(struct_data->members[0]), 1u); // U8
+    EXPECT_EQ(getTypeSize(struct_data->members[1]), 2u); // I16LE
+    EXPECT_EQ(getTypeSize(struct_data->members[2]), 4u); // I32LE
 
     free(struct_data);
 }
@@ -161,9 +161,9 @@ TEST_F(SDDL2StructureSplitIntegrationTest, StructureWithArrayField)
     EXPECT_EQ(struct_data->member_count, 3u);
     EXPECT_EQ(struct_data->total_size_bytes, 23u);
 
-    EXPECT_EQ(SDDL2_Type_size(struct_data->members[0]), 1u);  // U8
-    EXPECT_EQ(SDDL2_Type_size(struct_data->members[1]), 20u); // I32LE × 5
-    EXPECT_EQ(SDDL2_Type_size(struct_data->members[2]), 2u);  // I16LE
+    EXPECT_EQ(getTypeSize(struct_data->members[0]), 1u);  // U8
+    EXPECT_EQ(getTypeSize(struct_data->members[1]), 20u); // I32LE × 5
+    EXPECT_EQ(getTypeSize(struct_data->members[2]), 2u);  // I16LE
 
     free(struct_data);
 }
@@ -231,9 +231,9 @@ TEST_F(SDDL2StructureSplitIntegrationTest, FieldSizeExtraction)
                                       .width       = 1,
                                       .struct_data = nullptr };
 
-    EXPECT_EQ(SDDL2_Type_size(struct_data->members[0]), 1u);
-    EXPECT_EQ(SDDL2_Type_size(struct_data->members[1]), 4u);
-    EXPECT_EQ(SDDL2_Type_size(struct_data->members[2]), 8u);
+    EXPECT_EQ(getTypeSize(struct_data->members[0]), 1u);
+    EXPECT_EQ(getTypeSize(struct_data->members[1]), 4u);
+    EXPECT_EQ(getTypeSize(struct_data->members[2]), 8u);
 
     free(struct_data);
 }

--- a/tests/compress/graphs/sddl2/test_sddl2_tagged_segments.cpp
+++ b/tests/compress/graphs/sddl2/test_sddl2_tagged_segments.cpp
@@ -999,7 +999,7 @@ TEST_F(SDDL2TaggedSegmentsLargeTest, SegmentListGrowthDifferentTypes)
     for (int i = 0; i < NUM_SEGMENTS; i++) {
         int type_idx = i % 4;
         size_t expected_bytes =
-                element_counts[type_idx] * SDDL2_kind_size(types[type_idx]);
+                element_counts[type_idx] * getKindSize(types[type_idx]);
 
         EXPECT_EQ(segments.items[i].tag, (uint32_t)(100 + i));
         EXPECT_EQ(segments.items[i].type.kind, types[type_idx]);

--- a/tests/compress/graphs/sddl2/test_sddl2_type_structure.cpp
+++ b/tests/compress/graphs/sddl2/test_sddl2_type_structure.cpp
@@ -44,9 +44,9 @@ TEST_F(SDDL2TypeStructureTest, SimpleStructureCreation)
                                           .width       = 1,
                                           .struct_data = nullptr };
 
-    struct_data->total_size_bytes = SDDL2_Type_size(struct_data->members[0])
-            + SDDL2_Type_size(struct_data->members[1])
-            + SDDL2_Type_size(struct_data->members[2]);
+    struct_data->total_size_bytes = getTypeSize(struct_data->members[0])
+            + getTypeSize(struct_data->members[1])
+            + getTypeSize(struct_data->members[2]);
 
     EXPECT_EQ(struct_data->total_size_bytes, 7);
 
@@ -110,9 +110,9 @@ TEST_F(SDDL2TypeStructureTest, StructureWithArrayMembers)
                                             .width       = 1,
                                             .struct_data = nullptr };
 
-    struct_data->total_size_bytes = SDDL2_Type_size(struct_data->members[0])
-            + SDDL2_Type_size(struct_data->members[1])
-            + SDDL2_Type_size(struct_data->members[2]);
+    struct_data->total_size_bytes = getTypeSize(struct_data->members[0])
+            + getTypeSize(struct_data->members[1])
+            + getTypeSize(struct_data->members[2]);
 
     EXPECT_EQ(struct_data->total_size_bytes, 43);
 

--- a/tests/compress/graphs/sddl2/test_sddl2_vm.cpp
+++ b/tests/compress/graphs/sddl2/test_sddl2_vm.cpp
@@ -118,13 +118,13 @@ TEST_F(SDDL2VmTest, ValueKinds)
 
 TEST_F(SDDL2VmTest, TypeSizes)
 {
-    EXPECT_EQ(SDDL2_kind_size(SDDL2_TYPE_U8), 1u);
-    EXPECT_EQ(SDDL2_kind_size(SDDL2_TYPE_I8), 1u);
-    EXPECT_EQ(SDDL2_kind_size(SDDL2_TYPE_U16LE), 2u);
-    EXPECT_EQ(SDDL2_kind_size(SDDL2_TYPE_I16BE), 2u);
-    EXPECT_EQ(SDDL2_kind_size(SDDL2_TYPE_U32LE), 4u);
-    EXPECT_EQ(SDDL2_kind_size(SDDL2_TYPE_F32BE), 4u);
-    EXPECT_EQ(SDDL2_kind_size(SDDL2_TYPE_I64LE), 8u);
-    EXPECT_EQ(SDDL2_kind_size(SDDL2_TYPE_F64BE), 8u);
-    EXPECT_EQ(SDDL2_kind_size(SDDL2_TYPE_BYTES), 1u);
+    EXPECT_EQ(getKindSize(SDDL2_TYPE_U8), 1u);
+    EXPECT_EQ(getKindSize(SDDL2_TYPE_I8), 1u);
+    EXPECT_EQ(getKindSize(SDDL2_TYPE_U16LE), 2u);
+    EXPECT_EQ(getKindSize(SDDL2_TYPE_I16BE), 2u);
+    EXPECT_EQ(getKindSize(SDDL2_TYPE_U32LE), 4u);
+    EXPECT_EQ(getKindSize(SDDL2_TYPE_F32BE), 4u);
+    EXPECT_EQ(getKindSize(SDDL2_TYPE_I64LE), 8u);
+    EXPECT_EQ(getKindSize(SDDL2_TYPE_F64BE), 8u);
+    EXPECT_EQ(getKindSize(SDDL2_TYPE_BYTES), 1u);
 }

--- a/tests/compress/graphs/sddl2/test_sddl2_vm_kind_size.cpp
+++ b/tests/compress/graphs/sddl2/test_sddl2_vm_kind_size.cpp
@@ -5,9 +5,9 @@
  * Verifies that all 24 type kinds return the correct size in bytes.
  */
 
-#include <gtest/gtest.h>
+#include "tests/compress/graphs/sddl2/utils.h"
 
-#include "openzl/compress/graphs/sddl2/sddl2_vm.h"
+using namespace openzl::sddl2::testing;
 
 // ============================================================================
 // 1-byte types
@@ -15,10 +15,10 @@
 
 TEST(SDDL2KindSizeTest, OneByteTypes)
 {
-    EXPECT_EQ(SDDL2_kind_size(SDDL2_TYPE_BYTES), 1);
-    EXPECT_EQ(SDDL2_kind_size(SDDL2_TYPE_U8), 1);
-    EXPECT_EQ(SDDL2_kind_size(SDDL2_TYPE_I8), 1);
-    EXPECT_EQ(SDDL2_kind_size(SDDL2_TYPE_F8), 1);
+    EXPECT_EQ(getKindSize(SDDL2_TYPE_BYTES), 1);
+    EXPECT_EQ(getKindSize(SDDL2_TYPE_U8), 1);
+    EXPECT_EQ(getKindSize(SDDL2_TYPE_I8), 1);
+    EXPECT_EQ(getKindSize(SDDL2_TYPE_F8), 1);
 }
 
 // ============================================================================
@@ -28,16 +28,16 @@ TEST(SDDL2KindSizeTest, OneByteTypes)
 TEST(SDDL2KindSizeTest, TwoByteTypes)
 {
     // Integers
-    EXPECT_EQ(SDDL2_kind_size(SDDL2_TYPE_U16LE), 2);
-    EXPECT_EQ(SDDL2_kind_size(SDDL2_TYPE_U16BE), 2);
-    EXPECT_EQ(SDDL2_kind_size(SDDL2_TYPE_I16LE), 2);
-    EXPECT_EQ(SDDL2_kind_size(SDDL2_TYPE_I16BE), 2);
+    EXPECT_EQ(getKindSize(SDDL2_TYPE_U16LE), 2);
+    EXPECT_EQ(getKindSize(SDDL2_TYPE_U16BE), 2);
+    EXPECT_EQ(getKindSize(SDDL2_TYPE_I16LE), 2);
+    EXPECT_EQ(getKindSize(SDDL2_TYPE_I16BE), 2);
 
     // Floats
-    EXPECT_EQ(SDDL2_kind_size(SDDL2_TYPE_F16LE), 2);
-    EXPECT_EQ(SDDL2_kind_size(SDDL2_TYPE_F16BE), 2);
-    EXPECT_EQ(SDDL2_kind_size(SDDL2_TYPE_BF16LE), 2);
-    EXPECT_EQ(SDDL2_kind_size(SDDL2_TYPE_BF16BE), 2);
+    EXPECT_EQ(getKindSize(SDDL2_TYPE_F16LE), 2);
+    EXPECT_EQ(getKindSize(SDDL2_TYPE_F16BE), 2);
+    EXPECT_EQ(getKindSize(SDDL2_TYPE_BF16LE), 2);
+    EXPECT_EQ(getKindSize(SDDL2_TYPE_BF16BE), 2);
 }
 
 // ============================================================================
@@ -47,14 +47,14 @@ TEST(SDDL2KindSizeTest, TwoByteTypes)
 TEST(SDDL2KindSizeTest, FourByteTypes)
 {
     // Integers
-    EXPECT_EQ(SDDL2_kind_size(SDDL2_TYPE_U32LE), 4);
-    EXPECT_EQ(SDDL2_kind_size(SDDL2_TYPE_U32BE), 4);
-    EXPECT_EQ(SDDL2_kind_size(SDDL2_TYPE_I32LE), 4);
-    EXPECT_EQ(SDDL2_kind_size(SDDL2_TYPE_I32BE), 4);
+    EXPECT_EQ(getKindSize(SDDL2_TYPE_U32LE), 4);
+    EXPECT_EQ(getKindSize(SDDL2_TYPE_U32BE), 4);
+    EXPECT_EQ(getKindSize(SDDL2_TYPE_I32LE), 4);
+    EXPECT_EQ(getKindSize(SDDL2_TYPE_I32BE), 4);
 
     // Floats
-    EXPECT_EQ(SDDL2_kind_size(SDDL2_TYPE_F32LE), 4);
-    EXPECT_EQ(SDDL2_kind_size(SDDL2_TYPE_F32BE), 4);
+    EXPECT_EQ(getKindSize(SDDL2_TYPE_F32LE), 4);
+    EXPECT_EQ(getKindSize(SDDL2_TYPE_F32BE), 4);
 }
 
 // ============================================================================
@@ -64,21 +64,28 @@ TEST(SDDL2KindSizeTest, FourByteTypes)
 TEST(SDDL2KindSizeTest, EightByteTypes)
 {
     // Integers
-    EXPECT_EQ(SDDL2_kind_size(SDDL2_TYPE_U64LE), 8);
-    EXPECT_EQ(SDDL2_kind_size(SDDL2_TYPE_U64BE), 8);
-    EXPECT_EQ(SDDL2_kind_size(SDDL2_TYPE_I64LE), 8);
-    EXPECT_EQ(SDDL2_kind_size(SDDL2_TYPE_I64BE), 8);
+    EXPECT_EQ(getKindSize(SDDL2_TYPE_U64LE), 8);
+    EXPECT_EQ(getKindSize(SDDL2_TYPE_U64BE), 8);
+    EXPECT_EQ(getKindSize(SDDL2_TYPE_I64LE), 8);
+    EXPECT_EQ(getKindSize(SDDL2_TYPE_I64BE), 8);
 
     // Floats
-    EXPECT_EQ(SDDL2_kind_size(SDDL2_TYPE_F64LE), 8);
-    EXPECT_EQ(SDDL2_kind_size(SDDL2_TYPE_F64BE), 8);
+    EXPECT_EQ(getKindSize(SDDL2_TYPE_F64LE), 8);
+    EXPECT_EQ(getKindSize(SDDL2_TYPE_F64BE), 8);
 }
 
 // ============================================================================
 // Invalid type
 // ============================================================================
 
-TEST(SDDL2KindSizeTest, InvalidTypeReturnsZero)
+TEST(SDDL2KindSizeTest, InvalidTypeReturnsError)
 {
-    EXPECT_EQ(SDDL2_kind_size((SDDL2_Type_kind(9999))), 0);
+    size_t out;
+    EXPECT_NE(SDDL2_kind_size(SDDL2_Type_kind(9999), &out), SDDL2_OK);
+}
+
+TEST(SDDL2KindSizeTest, StructReturnsError)
+{
+    size_t out;
+    EXPECT_NE(SDDL2_kind_size(SDDL2_TYPE_STRUCTURE, &out), SDDL2_OK);
 }

--- a/tests/compress/graphs/sddl2/test_sddl2_vm_type_structure.cpp
+++ b/tests/compress/graphs/sddl2/test_sddl2_vm_type_structure.cpp
@@ -64,7 +64,7 @@ TEST_F(SDDL2VmTypeStructureTest, SimpleStructure)
     EXPECT_EQ(struct_data->members[1].kind, SDDL2_TYPE_I16LE);
     EXPECT_EQ(struct_data->members[2].kind, SDDL2_TYPE_I32LE);
 
-    EXPECT_EQ(SDDL2_Type_size(result.value.as_type), 7u);
+    EXPECT_EQ(getTypeSize(result.value.as_type), 7u);
 }
 
 TEST_F(SDDL2VmTypeStructureTest, StructureWithArrays)
@@ -126,7 +126,7 @@ TEST_F(SDDL2VmTypeStructureTest, ArrayOfStructures)
     EXPECT_EQ(struct_data->total_size_bytes, 5u); // Size of one instance
 
     // Total size = 5 bytes × 10 = 50 bytes
-    EXPECT_EQ(SDDL2_Type_size(result.value.as_type), 50u);
+    EXPECT_EQ(getTypeSize(result.value.as_type), 50u);
 }
 
 TEST_F(SDDL2VmTypeStructureTest, ZeroMemberStructure)

--- a/tests/compress/graphs/sddl2/utils.h
+++ b/tests/compress/graphs/sddl2/utils.h
@@ -110,6 +110,20 @@ class SDDL2StackTestCustomCapacity : public SDDL2TestBase {
 
 using SDDL2StackTest = SDDL2StackTestCustomCapacity<100>;
 
+static size_t getKindSize(SDDL2_Type_kind kind)
+{
+    size_t out = 0;
+    EXPECT_EQ(SDDL2_kind_size(kind, &out), SDDL2_OK);
+    return out;
+}
+
+static size_t getTypeSize(SDDL2_Type type)
+{
+    size_t out = 0;
+    EXPECT_EQ(SDDL2_Type_size(type, &out), SDDL2_OK);
+    return out;
+}
+
 static void popAndVerifyI64(SDDL2_Stack* stack, int64_t expected)
 {
     SDDL2_Value result;

--- a/tests/round_trip/test_sddl2_bytecode.cpp
+++ b/tests/round_trip/test_sddl2_bytecode.cpp
@@ -407,7 +407,8 @@ static SDDL2_Struct_data* create_structure_data(
     struct_data->total_size_bytes = 0;
     for (size_t i = 0; i < member_count; ++i) {
         struct_data->members[i] = members[i];
-        struct_data->total_size_bytes += SDDL2_Type_size(members[i]);
+        struct_data->total_size_bytes +=
+                openzl::sddl2::testing::getTypeSize(members[i]);
     }
 
     return struct_data;


### PR DESCRIPTION
Summary:

Modify `SDDL2_kind_size` and `SDDL2_Type_size` to return `SDDL2_Error` instead of returning size_t directly (with 0 as the error sentinel).

This eliminates the ambiguity where 0 could be a valid size (e.g. for `SDDL2_TYPE_STRUCTURE`) vs an error indicator.

Differential Revision: D102166154
