### PR TITLE
Easy: [OpenZL] Add train target to openzl:openzl target

### DIFF
--- a/BUCK
+++ b/BUCK
@@ -230,6 +230,15 @@ cpp_library(
     ],
 )
 
+cpp_library(
+    # @autodeps-skip
+    name = "openzl_training",
+    visibility = ["//openzl:openzl_training"],
+    exported_deps = [
+        "tools/training:train",  # @manual
+    ],
+)
+
 # Not intended to be widely used. A supported Python binding is coming.
 python_library(
     # @autodeps-skip


### PR DESCRIPTION
Summary: Allow training API to be exposed in MC branchable build targets by adding a new target that exposes training.

Reviewed By: felixhandte

Differential Revision: D102073329


