### PR TITLE
Easy: Convert TypeResult to struct (#671)

### DIFF
--- a/src/openzl/compress/graphs/sddl2/sddl2.c
+++ b/src/openzl/compress/graphs/sddl2/sddl2.c
@@ -571,11 +571,22 @@ static ZL_Report sddl2_apply_structure_split(
             nb_fields,
             nb_field_types);
 
-    // Step 3: Create copy parameter for field sizes
+    // Step 3: Build non-zero sizes for split-by-struct
+    size_t* nonzero_sizes = (size_t*)ZL_Graph_getScratchSpace(
+            graph, nb_fields * sizeof(size_t));
+    ZL_ERR_IF_NULL(nonzero_sizes, allocation);
+
+    size_t nb_nonzero = 0;
+    for (size_t i = 0; i < nb_fields; i++) {
+        if (field_sizes[i] > 0) {
+            nonzero_sizes[nb_nonzero++] = field_sizes[i];
+        }
+    }
+
     ZL_CopyParam const fieldSizesParam = {
         .paramId   = ZL_SPLITBYSTRUCT_FIELDSIZES_PID,
-        .paramPtr  = field_sizes,
-        .paramSize = nb_fields * sizeof(size_t)
+        .paramPtr  = nonzero_sizes,
+        .paramSize = nb_nonzero * sizeof(size_t)
     };
 
     // Package into LocalParams structure
@@ -592,43 +603,40 @@ static ZL_Report sddl2_apply_structure_split(
     // Validate we got the expected number of output edges
     ZL_ERR_IF_NE(
             split_outputs.nbEdges,
-            nb_fields,
+            nb_nonzero,
             GENERIC,
             "Split-by-struct produced %zu edges, expected %zu",
             split_outputs.nbEdges,
-            nb_fields);
+            nb_nonzero);
 
-    ZL_DLOG(BLOCK, "Split-by-struct produced %zu field edges", nb_fields);
+    ZL_DLOG(BLOCK, "Split-by-struct produced %zu field edges", nb_nonzero);
 
-    // Step 5: Apply Struct→Numeric conversion to each field edge
-    for (size_t i = 0; i < split_outputs.nbEdges; i++) {
-        SDDL2_Type_kind field_type_kind = field_types[i];
-
-        // Skip BYTES type (shouldn't happen with structures, but check anyway)
-        if (field_type_kind == SDDL2_TYPE_BYTES) {
-            ZL_DLOG(BLOCK, "Field %zu: skipping BYTES type", i);
+    // Step 5: Convert, tag, and route each field; skip IDs for zero-size
+    size_t edge_idx = 0;
+    for (size_t i = 0; i < nb_fields; i++) {
+        // Skip zero-size fields but still increment stream ID
+        if (field_sizes[i] == 0) {
+            ZL_DLOG(BLOCK, "Field %zu: skipped (zero size)", i);
+            *next_stream_id += 1;
             continue;
         }
 
-        // Apply Struct→Numeric conversion (split-by-struct outputs Struct
-        // edges)
-        ZL_ERR_IF_ERR(sddl2_apply_struct_field_conversion(
-                graph,
-                split_outputs.edges[i],
-                field_type_kind,
-                &split_outputs.edges[i]));
+        ZL_Edge* field_edge             = split_outputs.edges[edge_idx++];
+        SDDL2_Type_kind field_type_kind = field_types[i];
+        if (field_types[i] != SDDL2_TYPE_BYTES) {
+            ZL_ERR_IF_ERR(sddl2_apply_struct_field_conversion(
+                    graph, field_edge, field_type_kind, &field_edge));
+        }
 
         ZL_DLOG(BLOCK,
                 "Field %zu: converted Struct→Numeric (type kind %d)",
                 i,
                 (int)field_type_kind);
-    }
 
-    // Step 6: Attach clustering tags and route all field edges to destination
-    for (size_t i = 0; i < split_outputs.nbEdges; i++) {
-        ZL_ERR_IF_ERR(sddl2_set_next_stream_tag(
-                graph, split_outputs.edges[i], next_stream_id));
-        ZL_ERR_IF_ERR(ZL_Edge_setDestination(split_outputs.edges[i], dest));
+        // Attach clustering tag and route to destination
+        ZL_ERR_IF_ERR(
+                sddl2_set_next_stream_tag(graph, field_edge, next_stream_id));
+        ZL_ERR_IF_ERR(ZL_Edge_setDestination(field_edge, dest));
     }
 
     ZL_DLOG(BLOCK,
@@ -957,11 +965,10 @@ static ZL_Report sddl2_replay_segments(
         ZL_Graph* graph,
         ZL_Edge* input,
         const SDDL2_ReplaySegment* segments,
-        size_t num_segments)
+        size_t nbSegments)
 {
     ZL_RESULT_DECLARE_SCOPE_REPORT(graph);
-
-    if (num_segments == 0) {
+    if (nbSegments == 0) {
         ZL_ERR_IF_ERR(ZL_Edge_setDestination(input, ZL_GRAPH_STORE));
         return ZL_returnSuccess();
     }
@@ -971,24 +978,27 @@ static ZL_Report sddl2_replay_segments(
             "SDDL2 replay requires a non-null segment slice");
 
     size_t* segmentSizes = (size_t*)ZL_Graph_getScratchSpace(
-            graph, num_segments * sizeof(size_t));
+            graph, nbSegments * sizeof(size_t));
     ZL_ERR_IF_NULL(segmentSizes, allocation);
 
-    for (size_t i = 0; i < num_segments; i++) {
-        segmentSizes[i] = segments[i].size_bytes;
+    size_t nbNonZero = 0;
+    for (size_t i = 0; i < nbSegments; i++) {
+        if (segments[i].size_bytes > 0) {
+            segmentSizes[nbNonZero++] = segments[i].size_bytes;
+        }
     }
 
     ZL_TRY_LET(
             ZL_EdgeList,
             outputs,
-            ZL_Edge_runSplitNode(input, segmentSizes, num_segments));
+            ZL_Edge_runSplitNode(input, segmentSizes, nbNonZero));
     ZL_ERR_IF_NE(
             outputs.nbEdges,
-            num_segments,
+            nbNonZero,
             GENERIC,
             "SDDL2 replay split produced %zu edges for %zu segments",
             outputs.nbEdges,
-            num_segments);
+            nbNonZero);
 
     ZL_GraphID dest = ZL_GRAPH_COMPRESS_GENERIC;
     ZL_ERR_IF_ERR(sddl2_get_destination_graph(graph, &dest));
@@ -998,10 +1008,20 @@ static ZL_Report sddl2_replay_segments(
             sddl2_get_replay_start_stream_id(graph));
     ZL_IDType next_stream_id = (ZL_IDType)next_stream_id_value;
 
-    for (size_t i = 0; i < outputs.nbEdges; i++) {
+    size_t outputIdx = 0;
+    for (size_t i = 0; i < nbSegments; i++) {
+        if (segments[i].size_bytes == 0) {
+            // Skip zero-sized segments but still increment the stream id
+            ZL_TRY_LET(
+                    size_t,
+                    nbFields,
+                    sddl2_count_primitive_fields(graph, segments[i].type));
+            next_stream_id += (unsigned int)nbFields;
+            continue;
+        }
         ZL_ERR_IF_ERR(sddl2_process_segment(
                 graph,
-                outputs.edges[i],
+                outputs.edges[outputIdx++],
                 segments[i].type,
                 dest,
                 &next_stream_id));

--- a/src/openzl/compress/graphs/sddl2/sddl2.c
+++ b/src/openzl/compress/graphs/sddl2/sddl2.c
@@ -264,16 +264,13 @@ static ZL_Report sddl2_flatten_field_sizes(
                     graph, type.struct_data->members[i], field_sizes, index));
         }
     } else {
-        // Primitive type: calculate size and append
-        size_t field_size = SDDL2_Type_size(type);
-
-        // Skip zero-sized fields (invalid types)
-        if (field_size == 0) {
-            ZL_DLOG(BLOCK,
-                    "Skipping field with zero size (type kind %d)",
-                    (int)type.kind);
-            return ZL_returnSuccess();
-        }
+        size_t field_size;
+        ZL_ERR_IF_NE(
+                SDDL2_Type_size(type, &field_size),
+                SDDL2_OK,
+                GENERIC,
+                "Failed to compute size for type kind %d",
+                (int)type.kind);
 
         field_sizes[(*index)++] = field_size;
     }
@@ -667,12 +664,12 @@ static ZL_Report sddl2_apply_type_conversion(
 
     // Determine primitive element size in bytes (not including width)
     // For array types, we convert the base element, not the full array
-    size_t element_size = SDDL2_kind_size(type.kind);
-    ZL_ERR_IF_EQ(
-            element_size,
-            0,
+    size_t element_size;
+    ZL_ERR_IF_NE(
+            SDDL2_kind_size(type.kind, &element_size),
+            SDDL2_OK,
             GENERIC,
-            "Invalid SDDL2 type kind %d for segment (unsupported or zero-sized type)",
+            "Invalid SDDL2 type kind %d for segment (unsupported type)",
             (int)type.kind);
 
     // Determine endianness
@@ -1154,10 +1151,10 @@ static ZL_Report sddl2_get_chunk_split_unit_size(
 
     // Primitive kinds, including BYTES, split on their element size.
     // BYTES intentionally uses 1-byte units so raw byte spans can chunk.
-    size_t const unitBytes = SDDL2_kind_size(type.kind);
-    ZL_ERR_IF_EQ(
-            unitBytes,
-            0,
+    size_t unitBytes;
+    ZL_ERR_IF_NE(
+            SDDL2_kind_size(type.kind, &unitBytes),
+            SDDL2_OK,
             GENERIC,
             "Failed to derive a split unit size for SDDL2 segment chunking");
     return ZL_returnValue(unitBytes);

--- a/src/openzl/compress/graphs/sddl2/sddl2_vm.c
+++ b/src/openzl/compress/graphs/sddl2/sddl2_vm.c
@@ -93,13 +93,15 @@ void sddl2_fallback_free(void* ptr)
  * Handles both primitive types and complex structures.
  * ========================================================================= */
 
-size_t SDDL2_kind_size(SDDL2_Type_kind kind)
+SDDL2_Error SDDL2_kind_size(SDDL2_Type_kind kind, size_t* out_size)
 {
+    *out_size = (size_t)-1; // Initialize to invalid value
     switch (kind) {
         case SDDL2_TYPE_U8:
         case SDDL2_TYPE_I8:
         case SDDL2_TYPE_F8:
-            return 1;
+            *out_size = 1;
+            return SDDL2_OK;
         case SDDL2_TYPE_U16LE:
         case SDDL2_TYPE_U16BE:
         case SDDL2_TYPE_I16LE:
@@ -108,51 +110,48 @@ size_t SDDL2_kind_size(SDDL2_Type_kind kind)
         case SDDL2_TYPE_F16BE:
         case SDDL2_TYPE_BF16LE:
         case SDDL2_TYPE_BF16BE:
-            return 2;
+            *out_size = 2;
+            return SDDL2_OK;
         case SDDL2_TYPE_U32LE:
         case SDDL2_TYPE_U32BE:
         case SDDL2_TYPE_I32LE:
         case SDDL2_TYPE_I32BE:
         case SDDL2_TYPE_F32LE:
         case SDDL2_TYPE_F32BE:
-            return 4;
+            *out_size = 4;
+            return SDDL2_OK;
         case SDDL2_TYPE_U64LE:
         case SDDL2_TYPE_U64BE:
         case SDDL2_TYPE_I64LE:
         case SDDL2_TYPE_I64BE:
         case SDDL2_TYPE_F64LE:
         case SDDL2_TYPE_F64BE:
-            return 8;
+            *out_size = 8;
+            return SDDL2_OK;
         case SDDL2_TYPE_BYTES:
-            return 1; // Raw bytes, unit size is 1 byte
+            *out_size = 1;
+            return SDDL2_OK;
         case SDDL2_TYPE_STRUCTURE:
-            return 0; // Structures don't have a fixed kind size (use
-                      // struct_data)
+            return SDDL2_TYPE_MISMATCH;
         default:
-            return 0; // Unknown type
+            return SDDL2_TYPE_MISMATCH;
     }
 }
 
-size_t SDDL2_Type_size(SDDL2_Type type)
+SDDL2_Error SDDL2_Type_size(SDDL2_Type type, size_t* out_size)
 {
-    // Handle structures specially
     if (type.kind == SDDL2_TYPE_STRUCTURE) {
-        assert(type.struct_data != NULL);
         if (type.struct_data == NULL) {
-            // Should not happen
-            return 0;
+            return SDDL2_TYPE_MISMATCH;
         }
-        return type.struct_data->total_size_bytes * type.width;
+        *out_size = type.struct_data->total_size_bytes * type.width;
+        return SDDL2_OK;
     }
 
-    // For primitives, use kind size
-    size_t kind_size = SDDL2_kind_size(type.kind);
-    assert(kind_size > 0);
-    if (kind_size == 0) {
-        // Unknown type kind: should not happen
-        return 0;
-    }
-    return kind_size * type.width;
+    size_t ks;
+    SDDL2_TRY(SDDL2_kind_size(type.kind, &ks));
+    *out_size = ks * type.width;
+    return SDDL2_OK;
 }
 
 /* ============================================================================
@@ -391,7 +390,12 @@ SDDL2_Error SDDL2_op_type_structure(
 
     // Compute total size by summing all member sizes
     for (size_t i = 0; i < member_count; i++) {
-        size_t member_size = SDDL2_Type_size(struct_data->members[i]);
+        size_t member_size;
+        if (SDDL2_Type_size(struct_data->members[i], &member_size)
+            != SDDL2_OK) {
+            sddl2_free(struct_data, alloc_fn);
+            return SDDL2_TYPE_MISMATCH;
+        }
 
         // Check for size overflow when adding member_size
         if (ZL_overflowAddST(
@@ -419,10 +423,8 @@ SDDL2_Error SDDL2_op_type_sizeof(SDDL2_Stack* stack)
     SDDL2_Type type;
     SDDL2_TRY(pop_type(stack, &type));
 
-    // Get the size of the type
-    size_t size = SDDL2_Type_size(type);
-
-    // Push the size as I64
+    size_t size;
+    SDDL2_TRY(SDDL2_Type_size(type, &size));
     return push_i64(stack, (int64_t)size);
 }
 
@@ -1322,10 +1324,8 @@ static SDDL2_Error segment_create_internal(
     // Calculate actual size in bytes
     // total_type_size = size of one instance of the type (including width)
     // segment_size = element_count × total_type_size
-    size_t total_type_size = SDDL2_Type_size(type);
-    if (total_type_size == 0) {
-        return SDDL2_TYPE_MISMATCH; // Unknown or invalid type
-    }
+    size_t total_type_size;
+    SDDL2_TRY(SDDL2_Type_size(type, &total_type_size));
 
     // Check for overflow in element_count * total_type_size multiplication
     size_t size_bytes;

--- a/src/openzl/compress/graphs/sddl2/sddl2_vm.h
+++ b/src/openzl/compress/graphs/sddl2/sddl2_vm.h
@@ -481,16 +481,16 @@ SDDL2_Value SDDL2_Value_type(SDDL2_Type type);
 /**
  * Get the size in bytes of a single element of the given type kind (primitive
  * size). Returns 1 for BYTES (raw bytes with no known interpretation).
- * Returns 0 for unknown/invalid types.
+ * Returns SDDL2_TYPE_MISMATCH for unknown/invalid type kinds and for STRUCTURE.
  */
-size_t SDDL2_kind_size(SDDL2_Type_kind kind);
+SDDL2_Error SDDL2_kind_size(SDDL2_Type_kind kind, size_t* out_size);
 
 /**
  * Get the total size in bytes of a type (including width).
- * Calculates: SDDL2_kind_size(type.kind) × type.width
- * Returns 0 if error, like type.kind is unknown.
+ * Calculates: element_size × type.width
+ * Returns SDDL2_TYPE_MISMATCH for invalid types.
  */
-size_t SDDL2_Type_size(SDDL2_Type type);
+SDDL2_Error SDDL2_Type_size(SDDL2_Type type, size_t* out_size);
 
 /* ============================================================================
  * Type Operations

--- a/tests/compress/graphs/sddl2/test_sddl2_assembly_execution.cpp
+++ b/tests/compress/graphs/sddl2/test_sddl2_assembly_execution.cpp
@@ -1351,6 +1351,85 @@ TEST_F(SDDL2AssemblyExecutionTest, JumpIfLargerThanInstructions)
             SDDL2_INVALID_BYTECODE);
 }
 
+// ============================================================================
+// Zero-Size Tagged Segment Tests
+// ============================================================================
+
+TEST_F(SDDL2AssemblyExecutionTest, ZeroElementTaggedSegment)
+{
+    const std::string input = "Test";
+    ASSERT_EQ(
+            run(R"(
+                push.tag 100
+                push.type.u16le
+                push.i64 0
+                segment.create_tagged
+                halt
+            )",
+                input),
+            SDDL2_OK);
+    EXPECT_EQ(segments_.count, 1u);
+    EXPECT_EQ(segments_.items[0].tag, 100u);
+    EXPECT_EQ(segments_.items[0].start_pos, 0u);
+    EXPECT_EQ(segments_.items[0].size_bytes, 0u);
+    EXPECT_EQ(segments_.items[0].type.kind, SDDL2_TYPE_U16LE);
+    EXPECT_EQ(segments_.items[0].type.width, 1u);
+}
+
+TEST_F(SDDL2AssemblyExecutionTest, ZeroElementTaggedSegmentDoesNotAdvanceCursor)
+{
+    const std::string input({ 0x01, 0x00, 0x02, 0x00 });
+    ASSERT_EQ(
+            run(R"(
+                push.tag 100
+                push.type.u16le
+                push.i64 0
+                segment.create_tagged
+                push.tag 200
+                push.type.u16le
+                push.i64 2
+                segment.create_tagged
+                halt
+            )",
+                input),
+            SDDL2_OK);
+    EXPECT_EQ(segments_.count, 2u);
+    EXPECT_EQ(segments_.items[0].tag, 100u);
+    EXPECT_EQ(segments_.items[0].size_bytes, 0u);
+    EXPECT_EQ(segments_.items[0].start_pos, 0u);
+    EXPECT_EQ(segments_.items[1].tag, 200u);
+    EXPECT_EQ(segments_.items[1].size_bytes, 4u);
+    EXPECT_EQ(segments_.items[1].start_pos, 0u);
+}
+
+TEST_F(SDDL2AssemblyExecutionTest, ZeroWidthTypeInStructure)
+{
+    const std::string input({ 0x01, 0x00, 0x00, 0x00, 0x02, 0x00, 0x00, 0x00 });
+    ASSERT_EQ(
+            run(R"(
+                push.tag 100
+                push.type.i32le
+                push.type.u16le
+                push.i64 0
+                type.fixed_array
+                push.type.i32le
+                push.i64 3
+                type.structure
+                push.i64 1
+                segment.create_tagged
+                halt
+            )",
+                input),
+            SDDL2_OK);
+    EXPECT_EQ(segments_.count, 1u);
+    EXPECT_EQ(segments_.items[0].tag, 100u);
+    EXPECT_EQ(segments_.items[0].size_bytes, 8u);
+    EXPECT_EQ(segments_.items[0].type.kind, SDDL2_TYPE_STRUCTURE);
+    ASSERT_NE(segments_.items[0].type.struct_data, nullptr);
+    EXPECT_EQ(segments_.items[0].type.struct_data->member_count, 3u);
+    EXPECT_EQ(segments_.items[0].type.struct_data->total_size_bytes, 8u);
+}
+
 } // namespace testing
 } // namespace sddl2
 } // namespace openzl

--- a/tests/compress/graphs/sddl2/test_sddl2_code_execution.cpp
+++ b/tests/compress/graphs/sddl2/test_sddl2_code_execution.cpp
@@ -513,7 +513,7 @@ TEST_F(SDDL2CodeExecutionTest, WhenBlockTrueCondition)
 
 TEST_F(SDDL2CodeExecutionTest, WhenBlockFalseCondition)
 {
-    const std::vector<size_t> expected_sizes = { 1 };
+    const std::vector<size_t> expected_sizes = { 1, 0 };
     std::vector<uint8_t> input               = {
         0x00, // flag = 0 (false)
     };
@@ -555,7 +555,7 @@ TEST_F(SDDL2CodeExecutionTest, NestedWhenBlocks)
 
 TEST_F(SDDL2CodeExecutionTest, NestedWhenBlocksOuterFalse)
 {
-    const std::vector<size_t> expected_sizes = { 1, 1 };
+    const std::vector<size_t> expected_sizes = { 1, 1, 0 };
     std::vector<uint8_t> input               = {
         0x00, // a = 0 (outer false)
         0x02, // b = 2
@@ -578,7 +578,7 @@ TEST_F(SDDL2CodeExecutionTest, NestedWhenBlocksOuterFalse)
 
 TEST_F(SDDL2CodeExecutionTest, NestedWhenBlocksInnerFalse)
 {
-    const std::vector<size_t> expected_sizes = { 1, 1 };
+    const std::vector<size_t> expected_sizes = { 1, 1, 0 };
     std::vector<uint8_t> input               = {
         0x01, // a = 1 (outer true)
         0x05, // b = 5 (inner false, not 2)

--- a/tests/compress/graphs/sddl2/test_sddl2_field_extraction.cpp
+++ b/tests/compress/graphs/sddl2/test_sddl2_field_extraction.cpp
@@ -25,7 +25,7 @@ SDDL2_Type createStructureType(SDDL2_Type* members, size_t member_count)
 {
     size_t total_size = 0;
     for (size_t i = 0; i < member_count; i++) {
-        total_size += SDDL2_Type_size(members[i]);
+        total_size += getTypeSize(members[i]);
     }
 
     size_t alloc_size =
@@ -78,9 +78,9 @@ TEST_F(SDDL2FieldExtractionTest, SimpleFlatStructure)
     EXPECT_EQ(data->member_count, 3u);
     EXPECT_EQ(data->total_size_bytes, 7u);
 
-    EXPECT_EQ(SDDL2_Type_size(data->members[0]), 1u);
-    EXPECT_EQ(SDDL2_Type_size(data->members[1]), 2u);
-    EXPECT_EQ(SDDL2_Type_size(data->members[2]), 4u);
+    EXPECT_EQ(getTypeSize(data->members[0]), 1u);
+    EXPECT_EQ(getTypeSize(data->members[1]), 2u);
+    EXPECT_EQ(getTypeSize(data->members[2]), 4u);
 
     free(data);
 }
@@ -101,9 +101,9 @@ TEST_F(SDDL2FieldExtractionTest, StructureWithArrayField)
     EXPECT_EQ(data->member_count, 3u);
     EXPECT_EQ(data->total_size_bytes, 43u);
 
-    EXPECT_EQ(SDDL2_Type_size(data->members[0]), 1u);
-    EXPECT_EQ(SDDL2_Type_size(data->members[1]), 40u);
-    EXPECT_EQ(SDDL2_Type_size(data->members[2]), 2u);
+    EXPECT_EQ(getTypeSize(data->members[0]), 1u);
+    EXPECT_EQ(getTypeSize(data->members[1]), 40u);
+    EXPECT_EQ(getTypeSize(data->members[2]), 2u);
 
     free(data);
 }
@@ -125,7 +125,7 @@ TEST_F(SDDL2FieldExtractionTest, AllPrimitiveTypes)
 
     size_t expected_sizes[] = { 1, 2, 4, 8 };
     for (size_t i = 0; i < 4; i++) {
-        EXPECT_EQ(SDDL2_Type_size(data->members[i]), expected_sizes[i]);
+        EXPECT_EQ(getTypeSize(data->members[i]), expected_sizes[i]);
     }
 
     free(data);
@@ -177,10 +177,10 @@ TEST_F(SDDL2FieldExtractionTest, TypeSizeFunction)
     };
 
     SDDL2_Type struct_type = createStructureType(members, 2);
-    EXPECT_EQ(SDDL2_Type_size(struct_type), 5u); // 1 + 4
+    EXPECT_EQ(getTypeSize(struct_type), 5u); // 1 + 4
 
     struct_type.width = 10;
-    EXPECT_EQ(SDDL2_Type_size(struct_type), 50u); // 5 × 10
+    EXPECT_EQ(getTypeSize(struct_type), 50u); // 5 × 10
 
     free(struct_type.struct_data);
 }
@@ -237,7 +237,7 @@ TEST_F(SDDL2FieldExtractionTest, NestedStructure3Levels)
     };
     SDDL2_Type level3 = createStructureType(level3_members, 2);
 
-    EXPECT_EQ(SDDL2_Type_size(level3), 15u);
+    EXPECT_EQ(getTypeSize(level3), 15u);
 
     free(level1.struct_data);
     free(level2.struct_data);
@@ -261,7 +261,7 @@ TEST_F(SDDL2FieldExtractionTest, NestedStructureWithArrays)
     };
     SDDL2_Type outer = createStructureType(outer_members, 3);
 
-    EXPECT_EQ(SDDL2_Type_size(outer), 31u);
+    EXPECT_EQ(getTypeSize(outer), 31u);
 
     free(inner.struct_data);
     free(outer.struct_data);
@@ -291,7 +291,7 @@ TEST_F(SDDL2FieldExtractionTest, MultipleNestedStructures)
     };
     SDDL2_Type outer = createStructureType(outer_members, 3);
 
-    EXPECT_EQ(SDDL2_Type_size(outer), 19u);
+    EXPECT_EQ(getTypeSize(outer), 19u);
 
     free(structA.struct_data);
     free(structB.struct_data);
@@ -405,7 +405,7 @@ TEST_F(SDDL2FieldExtractionTest, FieldTypesSizesAlignment)
     ASSERT_EQ(type_index, 4u);
     for (size_t i = 0; i < 4; i++) {
         EXPECT_EQ(field_types[i], expected_types[i]);
-        EXPECT_EQ(SDDL2_kind_size(field_types[i]), expected_sizes[i]);
+        EXPECT_EQ(getKindSize(field_types[i]), expected_sizes[i]);
     }
 
     free(inner.struct_data);

--- a/tests/compress/graphs/sddl2/test_sddl2_graph.cpp
+++ b/tests/compress/graphs/sddl2/test_sddl2_graph.cpp
@@ -10,6 +10,7 @@
 #include "tools/sddl2/assembler/Assembler.h"
 #include "tools/sddl2/compiler/Compiler.h"
 
+#include "openzl/codecs/zl_generic.h"
 #include "openzl/compress/graphs/sddl2/sddl2.h"
 #include "openzl/cpp/CCtx.hpp"
 #include "openzl/cpp/CompressIntrospectionHooks.hpp"
@@ -162,6 +163,27 @@ class SDDL2GraphTest : public SDDL2TestBase {
         auto decompressed = decompress(compressed, &decompress_hook);
         EXPECT_EQ(decompress_hook.chunkCount, expected_chunks);
         EXPECT_EQ(input_view, decompressed);
+    }
+
+    template <typename T>
+    void expect_clustering_tags(
+            const std::string& code,
+            const std::vector<T>& input,
+            const std::set<int>& expected_tags)
+    {
+        poly::string_view input_view(
+                (const char*)input.data(), input.size() * sizeof(T));
+        auto bytecode = assemble_bytecode(code);
+        const poly::string_view bytecode_view(
+                (const char*)bytecode.data(), bytecode.size());
+        auto graphID = graphs::SDDL2(bytecode_view, ZL_GRAPH_COMPRESS_GENERIC)
+                               .parameterize(compressor_);
+        ClusteringTagCaptureHook hook;
+        auto compressed = compress_with_graph(
+                graphID, input_view, ZL_MAX_FORMAT_VERSION, &hook);
+        auto decompressed = decompress(compressed);
+        EXPECT_EQ(input_view, decompressed);
+        EXPECT_EQ(hook.tags, expected_tags);
     }
 #endif
 
@@ -665,6 +687,259 @@ TEST_F(SDDL2GraphTest, ExpectFail)
             input,
             "expect_true condition not met");
 }
+
+// ============================================================================
+// Stable Clustering Tags for Optional Fields
+// ============================================================================
+
+#if ZL_ALLOW_INTROSPECTION
+
+namespace {
+
+void append_u8(std::vector<uint8_t>& input, uint8_t v)
+{
+    input.push_back(v);
+}
+
+template <typename T>
+void append(std::vector<uint8_t>& input, std::mt19937& rng)
+{
+    std::uniform_int_distribution<T> dist;
+    T v = dist(rng);
+    for (size_t j = 0; j < sizeof(T); ++j) {
+        input.push_back(static_cast<uint8_t>(v >> (8 * j)));
+    }
+}
+
+template <typename T>
+void append_n(std::vector<uint8_t>& input, size_t n, std::mt19937& rng)
+{
+    for (size_t i = 0; i < n; ++i) {
+        append<T>(input, rng);
+    }
+}
+
+constexpr uint8_t TRUE = 3;
+
+} // namespace
+
+TEST_F(SDDL2GraphTest, TopLevelConditionalClusteringTagsStable)
+{
+    constexpr size_t kN = 10;
+    std::mt19937 rng(42);
+
+    auto make_input = [&](bool present) {
+        std::vector<uint8_t> input;
+        append_u8(input, present ? TRUE : 0);
+        if (present) {
+            append_n<uint32_t>(input, kN, rng);
+        }
+        append_n<uint16_t>(input, kN, rng);
+        return input;
+    };
+
+    std::string code = R"(
+        flag: UInt8
+        when flag {
+            optional: UInt32LE[)"
+            + std::to_string(kN) + R"(]
+        }
+        tail: UInt16LE[)"
+            + std::to_string(kN) + R"(]
+    )";
+
+    // flag=1: tags {0, 1, 2}
+    {
+        auto input = make_input(true);
+        expect_clustering_tags(code, input, { 0, 1, 2 });
+    }
+
+    // flag=0: tags {0, 2} — tag 1 reserved but not emitted
+    {
+        auto input = make_input(false);
+        expect_clustering_tags(code, input, { 0, 2 });
+    }
+}
+
+TEST_F(SDDL2GraphTest, RecordWithConditionalFieldsClusteringTagsStable)
+{
+    constexpr size_t kN = 10;
+    std::mt19937 rng(42);
+
+    auto make_input = [&](bool present) {
+        std::vector<uint8_t> input;
+        append_u8(input, present ? TRUE : 0);
+        for (size_t i = 0; i < kN; ++i) {
+            append<uint32_t>(input, rng);
+            if (present) {
+                append<uint16_t>(input, rng);
+            }
+            append<uint32_t>(input, rng);
+        }
+        return input;
+    };
+
+    std::string prog = R"(
+        Record Data(COND) = {
+            a: Int32LE,
+            when COND {
+                optional: Int16LE
+            },
+            b: Int32LE
+        }
+        flag: UInt8
+        : Data(flag)[)"
+            + std::to_string(kN) + R"(]
+    )";
+    // flag=1:
+    {
+        auto input = make_input(true);
+        expect_clustering_tags(prog, input, { 0, 1, 2, 3 });
+    }
+
+    // flag=0: tag 2 reserved but not emitted
+    {
+        auto input = make_input(false);
+        expect_clustering_tags(prog, input, { 0, 1, 3 });
+    }
+}
+
+TEST_F(SDDL2GraphTest, MultipleOptionalFieldsClusteringTagsStable)
+{
+    constexpr size_t kN = 10;
+    std::mt19937 rng(42);
+
+    auto make_input = [&](bool opt1_present, bool opt2_present) {
+        std::vector<uint8_t> input;
+        for (size_t i = 0; i < kN; ++i) {
+            append<uint32_t>(input, rng);
+            if (opt1_present) {
+                append<uint16_t>(input, rng);
+            }
+            if (opt2_present) {
+                append<uint32_t>(input, rng);
+            }
+            append<uint32_t>(input, rng);
+        }
+        return input;
+    };
+
+    auto make_code = [&](int f1, int f2) {
+        return std::string(R"(
+        Record Data(f1, f2) = {
+            a: Int32LE,
+            when f1 {
+                opt1: Int16LE
+            },
+            when f2 {
+                opt2: Int32LE
+            },
+            b: Int32LE
+        }
+        : Data()")
+                + std::to_string(f1) + ", " + std::to_string(f2) + ")["
+                + std::to_string(kN) + R"(]
+    )";
+    };
+
+    // Both present: tags {0, 1, 2, 3}
+    {
+        auto input = make_input(true, true);
+        expect_clustering_tags(make_code(1, 1), input, { 0, 1, 2, 3 });
+    }
+
+    // Only opt1 present: tags {0, 1, 3} — tag 2 reserved
+    {
+        auto input = make_input(true, false);
+        expect_clustering_tags(make_code(1, 0), input, { 0, 1, 3 });
+    }
+
+    // Only opt2 present: tags {0, 2, 3} — tag 1 reserved
+    {
+        auto input = make_input(false, true);
+        expect_clustering_tags(make_code(0, 1), input, { 0, 2, 3 });
+    }
+
+    // Neither present: tags {0, 3} — tags 1 and 2 reserved
+    {
+        auto input = make_input(false, false);
+        expect_clustering_tags(make_code(0, 0), input, { 0, 3 });
+    }
+}
+
+TEST_F(SDDL2GraphTest, RecordWithNestedConditionalFieldsClusteringTagsStable)
+{
+    constexpr size_t kN = 10;
+    std::mt19937 rng(42);
+
+    auto make_input =
+            [&](bool top_level_cond, bool outer_cond, bool inner_cond) {
+                std::vector<uint8_t> input;
+                append_u8(input, top_level_cond ? TRUE : 0);
+                append_u8(input, outer_cond ? TRUE : 0);
+                append_u8(input, inner_cond ? TRUE : 0);
+                if (top_level_cond) {
+                    for (size_t i = 0; i < kN; ++i) {
+                        append<uint32_t>(input, rng);
+                        if (outer_cond) {
+                            append<uint16_t>(input, rng);
+                            if (inner_cond) {
+                                append<uint32_t>(input, rng);
+                            }
+                            append<uint16_t>(input, rng);
+                        }
+                        append<uint32_t>(input, rng);
+                    }
+                }
+                append_n<uint32_t>(input, kN, rng);
+                return input;
+            };
+
+    std::string code = R"(
+        Record Inner(COND) = {
+            a: Int16LE, # 4
+            when COND {
+                opt: Int32LE # 5
+            },
+            b: Int16LE # 6
+        }
+        Record Outer(OUTER_COND, INNER_COND) = {
+            header: Int32LE, # 3
+            when OUTER_COND {
+                inner: Inner(INNER_COND)
+            },
+            footer: Int32LE # 7
+        }
+        top_level_flag: UInt8 # 0
+        outer_flag: UInt8 # 1
+        inner_flag: UInt8 # 2
+        when top_level_flag {
+            : Outer(outer_flag, inner_flag)[)"
+            + std::to_string(kN) + R"(]
+        }
+        tail: UInt32LE[] # 8
+    )";
+
+    // All conditions true
+    {
+        auto input = make_input(true, true, true);
+        expect_clustering_tags(code, input, { 0, 1, 2, 3, 4, 5, 6, 7, 8 });
+    }
+
+    // Inner condition false: tag 5 reserved
+    {
+        auto input = make_input(true, true, false);
+        expect_clustering_tags(code, input, { 0, 1, 2, 3, 4, 6, 7, 8 });
+    }
+
+    // Top-level condition false: tags 3, 4, 5, 6, 7 reserved
+    {
+        auto input = make_input(false, false, false);
+        expect_clustering_tags(code, input, { 0, 1, 2, 8 });
+    }
+}
+
+#endif
 
 } // namespace testing
 } // namespace sddl2

--- a/tests/compress/graphs/sddl2/test_sddl2_structure_split_integration.cpp
+++ b/tests/compress/graphs/sddl2/test_sddl2_structure_split_integration.cpp
@@ -60,9 +60,9 @@ TEST_F(SDDL2StructureSplitIntegrationTest, FlatStructureSplit)
     EXPECT_EQ(struct_data->member_count, 3u);
     EXPECT_EQ(struct_data->total_size_bytes, 7u);
 
-    EXPECT_EQ(SDDL2_Type_size(struct_data->members[0]), 1u); // U8
-    EXPECT_EQ(SDDL2_Type_size(struct_data->members[1]), 2u); // I16LE
-    EXPECT_EQ(SDDL2_Type_size(struct_data->members[2]), 4u); // I32LE
+    EXPECT_EQ(getTypeSize(struct_data->members[0]), 1u); // U8
+    EXPECT_EQ(getTypeSize(struct_data->members[1]), 2u); // I16LE
+    EXPECT_EQ(getTypeSize(struct_data->members[2]), 4u); // I32LE
 
     free(struct_data);
 }
@@ -161,9 +161,9 @@ TEST_F(SDDL2StructureSplitIntegrationTest, StructureWithArrayField)
     EXPECT_EQ(struct_data->member_count, 3u);
     EXPECT_EQ(struct_data->total_size_bytes, 23u);
 
-    EXPECT_EQ(SDDL2_Type_size(struct_data->members[0]), 1u);  // U8
-    EXPECT_EQ(SDDL2_Type_size(struct_data->members[1]), 20u); // I32LE × 5
-    EXPECT_EQ(SDDL2_Type_size(struct_data->members[2]), 2u);  // I16LE
+    EXPECT_EQ(getTypeSize(struct_data->members[0]), 1u);  // U8
+    EXPECT_EQ(getTypeSize(struct_data->members[1]), 20u); // I32LE × 5
+    EXPECT_EQ(getTypeSize(struct_data->members[2]), 2u);  // I16LE
 
     free(struct_data);
 }
@@ -231,9 +231,9 @@ TEST_F(SDDL2StructureSplitIntegrationTest, FieldSizeExtraction)
                                       .width       = 1,
                                       .struct_data = nullptr };
 
-    EXPECT_EQ(SDDL2_Type_size(struct_data->members[0]), 1u);
-    EXPECT_EQ(SDDL2_Type_size(struct_data->members[1]), 4u);
-    EXPECT_EQ(SDDL2_Type_size(struct_data->members[2]), 8u);
+    EXPECT_EQ(getTypeSize(struct_data->members[0]), 1u);
+    EXPECT_EQ(getTypeSize(struct_data->members[1]), 4u);
+    EXPECT_EQ(getTypeSize(struct_data->members[2]), 8u);
 
     free(struct_data);
 }

--- a/tests/compress/graphs/sddl2/test_sddl2_tagged_segments.cpp
+++ b/tests/compress/graphs/sddl2/test_sddl2_tagged_segments.cpp
@@ -999,7 +999,7 @@ TEST_F(SDDL2TaggedSegmentsLargeTest, SegmentListGrowthDifferentTypes)
     for (int i = 0; i < NUM_SEGMENTS; i++) {
         int type_idx = i % 4;
         size_t expected_bytes =
-                element_counts[type_idx] * SDDL2_kind_size(types[type_idx]);
+                element_counts[type_idx] * getKindSize(types[type_idx]);
 
         EXPECT_EQ(segments.items[i].tag, (uint32_t)(100 + i));
         EXPECT_EQ(segments.items[i].type.kind, types[type_idx]);

--- a/tests/compress/graphs/sddl2/test_sddl2_type_structure.cpp
+++ b/tests/compress/graphs/sddl2/test_sddl2_type_structure.cpp
@@ -44,9 +44,9 @@ TEST_F(SDDL2TypeStructureTest, SimpleStructureCreation)
                                           .width       = 1,
                                           .struct_data = nullptr };
 
-    struct_data->total_size_bytes = SDDL2_Type_size(struct_data->members[0])
-            + SDDL2_Type_size(struct_data->members[1])
-            + SDDL2_Type_size(struct_data->members[2]);
+    struct_data->total_size_bytes = getTypeSize(struct_data->members[0])
+            + getTypeSize(struct_data->members[1])
+            + getTypeSize(struct_data->members[2]);
 
     EXPECT_EQ(struct_data->total_size_bytes, 7);
 
@@ -110,9 +110,9 @@ TEST_F(SDDL2TypeStructureTest, StructureWithArrayMembers)
                                             .width       = 1,
                                             .struct_data = nullptr };
 
-    struct_data->total_size_bytes = SDDL2_Type_size(struct_data->members[0])
-            + SDDL2_Type_size(struct_data->members[1])
-            + SDDL2_Type_size(struct_data->members[2]);
+    struct_data->total_size_bytes = getTypeSize(struct_data->members[0])
+            + getTypeSize(struct_data->members[1])
+            + getTypeSize(struct_data->members[2]);
 
     EXPECT_EQ(struct_data->total_size_bytes, 43);
 

--- a/tests/compress/graphs/sddl2/test_sddl2_vm.cpp
+++ b/tests/compress/graphs/sddl2/test_sddl2_vm.cpp
@@ -118,13 +118,13 @@ TEST_F(SDDL2VmTest, ValueKinds)
 
 TEST_F(SDDL2VmTest, TypeSizes)
 {
-    EXPECT_EQ(SDDL2_kind_size(SDDL2_TYPE_U8), 1u);
-    EXPECT_EQ(SDDL2_kind_size(SDDL2_TYPE_I8), 1u);
-    EXPECT_EQ(SDDL2_kind_size(SDDL2_TYPE_U16LE), 2u);
-    EXPECT_EQ(SDDL2_kind_size(SDDL2_TYPE_I16BE), 2u);
-    EXPECT_EQ(SDDL2_kind_size(SDDL2_TYPE_U32LE), 4u);
-    EXPECT_EQ(SDDL2_kind_size(SDDL2_TYPE_F32BE), 4u);
-    EXPECT_EQ(SDDL2_kind_size(SDDL2_TYPE_I64LE), 8u);
-    EXPECT_EQ(SDDL2_kind_size(SDDL2_TYPE_F64BE), 8u);
-    EXPECT_EQ(SDDL2_kind_size(SDDL2_TYPE_BYTES), 1u);
+    EXPECT_EQ(getKindSize(SDDL2_TYPE_U8), 1u);
+    EXPECT_EQ(getKindSize(SDDL2_TYPE_I8), 1u);
+    EXPECT_EQ(getKindSize(SDDL2_TYPE_U16LE), 2u);
+    EXPECT_EQ(getKindSize(SDDL2_TYPE_I16BE), 2u);
+    EXPECT_EQ(getKindSize(SDDL2_TYPE_U32LE), 4u);
+    EXPECT_EQ(getKindSize(SDDL2_TYPE_F32BE), 4u);
+    EXPECT_EQ(getKindSize(SDDL2_TYPE_I64LE), 8u);
+    EXPECT_EQ(getKindSize(SDDL2_TYPE_F64BE), 8u);
+    EXPECT_EQ(getKindSize(SDDL2_TYPE_BYTES), 1u);
 }

--- a/tests/compress/graphs/sddl2/test_sddl2_vm_kind_size.cpp
+++ b/tests/compress/graphs/sddl2/test_sddl2_vm_kind_size.cpp
@@ -5,9 +5,9 @@
  * Verifies that all 24 type kinds return the correct size in bytes.
  */
 
-#include <gtest/gtest.h>
+#include "tests/compress/graphs/sddl2/utils.h"
 
-#include "openzl/compress/graphs/sddl2/sddl2_vm.h"
+using namespace openzl::sddl2::testing;
 
 // ============================================================================
 // 1-byte types
@@ -15,10 +15,10 @@
 
 TEST(SDDL2KindSizeTest, OneByteTypes)
 {
-    EXPECT_EQ(SDDL2_kind_size(SDDL2_TYPE_BYTES), 1);
-    EXPECT_EQ(SDDL2_kind_size(SDDL2_TYPE_U8), 1);
-    EXPECT_EQ(SDDL2_kind_size(SDDL2_TYPE_I8), 1);
-    EXPECT_EQ(SDDL2_kind_size(SDDL2_TYPE_F8), 1);
+    EXPECT_EQ(getKindSize(SDDL2_TYPE_BYTES), 1);
+    EXPECT_EQ(getKindSize(SDDL2_TYPE_U8), 1);
+    EXPECT_EQ(getKindSize(SDDL2_TYPE_I8), 1);
+    EXPECT_EQ(getKindSize(SDDL2_TYPE_F8), 1);
 }
 
 // ============================================================================
@@ -28,16 +28,16 @@ TEST(SDDL2KindSizeTest, OneByteTypes)
 TEST(SDDL2KindSizeTest, TwoByteTypes)
 {
     // Integers
-    EXPECT_EQ(SDDL2_kind_size(SDDL2_TYPE_U16LE), 2);
-    EXPECT_EQ(SDDL2_kind_size(SDDL2_TYPE_U16BE), 2);
-    EXPECT_EQ(SDDL2_kind_size(SDDL2_TYPE_I16LE), 2);
-    EXPECT_EQ(SDDL2_kind_size(SDDL2_TYPE_I16BE), 2);
+    EXPECT_EQ(getKindSize(SDDL2_TYPE_U16LE), 2);
+    EXPECT_EQ(getKindSize(SDDL2_TYPE_U16BE), 2);
+    EXPECT_EQ(getKindSize(SDDL2_TYPE_I16LE), 2);
+    EXPECT_EQ(getKindSize(SDDL2_TYPE_I16BE), 2);
 
     // Floats
-    EXPECT_EQ(SDDL2_kind_size(SDDL2_TYPE_F16LE), 2);
-    EXPECT_EQ(SDDL2_kind_size(SDDL2_TYPE_F16BE), 2);
-    EXPECT_EQ(SDDL2_kind_size(SDDL2_TYPE_BF16LE), 2);
-    EXPECT_EQ(SDDL2_kind_size(SDDL2_TYPE_BF16BE), 2);
+    EXPECT_EQ(getKindSize(SDDL2_TYPE_F16LE), 2);
+    EXPECT_EQ(getKindSize(SDDL2_TYPE_F16BE), 2);
+    EXPECT_EQ(getKindSize(SDDL2_TYPE_BF16LE), 2);
+    EXPECT_EQ(getKindSize(SDDL2_TYPE_BF16BE), 2);
 }
 
 // ============================================================================
@@ -47,14 +47,14 @@ TEST(SDDL2KindSizeTest, TwoByteTypes)
 TEST(SDDL2KindSizeTest, FourByteTypes)
 {
     // Integers
-    EXPECT_EQ(SDDL2_kind_size(SDDL2_TYPE_U32LE), 4);
-    EXPECT_EQ(SDDL2_kind_size(SDDL2_TYPE_U32BE), 4);
-    EXPECT_EQ(SDDL2_kind_size(SDDL2_TYPE_I32LE), 4);
-    EXPECT_EQ(SDDL2_kind_size(SDDL2_TYPE_I32BE), 4);
+    EXPECT_EQ(getKindSize(SDDL2_TYPE_U32LE), 4);
+    EXPECT_EQ(getKindSize(SDDL2_TYPE_U32BE), 4);
+    EXPECT_EQ(getKindSize(SDDL2_TYPE_I32LE), 4);
+    EXPECT_EQ(getKindSize(SDDL2_TYPE_I32BE), 4);
 
     // Floats
-    EXPECT_EQ(SDDL2_kind_size(SDDL2_TYPE_F32LE), 4);
-    EXPECT_EQ(SDDL2_kind_size(SDDL2_TYPE_F32BE), 4);
+    EXPECT_EQ(getKindSize(SDDL2_TYPE_F32LE), 4);
+    EXPECT_EQ(getKindSize(SDDL2_TYPE_F32BE), 4);
 }
 
 // ============================================================================
@@ -64,21 +64,28 @@ TEST(SDDL2KindSizeTest, FourByteTypes)
 TEST(SDDL2KindSizeTest, EightByteTypes)
 {
     // Integers
-    EXPECT_EQ(SDDL2_kind_size(SDDL2_TYPE_U64LE), 8);
-    EXPECT_EQ(SDDL2_kind_size(SDDL2_TYPE_U64BE), 8);
-    EXPECT_EQ(SDDL2_kind_size(SDDL2_TYPE_I64LE), 8);
-    EXPECT_EQ(SDDL2_kind_size(SDDL2_TYPE_I64BE), 8);
+    EXPECT_EQ(getKindSize(SDDL2_TYPE_U64LE), 8);
+    EXPECT_EQ(getKindSize(SDDL2_TYPE_U64BE), 8);
+    EXPECT_EQ(getKindSize(SDDL2_TYPE_I64LE), 8);
+    EXPECT_EQ(getKindSize(SDDL2_TYPE_I64BE), 8);
 
     // Floats
-    EXPECT_EQ(SDDL2_kind_size(SDDL2_TYPE_F64LE), 8);
-    EXPECT_EQ(SDDL2_kind_size(SDDL2_TYPE_F64BE), 8);
+    EXPECT_EQ(getKindSize(SDDL2_TYPE_F64LE), 8);
+    EXPECT_EQ(getKindSize(SDDL2_TYPE_F64BE), 8);
 }
 
 // ============================================================================
 // Invalid type
 // ============================================================================
 
-TEST(SDDL2KindSizeTest, InvalidTypeReturnsZero)
+TEST(SDDL2KindSizeTest, InvalidTypeReturnsError)
 {
-    EXPECT_EQ(SDDL2_kind_size((SDDL2_Type_kind(9999))), 0);
+    size_t out;
+    EXPECT_NE(SDDL2_kind_size(SDDL2_Type_kind(9999), &out), SDDL2_OK);
+}
+
+TEST(SDDL2KindSizeTest, StructReturnsError)
+{
+    size_t out;
+    EXPECT_NE(SDDL2_kind_size(SDDL2_TYPE_STRUCTURE, &out), SDDL2_OK);
 }

--- a/tests/compress/graphs/sddl2/test_sddl2_vm_type_structure.cpp
+++ b/tests/compress/graphs/sddl2/test_sddl2_vm_type_structure.cpp
@@ -64,7 +64,7 @@ TEST_F(SDDL2VmTypeStructureTest, SimpleStructure)
     EXPECT_EQ(struct_data->members[1].kind, SDDL2_TYPE_I16LE);
     EXPECT_EQ(struct_data->members[2].kind, SDDL2_TYPE_I32LE);
 
-    EXPECT_EQ(SDDL2_Type_size(result.value.as_type), 7u);
+    EXPECT_EQ(getTypeSize(result.value.as_type), 7u);
 }
 
 TEST_F(SDDL2VmTypeStructureTest, StructureWithArrays)
@@ -126,7 +126,7 @@ TEST_F(SDDL2VmTypeStructureTest, ArrayOfStructures)
     EXPECT_EQ(struct_data->total_size_bytes, 5u); // Size of one instance
 
     // Total size = 5 bytes × 10 = 50 bytes
-    EXPECT_EQ(SDDL2_Type_size(result.value.as_type), 50u);
+    EXPECT_EQ(getTypeSize(result.value.as_type), 50u);
 }
 
 TEST_F(SDDL2VmTypeStructureTest, ZeroMemberStructure)

--- a/tests/compress/graphs/sddl2/utils.h
+++ b/tests/compress/graphs/sddl2/utils.h
@@ -7,11 +7,16 @@
 #include <algorithm>
 #include <numeric>
 #include <random>
+#include <set>
+#include <vector>
 
+#include "openzl/codecs/zl_clustering.h"
 #include "openzl/compress/graphs/sddl2/sddl2_vm.h"
 #include "openzl/cpp/CompressIntrospectionHooks.hpp"
 #include "openzl/cpp/DecompressIntrospectionHooks.hpp"
 #include "openzl/zl_config.h"
+#include "openzl/zl_graph_api.h"
+#include "openzl/zl_input.h"
 
 namespace openzl {
 namespace sddl2 {
@@ -30,6 +35,31 @@ class CompressChunkCounterHook : public openzl::CompressIntrospectionHooks {
             const ZL_RuntimeGraphParameters*) override
     {
         ++chunkCount;
+    }
+};
+
+class ClusteringTagCaptureHook : public openzl::CompressIntrospectionHooks {
+   public:
+    std::set<int> tags;
+
+    void on_migraphEncode_start(
+            ZL_Graph*,
+            const ZL_Compressor*,
+            ZL_GraphID,
+            ZL_Edge* inputs[],
+            size_t nbInputs) override
+    {
+        for (size_t i = 0; i < nbInputs; ++i) {
+            const ZL_Input* input = ZL_Edge_getData(inputs[i]);
+            if (input == nullptr) {
+                continue;
+            }
+            ZL_IntMetadata meta = ZL_Input_getIntMetadata(
+                    input, ZL_CLUSTERING_TAG_METADATA_ID);
+            if (meta.isPresent) {
+                tags.insert(meta.mValue);
+            }
+        }
     }
 };
 

--- a/tests/compress/graphs/sddl2/utils.h
+++ b/tests/compress/graphs/sddl2/utils.h
@@ -110,6 +110,20 @@ class SDDL2StackTestCustomCapacity : public SDDL2TestBase {
 
 using SDDL2StackTest = SDDL2StackTestCustomCapacity<100>;
 
+static size_t getKindSize(SDDL2_Type_kind kind)
+{
+    size_t out = 0;
+    EXPECT_EQ(SDDL2_kind_size(kind, &out), SDDL2_OK);
+    return out;
+}
+
+static size_t getTypeSize(SDDL2_Type type)
+{
+    size_t out = 0;
+    EXPECT_EQ(SDDL2_Type_size(type, &out), SDDL2_OK);
+    return out;
+}
+
 static void popAndVerifyI64(SDDL2_Stack* stack, int64_t expected)
 {
     SDDL2_Value result;

--- a/tests/round_trip/test_sddl2_bytecode.cpp
+++ b/tests/round_trip/test_sddl2_bytecode.cpp
@@ -407,7 +407,8 @@ static SDDL2_Struct_data* create_structure_data(
     struct_data->total_size_bytes = 0;
     for (size_t i = 0; i < member_count; ++i) {
         struct_data->members[i] = members[i];
-        struct_data->total_size_bytes += SDDL2_Type_size(members[i]);
+        struct_data->total_size_bytes +=
+                openzl::sddl2::testing::getTypeSize(members[i]);
     }
 
     return struct_data;

--- a/tools/sddl2/compiler/codegen/CodeGenerator.cpp
+++ b/tools/sddl2/compiler/codegen/CodeGenerator.cpp
@@ -79,7 +79,10 @@ const std::map<Symbol, std::string> builtin_field_to_load = {
     { Symbol::I64BE, "load.i64be" },
 };
 
-using TypeResult = std::pair<AssemblyOutput, ASTPtr>;
+struct TypeResult {
+    AssemblyOutput asm_;
+    ASTPtr type_;
+};
 
 /**
  * Takes an AST and generates assembly code.
@@ -485,7 +488,7 @@ class CodeGeneratorImpl {
         // Consume the type
         output += generateConsume(type_result);
 
-        auto type = type_result.second;
+        auto type = type_result.type_;
 
         if (const auto builtin = type->as_builtin_field()) {
             // If the type is a builtin field save the loaded value
@@ -509,7 +512,7 @@ class CodeGeneratorImpl {
     AssemblyOutput generateConsume(TypeResult type_result)
     {
         AssemblyOutput output;
-        auto& type_asm = type_result.first;
+        auto& type_asm = type_result.asm_;
         output += "push.tag " + std::to_string(tag_++);
         output += std::move(type_asm);
         output += "push.i64 1";

--- a/tools/sddl2/compiler/codegen/CodeGenerator.cpp
+++ b/tools/sddl2/compiler/codegen/CodeGenerator.cpp
@@ -1,6 +1,7 @@
 // Copyright (c) Meta Platforms, Inc. and affiliates.
 
 #include <algorithm>
+#include <optional>
 #include <unordered_map>
 #include <vector>
 
@@ -181,23 +182,31 @@ class CodeGeneratorImpl {
      */
     AssemblyOutput generateWhen(const ASTWhen& when)
     {
+        auto saved_cond = cond_;
+
         AssemblyOutput output;
 
-        // Get code for body
-        auto body_asm = generateBlock(when.body());
-
-        // Push N (number of instructions in body)
-        output += "push.i64 " + std::to_string(body_asm.size());
-
-        // Evaluate condition
+        // Generate the condition
         output += generateValue(when.condition());
 
-        // Negate condition (cmp.eq with 0) so we skip the body when false
-        output += "push.zero";
-        output += "cmp.eq";
-        output += "jump_if";
+        // Handle nested whens
+        if (cond_.has_value()) {
+            output += "push.i64 " + std::to_string(cond_.value());
+            output += "var.load";
+            output += "logic.and";
+        }
 
-        output += std::move(body_asm);
+        // Save the current condition
+        cond_ = registers_.allocate();
+        output += "push.i64 " + std::to_string(cond_.value());
+        output += "var.store";
+
+        // Generate the body of the when.
+        output += generateBlock(when.body());
+
+        // Restore the condition
+        registers_.free(cond_.value());
+        cond_ = saved_cond;
 
         return output;
     }
@@ -252,6 +261,7 @@ class CodeGeneratorImpl {
     TypeResult generateType(const ASTPtr& type)
     {
         AssemblyOutput output;
+        ASTPtr output_type = type;
 
         switch (type->converted_node_type()) {
             case ConvertedNodeType::VAR: {
@@ -264,13 +274,14 @@ class CodeGeneratorImpl {
                 output += "push.i64 "
                         + std::to_string(registers_.get(var->name()));
                 output += "var.load";
-                return { std::move(output), it->second };
+                output_type = it->second;
+                break;
             }
             case ConvertedNodeType::BUILTIN_FIELD: {
                 output += "push.type."
                         + builtin_field_to_asm.at(
                                 type->as_builtin_field()->kw());
-                return { std::move(output), type };
+                break;
             }
             case ConvertedNodeType::RECORD: {
                 auto record = type->as_record();
@@ -292,20 +303,21 @@ class CodeGeneratorImpl {
                 output += "type.structure";
                 registers_.free(reg);
 
-                return { std::move(output), type };
+                break;
             }
             case ConvertedNodeType::RECORD_FIELD: {
                 auto field                   = type->as_record_field();
                 auto [field_asm, field_type] = generateType(field->type());
                 output += std::move(field_asm);
-                return { std::move(output), field_type };
+                output_type = field_type;
+                break;
             }
             case ConvertedNodeType::BYTES: {
                 auto bytes = type->as_bytes();
                 output += "push.type.bytes";
                 output += generateValue(bytes->len());
                 output += "type.fixed_array";
-                return { std::move(output), type };
+                break;
             }
             case ConvertedNodeType::ARRAY: {
                 auto array          = type->as_array();
@@ -322,7 +334,7 @@ class CodeGeneratorImpl {
                     output += "math.div";
                 }
                 output += "type.fixed_array";
-                return { std::move(output), type };
+                break;
             }
             case ConvertedNodeType::CALL: {
                 auto call               = type->as_call();
@@ -339,8 +351,7 @@ class CodeGeneratorImpl {
 
                 // Restore the registers
                 registers_ = std::move(saved_regs);
-
-                return { std::move(output), type };
+                break;
             }
             case ConvertedNodeType::NUM:
             case ConvertedNodeType::OP:
@@ -349,6 +360,17 @@ class CodeGeneratorImpl {
                 throw InvariantViolation(
                         type->loc(), "Expected a type, got a value.");
         }
+
+        // If the type is within a conditional block, convert it to a fixed
+        // array of either size 1 or 0 depending on the condition.
+        if (cond_.has_value()) {
+            output += "push.i64 " + std::to_string(cond_.value());
+            output += "var.load";
+            output += "push.zero";
+            output += "cmp.ne";
+            output += "type.fixed_array";
+        }
+        return { std::move(output), std::move(output_type) };
     }
 
     std::pair<const ASTVar&, std::vector<std::string>> flattenMember(
@@ -487,7 +509,7 @@ class CodeGeneratorImpl {
     AssemblyOutput generateConsume(TypeResult type_result)
     {
         AssemblyOutput output;
-        auto& [type_asm, _] = type_result;
+        auto& type_asm = type_result.first;
         output += "push.tag " + std::to_string(tag_++);
         output += std::move(type_asm);
         output += "push.i64 1";
@@ -500,6 +522,8 @@ class CodeGeneratorImpl {
 
     // Register allocation
     RegisterAllocator registers_;
+    // Condition register for when blocks
+    std::optional<size_t> cond_ = std::nullopt;
     std::unordered_map<std::string, ASTPtr> type_aliases_;
     std::unordered_map<std::string, ASTPtr> assumed_types_;
 };


### PR DESCRIPTION
Summary:

Refactor `TypeResult` from `std::pair<AssemblyOutput, ASTPtr>` to a named struct with `asm_` and `type_` members.

This improves code readability by replacing opaque `.first`/`.second` accessors with descriptive field names.

Differential Revision: D102354395


