### PR TITLE
Better estimate entropy costs (#680)

### DIFF
--- a/contrib/lz-research/LzCompressors.cpp
+++ b/contrib/lz-research/LzCompressors.cpp
@@ -124,21 +124,16 @@ lzZstdCompressor(int llBits, bool slow, bool iso = false, bool bucket = false)
     return compressor.serialize();
 }
 
-std::string lzStdCompressor(bool slow)
+std::string lzStdCompressor(bool u16Offset)
 {
     openzl::Compressor compressor;
     registerGraphComponents(compressor);
-    auto lzNode = ZL_NODE_LZ;
-    auto store  = graphs::Store{}();
-    auto huf    = graphs::Huffman{}();
-    auto lits   = huf;
-    // auto tokens    = huf;
-    auto offsets = slow ? ZL_GRAPH_PARTITION_BITPACK : store;
-    auto lens    = slow ? ZL_GRAPH_COMPRESS_SMALL_LENGTHS : store;
-    auto graph =
-            compressor.buildStaticGraph(lzNode, { lits, offsets, lens, lens });
-    (void)graph;
-    compressor.selectStartingGraph(ZL_GRAPH_LZ);
+    openzl::LocalParams params;
+    params.addIntParam(ZL_LzParam_windowLog, u16Offset ? 16 : 32);
+    auto graph = compressor.parameterizeGraph(
+            ZL_GRAPH_LZ,
+            openzl::GraphParameters{ .localParams = std::move(params) });
+    compressor.selectStartingGraph(graph);
     return compressor.serialize();
 }
 
@@ -262,10 +257,10 @@ std::string getSerializedCompressor(std::string_view name)
         return bucket16Compressor();
     } else if (name == "partition-offsets") {
         return partitionOffsetsCompressor();
-    } else if (name == "lz-std-fast") {
-        return lzStdCompressor(false);
-    } else if (name == "lz-std-slow") {
+    } else if (name == "lz-std-16") {
         return lzStdCompressor(true);
+    } else if (name == "lz-std-32") {
+        return lzStdCompressor(false);
     } else if (name == "huff16") {
         return huff16Compressor();
     }

--- a/contrib/lz-research/compressors.json
+++ b/contrib/lz-research/compressors.json
@@ -1,10 +1,21 @@
 [
     {
         "algorithm": "zstd",
+        "level": 1
+    },
+    {
+        "algorithm": "openzl",
+        "params": {
+            "CompressionLevel": 1
+        },
+        "compressor_name": "lz-std-32"
+    },
+    {
+        "algorithm": "zstd",
         "level": 1,
         "params": {
             "windowLog": 16,
-            "hashLog": 12
+            "hashLog": 14
         }
     },
     {
@@ -12,14 +23,25 @@
         "params": {
             "CompressionLevel": 1
         },
-        "compressor_name": "lz-std-slow"
+        "compressor_name": "lz-std-16"
+    },
+    {
+        "algorithm": "zstd",
+        "level": -1
+    },
+    {
+        "algorithm": "openzl",
+        "params": {
+            "CompressionLevel": -1
+        },
+        "compressor_name": "lz-std-32"
     },
     {
         "algorithm": "zstd",
         "level": -1,
         "params": {
             "windowLog": 16,
-            "hashLog": 12
+            "hashLog": 14
         }
     },
     {
@@ -27,6 +49,6 @@
         "params": {
             "CompressionLevel": -1
         },
-        "compressor_name": "lz-std-slow"
+        "compressor_name": "lz-std-16"
     }
 ]

--- a/cpp/include/openzl/cpp/codecs/Lz.hpp
+++ b/cpp/include/openzl/cpp/codecs/Lz.hpp
@@ -2,12 +2,34 @@
 
 #pragma once
 
+#include <utility>
+#include <vector>
+
 #include "openzl/codecs/zl_lz.h"
 #include "openzl/cpp/Compressor.hpp"
+#include "openzl/cpp/LocalParams.hpp"
+#include "openzl/cpp/codecs/Graph.hpp"
 #include "openzl/cpp/codecs/Metadata.hpp"
 #include "openzl/cpp/codecs/Node.hpp"
 
 namespace openzl {
+namespace detail {
+template <typename Parameters>
+void addLzLocalParams(LocalParams& lp, const Parameters& params)
+{
+    if (params.compressionLevel.has_value()) {
+        lp.addIntParam(
+                ZL_LzParam_compressionLevel, params.compressionLevel.value());
+    }
+    if (params.acceleration.has_value()) {
+        lp.addIntParam(ZL_LzParam_acceleration, params.acceleration.value());
+    }
+    if (params.windowLog.has_value()) {
+        lp.addIntParam(ZL_LzParam_windowLog, params.windowLog.value());
+    }
+}
+} // namespace detail
+
 namespace nodes {
 struct Lz : public Node {
    public:
@@ -26,14 +48,138 @@ struct Lz : public Node {
         .description      = "LZ77 compress a serial byte stream",
     };
 
+    struct Parameters {
+        /// Optionally override the compression level
+        poly::optional<int> compressionLevel;
+        /// Optionally override the match finder acceleration
+        poly::optional<int> acceleration;
+        /// Optionally override the maximum lookback window log
+        poly::optional<int> windowLog;
+    };
+
     Lz() {}
+    explicit Lz(Parameters p) : params_(std::move(p)) {}
+    explicit Lz(int compressionLevel)
+            : Lz(Parameters{ .compressionLevel = compressionLevel })
+    {
+    }
 
     NodeID baseNode() const override
     {
         return node;
     }
 
+    poly::optional<NodeParameters> parameters() const override
+    {
+        if (!params_.has_value()) {
+            return poly::nullopt;
+        }
+
+        LocalParams lp;
+        ::openzl::detail::addLzLocalParams(lp, *params_);
+        return NodeParameters{ .name        = "lz_with_parameters",
+                               .localParams = std::move(lp) };
+    }
+
+    /**
+     * Helper method to build a graph, since this is the most common operation,
+     * and the one that benefits most from brevity, since it is often nested.
+     */
+    GraphID operator()(
+            Compressor& compressor,
+            GraphID literals,
+            GraphID offsets,
+            GraphID literalLengths,
+            GraphID matchLengths) const
+    {
+        return buildGraph(
+                compressor,
+                std::initializer_list<GraphID>{
+                        literals, offsets, literalLengths, matchLengths });
+    }
+
     ~Lz() override = default;
+
+   private:
+    poly::optional<Parameters> params_{};
 };
 } // namespace nodes
+
+namespace graphs {
+
+class Lz : public Graph {
+   public:
+    static constexpr GraphID graph = ZL_GRAPH_LZ;
+
+    static constexpr GraphMetadata<1> metadata = {
+        .inputs      = { InputMetadata{ .typeMask = TypeMask::Serial } },
+        .description = "LZ77 compress a serial byte stream",
+    };
+
+    using NodeParams = nodes::Lz::Parameters;
+
+    struct Parameters {
+        /// Optionally override the node parameters
+        NodeParams nodeParams;
+        /// Optionally override the backend literals graph
+        poly::optional<GraphID> literalsGraph;
+        /// Optionally override the backend offsets graph
+        poly::optional<GraphID> offsetsGraph;
+        /// Optionally override the backend muxed bytes graph
+        poly::optional<GraphID> muxedBytesGraph;
+        /// Optionally override the backend overflow lengths graph
+        poly::optional<GraphID> overflowLengthsGraph;
+        /// Optionally override the backend mux lengths graph
+        poly::optional<GraphID> muxLengthsGraph;
+    };
+
+    Lz() {}
+    explicit Lz(Parameters p) : params_(std::move(p)) {}
+    explicit Lz(NodeParams p) : Lz(Parameters{ .nodeParams = std::move(p) }) {}
+    explicit Lz(int compressionLevel)
+            : Lz(NodeParams{ .compressionLevel = compressionLevel })
+    {
+    }
+
+    GraphID baseGraph() const override
+    {
+        return graph;
+    }
+
+    poly::optional<GraphParameters> parameters() const override
+    {
+        if (!params_.has_value()) {
+            return poly::nullopt;
+        }
+
+        LocalParams lp;
+        ::openzl::detail::addLzLocalParams(lp, params_->nodeParams);
+
+        std::vector<GraphID> graphs;
+        auto addGraph = [&](int key, poly::optional<GraphID> g) {
+            if (g.has_value()) {
+                lp.addIntParam(key, int(graphs.size()));
+                graphs.push_back(g.value());
+            }
+        };
+        addGraph(ZL_LzParam_literalsGraphIdx, params_->literalsGraph);
+        addGraph(ZL_LzParam_offsetsGraphIdx, params_->offsetsGraph);
+        addGraph(ZL_LzParam_muxedBytesGraphIdx, params_->muxedBytesGraph);
+        addGraph(
+                ZL_LzParam_overflowLengthsGraphIdx,
+                params_->overflowLengthsGraph);
+        addGraph(ZL_LzParam_muxLengthsGraphIdx, params_->muxLengthsGraph);
+
+        return GraphParameters{
+            .customGraphs = std::move(graphs),
+            .localParams  = std::move(lp),
+        };
+    }
+
+    ~Lz() override = default;
+
+   private:
+    poly::optional<Parameters> params_{};
+};
+} // namespace graphs
 } // namespace openzl

--- a/cpp/tests/TestCodecs.cpp
+++ b/cpp/tests/TestCodecs.cpp
@@ -1,6 +1,8 @@
 // Copyright (c) Meta Platforms, Inc. and affiliates.
 
 #include <climits>
+#include <utility>
+#include <vector>
 
 #include <gtest/gtest.h>
 
@@ -9,6 +11,18 @@
 
 using namespace ::testing;
 namespace openzl {
+namespace {
+
+std::vector<std::pair<int, int>> collectIntParams(const LocalParams& params)
+{
+    std::vector<std::pair<int, int>> result;
+    for (const auto& param : params.getIntParams()) {
+        result.emplace_back(param.paramId, param.paramValue);
+    }
+    return result;
+}
+
+} // namespace
 
 class TestCodecs : public testing::Test {
    public:
@@ -46,6 +60,77 @@ TEST_F(TestCodecs, lz4_hc)
     auto graph = graphs::Lz4(9).parameterize(compressor_);
     compressor_.selectStartingGraph(graph);
     auto compressed = testRoundTrip(compressor_, Input::refSerial(data));
+}
+
+TEST_F(TestCodecs, lzParameters)
+{
+    const auto muxLengthsGraph =
+            nodes::MuxLengths{}(compressor_, graphs::Store::graph);
+    const graphs::Lz lz(
+            graphs::Lz::Parameters{
+                    .nodeParams =
+                            graphs::Lz::NodeParams{
+                                    .compressionLevel = -1,
+                                    .acceleration     = 2,
+                                    .windowLog        = 16,
+                            },
+                    .literalsGraph        = graphs::Store::graph,
+                    .offsetsGraph         = graphs::Store::graph,
+                    .muxedBytesGraph      = graphs::Store::graph,
+                    .overflowLengthsGraph = graphs::Store::graph,
+                    .muxLengthsGraph      = muxLengthsGraph,
+            });
+
+    const auto graphParameters = lz.parameters();
+    ASSERT_TRUE(graphParameters.has_value());
+    ASSERT_TRUE(graphParameters->localParams.has_value());
+    ASSERT_TRUE(graphParameters->customGraphs.has_value());
+
+    const std::vector<std::pair<int, int>> expectedIntParams{
+        { ZL_LzParam_compressionLevel, -1 },
+        { ZL_LzParam_acceleration, 2 },
+        { ZL_LzParam_windowLog, 16 },
+        { ZL_LzParam_literalsGraphIdx, 0 },
+        { ZL_LzParam_offsetsGraphIdx, 1 },
+        { ZL_LzParam_muxedBytesGraphIdx, 2 },
+        { ZL_LzParam_overflowLengthsGraphIdx, 3 },
+        { ZL_LzParam_muxLengthsGraphIdx, 4 },
+    };
+    EXPECT_EQ(
+            collectIntParams(*graphParameters->localParams), expectedIntParams);
+
+    const std::vector<GraphID> expectedCustomGraphs{
+        graphs::Store::graph, graphs::Store::graph, graphs::Store::graph,
+        graphs::Store::graph, muxLengthsGraph,
+    };
+    EXPECT_EQ(*graphParameters->customGraphs, expectedCustomGraphs);
+
+    std::string data(10000, 'a');
+    auto graph = lz.parameterize(compressor_);
+    compressor_.selectStartingGraph(graph);
+    auto compressed = testRoundTrip(compressor_, Input::refSerial(data));
+}
+
+TEST_F(TestCodecs, lzNodeParameters)
+{
+    const nodes::Lz lz(
+            nodes::Lz::Parameters{
+                    .compressionLevel = 3,
+                    .acceleration     = 4,
+                    .windowLog        = 17,
+            });
+
+    const auto nodeParameters = lz.parameters();
+    ASSERT_TRUE(nodeParameters.has_value());
+    ASSERT_TRUE(nodeParameters->localParams.has_value());
+
+    const std::vector<std::pair<int, int>> expectedIntParams{
+        { ZL_LzParam_compressionLevel, 3 },
+        { ZL_LzParam_acceleration, 4 },
+        { ZL_LzParam_windowLog, 17 },
+    };
+    EXPECT_EQ(
+            collectIntParams(*nodeParameters->localParams), expectedIntParams);
 }
 
 TEST_F(TestCodecs, segmentSerial_defaultChunkSize)

--- a/include/openzl/codecs/zl_entropy.h
+++ b/include/openzl/codecs/zl_entropy.h
@@ -3,6 +3,7 @@
 #ifndef ZSTRONG_CODECS_ENTROPY_H
 #define ZSTRONG_CODECS_ENTROPY_H
 
+#include "openzl/zl_graph_api.h"
 #include "openzl/zl_graphs.h"
 
 #if defined(__cplusplus)
@@ -19,6 +20,35 @@ extern "C" {
 // decompression speed requirements. Supports both serialized & 2-byte struct
 // inputs
 #define ZL_GRAPH_ENTROPY ZL_MAKE_GRAPH_ID(ZL_StandardGraphID_entropy)
+
+/**
+ * If provided to an entropy graph, ZL_GRAPH_STORE will be selected unless
+ * using entropy compression saves at least this many bytes. If unset, the
+ * entropy graph will use a small default value of its choosing.
+ */
+#define ZL_ENTROPY_MIN_GAIN_BYTES_PID 66
+
+/**
+ * If provided to an entropy graph, ZL_GRAPH_STORE will be selected unless
+ * using entropy compression saves at least this percent of the input size. If
+ * unset, the entropy graph will use a small default value of its choosing.
+ */
+#define ZL_ENTROPY_MIN_GAIN_PCT_PID 80
+
+/**
+ * Sets the destination of @p edge to @p entropyGraph with the parameters
+ * @p minGainBytes and @p minGainPct.
+ *
+ * @param minGainBytes The value for ZL_ENTROPY_MIN_GAIN_BYTES_PID or < 0 to
+ * leave unset.
+ * @param minGainPct The value for ZL_ENTROPY_MIN_GAIN_PCT_PID or < 0 to leave
+ * unset.
+ */
+ZL_Report ZL_Edge_setEntropyDestination(
+        ZL_Edge* edge,
+        ZL_GraphID entropyGraph,
+        int minGainBytes,
+        int minGainPct);
 
 #if defined(__cplusplus)
 }

--- a/include/openzl/codecs/zl_lz.h
+++ b/include/openzl/codecs/zl_lz.h
@@ -72,6 +72,45 @@ typedef enum {
      * is subject to change.
      */
     ZL_LzParam_windowLog = 101,
+
+    /**
+     * If set, the customGraph at this index is used to compress the literals,
+     * rather than sending them to the default graph.
+     */
+    ZL_LzParam_literalsGraphIdx = 1000,
+
+    /**
+     * If set, the customGraph at this index is used to compress the offsets,
+     * rather than sending them to the default graph.
+     */
+    ZL_LzParam_offsetsGraphIdx = 1001,
+
+    /**
+     * If set, the customGraph at this index is used to compress the muxed
+     * bytes (first output of ZL_NODE_MUX_LENGTHS), rather than sending them to
+     * the default graph.
+     *
+     * @note Not used if ZL_LzParam_muxLengthsGraphIdx is set.
+     */
+    ZL_LzParam_muxedBytesGraphIdx = 1002,
+
+    /**
+     * If set, the customGraph at this index is used to compress the overflow
+     * lengths (second output of ZL_NODE_MUX_LENGTHS), rather than sending them
+     * to the default graph.
+     *
+     * @note Not used if ZL_LzParam_muxLengthsGraphIdx is set.
+     */
+    ZL_LzParam_overflowLengthsGraphIdx = 1003,
+
+    /**
+     * If set, the custom graph at this index is used to compress the literal
+     * lengths and match lengths, rather than sending them to
+     * ZL_NODE_MUX_LENGTHS.
+     *
+     * @note Must be a multi-input graph that accepts two 16-bit numeric inputs.
+     */
+    ZL_LzParam_muxLengthsGraphIdx = 1004,
 } ZL_LzParam;
 
 #if defined(__cplusplus)

--- a/include/openzl/codecs/zl_lz.h
+++ b/include/openzl/codecs/zl_lz.h
@@ -58,6 +58,20 @@ typedef enum {
      * @note This parameter is clamped to 1 if set to a lower value.
      */
     ZL_LzParam_acceleration = 100,
+
+    /**
+     * The log2 of the maximum lookback window in LZ match finding.
+     * windowSize = 1u << windowLog.
+     *
+     * The default value is set depending on the compression level and source
+     * size, and is capped at the source size.
+     *
+     * @note If the window size is <= 64K, then LZ will use 16-bit offsets
+     * rather than 32-bit offsets.
+     * @note currently, this value will be clamped between 10 and 28, but this
+     * is subject to change.
+     */
+    ZL_LzParam_windowLog = 101,
 } ZL_LzParam;
 
 #if defined(__cplusplus)

--- a/include/openzl/zl_graph_api.h
+++ b/include/openzl/zl_graph_api.h
@@ -146,6 +146,12 @@ int ZL_Graph_getCParam(const ZL_Graph* gctx, ZL_CParam gparam);
 /* Consultation requests for Local parameters */
 ZL_IntParam ZL_Graph_getLocalIntParam(const ZL_Graph* gctx, int intParamId);
 ZL_RefParam ZL_Graph_getLocalRefParam(const ZL_Graph* gctx, int refParamId);
+/**
+ * Bulk consultation request of *all* Local Parameters. This can be useful when
+ * one is trying to access all the Local Parameters at once for a codec using
+ * the encoder.
+ */
+const ZL_LocalParams* ZL_Graph_getLocalParams(const ZL_Graph* gctx);
 
 /**
  * Determines whether @nodeid is supported given the applied global parameters

--- a/src/openzl/codecs/entropy/encode_entropy_binding.c
+++ b/src/openzl/codecs/entropy/encode_entropy_binding.c
@@ -10,8 +10,6 @@
 #include "openzl/codecs/entropy/encode_entropy_selector.h"
 #include "openzl/codecs/entropy/encode_huffman_kernel.h"
 #include "openzl/common/assertion.h"
-#include "openzl/common/errors_internal.h" // ZS2_RET_IF*
-#include "openzl/compress/enc_interface.h"
 #include "openzl/compress/private_nodes.h"
 #include "openzl/fse/fse.h"
 #include "openzl/fse/huf.h"
@@ -25,6 +23,11 @@
 #include "openzl/zl_graph_api.h"
 
 #define ENTROPY_HISTORAM_PID 246
+
+#define ENTROPY_HUF_CTABLE_PID 247
+
+typedef const HUF_CElt* HufCTable;
+ZL_RESULT_DECLARE_TYPE(HufCTable);
 
 static ZL_Histogram const* getHistogram(ZL_Encoder* eictx, const ZL_Input* in)
 {
@@ -46,6 +49,68 @@ static ZL_Histogram const* getHistogram(ZL_Encoder* eictx, const ZL_Input* in)
     ZL_Histogram_build(
             histogram, ZL_Input_ptr(in), ZL_Input_numElts(in), eltWidth);
     return histogram;
+}
+
+static ZL_Report buildHufCTable(HUF_CElt* ctable, const ZL_Histogram* histogram)
+{
+    ZL_RESULT_DECLARE_SCOPE_REPORT(NULL);
+    ZL_ASSERT_NE(histogram->maxSymbol, 0, "Must've already ruled out constant");
+    size_t tableLog = HUF_optimalTableLog(
+            HUF_TABLELOG_DEFAULT, histogram->total, histogram->maxSymbol);
+    tableLog = HUF_buildCTable(
+            ctable, histogram->count, histogram->maxSymbol, (unsigned)tableLog);
+    ZL_ERR_IF(HUF_isError(tableLog), GENERIC);
+    return ZL_returnSuccess();
+}
+
+static ZL_RESULT_OF(HufCTable)
+        getHufCTable(ZL_Encoder* encoder, const ZL_Histogram* histogram)
+{
+    ZL_RESULT_DECLARE_SCOPE(HufCTable, encoder);
+    ZL_RefParam param =
+            ZL_Encoder_getLocalParam(encoder, ENTROPY_HUF_CTABLE_PID);
+    if (param.paramRef != NULL) {
+        return ZL_RESULT_WRAP_VALUE(HufCTable, param.paramRef);
+    }
+
+    HUF_CElt* ctable = ZL_Encoder_getScratchSpace(
+            encoder, HUF_CTABLE_SIZE(histogram->maxSymbol));
+    ZL_ERR_IF_NULL(ctable, allocation);
+    ZL_ERR_IF_ERR(buildHufCTable(ctable, histogram));
+
+    return ZL_RESULT_WRAP_VALUE(HufCTable, ctable);
+}
+
+static size_t estimateHuffmanSize(
+        HufCTable ctable,
+        const ZL_Histogram* histogram)
+{
+    const size_t symbolsSize = ZS_HUF_estimateCompressedSize(
+            ctable, histogram->count, histogram->maxSymbol);
+
+    // Account for Huffman header + jump table in X4 mode.
+    size_t const headerSize = 1
+            + (size_t)(ZL_nextPow2(histogram->total + 1) + 7) / 8
+            + (histogram->total >= 256 ? 6 : 0);
+
+    // Estimate the table size as the min of 5-bits per non-zero symbol, or
+    // 4-bits per symbol.
+    const size_t tableBitsC = 5u * histogram->cardinality;
+    const size_t tableBitsM = 4u * (histogram->maxSymbol + 1u);
+    const size_t tableSize  = (ZL_MIN(tableBitsC, tableBitsM) + 7u) / 8u;
+    return headerSize + tableSize + symbolsSize;
+}
+
+static size_t estimateFseSize(DataStatsU8* stats)
+{
+    const double entropy = DataStatsU8_getEntropy(stats);
+    const size_t symbolBits =
+            (size_t)(entropy * (double)DataStatsU8_totalElements(stats));
+
+    // Estimate header as 10-bits per non-zero symbol
+    const size_t headerBits = 10 * DataStatsU8_getCardinality(stats);
+
+    return (headerBits + symbolBits + 7) / 8;
 }
 
 ZL_Report EI_fse_v2(ZL_Encoder* eictx, const ZL_Input* ins[], size_t nbIns)
@@ -213,25 +278,14 @@ ZL_Report EI_huffman_v2(ZL_Encoder* eictx, const ZL_Input* ins[], size_t nbIns)
             "Must not use Huffman on constant data (should be impossible for users to trigger)");
 
     // 1. Build table
-    HUF_CElt* ctable;
+    ZL_TRY_LET(HufCTable, ctable, getHufCTable(eictx, histogram));
     {
         size_t const weightsSize = histogram->maxSymbol + 1;
         ZL_Output* const weightsStream =
                 ZL_Encoder_createTypedStream(eictx, 0, weightsSize, 1);
         ZL_ERR_IF_NULL(weightsStream, allocation);
         uint8_t* const weights = ZL_Output_ptr(weightsStream);
-
-        size_t tableLog = HUF_optimalTableLog(
-                HUF_TABLELOG_DEFAULT, srcSize, histogram->maxSymbol);
-        ctable = ZL_Encoder_getScratchSpace(
-                eictx, HUF_CTABLE_SIZE(histogram->maxSymbol));
-        ZL_ERR_IF_NULL(ctable, allocation);
-        tableLog = HUF_buildCTable(
-                ctable,
-                histogram->count,
-                histogram->maxSymbol,
-                (unsigned)tableLog);
-        ZL_ERR_IF(HUF_isError(tableLog), GENERIC);
+        const size_t tableLog  = (size_t)ctable[0];
 
         HUF_CElt const* ct = ctable + 1;
         for (size_t i = 0; i < weightsSize; ++i) {
@@ -528,45 +582,92 @@ static ZL_RESULT_OF(ZL_EdgeList)
 typedef enum {
     EBM_huf,
     EBM_fse,
+    EBM_store,
     EBM_any,
 } EntropyBackendMode;
 
-static EntropyBackendMode resolveMode(
+/// Resolves EBM_any to a concrete mode and returns the entropy compressed
+/// size
+static size_t resolveMode(
         DataStatsU8* stats,
-        EntropyBackendMode mode)
+        const ZL_Histogram* histogram,
+        HufCTable hufCTable,
+        size_t minGain,
+        EntropyBackendMode* mode)
 {
     // TODO: Better selection between Huffman & FSE
     // Take decompression speed into account
-    if (mode == EBM_any) {
-        size_t const nbElts = DataStatsU8_totalElements(stats);
-        size_t const fseSize =
-                (size_t)(DataStatsU8_getEntropy(stats) * (double)nbElts + 7)
-                / 8;
-        size_t const hufSize =
-                DataStatsU8_estimateHuffmanSizeFast(stats, /* delta */ false);
-        size_t const minGain = nbElts / 32;
-        if (fseSize + minGain < hufSize) {
-            return EBM_fse;
-        } else {
-            return EBM_huf;
-        }
+    const size_t nbElts = histogram->total;
+
+    if (nbElts <= 64) {
+        // Don't even attempt entropy compression on tiny inputs
+        *mode = EBM_store;
+        return nbElts;
     }
-    return mode;
+
+    if (*mode == EBM_any) {
+        ZL_ASSERT_NN(hufCTable);
+        const size_t hufSize    = estimateHuffmanSize(hufCTable, histogram);
+        const size_t fseSize    = estimateFseSize(stats);
+        const size_t minFseGain = nbElts / 100;
+        size_t entropySize;
+        if (fseSize + minFseGain <= hufSize) {
+            *mode       = EBM_fse;
+            entropySize = fseSize;
+        } else {
+            *mode       = EBM_huf;
+            entropySize = hufSize;
+        }
+        if (entropySize + minGain <= nbElts) {
+            return entropySize;
+        } else {
+            *mode = EBM_store;
+            return nbElts;
+        }
+    } else if (*mode == EBM_huf) {
+        ZL_ASSERT_NN(hufCTable);
+        const size_t hufSize = estimateHuffmanSize(hufCTable, histogram);
+        if (hufSize + minGain <= nbElts) {
+            return hufSize;
+        } else {
+            *mode = EBM_store;
+            return nbElts;
+        }
+    } else if (*mode == EBM_fse) {
+        ZL_ASSERT_NULL(hufCTable);
+        const size_t fseSize = estimateFseSize(stats);
+        if (fseSize + minGain <= nbElts) {
+            return fseSize;
+        } else {
+            *mode = EBM_store;
+            return nbElts;
+        }
+    } else {
+        ZL_ASSERT_EQ(*mode, EBM_store);
+        return nbElts;
+    }
 }
 
-static ZL_RESULT_OF(ZL_EdgeList) runNode_wHistogram(
+static ZL_RESULT_OF(ZL_EdgeList) runNode_withParams(
         ZL_Edge* sctx,
         ZL_NodeID node,
-        ZL_Histogram const* histogram)
+        ZL_Histogram const* histogram,
+        HufCTable ctable)
 {
-    ZL_RefParam const param = {
-        .paramId  = ENTROPY_HISTORAM_PID,
-        .paramRef = histogram,
+    ZL_RefParam const refParams[2] = {
+        {
+                .paramId  = ENTROPY_HISTORAM_PID,
+                .paramRef = histogram,
+        },
+        {
+                .paramId  = ENTROPY_HUF_CTABLE_PID,
+                .paramRef = ctable,
+        },
     };
     ZL_LocalParams params = {
         .refParams = {
-                .refParams = &param,
-                .nbRefParams = 1,
+                .refParams = refParams,
+                .nbRefParams = 2,
         },
     };
     return ZL_Edge_runNode_withParams(sctx, node, &params);
@@ -576,6 +677,9 @@ static ZL_Histogram* getHistogram8(ZL_Graph* gctx, DataStatsU8* stats)
 {
     ZL_Histogram* histogram = (ZL_Histogram*)ZL_Graph_getScratchSpace(
             gctx, sizeof(ZL_Histogram8));
+    if (histogram == NULL) {
+        return NULL;
+    }
     memcpy(histogram->count,
            DataStatsU8_getHistogram(stats),
            256 * sizeof(uint32_t));
@@ -583,6 +687,7 @@ static ZL_Histogram* getHistogram8(ZL_Graph* gctx, DataStatsU8* stats)
     histogram->maxSymbol    = DataStatsU8_getMaxElt(stats);
     histogram->elementSize  = 1;
     histogram->largestCount = 0;
+    histogram->cardinality  = (unsigned)DataStatsU8_getCardinality(stats);
     for (size_t i = 0; i < histogram->maxSymbol + 1; ++i) {
         histogram->largestCount =
                 ZL_MAX(histogram->count[i], histogram->largestCount);
@@ -602,12 +707,36 @@ static ZL_Report runBitpack(ZL_Edge* input)
     return ZL_returnSuccess();
 }
 
+static size_t getMinGainBytes(const ZL_Graph* graph, size_t contentSize)
+{
+    const size_t kDefaultMinGainBytes = 32;
+    const size_t kDefaultMinGainPct   = 1;
+
+    ZL_IntParam param =
+            ZL_Graph_getLocalIntParam(graph, ZL_ENTROPY_MIN_GAIN_BYTES_PID);
+    size_t minGainBytes = kDefaultMinGainBytes;
+    if (param.paramId != ZL_LP_INVALID_PARAMID) {
+        minGainBytes = (size_t)ZL_MAX(param.paramValue, 0);
+    }
+
+    param = ZL_Graph_getLocalIntParam(graph, ZL_ENTROPY_MIN_GAIN_PCT_PID);
+    size_t minGainPct = kDefaultMinGainPct;
+    if (param.paramId != ZL_LP_INVALID_PARAMID) {
+        minGainPct = (size_t)ZL_MIN(ZL_MAX(param.paramValue, 0), 100);
+    }
+
+    return ZL_MAX(minGainBytes, (contentSize / 100) * minGainPct);
+}
+
 /**
  * Entropy compresses a single chunk by selecting the most efficient backend
  * allowed by the mode.
  */
-static ZL_Report
-entropyCompressChunk(ZL_Graph* gctx, ZL_Edge* chunk, EntropyBackendMode mode)
+static ZL_Report entropyCompressChunk(
+        ZL_Graph* gctx,
+        ZL_Edge* chunk,
+        EntropyBackendMode mode,
+        size_t minGainBytes)
 {
     ZL_RESULT_DECLARE_SCOPE_REPORT(gctx);
     ZL_Input const* input = ZL_Edge_getData(chunk);
@@ -647,12 +776,13 @@ entropyCompressChunk(ZL_Graph* gctx, ZL_Edge* chunk, EntropyBackendMode mode)
         size_t const nbBits = (size_t)ZL_nextPow2(histogram->maxSymbol + 1);
         size_t const bitpackSize = ((nbElts * nbBits + 7) / 8) + /* header */ 2;
 
-        if (bitpackSize <= huffSize && bitpackSize < storeSize) {
+        if (bitpackSize <= huffSize
+            && bitpackSize + minGainBytes <= storeSize) {
             return runBitpack(chunk);
         }
 
         // Check if we can simply store the data
-        if (entropy > 15 || huffSize >= storeSize) {
+        if (entropy > 15 || huffSize + minGainBytes > storeSize) {
             return ZL_Edge_setDestination(chunk, ZL_GRAPH_STORE);
         }
 
@@ -678,11 +808,12 @@ entropyCompressChunk(ZL_Graph* gctx, ZL_Edge* chunk, EntropyBackendMode mode)
         ZL_TRY_LET(
                 ZL_EdgeList,
                 streams,
-                runNode_wHistogram(
+                runNode_withParams(
                         chunk,
                         (ZL_NodeID){
                                 ZL_PrivateStandardNodeID_huffman_struct_v2 },
-                        histogram));
+                        histogram,
+                        NULL));
         ZL_ASSERT_EQ(streams.nbEdges, 2);
         ZL_ERR_IF_ERR(ZL_Edge_setDestination(streams.edges[0], ZL_GRAPH_FSE));
         ZL_ERR_IF_ERR(ZL_Edge_setDestination(streams.edges[1], ZL_GRAPH_STORE));
@@ -691,70 +822,82 @@ entropyCompressChunk(ZL_Graph* gctx, ZL_Edge* chunk, EntropyBackendMode mode)
 
     DataStatsU8 stats;
     DataStatsU8_init(&stats, ZL_Input_ptr(input), nbElts);
+    ZL_Histogram* const histogram = getHistogram8(gctx, &stats);
+    ZL_ERR_IF_NULL(histogram, allocation);
+
+    if (mode == EBM_huf) {
+        // Short-circuit for uncompressible data (taken from FSE's Huffman)
+        if (histogram->largestCount <= (histogram->total >> 7) + 4) {
+            mode = EBM_store;
+        }
+    }
 
     if (DataStatsU8_getCardinality(&stats) == 1) {
         ZL_ASSERT(ZL_Graph_isConstantSupported(gctx));
         return ZL_Edge_setDestination(chunk, ZL_GRAPH_CONSTANT);
     }
 
-    // TODO: At higher compression levels use a better estimate
-    size_t const entropySize = mode == EBM_huf
-            ? DataStatsU8_estimateHuffmanSizeFast(&stats, /* delta */ false)
-            : (size_t)(DataStatsU8_getEntropy(&stats) * (double)nbElts + 7) / 8;
+    // Build the Huffman table if Huffman is allowed. This allows an accurate
+    // estimate of the Huffman compressed size. If Huffman is chosen the CTable
+    // will be passed down to the Huffman node.
+    HUF_CElt* hufCTable = NULL;
+    if (mode == EBM_huf || mode == EBM_any) {
+        hufCTable = ZL_Graph_getScratchSpace(
+                gctx, HUF_CTABLE_SIZE(histogram->maxSymbol));
+        ZL_ERR_IF_NULL(hufCTable, allocation);
+        ZL_ERR_IF_ERR(buildHufCTable(hufCTable, histogram));
+    }
 
-    size_t const headerSizeEstimate =
-            ZL_MAX(10, DataStatsU8_getCardinality(&stats) / 4);
-
-    size_t const baselineSize =
-            ZL_MIN(entropySize + headerSizeEstimate, nbElts);
+    const size_t entropySize =
+            resolveMode(&stats, histogram, hufCTable, minGainBytes, &mode);
+    ZL_ASSERT_LE(entropySize, nbElts);
 
     size_t const flatpackedSize = DataStatsU8_getFlatpackedSize(&stats);
     size_t const bitpackedSize  = DataStatsU8_getBitpackedSize(&stats);
 
     if (flatpackedSize < bitpackedSize) {
-        if (flatpackedSize < baselineSize) {
+        if (flatpackedSize < entropySize
+            && flatpackedSize + minGainBytes <= nbElts) {
             return ZL_Edge_setDestination(chunk, ZL_GRAPH_FLATPACK);
         }
     } else {
-        if (bitpackedSize < baselineSize) {
+        if (bitpackedSize <= entropySize
+            && bitpackedSize + minGainBytes <= nbElts) {
             return ZL_Edge_setDestination(chunk, ZL_GRAPH_BITPACK);
         }
     }
 
-    if (nbElts <= baselineSize) {
-        return ZL_Edge_setDestination(chunk, ZL_GRAPH_STORE);
-    }
-
-    // Select between FSE & Huffman
-    mode = resolveMode(&stats, mode);
-
-    ZL_Histogram* histogram = getHistogram8(gctx, &stats);
     if (mode == EBM_huf) {
         ZL_TRY_LET(
                 ZL_EdgeList,
                 streams,
-                runNode_wHistogram(
+                runNode_withParams(
                         chunk,
                         (ZL_NodeID){ ZL_PrivateStandardNodeID_huffman_v2 },
-                        histogram));
+                        histogram,
+                        hufCTable));
         ZL_ASSERT_EQ(streams.nbEdges, 2);
         ZL_ERR_IF_ERR(ZL_Edge_setDestination(streams.edges[0], ZL_GRAPH_FSE));
         ZL_ERR_IF_ERR(ZL_Edge_setDestination(streams.edges[1], ZL_GRAPH_STORE));
         return ZL_returnSuccess();
-    } else {
+    } else if (mode == EBM_fse) {
         ZL_TRY_LET(
                 ZL_EdgeList,
                 streams,
-                runNode_wHistogram(
+                runNode_withParams(
                         chunk,
                         (ZL_NodeID){ ZL_PrivateStandardNodeID_fse_v2 },
-                        histogram));
+                        histogram,
+                        hufCTable));
         ZL_ASSERT_EQ(streams.nbEdges, 2);
         ZL_ERR_IF_ERR(ZL_Edge_setDestination(
                 streams.edges[0],
                 (ZL_GraphID){ ZL_PrivateStandardGraphID_fse_ncount }));
         ZL_ERR_IF_ERR(ZL_Edge_setDestination(streams.edges[1], ZL_GRAPH_STORE));
         return ZL_returnSuccess();
+    } else {
+        ZL_ASSERT_EQ(mode, EBM_store);
+        return ZL_Edge_setDestination(chunk, ZL_GRAPH_STORE);
     }
 }
 
@@ -762,9 +905,24 @@ static ZL_Report
 entropyDynamicGraph(ZL_Graph* gctx, ZL_Edge* sctx, EntropyBackendMode mode)
 {
     ZL_RESULT_DECLARE_SCOPE_REPORT(gctx);
+
+    const size_t contentSize = ZL_Input_contentSize(ZL_Edge_getData(sctx));
+
+    if (contentSize <= 1) {
+        return ZL_Edge_setDestination(sctx, ZL_GRAPH_STORE);
+    }
+
+    const size_t minGainBytes = getMinGainBytes(gctx, contentSize);
+
     ZL_TRY_LET(ZL_EdgeList, chunks, chunkInputStream(gctx, &sctx));
     for (size_t i = 0; i < chunks.nbEdges; ++i) {
-        ZL_ERR_IF_ERR(entropyCompressChunk(gctx, chunks.edges[i], mode));
+        // Scale minGainBytes to divide evenly among the chunks
+        const size_t chunkSize =
+                ZL_Input_contentSize(ZL_Edge_getData(chunks.edges[i]));
+        const size_t scaledMinGainBytes =
+                (minGainBytes * chunkSize) / contentSize;
+        ZL_ERR_IF_ERR(entropyCompressChunk(
+                gctx, chunks.edges[i], mode, scaledMinGainBytes));
     }
     return ZL_returnSuccess();
 }
@@ -875,4 +1033,27 @@ EI_entropyDynamicGraph(ZL_Graph* gctx, ZL_Edge* inputs[], size_t nbIns)
         return ZL_Edge_setDestination(input, graph);
     }
     return entropyDynamicGraph(gctx, input, EBM_any);
+}
+
+ZL_Report ZL_Edge_setEntropyDestination(
+        ZL_Edge* edge,
+        ZL_GraphID entropyGraph,
+        int minGainBytes,
+        int minGainPct)
+{
+    ZL_IntParam intParams[2];
+    size_t numIntParams = 0;
+    if (minGainBytes >= 0) {
+        intParams[numIntParams++] =
+                (ZL_IntParam){ ZL_ENTROPY_MIN_GAIN_BYTES_PID, minGainBytes };
+    }
+    if (minGainPct >= 0) {
+        intParams[numIntParams++] =
+                (ZL_IntParam){ ZL_ENTROPY_MIN_GAIN_PCT_PID, minGainPct };
+    }
+    ZL_LocalParams lp = { .intParams = { intParams, numIntParams } };
+    ZL_RuntimeGraphParameters params = {
+        .localParams = &lp,
+    };
+    return ZL_Edge_setParameterizedDestination(&edge, 1, entropyGraph, &params);
 }

--- a/src/openzl/codecs/lz/decode_lz_kernel.c
+++ b/src/openzl/codecs/lz/decode_lz_kernel.c
@@ -373,6 +373,7 @@ static ZL_LzError ZL_Lz_decode_sequence(
     assert((size_t)*outPos <= dstSize);
     assert(*litPos <= numLiterals);
 
+    // Must handle integer overflow for these values
     ptrdiff_t const litLen = (ptrdiff_t)ZL_readN(
             (const uint8_t*)literalLengths + seq * literalLengthsEltWidth,
             (size_t)literalLengthsEltWidth);
@@ -384,10 +385,10 @@ static ZL_LzError ZL_Lz_decode_sequence(
             (size_t)matchLengthsEltWidth);
 
     // Copy literals
-    if (*litPos + litLen > numLiterals) {
+    if (litLen > numLiterals - *litPos) {
         return ZL_LzError_notEnoughLiterals;
     }
-    if (*outPos + litLen > (ptrdiff_t)dstSize) {
+    if (litLen < 0 || litLen > (ptrdiff_t)dstSize - *outPos) {
         return ZL_LzError_literalLengthTooLarge;
     }
     if (litLen > 0) {
@@ -400,12 +401,12 @@ static ZL_LzError ZL_Lz_decode_sequence(
     if (offset == 0) {
         return ZL_LzError_offsetZero;
     }
-    if (offset > *outPos) {
+    if (offset > *outPos || offset < 0) {
         return ZL_LzError_offsetTooLarge;
     }
 
     // Copy match (byte-by-byte to handle overlapping matches)
-    if (*outPos + matchLen > (ptrdiff_t)dstSize) {
+    if (matchLen < 0 || matchLen > (ptrdiff_t)dstSize - *outPos) {
         return ZL_LzError_matchLengthTooLarge;
     }
     for (ptrdiff_t i = 0; i < matchLen; ++i) {
@@ -531,9 +532,15 @@ ZL_FORCE_NOINLINE ZL_LzError ZL_Lz_decode_u16Loop(
             assert((size_t)litPos <= state->src.numLiterals);
             assert((size_t)outPos <= dstSize);
 
+            // These values are capped at 64K
+            // We validated the source size is <= PTRDIFF_MAX - 2 * UINT16_MAX
+            // before calling this loop to guarantee no overflow when adding
+            // to outPos.
             const ptrdiff_t litLen   = litLens[seq];
             const ptrdiff_t matchLen = matchLens[seq];
             const ptrdiff_t offset   = offs[seq];
+            assert(sizeof(ptrdiff_t) >= 4);
+            assert(litLen >= 0 && matchLen >= 0 && offset >= 0);
 
             const ptrdiff_t outMatch = outPos + litLen;
             const ptrdiff_t outNext  = outMatch + matchLen;
@@ -678,9 +685,11 @@ static ZL_LzError ZL_Lz_decode_u16(
 ZL_LzError
 ZL_Lz_decode(uint8_t* dst, size_t dstSize, const ZL_Lz_InSequences* src)
 {
+    const size_t maxSeqLenU16 = 2 * UINT16_MAX;
     // Optimize for cases that the encoder actually produces
     if (src->offsetsEltWidth == 2 && src->literalLengthsEltWidth == 2
-        && src->matchLengthsEltWidth == 2) {
+        && src->matchLengthsEltWidth == 2
+        && dstSize <= PTRDIFF_MAX - maxSeqLenU16 /* no overflow in outPos */) {
         return ZL_Lz_decode_u16(dst, dstSize, src);
     }
 

--- a/src/openzl/codecs/lz/decode_lz_kernel.c
+++ b/src/openzl/codecs/lz/decode_lz_kernel.c
@@ -483,6 +483,16 @@ typedef struct {
     ptrdiff_t litLimit;
 } ZL_Lz_DecodeState;
 
+ZL_FORCE_INLINE ptrdiff_t
+loadOffset(const void* offs, ptrdiff_t seq, size_t offWidth)
+{
+    if (offWidth == sizeof(uint16_t)) {
+        return ((const uint16_t*)offs)[seq];
+    }
+    ZL_ASSERT_EQ(offWidth, sizeof(uint32_t));
+    return ((const uint32_t*)offs)[seq];
+}
+
 /**
  * The hot LZ decoding loop.
  *
@@ -490,24 +500,24 @@ typedef struct {
  * @pre state->outPos <= dstSize - ZL_Lz_kOutSlop
  * @pre state->litPos <= state->litLimit
  *
- * NOTE: This is force outlined because the loop is tight on registers. If there
- * is a function call in the loop body, then the compiler has to worry about
- * callee saved registers, and spills more variables to the stack. So force
- * outline the hot loop and also ensure that every function it calls is force
- * inlined.
+ * NOTE: This is force inlined into width-specific force-outlined wrappers
+ * because the loop is tight on registers. If there is a function call in the
+ * loop body, then the compiler has to worry about callee saved registers, and
+ * spills more variables to the stack.
  *
  * NOTE: This kernel uses ptrdiff_t rather than pointers to avoid UB with
  * pointers, which are only valid within the buffer and one past the end.
  */
-ZL_FORCE_NOINLINE ZL_LzError ZL_Lz_decode_u16Loop(
+ZL_FORCE_INLINE ZL_LzError ZL_Lz_decode_fastLoop(
         uint8_t* const dst,
         size_t dstSize,
-        ZL_Lz_DecodeState* state)
+        ZL_Lz_DecodeState* state,
+        size_t offWidth)
 {
     uint8_t* const out              = dst;
     const size_t numSeqs            = state->src.numSequences;
     const uint8_t* const lits       = state->src.literals;
-    const uint16_t* const offs      = state->src.offsets;
+    const void* const offs          = state->src.offsets;
     const uint16_t* const litLens   = state->src.literalLengths;
     const uint16_t* const matchLens = state->src.matchLengths;
 
@@ -538,8 +548,8 @@ ZL_FORCE_NOINLINE ZL_LzError ZL_Lz_decode_u16Loop(
             // to outPos.
             const ptrdiff_t litLen   = litLens[seq];
             const ptrdiff_t matchLen = matchLens[seq];
-            const ptrdiff_t offset   = offs[seq];
-            assert(sizeof(ptrdiff_t) >= 4);
+            const ptrdiff_t offset   = loadOffset(offs, seq, offWidth);
+            assert(sizeof(ptrdiff_t) > offWidth);
             assert(litLen >= 0 && matchLen >= 0 && offset >= 0);
 
             const ptrdiff_t outMatch = outPos + litLen;
@@ -593,10 +603,30 @@ _exit:
     return ZL_LzError_ok;
 }
 
-static ZL_LzError ZL_Lz_decode_u16(
+ZL_FORCE_NOINLINE ZL_LzError ZL_Lz_decode_u16Loop(
         uint8_t* const dst,
         size_t dstSize,
-        const ZL_Lz_InSequences* src)
+        ZL_Lz_DecodeState* state)
+{
+    return ZL_Lz_decode_fastLoop(dst, dstSize, state, sizeof(uint16_t));
+}
+
+ZL_FORCE_NOINLINE ZL_LzError ZL_Lz_decode_u32Loop(
+        uint8_t* const dst,
+        size_t dstSize,
+        ZL_Lz_DecodeState* state)
+{
+    return ZL_Lz_decode_fastLoop(dst, dstSize, state, sizeof(uint32_t));
+}
+
+typedef ZL_LzError (
+        *ZL_Lz_LoopFn)(uint8_t* dst, size_t dstSize, ZL_Lz_DecodeState* state);
+
+static ZL_LzError ZL_Lz_decode_typed(
+        uint8_t* const dst,
+        size_t dstSize,
+        const ZL_Lz_InSequences* src,
+        ZL_Lz_LoopFn loopFn)
 {
     ZL_Lz_DecodeState state = {
         .src      = *src,
@@ -641,7 +671,7 @@ static ZL_LzError ZL_Lz_decode_u16(
         }
         if (state.outPos <= outLimit && state.litPos <= state.litLimit
             && state.seq <= seqLimit) {
-            const ZL_LzError err = ZL_Lz_decode_u16Loop(dst, dstSize, &state);
+            const ZL_LzError err = loopFn(dst, dstSize, &state);
             if (err != ZL_LzError_ok) {
                 return err;
             }
@@ -655,11 +685,10 @@ static ZL_LzError ZL_Lz_decode_u16(
         }
 
         if (state.seq < numSeqs) {
-            // Execute a single sequence. We need to do it here because
-            // ZL_Lz_decode_u16Loop may be exactly one sequence short of hitting
-            // a limit, so we need to execute one before transferring the
-            // literals (if that was the limiting factor), otherwise we will
-            // infinite loop.
+            // Execute a single sequence. The loop function may be exactly one
+            // sequence short of hitting a limit, so we need to execute one
+            // before transferring the literals (if that was the limiting
+            // factor), otherwise we will infinite loop.
             //
             // Then, after transferring literals, this code also handles the
             // trailing sequences.
@@ -677,7 +706,6 @@ static ZL_LzError ZL_Lz_decode_u16(
         }
     }
 
-    // Copy the remaining literals
     return ZL_Lz_decode_lastLiterals(
             dst, dstSize, &state.src, state.outPos, state.litPos);
 }
@@ -690,7 +718,13 @@ ZL_Lz_decode(uint8_t* dst, size_t dstSize, const ZL_Lz_InSequences* src)
     if (src->offsetsEltWidth == 2 && src->literalLengthsEltWidth == 2
         && src->matchLengthsEltWidth == 2
         && dstSize <= PTRDIFF_MAX - maxSeqLenU16 /* no overflow in outPos */) {
-        return ZL_Lz_decode_u16(dst, dstSize, src);
+        return ZL_Lz_decode_typed(dst, dstSize, src, ZL_Lz_decode_u16Loop);
+    }
+    if (src->offsetsEltWidth == 4 && src->literalLengthsEltWidth == 2
+        && src->matchLengthsEltWidth == 2
+        && dstSize <= PTRDIFF_MAX - maxSeqLenU16 /* no overflow in outPos */
+        && sizeof(ptrdiff_t) == 8 /* offset must be non-negative*/) {
+        return ZL_Lz_decode_typed(dst, dstSize, src, ZL_Lz_decode_u32Loop);
     }
 
     // Generic fallback to handle any width to allow us to update the encoder

--- a/src/openzl/codecs/lz/encode_lz_binding.c
+++ b/src/openzl/codecs/lz/encode_lz_binding.c
@@ -481,11 +481,38 @@ static ZL_GraphID getGraph(
     }
 }
 
+static ZL_Report setEntropyDestinationOrOverride(
+        const ZL_Graph* gctx,
+        ZL_Edge* edge,
+        ZL_GraphIDList customGraphs,
+        int overrideParam,
+        ZL_GraphID entropyGraph,
+        int minGainForHuffmanBytes)
+{
+    ZL_RESULT_DECLARE_SCOPE_REPORT(edge);
+
+    const ZL_GraphID override =
+            getGraph(gctx, customGraphs, overrideParam, ZL_GRAPH_ILLEGAL);
+    if (override.gid != ZL_GRAPH_ILLEGAL.gid) {
+        ZL_ERR_IF_ERR(ZL_Edge_setDestination(edge, override));
+    } else {
+        ZL_ERR_IF_ERR(ZL_Edge_setEntropyDestination(
+                edge, entropyGraph, minGainForHuffmanBytes, -1));
+    }
+    return ZL_returnSuccess();
+}
+
 ZL_Report EI_lzDynGraph(ZL_Graph* gctx, ZL_Edge* inputs[], size_t nbIns)
 {
     ZL_RESULT_DECLARE_SCOPE_REPORT(gctx);
     ZL_ASSERT_EQ(nbIns, 1);
-    ZL_Edge* input = inputs[0];
+    ZL_Edge* input         = inputs[0];
+    const size_t inputSize = ZL_Input_contentSize(ZL_Edge_getData(input));
+    // Huffman must save at least this much to be considered.
+    // The combination of a small percent of the source size and a fixed
+    // component strongly discourages Huffman for small inputs where the speed
+    // penalty is large, and has little impact on large inputs.
+    const int minGainForHuffmanBytes = (int)(inputSize / 200) + 50;
 
     const ZL_LocalParams* localParams = GCTX_getAllLocalParams(gctx);
 
@@ -503,12 +530,9 @@ ZL_Report EI_lzDynGraph(ZL_Graph* gctx, ZL_Edge* inputs[], size_t nbIns)
 
     const int compressionLevel        = getCompressionLevelGraph(gctx);
     const ZL_GraphIDList customGraphs = ZL_Graph_getCustomGraphs(gctx);
-
     const ZL_GraphID huffOrStore =
             compressionLevel >= 0 ? ZL_GRAPH_HUFFMAN : ZL_GRAPH_STORE;
 
-    const ZL_GraphID literalsGraph = getGraph(
-            gctx, customGraphs, ZL_LzParam_literalsGraphIdx, huffOrStore);
     const ZL_GraphID offsetsGraph = getGraph(
             gctx,
             customGraphs,
@@ -520,7 +544,13 @@ ZL_Report EI_lzDynGraph(ZL_Graph* gctx, ZL_Edge* inputs[], size_t nbIns)
             ZL_LzParam_muxLengthsGraphIdx,
             ZL_GRAPH_ILLEGAL);
 
-    ZL_ERR_IF_ERR(ZL_Edge_setDestination(literals, literalsGraph));
+    ZL_ERR_IF_ERR(setEntropyDestinationOrOverride(
+            gctx,
+            literals,
+            customGraphs,
+            ZL_LzParam_literalsGraphIdx,
+            huffOrStore,
+            minGainForHuffmanBytes));
     ZL_ERR_IF_ERR(ZL_Edge_setDestination(offsets, offsetsGraph));
 
     ZL_Edge* muxInputs[2] = { literalLengths, matchLengths };
@@ -536,18 +566,21 @@ ZL_Report EI_lzDynGraph(ZL_Graph* gctx, ZL_Edge* inputs[], size_t nbIns)
                 ZL_Edge_runMultiInputNode(muxInputs, 2, ZL_NODE_MUX_LENGTHS));
         ZL_ASSERT_EQ(muxStreams.nbEdges, 2);
 
-        const ZL_GraphID muxedBytesGraph = getGraph(
-                gctx, customGraphs, ZL_LzParam_muxedBytesGraphIdx, huffOrStore);
-        const ZL_GraphID overflowLengthsGraph = getGraph(
+        ZL_ERR_IF_ERR(setEntropyDestinationOrOverride(
                 gctx,
+                muxStreams.edges[0],
+                customGraphs,
+                ZL_LzParam_muxedBytesGraphIdx,
+                huffOrStore,
+                minGainForHuffmanBytes));
+
+        ZL_ERR_IF_ERR(setEntropyDestinationOrOverride(
+                gctx,
+                muxStreams.edges[1],
                 customGraphs,
                 ZL_LzParam_overflowLengthsGraphIdx,
-                ZL_GRAPH_COMPRESS_SMALL_LENGTHS);
-
-        ZL_ERR_IF_ERR(
-                ZL_Edge_setDestination(muxStreams.edges[0], muxedBytesGraph));
-        ZL_ERR_IF_ERR(ZL_Edge_setDestination(
-                muxStreams.edges[1], overflowLengthsGraph));
+                ZL_GRAPH_COMPRESS_SMALL_LENGTHS,
+                minGainForHuffmanBytes));
     }
 
     return ZL_returnSuccess();

--- a/src/openzl/codecs/lz/encode_lz_binding.c
+++ b/src/openzl/codecs/lz/encode_lz_binding.c
@@ -17,6 +17,9 @@
 #include "openzl/zl_data.h"
 #include "openzl/zl_graph_api.h"
 
+#define ZL_LZ_MIN_WINDOW_LOG 10
+#define ZL_LZ_MAX_WINDOW_LOG 28
+
 /**
  * Set the maximum bytes to process to 4B to avoid overflow in the match finder.
  * It could likely be higher, but this is close enough to 2^32-1.
@@ -155,6 +158,22 @@ static int getAcceleration(const ZL_Encoder* eictx)
     }
 }
 
+static uint32_t getWindowLog(const ZL_Encoder* eictx, size_t srcSize)
+{
+    const ZL_IntParam windowLogParam =
+            ZL_Encoder_getLocalIntParam(eictx, ZL_LzParam_windowLog);
+
+    int windowLog = ZL_LZ_MAX_WINDOW_LOG;
+    if (windowLogParam.paramId != ZL_LP_INVALID_PARAMID) {
+        windowLog = windowLogParam.paramValue;
+    }
+
+    windowLog = ZL_MIN(windowLog, ZL_nextPow2(srcSize));
+
+    return (uint32_t)ZL_MAX(
+            ZL_LZ_MIN_WINDOW_LOG, ZL_MIN(windowLog, ZL_LZ_MAX_WINDOW_LOG));
+}
+
 ZL_Report EI_lz(ZL_Encoder* eictx, const ZL_Input* ins[], size_t nbIns)
 {
     ZL_RESULT_DECLARE_SCOPE_REPORT(eictx);
@@ -172,13 +191,17 @@ ZL_Report EI_lz(ZL_Encoder* eictx, const ZL_Input* ins[], size_t nbIns)
             "LZ only supports up to 4B of input");
 
     size_t const maxNumSeq = ZL_Lz_maxNumSequences(srcSize);
+    // Offsets are up to than 2^windowLog-1; use 32-bits when they won't fit u16
+    const uint32_t windowLog = getWindowLog(eictx, srcSize);
+    const size_t offsetEltWidth =
+            (windowLog > 16) ? sizeof(uint32_t) : sizeof(uint16_t);
 
     // Create output streams
     size_t const literalsCapacity = srcSize + ZL_LZ_LIT_OVER_LENGTH;
     ZL_Output* const literals =
             ZL_Encoder_createTypedStream(eictx, 0, literalsCapacity, 1);
     ZL_Output* const offsets =
-            ZL_Encoder_createTypedStream(eictx, 1, maxNumSeq, 2);
+            ZL_Encoder_createTypedStream(eictx, 1, maxNumSeq, offsetEltWidth);
     ZL_Output* const literalLengths =
             ZL_Encoder_createTypedStream(eictx, 2, maxNumSeq, 2);
     ZL_Output* const matchLengths =
@@ -190,7 +213,8 @@ ZL_Report EI_lz(ZL_Encoder* eictx, const ZL_Input* ins[], size_t nbIns)
     ZL_ERR_IF_NULL(matchLengths, allocation);
 
     // Allocate hash table from scratch space
-    size_t const hashTableSize = ZS_FastTable_tableSize(ZL_LZ_TABLE_LOG);
+    size_t const hashTableSize =
+            ZS_FastTable_tableSize(ZL_Lz_tableLog(windowLog));
     void* hashTableMem = ZL_Encoder_getScratchSpace(eictx, hashTableSize);
     ZL_ERR_IF_NULL(hashTableMem, allocation);
 
@@ -199,7 +223,8 @@ ZL_Report EI_lz(ZL_Encoder* eictx, const ZL_Input* ins[], size_t nbIns)
         .literalsCapacity = literalsCapacity,
         .numLiterals      = 0,
 
-        .offsets           = (uint16_t*)ZL_Output_ptr(offsets),
+        .offsets           = ZL_Output_ptr(offsets),
+        .offsetWidth       = offsetEltWidth,
         .literalLengths    = (uint16_t*)ZL_Output_ptr(literalLengths),
         .matchLengths      = (uint16_t*)ZL_Output_ptr(matchLengths),
         .sequencesCapacity = maxNumSeq,
@@ -211,6 +236,7 @@ ZL_Report EI_lz(ZL_Encoder* eictx, const ZL_Input* ins[], size_t nbIns)
             (const uint8_t*)ZL_Input_ptr(in),
             srcSize,
             hashTableMem,
+            windowLog,
             getAcceleration(eictx));
 
     // Write the original size as a varint codec header

--- a/src/openzl/codecs/lz/encode_lz_binding.c
+++ b/src/openzl/codecs/lz/encode_lz_binding.c
@@ -465,6 +465,22 @@ static int getCompressionLevelGraph(const ZL_Graph* graph)
     }
 }
 
+static ZL_GraphID getGraph(
+        const ZL_Graph* gctx,
+        ZL_GraphIDList customGraphs,
+        int overrideParam,
+        ZL_GraphID defaultGraph)
+{
+    const ZL_IntParam param = ZL_Graph_getLocalIntParam(gctx, overrideParam);
+    if (param.paramId == ZL_LP_INVALID_PARAMID) {
+        return defaultGraph;
+    } else if ((size_t)param.paramValue >= customGraphs.nbGraphIDs) {
+        return ZL_GRAPH_ILLEGAL;
+    } else {
+        return customGraphs.graphids[param.paramValue];
+    }
+}
+
 ZL_Report EI_lzDynGraph(ZL_Graph* gctx, ZL_Edge* inputs[], size_t nbIns)
 {
     ZL_RESULT_DECLARE_SCOPE_REPORT(gctx);
@@ -485,36 +501,54 @@ ZL_Report EI_lzDynGraph(ZL_Graph* gctx, ZL_Edge* inputs[], size_t nbIns)
     ZL_Edge* const literalLengths = streams.edges[2];
     ZL_Edge* const matchLengths   = streams.edges[3];
 
-    const int compressionLevel = getCompressionLevelGraph(gctx);
+    const int compressionLevel        = getCompressionLevelGraph(gctx);
+    const ZL_GraphIDList customGraphs = ZL_Graph_getCustomGraphs(gctx);
 
-    // Send literals to Huffman
-    if (compressionLevel >= 0) {
-        ZL_ERR_IF_ERR(ZL_Edge_setDestination(literals, ZL_GRAPH_HUFFMAN));
-    } else {
-        ZL_ERR_IF_ERR(ZL_Edge_setDestination(literals, ZL_GRAPH_STORE));
-    }
+    const ZL_GraphID huffOrStore =
+            compressionLevel >= 0 ? ZL_GRAPH_HUFFMAN : ZL_GRAPH_STORE;
 
-    // Send offsets to partition bitpack
-    ZL_ERR_IF_ERR(ZL_Edge_setDestination(offsets, ZL_GRAPH_PARTITION_BITPACK));
+    const ZL_GraphID literalsGraph = getGraph(
+            gctx, customGraphs, ZL_LzParam_literalsGraphIdx, huffOrStore);
+    const ZL_GraphID offsetsGraph = getGraph(
+            gctx,
+            customGraphs,
+            ZL_LzParam_offsetsGraphIdx,
+            ZL_GRAPH_PARTITION_BITPACK);
+    const ZL_GraphID muxLengthsGraph = getGraph(
+            gctx,
+            customGraphs,
+            ZL_LzParam_muxLengthsGraphIdx,
+            ZL_GRAPH_ILLEGAL);
 
-    // Run mux_lengths node (auto-computes split point and min match length)
+    ZL_ERR_IF_ERR(ZL_Edge_setDestination(literals, literalsGraph));
+    ZL_ERR_IF_ERR(ZL_Edge_setDestination(offsets, offsetsGraph));
+
     ZL_Edge* muxInputs[2] = { literalLengths, matchLengths };
-    ZL_TRY_LET(
-            ZL_EdgeList,
-            muxStreams,
-            ZL_Edge_runMultiInputNode(muxInputs, 2, ZL_NODE_MUX_LENGTHS));
-    ZL_ASSERT_EQ(muxStreams.nbEdges, 2);
 
-    // Route mux_lengths outputs: muxed bytes and overflow lengths to Huffman
-    if (compressionLevel >= 0) {
-        ZL_ERR_IF_ERR(
-                ZL_Edge_setDestination(muxStreams.edges[0], ZL_GRAPH_HUFFMAN));
+    if (muxLengthsGraph.gid != ZL_GRAPH_ILLEGAL.gid) {
+        ZL_ERR_IF_ERR(ZL_Edge_setParameterizedDestination(
+                muxInputs, 2, muxLengthsGraph, NULL));
     } else {
+        // Run mux_lengths node (auto-computes split point and min match length)
+        ZL_TRY_LET(
+                ZL_EdgeList,
+                muxStreams,
+                ZL_Edge_runMultiInputNode(muxInputs, 2, ZL_NODE_MUX_LENGTHS));
+        ZL_ASSERT_EQ(muxStreams.nbEdges, 2);
+
+        const ZL_GraphID muxedBytesGraph = getGraph(
+                gctx, customGraphs, ZL_LzParam_muxedBytesGraphIdx, huffOrStore);
+        const ZL_GraphID overflowLengthsGraph = getGraph(
+                gctx,
+                customGraphs,
+                ZL_LzParam_overflowLengthsGraphIdx,
+                ZL_GRAPH_COMPRESS_SMALL_LENGTHS);
+
         ZL_ERR_IF_ERR(
-                ZL_Edge_setDestination(muxStreams.edges[0], ZL_GRAPH_STORE));
+                ZL_Edge_setDestination(muxStreams.edges[0], muxedBytesGraph));
+        ZL_ERR_IF_ERR(ZL_Edge_setDestination(
+                muxStreams.edges[1], overflowLengthsGraph));
     }
-    ZL_ERR_IF_ERR(ZL_Edge_setDestination(
-            muxStreams.edges[1], ZL_GRAPH_COMPRESS_SMALL_LENGTHS));
 
     return ZL_returnSuccess();
 }

--- a/src/openzl/codecs/lz/encode_lz_kernel.c
+++ b/src/openzl/codecs/lz/encode_lz_kernel.c
@@ -20,9 +20,15 @@
 #endif
 
 #define ZL_LZ_HASH_LEN 7
+#define ZL_LZ_DEFAULT_TABLE_LOG 14
 
 #define ZL_LZ_MATCH_OVER_LENGTH 16
 #define ZL_LZ_SEARCH_STRENGTH 8
+
+uint32_t ZL_Lz_tableLog(uint32_t windowLog)
+{
+    return ZL_MIN(windowLog + 1, ZL_LZ_DEFAULT_TABLE_LOG);
+}
 
 static ptrdiff_t matchLength(
         uint8_t const* const in,
@@ -74,6 +80,28 @@ size_t ZL_Lz_maxNumSequences(size_t srcSize)
     return srcSize / ZL_LZ_MIN_MATCH + srcSize / ZL_LZ_MAX_LENGTH + 2;
 }
 
+static void
+storeOffset(void* offsets, size_t offsetWidth, size_t seq, ptrdiff_t offset)
+{
+    ZL_ASSERT_GT(offset, 0);
+    if (offsetWidth == sizeof(uint16_t)) {
+        ZL_ASSERT_LE(offset, UINT16_MAX);
+        ((uint16_t*)offsets)[seq] = (uint16_t)offset;
+    } else {
+        ZL_ASSERT_EQ(offsetWidth, sizeof(uint32_t));
+        ZL_ASSERT_LE(offset, UINT32_MAX);
+        ((uint32_t*)offsets)[seq] = (uint32_t)offset;
+    }
+}
+
+static ptrdiff_t getMaxOffset(size_t offsetWidth, uint32_t windowLog)
+{
+    ptrdiff_t maxOffset = offsetWidth == sizeof(uint32_t)
+            ? (ptrdiff_t)ZL_LZ_MAX_OFFSET_U32
+            : (ptrdiff_t)ZL_LZ_MAX_OFFSET_U16;
+    return ZL_MIN(maxOffset, (ptrdiff_t)(1u << windowLog));
+}
+
 /**
  * Match finding algorithm that runs the equivalent of the ZSTD_fast strategy.
  *
@@ -85,6 +113,7 @@ void ZL_Lz_encode(
         const uint8_t* const src,
         size_t srcSize,
         void* hashTableMem,
+        uint32_t windowLog,
         int acceleration)
 {
     if (srcSize == 0) {
@@ -95,9 +124,12 @@ void ZL_Lz_encode(
 
     assert(dst->literalsCapacity >= srcSize + ZL_LZ_LIT_OVER_LENGTH);
     assert(dst->sequencesCapacity >= ZL_Lz_maxNumSequences(srcSize));
+    assert(dst->offsetWidth == sizeof(uint16_t)
+           || dst->offsetWidth == sizeof(uint32_t));
 
-    ZS_FastTable table = { 0, 0, 0 };
-    ZS_FastTable_init(&table, hashTableMem, ZL_LZ_TABLE_LOG, ZL_LZ_HASH_LEN);
+    const uint32_t tableLog = ZL_Lz_tableLog(windowLog);
+    ZS_FastTable table      = { 0, 0, 0 };
+    ZS_FastTable_init(&table, hashTableMem, tableLog, ZL_LZ_HASH_LEN);
 
     const ptrdiff_t kSrcOverLength =
             ZL_MAX(ZL_LZ_LIT_OVER_LENGTH, ZL_LZ_MATCH_OVER_LENGTH);
@@ -112,7 +144,9 @@ void ZL_Lz_encode(
     uint8_t* lits             = dst->literals;
     uint16_t* const litLens   = dst->literalLengths;
     uint16_t* const matchLens = dst->matchLengths;
-    uint16_t* const offsets   = dst->offsets;
+    void* const offsets       = dst->offsets;
+    const size_t offsetWidth  = dst->offsetWidth;
+    const ptrdiff_t maxOffset = getMaxOffset(offsetWidth, windowLog);
 
     size_t seq = 0;
 
@@ -126,8 +160,7 @@ void ZL_Lz_encode(
         ptrdiff_t match            = ZS_FastTable_getAndUpdateT(
                 &table, inPtr, (uint32_t)inPos, ZL_LZ_HASH_LEN);
         const ptrdiff_t distance = inPos - match;
-        if (ZL_read32(in + match) == ZL_read32(inPtr)
-            && distance <= ZL_LZ_MAX_OFFSET) {
+        if (ZL_read32(in + match) == ZL_read32(inPtr) && distance < maxOffset) {
             ptrdiff_t ml = 4 + matchLength(in, inPos + 4, match + 4, inEnd);
 
             // Walk the match backwards
@@ -158,7 +191,7 @@ void ZL_Lz_encode(
                 while (ll > ZL_LZ_MAX_LENGTH) {
                     litLens[seq]   = ZL_LZ_MAX_LENGTH;
                     matchLens[seq] = 0;
-                    offsets[seq]   = 1;
+                    storeOffset(offsets, offsetWidth, seq, 1);
                     ++seq;
                     ll -= ZL_LZ_MAX_LENGTH;
                 }
@@ -166,7 +199,7 @@ void ZL_Lz_encode(
             }
             if (ZL_LIKELY(ml <= ZL_LZ_MAX_LENGTH)) {
                 matchLens[seq] = (uint16_t)ml;
-                offsets[seq]   = (uint16_t)distance;
+                storeOffset(offsets, offsetWidth, seq, distance);
                 ++seq;
             } else {
                 // If the match length is too large, split it into multiple
@@ -178,7 +211,7 @@ void ZL_Lz_encode(
                             ZL_MIN(remainingMatchLength, ZL_LZ_MAX_LENGTH);
                     // litlens[seq] is already set
                     matchLens[seq] = (uint16_t)bounded;
-                    offsets[seq]   = (uint16_t)distance;
+                    storeOffset(offsets, offsetWidth, seq, distance);
                     ++seq;
 
                     remainingMatchLength -= bounded;

--- a/src/openzl/codecs/lz/encode_lz_kernel.h
+++ b/src/openzl/codecs/lz/encode_lz_kernel.h
@@ -6,17 +6,21 @@
 #include <stddef.h>
 #include <stdint.h>
 
+#include "openzl/codecs/partition/common_partition.h"
+
 #define ZL_LZ_LIT_OVER_LENGTH 32
 #define ZL_LZ_MIN_MATCH 4
-#define ZL_LZ_TABLE_LOG 14
-#define ZL_LZ_MAX_OFFSET UINT16_MAX
+// All offsets must be strictly less than this.
+#define ZL_LZ_MAX_OFFSET_U16 (1u << 16)
+#define ZL_LZ_MAX_OFFSET_U32 ZL_PARTITION_MAX_PARTITION_SIZE_FOR_UNROLL2
 
 typedef struct {
     uint8_t* literals;
     size_t literalsCapacity;
     size_t numLiterals;
 
-    uint16_t* offsets;
+    void* offsets;
+    size_t offsetWidth;
     uint16_t* literalLengths;
     uint16_t* matchLengths;
     size_t sequencesCapacity;
@@ -28,6 +32,9 @@ typedef struct {
  * for an input of srcSize bytes.
  */
 size_t ZL_Lz_maxNumSequences(size_t srcSize);
+
+/// @returns The table log for the given window log.
+uint32_t ZL_Lz_tableLog(uint32_t windowLog);
 
 /**
  * Encodes src[0..srcSize) into LZ sequences.
@@ -48,6 +55,7 @@ void ZL_Lz_encode(
         const uint8_t* src,
         size_t srcSize,
         void* hashTableMem,
+        uint32_t windowLog,
         int acceleration);
 
 #endif

--- a/src/openzl/codecs/partition/common_partition.h
+++ b/src/openzl/codecs/partition/common_partition.h
@@ -62,6 +62,10 @@ typedef struct {
 /// The maximum partition size where encode & decode can unroll the loop 4 times
 /// when reading and writing the offset bits.
 #define ZL_PARTITION_MAX_PARTITION_SIZE_FOR_UNROLL4 (1u << 14)
+/// The maximum partition size where encode & decode can unroll the loop 2 times
+/// when reading and writing the offset bits.
+/// 2 * 28 + 7 = 63 bits, which fits in the 63-bit bitstream accumulator.
+#define ZL_PARTITION_MAX_PARTITION_SIZE_FOR_UNROLL2 (1u << 28)
 
 /// Header flag bits for the partition codec header byte.
 /// Bits [1:0]: log2(element width in bytes).
@@ -74,6 +78,13 @@ typedef struct {
 #define ZL_PARTITION_HEADER_UNUSED_BIT 0x10
 /// Bit 5: all partition sizes are powers of 2.
 #define ZL_PARTITION_HEADER_IS_POW2_BIT 0x20
+
+/// Instead of operating on raw values, bucket values by dropping low bits up to
+/// PB_LINEAR_THRESHOLD, then use power-of-two buckets above that.
+#define PB_PRECISION_LOSS 4
+#define PB_LINEAR_THRESHOLD_LOG 16
+#define PB_LINEAR_THRESHOLD (1u << PB_LINEAR_THRESHOLD_LOG)
+#define PB_LINEAR_BUCKETS (PB_LINEAR_THRESHOLD >> PB_PRECISION_LOSS)
 
 /// Parse partition parameters from a codec header buffer.
 /// For presets, @p partitionSizesBuffer is unused and params->partitionSizes

--- a/src/openzl/codecs/partition/decode_partition_bitpack_fusion.c
+++ b/src/openzl/codecs/partition/decode_partition_bitpack_fusion.c
@@ -41,6 +41,26 @@ ZL_UNUSED_ATTR static void expandLUT5(
     }
 }
 
+/// Pack two u32 LUT entries into one u64, indexed by a pair of 4-bit bucket
+/// IDs. This lets the fast loop decode two u32 values with a single PDEP+add.
+static void expandLUT4_u32(const uint32_t* LUTx1, uint64_t LUTx2[256])
+{
+    for (size_t idx = 0; idx < 256; ++idx) {
+        const size_t lo = idx & 0xF;
+        const size_t hi = idx >> 4;
+        LUTx2[idx]      = (uint64_t)LUTx1[lo] | ((uint64_t)LUTx1[hi] << 32);
+    }
+}
+
+static void expandLUT5_u32(const uint32_t* LUTx1, uint64_t LUTx2[1024])
+{
+    for (size_t idx = 0; idx < 1024; ++idx) {
+        const size_t lo = idx & 31;
+        const size_t hi = idx >> 5;
+        LUTx2[idx]      = (uint64_t)LUTx1[lo] | ((uint64_t)LUTx1[hi] << 32);
+    }
+}
+
 // ---------------------------------------------------------------------------
 // computeLimit: safe iteration bound for fast-path loops
 // ---------------------------------------------------------------------------
@@ -121,7 +141,8 @@ static size_t computeLimit(
 // DecodeTail: Decode the tail of the stream with a scalar safe path.
 // ---------------------------------------------------------------------------
 static ZL_Report decodeTail(
-        uint16_t* out,
+        void* out,
+        size_t eltWidth,
         size_t i,
         size_t numElts,
         const uint8_t* fixed,
@@ -146,7 +167,12 @@ static ZL_Report decodeTail(
         ZL_ERR_IF_GE(bucket, numPartitions, corruption, "Bucket ID OOB");
         uint64_t offset = ZS_BitDStreamFF_read(&varBits, bits[bucket]);
         ZS_BitDStreamFF_reload(&varBits);
-        out[i] = (uint16_t)(bases[bucket] + offset);
+        const uint64_t value = bases[bucket] + offset;
+        if (eltWidth == 4) {
+            ((uint32_t*)out)[i] = (uint32_t)value;
+        } else {
+            ((uint16_t*)out)[i] = (uint16_t)value;
+        }
     }
     ZL_ERR_IF_ERR(ZS_BitDStreamFF_finish(&fixedBits));
     ZL_ERR_IF_ERR(ZS_BitDStreamFF_finish(&varBits));
@@ -282,7 +308,7 @@ static ZL_Report decodePartitionBitpack4(
 
                 const uint64_t vData  = ZL_readLE64(v) >> bitsConsumed;
                 const uint64_t offset = ZL_bitDeposit64(vData, mask);
-                ZL_writeLE64(o, base + offset);
+                ZS_write64(o, base + offset);
                 o += 4;
                 bitsConsumed += (size_t)ZL_popcount64(mask);
                 v += bitsConsumed >> 3;
@@ -297,7 +323,7 @@ static ZL_Report decodePartitionBitpack4(
                 f += 2;
                 const uint64_t vData  = ZL_readLE64(v) >> bitsConsumed;
                 const uint64_t offset = ZL_bitDeposit64(vData, mask);
-                ZL_writeLE64(o, base + offset);
+                ZS_write64(o, base + offset);
                 o += 4;
                 bitsConsumed += (size_t)ZL_popcount64(mask);
                 v += bitsConsumed >> 3;
@@ -309,6 +335,7 @@ static ZL_Report decodePartitionBitpack4(
 
     return decodeTail(
             out,
+            sizeof(uint16_t),
             i,
             numElts,
             f,
@@ -491,7 +518,7 @@ static ZL_Report decodePartitionBitpack5(
 
                 const uint64_t vData  = ZL_readLE64(v) >> bitsConsumed;
                 const uint64_t offset = ZL_bitDeposit64(vData, mask);
-                ZL_writeLE64(o, base + offset);
+                ZS_write64(o, base + offset);
                 o += 4;
                 bitsConsumed += (size_t)ZL_popcount64(mask);
                 v += bitsConsumed >> 3;
@@ -514,7 +541,7 @@ static ZL_Report decodePartitionBitpack5(
                             | ((uint64_t)maskLUTx2[fs[k + 1]] << 32);
                     const uint64_t vData  = ZL_readLE64(v) >> bitsConsumed;
                     const uint64_t offset = ZL_bitDeposit64(vData, mask);
-                    ZL_writeLE64(o, base + offset);
+                    ZS_write64(o, base + offset);
                     o += 4;
                     bitsConsumed += (size_t)ZL_popcount64(mask);
                     v += bitsConsumed >> 3;
@@ -527,6 +554,178 @@ static ZL_Report decodePartitionBitpack5(
 
     return decodeTail(
             out,
+            sizeof(uint16_t),
+            i,
+            numElts,
+            f,
+            fEnd,
+            5,
+            v,
+            vEnd,
+            bitsConsumed,
+            bases,
+            bits,
+            numPartitions);
+}
+
+static ZL_Report decodePartitionBitpack4_u32(
+        uint32_t* out,
+        size_t numElts,
+        const uint8_t* fixed,
+        size_t fixedSize,
+        const uint8_t* var,
+        size_t varSize,
+        const uint64_t* bases,
+        const uint8_t* bits,
+        size_t numPartitions,
+        size_t maxVarBits,
+        uint64_t baseLUTx2[256],
+        uint64_t maskLUTx2[256])
+{
+    ZL_RESULT_DECLARE_SCOPE_REPORT(NULL);
+    ZL_ASSERT_LE(numPartitions, 16);
+
+    uint32_t baseLUTx1[16] = { 0 };
+    uint32_t maskLUTx1[16] = { 0 };
+    for (size_t p = 0; p < numPartitions; ++p) {
+        baseLUTx1[p] = (uint32_t)bases[p];
+        maskLUTx1[p] = (uint32_t)((1ULL << bits[p]) - 1);
+    }
+    expandLUT4_u32(baseLUTx1, baseLUTx2);
+    expandLUT4_u32(maskLUTx1, maskLUTx2);
+
+    uint32_t* o                  = out;
+    const uint8_t* f             = fixed;
+    const uint8_t* const fEnd    = fixed + fixedSize;
+    const uint8_t* v             = var;
+    const uint8_t* const vEnd    = var + varSize;
+    const size_t kEltsPerIter    = 8;
+    const size_t kFixedBytesIter = 4; // 8 elts * 4 bits / 8 = 4 bytes
+    size_t i                     = 0;
+    size_t bitsConsumed          = 0;
+
+    for (;;) {
+        const size_t limit = computeLimit(
+                i,
+                numElts,
+                kEltsPerIter,
+                maxVarBits,
+                v,
+                vEnd,
+                f,
+                fEnd,
+                kFixedBytesIter);
+        if (i >= limit) {
+            break;
+        }
+        for (; i < limit; i += kEltsPerIter) {
+            for (size_t u = 0; u < kEltsPerIter; u += 2) {
+                const uint64_t base = baseLUTx2[*f];
+                const uint64_t mask = maskLUTx2[*f];
+                ++f;
+                const uint64_t vData  = ZL_readLE64(v) >> bitsConsumed;
+                const uint64_t offset = ZL_bitDeposit64(vData, mask);
+                ZS_write64(o, base + offset);
+                o += 2;
+                bitsConsumed += (size_t)ZL_popcount64(mask);
+                v += bitsConsumed >> 3;
+                bitsConsumed &= 7;
+            }
+        }
+    }
+
+    return decodeTail(
+            out,
+            sizeof(uint32_t),
+            i,
+            numElts,
+            f,
+            fEnd,
+            4,
+            v,
+            vEnd,
+            bitsConsumed,
+            bases,
+            bits,
+            numPartitions);
+}
+
+static ZL_Report decodePartitionBitpack5_u32(
+        uint32_t* out,
+        size_t numElts,
+        const uint8_t* fixed,
+        size_t fixedSize,
+        const uint8_t* var,
+        size_t varSize,
+        const uint64_t* bases,
+        const uint8_t* bits,
+        size_t numPartitions,
+        size_t maxVarBits,
+        uint64_t baseLUTx2[1024],
+        uint64_t maskLUTx2[1024])
+{
+    ZL_RESULT_DECLARE_SCOPE_REPORT(NULL);
+    ZL_ASSERT_LE(numPartitions, 32);
+
+    uint32_t baseLUTx1[32] = { 0 };
+    uint32_t maskLUTx1[32] = { 0 };
+    for (size_t p = 0; p < numPartitions; ++p) {
+        baseLUTx1[p] = (uint32_t)bases[p];
+        maskLUTx1[p] = (uint32_t)((1ULL << bits[p]) - 1);
+    }
+    expandLUT5_u32(baseLUTx1, baseLUTx2);
+    expandLUT5_u32(maskLUTx1, maskLUTx2);
+
+    uint32_t* o                  = out;
+    const uint8_t* f             = fixed;
+    const uint8_t* const fEnd    = fixed + fixedSize;
+    const uint8_t* v             = var;
+    const uint8_t* const vEnd    = var + varSize;
+    const size_t kEltsPerIter    = 8;
+    const size_t kFixedBytesIter = 5; // 8 elts * 5 bits / 8 = 5 bytes
+    size_t i                     = 0;
+    size_t bitsConsumed          = 0;
+
+    for (;;) {
+        const size_t limit = computeLimit(
+                i,
+                numElts,
+                kEltsPerIter,
+                maxVarBits,
+                v,
+                vEnd,
+                f,
+                fEnd,
+                kFixedBytesIter);
+        if (i >= limit) {
+            break;
+        }
+        for (; i < limit; i += kEltsPerIter) {
+            const uint64_t F     = ZL_readLE64(f);
+            const uint64_t fs[4] = {
+                (F >> 0) & 1023,
+                (F >> 10) & 1023,
+                (F >> 20) & 1023,
+                (F >> 30) & 1023,
+            };
+            f += 5;
+            for (size_t k = 0; k < 4; ++k) {
+                const uint64_t base   = baseLUTx2[fs[k]];
+                const uint64_t mask   = maskLUTx2[fs[k]];
+                const uint64_t vData  = ZL_readLE64(v) >> bitsConsumed;
+                const uint64_t offset = ZL_bitDeposit64(vData, mask);
+                ZS_write64(o, base + offset);
+                o += 2;
+                bitsConsumed += (size_t)ZL_popcount64(mask);
+                v += bitsConsumed >> 3;
+                bitsConsumed &= 7;
+            }
+        }
+    }
+
+    return decodeTail(
+            out,
+            sizeof(uint32_t),
             i,
             numElts,
             f,
@@ -606,11 +805,17 @@ ZL_Report ZL_partitionBitpackFusedDecode(ZL_DecoderFusion* state)
             partHeader.size,
             partitionSizesBuffer));
 
-    // --- Fallback for non-uint16_t output ---
-    if (outEltWidth != 2 || nbBits < 4 || nbBits > 5
-        || params.numPartitions > (1u << nbBits)
-        || ZL_PartitionParams_getLargestPartitionSize(&params)
-                > ZL_PARTITION_MAX_PARTITION_SIZE_FOR_UNROLL4) {
+    const uint64_t largestPartitionSize =
+            ZL_PartitionParams_getLargestPartitionSize(&params);
+    const bool useU16FastPath = outEltWidth == 2 && nbBits >= 4 && nbBits <= 5
+            && params.numPartitions <= (1u << nbBits)
+            && largestPartitionSize
+                    <= ZL_PARTITION_MAX_PARTITION_SIZE_FOR_UNROLL4;
+    const bool useU32FastPath = outEltWidth == 4 && nbBits >= 4 && nbBits <= 5
+            && params.numPartitions <= (1u << nbBits)
+            && largestPartitionSize
+                    <= ZL_PARTITION_MAX_PARTITION_SIZE_FOR_UNROLL2;
+    if (!useU16FastPath && !useU32FastPath) {
         return ZL_partitionBitpackFusedDecode_fallback(state);
     }
 
@@ -627,7 +832,7 @@ ZL_Report ZL_partitionBitpackFusedDecode(ZL_DecoderFusion* state)
     const uint8_t* offsetsData = (const uint8_t*)ZL_Input_ptr(offsetsIn);
     const size_t offsetsSize   = ZL_Input_numElts(offsetsIn);
 
-    // --- Fast path: uint16_t output ---
+    // --- Fast path: uint16_t or uint32_t output ---
     const size_t numPartitions = params.numPartitions;
 
     // Compute uint16_t bases and uint8_t bits
@@ -641,66 +846,117 @@ ZL_Report ZL_partitionBitpackFusedDecode(ZL_DecoderFusion* state)
     ZL_PartitionParams_computeBits(&params, varBits);
 
     const size_t maxVarBits = NUMOP_findMaxU8(varBits, numPartitions);
-    ZL_ASSERT_LE(maxVarBits, 14, "Already validated");
-
-#if ZL_HAS_SSSE3
-    // SSSE3 variants don't use these LUTs
-    uint32_t* baseLUTx2 = NULL;
-    uint32_t* maskLUTx2 = NULL;
-#else
-    // Allocate LUT scratch space (decodePartitionBitpack5 needs 1024 entries,
-    // decodePartitionBitpack4 needs 256)
-    const size_t lutSize = (nbBits == 5) ? 1024 : 256;
-    uint32_t* baseLUTx2  = (uint32_t*)ZL_DecoderFusion_getScratchSpace(
-            state, sizeof(uint32_t) * lutSize);
-    ZL_ERR_IF_NULL(baseLUTx2, allocation);
-    uint32_t* maskLUTx2 = (uint32_t*)ZL_DecoderFusion_getScratchSpace(
-            state, sizeof(uint32_t) * lutSize);
-    ZL_ERR_IF_NULL(maskLUTx2, allocation);
-#endif
 
     // Create output stream
     ZL_Output* const out =
             ZL_DecoderFusion_createTypedStream(state, 0, numElts, outEltWidth);
     ZL_ERR_IF_NULL(out, allocation);
-    uint16_t* outPtr = (uint16_t*)ZL_Output_ptr(out);
 
     // Dispatch to specialized decoder
     ZL_Report ret;
-    switch (nbBits) {
-        case 4:
-            ret = decodePartitionBitpack4(
-                    outPtr,
-                    numElts,
-                    packedData,
-                    packedSize,
-                    offsetsData,
-                    offsetsSize,
-                    basesU64,
-                    varBits,
-                    numPartitions,
-                    maxVarBits,
-                    baseLUTx2,
-                    maskLUTx2);
-            break;
-        case 5:
-            ret = decodePartitionBitpack5(
-                    outPtr,
-                    numElts,
-                    packedData,
-                    packedSize,
-                    offsetsData,
-                    offsetsSize,
-                    basesU64,
-                    varBits,
-                    numPartitions,
-                    maxVarBits,
-                    baseLUTx2,
-                    maskLUTx2);
-            break;
-        default:
-            ZL_ASSERT_FAIL("Unreachable");
-            break;
+    if (useU16FastPath) {
+        ZL_ASSERT_LE(maxVarBits, 14, "Already validated");
+
+#if ZL_HAS_SSSE3
+        // SSSE3 variants don't use these LUTs
+        uint32_t* baseLUTx2 = NULL;
+        uint32_t* maskLUTx2 = NULL;
+#else
+        // Allocate LUT scratch space (decodePartitionBitpack5 needs 1024
+        // entries, decodePartitionBitpack4 needs 256).
+        const size_t lutSize = (nbBits == 5) ? 1024 : 256;
+        uint32_t* baseLUTx2  = (uint32_t*)ZL_DecoderFusion_getScratchSpace(
+                state, sizeof(uint32_t) * lutSize);
+        ZL_ERR_IF_NULL(baseLUTx2, allocation);
+        uint32_t* maskLUTx2 = (uint32_t*)ZL_DecoderFusion_getScratchSpace(
+                state, sizeof(uint32_t) * lutSize);
+        ZL_ERR_IF_NULL(maskLUTx2, allocation);
+#endif
+
+        uint16_t* outPtr = (uint16_t*)ZL_Output_ptr(out);
+        switch (nbBits) {
+            case 4:
+                ret = decodePartitionBitpack4(
+                        outPtr,
+                        numElts,
+                        packedData,
+                        packedSize,
+                        offsetsData,
+                        offsetsSize,
+                        basesU64,
+                        varBits,
+                        numPartitions,
+                        maxVarBits,
+                        baseLUTx2,
+                        maskLUTx2);
+                break;
+            case 5:
+                ret = decodePartitionBitpack5(
+                        outPtr,
+                        numElts,
+                        packedData,
+                        packedSize,
+                        offsetsData,
+                        offsetsSize,
+                        basesU64,
+                        varBits,
+                        numPartitions,
+                        maxVarBits,
+                        baseLUTx2,
+                        maskLUTx2);
+                break;
+            default:
+                ZL_ASSERT_FAIL("Unreachable");
+                break;
+        }
+    } else {
+        ZL_ASSERT(useU32FastPath);
+        ZL_ASSERT_LE(maxVarBits, 28, "Already validated");
+
+        const size_t lutSize   = (nbBits == 5) ? 1024 : 256;
+        uint64_t* baseLUTx2U32 = (uint64_t*)ZL_DecoderFusion_getScratchSpace(
+                state, sizeof(uint64_t) * lutSize);
+        ZL_ERR_IF_NULL(baseLUTx2U32, allocation);
+        uint64_t* maskLUTx2U32 = (uint64_t*)ZL_DecoderFusion_getScratchSpace(
+                state, sizeof(uint64_t) * lutSize);
+        ZL_ERR_IF_NULL(maskLUTx2U32, allocation);
+
+        uint32_t* outPtr = (uint32_t*)ZL_Output_ptr(out);
+        switch (nbBits) {
+            case 4:
+                ret = decodePartitionBitpack4_u32(
+                        outPtr,
+                        numElts,
+                        packedData,
+                        packedSize,
+                        offsetsData,
+                        offsetsSize,
+                        basesU64,
+                        varBits,
+                        numPartitions,
+                        maxVarBits,
+                        baseLUTx2U32,
+                        maskLUTx2U32);
+                break;
+            case 5:
+                ret = decodePartitionBitpack5_u32(
+                        outPtr,
+                        numElts,
+                        packedData,
+                        packedSize,
+                        offsetsData,
+                        offsetsSize,
+                        basesU64,
+                        varBits,
+                        numPartitions,
+                        maxVarBits,
+                        baseLUTx2U32,
+                        maskLUTx2U32);
+                break;
+            default:
+                ZL_ASSERT_FAIL("Unreachable");
+                break;
+        }
     }
     ZL_ERR_IF_ERR(ret);
 

--- a/src/openzl/codecs/partition/decode_partition_kernel.c
+++ b/src/openzl/codecs/partition/decode_partition_kernel.c
@@ -3,6 +3,8 @@
 #include "openzl/codecs/partition/decode_partition_kernel.h"
 
 #include "openzl/codecs/common/bitstream/ff_bitstream.h"
+#include "openzl/shared/bits.h"
+#include "openzl/shared/mem.h"
 #include "openzl/zl_errors.h"
 
 /// The bitstream accumulator holds 63 bits, and after a reload up to 7 bits
@@ -54,7 +56,6 @@ ZL_writeValue(void* dst, size_t index, uint64_t value, size_t eltWidth)
             break;
     }
 }
-
 ZL_Report ZL_partitionDecode(
         void* dst,
         size_t eltWidth,

--- a/src/openzl/codecs/partition/encode_partition_bitpack.c
+++ b/src/openzl/codecs/partition/encode_partition_bitpack.c
@@ -2,10 +2,12 @@
 
 #include "openzl/codecs/partition/encode_partition_bitpack.h"
 
+#include <stdint.h>
 #include <string.h>
 
 #include "openzl/zl_graph_api.h"
 
+#include "openzl/codecs/partition/common_partition.h"
 #include "openzl/codecs/zl_bitpack.h"
 #include "openzl/codecs/zl_partition.h"
 #include "openzl/codecs/zl_store.h"
@@ -18,16 +20,6 @@
 // Constants
 // ---------------------------------------------------------------------------
 
-/// Instead of operating in a 64K histogram, operate on a 64K >>
-/// PB_PRECISION_LOSS histogram. This is imporant for two reasons:
-/// 1. It significantly speeds up the optimization algorithms.
-/// 2. The partition encoding kernel's LUT size reduces by this factor.
-#define PB_PRECISION_LOSS 4
-/// Limiting the maximum partition size speeds up encoding & decoding
-/// significantly because they can guarantee that they can decode 4 values when
-/// reading 64-bits from the bitstream (accounting for the up to 7 bits that
-/// have already been consumed from the previous iteration): 14 * 4 + 7 = 63.
-#define PB_MAX_BUCKET_SIZE (1u << 14)
 /// Add a small fixed cost per partition
 #define PB_OVERHEAD_BITS 24
 /// The maximum possible number of partitions
@@ -39,31 +31,85 @@
 // Helpers
 // ---------------------------------------------------------------------------
 
+/// Number of histogram buckets needed for values of the given bit width.
+/// For u16 (valueBits=16): all buckets are linear, so 2^(16-4) = 4096.
+/// For u32 (valueBits=32): 4096 linear buckets + 16 log-scale buckets = 4112.
+static uint32_t PB_histCapacity(size_t valueBits)
+{
+    if (valueBits <= PB_LINEAR_THRESHOLD_LOG) {
+        return (uint32_t)1 << (valueBits - PB_PRECISION_LOSS);
+    }
+    return PB_LINEAR_BUCKETS + (uint32_t)valueBits - PB_LINEAR_THRESHOLD_LOG;
+}
+
+/// Map a raw value to its histogram bucket index.
+/// Below the threshold: uniform buckets of width 2^PB_PRECISION_LOSS.
+/// Above: one bucket per power-of-two range [2^k, 2^(k+1)).
 static uint32_t PB_idx2bucket(uint32_t idx)
 {
-    return idx >> PB_PRECISION_LOSS;
+    if (idx < PB_LINEAR_THRESHOLD) {
+        return idx >> PB_PRECISION_LOSS;
+    }
+    return PB_LINEAR_BUCKETS + (uint32_t)ZL_highbit32(idx)
+            - PB_LINEAR_THRESHOLD_LOG;
 }
 
-static uint32_t PB_bucket2idx(uint32_t bucket)
+static uint32_t PB_readValue(const void* data, size_t i, size_t eltWidth)
 {
-    return bucket << PB_PRECISION_LOSS;
+    if (eltWidth == 2) {
+        return ((const uint16_t*)data)[i];
+    }
+    ZL_ASSERT_EQ(eltWidth, 4);
+    return ((const uint32_t*)data)[i];
 }
 
-static size_t PB_bucketSize(uint32_t b, uint32_t e)
+/// Build cumulative value-space boundaries for each histogram bucket.
+/// These map bucket indices back to actual values, so the DP optimizer can
+/// compute partition sizes in value-space (not bucket-space). For linear
+/// buckets this is uniform; for log buckets each spans a power-of-two range.
+static void PB_buildCumBases(uint64_t* cumBases, size_t valueBits)
 {
-    return (e - b) << PB_PRECISION_LOSS;
+    const uint32_t histCapacity = PB_histCapacity(valueBits);
+    const uint32_t linearBuckets =
+            ZL_MIN(histCapacity, (uint32_t)PB_LINEAR_BUCKETS);
+    for (size_t i = 0; i <= linearBuckets; ++i) {
+        cumBases[i] = i << PB_PRECISION_LOSS;
+    }
+    for (size_t i = 1; linearBuckets + i <= histCapacity; ++i) {
+        cumBases[linearBuckets + i] = 1ULL << (PB_LINEAR_THRESHOLD_LOG + i);
+    }
+}
+
+static uint64_t PB_bucketSize(const uint64_t* cumBases, uint32_t b, uint32_t e)
+{
+    return cumBases[e] - cumBases[b];
 }
 
 typedef struct {
     /// Size: histSize + 1
     /// Last value is the total count from [0, histSize)
     const uint32_t* cumHist;
+    /// Size: histSize + 1
+    /// Cumulative value-space bucket boundaries.
+    const uint64_t* cumBases;
     uint32_t histSize;
+    uint64_t maxBucketSize;
 } PB_CumHist;
 
 // ---------------------------------------------------------------------------
 // Cost function
 // ---------------------------------------------------------------------------
+
+/// @returns true iff the given partition is legal (i.e. the bucket size is
+/// within the max allowed).
+static bool PB_isLegalPartition(
+        const uint64_t* cumBases,
+        uint64_t maxBucketSize,
+        uint32_t begin,
+        uint32_t end)
+{
+    return begin < end && (cumBases[end] - cumBases[begin]) <= maxBucketSize;
+}
 
 /// Compute total bit cost for a set of partitions over a cumulative histogram.
 /// It consists of the cost of the fixed bitpacked partition IDs, which take
@@ -71,30 +117,32 @@ typedef struct {
 /// each of which takes ceil(log2(partitionSizes[i])) for a value that falls
 /// into partition i.
 ///
-/// @param cumHist Cumulative histogram, size = histSize + 1
-/// @param histSize Number of entries in cumHist - 1
+/// @param cumHist Cumulative histogram
 /// @param partitions Array of partition start indices
 /// @param numPartitions Number of partitions
 /// @param totalPartitions Total partition count for bucket bits calculation
-static uint32_t PB_fixedBucketCost(
-        const uint32_t* cumHist,
-        uint32_t histSize,
+static uint64_t PB_fixedBucketCost(
+        PB_CumHist cumHist,
         const uint32_t* partitions,
         size_t numPartitions,
         size_t totalPartitions)
 {
-    const uint32_t totalCount = cumHist[histSize];
+    const uint32_t totalCount = cumHist.cumHist[cumHist.histSize];
     const uint32_t bucketBits = (uint32_t)ZL_nextPow2(totalPartitions);
-    uint32_t cost             = totalCount * bucketBits;
+    uint64_t cost             = (uint64_t)totalCount * bucketBits;
     for (size_t i = 0; i < numPartitions; ++i) {
         const uint32_t b = partitions[i];
         const uint32_t e =
-                (i + 1 == numPartitions) ? histSize : partitions[i + 1];
+                (i + 1 == numPartitions) ? cumHist.histSize : partitions[i + 1];
         ZL_ASSERT_LT(b, e);
-        ZL_ASSERT_LE(e - b, PB_idx2bucket(PB_MAX_BUCKET_SIZE));
-        const uint32_t count   = cumHist[e] - cumHist[b];
-        const uint32_t offBits = (uint32_t)ZL_nextPow2(PB_bucketSize(b, e));
-        cost += PB_OVERHEAD_BITS + count * offBits;
+        if (!PB_isLegalPartition(
+                    cumHist.cumBases, cumHist.maxBucketSize, b, e)) {
+            return UINT64_MAX;
+        }
+        const uint32_t count = cumHist.cumHist[e] - cumHist.cumHist[b];
+        const uint32_t offBits =
+                (uint32_t)ZL_nextPow2(PB_bucketSize(cumHist.cumBases, b, e));
+        cost += PB_OVERHEAD_BITS + (uint64_t)count * offBits;
     }
     return cost;
 }
@@ -105,21 +153,22 @@ static uint32_t PB_fixedBucketCost(
 
 /// Cost function context for the DP partition algorithm.
 typedef struct {
-    const uint32_t* cumHist;
-    uint32_t histSize;
-    size_t numPartitions; // total target partitions, for bucketBits calc
-    uint32_t fixedCost;   // fixed cost for bucket bits
+    PB_CumHist ch;
+    uint32_t fixedCost; // fixed cost for bucket bits
 } PB_DPCostCtx;
 
 /// Cost of a single bucket spanning [b, e) in the cumulative histogram.
-static uint32_t PB_dpBucketCost(const PB_DPCostCtx* ctx, uint32_t b, uint32_t e)
+static uint64_t PB_dpBucketCost(const PB_DPCostCtx* ctx, uint32_t b, uint32_t e)
 {
     ZL_ASSERT_LT(b, e);
-    ZL_ASSERT_LE(e, ctx->histSize);
-    ZL_ASSERT_LE(e - b, PB_idx2bucket(PB_MAX_BUCKET_SIZE));
-    const uint32_t count    = ctx->cumHist[e] - ctx->cumHist[b];
-    const size_t bucketSize = PB_bucketSize(b, e);
-    return count * (ctx->fixedCost + (unsigned)ZL_nextPow2(bucketSize));
+    ZL_ASSERT_LE(e, ctx->ch.histSize);
+    if (!PB_isLegalPartition(ctx->ch.cumBases, ctx->ch.maxBucketSize, b, e)) {
+        return UINT64_MAX;
+    }
+    const uint32_t count      = ctx->ch.cumHist[e] - ctx->ch.cumHist[b];
+    const uint64_t bucketSize = PB_bucketSize(ctx->ch.cumBases, b, e);
+    return (uint64_t)count
+            * (ctx->fixedCost + (unsigned)ZL_nextPow2(bucketSize));
 }
 
 /// Compute the optimal partitions using dyanmic programming. Limits all but the
@@ -139,24 +188,23 @@ static size_t PB_dpPartition(
         uint32_t* outPartitions,
         ZL_Graph* graph)
 {
-    const uint32_t N  = ctx->histSize;
+    const uint32_t N  = ctx->ch.histSize;
     const uint32_t B  = ZL_MIN((uint32_t)numBuckets, N);
     const uint32_t B1 = B + 1;
     const uint32_t N1 = N + 1;
 
-    const uint32_t maxBucketSize = PB_idx2bucket(PB_MAX_BUCKET_SIZE);
-
     // Allocate DP tables from graph scratch space (arena, no free needed)
-    const size_t tableBytes = (size_t)N1 * B1 * sizeof(uint32_t);
-    uint32_t* opt   = (uint32_t*)ZL_Graph_getScratchSpace(graph, tableBytes);
-    uint32_t* begin = (uint32_t*)ZL_Graph_getScratchSpace(graph, tableBytes);
+    const size_t optBytes   = (size_t)N1 * B1 * sizeof(uint64_t);
+    const size_t beginBytes = (size_t)N1 * B1 * sizeof(uint32_t);
+    uint64_t* opt   = (uint64_t*)ZL_Graph_getScratchSpace(graph, optBytes);
+    uint32_t* begin = (uint32_t*)ZL_Graph_getScratchSpace(graph, beginBytes);
     if (!opt || !begin) {
         return 0;
     }
 
     // Initialize
-    memset(opt, -1, tableBytes);
-    memset(begin, -1, tableBytes);
+    memset(opt, -1, optBytes);
+    memset(begin, -1, beginBytes);
 
     opt[N1 * 0 + 0]   = 0;
     begin[N1 * 0 + 0] = 0;
@@ -164,17 +212,24 @@ static size_t PB_dpPartition(
     for (uint32_t e = 1; e < N1; ++e) {
         const size_t maxPossibleBuckets = ZL_MIN(e, B);
         for (uint32_t k = 1; k <= maxPossibleBuckets; ++k) {
-            const uint32_t maxSz = ZL_MIN(maxBucketSize, e - (k - 1));
+            const uint32_t maxSz = e - (k - 1);
             for (uint32_t size = 1; size <= maxSz;
                  size          = (e == N) ? size + 1 : size * 2) {
-                const uint32_t b        = e - size;
-                const uint32_t prevCost = opt[N1 * (k - 1) + b];
-                if (prevCost == UINT32_MAX) {
+                const uint32_t b = e - size;
+                if (ctx->ch.cumBases[e] - ctx->ch.cumBases[b]
+                    > ctx->ch.maxBucketSize) {
+                    break;
+                }
+                const uint64_t prevCost = opt[N1 * (k - 1) + b];
+                if (prevCost == UINT64_MAX) {
                     continue;
                 }
-                const uint32_t oldCost = opt[N1 * k + e];
-                const uint32_t endCost = PB_dpBucketCost(ctx, b, e);
-                const uint32_t newCost = prevCost + endCost;
+                const uint64_t oldCost = opt[N1 * k + e];
+                const uint64_t endCost = PB_dpBucketCost(ctx, b, e);
+                if (endCost == UINT64_MAX) {
+                    continue;
+                }
+                const uint64_t newCost = prevCost + endCost;
                 if (newCost < oldCost) {
                     opt[N1 * k + e]   = newCost;
                     begin[N1 * k + e] = b;
@@ -201,8 +256,7 @@ static size_t PB_dpPartition(
 // ---------------------------------------------------------------------------
 
 typedef struct {
-    const uint32_t* cumHist;
-    uint32_t histSize;
+    PB_CumHist ch;
     /// number of prefix partitions
     size_t prefixSize;
     uint32_t* partitions; // working array
@@ -214,12 +268,13 @@ typedef struct {
 
 /// @returns The cost of a single partition [b, e) excluding the global
 /// bucketBits term (which is independent of the partition sizes).
-static uint32_t
-PB_singlePartitionCost(const uint32_t* cumHist, uint32_t b, uint32_t e)
+static uint64_t
+PB_singlePartitionCost(const PB_CumHist* ch, uint32_t b, uint32_t e)
 {
-    const uint32_t count   = cumHist[e] - cumHist[b];
-    const uint32_t offBits = (uint32_t)ZL_nextPow2(PB_bucketSize(b, e));
-    return PB_OVERHEAD_BITS + count * offBits;
+    const uint32_t count = ch->cumHist[e] - ch->cumHist[b];
+    const uint32_t offBits =
+            (uint32_t)ZL_nextPow2(PB_bucketSize(ch->cumBases, b, e));
+    return PB_OVERHEAD_BITS + (uint64_t)count * offBits;
 }
 
 /// @returns the end of partition @p i.
@@ -230,12 +285,6 @@ static uint32_t PB_partitionEnd(
         size_t i)
 {
     return (i + 1 == numPartitions) ? histSize : partitions[i + 1];
-}
-
-/// @returns true iff the partition from [begin, end) is legal
-static bool PB_isLegalPartition(uint32_t begin, uint32_t end)
-{
-    return begin < end && (end - begin) <= PB_idx2bucket(PB_MAX_BUCKET_SIZE);
 }
 
 /// Grows partition @p idx by doubling its size, and rounding all following
@@ -313,30 +362,30 @@ static size_t PB_shrinkPartitions(
 /// Compute cost of modified partitions [from, to), where out contains the
 /// modified boundaries and partitions has the original values (used for the
 /// end of partition to-1 if to < n, and partition from's begin is unchanged).
-static uint32_t PB_modifiedRangeCost(
-        const uint32_t* cumHist,
+static uint64_t PB_modifiedRangeCost(
+        const PB_CumHist* ch,
         const uint32_t* partitions,
         const uint32_t* out,
         size_t n,
-        uint32_t histSize,
         size_t from,
         size_t to)
 {
-    uint32_t cost = 0;
+    uint64_t cost = 0;
     for (size_t i = from; i < to; ++i) {
         const uint32_t b = (i == from) ? partitions[i] : out[i];
         uint32_t e;
         if (i + 1 == n) {
-            e = histSize;
+            e = ch->histSize;
         } else if (i + 1 < to) {
             e = out[i + 1];
         } else {
             e = partitions[i + 1];
         }
-        if (e > histSize || !PB_isLegalPartition(b, e)) {
-            return UINT32_MAX;
+        if (e > ch->histSize
+            || !PB_isLegalPartition(ch->cumBases, ch->maxBucketSize, b, e)) {
+            return UINT64_MAX;
         }
-        cost += PB_singlePartitionCost(cumHist, b, e);
+        cost += PB_singlePartitionCost(ch, b, e);
     }
     return cost;
 }
@@ -345,24 +394,18 @@ static uint32_t PB_modifiedRangeCost(
 /// Returns true if the mutation was accepted.
 static bool PB_tryMutation(
         PB_GreedyOpt* opt,
-        uint32_t* partCost,
-        uint32_t* currentCost,
+        uint64_t* partCost,
+        uint64_t* currentCost,
         size_t n,
         size_t idx,
         size_t cascadeEnd)
 {
-    uint32_t newRangeCost = PB_modifiedRangeCost(
-            opt->cumHist,
-            opt->partitions,
-            opt->scratch,
-            n,
-            opt->histSize,
-            idx,
-            cascadeEnd);
-    if (newRangeCost == UINT32_MAX) {
+    uint64_t newRangeCost = PB_modifiedRangeCost(
+            &opt->ch, opt->partitions, opt->scratch, n, idx, cascadeEnd);
+    if (newRangeCost == UINT64_MAX) {
         return false;
     }
-    uint32_t oldRangeCost = 0;
+    uint64_t oldRangeCost = 0;
     for (size_t j = idx; j < cascadeEnd; ++j) {
         oldRangeCost += partCost[j];
     }
@@ -376,8 +419,8 @@ static bool PB_tryMutation(
     for (size_t j = idx; j < cascadeEnd; ++j) {
         const uint32_t b = opt->partitions[j];
         const uint32_t e =
-                PB_partitionEnd(opt->partitions, n, opt->histSize, j);
-        partCost[j] = PB_singlePartitionCost(opt->cumHist, b, e);
+                PB_partitionEnd(opt->partitions, n, opt->ch.histSize, j);
+        partCost[j] = PB_singlePartitionCost(&opt->ch, b, e);
     }
     return true;
 }
@@ -397,23 +440,27 @@ static void PB_iterativeImprovement(PB_GreedyOpt* opt)
         return;
     }
 
-    uint32_t partCost[PB_MAX_PARTITIONS];
-    uint32_t sumCost = 0;
+    uint64_t partCost[PB_MAX_PARTITIONS];
+    uint64_t sumCost = 0;
     for (size_t i = 0; i < n; ++i) {
         const uint32_t b = opt->partitions[i];
         const uint32_t e =
-                PB_partitionEnd(opt->partitions, n, opt->histSize, i);
-        partCost[i] = PB_singlePartitionCost(opt->cumHist, b, e);
+                PB_partitionEnd(opt->partitions, n, opt->ch.histSize, i);
+        if (!PB_isLegalPartition(
+                    opt->ch.cumBases, opt->ch.maxBucketSize, b, e)) {
+            return;
+        }
+        partCost[i] = PB_singlePartitionCost(&opt->ch, b, e);
         sumCost += partCost[i];
     }
 
-    const uint32_t totalCount = opt->cumHist[opt->histSize];
+    const uint32_t totalCount = opt->ch.cumHist[opt->ch.histSize];
     const uint32_t bucketBits = (uint32_t)ZL_nextPow2(opt->targetPartitions);
-    const uint32_t baseCost   = totalCount * bucketBits;
-    uint32_t currentCost      = baseCost + sumCost;
+    const uint64_t baseCost   = (uint64_t)totalCount * bucketBits;
+    uint64_t currentCost      = baseCost + sumCost;
 
     for (;;) {
-        const uint32_t startCost = currentCost;
+        const uint64_t startCost = currentCost;
         for (size_t idx = 0; idx + 1 < n; ++idx) {
             size_t cascadeEnd =
                     PB_growPartitions(opt->partitions, idx, opt->scratch, n);
@@ -440,7 +487,7 @@ PB_dividePartitionAt(const PB_GreedyOpt* opt, uint32_t* out, size_t i)
 {
     const uint32_t begin = opt->partitions[i];
     const uint32_t end   = PB_partitionEnd(
-            opt->partitions, opt->numPartitions, opt->histSize, i);
+            opt->partitions, opt->numPartitions, opt->ch.histSize, i);
     const uint32_t sz      = end - begin;
     const uint32_t newSize = 1u << ((unsigned)ZL_nextPow2(sz) - 1);
 
@@ -456,18 +503,45 @@ PB_dividePartitionAt(const PB_GreedyOpt* opt, uint32_t* out, size_t i)
 
 /// @returns the gain from splitting partition [begin, end) into two where the
 /// first partition is the largest power of two smaller than the current size.
-static int32_t
-PB_splitGain(const uint32_t* cumHist, uint32_t begin, uint32_t end)
+static int64_t PB_splitGain(const PB_CumHist* ch, uint32_t begin, uint32_t end)
 {
     assert(end - begin > 1);
-    assert(PB_isLegalPartition(begin, end));
-    const uint32_t oldCost   = PB_singlePartitionCost(cumHist, begin, end);
+    const uint64_t oldCost   = PB_singlePartitionCost(ch, begin, end);
     const uint32_t sz        = end - begin;
     const uint32_t newSize   = 1u << ((unsigned)ZL_nextPow2(sz) - 1);
     const uint32_t mid       = begin + newSize;
-    const uint32_t leftCost  = PB_singlePartitionCost(cumHist, begin, mid);
-    const uint32_t rightCost = PB_singlePartitionCost(cumHist, mid, end);
-    return (int32_t)oldCost - (int32_t)(leftCost + rightCost);
+    const uint64_t leftCost  = PB_singlePartitionCost(ch, begin, mid);
+    const uint64_t rightCost = PB_singlePartitionCost(ch, mid, end);
+    return (int64_t)oldCost - (int64_t)(leftCost + rightCost);
+}
+
+static int64_t
+PB_partitionSplitGain(const PB_GreedyOpt* opt, uint32_t begin, uint32_t end)
+{
+    if (!PB_isLegalPartition(
+                opt->ch.cumBases, opt->ch.maxBucketSize, begin, end)) {
+        return INT64_MAX;
+    }
+    if (end - begin <= 1) {
+        return INT64_MIN;
+    }
+    return PB_splitGain(&opt->ch, begin, end);
+}
+
+static bool PB_partitionsAreLegal(
+        const uint32_t* partitions,
+        size_t numPartitions,
+        const PB_CumHist* ch)
+{
+    for (size_t i = 0; i < numPartitions; ++i) {
+        const uint32_t b = partitions[i];
+        const uint32_t e =
+                PB_partitionEnd(partitions, numPartitions, ch->histSize, i);
+        if (!PB_isLegalPartition(ch->cumBases, ch->maxBucketSize, b, e)) {
+            return false;
+        }
+    }
+    return true;
 }
 
 /**
@@ -479,30 +553,27 @@ static void PB_dividePartitions(PB_GreedyOpt* opt, size_t targetPartitions)
 {
     // Cache split gains to avoid O(N^2) rescanning.
     // gains[i] = gain from splitting partition i; INT32_MIN = unsplittable.
-    int32_t gains[PB_MAX_PARTITIONS];
+    int64_t gains[PB_MAX_PARTITIONS];
     {
         const size_t n     = opt->numPartitions;
         const size_t start = opt->prefixSize > 0 ? opt->prefixSize - 1 : 0;
         for (size_t i = 0; i < start; ++i) {
-            gains[i] = INT32_MIN;
+            gains[i] = INT64_MIN;
         }
         for (size_t i = start; i < n; ++i) {
             const uint32_t b = opt->partitions[i];
             const uint32_t e =
-                    PB_partitionEnd(opt->partitions, n, opt->histSize, i);
-            gains[i] = (e - b <= 1) ? INT32_MIN
-                    : !PB_isLegalPartition(b, e)
-                    ? INT32_MAX
-                    : PB_splitGain(opt->cumHist, b, e);
+                    PB_partitionEnd(opt->partitions, n, opt->ch.histSize, i);
+            gains[i] = PB_partitionSplitGain(opt, b, e);
         }
     }
 
     while (opt->numPartitions < targetPartitions) {
         const size_t n   = opt->numPartitions;
-        int32_t bestGain = INT32_MIN;
+        int64_t bestGain = INT64_MIN;
         size_t bestIdx   = (size_t)-1;
         for (size_t i = 0; i < n; ++i) {
-            if (gains[i] == INT32_MAX) {
+            if (gains[i] == INT64_MAX) {
                 // Illegal partition - must split immediately
                 bestIdx = i;
                 break;
@@ -513,6 +584,12 @@ static void PB_dividePartitions(PB_GreedyOpt* opt, size_t targetPartitions)
             }
         }
         if (bestIdx == (size_t)-1) {
+            break;
+        }
+        const uint32_t bestBegin = opt->partitions[bestIdx];
+        const uint32_t bestEnd =
+                PB_partitionEnd(opt->partitions, n, opt->ch.histSize, bestIdx);
+        if (bestEnd - bestBegin <= 1) {
             break;
         }
 
@@ -529,11 +606,8 @@ static void PB_dividePartitions(PB_GreedyOpt* opt, size_t targetPartitions)
              ++j) {
             const uint32_t b = opt->partitions[j];
             const uint32_t e = PB_partitionEnd(
-                    opt->partitions, opt->numPartitions, opt->histSize, j);
-            gains[j] = (e - b <= 1) ? INT32_MIN
-                    : !PB_isLegalPartition(b, e)
-                    ? INT32_MAX
-                    : PB_splitGain(opt->cumHist, b, e);
+                    opt->partitions, opt->numPartitions, opt->ch.histSize, j);
+            gains[j] = PB_partitionSplitGain(opt, b, e);
         }
     }
 }
@@ -557,8 +631,7 @@ static size_t PB_greedyOptimize(
     uint32_t scratch[PB_MAX_PARTITIONS + 1];
 
     PB_GreedyOpt opt;
-    opt.cumHist          = cumHist.cumHist;
-    opt.histSize         = cumHist.histSize;
+    opt.ch               = cumHist;
     opt.targetPartitions = targetPartitions;
     opt.partitions       = outPartitions;
     opt.scratch          = scratch;
@@ -584,6 +657,10 @@ static size_t PB_greedyOptimize(
         // Iteratively improve the partition boundries one at a time until we
         // reach a local minima.
         PB_iterativeImprovement(&opt);
+    }
+
+    if (!PB_partitionsAreLegal(opt.partitions, opt.numPartitions, &opt.ch)) {
+        return 0;
     }
 
     return opt.numPartitions;
@@ -615,52 +692,68 @@ static size_t PB_fixedPartitionFastInner(
     }
 
     PB_DPCostCtx ctx;
-    ctx.cumHist       = cumHist.cumHist;
-    ctx.histSize      = cumHist.histSize;
-    ctx.numPartitions = numPartitions;
-    ctx.fixedCost     = (unsigned)ZL_nextPow2(numPartitions);
+    ctx.ch        = cumHist;
+    ctx.fixedCost = (unsigned)ZL_nextPow2(numPartitions);
     return PB_dpPartition(numPartitions, &ctx, outPartitions, graph);
 }
 
 // ---------------------------------------------------------------------------
-// fixedPartitionFast (outer, over raw uint16_t data)
+// fixedPartitionFast (outer, over raw numeric data)
 // ---------------------------------------------------------------------------
 
 typedef struct {
-    uint32_t* partitions;
+    uint64_t* partitions;
     size_t numPartitions;
-    size_t bitCost;
-    uint32_t maxSymbolValue;
+    uint64_t bitCost;
+    uint64_t maxSymbolValue;
 } PB_PartitionResult;
 
 static bool PB_buildCumHist(
         PB_CumHist* out,
-        const uint16_t* data,
+        const void* data,
         size_t numElts,
+        size_t eltWidth,
         bool optimal,
         ZL_Graph* graph)
 {
-    uint32_t histSize    = 1u << (16 - PB_PRECISION_LOSS);
-    uint32_t* const hist = (uint32_t*)ZL_Graph_getScratchSpace(
-            graph, (histSize + 1) * sizeof(uint32_t));
+    const size_t valueBits      = eltWidth * 8;
+    const uint32_t histCapacity = PB_histCapacity(valueBits);
+    uint32_t* const hist        = (uint32_t*)ZL_Graph_getScratchSpace(
+            graph, (histCapacity + 1) * sizeof(uint32_t));
     if (hist == NULL) {
         return false;
     }
+    uint64_t* const cumBases = (uint64_t*)ZL_Graph_getScratchSpace(
+            graph, (histCapacity + 1) * sizeof(uint64_t));
+    if (cumBases == NULL) {
+        return false;
+    }
+    PB_buildCumBases(cumBases, valueBits);
 
     const uint32_t skip = optimal ? 1 : 3;
 
-    memset(hist, 0, histSize * sizeof(uint32_t));
+    uint32_t minBucket = histCapacity - 1;
+    uint32_t maxBucket = 0;
+    memset(hist, 0, histCapacity * sizeof(uint32_t));
     for (size_t i = 0; i < numElts; i += skip) {
-        ++hist[PB_idx2bucket(data[i])];
+        const uint32_t bucket = PB_idx2bucket(PB_readValue(data, i, eltWidth));
+        ++hist[bucket];
     }
 
-    if (skip > 1) {
-        // Since we are skipping data, we don't know the min/max value
-        // So we need to add dummy entries at the beginning and end
-        hist[0] += (hist[0] == 0);
-        hist[histSize - 1] += (hist[histSize - 1] == 0);
+    if (skip > 1 && numElts > 0) {
+        // Since we are skipping data while building the histogram, add dummy
+        // entries at the actual observed range boundaries.
+        for (size_t i = 0; i < numElts; ++i) {
+            const uint32_t bucket =
+                    PB_idx2bucket(PB_readValue(data, i, eltWidth));
+            minBucket = ZL_MIN(minBucket, bucket);
+            maxBucket = ZL_MAX(maxBucket, bucket);
+        }
+        hist[minBucket] += (hist[minBucket] == 0);
+        hist[maxBucket] += (hist[maxBucket] == 0);
     }
 
+    uint32_t histSize = histCapacity;
     while (histSize > 0 && hist[histSize - 1] == 0) {
         --histSize;
     }
@@ -676,31 +769,65 @@ static bool PB_buildCumHist(
     }
     hist[histSize] = sum;
 
-    out->cumHist  = hist;
-    out->histSize = histSize;
+    out->cumHist       = hist;
+    out->cumBases      = cumBases;
+    out->histSize      = histSize;
+    out->maxBucketSize = (eltWidth == 2)
+            ? ZL_PARTITION_MAX_PARTITION_SIZE_FOR_UNROLL4
+            : ZL_PARTITION_MAX_PARTITION_SIZE_FOR_UNROLL2;
 
     return true;
 }
 
-/// Compute optimal partition boundaries for 16-bit data.
+static bool PB_buildCumHistU16(
+        PB_CumHist* out,
+        const void* data,
+        size_t numElts,
+        bool optimal,
+        ZL_Graph* graph)
+{
+    return PB_buildCumHist(
+            out, data, numElts, sizeof(uint16_t), optimal, graph);
+}
+
+static bool PB_buildCumHistU32(
+        PB_CumHist* out,
+        const void* data,
+        size_t numElts,
+        bool optimal,
+        ZL_Graph* graph)
+{
+    return PB_buildCumHist(
+            out, data, numElts, sizeof(uint32_t), optimal, graph);
+}
+
+/// Compute optimal partition boundaries for numeric data.
 /// All allocations use stack or graph scratch space (no malloc/free).
 static PB_PartitionResult PB_fixedPartition(
-        const uint16_t* data,
+        const void* data,
         size_t numElts,
+        size_t eltWidth,
         bool optimal,
         ZL_Graph* graph)
 {
     PB_PartitionResult result = { NULL, 0, 0, 0 };
 
     PB_CumHist cumHist;
-    if (!PB_buildCumHist(&cumHist, data, numElts, optimal, graph)) {
-        return result;
+    if (eltWidth == 2) {
+        if (!PB_buildCumHistU16(&cumHist, data, numElts, optimal, graph)) {
+            return result;
+        }
+    } else {
+        assert(eltWidth == 4);
+        if (!PB_buildCumHistU32(&cumHist, data, numElts, optimal, graph)) {
+            return result;
+        }
     }
 
     // Try 16 and 32 partitions, keep best
     uint32_t bestBuf[PB_MAX_PARTITIONS];
     size_t bestSize   = 0;
-    uint32_t bestCost = UINT32_MAX;
+    uint64_t bestCost = UINT64_MAX;
 
     uint32_t trialBuf[PB_MAX_PARTITIONS];
     const size_t trialCounts[] = { 16, 32 };
@@ -711,8 +838,10 @@ static PB_PartitionResult PB_fixedPartition(
         if (actual == 0) {
             continue;
         }
-        uint32_t cost = PB_fixedBucketCost(
-                cumHist.cumHist, cumHist.histSize, trialBuf, actual, actual);
+        uint64_t cost = PB_fixedBucketCost(cumHist, trialBuf, actual, actual);
+        if (cost == UINT64_MAX) {
+            continue;
+        }
         // Give a small bias towards fewer partitions because it is faster to
         // decode with 16 partitions than 32 partitions.
         if (cost + (cost / 64) < bestCost) {
@@ -729,17 +858,17 @@ static PB_PartitionResult PB_fixedPartition(
     }
 
     // Store partition boundaries in scratch space
-    result.partitions = (uint32_t*)ZL_Graph_getScratchSpace(
-            graph, bestSize * sizeof(uint32_t));
+    result.partitions = (uint64_t*)ZL_Graph_getScratchSpace(
+            graph, bestSize * sizeof(uint64_t));
     if (!result.partitions) {
         return result;
     }
     for (size_t i = 0; i < bestSize; ++i) {
-        result.partitions[i] = PB_bucket2idx(bestBuf[i]);
+        result.partitions[i] = cumHist.cumBases[bestBuf[i]];
     }
     result.numPartitions  = bestSize;
     result.bitCost        = bestCost;
-    result.maxSymbolValue = PB_bucket2idx(cumHist.histSize) - 1;
+    result.maxSymbolValue = cumHist.cumBases[cumHist.histSize] - 1;
 
     return result;
 }
@@ -760,12 +889,12 @@ EI_partitionBitpackDynGraph(ZL_Graph* graph, ZL_Edge** inputs, size_t numInputs)
     ZL_Edge* inputEdge    = inputs[0];
     const ZL_Input* input = ZL_Edge_getData(inputEdge);
     const size_t numElts  = ZL_Input_numElts(input);
+    const size_t eltWidth = ZL_Input_eltWidth(input);
 
-    ZL_ERR_IF_NE(
-            ZL_Input_eltWidth(input),
-            2,
+    ZL_ERR_IF(
+            eltWidth != 2 && eltWidth != 4,
             node_invalid_input,
-            "Currently only 2-byte numeric values are accepted");
+            "Only 2-byte and 4-byte numeric values are accepted");
 
     const ZL_IntParam optimalParam = ZL_Graph_getLocalIntParam(
             graph, ZL_GRAPH_PARTITION_BITPACK_OPTIMAL_PID);
@@ -782,7 +911,7 @@ EI_partitionBitpackDynGraph(ZL_Graph* graph, ZL_Edge** inputs, size_t numInputs)
     // Compute the partitioning that attempts to minimize the size of the
     // bitpacked partition indices + the offsets into the partitions.
     PB_PartitionResult pr = PB_fixedPartition(
-            (const uint16_t*)ZL_Input_ptr(input), numElts, optimal, graph);
+            ZL_Input_ptr(input), numElts, eltWidth, optimal, graph);
     if (pr.partitions == NULL) {
         // Allocation failure — fall back to store
         ZL_ERR_IF_ERR(ZL_Edge_setDestination(inputEdge, ZL_GRAPH_STORE));
@@ -799,8 +928,8 @@ EI_partitionBitpackDynGraph(ZL_Graph* graph, ZL_Edge** inputs, size_t numInputs)
     {
         bool allOne = true;
         for (size_t i = 0; i < pr.numPartitions; ++i) {
-            const uint32_t begin = pr.partitions[i];
-            const uint32_t end   = (i + 1 == pr.numPartitions)
+            const uint64_t begin = pr.partitions[i];
+            const uint64_t end   = (i + 1 == pr.numPartitions)
                       ? (pr.maxSymbolValue + 1)
                       : pr.partitions[i + 1];
             if (begin + 1 != end) {
@@ -816,7 +945,7 @@ EI_partitionBitpackDynGraph(ZL_Graph* graph, ZL_Edge** inputs, size_t numInputs)
 
     // Fallback to store if not enough gain
     const size_t maxByteCost =
-            (sizeof(uint16_t) * (100 - PB_MIN_GAIN_PCT) * numElts) / 100;
+            (eltWidth * (100 - PB_MIN_GAIN_PCT) * numElts) / 100;
     if (pr.bitCost / 8 >= maxByteCost) {
         ZL_ERR_IF_ERR(ZL_Edge_setDestination(inputEdge, ZL_GRAPH_STORE));
         return ZL_returnSuccess();

--- a/src/openzl/codecs/partition/encode_partition_kernel.c
+++ b/src/openzl/codecs/partition/encode_partition_kernel.c
@@ -3,9 +3,12 @@
 #include "openzl/codecs/partition/encode_partition_kernel.h"
 
 #include "openzl/codecs/common/bitstream/ff_bitstream.h"
+#include "openzl/shared/bits.h"
 #include "openzl/shared/numeric_operations.h"
 #include "openzl/shared/utils.h"
 #include "openzl/zl_errors.h"
+
+#define PB_U32_LOG_BUCKETS (32 - PB_LINEAR_THRESHOLD_LOG)
 
 /// Find the bucket for @p value using binary search.
 /// Returns the index i such that partitions[i] <= value, and either
@@ -115,7 +118,7 @@ static ZL_Report ZL_partitionEncode_generic(
     return ret;
 }
 
-static const uint8_t* ZL_PartitionEncodeU16_buildPartitionLUT(
+static const uint8_t* ZL_PartitionEncode_buildPartitionLUT(
         ZL_PartitionParams const* params,
         ZL_PartitionScratchAlloc scratch,
         size_t lutShift,
@@ -145,6 +148,61 @@ static const uint8_t* ZL_PartitionEncodeU16_buildPartitionLUT(
         }
     }
     return partitionLUT;
+}
+
+/// Map a u32 value to its partition index using the hybrid LUT.
+/// Below the linear threshold: direct LUT lookup (same as u16).
+/// At or above: index by floor(log2(value)), which works because partition
+/// boundaries above the threshold are constrained to powers of two.
+static size_t ZL_PartitionEncode_u32Partition(
+        uint32_t value,
+        const uint8_t* partitionLUT,
+        const uint8_t* logPartitions,
+        size_t lutShift)
+{
+    if (value < PB_LINEAR_THRESHOLD) {
+        return partitionLUT[value >> lutShift];
+    }
+    return logPartitions[ZL_highbit32(value) - PB_LINEAR_THRESHOLD_LOG];
+}
+
+/// The hybrid LUT requires partition boundaries above the linear threshold to
+/// be distinct powers of two, so that floor(log2(value)) uniquely identifies
+/// the partition. Within the linear range, any boundary is fine.
+static bool ZL_PartitionEncode_u32BoundarySupported(
+        uint64_t value,
+        uint64_t prevPow2Boundary)
+{
+    if (value <= PB_LINEAR_THRESHOLD) {
+        return true;
+    }
+    return value <= (1ULL << 32) && ZL_isPow2(value)
+            && value > prevPow2Boundary;
+}
+
+static bool ZL_PartitionEncodeU32_canUseHybridLUT(
+        ZL_PartitionParams const* params)
+{
+    uint64_t boundary         = params->startValue;
+    uint64_t prevPow2Boundary = 0;
+    if (!ZL_PartitionEncode_u32BoundarySupported(boundary, prevPow2Boundary)) {
+        return false;
+    }
+    for (size_t i = 0; i < params->numPartitions; ++i) {
+        if (UINT64_MAX - boundary < params->partitionSizes[i]) {
+            return false;
+        }
+        if (boundary > PB_LINEAR_THRESHOLD) {
+            prevPow2Boundary = boundary;
+        }
+        boundary += params->partitionSizes[i];
+        if (i + 1 < params->numPartitions
+            && !ZL_PartitionEncode_u32BoundarySupported(
+                    boundary, prevPow2Boundary)) {
+            return false;
+        }
+    }
+    return boundary <= (1ULL << 32);
 }
 
 /// Expanded LUT for batched encoding: precompute base and mask for each
@@ -222,7 +280,7 @@ static ZL_Report ZL_partitionEncodeU16(
     // Build per-value LUTs for the partition
     const size_t lutShift = ZL_PartitionParams_getNumTrailingZeros(params);
     const size_t lutSize  = 65536 >> lutShift;
-    const uint8_t* const partitionLUT = ZL_PartitionEncodeU16_buildPartitionLUT(
+    const uint8_t* const partitionLUT = ZL_PartitionEncode_buildPartitionLUT(
             params, scratch, lutShift, lutSize);
     ZL_ERR_IF_NULL(partitionLUT, allocation);
 
@@ -286,7 +344,7 @@ static ZL_Report ZL_partitionEncodeU16(
         const size_t bits = LUTx2.bits[p01] + LUTx2.bits[p23];
 
         // Read 4 uint16_t values as one uint64_t
-        const uint64_t data = ZL_readLE64(ip);
+        const uint64_t data = ZL_read64(ip);
 
         // Extract offset bits using PEXT
         uint64_t const packedOffsetBits = ZL_bitExtract64(data - base, mask);
@@ -300,6 +358,152 @@ static ZL_Report ZL_partitionEncodeU16(
     for (; i < srcSize; ++i) {
         uint16_t const value  = src[i];
         const size_t p        = partitionLUT[value >> lutShift];
+        partitions[i]         = (uint8_t)p;
+        uint64_t const offset = value - baseLUTx1[p];
+        size_t const nbits    = bitsLUTx1[p];
+        ZS_BitCStreamFF_write(&off, offset, nbits);
+        ZS_BitCStreamFF_flush(&off);
+    }
+    ZL_TRY_LET(size_t, offSize, ZS_BitCStreamFF_finish(&off));
+    return ZL_returnValue(offSize);
+}
+
+typedef struct {
+    const uint64_t* base;
+    const uint64_t* mask;
+    const uint8_t* bits;
+} ZL_PartitionLUTx2U32;
+
+static bool ZL_PartitionLUTx2U32_build(
+        ZL_PartitionLUTx2U32* LUTx2,
+        const uint64_t* baseLUT,
+        const uint8_t* bitsLUT,
+        size_t partitionBits,
+        ZL_PartitionScratchAlloc scratch)
+{
+    ZL_ASSERT_LE(partitionBits, 8);
+    size_t const sizeX1        = (size_t)1 << partitionBits;
+    size_t const sizeX2        = (size_t)1 << (2 * partitionBits);
+    size_t const partitionMask = sizeX1 - 1;
+
+    uint64_t* base =
+            scratch.alloc(scratch.opaque, sizeX2 * sizeof(*LUTx2->base));
+    uint64_t* mask =
+            scratch.alloc(scratch.opaque, sizeX2 * sizeof(*LUTx2->mask));
+    uint8_t* bits =
+            scratch.alloc(scratch.opaque, sizeX2 * sizeof(*LUTx2->bits));
+
+    if (!base || !mask || !bits) {
+        return false;
+    }
+
+    for (size_t idx = 0; idx < sizeX2; ++idx) {
+        const size_t lo = idx & partitionMask;
+        const size_t hi = idx >> partitionBits;
+
+        base[idx] = (uint64_t)(uint32_t)baseLUT[lo]
+                | ((uint64_t)(uint32_t)baseLUT[hi] << 32);
+        mask[idx] = ((1ULL << bitsLUT[lo]) - 1)
+                | (((1ULL << bitsLUT[hi]) - 1) << 32);
+        bits[idx] = bitsLUT[lo] + bitsLUT[hi];
+    }
+
+    LUTx2->base = base;
+    LUTx2->mask = mask;
+    LUTx2->bits = bits;
+
+    return true;
+}
+
+static ZL_Report ZL_partitionEncodeU32(
+        uint8_t* offPtr,
+        size_t offCapacity,
+        uint8_t* partitions,
+        uint32_t const* src,
+        size_t srcSize,
+        ZL_PartitionParams const* params,
+        ZL_PartitionScratchAlloc scratch)
+{
+    ZL_RESULT_DECLARE_SCOPE_REPORT(NULL);
+
+    uint64_t baseLUTx1[ZL_PARTITION_MAX_PARTITIONS] = { 0 };
+    uint8_t bitsLUTx1[ZL_PARTITION_MAX_PARTITIONS]  = { 0 };
+    ZL_PartitionParams_computeBasesU64(params, baseLUTx1);
+    ZL_PartitionParams_computeBits(params, bitsLUTx1);
+
+    const size_t lutShift = ZL_PartitionParams_getNumTrailingZeros(params);
+    const size_t lutSize  = ZL_MAX((size_t)1, PB_LINEAR_THRESHOLD >> lutShift);
+    const uint8_t* const partitionLUT = ZL_PartitionEncode_buildPartitionLUT(
+            params, scratch, lutShift, lutSize);
+    ZL_ERR_IF_NULL(partitionLUT, allocation);
+
+    const size_t numPartitions = params->numPartitions;
+    const uint64_t minValue    = params->startValue;
+    const uint64_t maxValue    = baseLUTx1[numPartitions - 1]
+            + (params->partitionSizes[numPartitions - 1] - 1);
+    if (minValue > 0 || maxValue < UINT32_MAX) {
+        bool isValid = true;
+        for (size_t i = 0; i < srcSize; ++i) {
+            if (src[i] < minValue || src[i] > maxValue) {
+                isValid = false;
+            }
+        }
+        ZL_ERR_IF_NOT(
+                isValid,
+                node_invalid_input,
+                "Value out of range of partitions");
+    }
+
+    uint8_t logPartitions[PB_U32_LOG_BUCKETS] = { 0 };
+    for (size_t i = 0; i < PB_U32_LOG_BUCKETS; ++i) {
+        const uint64_t value = 1ULL << (PB_LINEAR_THRESHOLD_LOG + i);
+        const size_t partition =
+                ZL_findBucket(value, baseLUTx1, numPartitions, maxValue);
+        logPartitions[i] = partition < numPartitions ? (uint8_t)partition : 0;
+    }
+
+    const size_t bucketBits = (size_t)ZL_nextPow2(numPartitions);
+
+    ZL_PartitionLUTx2U32 LUTx2;
+    ZL_ERR_IF_NOT(
+            ZL_PartitionLUTx2U32_build(
+                    &LUTx2, baseLUTx1, bitsLUTx1, bucketBits, scratch),
+            allocation);
+
+    ZS_BitCStreamFF off = ZS_BitCStreamFF_init(offPtr, offCapacity);
+    size_t i            = 0;
+
+    // Encode 2 u32 values at a time: read them as one u64, subtract the
+    // packed bases, then PEXT extracts both offset fields in one operation.
+    const size_t limit = srcSize < 2 ? 0 : srcSize - 1;
+    for (; i < limit; i += 2) {
+        ZL_ASSERT_LE(i + 2, srcSize);
+        const uint32_t* const ip = src + i;
+
+        const size_t p0 = ZL_PartitionEncode_u32Partition(
+                ip[0], partitionLUT, logPartitions, lutShift);
+        const size_t p1 = ZL_PartitionEncode_u32Partition(
+                ip[1], partitionLUT, logPartitions, lutShift);
+
+        partitions[i + 0] = (uint8_t)p0;
+        partitions[i + 1] = (uint8_t)p1;
+
+        const size_t p01    = p0 | (p1 << bucketBits);
+        const uint64_t base = LUTx2.base[p01];
+        const uint64_t mask = LUTx2.mask[p01];
+        const size_t bits   = LUTx2.bits[p01];
+
+        const uint64_t data             = ZL_read64(ip);
+        uint64_t const packedOffsetBits = ZL_bitExtract64(data - base, mask);
+
+        ZS_BitCStreamFF_write(&off, packedOffsetBits, bits);
+        ZS_BitCStreamFF_flush(&off);
+    }
+
+    for (; i < srcSize; ++i) {
+        uint32_t const value = src[i];
+        const size_t p       = ZL_PartitionEncode_u32Partition(
+                value, partitionLUT, logPartitions, lutShift);
         partitions[i]         = (uint8_t)p;
         uint64_t const offset = value - baseLUTx1[p];
         size_t const nbits    = bitsLUTx1[p];
@@ -332,6 +536,19 @@ ZL_Report ZL_partitionEncode(
                 bitsCapacity,
                 buckets,
                 (uint16_t const*)src,
+                srcSize,
+                params,
+                scratch);
+    }
+    if (eltWidth == 4
+        && ZL_PartitionParams_getLargestPartitionSize(params)
+                <= ZL_PARTITION_MAX_PARTITION_SIZE_FOR_UNROLL2
+        && ZL_PartitionEncodeU32_canUseHybridLUT(params)) {
+        return ZL_partitionEncodeU32(
+                bitsDst,
+                bitsCapacity,
+                buckets,
+                (uint32_t const*)src,
                 srcSize,
                 params,
                 scratch);

--- a/src/openzl/compress/dyngraph_interface.c
+++ b/src/openzl/compress/dyngraph_interface.c
@@ -104,6 +104,12 @@ ZL_RefParam ZL_Graph_getLocalRefParam(const ZL_Graph* gctx, int refParamId)
     return LP_getLocalRefParam(&gctx->dgd->localParams, refParamId);
 }
 
+const ZL_LocalParams* ZL_Graph_getLocalParams(const ZL_Graph* gctx)
+{
+    ZL_ASSERT_NN(gctx);
+    return &gctx->dgd->localParams;
+}
+
 const ZL_LocalParams* GCTX_getAllLocalParams(const ZL_Graph* gctx)
 {
     ZL_ASSERT_NN(gctx);

--- a/src/openzl/compress/gcparams.c
+++ b/src/openzl/compress/gcparams.c
@@ -59,6 +59,22 @@ const GCParamToName GCParams_kAllParams[] = {
     { ZL_CParam_minStreamSize, { (const char*[]){ "minStreamSize" }, 1 } }
 };
 
+static ZL_Report setTernaryParam(ZL_TernaryParam* param, int value)
+{
+    ZL_RESULT_DECLARE_SCOPE_REPORT(NULL);
+    switch (value) {
+        case ZL_TernaryParam_enable:
+        case ZL_TernaryParam_disable:
+        case ZL_TernaryParam_auto:
+            *param = (ZL_TernaryParam)value;
+            return ZL_returnSuccess();
+        default:
+            ZL_ERR(compressionParameter_invalid,
+                   "Ternary param value invalid: %d",
+                   value);
+    }
+}
+
 ZL_Report
 GCParams_setParameter(GCParams* gcparams, ZL_CParam paramId, int value)
 {
@@ -77,19 +93,18 @@ GCParams_setParameter(GCParams* gcparams, ZL_CParam paramId, int value)
             gcparams->decompressionLevel = value;
             break;
         case ZL_CParam_permissiveCompression:
-            // TODO (@Cyan): provide bounds
-            gcparams->permissiveCompression = (ZL_TernaryParam)value;
+            ZL_ERR_IF_ERR(
+                    setTernaryParam(&gcparams->permissiveCompression, value));
             break;
         case ZL_CParam_compressedChecksum:
-            // TODO (@Cyan): provide bounds
-            gcparams->compressedChecksum = (ZL_TernaryParam)value;
+            ZL_ERR_IF_ERR(
+                    setTernaryParam(&gcparams->compressedChecksum, value));
             break;
         case ZL_CParam_contentChecksum:
-            // TODO (@Cyan): provide bounds
-            gcparams->contentChecksum = (ZL_TernaryParam)value;
+            ZL_ERR_IF_ERR(setTernaryParam(&gcparams->contentChecksum, value));
             break;
         case ZL_CParam_storeOnExpansion:
-            gcparams->storeOnExpansion = (ZL_TernaryParam)value;
+            ZL_ERR_IF_ERR(setTernaryParam(&gcparams->storeOnExpansion, value));
             break;
         case ZL_CParam_minStreamSize:
             // TODO (@Cyan): provide bounds

--- a/src/openzl/compress/graphs/small_lengths_graph.c
+++ b/src/openzl/compress/graphs/small_lengths_graph.c
@@ -9,6 +9,7 @@
 #include "openzl/codecs/zl_sentinel.h"
 #include "openzl/codecs/zl_store.h"
 #include "openzl/common/assertion.h"
+#include "openzl/zl_compressor.h"
 
 static const size_t kInputStoreThreshold = 50;
 static const size_t kLargeStoreThreshold = 100;
@@ -20,7 +21,7 @@ ZL_Report ZL_compressSmallLengthsGraph(
 {
     ZL_RESULT_DECLARE_SCOPE_REPORT(graph);
     ZL_ASSERT_EQ(numInputs, 1);
-    ZL_Edge* const edge         = inputs[0];
+    ZL_Edge* edge               = inputs[0];
     const ZL_Input* const input = ZL_Edge_getData(edge);
 
     if (ZL_Input_numElts(input) < kInputStoreThreshold) {
@@ -29,7 +30,11 @@ ZL_Report ZL_compressSmallLengthsGraph(
 
     if (ZL_Input_eltWidth(input) == 1) {
         // 1-byte values go directly to Huffman
-        return ZL_Edge_setDestination(edge, ZL_GRAPH_HUFFMAN);
+        ZL_RuntimeGraphParameters params = {
+            .localParams = ZL_Graph_getLocalParams(graph),
+        };
+        return ZL_Edge_setParameterizedDestination(
+                &edge, 1, ZL_GRAPH_HUFFMAN, &params);
     }
 
     if (!ZL_Graph_isNodeSupported(graph, ZL_NODE_SENTINEL_BYTE)) {
@@ -43,11 +48,15 @@ ZL_Report ZL_compressSmallLengthsGraph(
             ZL_EdgeList, edges, ZL_Edge_runNode(edge, ZL_NODE_SENTINEL_BYTE));
     ZL_ASSERT_EQ(edges.nbEdges, 2);
 
-    ZL_Edge* const smallEdge = edges.edges[0];
-    ZL_Edge* const largeEdge = edges.edges[1];
+    ZL_Edge* smallEdge = edges.edges[0];
+    ZL_Edge* largeEdge = edges.edges[1];
 
     // Small values go to Huffman (they are U8)
-    ZL_ERR_IF_ERR(ZL_Edge_setDestination(smallEdge, ZL_GRAPH_HUFFMAN));
+    ZL_RuntimeGraphParameters params = {
+        .localParams = ZL_Graph_getLocalParams(graph),
+    };
+    ZL_ERR_IF_ERR(ZL_Edge_setParameterizedDestination(
+            &smallEdge, 1, ZL_GRAPH_HUFFMAN, &params));
 
     const ZL_Input* const largeInput = ZL_Edge_getData(largeEdge);
 

--- a/src/openzl/shared/data_stats.c
+++ b/src/openzl/shared/data_stats.c
@@ -289,13 +289,22 @@ size_t DataStatsU8_estimateHuffmanSizeFast(DataStatsU8* stats, bool delta)
 {
     double entropy = delta ? DataStatsU8_getDeltaEntropy(stats)
                            : DataStatsU8_getEntropy(stats);
-    if (entropy > 7) {
-        return stats->srcSize;
-    }
-    entropy = ZL_MAX(
-            entropy,
-            1); // We need at least one bit if we have more than one symbol
-    return (size_t)((entropy * (double)stats->srcSize) / 8);
+    // We need at least one bit if we have more than one symbol
+    entropy = ZL_MAX(entropy, 1);
+
+    const size_t symbolsSize = (size_t)((entropy * (double)stats->srcSize)) / 8;
+
+    // Account for Huffman codec header. Use an upper-bound given that we've
+    // significantly under-estimated the symbolsSize.
+    size_t const headerSize = 9;
+
+    // Estimate the table size as the min of 5-bits per non-zero symbol, or
+    // 4-bits per symbol.
+    const size_t tableBitsC = 5u * DataStatsU8_getCardinality(stats);
+    const size_t tableBitsM = 4u * (DataStatsU8_getMaxElt(stats) + 1u);
+    const size_t tableSize  = (ZL_MIN(tableBitsC, tableBitsM) + 7u) / 8u;
+
+    return headerSize + tableSize + symbolsSize;
 }
 
 static size_t DataStatsU8_estimateBitpackedSize(DataStatsU8* stats)

--- a/src/openzl/shared/data_stats.h
+++ b/src/openzl/shared/data_stats.h
@@ -102,8 +102,12 @@ size_t DataStatsU8_getHuffmanSize(DataStatsU8* stats);
 size_t DataStatsU8_getDeltaHuffmanSize(DataStatsU8* stats);
 
 /* DataStatsU8_estimateHuffmanSizeFast::
- * Uses entropy estimation to estimate size of huffman encoding, this is a rough
- * estimation the doesn't include headers. */
+ * Uses entropy estimation to estimate size of huffman encoding.
+ * Does not calculate the loss from Huffman compared to optimal entropy coding,
+ * but does include the header size.
+ *
+ * NOTE: Consider not using this in new code, it is not a good estimate.
+ */
 size_t DataStatsU8_estimateHuffmanSizeFast(DataStatsU8* stats, bool delta);
 
 /* DataStatsU8_getBitpackedSize::

--- a/tests/compress/test_compress_params.cpp
+++ b/tests/compress/test_compress_params.cpp
@@ -109,6 +109,53 @@ TEST_F(CompressParamsTest, strToParam)
     ASSERT_TRUE(ZL_isError(GCParams_strToParam("")));
 }
 
+TEST_F(CompressParamsTest, setTernaryParam_validValues)
+{
+    const ZL_CParam ternaryParams[] = {
+        ZL_CParam_permissiveCompression,
+        ZL_CParam_compressedChecksum,
+        ZL_CParam_contentChecksum,
+        ZL_CParam_storeOnExpansion,
+    };
+    const int validValues[] = {
+        ZL_TernaryParam_auto,
+        ZL_TernaryParam_enable,
+        ZL_TernaryParam_disable,
+    };
+
+    for (auto param : ternaryParams) {
+        GCParams gcparams = GCParams_default;
+        for (auto value : validValues) {
+            EXPECT_FALSE(
+                    ZL_isError(GCParams_setParameter(&gcparams, param, value)))
+                    << "param=" << GCParams_paramToStr(param)
+                    << " value=" << value;
+            EXPECT_EQ(GCParams_getParameter(&gcparams, param), value);
+        }
+    }
+}
+
+TEST_F(CompressParamsTest, setTernaryParam_invalidValues)
+{
+    const ZL_CParam ternaryParams[] = {
+        ZL_CParam_permissiveCompression,
+        ZL_CParam_compressedChecksum,
+        ZL_CParam_contentChecksum,
+        ZL_CParam_storeOnExpansion,
+    };
+    const int invalidValues[] = { 3, -1, 42 };
+
+    for (auto param : ternaryParams) {
+        for (auto value : invalidValues) {
+            GCParams gcparams = GCParams_default;
+            EXPECT_TRUE(
+                    ZL_isError(GCParams_setParameter(&gcparams, param, value)))
+                    << "param=" << GCParams_paramToStr(param)
+                    << " value=" << value;
+        }
+    }
+}
+
 TEST_F(CompressParamsTest, paramToStr)
 {
     ASSERT_EQ(

--- a/tests/registry/components/Entropy.cpp
+++ b/tests/registry/components/Entropy.cpp
@@ -8,6 +8,43 @@
 
 namespace openzl::tests::components {
 namespace {
+std::vector<OpenZLComponent::Benchmark>
+entropyBenchmarks(Compressor& compressor, datagen::DataGen& gen, GraphID graph)
+{
+    std::vector<OpenZLComponent::Benchmark> benchmarks;
+
+    struct Params {
+        size_t inputSize;
+        size_t numInputs;
+    };
+    // Sizes tuned to provide approximately equal weight to each benchmark in
+    // compression speed.
+    constexpr std::array<Params, 4> kParams = {
+        Params{ 100, 600 },
+        Params{ 1000, 500 },
+        Params{ 10000, 150 },
+        Params{ 100000, 20 },
+    };
+
+    benchmarks.reserve(kParams.size());
+    for (const auto& params : kParams) {
+        std::vector<std::unique_ptr<OpenZLInput>> inputs;
+        inputs.reserve(params.numInputs);
+        datagen::CompressibleStringProducer producer(
+                gen.getRandWrapper(), params.inputSize, 0.1);
+        for (size_t i = 0; i < params.numInputs; ++i) {
+            inputs.push_back(SerialOpenZLInput::make(producer("input")));
+        }
+        OpenZLComponent::Benchmark benchmark = {
+            .name   = "InputSize:" + std::to_string(params.inputSize),
+            .graph  = graph,
+            .inputs = std::move(inputs),
+        };
+        benchmarks.push_back(std::move(benchmark));
+    }
+
+    return benchmarks;
+}
 
 // ---- Fse ----
 
@@ -73,6 +110,13 @@ class FseComponent : public OpenZLComponent {
             inputs.push_back(SerialOpenZLInput::make(producer("input")));
         }
         return inputs;
+    }
+
+    std::vector<Benchmark> benchmarks(
+            Compressor& compressor,
+            datagen::DataGen& gen) const override
+    {
+        return entropyBenchmarks(compressor, gen, ZL_GRAPH_FSE);
     }
 };
 
@@ -155,7 +199,8 @@ class HuffmanComponent : public OpenZLComponent {
                     break;
                 }
                 case 2: {
-                    // Huffman supports u8 (eltWidth 1) and u16 (eltWidth 2)
+                    // Huffman supports u8 (eltWidth 1) and u16
+                    // (eltWidth 2)
                     if (gen.boolean("use_u8")) {
                         auto maxElts = std::min(
                                 maxInputSize / sizeof(uint8_t), size_t(131072));
@@ -173,6 +218,13 @@ class HuffmanComponent : public OpenZLComponent {
             }
         }
         return inputs;
+    }
+
+    std::vector<Benchmark> benchmarks(
+            Compressor& compressor,
+            datagen::DataGen& gen) const override
+    {
+        return entropyBenchmarks(compressor, gen, ZL_GRAPH_HUFFMAN);
     }
 };
 
@@ -264,6 +316,13 @@ class EntropyComponent : public OpenZLComponent {
             }
         }
         return inputs;
+    }
+
+    std::vector<Benchmark> benchmarks(
+            Compressor& compressor,
+            datagen::DataGen& gen) const override
+    {
+        return entropyBenchmarks(compressor, gen, ZL_GRAPH_ENTROPY);
     }
 };
 

--- a/tests/registry/components/Lz.cpp
+++ b/tests/registry/components/Lz.cpp
@@ -68,7 +68,7 @@ class LzComponent : public OpenZLComponent {
             int overrideParam)
     {
         if (gen.u8_range("override_successor", 0, 1) == 1) {
-            params.addIntParam(overrideParam, successors.size());
+            params.addIntParam(overrideParam, (int)successors.size());
             successors.push_back(ZL_GRAPH_STORE);
         }
     }

--- a/tests/registry/components/Lz.cpp
+++ b/tests/registry/components/Lz.cpp
@@ -61,6 +61,18 @@ class LzComponent : public OpenZLComponent {
         }
     }
 
+    static void maybeOverrideSuccessor(
+            LocalParams& params,
+            std::vector<GraphID>& successors,
+            datagen::DataGen& gen,
+            int overrideParam)
+    {
+        if (gen.u8_range("override_successor", 0, 1) == 1) {
+            params.addIntParam(overrideParam, successors.size());
+            successors.push_back(ZL_GRAPH_STORE);
+        }
+    }
+
     std::vector<GraphID> generateGraphs(
             Compressor& compressor,
             datagen::DataGen& gen,
@@ -70,12 +82,30 @@ class LzComponent : public OpenZLComponent {
         graphs.reserve(num);
         for (size_t i = 0; i < num; ++i) {
             LocalParams params;
+            std::vector<GraphID> successors;
             maybeSetParam(params, gen, ZL_LzParam_compressionLevel, -10, 10);
             maybeSetParam(params, gen, ZL_LzParam_acceleration, -10, 100);
             maybeSetParam(params, gen, ZL_LzParam_windowLog, 10, 28);
+
+            maybeOverrideSuccessor(
+                    params, successors, gen, ZL_LzParam_literalsGraphIdx);
+            maybeOverrideSuccessor(
+                    params, successors, gen, ZL_LzParam_offsetsGraphIdx);
+            maybeOverrideSuccessor(
+                    params, successors, gen, ZL_LzParam_muxedBytesGraphIdx);
+            maybeOverrideSuccessor(
+                    params,
+                    successors,
+                    gen,
+                    ZL_LzParam_overflowLengthsGraphIdx);
+            maybeOverrideSuccessor(
+                    params, successors, gen, ZL_LzParam_muxLengthsGraphIdx);
             graphs.push_back(compressor.parameterizeGraph(
                     ZL_GRAPH_LZ,
-                    GraphParameters{ .localParams = std::move(params) }));
+                    GraphParameters{
+                            .customGraphs = std::move(successors),
+                            .localParams  = std::move(params),
+                    }));
         }
         return graphs;
     }

--- a/tests/registry/components/Lz.cpp
+++ b/tests/registry/components/Lz.cpp
@@ -72,6 +72,7 @@ class LzComponent : public OpenZLComponent {
             LocalParams params;
             maybeSetParam(params, gen, ZL_LzParam_compressionLevel, -10, 10);
             maybeSetParam(params, gen, ZL_LzParam_acceleration, -10, 100);
+            maybeSetParam(params, gen, ZL_LzParam_windowLog, 10, 28);
             graphs.push_back(compressor.parameterizeGraph(
                     ZL_GRAPH_LZ,
                     GraphParameters{ .localParams = std::move(params) }));

--- a/tests/registry/components/PartitionBitpack.cpp
+++ b/tests/registry/components/PartitionBitpack.cpp
@@ -12,6 +12,19 @@
 namespace openzl::tests::components {
 namespace {
 
+// Cap u32 test values so most land in the linear histogram region, giving the
+// partition optimizer enough density to find non-trivial partitions.
+constexpr uint64_t kMaxGeneratedU32 = 1u << 23;
+
+template <typename T>
+T maxValue()
+{
+    if constexpr (std::is_same_v<T, uint32_t>) {
+        return kMaxGeneratedU32;
+    }
+    return std::numeric_limits<T>::max();
+}
+
 class PartitionBitpackComponent : public OpenZLComponent {
    public:
     std::string name() const override
@@ -55,7 +68,15 @@ class PartitionBitpackComponent : public OpenZLComponent {
 
         // Custom 8 partitions: 3-bit bucket IDs
         graphs.push_back(
-                nodes::Partition{ 0, { 2, 2, 4, 8, 16, 32, 64, 65408 } }(
+                nodes::Partition{ 0,
+                                  { 2,
+                                    2,
+                                    4,
+                                    8,
+                                    16,
+                                    32,
+                                    64,
+                                    kMaxGeneratedU32 + 1 - 128 } }(
                         compressor, ZL_GRAPH_BITPACK, ZL_GRAPH_STORE));
 
         // QuantizeLengths preset: 44 partitions, 6-bit bucket IDs
@@ -107,28 +128,57 @@ class PartitionBitpackComponent : public OpenZLComponent {
         return inputs;
     }
 
+    template <typename T>
     std::unique_ptr<OpenZLInput> generateLogUniformInput(
             datagen::DataGen& gen,
             size_t inputSize) const
     {
-        datagen::VectorProducer<uint16_t> dist(
-                std::make_unique<datagen::LogUniformDistribution<uint16_t>>(
-                        gen.getRandWrapper()),
+        datagen::VectorProducer<T> dist(
+                std::make_unique<datagen::LogUniformDistribution<T>>(
+                        gen.getRandWrapper(), 1, maxValue<T>()),
                 std::make_unique<datagen::ConstantDistribution<size_t>>(
                         inputSize));
-        return NumericOpenZLInput<uint16_t>::make(dist("vector"));
+        return NumericOpenZLInput<T>::make(dist("vector"));
     }
 
+    template <typename T>
     std::unique_ptr<OpenZLInput> generateUniformInput(
             datagen::DataGen& gen,
             size_t inputSize) const
     {
-        datagen::VectorProducer<uint16_t> dist(
-                std::make_unique<datagen::UniformDistribution<uint16_t>>(
-                        gen.getRandWrapper()),
+        datagen::VectorProducer<T> dist(
+                std::make_unique<datagen::UniformDistribution<T>>(
+                        gen.getRandWrapper(), 1, maxValue<T>()),
                 std::make_unique<datagen::ConstantDistribution<size_t>>(
                         inputSize));
-        return NumericOpenZLInput<uint16_t>::make(dist("vector"));
+        return NumericOpenZLInput<T>::make(dist("vector"));
+    }
+
+    template <typename T>
+    std::unique_ptr<OpenZLInput> generateInput(
+            datagen::DataGen& gen,
+            size_t maxInputSize) const
+    {
+        auto inputSize =
+                gen.usize_range("num_elts", 0, maxInputSize / sizeof(T));
+        if (gen.coin("log_uniform", 0.5)) {
+            return generateLogUniformInput<T>(gen, inputSize);
+        } else {
+            return generateUniformInput<T>(gen, inputSize);
+        }
+    }
+
+    std::unique_ptr<OpenZLInput> generateInput(
+            datagen::DataGen& gen,
+            size_t maxInputSize,
+            size_t eltWidth) const
+    {
+        if (eltWidth == 2) {
+            return generateInput<uint16_t>(gen, maxInputSize);
+        } else {
+            assert(eltWidth == 4);
+            return generateInput<uint32_t>(gen, maxInputSize);
+        }
     }
 
     std::vector<std::unique_ptr<OpenZLInput>> generateInputs(
@@ -141,13 +191,8 @@ class PartitionBitpackComponent : public OpenZLComponent {
         std::vector<std::unique_ptr<OpenZLInput>> inputs;
         inputs.reserve(num);
         for (size_t i = 0; i < num; ++i) {
-            auto numElts = gen.usize_range(
-                    "num_elts", 0, maxInputSize / sizeof(uint16_t));
-            if (gen.coin("log_uniform", 0.5)) {
-                inputs.push_back(generateLogUniformInput(gen, numElts));
-            } else {
-                inputs.push_back(generateUniformInput(gen, numElts));
-            }
+            auto eltWidth = gen.coin("elt_width_4", 0.5) ? 4 : 2;
+            inputs.push_back(generateInput(gen, maxInputSize, eltWidth));
         }
         return inputs;
     }
@@ -159,14 +204,15 @@ class PartitionBitpackComponent : public OpenZLComponent {
         struct BenchmarkParams {
             size_t inputSize;
             size_t numInputs;
+            size_t width;
         };
         // Tuned so that each benchmark takes approximately the same amount
         // of compression time, so each scenario is approximately evenly
         // weighted.
-        std::array<BenchmarkParams, 3> kParams = {
-            BenchmarkParams{ 1000, 20 },
-            BenchmarkParams{ 10000, 20 },
-            BenchmarkParams{ 100000, 10 },
+        std::array<BenchmarkParams, 6> kParams = {
+            BenchmarkParams{ 1000, 20, 2 },   BenchmarkParams{ 10000, 20, 2 },
+            BenchmarkParams{ 100000, 10, 2 }, BenchmarkParams{ 1000, 20, 4 },
+            BenchmarkParams{ 10000, 20, 4 },  BenchmarkParams{ 100000, 10, 4 },
         };
         std::vector<Benchmark> benchmarks;
         benchmarks.reserve(kParams.size());
@@ -174,12 +220,23 @@ class PartitionBitpackComponent : public OpenZLComponent {
             std::vector<std::unique_ptr<OpenZLInput>> inputs;
             inputs.reserve(param.numInputs);
             for (size_t i = 0; i < param.numInputs; ++i) {
-                inputs.push_back(generateLogUniformInput(gen, param.inputSize));
+                if (param.width == 2) {
+                    inputs.push_back(
+                            generateLogUniformInput<uint16_t>(
+                                    gen, param.inputSize));
+                } else {
+                    assert(param.width == 4);
+                    inputs.push_back(
+                            generateLogUniformInput<uint32_t>(
+                                    gen, param.inputSize));
+                }
             }
             benchmarks.push_back(
                     Benchmark{
                             .name = "InputSize:"
-                                    + std::to_string(param.inputSize),
+                                    + std::to_string(param.inputSize)
+                                    + "/EltWidth:"
+                                    + std::to_string(param.width),
                             .graph  = ZL_GRAPH_PARTITION_BITPACK,
                             .inputs = std::move(inputs),
                     });

--- a/tests/unittest/transforms/test_lz_kernel.cpp
+++ b/tests/unittest/transforms/test_lz_kernel.cpp
@@ -1,0 +1,177 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#include <cstdint>
+#include <cstring>
+#include <vector>
+
+#include <gtest/gtest.h>
+
+extern "C" {
+#include "openzl/codecs/lz/decode_lz_kernel.h"
+}
+
+namespace {
+
+ZL_Lz_InSequences makeSequences(
+        const uint8_t* literals,
+        size_t numLiterals,
+        const void* offsets,
+        const void* literalLengths,
+        const void* matchLengths,
+        size_t numSequences,
+        size_t eltWidth)
+{
+    return {
+        .literals               = literals,
+        .numLiterals            = numLiterals,
+        .offsets                = offsets,
+        .offsetsEltWidth        = eltWidth,
+        .literalLengths         = literalLengths,
+        .literalLengthsEltWidth = eltWidth,
+        .matchLengths           = matchLengths,
+        .matchLengthsEltWidth   = eltWidth,
+        .numSequences           = numSequences,
+    };
+}
+
+TEST(LzDecodeTest, BasicValid)
+{
+    // "ABCDBC" encoded as: litLen=4 ("ABCD"), offset=3, matchLen=2 ("BC")
+    uint8_t literals[]   = { 'A', 'B', 'C', 'D' };
+    uint64_t litLens[]   = { 4 };
+    uint64_t offsets[]   = { 3 };
+    uint64_t matchLens[] = { 2 };
+
+    auto src = makeSequences(
+            literals, 4, offsets, litLens, matchLens, 1, sizeof(uint64_t));
+
+    uint8_t dst[6] = {};
+    EXPECT_EQ(ZL_Lz_decode(dst, 6, &src), ZL_LzError_ok);
+    EXPECT_EQ(memcmp(dst, "ABCDBC", 6), 0);
+}
+
+TEST(LzDecodeOverflowTest, NegativeLiteralLength)
+{
+    // 8-byte litLen with high bit set → negative ptrdiff_t.
+    // Passes the notEnoughLiterals check (negative < 0 ≤ numLiterals),
+    // caught by the litLen < 0 check added in the fix.
+    uint64_t litLens[]   = { static_cast<uint64_t>(PTRDIFF_MIN) };
+    uint64_t offsets[]   = { 1 };
+    uint64_t matchLens[] = { 0 };
+
+    auto src = makeSequences(
+            nullptr, 0, offsets, litLens, matchLens, 1, sizeof(uint64_t));
+
+    uint8_t dst[16] = {};
+    EXPECT_EQ(
+            ZL_Lz_decode(dst, sizeof(dst), &src),
+            ZL_LzError_literalLengthTooLarge);
+}
+
+TEST(LzDecodeOverflowTest, NegativeOffset)
+{
+    // 8-byte offset with high bit set → negative ptrdiff_t.
+    // litLen=4 to advance outPos so the offset validity window is non-empty.
+    // Old code only checked offset > outPos (negative < 4 → passes).
+    // New code also checks offset < 0.
+    uint8_t literals[4]  = {};
+    uint64_t litLens[]   = { 4 };
+    uint64_t offsets[]   = { static_cast<uint64_t>(PTRDIFF_MIN) };
+    uint64_t matchLens[] = { 1 };
+
+    auto src = makeSequences(
+            literals, 4, offsets, litLens, matchLens, 1, sizeof(uint64_t));
+
+    uint8_t dst[16] = {};
+    EXPECT_EQ(ZL_Lz_decode(dst, sizeof(dst), &src), ZL_LzError_offsetTooLarge);
+}
+
+TEST(LzDecodeOverflowTest, NegativeMatchLength)
+{
+    // 8-byte matchLen with high bit set → negative ptrdiff_t.
+    // litLen=4 to produce output for a valid offset.
+    // Old code: outPos + matchLen = 4 + PTRDIFF_MIN = wraps, < dstSize →
+    // passes. New code: matchLen < 0 → caught.
+    uint8_t literals[4]  = {};
+    uint64_t litLens[]   = { 4 };
+    uint64_t offsets[]   = { 1 };
+    uint64_t matchLens[] = { static_cast<uint64_t>(PTRDIFF_MIN) };
+
+    auto src = makeSequences(
+            literals, 4, offsets, litLens, matchLens, 1, sizeof(uint64_t));
+
+    uint8_t dst[16] = {};
+    EXPECT_EQ(
+            ZL_Lz_decode(dst, sizeof(dst), &src),
+            ZL_LzError_matchLengthTooLarge);
+}
+
+TEST(LzDecodeOverflowTest, LargeLitLenOverflowsLitPosAddition)
+{
+    // Two sequences: seq 0 advances litPos to 4, seq 1 has litLen =
+    // PTRDIFF_MAX. Old code: litPos + litLen = 4 + PTRDIFF_MAX → signed
+    // overflow (UB),
+    //   wraps negative → negative > numLiterals → false → not caught.
+    // New code: litLen > numLiterals - litPos → PTRDIFF_MAX > 4 → caught.
+    uint8_t literals[8]  = {};
+    uint64_t litLens[]   = { 4, static_cast<uint64_t>(PTRDIFF_MAX) };
+    uint64_t offsets[]   = { 1, 1 };
+    uint64_t matchLens[] = { 1, 0 };
+
+    auto src = makeSequences(
+            literals, 8, offsets, litLens, matchLens, 2, sizeof(uint64_t));
+
+    uint8_t dst[256] = {};
+    EXPECT_EQ(
+            ZL_Lz_decode(dst, sizeof(dst), &src), ZL_LzError_notEnoughLiterals);
+}
+
+TEST(LzDecodeOverflowTest, LargeMatchLenOverflowsOutPosAddition)
+{
+    // litLen=4 advances outPos to 4, then matchLen = PTRDIFF_MAX.
+    // Old code: outPos + matchLen = 4 + PTRDIFF_MAX → signed overflow (UB),
+    //   wraps negative → negative > dstSize → false → not caught.
+    // New code: matchLen > dstSize - outPos → PTRDIFF_MAX > 252 → caught.
+    uint8_t literals[4]  = {};
+    uint64_t litLens[]   = { 4 };
+    uint64_t offsets[]   = { 1 };
+    uint64_t matchLens[] = { static_cast<uint64_t>(PTRDIFF_MAX) };
+
+    auto src = makeSequences(
+            literals, 4, offsets, litLens, matchLens, 1, sizeof(uint64_t));
+
+    uint8_t dst[256] = {};
+    EXPECT_EQ(
+            ZL_Lz_decode(dst, sizeof(dst), &src),
+            ZL_LzError_matchLengthTooLarge);
+}
+
+TEST(LzDecodeOverflowTest, LargeLitLenOverflowsOutPosAddition)
+{
+    // Two sequences: seq 0 advances outPos to 5, seq 1 has litLen that
+    // overflows outPos + litLen. numLiterals = PTRDIFF_MAX so the
+    // notEnoughLiterals check passes (litLen == numLiterals - litPos).
+    // Old code: outPos + litLen = 5 + (PTRDIFF_MAX-4) → signed overflow (UB),
+    //   wraps negative → negative > dstSize → false → not caught.
+    // New code: litLen > dstSize - outPos → (PTRDIFF_MAX-4) > 251 → caught.
+    uint8_t literals[4]  = {};
+    uint64_t litLens[]   = { 4, static_cast<uint64_t>(PTRDIFF_MAX) - 4 };
+    uint64_t offsets[]   = { 1, 1 };
+    uint64_t matchLens[] = { 1, 0 };
+
+    auto src = makeSequences(
+            literals,
+            PTRDIFF_MAX,
+            offsets,
+            litLens,
+            matchLens,
+            2,
+            sizeof(uint64_t));
+
+    uint8_t dst[256] = {};
+    EXPECT_EQ(
+            ZL_Lz_decode(dst, sizeof(dst), &src),
+            ZL_LzError_literalLengthTooLarge);
+}
+
+} // namespace


### PR DESCRIPTION
Summary:

## Huffman Changes
* Add parameters `ZL_ENTROPY_MIN_GAIN_BYTES_PID` (default 32) and `ZL_ENTROPY_MIN_GAIN_PCT_PID` (default 1) to the entropy graph that control the minimum gain in bytes or percent to allow entropy compression.
* Improve Huffman estimation by building the Huffman CTable in the entropy graph to estimate the compressed size exactly, and if Huffman is selected passing the CTable down to the Huffman node.
* Improve estimation of Huffman and FSE header sizes based on empirical evidence.

## LZ Changes
* Use `ZL_ENTROPY_MIN_GAIN_BYTES_PID` to set a more conservative bound on when to use Huffman based on the input size, rather than the size of the Huffman compressed stream.
* Have `ZL_GRAPH_COMPRESS_SMALL_LENGTHS` (which is private) forward its parameters to `ZL_GRAPH_HUFFMAN` so we can control `ZL_ENTROPY_MIN_GAIN_BYTES_PID`.

Reviewed By: Cyan4973

Differential Revision: D102352000
