### PR TITLE
Fix make_canonical_parquet to return 0 on success

### DIFF
--- a/tools/parquet/make_canonical_parquet.cpp
+++ b/tools/parquet/make_canonical_parquet.cpp
@@ -110,5 +110,5 @@ int main(int argc, char** argv)
         write_canonical_parquet_file(outPath.string(), table);
     }
 
-    return 1;
+    return 0;
 }


### PR DESCRIPTION
Summary:
The make_canonical_parquet CLI tool was returning 1 (failure) on successful execution. This is unintuitive for CLI tools, where 0 conventionally indicates success. Changed the return value from 1 to 0.

Fixes https://github.com/facebook/openzl/issues/416

Differential Revision: D102801067


