### PR TITLE
Require auto-sized arrays to be the last statement

### DIFF
--- a/tools/sddl2/compiler/semantic_analyzer/SemanticAnalyzer.cpp
+++ b/tools/sddl2/compiler/semantic_analyzer/SemanticAnalyzer.cpp
@@ -98,10 +98,12 @@ class SemanticAnalyzerImpl {
     // Data members
     const detail::Logger& log_;
     std::unordered_map<std::string, Type> var_types_;
+    bool auto_sized_consumed_ = false;
 
     // Analysis methods
     Type analyzeNode(const ASTPtr& node)
     {
+        checkAutoSizedConsumed(node->loc());
         switch (node->converted_node_type()) {
             case ConvertedNodeType::NUM:
                 return Type{ TypeKind::NUMERIC };
@@ -151,6 +153,8 @@ class SemanticAnalyzerImpl {
         expectFieldType(array.field()->loc(), analyzeNode(array.field()));
         if (array.len()) {
             expectNumeric(array.len()->loc(), analyzeNode(array.len()));
+        } else {
+            auto_sized_consumed_ = true;
         }
         return Type{ TypeKind::ARRAY, &array };
     }
@@ -359,6 +363,14 @@ class SemanticAnalyzerImpl {
             analyzeNode(stmt);
         }
         return Type{ TypeKind::NONE };
+    }
+
+    void checkAutoSizedConsumed(const SourceLocation& loc)
+    {
+        if (auto_sized_consumed_) {
+            throw SemanticError(
+                    loc, "Auto-sized array must be last statement.");
+        }
     }
 };
 

--- a/tools/sddl2/compiler/tests/SemanticAnalyzerTest.cpp
+++ b/tools/sddl2/compiler/tests/SemanticAnalyzerTest.cpp
@@ -371,4 +371,67 @@ TEST_F(SemanticAnalyzerTest, MemberAccessOnNonConditionalField)
     expect_success(prog);
 }
 
+TEST_F(SemanticAnalyzerTest, AutoSizedArrayAsLastExpression)
+{
+    const auto prog = R"(
+        : Int32LE
+        : Int32LE[]
+    )";
+    expect_success(prog);
+}
+
+TEST_F(SemanticAnalyzerTest, AutoSizedConsumeNotLastExpression)
+{
+    const auto prog = R"(
+        : Int32LE[]
+        : Int32LE
+    )";
+    expect_error(prog, "Auto-sized array must be last statement");
+}
+
+TEST_F(SemanticAnalyzerTest, AutoSizedArrayAsLastRecordField)
+{
+    const auto prog = R"(
+        : record() {
+            field: Int32LE,
+            items: Int32LE[]
+        }
+    )";
+    expect_success(prog);
+}
+
+TEST_F(SemanticAnalyzerTest, AutoSizedArrayNotLastRecordField)
+{
+    const auto prog = R"(
+        : record() {
+            items: Int32LE[],
+            field: Int32LE
+        }
+    )";
+    expect_error(prog, "Auto-sized array must be last statement");
+}
+
+TEST_F(SemanticAnalyzerTest, ConsumeAfterRecordWithAutoSizedLastField)
+{
+    const auto prog = R"(
+        record Data() {
+            field: Int32LE,
+            items: Int32LE[]
+        }
+        : Data
+    )";
+    expect_error(prog, "Auto-sized array must be last statement");
+}
+
+TEST_F(SemanticAnalyzerTest, ConsumeAfterWhenBlockWithAutoSizedArray)
+{
+    const auto prog = R"(
+        flag: UInt8
+        when flag == 1 {
+            : Int32LE[]
+        }
+        : Int32LE
+    )";
+    expect_error(prog, "Auto-sized array must be last statement");
+}
 } // namespace openzl::sddl2::tests


### PR DESCRIPTION
Summary:
An auto-sized array (`Type[]` without an explicit length) consumes the remainder of the input, so nothing meaningful can follow it.

This diff adds validation in the semantic analyzer which checks for any statements after auto-sized array consumption.

Differential Revision: D102845798


