### PR TITLE
Fix AFL initialization timeout

### DIFF
--- a/tests/version/defs.bzl
+++ b/tests/version/defs.bzl
@@ -17,6 +17,13 @@ def version_fuzzer(name):
 
         cpp_lionhead_harness(
             name = name,
+            # Set 10 minute initialization timeout because the version fuzzers
+            # do heavy initialization work in the first iteration.
+            default_harness_config = {
+                "environment": {
+                    "AFL_FORKSRV_INIT_TMOUT": "600000",
+                },
+            },
             # Additional versions to run beyond the opt-asan default
             extra_variants = [
                 "dbgo-asan",


### PR DESCRIPTION
Summary:
AFL fuzzers were timing out during initialization so make the initialization timeout 10 minutes.

See https://fb.workplace.com/groups/lionhead/posts/2401447520329090

Differential Revision: D103034722


