### PR TITLE
Set 60 second timeout in our fuzzers

### DIFF
--- a/defs.bzl
+++ b/defs.bzl
@@ -199,6 +199,11 @@ ZS_FUZZ_METADATA = Metadata(
     user_interaction_required = Interaction.ZERO_CLICK,
 )
 
+_DEFAULT_HARNESS_CONFIG = {
+    # Set 1 minute timeout on inputs, rather than the 10 second default
+    "perInputTimeout": 60,
+}
+
 def _zs_src_file_compiler_flags(src):
     flags = []
     if not is_string(src):
@@ -360,6 +365,7 @@ def zs_fuzzers(ftest_names, generator = None, **kwargs):
                     "remote_execution.linux": {},
                     "tw.lionhead": {},
                 },
+                default_harness_config = _DEFAULT_HARNESS_CONFIG,
                 harness_configs = {mode: generator_config for mode in ZS_HARNESS_MODES},
                 harness_default_modes = {
                     "coverage": "fbcode//security/lionhead/mode/opt-cov.v2",
@@ -379,6 +385,7 @@ def zs_fuzzers(ftest_names, generator = None, **kwargs):
             name = name if not generator else name + "_NoGenerator",
             metadata = ZS_FUZZ_METADATA,
             ftest_name = ftest_name,
+            default_harness_config = _DEFAULT_HARNESS_CONFIG,
             harness_configs = {mode: {} for mode in ZS_HARNESS_MODES},
             **kwargs
         )

--- a/tests/version/defs.bzl
+++ b/tests/version/defs.bzl
@@ -17,12 +17,14 @@ def version_fuzzer(name):
 
         cpp_lionhead_harness(
             name = name,
-            # Set 10 minute initialization timeout because the version fuzzers
-            # do heavy initialization work in the first iteration.
             default_harness_config = {
+                # Set 10 minute initialization timeout because the version fuzzers
+                # do heavy initialization work in the first iteration.
                 "environment": {
                     "AFL_FORKSRV_INIT_TMOUT": "600000",
                 },
+                # Set 1 minute timeout on inputs, rather than the 10 second default
+                "perInputTimeout": 60,
             },
             # Additional versions to run beyond the opt-asan default
             extra_variants = [

--- a/tests/version/defs.bzl
+++ b/tests/version/defs.bzl
@@ -17,6 +17,13 @@ def version_fuzzer(name):
 
         cpp_lionhead_harness(
             name = name,
+            # Set 10 minute initialization timeout because the version fuzzers
+            # do heavy initialization work in the first iteration.
+            default_harness_config = {
+                "environment": {
+                    "AFL_FORKSRV_INIT_TMOUT": "600000",
+                },
+            },
             # Additional versions to run beyond the opt-asan default
             extra_variants = [
                 "dbgo-asan",


### PR DESCRIPTION
Summary:
Fuzzers can be relatively slow, especially when running compression round trips on larger inputs. Set a 60 second timeout so that we don't get noise on 10 second timeouts, which is the default.

This is especially problematic because timeouts stop fuzzers from initializing, and when an input times out the fuzzer job has to restart.

Differential Revision: D103053430


