### PR TITLE
print CLI version string based on the library version

### DIFF
--- a/cli/zli.cpp
+++ b/cli/zli.cpp
@@ -51,7 +51,19 @@ int impl(int argc, char** argv)
     auto usage = [&](const Cmd& cmd) -> std::string {
         auto help = cmd == Cmd::UNSPECIFIED ? argParser.help()
                                             : argParser.help(cmd);
-        return "Demo CLI for OpenZL. NO VERSION STABILITY IS IMPLIED!!\n"
+
+        // version string
+        char version[32] = {};
+        snprintf(
+                version,
+                31,
+                "%d.%d.%d",
+                ZL_LIBRARY_VERSION_MAJOR,
+                ZL_LIBRARY_VERSION_MINOR,
+                ZL_LIBRARY_VERSION_PATCH);
+
+        return "Demo CLI for OpenZL. Version " + std::string(version) +
+                "\nNO VERSION STABILITY IS IMPLIED!!\n"
                 "\n"
                 "Usage: " + std::string(argv[0]) + " <command> [options] <args>\n"
                 "\n"


### PR DESCRIPTION
Summary: Prints the version of the library when `zli -h` is called. Since the demo CLI is a dev utility and not a blessed prod CLI, it's ok to share the library version scheme

Differential Revision: D103011640


