### PR TITLE
Fix compressor serialization generator failures

### DIFF
--- a/tests/serialization/fuzz_compressor_serialization_generator.cpp
+++ b/tests/serialization/fuzz_compressor_serialization_generator.cpp
@@ -55,6 +55,9 @@ std::vector<std::string> generateFuzzDeserializeAndCompressSimpleCorpus()
             auto randomSeed = rw->u32("seed");
             auto openzlComponent =
                     makeOpenZLComponent((OpenZLComponentID)componentId);
+            if (!openzlComponent->supportsSerialization()) {
+                continue;
+            }
             openzl::Compressor compressor;
             std::vector<openzl::GraphID> graphs =
                     openzlComponent->predefinedGraphs(compressor);


### PR DESCRIPTION
Summary: Fix the compressor serialization generator failures. This happens because the openzlComponent may not support serialization, and the generator picks the component and tries to serialize a graph that is generated using that component.

Reviewed By: terrelln

Differential Revision: D103065907


