### PR TITLE
sort nodes in visualizer keyboard mode

### DIFF
--- a/tools/visualization_app/src/App.tsx
+++ b/tools/visualization_app/src/App.tsx
@@ -1,20 +1,73 @@
 // Copyright (c) Meta Platforms, Inc. and affiliates.
 
-import {useState, useRef} from 'react';
+import {useState, useRef, useCallback, useEffect} from 'react';
 import './App.css';
 import {extractStreamdumpFromCborFile} from './utils/decodeCbor.ts';
 import {StreamdumpGraph} from './components/StreamdumpGraph.tsx';
 import {Streamdump} from './models/Streamdump.ts';
 import Toolbar from './components/Toolbar.tsx';
-import {Box} from '@chakra-ui/react';
+import {
+  Box,
+  createToaster,
+  ToastCloseTrigger,
+  ToastDescription,
+  Toaster,
+  ToastRoot,
+  ToastTitle,
+} from '@chakra-ui/react';
+
+export const toaster = createToaster({placement: 'bottom-end'});
 
 export default function App() {
   const [cborData, setCborData] = useState<Streamdump | null>(null);
-  // Values required to update input the visualization when uploading a file
+  const [isTrackpadMode, setIsTrackpadMode] = useState(false);
+  const [isKeyboardMode, setIsKeyboardMode] = useState(true);
+  const toggleKeyboardNavRef = useRef<(() => void) | null>(null);
+
   const [fileInputKey, setFileInputKey] = useState<number>(0);
   const fileInputRef = useRef<HTMLInputElement>(null);
 
-  // Invoke to decode and display a new file uploaded
+  const toggleTrackpadMode = useCallback(() => {
+    const next = !isTrackpadMode;
+    setIsTrackpadMode(next);
+    toaster.create({
+      title: next ? 'Trackpad mode enabled' : 'Mouse mode enabled',
+      type: 'info',
+      duration: 1500,
+    });
+  }, [isTrackpadMode]);
+
+  const toggleKeyboardNav = useCallback(() => {
+    toggleKeyboardNavRef.current?.();
+    const next = !isKeyboardMode;
+    setIsKeyboardMode(next);
+    toaster.create({
+      title: next ? 'Keyboard shortcuts activated' : 'Keyboard shortcuts deactivated',
+      description: next ? 'Please see the legend for details.' : '',
+      type: 'info',
+      duration: 1500,
+    });
+  }, [isKeyboardMode]);
+
+  // Global key listeners for T and K shortcuts
+  useEffect(() => {
+    const handleKeyDown = (e: KeyboardEvent) => {
+      switch (e.key.toLowerCase()) {
+        case 't':
+          e.preventDefault();
+          toggleTrackpadMode();
+          break;
+        case 'k':
+          e.preventDefault();
+          toggleKeyboardNav();
+          break;
+      }
+    };
+
+    window.addEventListener('keydown', handleKeyDown);
+    return () => window.removeEventListener('keydown', handleKeyDown);
+  }, [toggleTrackpadMode, toggleKeyboardNav]);
+
   const handleFileChange = async (event: React.ChangeEvent<HTMLInputElement>) => {
     const file = event.target.files?.[0];
     if (!file) {
@@ -40,7 +93,22 @@ export default function App() {
 
   return (
     <div className="wrapper">
-      <Toolbar onUploadCborFile={handleFileButtonClick} />
+      <Toaster toaster={toaster} style={{zIndex: 10000} /*Bring toaster to front*/}>
+        {(toast) => (
+          <ToastRoot minWidth="350px" flexDirection="column" alignItems="left">
+            <ToastTitle>{toast.title as string}</ToastTitle>
+            <ToastDescription>{toast.description as string}</ToastDescription>
+            <ToastCloseTrigger />
+          </ToastRoot>
+        )}
+      </Toaster>
+      <Toolbar
+        onUploadCborFile={handleFileButtonClick}
+        onToggleTrackpadMode={toggleTrackpadMode}
+        onToggleKeyboardNav={toggleKeyboardNav}
+        isTrackpadMode={isTrackpadMode}
+        isKeyboardMode={isKeyboardMode}
+      />
 
       <div className="content">
         {/* Used to input a new file. This <input /> is needed, as a button in the toolbar invoke this input, to open file explorer and load new data once something is uploaded */}
@@ -53,7 +121,12 @@ export default function App() {
         />
 
         <Box h="100%" w="100%" paddingLeft={'5%'} paddingRight={'5%'} paddingTop={4} paddingBottom={4}>
-          <StreamdumpGraph data={cborData} />
+          <StreamdumpGraph
+            data={cborData}
+            isTrackpadMode={isTrackpadMode}
+            toggleKeyboardNavRef={toggleKeyboardNavRef}
+            onKeyboardNavDeactivate={() => setIsKeyboardMode(false)}
+          />
         </Box>
       </div>
     </div>

--- a/tools/visualization_app/src/App.tsx
+++ b/tools/visualization_app/src/App.tsx
@@ -52,6 +52,10 @@ export default function App() {
   // Global key listeners for T and K shortcuts
   useEffect(() => {
     const handleKeyDown = (e: KeyboardEvent) => {
+      const target = e.target as HTMLElement;
+      if (target.tagName === 'INPUT' || target.tagName === 'TEXTAREA' || target.tagName === 'SELECT' || target.isContentEditable) {
+        return;
+      }
       switch (e.key.toLowerCase()) {
         case 't':
           e.preventDefault();
@@ -124,8 +128,8 @@ export default function App() {
           <StreamdumpGraph
             data={cborData}
             isTrackpadMode={isTrackpadMode}
+            isKeyboardMode={isKeyboardMode}
             toggleKeyboardNavRef={toggleKeyboardNavRef}
-            onKeyboardNavDeactivate={() => setIsKeyboardMode(false)}
           />
         </Box>
       </div>

--- a/tools/visualization_app/src/components/Legend.tsx
+++ b/tools/visualization_app/src/components/Legend.tsx
@@ -122,13 +122,13 @@ function DrawerBody() {
                   <Table.Cell>
                     <Kbd>Tab</Kbd>
                   </Table.Cell>
-                  <Table.Cell>Navigate to siblings with next largest stream share</Table.Cell>
+                  <Table.Cell>Navigate to siblings with next smallest stream share</Table.Cell>
                 </Table.Row>
                 <Table.Row>
                   <Table.Cell>
                     <Kbd>Tab</Kbd>+<Kbd>Shift</Kbd>
                   </Table.Cell>
-                  <Table.Cell>Navigate to siblings with next smallest stream share</Table.Cell>
+                  <Table.Cell>Navigate to siblings with next largest stream share</Table.Cell>
                 </Table.Row>
               </Table.Body>
             </Table.Root>

--- a/tools/visualization_app/src/components/Legend.tsx
+++ b/tools/visualization_app/src/components/Legend.tsx
@@ -1,7 +1,7 @@
 // Copyright (c) Meta Platforms, Inc. and affiliates.
 
 import {VscChevronDown, VscEye, VscEyeClosed, VscFoldDown, VscFoldUp, VscQuestion} from 'react-icons/vsc';
-import {Box, CloseButton, Drawer, Portal, HStack, VStack, IconButton} from '@chakra-ui/react';
+import {Box, CloseButton, Drawer, Portal, HStack, VStack, IconButton, Table, Kbd} from '@chakra-ui/react';
 import {CiCircleMore} from '../icons/TablerIcons';
 import '../styles/legend.css';
 import '../styles/toolbar.css';
@@ -77,6 +77,63 @@ function DrawerBody() {
             </div>
           </div>
         </Box>
+        <Box className="legend-info-box">
+          <h4 className="info-box-title">Keyboard Shortcuts</h4>
+          <div className="info-box-content">
+            <Table.Root size="sm" variant="outline">
+              <Table.Header>
+                <Table.Row>
+                  <Table.ColumnHeader>Shortcut</Table.ColumnHeader>
+                  <Table.ColumnHeader>Action</Table.ColumnHeader>
+                </Table.Row>
+              </Table.Header>
+              <Table.Body>
+                <Table.Row>
+                  <Table.Cell>
+                    <Kbd>K</Kbd>
+                  </Table.Cell>
+                  <Table.Cell>Toggle keyboard shortcuts</Table.Cell>
+                </Table.Row>
+                <Table.Row>
+                  <Table.Cell>
+                    <Kbd>T</Kbd>
+                  </Table.Cell>
+                  <Table.Cell>Toggle trackpad mode</Table.Cell>
+                </Table.Row>
+                <Table.Row>
+                  <Table.Cell>
+                    <Kbd>↑</Kbd> <Kbd>↓</Kbd>
+                  </Table.Cell>
+                  <Table.Cell>Navigate along path</Table.Cell>
+                </Table.Row>
+                <Table.Row>
+                  <Table.Cell>
+                    <Kbd>←</Kbd> <Kbd>→</Kbd>
+                  </Table.Cell>
+                  <Table.Cell>Cycle siblings</Table.Cell>
+                </Table.Row>
+                <Table.Row>
+                  <Table.Cell>
+                    <Kbd>Ctrl</Kbd>+Click
+                  </Table.Cell>
+                  <Table.Cell>Jump to node</Table.Cell>
+                </Table.Row>
+                <Table.Row>
+                  <Table.Cell>
+                    <Kbd>Tab</Kbd>
+                  </Table.Cell>
+                  <Table.Cell>Navigate to siblings with next largest stream share</Table.Cell>
+                </Table.Row>
+                <Table.Row>
+                  <Table.Cell>
+                    <Kbd>Tab</Kbd>+<Kbd>Shift</Kbd>
+                  </Table.Cell>
+                  <Table.Cell>Navigate to siblings with next smallest stream share</Table.Cell>
+                </Table.Row>
+              </Table.Body>
+            </Table.Root>
+          </div>
+        </Box>
       </VStack>
     </div>
   );
@@ -84,7 +141,7 @@ function DrawerBody() {
 
 export function Legend() {
   return (
-    <Drawer.Root>
+    <Drawer.Root size="md">
       <Drawer.Trigger asChild>
         <IconButton className="toolbar-button">
           <VscQuestion />

--- a/tools/visualization_app/src/components/Legend.tsx
+++ b/tools/visualization_app/src/components/Legend.tsx
@@ -83,7 +83,7 @@ function DrawerBody() {
             <Table.Root size="sm" variant="outline">
               <Table.Header>
                 <Table.Row>
-                  <Table.ColumnHeader>Shortcut</Table.ColumnHeader>
+                  <Table.ColumnHeader minW="125px">Shortcut</Table.ColumnHeader>
                   <Table.ColumnHeader>Action</Table.ColumnHeader>
                 </Table.Row>
               </Table.Header>
@@ -117,6 +117,18 @@ function DrawerBody() {
                     <Kbd>Ctrl</Kbd>+Click
                   </Table.Cell>
                   <Table.Cell>Jump to node</Table.Cell>
+                </Table.Row>
+                <Table.Row>
+                  <Table.Cell>
+                    <Kbd>Enter</Kbd>
+                  </Table.Cell>
+                  <Table.Cell>Expand a codec/graph</Table.Cell>
+                </Table.Row>
+                <Table.Row>
+                  <Table.Cell>
+                    <Kbd>Enter</Kbd>+<Kbd>Shift</Kbd>
+                  </Table.Cell>
+                  <Table.Cell>Collapse a codec/graph</Table.Cell>
                 </Table.Row>
                 <Table.Row>
                   <Table.Cell>

--- a/tools/visualization_app/src/components/Settings.tsx
+++ b/tools/visualization_app/src/components/Settings.tsx
@@ -1,0 +1,103 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+import {VscGear} from 'react-icons/vsc';
+import {
+  Box,
+  CloseButton,
+  Drawer,
+  Portal,
+  VStack,
+  HStack,
+  Spacer,
+  IconButton,
+  SegmentGroup,
+  Kbd,
+  Switch,
+} from '@chakra-ui/react';
+
+function DrawerBody({
+  onToggleTrackpadMode,
+  onToggleKeyboardNav,
+  isTrackpadMode,
+  isKeyboardMode,
+}: {
+  onToggleTrackpadMode: () => void;
+  onToggleKeyboardNav: () => void;
+  isTrackpadMode: boolean;
+  isKeyboardMode: boolean;
+}) {
+  return (
+    <div className="settings-content">
+      <VStack align="stretch" gap={4}>
+        <Box className="legend-info-box">
+          <h4 className="info-box-title">Controls</h4>
+          <HStack>
+            <SegmentGroup.Root
+              value={isTrackpadMode ? 'Trackpad' : 'Mouse'}
+              onValueChange={() => onToggleTrackpadMode()}>
+              <SegmentGroup.Indicator />
+              <SegmentGroup.Items items={['Mouse', 'Trackpad']} />
+            </SegmentGroup.Root>
+            <Spacer />
+            <Kbd marginRight={2}>T</Kbd>
+          </HStack>
+        </Box>
+        <Box className="legend-info-box">
+          <h4 className="info-box-title">Navigation</h4>
+          <HStack>
+            <Switch.Root checked={isKeyboardMode} defaultChecked onCheckedChange={() => onToggleKeyboardNav()}>
+              <Switch.HiddenInput />
+              <Switch.Control />
+              <Switch.Label>Toggle keyboard shortcuts</Switch.Label>
+            </Switch.Root>
+            <Spacer />
+            <Kbd marginRight={2}>K</Kbd>
+          </HStack>
+        </Box>
+      </VStack>
+    </div>
+  );
+}
+
+export function SettingsPanel({
+  onToggleTrackpadMode,
+  onToggleKeyboardNav,
+  isTrackpadMode,
+  isKeyboardMode,
+}: {
+  onToggleTrackpadMode: () => void;
+  onToggleKeyboardNav: () => void;
+  isTrackpadMode: boolean;
+  isKeyboardMode: boolean;
+}) {
+  return (
+    <Drawer.Root size="md">
+      <Drawer.Trigger asChild>
+        <IconButton className="toolbar-button" aria-label="Settings">
+          <VscGear />
+        </IconButton>
+      </Drawer.Trigger>
+      <Portal>
+        <Drawer.Backdrop />
+        <Drawer.Positioner>
+          <Drawer.Content className="drawer">
+            <Drawer.Header>
+              <Drawer.Title className="drawer">Settings</Drawer.Title>
+            </Drawer.Header>
+            <Drawer.Body>
+              <DrawerBody
+                onToggleTrackpadMode={onToggleTrackpadMode}
+                onToggleKeyboardNav={onToggleKeyboardNav}
+                isTrackpadMode={isTrackpadMode}
+                isKeyboardMode={isKeyboardMode}
+              />
+            </Drawer.Body>
+            <Drawer.CloseTrigger asChild>
+              <CloseButton size="sm" />
+            </Drawer.CloseTrigger>
+          </Drawer.Content>
+        </Drawer.Positioner>
+      </Portal>
+    </Drawer.Root>
+  );
+}

--- a/tools/visualization_app/src/components/StreamdumpGraph.tsx
+++ b/tools/visualization_app/src/components/StreamdumpGraph.tsx
@@ -8,6 +8,12 @@ import {StreamdumpGraphView} from '../graphVisualization/views/StreamdumpGraphVi
 import {ReactFlowProvider} from '@xyflow/react';
 import {Box, Code, CodeBlock, Float, IconButton, Text, Tabs, useTabs, Heading, Span} from '@chakra-ui/react';
 
+interface StreamdumpGraphProps extends NullableStreamdump {
+  isTrackpadMode: boolean;
+  toggleKeyboardNavRef?: React.RefObject<(() => void) | null>;
+  onKeyboardNavDeactivate?: () => void;
+}
+
 const cliInvocation = 'zli compress --trace /tmp/streamdump.cbor -p serial -o /dev/null myfile.txt';
 const cliDecompressInvocation = 'zli decompress --trace /tmp/decompress_trace.cbor -o myfile.txt myfile.txt.zl';
 const files = [
@@ -172,7 +178,7 @@ function NoDataHelper() {
 }
 
 // Create a new component to use the hooks inside the provider
-function StreamdumpGraphContent({data}: NullableStreamdump) {
+function StreamdumpGraphContent({data, isTrackpadMode}: StreamdumpGraphProps) {
   const {nodes, edges, onNodesChange, onEdgesChange, handleAllStandardGraphsCollapse, areStandardGraphsCollapsed} =
     useStreamdumpGraphController({data});
 
@@ -196,15 +202,25 @@ function StreamdumpGraphContent({data}: NullableStreamdump) {
       handleAllStandardGraphsCollapse={handleAllStandardGraphsCollapse}
       areStandardGraphsCollapsed={areStandardGraphsCollapsed}
       versionInfo={versionInfo}
+      isTrackpadMode={isTrackpadMode}
     />
   );
 }
 
-export function StreamdumpGraph({data}: NullableStreamdump) {
-  // Wrap everything in ReactFlowProvider
+export function StreamdumpGraph({
+  data,
+  isTrackpadMode,
+  toggleKeyboardNavRef,
+  onKeyboardNavDeactivate,
+}: StreamdumpGraphProps) {
   return (
     <ReactFlowProvider>
-      <StreamdumpGraphContent data={data} />
+      <StreamdumpGraphContent
+        data={data}
+        isTrackpadMode={isTrackpadMode}
+        toggleKeyboardNavRef={toggleKeyboardNavRef}
+        onKeyboardNavDeactivate={onKeyboardNavDeactivate}
+      />
     </ReactFlowProvider>
   );
 }

--- a/tools/visualization_app/src/components/StreamdumpGraph.tsx
+++ b/tools/visualization_app/src/components/StreamdumpGraph.tsx
@@ -1,6 +1,7 @@
 // Copyright (c) Meta Platforms, Inc. and affiliates.
 
 import '@xyflow/react/dist/style.css';
+import {useEffect, useRef} from 'react';
 import type {NullableStreamdump} from '../interfaces/NullableStreamdump';
 import '../styles/streamdumpGraph.css';
 import {useStreamdumpGraphController} from '../graphVisualization/controllers/StreamdumpGraphController';
@@ -10,8 +11,8 @@ import {Box, Code, CodeBlock, Float, IconButton, Text, Tabs, useTabs, Heading, S
 
 interface StreamdumpGraphProps extends NullableStreamdump {
   isTrackpadMode: boolean;
-  toggleKeyboardNavRef?: React.RefObject<(() => void) | null>;
-  onKeyboardNavDeactivate?: () => void;
+  isKeyboardMode: boolean;
+  toggleKeyboardNavRef: React.RefObject<(() => void) | null>;
 }
 
 const cliInvocation = 'zli compress --trace /tmp/streamdump.cbor -p serial -o /dev/null myfile.txt';
@@ -178,9 +179,46 @@ function NoDataHelper() {
 }
 
 // Create a new component to use the hooks inside the provider
-function StreamdumpGraphContent({data, isTrackpadMode}: StreamdumpGraphProps) {
-  const {nodes, edges, onNodesChange, onEdgesChange, handleAllStandardGraphsCollapse, areStandardGraphsCollapsed} =
-    useStreamdumpGraphController({data});
+function StreamdumpGraphContent({data, isTrackpadMode, isKeyboardMode, toggleKeyboardNavRef}: StreamdumpGraphProps) {
+  const {
+    nodes,
+    edges,
+    onNodesChange,
+    onEdgesChange,
+    handleAllStandardGraphsCollapse,
+    areStandardGraphsCollapsed,
+    keyboardNav,
+  } = useStreamdumpGraphController({data});
+
+  // Update keyboard nav toggle ref
+  useEffect(() => {
+    if (toggleKeyboardNavRef) {
+      toggleKeyboardNavRef.current = () => {
+        if (isKeyboardMode) {
+          keyboardNav.deactivate();
+        } else {
+          keyboardNav.activate();
+        }
+      };
+    }
+    return () => {
+      if (toggleKeyboardNavRef) {
+        toggleKeyboardNavRef.current = null;
+      }
+    };
+  }, [isKeyboardMode, keyboardNav, toggleKeyboardNavRef]);
+
+  // Auto-activate keyboard nav when data changes (new file loaded) and keyboard mode is on
+  const activatedForDataRef = useRef<unknown>(null);
+  useEffect(() => {
+    if (data && isKeyboardMode && activatedForDataRef.current !== data) {
+      const timer = setTimeout(() => {
+        keyboardNav.activate();
+        activatedForDataRef.current = data;
+      }, 300);
+      return () => clearTimeout(timer);
+    }
+  }, [data, isKeyboardMode, keyboardNav]);
 
   if (!data) {
     return <NoDataHelper />;
@@ -203,23 +241,20 @@ function StreamdumpGraphContent({data, isTrackpadMode}: StreamdumpGraphProps) {
       areStandardGraphsCollapsed={areStandardGraphsCollapsed}
       versionInfo={versionInfo}
       isTrackpadMode={isTrackpadMode}
+      isKeyboardMode={isKeyboardMode}
+      keyboardNav={keyboardNav}
     />
   );
 }
 
-export function StreamdumpGraph({
-  data,
-  isTrackpadMode,
-  toggleKeyboardNavRef,
-  onKeyboardNavDeactivate,
-}: StreamdumpGraphProps) {
+export function StreamdumpGraph({data, isTrackpadMode, isKeyboardMode, toggleKeyboardNavRef}: StreamdumpGraphProps) {
   return (
     <ReactFlowProvider>
       <StreamdumpGraphContent
         data={data}
         isTrackpadMode={isTrackpadMode}
+        isKeyboardMode={isKeyboardMode}
         toggleKeyboardNavRef={toggleKeyboardNavRef}
-        onKeyboardNavDeactivate={onKeyboardNavDeactivate}
       />
     </ReactFlowProvider>
   );

--- a/tools/visualization_app/src/components/Toolbar.tsx
+++ b/tools/visualization_app/src/components/Toolbar.tsx
@@ -2,11 +2,16 @@
 
 import '../styles/toolbar.css';
 import {Legend} from './Legend';
+import {SettingsPanel} from './Settings';
 import logoUrl from '/OpenZL_logo.png?url';
 import {Box, Flex, HStack, VStack, Heading} from '@chakra-ui/react';
 
 interface ToolbarProps {
   onUploadCborFile: () => void;
+  onToggleTrackpadMode: () => void;
+  onToggleKeyboardNav: () => void;
+  isTrackpadMode: boolean;
+  isKeyboardMode: boolean;
 }
 
 interface Props {
@@ -50,7 +55,15 @@ const Toolbar: React.FC<ToolbarProps> = (props: ToolbarProps) => {
               Trace Visualization
             </Heading>
           </HStack>
-          <Legend />
+          <HStack gap={0} className="toolbar-icons">
+            <SettingsPanel
+              onToggleTrackpadMode={props.onToggleTrackpadMode}
+              onToggleKeyboardNav={props.onToggleKeyboardNav}
+              isTrackpadMode={props.isTrackpadMode}
+              isKeyboardMode={props.isKeyboardMode}
+            />
+            <Legend />
+          </HStack>
         </Flex>
         <Flex h={10} alignItems={'center'} justifyContent={'space-between'}>
           <HStack as={'nav'} gap={4} display={{base: 'none', md: 'flex'}}>

--- a/tools/visualization_app/src/graphVisualization/controllers/LayoutController.ts
+++ b/tools/visualization_app/src/graphVisualization/controllers/LayoutController.ts
@@ -6,7 +6,7 @@ import {InternalCodecNode} from '../models/InternalCodecNode';
 import {InternalGraphNode} from '../models/InternalGraphNode';
 import {InternalEdge} from '../models/InternalEdge';
 import type {InternalNode} from '../models/InternalNode';
-import {NodeType} from '../models/types';
+import {NodeType, type RF_nodeId} from '../models/types';
 
 // Values useful for dagre laying out the graph.
 // IMPORTANT: These values are not the final values used for sizing of nodes, this happens from the css definitions
@@ -190,4 +190,27 @@ export function applyLayout(
   const positionedNodes = calculateLayout(reactFlowNodes, reactFlowEdges, direction);
 
   return {nodes: positionedNodes, edges: reactFlowEdges};
+}
+
+export function sortNavlinksByPosition(positionedNodes: Node[], changedNodes?: InternalNode[]): void {
+  const xPositions = new Map<string, number>();
+  for (const node of positionedNodes) {
+    xPositions.set(node.id, node.position.x);
+  }
+
+  const sortByX = (a: RF_nodeId, b: RF_nodeId) => (xPositions.get(a) ?? 0) - (xPositions.get(b) ?? 0);
+
+  if (changedNodes) {
+    for (const internal of changedNodes) {
+      internal.children.sort(sortByX);
+      internal.parents.sort(sortByX);
+    }
+  } else {
+    for (const node of positionedNodes) {
+      if (node.type !== NodeType.Codec && node.type !== NodeType.Graph && node.type !== NodeType.Segmenter) continue;
+      const internal = node.data.internalNode as InternalNode;
+      internal.children.sort(sortByX);
+      internal.parents.sort(sortByX);
+    }
+  }
 }

--- a/tools/visualization_app/src/graphVisualization/controllers/StreamdumpGraphController.ts
+++ b/tools/visualization_app/src/graphVisualization/controllers/StreamdumpGraphController.ts
@@ -5,7 +5,7 @@ import {useNodesState, useEdgesState, useReactFlow} from '@xyflow/react';
 import type {Node, Edge} from '@xyflow/react';
 import {InteractiveStreamdumpGraph} from '../models/InteractiveStreamdumpGraph';
 import {useKeyboardNavigation} from './useKeyboardShortcuts';
-import {applyLayout} from './LayoutController';
+import {applyLayout, sortNavlinksByPosition} from './LayoutController';
 import type {NullableStreamdump} from '../../interfaces/NullableStreamdump';
 import {InternalCodecNode} from '../models/InternalCodecNode';
 import {InternalGraphNode} from '../models/InternalGraphNode';
@@ -33,6 +33,7 @@ export function useStreamdumpGraphController({data}: NullableStreamdump) {
         const {dagOrderedNodes: visibleNodes, edges: visibleEdges} =
           interactiveStreamdumpGraph.getVisibleStreamdumpGraph();
         const {nodes: updatedNodes, edges: updatedEdges} = applyLayout(visibleNodes, visibleEdges);
+        sortNavlinksByPosition(updatedNodes);
         setNodes(updatedNodes);
         setEdges(updatedEdges);
         const maybeSegmenterNode = updatedNodes.find((n) => n.type === NodeType.Segmenter);
@@ -92,10 +93,11 @@ export function useStreamdumpGraphController({data}: NullableStreamdump) {
   const handleNodeCollapse = useCallback(
     (node: InternalCodecNode) => {
       if (interactiveStreamdumpGraph) {
-        const newlyVisibleNodes = interactiveStreamdumpGraph.toggleSubgraphCollapse(node);
+        const {newlyVisibleNodes, rebuiltNavlinkNodes} = interactiveStreamdumpGraph.toggleSubgraphCollapse(node);
         const {dagOrderedNodes: visibleNodes, edges: visibleEdges} =
           interactiveStreamdumpGraph.getVisibleStreamdumpGraph();
         const {nodes: updatedNodes, edges: updatedEdges} = applyLayout(visibleNodes, visibleEdges);
+        sortNavlinksByPosition(updatedNodes, rebuiltNavlinkNodes);
         setNodes(updatedNodes);
         setEdges(updatedEdges);
 
@@ -146,10 +148,11 @@ export function useStreamdumpGraphController({data}: NullableStreamdump) {
   const handleGraphCollapse = useCallback(
     (graph: InternalGraphNode) => {
       if (interactiveStreamdumpGraph) {
-        const newlyVisibleNodes = interactiveStreamdumpGraph.toggleGraphCollapse(graph);
+        const {newlyVisibleNodes, rebuiltNavlinkNodes} = interactiveStreamdumpGraph.toggleGraphCollapse(graph);
         const {dagOrderedNodes: visibleNodes, edges: visibleEdges} =
           interactiveStreamdumpGraph.getVisibleStreamdumpGraph();
         const {nodes: updatedNodes, edges: updatedEdges} = applyLayout(visibleNodes, visibleEdges);
+        sortNavlinksByPosition(updatedNodes, rebuiltNavlinkNodes);
         setNodes(updatedNodes);
         setEdges(updatedEdges);
 
@@ -212,6 +215,7 @@ export function useStreamdumpGraphController({data}: NullableStreamdump) {
       const {dagOrderedNodes: visibleNodes, edges: visibleEdges} =
         interactiveStreamdumpGraph.getVisibleStreamdumpGraph();
       const {nodes: updatedNodes, edges: updatedEdges} = applyLayout(visibleNodes, visibleEdges);
+      sortNavlinksByPosition(updatedNodes);
       setNodes(updatedNodes);
       setEdges(updatedEdges);
       toggleStandardGraphsCollapsedFlag(!areStandardGraphsCollapsed);
@@ -231,10 +235,11 @@ export function useStreamdumpGraphController({data}: NullableStreamdump) {
   const handleNodeExpandOneLevel = useCallback(
     (node: InternalCodecNode) => {
       if (interactiveStreamdumpGraph) {
-        const newlyVisibleNodes = interactiveStreamdumpGraph.expandOneLevel(node);
+        const {newlyVisibleNodes, rebuiltNavlinkNodes} = interactiveStreamdumpGraph.expandOneLevel(node);
         const {dagOrderedNodes: visibleNodes, edges: visibleEdges} =
           interactiveStreamdumpGraph.getVisibleStreamdumpGraph();
         const {nodes: updatedNodes, edges: updatedEdges} = applyLayout(visibleNodes, visibleEdges);
+        sortNavlinksByPosition(updatedNodes, rebuiltNavlinkNodes);
         setNodes(updatedNodes);
         setEdges(updatedEdges);
 
@@ -296,6 +301,7 @@ export function useStreamdumpGraphController({data}: NullableStreamdump) {
       const {dagOrderedNodes: visibleNodes, edges: visibleEdges} =
         newInteractiveStreamdumpGraph.getVisibleStreamdumpGraph();
       const {nodes: laidOutNodes, edges: laidOutEdges} = applyLayout(visibleNodes, visibleEdges);
+      sortNavlinksByPosition(laidOutNodes);
       setNodes(laidOutNodes);
       setEdges(laidOutEdges);
       toggleStandardGraphsCollapsedFlag(!areStandardGraphsCollapsed);

--- a/tools/visualization_app/src/graphVisualization/controllers/StreamdumpGraphController.ts
+++ b/tools/visualization_app/src/graphVisualization/controllers/StreamdumpGraphController.ts
@@ -4,6 +4,7 @@ import {useCallback, useState, useEffect, useMemo} from 'react';
 import {useNodesState, useEdgesState, useReactFlow} from '@xyflow/react';
 import type {Node, Edge} from '@xyflow/react';
 import {InteractiveStreamdumpGraph} from '../models/InteractiveStreamdumpGraph';
+import {useKeyboardNavigation} from './useKeyboardShortcuts';
 import {applyLayout} from './LayoutController';
 import type {NullableStreamdump} from '../../interfaces/NullableStreamdump';
 import {InternalCodecNode} from '../models/InternalCodecNode';
@@ -28,6 +29,7 @@ export function useStreamdumpGraphController({data}: NullableStreamdump) {
     (chunkNum: number) => {
       if (interactiveStreamdumpGraph) {
         interactiveStreamdumpGraph.setVisibleChunk(chunkNum);
+        interactiveStreamdumpGraph.buildAllNavlinks();
         const {dagOrderedNodes: visibleNodes, edges: visibleEdges} =
           interactiveStreamdumpGraph.getVisibleStreamdumpGraph();
         const {nodes: updatedNodes, edges: updatedEdges} = applyLayout(visibleNodes, visibleEdges);
@@ -37,10 +39,10 @@ export function useStreamdumpGraphController({data}: NullableStreamdump) {
         if (!maybeSegmenterNode) {
           return;
         }
-        if (!(maybeSegmenterNode instanceof InternalSegmenterNode)) {
+        const segmenterInternalNode = maybeSegmenterNode.data?.internalNode as InternalSegmenterNode | undefined;
+        if (!segmenterInternalNode) {
           return;
         }
-        const segmenterNode = maybeSegmenterNode as InternalSegmenterNode;
         const newlyVisibleNodes = visibleNodes.map((n) => n.rfid as RF_nodeId);
 
         // Focus on newly visible nodes after a short delay to allow DOM to update
@@ -52,18 +54,20 @@ export function useStreamdumpGraphController({data}: NullableStreamdump) {
               reactFlowInstance.fitView({
                 padding: 0.2,
                 includeHiddenNodes: false,
-                duration: 1600, // Longer animation to show the entire subgraph smoothly
+                duration: 1600,
+                maxZoom: 0.75,
                 nodes: updatedNodes.filter((n) => newlyVisibleNodes.includes(n.id as RF_nodeId)),
               });
 
               // Go back to node that was just expanded
               setTimeout(() => {
-                const expandedNode = updatedNodes.find((n) => n.id === segmenterNode.rfid);
+                const expandedNode = updatedNodes.find((n) => n.id === segmenterInternalNode.rfid);
                 if (expandedNode) {
                   reactFlowInstance.fitView({
                     padding: 0.2,
                     includeHiddenNodes: false,
                     duration: 800,
+                    maxZoom: 0.75,
                     nodes: [expandedNode],
                   });
                 }
@@ -74,6 +78,7 @@ export function useStreamdumpGraphController({data}: NullableStreamdump) {
                 padding: 0.2,
                 includeHiddenNodes: false,
                 duration: 800,
+                maxZoom: 0.75,
                 nodes: updatedNodes.filter((n) => newlyVisibleNodes.includes(n.id as RF_nodeId)),
               });
             }
@@ -98,11 +103,12 @@ export function useStreamdumpGraphController({data}: NullableStreamdump) {
           if (newlyVisibleNodes && newlyVisibleNodes.length > 0) {
             // For large subgraphs, we can expand to show the entire subgraph, and then focus back onto the expanded node
             if (newlyVisibleNodes.length > 20) {
-              // Show newly expanded ndoes
+              // Show newly expanded nodes
               reactFlowInstance.fitView({
                 padding: 0.2,
                 includeHiddenNodes: false,
                 duration: 1600, // Longer animation to show the entire subgraph smoothly
+                maxZoom: 0.75,
                 nodes: updatedNodes.filter((n) => newlyVisibleNodes.includes(n.id as RF_nodeId)),
               });
 
@@ -114,6 +120,7 @@ export function useStreamdumpGraphController({data}: NullableStreamdump) {
                     padding: 0.2,
                     includeHiddenNodes: false,
                     duration: 800,
+                    maxZoom: 0.75,
                     nodes: [expandedNode],
                   });
                 }
@@ -124,6 +131,7 @@ export function useStreamdumpGraphController({data}: NullableStreamdump) {
                 padding: 0.2,
                 includeHiddenNodes: false,
                 duration: 800,
+                maxZoom: 0.75,
                 nodes: updatedNodes.filter((n) => newlyVisibleNodes.includes(n.id as RF_nodeId)),
               });
             }
@@ -155,6 +163,7 @@ export function useStreamdumpGraphController({data}: NullableStreamdump) {
                 padding: 0.4,
                 includeHiddenNodes: false,
                 duration: 400,
+                maxZoom: 0.75,
               });
 
               // Then focus on the expanded graph with a smoother animation
@@ -165,6 +174,7 @@ export function useStreamdumpGraphController({data}: NullableStreamdump) {
                     padding: 0.2,
                     includeHiddenNodes: false,
                     duration: 800,
+                    maxZoom: 0.75,
                     nodes: [expandedGraph],
                   });
                 }
@@ -175,6 +185,7 @@ export function useStreamdumpGraphController({data}: NullableStreamdump) {
                 padding: 0.2,
                 includeHiddenNodes: false,
                 duration: 800,
+                maxZoom: 0.75,
                 nodes: updatedNodes.filter((n) => newlyVisibleNodes.includes(n.id as RF_nodeId)),
               });
             }
@@ -184,6 +195,16 @@ export function useStreamdumpGraphController({data}: NullableStreamdump) {
     },
     [interactiveStreamdumpGraph, setNodes, setEdges, reactFlowInstance],
   );
+
+  const getCodecChildren = useCallback(
+    (codec: InternalCodecNode) => {
+      return interactiveStreamdumpGraph ? interactiveStreamdumpGraph.getCodecChildren(codec) : [];
+    },
+    [interactiveStreamdumpGraph],
+  );
+
+  // Keyboard shortcuts
+  const keyboardNav = useKeyboardNavigation(nodes, handleGraphCollapse, handleNodeCollapse, getCodecChildren);
 
   const handleAllStandardGraphsCollapse = useCallback(() => {
     if (interactiveStreamdumpGraph) {
@@ -195,12 +216,13 @@ export function useStreamdumpGraphController({data}: NullableStreamdump) {
       setEdges(updatedEdges);
       toggleStandardGraphsCollapsedFlag(!areStandardGraphsCollapsed);
 
-      // Move to fit the entire graph in the screen afer expanding/collapsing all standard graphs
+      // Move to fit the entire graph in the screen after expanding/collapsing all standard graphs
       setTimeout(() => {
         reactFlowInstance.fitView({
           padding: 0.2,
           includeHiddenNodes: false,
           duration: 800,
+          maxZoom: 0.75,
         });
       }, 50);
     }
@@ -222,6 +244,7 @@ export function useStreamdumpGraphController({data}: NullableStreamdump) {
             padding: 0.2,
             includeHiddenNodes: false,
             duration: 800,
+            maxZoom: 0.75,
             nodes: updatedNodes.filter((n) => newlyVisibleNodes.includes(n.id as RF_nodeId)),
           });
         }, 50);
@@ -231,6 +254,7 @@ export function useStreamdumpGraphController({data}: NullableStreamdump) {
   );
 
   // Providing nodes with their proper collapse handlers
+  // Each node type gets its appropriate handler attached via data props
   const nodesWithCollapseHandler = useMemo(() => {
     return nodes.map((node) => {
       if (node.type === NodeType.Codec) {
@@ -267,6 +291,7 @@ export function useStreamdumpGraphController({data}: NullableStreamdump) {
   const initializeGraph = useCallback(() => {
     if (data) {
       const newInteractiveStreamdumpGraph = new InteractiveStreamdumpGraph(data, STANDARD_GRAPHS_START_COLLAPSED);
+      newInteractiveStreamdumpGraph.buildAllNavlinks();
       setInteractiveStreamdumpGraph(newInteractiveStreamdumpGraph);
       const {dagOrderedNodes: visibleNodes, edges: visibleEdges} =
         newInteractiveStreamdumpGraph.getVisibleStreamdumpGraph();
@@ -281,6 +306,7 @@ export function useStreamdumpGraphController({data}: NullableStreamdump) {
           padding: 0.2,
           includeHiddenNodes: false,
           duration: 800,
+          maxZoom: 0.75,
         });
       }, 100);
     }
@@ -298,5 +324,6 @@ export function useStreamdumpGraphController({data}: NullableStreamdump) {
     onEdgesChange,
     handleAllStandardGraphsCollapse,
     areStandardGraphsCollapsed,
+    keyboardNav,
   };
 }

--- a/tools/visualization_app/src/graphVisualization/controllers/useKeyboardShortcuts.ts
+++ b/tools/visualization_app/src/graphVisualization/controllers/useKeyboardShortcuts.ts
@@ -1,0 +1,224 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+import {useCallback, useEffect, useMemo, useReducer, useRef} from 'react';
+import {useReactFlow} from '@xyflow/react';
+import type {Node} from '@xyflow/react';
+import {toaster} from '../../App';
+import type {InternalNode} from '../models/InternalNode';
+import {InternalCodecNode} from '../models/InternalCodecNode';
+import {InternalGraphNode} from '../models/InternalGraphNode';
+import {NodeType, type RF_nodeId} from '../models/types';
+
+type KeyboardNavState = {
+  isActive: boolean;
+  selectedNode: InternalNode | null;
+};
+
+type KeyboardNavAction =
+  | {type: 'ACTIVATE'; node: InternalNode}
+  | {type: 'DEACTIVATE'}
+  | {type: 'SELECT_NODE'; node: InternalNode};
+
+// use reducer to manage state and dispatch actions
+function reducer(state: KeyboardNavState, action: KeyboardNavAction): KeyboardNavState {
+  switch (action.type) {
+    case 'ACTIVATE':
+      return {isActive: true, selectedNode: action.node};
+    case 'DEACTIVATE':
+      return {isActive: false, selectedNode: null};
+    case 'SELECT_NODE':
+      return state.isActive ? {...state, selectedNode: action.node} : state;
+  }
+}
+
+export interface KeyboardNavControls {
+  selectedNodeId: RF_nodeId | null;
+  activate: () => void;
+  deactivate: () => void;
+}
+
+export function useKeyboardNavigation(
+  nodes: Node[],
+  handleGraphCollapse: (node: InternalGraphNode) => void,
+  handleNodeCollapse: (node: InternalCodecNode) => void,
+  getCodecChildren: (codec: InternalCodecNode) => InternalCodecNode[],
+): KeyboardNavControls {
+  const [state, dispatch] = useReducer(reducer, {
+    isActive: false,
+    selectedNode: null,
+  });
+
+  const reactFlow = useReactFlow();
+  const nodesRef = useRef(nodes);
+  nodesRef.current = nodes;
+
+  const handleGraphCollapseRef = useRef(handleGraphCollapse);
+  const handleNodeCollapseRef = useRef(handleNodeCollapse);
+  const getCodecChildrenRef = useRef(getCodecChildren);
+  handleGraphCollapseRef.current = handleGraphCollapse;
+  handleNodeCollapseRef.current = handleNodeCollapse;
+  getCodecChildrenRef.current = getCodecChildren;
+
+  // Lookup table from  RF_nodeId to InternalNode
+  const nodeMap = useMemo(() => {
+    const map = new Map<RF_nodeId, InternalNode>();
+    for (const n of nodes) {
+      if (!n.hidden && n.data?.internalNode) {
+        map.set(n.id as RF_nodeId, n.data.internalNode as InternalNode);
+      }
+    }
+    return map;
+  }, [nodes]);
+
+  const nodeMapRef = useRef(nodeMap);
+  nodeMapRef.current = nodeMap;
+
+  // Selectable nodes: codecs and collapsed graphs (pill-shaped).
+  // Non-selectable: segmenters and expanded graphs (dotted containers).
+  const isSelectable = (node: InternalNode): boolean => {
+    if (node.type === NodeType.Codec) return true;
+    if (node.type === NodeType.Graph && node.isCollapsed) return true;
+    return false;
+  };
+
+  // Follow nav links, skipping non-selectable nodes.
+  const resolveToSelectable = useCallback(
+    (rfid: RF_nodeId | undefined, direction: 'up' | 'down'): InternalNode | null => {
+      if (!rfid) return null;
+      const node = nodeMapRef.current.get(rfid);
+      if (!node) return null;
+      if (isSelectable(node)) return node;
+      const next = direction === 'down' ? node.children[0] : node.parents[0];
+      return resolveToSelectable(next, direction);
+    },
+    [],
+  );
+
+  const findNeighbor = useCallback(
+    (direction: 'up' | 'down' | 'left' | 'right'): InternalNode | null => {
+      const currentNode = state.selectedNode;
+      if (!currentNode) return null;
+
+      if (direction === 'down') {
+        return resolveToSelectable(currentNode.children[0], 'down');
+      }
+
+      if (direction === 'up') {
+        return resolveToSelectable(currentNode.parents[0], 'up');
+      }
+
+      // Left/Right: move among siblings (children of same parent)
+      if (currentNode.parents.length === 0) return null;
+      const parent = nodeMapRef.current.get(currentNode.parents[0]);
+      if (!parent) return null;
+
+      const siblings = parent.children;
+      const currentIndex = siblings.indexOf(currentNode.rfid);
+      if (currentIndex === -1) return null;
+
+      const nextIndex = direction === 'right' ? currentIndex + 1 : currentIndex - 1;
+      if (nextIndex < 0 || nextIndex >= siblings.length) return null;
+
+      return nodeMapRef.current.get(siblings[nextIndex]) ?? null;
+    },
+    [state.selectedNode, resolveToSelectable],
+  );
+
+  const activate = useCallback(() => {
+    const startRfNode = nodesRef.current.find(
+      (n) =>
+        !n.hidden &&
+        n.data?.internalNode &&
+        ((n.data.internalNode as {name?: string}).name === 'zl.#start' ||
+          (n.data.internalNode as {name?: string}).name === 'zl.#regen'),
+    );
+    if (startRfNode) {
+      dispatch({type: 'ACTIVATE', node: startRfNode.data?.internalNode as InternalNode});
+      reactFlow.fitView({
+        nodes: [{id: startRfNode.id}],
+        duration: 800,
+        padding: 0.2,
+        maxZoom: 0.75,
+      });
+    } else {
+      toaster.create({
+        title: 'Cannot activate keyboard shortcuts',
+        description: 'No start node (zl.#start) found.',
+        type: 'warning',
+        duration: 3000,
+      });
+    }
+  }, [reactFlow]);
+
+  useEffect(() => {
+    if (!state.isActive) return;
+
+    const handleKeyDown = (e: KeyboardEvent) => {
+      const target = e.target as HTMLElement;
+      if (
+        target.tagName === 'INPUT' ||
+        target.tagName === 'TEXTAREA' ||
+        target.tagName === 'SELECT' ||
+        target.isContentEditable
+      ) {
+        // Graph naviagtion fires only when focus on graph canvas itself
+        return;
+      }
+
+      const directionMap: Record<string, 'up' | 'down' | 'left' | 'right'> = {
+        ArrowUp: 'up',
+        ArrowDown: 'down',
+        ArrowLeft: 'left',
+        ArrowRight: 'right',
+      };
+
+      const direction = directionMap[e.key];
+      if (!direction) return;
+      e.preventDefault();
+
+      const tryExpandDown = () => {
+        const currentNode = state.selectedNode;
+        if (!currentNode || !currentNode.isCollapsed) return;
+
+        if (currentNode instanceof InternalGraphNode) {
+          const firstCodec = currentNode.codecs[0];
+          // cannot expand collapsed graph node if there is no codec nodes in it
+          if (firstCodec == null) return;
+          handleGraphCollapseRef.current(currentNode);
+          // skip non-selectable expanded graph node
+          if (firstCodec) dispatch({type: 'SELECT_NODE', node: firstCodec});
+        } else if (currentNode instanceof InternalCodecNode) {
+          handleNodeCollapseRef.current(currentNode);
+        }
+      };
+
+      const neighbor = findNeighbor(direction);
+
+      if (!neighbor && direction === 'down' && state.selectedNode) {
+        tryExpandDown();
+      } else if (neighbor) {
+        dispatch({type: 'SELECT_NODE', node: neighbor});
+        reactFlow.fitView({
+          nodes: [{id: neighbor.rfid}],
+          duration: 100,
+          padding: 0.2,
+          maxZoom: 0.75,
+        });
+      }
+    };
+
+    window.addEventListener('keydown', handleKeyDown);
+    return () => window.removeEventListener('keydown', handleKeyDown);
+  }, [state.isActive, state.selectedNode, findNeighbor, reactFlow]);
+
+  const deactivate = useCallback(() => dispatch({type: 'DEACTIVATE'}), []);
+
+  return useMemo(
+    () => ({
+      selectedNodeId: state.selectedNode?.rfid ?? null,
+      activate,
+      deactivate,
+    }),
+    [state.selectedNode?.rfid, activate, deactivate],
+  );
+}

--- a/tools/visualization_app/src/graphVisualization/controllers/useKeyboardShortcuts.ts
+++ b/tools/visualization_app/src/graphVisualization/controllers/useKeyboardShortcuts.ts
@@ -4,9 +4,9 @@ import {useCallback, useEffect, useMemo, useReducer, useRef} from 'react';
 import {useReactFlow} from '@xyflow/react';
 import type {Node} from '@xyflow/react';
 import {toaster} from '../../App';
-import type {InternalNode} from '../models/InternalNode';
 import {InternalCodecNode} from '../models/InternalCodecNode';
 import {InternalGraphNode} from '../models/InternalGraphNode';
+import type {InternalNode} from '../models/InternalNode';
 import {NodeType, type RF_nodeId} from '../models/types';
 
 type KeyboardNavState = {
@@ -72,7 +72,6 @@ export function useKeyboardNavigation(
 
   const nodeMapRef = useRef(nodeMap);
   nodeMapRef.current = nodeMap;
-
   // Selectable nodes: codecs and collapsed graphs (pill-shaped).
   // Non-selectable: segmenters and expanded graphs (dotted containers).
   const isSelectable = (node: InternalNode): boolean => {
@@ -95,7 +94,7 @@ export function useKeyboardNavigation(
   );
 
   const findNeighbor = useCallback(
-    (direction: 'up' | 'down' | 'left' | 'right'): InternalNode | null => {
+    (direction: 'up' | 'down' | 'left' | 'right' | 'tab', modifier?: 'shift' | null): InternalNode | null => {
       const currentNode = state.selectedNode;
       if (!currentNode) return null;
 
@@ -106,13 +105,36 @@ export function useKeyboardNavigation(
       if (direction === 'up') {
         return resolveToSelectable(currentNode.parents[0], 'up');
       }
-
       // Left/Right: move among siblings (children of same parent)
       if (currentNode.parents.length === 0) return null;
       const parent = nodeMapRef.current.get(currentNode.parents[0]);
       if (!parent) return null;
 
+      // Tab: navigate siblings sorted by stream share
+      if (direction === 'tab') {
+        const sortedSiblings = parent.sortedChildren;
+        // if 0 or 1 sorted sibling this is trivial
+        if (sortedSiblings.length <= 1) return null;
+
+        const currentIndex = sortedSiblings.indexOf(currentNode.rfid);
+        if (currentIndex === -1) return null;
+
+        // tab = next smallest, shift+tab = next largest
+        let nextIndex = modifier === 'shift' ? currentIndex - 1 : currentIndex + 1;
+        if (nextIndex < 0) {
+          nextIndex = sortedSiblings.length - 1;
+        }
+        if (nextIndex >= sortedSiblings.length) {
+          nextIndex = 0;
+        }
+
+        return nodeMapRef.current.get(sortedSiblings[nextIndex]) ?? null;
+      }
+
+      // Left/Right: move among siblings (children of same parent)
       const siblings = parent.children;
+      if (siblings.length <= 1) return null;
+
       const currentIndex = siblings.indexOf(currentNode.rfid);
       if (currentIndex === -1) return null;
 
@@ -165,11 +187,12 @@ export function useKeyboardNavigation(
         return;
       }
 
-      const directionMap: Record<string, 'up' | 'down' | 'left' | 'right'> = {
+      const directionMap: Record<string, 'up' | 'down' | 'left' | 'right' | 'tab'> = {
         ArrowUp: 'up',
         ArrowDown: 'down',
         ArrowLeft: 'left',
         ArrowRight: 'right',
+        Tab: 'tab',
       };
 
       const direction = directionMap[e.key];
@@ -192,9 +215,10 @@ export function useKeyboardNavigation(
         }
       };
 
-      const neighbor = findNeighbor(direction);
+      const modifier: 'shift' | null = e.shiftKey ? 'shift' : null;
+      const neighbor = findNeighbor(direction, modifier);
 
-      if (!neighbor && direction === 'down' && state.selectedNode) {
+      if (!neighbor && direction === 'down' && state.selectedNode?.isCollapsed) {
         tryExpandDown();
       } else if (neighbor) {
         dispatch({type: 'SELECT_NODE', node: neighbor});

--- a/tools/visualization_app/src/graphVisualization/controllers/useKeyboardShortcuts.ts
+++ b/tools/visualization_app/src/graphVisualization/controllers/useKeyboardShortcuts.ts
@@ -94,54 +94,61 @@ export function useKeyboardNavigation(
   );
 
   const findNeighbor = useCallback(
-    (direction: 'up' | 'down' | 'left' | 'right' | 'tab', modifier?: 'shift' | null): InternalNode | null => {
+    (direction: 'up' | 'down' | 'left' | 'right' | 'tab' | 'enter', modifier?: 'shift' | null): InternalNode | null => {
       const currentNode = state.selectedNode;
       if (!currentNode) return null;
 
-      if (direction === 'down') {
-        return resolveToSelectable(currentNode.children[0], 'down');
-      }
+      switch (direction) {
+        case 'down':
+          return resolveToSelectable(currentNode.children[0], 'down');
+        case 'up':
+          return resolveToSelectable(currentNode.parents[0], 'up');
+        case 'tab': {
+          // Tab: navigate siblings sorted by stream share
+          if (currentNode.parents.length === 0) return null;
+          const parent = nodeMapRef.current.get(currentNode.parents[0]);
+          if (!parent) return null;
 
-      if (direction === 'up') {
-        return resolveToSelectable(currentNode.parents[0], 'up');
-      }
-      // Left/Right: move among siblings (children of same parent)
-      if (currentNode.parents.length === 0) return null;
-      const parent = nodeMapRef.current.get(currentNode.parents[0]);
-      if (!parent) return null;
+          const sortedSiblings = parent.sortedChildren;
+          // if 0 or 1 sorted sibling this is trivial
+          if (sortedSiblings.length <= 1) return null;
 
-      // Tab: navigate siblings sorted by stream share
-      if (direction === 'tab') {
-        const sortedSiblings = parent.sortedChildren;
-        // if 0 or 1 sorted sibling this is trivial
-        if (sortedSiblings.length <= 1) return null;
+          const currentIndex = sortedSiblings.indexOf(currentNode.rfid);
+          if (currentIndex === -1) return null;
 
-        const currentIndex = sortedSiblings.indexOf(currentNode.rfid);
-        if (currentIndex === -1) return null;
+          // tab = next smallest, shift+tab = next largest
+          let nextIndex = modifier === 'shift' ? currentIndex - 1 : currentIndex + 1;
+          if (nextIndex < 0) {
+            nextIndex = sortedSiblings.length - 1;
+          }
+          if (nextIndex >= sortedSiblings.length) {
+            nextIndex = 0;
+          }
 
-        // tab = next smallest, shift+tab = next largest
-        let nextIndex = modifier === 'shift' ? currentIndex - 1 : currentIndex + 1;
-        if (nextIndex < 0) {
-          nextIndex = sortedSiblings.length - 1;
+          return nodeMapRef.current.get(sortedSiblings[nextIndex]) ?? null;
         }
-        if (nextIndex >= sortedSiblings.length) {
-          nextIndex = 0;
+        case 'right':
+        case 'left': {
+          // Left/Right: move among siblings (children of same parent)
+          if (currentNode.parents.length === 0) return null;
+          const parent = nodeMapRef.current.get(currentNode.parents[0]);
+          if (!parent) return null;
+
+          const siblings = parent.children;
+          if (siblings.length <= 1) return null;
+
+          const currentIndex = siblings.indexOf(currentNode.rfid);
+          if (currentIndex === -1) return null;
+
+          const nextIndex = direction === 'right' ? currentIndex + 1 : currentIndex - 1;
+          if (nextIndex < 0 || nextIndex >= siblings.length) return null;
+
+          return nodeMapRef.current.get(siblings[nextIndex]) ?? null;
         }
-
-        return nodeMapRef.current.get(sortedSiblings[nextIndex]) ?? null;
+        case 'enter':
+        default:
+          return null;
       }
-
-      // Left/Right: move among siblings (children of same parent)
-      const siblings = parent.children;
-      if (siblings.length <= 1) return null;
-
-      const currentIndex = siblings.indexOf(currentNode.rfid);
-      if (currentIndex === -1) return null;
-
-      const nextIndex = direction === 'right' ? currentIndex + 1 : currentIndex - 1;
-      if (nextIndex < 0 || nextIndex >= siblings.length) return null;
-
-      return nodeMapRef.current.get(siblings[nextIndex]) ?? null;
     },
     [state.selectedNode, resolveToSelectable],
   );
@@ -187,19 +194,20 @@ export function useKeyboardNavigation(
         return;
       }
 
-      const directionMap: Record<string, 'up' | 'down' | 'left' | 'right' | 'tab'> = {
+      const directionMap: Record<string, 'up' | 'down' | 'left' | 'right' | 'tab' | 'enter'> = {
         ArrowUp: 'up',
         ArrowDown: 'down',
         ArrowLeft: 'left',
         ArrowRight: 'right',
         Tab: 'tab',
+        Enter: 'enter',
       };
 
       const direction = directionMap[e.key];
       if (!direction) return;
       e.preventDefault();
 
-      const tryExpandDown = () => {
+      const tryExpand = () => {
         const currentNode = state.selectedNode;
         if (!currentNode || !currentNode.isCollapsed) return;
 
@@ -215,11 +223,41 @@ export function useKeyboardNavigation(
         }
       };
 
+      const tryCollapse = () => {
+        const currentNode = state.selectedNode;
+        if (!currentNode) return;
+
+        // Codec is expanded
+        if (!currentNode.isCollapsed) {
+          // We cannot access a expanded graph node so we only need to check codec
+          if (currentNode instanceof InternalCodecNode) {
+            handleNodeCollapseRef.current(currentNode);
+          }
+          return;
+        }
+
+        // Node is already collapsed bubble up and collapse its parent graph,
+        // then move selection to the now-collapsed parent.
+        if (
+          currentNode instanceof InternalCodecNode &&
+          currentNode.parentGraph &&
+          !currentNode.parentGraph.isCollapsed
+        ) {
+          // This is because we cannot directly navigate to a expanded graph node so we will use any child of expanded graph to collapse it
+          handleGraphCollapseRef.current(currentNode.parentGraph);
+          dispatch({type: 'SELECT_NODE', node: currentNode.parentGraph});
+        }
+      };
+
       const modifier: 'shift' | null = e.shiftKey ? 'shift' : null;
       const neighbor = findNeighbor(direction, modifier);
 
-      if (!neighbor && direction === 'down' && state.selectedNode?.isCollapsed) {
-        tryExpandDown();
+      if (direction === 'enter' && state.selectedNode && modifier === 'shift') {
+        tryCollapse();
+      } else if (direction === 'enter' && state.selectedNode) {
+        tryExpand();
+      } else if (!neighbor && direction === 'down' && state.selectedNode?.isCollapsed) {
+        tryExpand();
       } else if (neighbor) {
         dispatch({type: 'SELECT_NODE', node: neighbor});
         reactFlow.fitView({

--- a/tools/visualization_app/src/graphVisualization/models/CodecDag.ts
+++ b/tools/visualization_app/src/graphVisualization/models/CodecDag.ts
@@ -11,17 +11,23 @@ import type {Stream} from '../../models/Stream';
  */
 export class CodecDag {
   private readonly adjList: Map<CodecID, Set<CodecID>>;
+  private readonly reverseAdjList: Map<CodecID, Set<CodecID>>;
   private readonly codecList: InternalCodecNode[]; // list of codecs in ID order for lookup purposes
   private readonly dagOrderList: InternalCodecNode[];
 
   constructor(codecs: InternalCodecNode[], streams: Stream[]) {
     this.adjList = new Map();
+    this.reverseAdjList = new Map();
     this.codecList = codecs;
+    codecs.forEach((codec) => {
+      this.reverseAdjList.set(codec.id, new Set());
+    });
     codecs.forEach((codec) => {
       const childSet = new Set<CodecID>();
       for (const streamId of codec.outputStreams) {
         const targetCodecId = streams[streamId].targetCodec;
         childSet.add(targetCodecId);
+        this.reverseAdjList.get(targetCodecId)!.add(codec.id);
       }
       this.adjList.set(codec.id, childSet);
     });
@@ -41,6 +47,11 @@ export class CodecDag {
 
   getChildren(codec: InternalCodecNode): InternalCodecNode[] {
     const ids = Array.from(this.adjList.get(codec.id) ?? []);
+    return ids.map((id) => this.codecList[id]);
+  }
+
+  getParents(codec: InternalCodecNode): InternalCodecNode[] {
+    const ids = Array.from(this.reverseAdjList.get(codec.id) ?? []);
     return ids.map((id) => this.codecList[id]);
   }
 

--- a/tools/visualization_app/src/graphVisualization/models/InteractiveChunkGraph.ts
+++ b/tools/visualization_app/src/graphVisualization/models/InteractiveChunkGraph.ts
@@ -352,7 +352,7 @@ export class InteractiveChunkGraph {
     });
   }
 
-  rebuildNavlinksFor(nodeIds: RF_nodeId[]): void {
+  rebuildNavlinksFor(nodeIds: RF_nodeId[]): InternalNode[] {
     const toRebuild = new Set<RF_nodeId>(nodeIds);
 
     // Also rebuild parents of changed nodes so their children arrays stay correct
@@ -378,17 +378,21 @@ export class InteractiveChunkGraph {
       }
     }
 
+    const rebuiltNodes: InternalNode[] = [];
     for (const rfid of toRebuild) {
       const codec = this.codecByRfid.get(rfid);
       if (codec) {
         this.rebuildNavlinksForCodec(codec);
+        rebuiltNodes.push(codec);
         continue;
       }
       const graph = this.graphByRfid.get(rfid);
       if (graph) {
         this.rebuildNavlinksForGraph(graph);
+        rebuiltNodes.push(graph);
       }
     }
+    return rebuiltNodes;
   }
 
   private getEdgeShare(source: InternalCodecNode, target: InternalCodecNode): number {
@@ -444,7 +448,7 @@ export class InteractiveChunkGraph {
     return this.getDescendants(codec, visitedDescendants, (_childCodecId) => true);
   }
 
-  toggleSubgraphCollapse(codec: InternalCodecNode): RF_nodeId[] {
+  toggleSubgraphCollapse(codec: InternalCodecNode): {newlyVisibleNodes: RF_nodeId[], rebuiltNavlinkNodes: InternalNode[]} {
     const newlyVisibleNodes: RF_nodeId[] = [];
 
     // Expanding this node's subgraph
@@ -512,11 +516,11 @@ export class InteractiveChunkGraph {
       });
     }
 
-    this.rebuildNavlinksFor(newlyVisibleNodes);
-    return newlyVisibleNodes;
+    const rebuiltNavlinkNodes = this.rebuildNavlinksFor(newlyVisibleNodes);
+    return {newlyVisibleNodes, rebuiltNavlinkNodes};
   }
   // Function to support the feature of level-by-level expansion of the graph
-  expandOneLevel(codec: InternalCodecNode): RF_nodeId[] {
+  expandOneLevel(codec: InternalCodecNode): {newlyVisibleNodes: RF_nodeId[], rebuiltNavlinkNodes: InternalNode[]} {
     const newlyVisibleNodes: RF_nodeId[] = [];
     codec.isCollapsed = false;
     newlyVisibleNodes.push(codec.rfid);
@@ -539,8 +543,8 @@ export class InteractiveChunkGraph {
       }
     });
 
-    this.rebuildNavlinksFor(newlyVisibleNodes);
-    return newlyVisibleNodes;
+    const rebuiltNavlinkNodes = this.rebuildNavlinksFor(newlyVisibleNodes);
+    return {newlyVisibleNodes, rebuiltNavlinkNodes};
   }
 
   // Helper function to display codecs in a function graph without overriding any collapsed odecs within the function graph
@@ -563,7 +567,7 @@ export class InteractiveChunkGraph {
   }
 
   // Function to support the feature of collapsing/expanding a function graph
-  toggleGraphCollapse(graph: InternalGraphNode): RF_nodeId[] {
+  toggleGraphCollapse(graph: InternalGraphNode): {newlyVisibleNodes: RF_nodeId[], rebuiltNavlinkNodes: InternalNode[]} {
     const newlyVisibleNodes: RF_nodeId[] = [];
     // Expanding this function graph
     if (graph.isCollapsed) {
@@ -586,13 +590,14 @@ export class InteractiveChunkGraph {
       // Add the function graph itself as a newly visible node as we want the screen to focus on it
       newlyVisibleNodes.push(graph.rfid);
     }
-    this.rebuildNavlinksFor(newlyVisibleNodes);
-    return newlyVisibleNodes;
+    const rebuiltNavlinkNodes = this.rebuildNavlinksFor(newlyVisibleNodes);
+    return {newlyVisibleNodes, rebuiltNavlinkNodes};
   }
 
   // collapses the graph component and all its successors into one node
-  toggleGraphHide(graph: InternalGraphNode): RF_nodeId[] {
-    let nodesToFocus = this.toggleSubgraphCollapse(graph.codecs[0]);
+  toggleGraphHide(graph: InternalGraphNode): {newlyVisibleNodes: RF_nodeId[], rebuiltNavlinkNodes: InternalNode[]} {
+    const {newlyVisibleNodes: subgraphNodes, rebuiltNavlinkNodes} = this.toggleSubgraphCollapse(graph.codecs[0]);
+    let nodesToFocus = subgraphNodes;
     if (graph.isCollapsed) {
       graph.isCollapsed = false;
       nodesToFocus.push(graph.rfid);
@@ -607,8 +612,9 @@ export class InteractiveChunkGraph {
       nodesToFocus = [graph.rfid];
     }
     console.assert(graph.isVisible);
-    this.rebuildNavlinksFor(nodesToFocus);
-    return nodesToFocus;
+    const moreRebuilt = this.rebuildNavlinksFor(nodesToFocus);
+    rebuiltNavlinkNodes.push(...moreRebuilt);
+    return {newlyVisibleNodes: nodesToFocus, rebuiltNavlinkNodes};
   }
 
   // Function to support the feature of collapsing/expanding all standard graphs

--- a/tools/visualization_app/src/graphVisualization/models/InteractiveChunkGraph.ts
+++ b/tools/visualization_app/src/graphVisualization/models/InteractiveChunkGraph.ts
@@ -23,6 +23,8 @@ export class InteractiveChunkGraph {
   private streams: Stream[] = [];
   private graphs: InternalGraphNode[] = [];
   private codecDag: CodecDag | null = null;
+  private codecByRfid = new Map<RF_nodeId, InternalCodecNode>();
+  private graphByRfid = new Map<RF_nodeId, InternalGraphNode>();
 
   private edgeViewModels = new Map<RF_edgeId, InternalEdge>();
 
@@ -85,7 +87,9 @@ export class InteractiveChunkGraph {
       }
     }
 
-    // populate codecDag
+    // populate lookup maps and DAG
+    this.codecByRfid = new Map(this.codecs.map((c) => [c.rfid, c]));
+    this.graphByRfid = new Map(this.graphs.map((g) => [g.rfid, g]));
     this.codecDag = new CodecDag(this.codecs, this.streams);
 
     // Create the edges view models for codec -> codec edges
@@ -285,6 +289,99 @@ export class InteractiveChunkGraph {
     return {dagOrderedNodes: Array.from(visibleNodeSet), edges: Array.from(visibleEdgeSet)};
   }
 
+  getCodecChildren(codec: InternalCodecNode): InternalCodecNode[] {
+    return this.codecDag ? this.codecDag.getChildren(codec) : [];
+  }
+
+  // Given the visible node that represents a codec or graph, find its visible
+  // navigable neighbors using the DAG and link them via parents/children.
+  private rebuildNavlinksForCodec(codec: InternalCodecNode): void {
+    codec.parents = [];
+    codec.children = [];
+
+    // Link to visible DAG children (or their collapsed parent graph)
+    for (const child of this.codecDag!.getChildren(codec)) {
+      if (child.isVisible) {
+        this.addNavLink(codec, child);
+      } else if (child.parentGraph && child.parentGraph.isVisible && child.parentGraph.isCollapsed) {
+        this.addNavLink(codec, child.parentGraph);
+      }
+    }
+
+    // Link to visible DAG parents (or their collapsed parent graph)
+    for (const parent of this.codecDag!.getParents(codec)) {
+      if (parent.isVisible) {
+        this.addNavLink(parent, codec);
+      } else if (parent.parentGraph && parent.parentGraph.isVisible && parent.parentGraph.isCollapsed) {
+        this.addNavLink(parent.parentGraph, codec);
+      }
+    }
+  }
+
+  private rebuildNavlinksForGraph(graph: InternalGraphNode): void {
+    graph.parents = [];
+    graph.children = [];
+
+    for (const edge of graph.incomingEdges) {
+      if (!edge.source.isVisible) continue;
+      if (edge.source instanceof InternalGraphNode && !edge.source.isCollapsed) continue;
+      this.addNavLink(edge.source, graph);
+    }
+    for (const edge of graph.outgoingEdges) {
+      if (!edge.target.isVisible) continue;
+      if (edge.target instanceof InternalGraphNode && !edge.target.isCollapsed) continue;
+      this.addNavLink(graph, edge.target);
+    }
+  }
+
+  rebuildNavlinksFor(nodeIds: RF_nodeId[]): void {
+    const toRebuild = new Set<RF_nodeId>(nodeIds);
+
+    // Also rebuild parents of changed nodes so their children arrays stay correct
+    for (const rfid of nodeIds) {
+      const codec = this.codecByRfid.get(rfid);
+      if (codec) {
+        for (const parent of this.codecDag!.getParents(codec)) {
+          if (parent.isVisible) toRebuild.add(parent.rfid);
+          else if (parent.parentGraph?.isVisible) toRebuild.add(parent.parentGraph.rfid);
+        }
+        continue;
+      }
+      const graph = this.graphByRfid.get(rfid);
+      if (graph) {
+        // Rebuild parents of the graph's root codec
+        const rootCodec = graph.codecs[0];
+        if (rootCodec) {
+          for (const parent of this.codecDag!.getParents(rootCodec)) {
+            if (parent.isVisible) toRebuild.add(parent.rfid);
+            else if (parent.parentGraph?.isVisible) toRebuild.add(parent.parentGraph.rfid);
+          }
+        }
+      }
+    }
+
+    for (const rfid of toRebuild) {
+      const codec = this.codecByRfid.get(rfid);
+      if (codec) {
+        this.rebuildNavlinksForCodec(codec);
+        continue;
+      }
+      const graph = this.graphByRfid.get(rfid);
+      if (graph) {
+        this.rebuildNavlinksForGraph(graph);
+      }
+    }
+  }
+
+  private addNavLink(parent: InternalNode, child: InternalNode): void {
+    if (!parent.children.includes(child.rfid)) {
+      parent.children.push(child.rfid);
+    }
+    if (!child.parents.includes(parent.rfid)) {
+      child.parents.push(parent.rfid);
+    }
+  }
+
   // Function to get descendants of a codec under some defined recursion condition
   // Note: this is not tail-recursive. This may eventually become problematic for super deep graphs...
   private getDescendants(
@@ -361,11 +458,15 @@ export class InteractiveChunkGraph {
         if (graph != null) {
           if (graph.isCollapsed) {
             graph.isVisible = false;
+            graph.parents = [];
+            graph.children = [];
           } else {
             graphsToCheck.add(graph);
           }
         }
         childCodec.isVisible = false;
+        childCodec.parents = [];
+        childCodec.children = [];
       });
 
       // For function graphs that aren't collapsed, if all codecs within it are hidden, we want to hide the function graph as well
@@ -373,13 +474,15 @@ export class InteractiveChunkGraph {
         const allNodesHidden = graph.codecs.every((codec) => !codec.isVisible);
         if (allNodesHidden) {
           graph.isVisible = false;
+          graph.parents = [];
+          graph.children = [];
         }
       });
     }
 
+    this.rebuildNavlinksFor(newlyVisibleNodes);
     return newlyVisibleNodes;
   }
-
   // Function to support the feature of level-by-level expansion of the graph
   expandOneLevel(codec: InternalCodecNode): RF_nodeId[] {
     const newlyVisibleNodes: RF_nodeId[] = [];
@@ -404,6 +507,7 @@ export class InteractiveChunkGraph {
       }
     });
 
+    this.rebuildNavlinksFor(newlyVisibleNodes);
     return newlyVisibleNodes;
   }
 
@@ -432,6 +536,8 @@ export class InteractiveChunkGraph {
     // Expanding this function graph
     if (graph.isCollapsed) {
       graph.isCollapsed = false;
+      graph.parents = [];
+      graph.children = [];
       this.displayCodecsInGraph(graph.codecs[0], graph, new Set<InternalCodecNode>(), newlyVisibleNodes);
     }
     // Collapsing this function graph
@@ -440,11 +546,13 @@ export class InteractiveChunkGraph {
       // Hide all codecs within the function graph
       graph.codecs.forEach((codec) => {
         codec.isVisible = false;
+        codec.parents = [];
+        codec.children = [];
       });
       // Add the function graph itself as a newly visible node as we want the screen to focus on it
       newlyVisibleNodes.push(graph.rfid);
     }
-
+    this.rebuildNavlinksFor(newlyVisibleNodes);
     return newlyVisibleNodes;
   }
 
@@ -456,9 +564,15 @@ export class InteractiveChunkGraph {
       nodesToFocus.push(graph.rfid);
     } else {
       graph.isCollapsed = true;
+      graph.codecs.forEach((codec) => {
+        codec.isVisible = false;
+        codec.parents = [];
+        codec.children = [];
+      });
       nodesToFocus = [graph.rfid];
     }
     console.assert(graph.isVisible);
+    this.rebuildNavlinksFor(nodesToFocus);
     return nodesToFocus;
   }
 

--- a/tools/visualization_app/src/graphVisualization/models/InteractiveChunkGraph.ts
+++ b/tools/visualization_app/src/graphVisualization/models/InteractiveChunkGraph.ts
@@ -298,13 +298,19 @@ export class InteractiveChunkGraph {
   private rebuildNavlinksForCodec(codec: InternalCodecNode): void {
     codec.parents = [];
     codec.children = [];
+    const childShareMap = new Map<RF_nodeId, number>();
 
     // Link to visible DAG children (or their collapsed parent graph)
     for (const child of this.codecDag!.getChildren(codec)) {
+      // Find the edge share from codec to child
+      const edgeShare = this.getEdgeShare(codec, child);
       if (child.isVisible) {
         this.addNavLink(codec, child);
+        childShareMap.set(child.rfid, edgeShare);
       } else if (child.parentGraph && child.parentGraph.isVisible && child.parentGraph.isCollapsed) {
         this.addNavLink(codec, child.parentGraph);
+        const existing = childShareMap.get(child.parentGraph.rfid) ?? 0;
+        childShareMap.set(child.parentGraph.rfid, Math.max(existing, edgeShare));
       }
     }
 
@@ -316,11 +322,17 @@ export class InteractiveChunkGraph {
         this.addNavLink(parent.parentGraph, codec);
       }
     }
+
+    // Sort children by descending edge share
+    codec.sortedChildren = [...codec.children].sort((a, b) => {
+      return (childShareMap.get(b) ?? 0) - (childShareMap.get(a) ?? 0);
+    });
   }
 
   private rebuildNavlinksForGraph(graph: InternalGraphNode): void {
     graph.parents = [];
     graph.children = [];
+    const childShareMap = new Map<RF_nodeId, number>();
 
     for (const edge of graph.incomingEdges) {
       if (!edge.source.isVisible) continue;
@@ -331,7 +343,13 @@ export class InteractiveChunkGraph {
       if (!edge.target.isVisible) continue;
       if (edge.target instanceof InternalGraphNode && !edge.target.isCollapsed) continue;
       this.addNavLink(graph, edge.target);
+      const existing = childShareMap.get(edge.target.rfid) ?? 0;
+      childShareMap.set(edge.target.rfid, Math.max(existing, edge.share));
     }
+
+    graph.sortedChildren = [...graph.children].sort((a, b) => {
+      return (childShareMap.get(b) ?? 0) - (childShareMap.get(a) ?? 0);
+    });
   }
 
   rebuildNavlinksFor(nodeIds: RF_nodeId[]): void {
@@ -371,6 +389,17 @@ export class InteractiveChunkGraph {
         this.rebuildNavlinksForGraph(graph);
       }
     }
+  }
+
+  private getEdgeShare(source: InternalCodecNode, target: InternalCodecNode): number {
+    for (const streamId of source.outputStreams) {
+      const stream = this.streams[streamId];
+      if (stream.targetCodec === target.id) {
+        const edge = this.edgeViewModels.get(stream.rfId);
+        if (edge) return edge.share;
+      }
+    }
+    return 0;
   }
 
   private addNavLink(parent: InternalNode, child: InternalNode): void {
@@ -460,6 +489,7 @@ export class InteractiveChunkGraph {
             graph.isVisible = false;
             graph.parents = [];
             graph.children = [];
+            graph.sortedChildren = [];
           } else {
             graphsToCheck.add(graph);
           }
@@ -467,6 +497,7 @@ export class InteractiveChunkGraph {
         childCodec.isVisible = false;
         childCodec.parents = [];
         childCodec.children = [];
+        childCodec.sortedChildren = [];
       });
 
       // For function graphs that aren't collapsed, if all codecs within it are hidden, we want to hide the function graph as well
@@ -476,6 +507,7 @@ export class InteractiveChunkGraph {
           graph.isVisible = false;
           graph.parents = [];
           graph.children = [];
+          graph.sortedChildren = [];
         }
       });
     }
@@ -538,6 +570,7 @@ export class InteractiveChunkGraph {
       graph.isCollapsed = false;
       graph.parents = [];
       graph.children = [];
+      graph.sortedChildren = [];
       this.displayCodecsInGraph(graph.codecs[0], graph, new Set<InternalCodecNode>(), newlyVisibleNodes);
     }
     // Collapsing this function graph
@@ -548,6 +581,7 @@ export class InteractiveChunkGraph {
         codec.isVisible = false;
         codec.parents = [];
         codec.children = [];
+        codec.sortedChildren = [];
       });
       // Add the function graph itself as a newly visible node as we want the screen to focus on it
       newlyVisibleNodes.push(graph.rfid);
@@ -568,6 +602,7 @@ export class InteractiveChunkGraph {
         codec.isVisible = false;
         codec.parents = [];
         codec.children = [];
+        codec.sortedChildren = [];
       });
       nodesToFocus = [graph.rfid];
     }

--- a/tools/visualization_app/src/graphVisualization/models/InteractiveStreamdumpGraph.ts
+++ b/tools/visualization_app/src/graphVisualization/models/InteractiveStreamdumpGraph.ts
@@ -191,5 +191,23 @@ export class InteractiveStreamdumpGraph {
         source.children.push(target.rfid);
       }
     }
+
+    // Build a map from (source rfid, target rfid) to edge share for sorting
+    const edgeShareMap = new Map<string, number>();
+    for (const edge of edges) {
+      const key = `${edge.source.rfid}->${edge.target.rfid}`;
+      const existing = edgeShareMap.get(key);
+      if (existing == null || edge.share > existing) {
+        edgeShareMap.set(key, edge.share);
+      }
+    }
+
+    for (const node of dagOrderedNodes) {
+      node.sortedChildren = [...node.children].sort((a, b) => {
+        const shareA = edgeShareMap.get(`${node.rfid}->${a}`) ?? 0;
+        const shareB = edgeShareMap.get(`${node.rfid}->${b}`) ?? 0;
+        return shareB - shareA;
+      });
+    }
   }
 }

--- a/tools/visualization_app/src/graphVisualization/models/InteractiveStreamdumpGraph.ts
+++ b/tools/visualization_app/src/graphVisualization/models/InteractiveStreamdumpGraph.ts
@@ -112,7 +112,7 @@ export class InteractiveStreamdumpGraph {
     return [];
   }
 
-  toggleSubgraphCollapse(codec: InternalCodecNode): RF_nodeId[] {
+  toggleSubgraphCollapse(codec: InternalCodecNode): {newlyVisibleNodes: RF_nodeId[], rebuiltNavlinkNodes: InternalNode[]} {
     if (this.chunkGraphs[0].contains(codec)) {
       return this.chunkGraphs[0].toggleSubgraphCollapse(codec);
     }
@@ -122,10 +122,9 @@ export class InteractiveStreamdumpGraph {
     throw new Error(
       `Could not find codec ${codec.id} in root chunk or currently selected chunk ${this.visibleChunkIndex}`,
     );
-    return this.chunkGraphs[0].toggleSubgraphCollapse(codec);
   }
 
-  expandOneLevel(codec: InternalCodecNode): RF_nodeId[] {
+  expandOneLevel(codec: InternalCodecNode): {newlyVisibleNodes: RF_nodeId[], rebuiltNavlinkNodes: InternalNode[]} {
     if (this.chunkGraphs[0].contains(codec)) {
       return this.chunkGraphs[0].expandOneLevel(codec);
     }
@@ -137,7 +136,7 @@ export class InteractiveStreamdumpGraph {
     );
   }
 
-  toggleGraphCollapse(graph: InternalGraphNode): RF_nodeId[] {
+  toggleGraphCollapse(graph: InternalGraphNode): {newlyVisibleNodes: RF_nodeId[], rebuiltNavlinkNodes: InternalNode[]} {
     if (this.chunkGraphs[0].contains(graph)) {
       return this.chunkGraphs[0].toggleGraphCollapse(graph);
     }
@@ -149,7 +148,7 @@ export class InteractiveStreamdumpGraph {
     );
   }
 
-  toggleGraphHide(graph: InternalGraphNode): RF_nodeId[] {
+  toggleGraphHide(graph: InternalGraphNode): {newlyVisibleNodes: RF_nodeId[], rebuiltNavlinkNodes: InternalNode[]} {
     if (this.chunkGraphs[0].contains(graph)) {
       return this.chunkGraphs[0].toggleGraphHide(graph);
     }

--- a/tools/visualization_app/src/graphVisualization/models/InteractiveStreamdumpGraph.ts
+++ b/tools/visualization_app/src/graphVisualization/models/InteractiveStreamdumpGraph.ts
@@ -2,7 +2,7 @@
 
 import {InternalCodecNode} from './InternalCodecNode';
 import {InternalGraphNode} from './InternalGraphNode';
-import type {RF_nodeId} from './types';
+import {NodeType, type RF_nodeId} from './types';
 import type {SerializedStreamdumpV1} from '../../interfaces/SerializedStreamdump';
 import {InteractiveChunkGraph} from './InteractiveChunkGraph';
 import type {InternalNode} from './InternalNode';
@@ -102,6 +102,16 @@ export class InteractiveStreamdumpGraph {
     };
   }
 
+  getCodecChildren(codec: InternalCodecNode): InternalCodecNode[] {
+    if (this.chunkGraphs[0].contains(codec)) {
+      return this.chunkGraphs[0].getCodecChildren(codec);
+    }
+    if (this.visibleChunkIndex != null && this.chunkGraphs[this.visibleChunkIndex].contains(codec)) {
+      return this.chunkGraphs[this.visibleChunkIndex].getCodecChildren(codec);
+    }
+    return [];
+  }
+
   toggleSubgraphCollapse(codec: InternalCodecNode): RF_nodeId[] {
     if (this.chunkGraphs[0].contains(codec)) {
       return this.chunkGraphs[0].toggleSubgraphCollapse(codec);
@@ -154,6 +164,32 @@ export class InteractiveStreamdumpGraph {
   toggleAllStandardGraphs(isCollapsed: boolean): void {
     for (const chunkGraph of this.chunkGraphs) {
       chunkGraph.toggleAllStandardGraphs(isCollapsed);
+    }
+  }
+
+  buildAllNavlinks(): void {
+    const {dagOrderedNodes, edges} = this.getVisibleStreamdumpGraph();
+
+    for (const node of dagOrderedNodes) {
+      node.parents = [];
+      node.children = [];
+    }
+
+    // Only link nodes that are in the visible set (avoids dangling refs to omitted chunk start nodes)
+    const visibleRfids = new Set(dagOrderedNodes.map((n) => n.rfid));
+    const navigableTypes = new Set([NodeType.Codec, NodeType.Graph, NodeType.Segmenter]);
+    for (const edge of edges) {
+      const {source, target} = edge;
+      if (!navigableTypes.has(source.type) || !navigableTypes.has(target.type)) continue;
+      if (!visibleRfids.has(source.rfid) || !visibleRfids.has(target.rfid)) continue;
+      if (source instanceof InternalGraphNode && !source.isCollapsed) continue;
+      if (target instanceof InternalGraphNode && !target.isCollapsed) continue;
+      if (!target.parents.includes(source.rfid)) {
+        target.parents.push(source.rfid);
+      }
+      if (!source.children.includes(target.rfid)) {
+        source.children.push(target.rfid);
+      }
     }
   }
 }

--- a/tools/visualization_app/src/graphVisualization/models/InternalNode.ts
+++ b/tools/visualization_app/src/graphVisualization/models/InternalNode.ts
@@ -10,6 +10,10 @@ export class InternalNode {
   isCollapsed = false;
   isVisible = true;
   inLargestCompressionPath = false;
+  // Note the following properties are visual parents/children
+  // used for visualization , which can include collapsed graphs.
+  parents: RF_nodeId[] = [];
+  children: RF_nodeId[] = [];
 
   constructor(rfid: RF_nodeId, type: NodeType) {
     this.rfid = rfid;

--- a/tools/visualization_app/src/graphVisualization/models/InternalNode.ts
+++ b/tools/visualization_app/src/graphVisualization/models/InternalNode.ts
@@ -14,6 +14,7 @@ export class InternalNode {
   // used for visualization , which can include collapsed graphs.
   parents: RF_nodeId[] = [];
   children: RF_nodeId[] = [];
+  sortedChildren: RF_nodeId[] = [];
 
   constructor(rfid: RF_nodeId, type: NodeType) {
     this.rfid = rfid;

--- a/tools/visualization_app/src/graphVisualization/views/NodeView.tsx
+++ b/tools/visualization_app/src/graphVisualization/views/NodeView.tsx
@@ -88,7 +88,9 @@ export function CodecNode({data}: NodeViewProps) {
   }
   return (
     <div
-      className={`codec-node ${codec.isCollapsed ? 'collapsed' : ''} ${codec.name === 'zl.store' || codec.name === 'zl.#start' ? 'special-node' : ''}`}
+      className={`codec-node ${codec.isCollapsed ? 'collapsed' : ''} ${
+        codec.name === 'zl.store' || codec.name === 'zl.#start' ? 'special-node' : ''
+      }`}
       style={codec.inLargestCompressionPath ? {border: '7px solid #2ed78b'} : {}}>
       {/* Input edge handle declaration for a node*/}
       <Handle type="target" position={Position.Top} id="target" style={{background: '#555'}} />

--- a/tools/visualization_app/src/graphVisualization/views/StreamdumpGraphView.tsx
+++ b/tools/visualization_app/src/graphVisualization/views/StreamdumpGraphView.tsx
@@ -10,6 +10,7 @@ import {Button} from '@chakra-ui/react/button';
 import {Flex} from '@chakra-ui/react/flex';
 
 import {OperationType} from '../../models/idTypes';
+import type {KeyboardNavControls} from '../controllers/useKeyboardShortcuts';
 
 const showExpansionButton = false;
 
@@ -29,6 +30,8 @@ interface StreamdumpGraphViewProps {
   areStandardGraphsCollapsed: boolean;
   versionInfo: VersionInfo;
   isTrackpadMode: boolean;
+  isKeyboardMode: boolean;
+  keyboardNav: KeyboardNavControls;
 }
 
 export function StreamdumpGraphView({
@@ -40,6 +43,8 @@ export function StreamdumpGraphView({
   areStandardGraphsCollapsed,
   versionInfo,
   isTrackpadMode,
+  isKeyboardMode,
+  keyboardNav,
 }: StreamdumpGraphViewProps) {
   const reactFlowInstance = useReactFlow();
 
@@ -47,11 +52,22 @@ export function StreamdumpGraphView({
   useEffect(() => {
     // The controller will use this instance for viewport manipulation, which is handled internally by React Flow
   }, [reactFlowInstance]);
+  const selectedNodeId = isKeyboardMode ? keyboardNav.selectedNodeId : null;
+
+  // TODO: Nice to have. Move DOM focus to the selected node and add ARIA attributes (e.g. aria-selected,
+  // aria-current) during arrow-key navigation so keyboard and screen-reader users have a
+  // programmatic indication of which node is currently selected.
   return (
     <Box
       w={'100%'}
       h={'100%'}
       className={versionInfo.operationType === OperationType.Decompress ? 'decompress-trace' : ''}>
+      {selectedNodeId && (
+        <style>{`[data-id="${selectedNodeId}"] .codec-node,
+          [data-id="${selectedNodeId}"] .graph-node {
+            box-shadow: 0 0 25px 5px #e7e43a;
+          }`}</style>
+      )}
       <ReactFlow
         nodes={nodes}
         edges={edges}

--- a/tools/visualization_app/src/graphVisualization/views/StreamdumpGraphView.tsx
+++ b/tools/visualization_app/src/graphVisualization/views/StreamdumpGraphView.tsx
@@ -1,6 +1,6 @@
 // Copyright (c) Meta Platforms, Inc. and affiliates.
 
-import {useState, useEffect} from 'react';
+import {useEffect} from 'react';
 import {ReactFlow, Controls, Background, ConnectionLineType, Panel, useReactFlow} from '@xyflow/react';
 import type {Node, Edge, NodeChange, EdgeChange} from '@xyflow/react';
 import '@xyflow/react/dist/style.css';
@@ -28,6 +28,7 @@ interface StreamdumpGraphViewProps {
   handleAllStandardGraphsCollapse: () => void;
   areStandardGraphsCollapsed: boolean;
   versionInfo: VersionInfo;
+  isTrackpadMode: boolean;
 }
 
 export function StreamdumpGraphView({
@@ -38,8 +39,8 @@ export function StreamdumpGraphView({
   handleAllStandardGraphsCollapse,
   areStandardGraphsCollapsed,
   versionInfo,
+  isTrackpadMode,
 }: StreamdumpGraphViewProps) {
-  const [isTrackpadMode, setIsTrackpadMode] = useState<boolean>(false);
   const reactFlowInstance = useReactFlow();
 
   // Make the React Flow instance available to the controller
@@ -66,16 +67,6 @@ export function StreamdumpGraphView({
         <Controls />
         <Panel style={{width: '100%'}}>
           <Flex justify="space-between">
-            <Button
-              variant="surface"
-              onClick={() => setIsTrackpadMode(!isTrackpadMode)}
-              title={
-                isTrackpadMode
-                  ? 'Pinch to zoom in/out, swipe or click and drag to move across graph'
-                  : 'Scroll to zoom in/out, click and drag to move across graph'
-              }>
-              {isTrackpadMode ? 'Switch to Mouse Controls' : 'Switch to Trackpad Controls'}
-            </Button>
             <div className="header-text">
               <p style={{fontWeight: 'bold'}}>
                 {versionInfo.operationType === OperationType.Decompress ? 'Decompression Trace' : 'Compression Trace'}

--- a/tools/visualization_app/src/styles/toolbar.css
+++ b/tools/visualization_app/src/styles/toolbar.css
@@ -52,6 +52,10 @@
   text-decoration: 'none';
 }
 
+.toolbar-icons .toolbar-button {
+  margin: 0 1px;
+}
+
 .toolbar-divider {
   width: 1px;
   height: 30px;


### PR DESCRIPTION
Summary: Dagre can change layout so that graph is better organized. We need to sort the parent/child nodes so that keyboard navigation makes sense. Sort nodes after layout is applied so we can get the correct positional ordering.

Differential Revision: D103063890


