### PR TITLE
Enforce that segmenters produce at least one segment (#695)

### DIFF
--- a/include/openzl/zl_errors_types.h
+++ b/include/openzl/zl_errors_types.h
@@ -64,6 +64,7 @@ typedef enum {
     ZL_ErrorCode_outputNotCommitted                   = 24,
     ZL_ErrorCode_outputNotReserved                    = 25,
     ZL_ErrorCode_segmenter_inputNotConsumed           = 26,
+    ZL_ErrorCode_segmenter_noSegments                 = 27,
     /* graph stage errors */
     ZL_ErrorCode_graph_invalid               = 30,
     ZL_ErrorCode_graph_nonserializable       = 31,

--- a/src/openzl/common/errors.c
+++ b/src/openzl/common/errors.c
@@ -48,6 +48,8 @@ const char* ZL_ErrorCode_toString(ZL_ErrorCode code)
             return ZL_ErrorCode_compressionParameter_invalid__desc_str;
         case ZL_ErrorCode_segmenter_inputNotConsumed:
             return ZL_ErrorCode_segmenter_inputNotConsumed__desc_str;
+        case ZL_ErrorCode_segmenter_noSegments:
+            return ZL_ErrorCode_segmenter_noSegments__desc_str;
         case ZL_ErrorCode_graph_invalid:
             return ZL_ErrorCode_graph_invalid__desc_str;
         case ZL_ErrorCode_graph_nonserializable:

--- a/src/openzl/common/errors_internal.h
+++ b/src/openzl/common/errors_internal.h
@@ -77,6 +77,8 @@ ZL_BEGIN_C_DECLS
     "Compression parameter invalid"
 #define ZL_ErrorCode_segmenter_inputNotConsumed__desc_str \
     "Segmenter did not consume entirely all inputs"
+#define ZL_ErrorCode_segmenter_noSegments__desc_str \
+    "Segmenter did not produce any segments"
 #define ZL_ErrorCode_graph_invalid__desc_str "Graph invalid"
 #define ZL_ErrorCode_graph_nonserializable__desc_str \
     "Graph incompatible with serialization"

--- a/src/openzl/compress/segmenter.c
+++ b/src/openzl/compress/segmenter.c
@@ -22,6 +22,7 @@ struct ZL_Segmenter_s {
     ZL_Data** inputs;
     size_t nbInputs;
     size_t* consumed;
+    size_t numChunks;
     Arena* sessionArena;
     Arena* chunkArena;
 };
@@ -57,6 +58,7 @@ ZL_Segmenter* SEGM_init(
     if (seg == NULL)
         return NULL;
     seg->segDesc      = segDesc;
+    seg->numChunks    = 0;
     seg->cctx         = cctx;
     seg->rtgm         = rtgm;
     seg->sessionArena = sessionArena;
@@ -100,20 +102,24 @@ ZL_Report SEGM_runSegmenter(ZL_Segmenter* segCtx)
     ZL_ASSERT_NN(segCtx);
     ZL_SegmenterFn const segfn = segCtx->segDesc->segmenterFn;
     ZL_ASSERT_NN(segfn);
-    ZL_Report const r = segfn(segCtx);
+    ZL_ERR_IF_ERR(segfn(segCtx), "Segmenter function failed");
 
-    // if successful, check that all inputs were consumed
-    if (!ZL_isError(r)) {
-        for (size_t n = 0; n < segCtx->nbInputs; n++) {
-            ZL_ERR_IF_LT(
-                    segCtx->consumed[n],
-                    ZL_Data_numElts(segCtx->inputs[n]),
-                    segmenter_inputNotConsumed,
-                    "input %zu wasn't entirely consumed",
-                    n);
-        }
+    // Check post-conditions
+    ZL_ERR_IF_EQ(
+            segCtx->numChunks,
+            (size_t)0,
+            segmenter_noSegments,
+            "segmenter must produce at least one segment");
+    for (size_t n = 0; n < segCtx->nbInputs; n++) {
+        ZL_ERR_IF_LT(
+                segCtx->consumed[n],
+                ZL_Data_numElts(segCtx->inputs[n]),
+                segmenter_inputNotConsumed,
+                "input %zu wasn't entirely consumed",
+                n);
     }
-    return r;
+
+    return ZL_returnSuccess();
 }
 
 /* ===   accessors   === */
@@ -325,6 +331,7 @@ ZL_Report ZL_Segmenter_processChunk(
             /* depth */ 1));
 
     ZL_Report r = CCTX_flushChunk(cctx, (void*)chunkInputs, numInputs);
+    segCtx->numChunks++;
 
     // clean and exit
     for (size_t n = 0; n < numInputs; n++) {

--- a/tests/round_trip/test_segmenter.cpp
+++ b/tests/round_trip/test_segmenter.cpp
@@ -729,6 +729,61 @@ TEST(Segmenter, singleChunkFallback_preservesRuntimeGraphParams)
             "single-chunk segmenter with runtime graph params on old format");
 }
 
+/* =======   Zero segments must fail (issue #253)   ======== */
+
+ZL_Report zeroSegmentSegmenterFn(ZL_Segmenter* sctx)
+{
+    ZL_RESULT_DECLARE_SCOPE_REPORT(sctx);
+    const ZL_Input* const input = ZL_Segmenter_getInput(sctx, 0);
+    ZL_ERR_IF_NE(ZL_Input_numElts(input), 0, node_invalid_input);
+    return ZL_returnSuccess();
+}
+
+static ZL_SegmenterDesc const zeroSegmentSegmenter = {
+    .name           = "Zero Segment Segmenter",
+    .segmenterFn    = zeroSegmentSegmenterFn,
+    .inputTypeMasks = (const ZL_Type[]){ ZL_Type_serial },
+    .numInputs      = 1,
+};
+
+TEST(Segmenter, zeroSegments_mustFail)
+{
+    if (g_testVersion < ZL_CHUNK_VERSION_MIN)
+        return;
+
+    size_t const compressedBound = ZL_compressBound(0);
+    void* const compressed       = malloc(compressedBound);
+    ASSERT_NE(compressed, nullptr);
+
+    g_segmenterDescPtr = &zeroSegmentSegmenter;
+
+    ZL_CCtx* const cctx = ZL_CCtx_create();
+    ASSERT_NE(cctx, nullptr);
+    ZL_Compressor* const compressor = ZL_Compressor_create();
+    ASSERT_NE(compressor, nullptr);
+    ZL_Report gssr =
+            ZL_Compressor_initUsingGraphFn(compressor, registerSegmenter);
+    ASSERT_FALSE(ZL_isError(gssr));
+    ZL_Report rcgr = ZL_CCtx_refCompressor(cctx, compressor);
+    ASSERT_FALSE(ZL_isError(rcgr));
+
+    ZL_TypedRef* input = ZL_TypedRef_createSerial(NULL, 0);
+    ASSERT_NE(input, nullptr);
+    ZL_Report const r =
+            ZL_CCtx_compressTypedRef(cctx, compressed, compressedBound, input);
+    EXPECT_TRUE(ZL_isError(r))
+            << "Compression must fail when segmenter produces zero segments";
+
+    // The decompressor rejects frames with zero segments. We could change the
+    // decompressor to accept them, in which case we'd need to validate that
+    // round trips succeed here.
+
+    ZL_TypedRef_free(input);
+    ZL_Compressor_free(compressor);
+    ZL_CCtx_free(cctx);
+    free(compressed);
+}
+
 /* *********************************************** */
 /* =======   Expected clean failure tests ======== */
 /* *********************************************** */


### PR DESCRIPTION
Summary:

Previously, a segmenter that returned success without ever calling `ZL_Segmenter_processChunk()` would cause a crash in debug builds (assertion failure in CCTX_listBuffersToStore) or silently produce corrupt compressed data in release builds. This was because there was no validation that the segmenter actually produced any segments.

Add a numChunks counter to `ZL_Segmenter_s`, increment it in `ZL_Segmenter_processChunk()`, and validate `numChunks > 0` in `SEGM_runSegmenter()` after the user's segmenter function returns. If no segments were produced, return the new `ZL_ErrorCode_segmenter_noSegments` error.

Fixes https://github.com/facebook/openzl/issues/253

Differential Revision: D103079914


