### PR TITLE
Adapt custom components in openzl to new component registration pattern [1/n]

### DIFF
--- a/custom_transforms/thrift/directed_selector.c
+++ b/custom_transforms/thrift/directed_selector.c
@@ -5,7 +5,7 @@
 #include "openzl/zl_data.h"
 #include "openzl/zl_selector.h"
 
-static ZL_GraphID directed_selector_impl(
+ZL_GraphID directed_selector_impl(
         const ZL_Selector* selCtx,
         const ZL_Input* inputStream,
         const ZL_GraphID* customGraphs,

--- a/custom_transforms/thrift/directed_selector.h
+++ b/custom_transforms/thrift/directed_selector.h
@@ -3,6 +3,7 @@
 #pragma once
 
 #include "openzl/zl_compressor.h"
+#include "openzl/zl_selector.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -13,6 +14,17 @@ extern "C" {
  * to use.
  */
 static const int kDirectedSelectorMetadataID = 0;
+
+/**
+ * The directed selector implementation function.
+ * Selects a successor graph based on integer metadata at
+ * kDirectedSelectorMetadataID.
+ */
+ZL_GraphID directed_selector_impl(
+        const ZL_Selector* selCtx,
+        const ZL_Input* inputStream,
+        const ZL_GraphID* customGraphs,
+        size_t nbCustomGraphs);
 
 /**
  * Registers the base directed selector graph if not already registered.

--- a/custom_transforms/thrift/empty_input_selector.c
+++ b/custom_transforms/thrift/empty_input_selector.c
@@ -4,7 +4,7 @@
 
 #include "openzl/zl_data.h"
 
-static ZL_GraphID empty_input_selector_impl(
+ZL_GraphID empty_input_selector_impl(
         const ZL_Selector* selCtx,
         const ZL_Input* inputStream,
         const ZL_GraphID* customGraphs,

--- a/custom_transforms/thrift/empty_input_selector.h
+++ b/custom_transforms/thrift/empty_input_selector.h
@@ -10,6 +10,16 @@ extern "C" {
 #endif
 
 /**
+ * The empty input selector implementation function.
+ * Routes to successors[0] if input is empty, successors[1] otherwise.
+ */
+ZL_GraphID empty_input_selector_impl(
+        const ZL_Selector* selCtx,
+        const ZL_Input* inputStream,
+        const ZL_GraphID* customGraphs,
+        size_t nbCustomGraphs);
+
+/**
  * A selector that behaves as follows:
  *
  *   if (input.empty()) {


### PR DESCRIPTION
Summary:
Move custom components (directed_selector, empty_input_selector) for thrift graph in OpenZL to new registration pattern in MC. To achieve this:
1. Expose the function graph in openzl via the header file
2. Use the `MANAGED_COMPRESSION_DECLARE_CUSTOM_OPENZL_SELECTOR` + `instantiate` functions in `SerializedThriftGraph.cpp`

Reviewed By: felixhandte

Differential Revision: D102695392


