### PR TITLE
openzl: codemod internal ZS2_ names to ZL_

### DIFF
--- a/src/openzl/common/refcount.c
+++ b/src/openzl/common/refcount.c
@@ -6,7 +6,7 @@
 #include "openzl/common/allocation.h"
 #include "openzl/zl_errors.h"
 
-struct ZS2_Refcount_Control {
+struct ZL_Refcount_Control {
     void* ptr;
     ZL_Refcount_FreeFn freeFn;
     void* freeState;
@@ -30,7 +30,7 @@ ZL_Report ZL_Refcount_init(
         // managed reference => free MUST be defined
         ZL_ASSERT_NN(freeFn);
         ZL_ASSERT_NN(ctrlAlloc->sfree);
-        struct ZS2_Refcount_Control* const ctrl =
+        struct ZL_Refcount_Control* const ctrl =
                 ctrlAlloc->malloc(ctrlAlloc->opaque, sizeof(*ctrl));
         ZL_ERR_IF_NULL(ctrl, allocation);
 
@@ -61,7 +61,7 @@ static void* mallocFn(void* opaque, size_t s)
     return ZL_malloc(s);
 }
 
-static const ALLOC_CustomAllocation ZS2_Refcount_defaultAllocation = {
+static const ALLOC_CustomAllocation ZL_Refcount_defaultAllocation = {
     .malloc = mallocFn,
     .sfree  = freeFn,
     .opaque = NULL
@@ -70,7 +70,7 @@ static const ALLOC_CustomAllocation ZS2_Refcount_defaultAllocation = {
 ZL_Report ZL_Refcount_initMalloc(ZL_Refcount* rc, void* ptr)
 {
     return ZL_Refcount_init(
-            rc, ptr, &ZS2_Refcount_defaultAllocation, freeFn, NULL);
+            rc, ptr, &ZL_Refcount_defaultAllocation, freeFn, NULL);
 }
 
 ZL_Report ZL_Refcount_initConstRef(ZL_Refcount* rc, const void* ptr)
@@ -94,11 +94,11 @@ ZL_Report ZL_Refcount_initMutRef(ZL_Refcount* rc, void* ptr)
 }
 
 // simple redirectors, just for type matching
-static void* ZS2_Refcount_arenaMalloc(void* arena, size_t s)
+static void* ZL_Refcount_arenaMalloc(void* arena, size_t s)
 {
     return ALLOC_Arena_malloc(arena, s);
 }
-static void ZS2_Refcount_arenaFree(void* arena, void* p)
+static void ZL_Refcount_arenaFree(void* arena, void* p)
 {
     ALLOC_Arena_free(arena, p);
 }
@@ -113,11 +113,11 @@ void* ZL_Refcount_inArena(ZL_Refcount* rc, Arena* arena, size_t s)
                 s);
         return NULL;
     }
-    const ALLOC_CustomAllocation ca = { ZS2_Refcount_arenaMalloc,
-                                        ZS2_Refcount_arenaFree,
+    const ALLOC_CustomAllocation ca = { ZL_Refcount_arenaMalloc,
+                                        ZL_Refcount_arenaFree,
                                         arena };
     ZL_Report const rcir =
-            ZL_Refcount_init(rc, buffer, &ca, ZS2_Refcount_arenaFree, arena);
+            ZL_Refcount_init(rc, buffer, &ca, ZL_Refcount_arenaFree, arena);
     if (ZL_isError(rcir)) {
         // Note(@Cyan): could be worth passing to some error context
         ZL_DLOG(ERROR,

--- a/src/openzl/common/refcount.h
+++ b/src/openzl/common/refcount.h
@@ -23,7 +23,7 @@ typedef void (*ZL_Refcount_FreeFn)(void* opaque, void* ptr)
  */
 typedef struct {
     void* _ptr;
-    struct ZS2_Refcount_Control* _ref;
+    struct ZL_Refcount_Control* _ref;
     bool _mutable;
 } ZL_Refcount;
 
@@ -31,7 +31,7 @@ typedef struct {
  * Takes ownership of @p ptr and frees it with `(*freeFn)(opaque, ptr)`.
  *
  * @p ptr The pointer to reference count.
- * @p ctrlAlloc Used to manage ZS2_Refcount_Control* lifetime.
+ * @p ctrlAlloc Used to manage ZL_Refcount_Control* lifetime.
  * If == NULL, @p ptr is considered an externally managed memory,
  * and just referenced (no Free operation will be triggered).
  * @p freeBufferFn The function used to free the pointer on reaching 0.
@@ -47,7 +47,7 @@ ZL_Report ZL_Refcount_init(
         void* opaque);
 
 /// Initializes the reference with a pointer that has been created with
-/// malloc(). ZS2_Refcount_Control* will be allocated with malloc() too.
+/// malloc(). ZL_Refcount_Control* will be allocated with malloc() too.
 ZL_Report ZL_Refcount_initMalloc(ZL_Refcount* rc, void* ptr);
 
 /// Initializes the reference with a constant reference that will not be freed.
@@ -60,7 +60,7 @@ ZL_Report ZL_Refcount_initConstRef(ZL_Refcount* rc, void const* ptr);
 ZL_Report ZL_Refcount_initMutRef(ZL_Refcount* rc, void* ptr);
 
 /// Helper function, which **allocates** a buffer of size @s within provided
-/// @arena, and also allocated the control structure ZS2_Refcount_Control* in
+/// @arena, and also allocated the control structure ZL_Refcount_Control* in
 /// the same Arena, for compatibility with Arena's freeAll().
 /// @return NULL on error.
 void* ZL_Refcount_inArena(ZL_Refcount* rc, Arena* arena, size_t s);

--- a/src/openzl/common/stream.c
+++ b/src/openzl/common/stream.c
@@ -1098,7 +1098,7 @@ ZL_Report STREAM_setIntMetadata(Stream* s, int mId, int mValue)
     return ZL_returnSuccess();
 }
 
-#define ZS2_INTMETADATA_NOT_PRESENT (-1)
+#define ZL_INTMETADATA_NOT_PRESENT (-1)
 ZL_IntMetadata STREAM_getIntMetadata(const Stream* s, int mId)
 {
     ZL_ASSERT_NN(s);
@@ -1106,7 +1106,7 @@ ZL_IntMetadata STREAM_getIntMetadata(const Stream* s, int mId)
     if (idx < 0)
         return (ZL_IntMetadata){
             .isPresent = 0,
-            .mValue    = ZS2_INTMETADATA_NOT_PRESENT,
+            .mValue    = ZL_INTMETADATA_NOT_PRESENT,
         };
     return (ZL_IntMetadata){
         .isPresent = 1,

--- a/src/openzl/common/wire_format.c
+++ b/src/openzl/common/wire_format.c
@@ -4,8 +4,8 @@
 
 #include "openzl/shared/mem.h"
 
-#define ZS2_MIN_MAGIC (ZSTRONG_MAGIC_NUMBER_BASE + ZL_MIN_FORMAT_VERSION)
-#define ZS2_MAX_MAGIC (ZSTRONG_MAGIC_NUMBER_BASE + ZL_MAX_FORMAT_VERSION)
+#define ZL_MIN_MAGIC (ZSTRONG_MAGIC_NUMBER_BASE + ZL_MIN_FORMAT_VERSION)
+#define ZL_MAX_MAGIC (ZSTRONG_MAGIC_NUMBER_BASE + ZL_MAX_FORMAT_VERSION)
 
 ZL_Report ZL_getFormatVersionFromFrame(void const* src, size_t srcSize)
 {
@@ -28,13 +28,13 @@ ZL_Report ZL_getFormatVersionFromMagic(uint32_t magic)
     // Detect invalid magic numbers - outside of the range of versions
     // we know about. Pad the top end of the range to handle versions added
     // after this library was shipped.
-    if (magic < ZSTRONG_MAGIC_NUMBER_BASE || magic > ZS2_MAX_MAGIC + 16)
+    if (magic < ZSTRONG_MAGIC_NUMBER_BASE || magic > ZL_MAX_MAGIC + 16)
         ZL_ERR(header_unknown);
 
     // Detect magic numbers we used for older versions that we no longer
     // support or newer versions we don't yet support.
-    ZL_ERR_IF_LT(magic, ZS2_MIN_MAGIC, formatVersion_unsupported);
-    ZL_ERR_IF_GT(magic, ZS2_MAX_MAGIC, formatVersion_unsupported);
+    ZL_ERR_IF_LT(magic, ZL_MIN_MAGIC, formatVersion_unsupported);
+    ZL_ERR_IF_GT(magic, ZL_MAX_MAGIC, formatVersion_unsupported);
 
     // Extract the supported version number.
     uint32_t const version = magic - ZSTRONG_MAGIC_NUMBER_BASE;

--- a/src/openzl/decompress/decompress2.c
+++ b/src/openzl/decompress/decompress2.c
@@ -490,7 +490,7 @@ static ZL_Report ZL_AppendToOutputOptimization_commitInput(
  * the output buffer, and all inputs starting from `tailInputIdx` by prepending
  * to the tail of the output buffer. Stops when an uncommitted input is reached.
  */
-static ZL_Report ZS2_AppendToOutputOptimization_commitInputs(
+static ZL_Report ZL_AppendToOutputOptimization_commitInputs(
         ZL_AppendToOutputOptimization* append)
 {
     ZL_RESULT_DECLARE_SCOPE_REPORT(NULL);
@@ -540,7 +540,7 @@ static ZL_Report ZL_AppendToOutputOptimization_preTransformHook(
     ZL_AppendToOutputOptimization* append = info->appendOpt;
     ZL_ASSERT_NN(append);
 
-    ZL_ERR_IF_ERR(ZS2_AppendToOutputOptimization_commitInputs(append));
+    ZL_ERR_IF_ERR(ZL_AppendToOutputOptimization_commitInputs(append));
 
     if (info == info->appendOpt->outputInfo) {
         ZL_ERR_IF_NE(
@@ -614,7 +614,7 @@ static ZL_Report ZL_AppendToOutputOptimization_newStreamHook(
         return ZL_returnValue(0);
     }
 
-    ZL_ERR_IF_ERR(ZS2_AppendToOutputOptimization_commitInputs(append));
+    ZL_ERR_IF_ERR(ZL_AppendToOutputOptimization_commitInputs(append));
 
     size_t bytesNeeded;
     ZL_ERR_IF(


### PR DESCRIPTION
Summary:
Answers Github issue 26. 

Rename only file-local and internal ZS2_ helpers, macros, and private refcount internals in `openzl/dev` (common and decompress code). This is the simplest step, and should be mergeable before the release.

There are still some `ZS2_` prefixes left, but they are employed outside of this openzl repository (managed compression notably).
So they will be dealt with more cautiously in future `diff`.

Differential Revision: D103100541


