### PR TITLE
fix: use ZL_free instead of free for ZL_malloc-allocated memory

### DIFF
--- a/src/openzl/compress/compress2.c
+++ b/src/openzl/compress/compress2.c
@@ -83,7 +83,7 @@ static ZL_Report writeFrameHeader(
     ZL_Report const r =
             EFH_writeFrameHeader(dst, dstCapacity, &fi, formatVersion);
 
-    free(inputDescs);
+    ZL_free(inputDescs);
     return r;
 }
 


### PR DESCRIPTION
## Problem

In `writeFrameHeader()` (`compress2.c:86`), `inputDescs` is allocated with `ZL_malloc` (via `ALLOC_MALLOC_CHECKED`) but freed with stdlib `free()`.

When `ZL_malloc` is overridden (e.g. with jemalloc as mentioned in #701), this causes undefined behavior because the allocation and deallocation functions don't match.

## Fix

Replace `free(inputDescs)` with `ZL_free(inputDescs)` on line 86.

This matches the pattern used elsewhere in the codebase (e.g. `table.h:357`, `vector.h:476`).

Fixes #701