### PR TITLE
Speed up OpenZLComponentFuzzer_*

### DIFF
--- a/tests/datagen/DataGen.h
+++ b/tests/datagen/DataGen.h
@@ -219,6 +219,11 @@ class DataGen {
         return rw_->has_more_data();
     }
 
+    size_t num_remaining_bytes() const
+    {
+        return rw_->num_remaining_bytes();
+    }
+
     std::vector<uint8_t> all_remaining_bytes()
     {
         return rw_->all_remaining_bytes();

--- a/tests/datagen/random_producer/LionheadFDPWrapper.h
+++ b/tests/datagen/random_producer/LionheadFDPWrapper.h
@@ -30,7 +30,7 @@ class LionheadFDPWrapper : public RandWrapper {
     {
         return fdp_->has_more_data();
     }
-    size_t remaining_input_length()
+    size_t num_remaining_bytes() const override
     {
         return fdp_->remaining_input_length();
     }

--- a/tests/datagen/random_producer/PRNGWrapper.h
+++ b/tests/datagen/random_producer/PRNGWrapper.h
@@ -106,6 +106,12 @@ class PRNGWrapper : public RandWrapper {
         return true;
     }
 
+    size_t num_remaining_bytes() const override
+    {
+        throw std::runtime_error(
+                "num_remaining_bytes() only available for fuzzers");
+    }
+
     std::vector<uint8_t> all_remaining_bytes() override
     {
         throw std::runtime_error(

--- a/tests/datagen/random_producer/RandWrapper.h
+++ b/tests/datagen/random_producer/RandWrapper.h
@@ -48,6 +48,7 @@ class RandWrapper {
 
     // only applicable to fuzzers
     virtual bool has_more_data()                       = 0;
+    virtual size_t num_remaining_bytes() const         = 0;
     virtual std::vector<uint8_t> all_remaining_bytes() = 0;
 
     virtual bool boolean(NameType name)

--- a/tests/fuzz/OpenZLComponentFuzzer.cpp
+++ b/tests/fuzz/OpenZLComponentFuzzer.cpp
@@ -199,27 +199,21 @@ FUZZ(OpenZLComponentFuzzer, FuzzRoundTrip)
                 formatVersion);
     }
 
-    while (gen.has_more_data()) {
-        const size_t size = gen.usize_range("input_size", 1, 4096);
-        auto inputs =
-                component->generateInputs(gen, 1, size, compressor, graph);
-        if (inputs.empty()) {
-            break;
-        }
-        for (const auto& input : inputs) {
-            try {
-                fuzzRoundTrip(
-                        *component, compressor, *input, graph, formatVersion);
-            } catch (const Exception& e) {
-                // The format version and graph are selected independently by
-                // the fuzzer. A graph may exceed the runtime limits (nodes,
-                // streams, inputs) of an older format version. This is not an
-                // input validity issue, so we allow it.
-                if (e.code() != ZL_ErrorCode_formatVersion_unsupported) {
-                    throw;
-                }
-                return;
+    const size_t size = gen.usize_range(
+            "input_size", 1, std::max(size_t(1), gen.num_remaining_bytes()));
+    auto inputs = component->generateInputs(gen, 1, size, compressor, graph);
+    for (const auto& input : inputs) {
+        try {
+            fuzzRoundTrip(*component, compressor, *input, graph, formatVersion);
+        } catch (const Exception& e) {
+            // The format version and graph are selected independently by
+            // the fuzzer. A graph may exceed the runtime limits (nodes,
+            // streams, inputs) of an older format version. This is not an
+            // input validity issue, so we allow it.
+            if (e.code() != ZL_ErrorCode_formatVersion_unsupported) {
+                throw;
             }
+            return;
         }
     }
 }
@@ -256,15 +250,13 @@ FUZZ(OpenZLComponentFuzzer, FuzzCompress)
                 formatVersion);
     }
 
-    while (gen.has_more_data()) {
-        auto input = generateInput(gen, compressor, graph, formatVersion);
-        try {
-            // TODO: Permissive mode doesn't guarantee success when hitting
-            // runtime limits on the number of nodes or streams.
-            fuzzRoundTrip(*component, compressor, *input, graph, formatVersion);
-        } catch (...) {
-            // Raising exceptions is okay, just can't crash
-        }
+    auto input = generateInput(gen, compressor, graph, formatVersion);
+    try {
+        // TODO: Permissive mode doesn't guarantee success when hitting
+        // runtime limits on the number of nodes or streams.
+        fuzzRoundTrip(*component, compressor, *input, graph, formatVersion);
+    } catch (...) {
+        // Raising exceptions is okay, just can't crash
     }
 }
 

--- a/tests/registry/components/Sentinel.cpp
+++ b/tests/registry/components/Sentinel.cpp
@@ -134,7 +134,8 @@ class SentinelNumComponent : public OpenZLComponent {
             auto width     = gen.choices<size_t>("width", { 1, 2, 4, 8 });
             size_t maxElts = maxInputSize / width;
             if (maxElts < minElts) {
-                maxElts = minElts;
+                // Cannot generate a valid input
+                continue;
             }
             size_t numElts = gen.usize_range("numElts", minElts, maxElts);
 


### PR DESCRIPTION
Summary: It was trying to consume the entire fuzzer input. It turns out that this was slowing down the fuzzers to the point where it spent at least half of the fuzzing time just loading the corpus. Instead, just generate a single input.

Differential Revision: D103218107


