### PR TITLE
C++: Easy: Store Whole ZL_Error in Exception (#705)

### DIFF
--- a/cpp/include/openzl/cpp/Exception.hpp
+++ b/cpp/include/openzl/cpp/Exception.hpp
@@ -28,7 +28,7 @@ class Exception : public std::runtime_error {
     /// @see ExceptionBuilder
     Exception(
             poly::string_view msg,
-            poly::optional<ZL_ErrorCode> code,
+            poly::optional<ZL_Error> error,
             poly::string_view errorContext,
             poly::source_location location);
 
@@ -37,9 +37,13 @@ class Exception : public std::runtime_error {
         return msg_;
     }
 
-    const poly::optional<ZL_ErrorCode>& code() const noexcept
+    poly::optional<ZL_ErrorCode> code() const noexcept
     {
-        return code_;
+        if (error_) {
+            return ZL_E_code(error_.value());
+        } else {
+            return {};
+        }
     }
 
     poly::string_view errorContext() const noexcept
@@ -54,7 +58,7 @@ class Exception : public std::runtime_error {
 
    private:
     std::string msg_;
-    poly::optional<ZL_ErrorCode> code_;
+    poly::optional<ZL_Error> error_;
     std::string errorContext_;
     poly::source_location location_;
 };

--- a/cpp/src/openzl/cpp/Exception.cpp
+++ b/cpp/src/openzl/cpp/Exception.cpp
@@ -10,7 +10,7 @@ namespace openzl {
 namespace {
 std::string formatMsg(
         std::string_view msg,
-        const poly::optional<ZL_ErrorCode>& code,
+        const poly::optional<ZL_Error>& error,
         poly::string_view errorContext,
         const poly::source_location& location)
 {
@@ -21,11 +21,11 @@ std::string formatMsg(
         out += msg;
         out += '\n';
     }
-    if (code.has_value()) {
+    if (error.has_value()) {
         out += "OpenZL error code: ";
-        out += std::to_string(code.value());
+        out += std::to_string(ZL_E_code(error.value()));
         out += "\nOpenZL error string: ";
-        out += ZL_ErrorCode_toString(code.value());
+        out += ZL_ErrorCode_toString(ZL_E_code(error.value()));
         out += "\n";
     }
     if (!errorContext.empty()) {
@@ -60,12 +60,12 @@ Exception::Exception(poly::string_view msg, poly::source_location location)
 
 Exception::Exception(
         poly::string_view msg,
-        poly::optional<ZL_ErrorCode> code,
+        poly::optional<ZL_Error> error,
         poly::string_view errorContext,
         poly::source_location location)
-        : std::runtime_error(formatMsg(msg, code, errorContext, location)),
+        : std::runtime_error(formatMsg(msg, error, errorContext, location)),
           msg_(msg),
-          code_(std::move(code)),
+          error_(std::move(error)),
           errorContext_(errorContext),
           location_(std::move(location))
 {
@@ -148,11 +148,7 @@ ExceptionBuilder&& ExceptionBuilder::addErrorContext<ZL_Graph>(
 
 Exception ExceptionBuilder::build() && noexcept
 {
-    poly::optional<ZL_ErrorCode> code;
-    if (error_.has_value()) {
-        code.emplace(ZL_E_code(error_.value()));
-    }
-    return Exception(msg_, code, errorContext_, std::move(location_));
+    return Exception(msg_, error_, errorContext_, std::move(location_));
 }
 
 ZL_Error_Array get_warnings(const ZL_CCtx* const& cctx)


### PR DESCRIPTION
Summary:

As title.

Reviewed By: kevinjzhang

Differential Revision: D101645553


