### PR TITLE
Fix `-Wtypedef-redefinition` errors in public headers for C99 compatibility (#712)

### DIFF
--- a/.github/workflows/dev-ci.yml
+++ b/.github/workflows/dev-ci.yml
@@ -188,6 +188,15 @@ jobs:
       - name: Run tests
         run: make test
 
+  # Header compatibility tests (compile-only)
+  test-c99-compat:
+    name: C99 Compatibility
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Verify public headers compile under strict C99
+        run: CC=clang make c99_compat
+
   # CLI integration testing
   test-cli:
     name: CLI Integration Tests

--- a/Makefile
+++ b/Makefile
@@ -320,6 +320,14 @@ $(eval $(call c_program_shared_o,zs2_selector,examples/zs2_selector.o tools/file
 zs2_round_trip:
 $(eval $(call cxx_program_shared_o,zs2_round_trip,tests/round_trip.o tools/fileio/fileio.o $(SHARED_COMPONENTS_CXXOBJS) $(LIBOBJS),$(LIBZSTD_A) $(LIBLZ4_A)))
 
+# ********     Compatibility tests     ********
+
+# Compile-only check that public headers remain usable from a strict C99 TU.
+.PHONY: c99_compat
+c99_compat:
+	$(CC) -std=c99 -Werror -Wall -Wextra -Iinclude \
+	    -c tests/compat/c99_compat.c -o /dev/null
+
 # ********     Cleaning     ********
 
 .PHONY: clean

--- a/include/openzl/zl_compressor.h
+++ b/include/openzl/zl_compressor.h
@@ -20,7 +20,7 @@
 #include "openzl/zl_compress.h"     // ZL_CCtx
 #include "openzl/zl_errors.h"       // ZL_Report, ZL_ErrorCode
 #include "openzl/zl_localParams.h"  // ZL_LocalParams
-#include "openzl/zl_opaque_types.h" // ZL_GraphID
+#include "openzl/zl_opaque_types.h" // ZL_GraphID, ZL_Compressor
 #include "openzl/zl_portability.h"  // ZL_NOEXCEPT_FUNC_PTR
 #include "openzl/zl_public_nodes.h"
 
@@ -56,8 +56,6 @@ extern "C" {
  *
  * @{
  */
-
-typedef struct ZL_Compressor_s ZL_Compressor;
 
 /**
  * @brief Create a new @ref ZL_Compressor.

--- a/include/openzl/zl_ctransform_legacy.h
+++ b/include/openzl/zl_ctransform_legacy.h
@@ -50,7 +50,7 @@ extern "C" {
  * though this API does not define any specific list of error codes.
  **/
 
-typedef size_t (*ZL_PipeDstCapacityFn)(const void* src, size_t srcSize)
+typedef size_t (*ZL_CPipeDstCapacityFn)(const void* src, size_t srcSize)
         ZL_NOEXCEPT_FUNC_PTR;
 typedef size_t (*ZL_PipeEncoderFn)(
         void* dst,
@@ -61,7 +61,7 @@ typedef size_t (*ZL_PipeEncoderFn)(
 typedef struct {
     ZL_IDType CTid;
     ZL_PipeEncoderFn transform_f;
-    ZL_PipeDstCapacityFn dstBound_f;
+    ZL_CPipeDstCapacityFn dstBound_f;
     const char* name; // Optional display name, for debugging purposes. Allowed
                       // to be NULL.
 } ZL_PipeEncoderDesc;

--- a/include/openzl/zl_decompress.h
+++ b/include/openzl/zl_decompress.h
@@ -7,6 +7,7 @@
 #include "openzl/zl_common_types.h"
 #include "openzl/zl_errors.h"        // ZL_Report, ZL_isError()
 #include "openzl/zl_introspection.h" // ZL_DecompressIntrospectionHooks
+#include "openzl/zl_opaque_types.h"  // ZL_DCtx
 #include "openzl/zl_output.h"
 
 #if defined(__cplusplus)
@@ -67,11 +68,6 @@ ZL_Report ZL_getCompressedSize(const void* compressed, size_t testedSize);
 // ------------------------------------------------
 // One-pass decompression with advanced parameters
 // ------------------------------------------------
-
-/**
- * @brief Decompression context for state management (incomplete type).
- */
-typedef struct ZL_DCtx_s ZL_DCtx;
 
 /**
  * @brief Creates a new decompression context.

--- a/include/openzl/zl_dtransform.h
+++ b/include/openzl/zl_dtransform.h
@@ -18,6 +18,7 @@
 #include "openzl/zl_decompress.h" // ZL_DCtx
 #include "openzl/zl_dtransform_legacy.h" // Pipe and Split transforms
 #include "openzl/zl_errors.h"            // ZL_Report, ZL_isError()
+#include "openzl/zl_opaque_types.h"      // ZL_Decoder
 #include "openzl/zl_portability.h"       // ZL_NOEXCEPT_FUNC_PTR
 
 #if defined(__cplusplus)
@@ -67,8 +68,6 @@ extern "C" {
  * with both encoder and decoder working approximately the same way.
  * Consistency is what tilted the balance in favor of current design.
  **/
-
-typedef struct ZL_Decoder_s ZL_Decoder; // incomplete type
 
 typedef ZL_Report (*ZL_TypedDecoderFn)(ZL_Decoder* dictx, const ZL_Input* src[])
         ZL_NOEXCEPT_FUNC_PTR;

--- a/include/openzl/zl_dtransform_legacy.h
+++ b/include/openzl/zl_dtransform_legacy.h
@@ -44,7 +44,7 @@ extern "C" {
  * Any @return value > dstCapacity will be interpreted as an error.
  */
 
-typedef size_t (*ZL_PipeDstCapacityFn)(const void* src, size_t srcSize)
+typedef size_t (*ZL_DPipeDstCapacityFn)(const void* src, size_t srcSize)
         ZL_NOEXCEPT_FUNC_PTR;
 typedef size_t (*ZL_PipeDecoderFn)(
         void* dst,
@@ -54,7 +54,7 @@ typedef size_t (*ZL_PipeDecoderFn)(
 
 typedef struct {
     ZL_IDType CTid;
-    ZL_PipeDstCapacityFn dstBound_f;
+    ZL_DPipeDstCapacityFn dstBound_f;
     ZL_PipeDecoderFn transform_f;
     const char* name; // Optional display name, for debugging purposes. Allowed
                       // to be NULL.

--- a/include/openzl/zl_graph_api.h
+++ b/include/openzl/zl_graph_api.h
@@ -46,8 +46,6 @@ extern "C" {
  * Note: Function Graph is (currently) the only way to deal with multiple
  * Inputs.
  */
-typedef struct ZL_Graph_s ZL_Graph;
-typedef struct ZL_Edge_s ZL_Edge;
 typedef struct ZL_FunctionGraphDesc ZL_FunctionGraphDesc;
 /**
  * The function signature for function graphs.
@@ -201,8 +199,6 @@ const char* ZL_Graph_getErrorContextString_fromError(
 
 /* Actions */
 /* ------- */
-
-typedef struct ZL_GraphParameters_s ZL_RuntimeGraphParameters;
 
 /* Scratch space allocation:
  * When the function graph function needs some temporary space for some

--- a/include/openzl/zl_introspection.h
+++ b/include/openzl/zl_introspection.h
@@ -8,9 +8,6 @@
 #include "openzl/zl_localParams.h"
 #include "openzl/zl_opaque_types.h"
 
-// Forward declaration to avoid circular dependency with zl_graph_api.h
-typedef struct ZL_GraphParameters_s ZL_RuntimeGraphParameters;
-
 // Introspection hooks for compress
 typedef struct ZL_CompressIntrospectionHooks_s {
     void* opaque; // an opaque pointer, passed as-is to all the hooks as the

--- a/include/openzl/zl_opaque_types.h
+++ b/include/openzl/zl_opaque_types.h
@@ -82,6 +82,7 @@ typedef struct ZL_Decoder_s ZL_Decoder;
 typedef struct ZL_Selector_s ZL_Selector;
 typedef struct ZL_Graph_s ZL_Graph;
 typedef struct ZL_Edge_s ZL_Edge;
+typedef struct ZL_GraphParameters_s ZL_RuntimeGraphParameters;
 typedef struct ZL_Segmenter_s ZL_Segmenter;
 typedef struct ZL_DictLoader_s ZL_DictLoader;
 

--- a/include/openzl/zl_segmenter.h
+++ b/include/openzl/zl_segmenter.h
@@ -8,10 +8,9 @@
 
 #include "openzl/zl_common_types.h" // ZL_OpaquePtr
 #include "openzl/zl_compress.h"     // ZL_CParam
-#include "openzl/zl_graph_api.h"    // ZL_RuntimeGraphParameters
 #include "openzl/zl_localParams.h"  // ZL_LocalParams
 #include "openzl/zl_materializer.h" // ZL_MaterializerDesc
-#include "openzl/zl_opaque_types.h" // ZL_GraphID
+#include "openzl/zl_opaque_types.h" // ZL_GraphID, ZL_RuntimeGraphParameters, ZL_Segmenter
 
 #if defined(__cplusplus)
 extern "C" {
@@ -77,7 +76,6 @@ extern "C" {
  */
 #define ZL_DEFAULT_SEGMENTER_CHUNK_BYTE_SIZE (16 << 20)
 
-typedef struct ZL_Segmenter_s ZL_Segmenter;
 typedef ZL_Report (*ZL_SegmenterFn)(ZL_Segmenter* sctx);
 
 typedef struct {

--- a/src/openzl/codecs/rolz/encode_rolz_binding.c
+++ b/src/openzl/codecs/rolz/encode_rolz_binding.c
@@ -79,7 +79,7 @@ EI_fastlz_typed(ZL_Encoder* eictx, const ZL_Input* ins[], size_t nbIns)
  * ===============================================
  */
 
-// ZL_PipeDstCapacityFn
+// ZL_CPipeDstCapacityFn
 size_t EI_rolz_dstBound(const void* src, size_t srcSize)
 {
     (void)src;
@@ -108,7 +108,7 @@ size_t EI_rolz(void* dst, size_t dstCapacity, const void* src, size_t srcSize)
     return ZL_validResult(r) + 4;
 }
 
-// ZL_PipeDstCapacityFn
+// ZL_CPipeDstCapacityFn
 size_t EI_fastlz_dstBound(const void* src, size_t srcSize)
 {
     (void)src;

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -13,6 +13,7 @@ function(add_zs_test TESTNAME)
 endfunction()
 
 add_subdirectory(datagen)
+add_subdirectory(compat)
 
 file(
     GLOB_RECURSE test_fixtures

--- a/tests/compat/CMakeLists.txt
+++ b/tests/compat/CMakeLists.txt
@@ -1,0 +1,18 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+
+# Compatibility tests for OpenZL public headers under various language modes.
+# Each test compiles a trivial program that #includes the umbrella header
+# (openzl/openzl.h) and exits. The build is the actual check; the runtime body
+# is a no-op.
+
+add_executable(c99_compat c99_compat.c)
+target_link_libraries(c99_compat PRIVATE openzl)
+set_target_properties(c99_compat PROPERTIES
+    C_STANDARD 99
+    C_STANDARD_REQUIRED ON
+    C_EXTENSIONS OFF
+)
+if(NOT MSVC)
+    target_compile_options(c99_compat PRIVATE -Werror -Wall -Wextra)
+endif()
+add_test(NAME c99_compat COMMAND c99_compat)

--- a/tests/compat/c99_compat.c
+++ b/tests/compat/c99_compat.c
@@ -1,0 +1,13 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+// Compile-time check that OpenZL's public headers remain usable from a strict
+// C99 translation unit. The body is intentionally trivial — building this
+// target IS the test. Guards against regressions like the duplicate-typedef
+// issue fixed in PR #293 (typedef redefinition is a C11 feature).
+
+#include "openzl/openzl.h"
+
+int main(void)
+{
+    return 0;
+}


### PR DESCRIPTION
Summary:

Public headers had duplicate typedef definitions that triggered `-Wtypedef-redefinition` errors when included in C99 mode (the redundant typedef construct is C11+). The original PR fixed 3 such errors in `zl_graph_api.h`; review surfaced 4 more across other public headers, all now resolved.

Cleanup beyond the original PR:
- Forward-typedefs of opaque types (`ZL_Compressor`, `ZL_DCtx`, `ZL_Decoder`, `ZL_Segmenter`, `ZL_RuntimeGraphParameters`) are now declared once, in `zl_opaque_types.h`. Consumer headers include it directly rather than relying on transitive chains.
- `ZL_PipeDstCapacityFn` (legacy, identical declaration in two unrelated headers) is disambiguated as `ZL_CPipeDstCapacityFn` / `ZL_DPipeDstCapacityFn`, following the existing C/D prefix convention. No internal consumer references the old name.

A tiny compile-only test (`tests/compat/c99_compat.c`, which `#include`s the umbrella header `openzl/openzl.h`) is wired into `make c99_compat` and a new `test-c99-compat` GitHub CI job to prevent regression. Flags: `-std=c99 -Werror -Wall -Wextra` (no `-pedantic` — anonymous unions in `zl_graph_api.h` are intentional).


Test Plan:
```
make c99_compat              # default cc (GCC) — exits 0
make c99_compat CC=clang     # Clang — exits 0
buck2 build fbcode//openzl/dev:{openzl_core,compress,decompress}  # passes
buck2 test  fbcode//openzl/dev/tests:unittest                     # 556/556 pass
```

Original PR test plan (cmake build + install + C99 compile against installed headers + `ctest` 1202 tests) preserved unchanged.

Reviewed By: terrelln

Differential Revision: D103243240

Pulled By: Cyan4973


Signed-off-by: otegami <otegami@clear-code.com>