### PR TITLE
Stop using the serialized compressor in clustering training (#713)

### DIFF
--- a/tools/training/clustering/clustering_graph_trainer.cpp
+++ b/tools/training/clustering/clustering_graph_trainer.cpp
@@ -3,6 +3,7 @@
 #include <vector>
 
 #include "openzl/common/allocation.h"
+#include "openzl/compress/cgraph.h"
 #include "openzl/compress/graphs/generic_clustering_graph.h"
 #include "openzl/cpp/CCtx.hpp"
 #include "openzl/cpp/Exception.hpp"
@@ -31,18 +32,14 @@ namespace {
  * NOTE: this function does not swap this new clustering graph into the
  * original graph, it just registers it on the compressor.
  */
-std::string addAceSuccessors(
-        Compressor& compressor,
-        ZL_GraphID trainedClusteringGraphID)
+void setAceSuccessors(Compressor& compressor, GraphID trainedClusteringGraphID)
 {
     // Add the same number of ACE successors as there are clustering
     // successors
-    auto numClusteringSuccessors =
-            extractSuccessorsFromCbor(
-                    compressor.serialize(),
-                    ZL_Compressor_Graph_getName(
-                            compressor.get(), trainedClusteringGraphID))
-                    .size();
+    const size_t numClusteringSuccessors =
+            ZL_Compressor_Graph_getCustomGraphs(
+                    compressor.get(), trainedClusteringGraphID)
+                    .nbGraphIDs;
 
     std::vector<ZL_GraphID> aceGraphIds;
     aceGraphIds.reserve(numClusteringSuccessors);
@@ -50,24 +47,13 @@ std::string addAceSuccessors(
         aceGraphIds.push_back(ZL_Compressor_buildACEGraph(compressor.get()));
     }
 
-    // Create and register new clustering graph with the ACE successors
-    auto localParams = ZL_Compressor_Graph_getLocalParams(
-            compressor.get(), trainedClusteringGraphID);
-
-    ZL_ParameterizedGraphDesc const newClusteringGraphDesc = {
-        .graph          = trainedClusteringGraphID,
+    ZL_GraphParameters params = {
         .customGraphs   = aceGraphIds.data(),
         .nbCustomGraphs = aceGraphIds.size(),
-        .localParams    = &localParams
     };
 
-    // Replace original clustering graph with the new one
-    auto clusterGraphWithAceSuccessorsID =
-            ZL_Compressor_registerParameterizedGraph(
-                    compressor.get(), &newClusteringGraphDesc);
-
-    return ZL_Compressor_Graph_getName(
-            compressor.get(), clusterGraphWithAceSuccessorsID);
+    compressor.unwrap(ZL_Compressor_overrideGraphParams(
+            compressor.get(), trainedClusteringGraphID, &params));
 }
 
 /**
@@ -80,33 +66,22 @@ ZL_GraphID clusterSuccessors(
         const std::vector<MultiInput>& inputs,
         Compressor& compressor,
         const TrainParams& trainParams,
-        const std::string& clusteringGraphUniqueNameUntrained)
+        GraphID clusteringGraphUniqueIDUntrained)
 {
-    auto cctx                                = refCCtxForTraining(compressor);
-    const auto serializedCompressorUntrained = compressor.serialize();
+    auto cctx = refCCtxForTraining(compressor);
+
+    const std::string clusteringGraphUniqueNameUntrained =
+            ZL_Compressor_Graph_getName(
+                    compressor.get(), clusteringGraphUniqueIDUntrained);
 
     // Get successors for training
-    auto successorsFromSerialization = extractSuccessorsFromCbor(
-            serializedCompressorUntrained, clusteringGraphUniqueNameUntrained);
-    std::vector<ZL_GraphID> successorsVec;
-    successorsVec.reserve(successorsFromSerialization.size());
-    for (const auto& successor : successorsFromSerialization) {
-        ZL_GraphID graphId =
-                ZL_Compressor_getGraph(compressor.get(), successor.c_str());
-        successorsVec.push_back(graphId);
-    }
+    const auto successorsVec =
+            getCustomGraphs(compressor, clusteringGraphUniqueIDUntrained);
 
     // Get clustering codecs for training
-    auto nodesFromSerialization = extractNodesFromCbor(
-            serializedCompressorUntrained, CLUSTERING_GRAPH_NAME);
+    std::vector<ZL_NodeID> clusteringCodecs =
+            getCustomNodes(compressor, clusteringGraphUniqueIDUntrained);
 
-    std::vector<ZL_NodeID> clusteringCodecs;
-    clusteringCodecs.reserve(nodesFromSerialization.size());
-    for (const auto& node : nodesFromSerialization) {
-        ZL_NodeID nodeID =
-                ZL_Compressor_getNode(compressor.get(), node.c_str());
-        clusteringCodecs.push_back(nodeID);
-    }
     auto samples = collectInputStreamsForGraph(
             inputs, clusteringGraphUniqueNameUntrained, cctx);
     Logger::log_c(
@@ -137,17 +112,50 @@ ZL_GraphID clusterSuccessors(
  * Get the unique name of the clustering graph in the compressor's
  * graph. There is expected to be exactly one clustering graph.
  */
-std::string getClusteringGraphUniqueName(Compressor& compressor)
+ZL_GraphID getClusteringGraphUniqueID(const Compressor& compressor)
 {
-    auto clusteringGraphNames = findAllGraphsWithPrefix(
-            compressor.serialize(), CLUSTERING_GRAPH_NAME);
-    if (clusteringGraphNames.size() != 1) {
+    auto clusteringGraphs =
+            findAllGraphsWithPrefix(compressor, CLUSTERING_GRAPH_NAME);
+    if (clusteringGraphs.size() != 1) {
         throw Exception(
                 "Graph must contain a single clustering graph, instead it contains "
-                + std::to_string(clusteringGraphNames.size())
+                + std::to_string(clusteringGraphs.size())
                 + " clustering graphs");
     }
-    return clusteringGraphNames[0];
+    auto baseGraph = ZL_Compressor_Graph_getBaseGraphID(
+            compressor.get(), clusteringGraphs[0]);
+    if (baseGraph != ZL_GRAPH_CLUSTERING) {
+        throw Exception(
+                "Clustering graph is not a parameterized version of ZL_GRAPH_CLUSTERING");
+    }
+
+    return clusteringGraphs[0];
+}
+
+void overrideClusteringGraphParams(
+        Compressor& compressor,
+        GraphID untrainedGraph,
+        GraphID trainedGraph)
+{
+    assert(ZL_Compressor_Graph_getBaseGraphID(compressor.get(), untrainedGraph)
+           == ZL_GRAPH_CLUSTERING);
+    assert(ZL_Compressor_Graph_getBaseGraphID(compressor.get(), trainedGraph)
+           == ZL_GRAPH_CLUSTERING);
+
+    auto graphs = getCustomGraphs(compressor, trainedGraph);
+    auto nodes  = getCustomNodes(compressor, trainedGraph);
+    auto localParams =
+            ZL_Compressor_Graph_getLocalParams(compressor.get(), trainedGraph);
+
+    const ZL_GraphParameters params = {
+        .customGraphs   = graphs.data(),
+        .nbCustomGraphs = graphs.size(),
+        .customNodes    = nodes.data(),
+        .nbCustomNodes  = nodes.size(),
+        .localParams    = &localParams,
+    };
+    compressor.unwrap(ZL_Compressor_overrideGraphParams(
+            compressor.get(), untrainedGraph, &params));
 }
 
 } // namespace
@@ -159,33 +167,32 @@ std::shared_ptr<const std::string_view> trainClusteringGraph(
 {
     // Get name of untrained clustering graph which will be replaced in the
     // final trained graph
-    const auto clusteringGraphUniqueNameUntrained =
-            getClusteringGraphUniqueName(compressor);
+    const auto clusteringGraphUniqueIDUntrained =
+            getClusteringGraphUniqueID(compressor);
 
     // Cluster successors (or don't cluster)
     ZL_GraphID trainedClusteringGraphID = trainParams.noClustering
-            ? ZL_Compressor_getGraph(
-                      compressor.get(),
-                      clusteringGraphUniqueNameUntrained.c_str())
+            ? clusteringGraphUniqueIDUntrained
             : clusterSuccessors(
                       inputs,
                       compressor,
                       trainParams,
-                      clusteringGraphUniqueNameUntrained);
+                      clusteringGraphUniqueIDUntrained);
 
-    // Replace default successors with ACE successors or keep original name
-    const std::string clusteringGraphUniqueNameFinal =
-            trainParams.noAceSuccessors
-            ? ZL_Compressor_Graph_getName(
-                      compressor.get(), trainedClusteringGraphID)
-            : addAceSuccessors(compressor, trainedClusteringGraphID);
+    if (!trainParams.noAceSuccessors) {
+        // Replace default successors with ACE successors by overriding
+        // graph parameters
+        setAceSuccessors(compressor, trainedClusteringGraphID);
+    }
 
     // Replace original clustering graph with the new one that uses
-    // clustering and/or ACE successors
-    return createSharedStringView(renameGraphInCompressor(
-            compressor.serialize(),
-            clusteringGraphUniqueNameUntrained,
-            clusteringGraphUniqueNameFinal));
+    // clustering and/or ACE successors by overriding graph parameters
+    overrideClusteringGraphParams(
+            compressor,
+            clusteringGraphUniqueIDUntrained,
+            trainedClusteringGraphID);
+
+    return createSharedStringView(compressor.serialize());
 }
 
 } // namespace openzl::training

--- a/tools/training/graph_mutation/graph_mutation_utils.cpp
+++ b/tools/training/graph_mutation/graph_mutation_utils.cpp
@@ -7,6 +7,7 @@
 #include "openzl/common/a1cbor_helpers.h"
 #include "openzl/common/allocation.h"
 #include "openzl/cpp/Compressor.hpp"
+#include "openzl/zl_reflection.h"
 
 #include "tools/logger/Logger.h"
 #include "tools/training/graph_mutation/graph_mutation_utils.h"
@@ -16,6 +17,35 @@ namespace openzl::training::graph_mutation {
 using namespace tools::logger;
 
 namespace {
+
+template <typename Fn>
+std::vector<GraphID> findGraphsWhere(const Compressor& compressor, Fn&& fn)
+{
+    struct State {
+        Fn& fn;
+        std::vector<GraphID> result{};
+    };
+    State state{ fn };
+
+    auto callback = [](void* opaque,
+                       const ZL_Compressor* c,
+                       ZL_GraphID graph) noexcept {
+        const CompressorRef cref(const_cast<ZL_Compressor*>(c));
+        auto& s = *static_cast<State*>(opaque);
+        try {
+            if (s.fn(cref, graph)) {
+                s.result.push_back(graph);
+            }
+        } catch (...) {
+            return ZL_returnError(ZL_ErrorCode_GENERIC);
+        }
+        return ZL_returnSuccess();
+    };
+
+    compressor.unwrap(
+            ZL_Compressor_forEachGraph(compressor.get(), callback, &state));
+    return state.result;
+}
 
 /*
  * @brief A wrapper class for a CBOR data bundle.
@@ -54,65 +84,6 @@ std::string getStartGraphName(const A1C_Item* root)
     }
 
     return std::string(startField->string.data, startField->string.size);
-}
-
-/**
- * @brief Replaces all references to a graph name in other graphs' dependency
- * arrays.
- *
- * Scans through all graphs in the compressor and updates any references to the
- * old graph name found in their "graphs" arrays (dependency lists). This
- * function only updates references - it does not modify the original graph
- * definition key, the start graph field, or base graph references.
- *
- * @param graphsItem The CBOR item containing all graphs map
- * @param oldName The old graph name to find and replace in references
- * @param newName The new graph name to substitute in references
- * @param arena The memory arena for CBOR string operations
- */
-void replaceGraphNameReferences(
-        A1C_Item* graphsItem,
-        std::string_view oldName,
-        std::string_view newName,
-        A1C_Arena* arena)
-{
-    // Update all references to the old graph name in all graphs
-    for (size_t i = 0; i < graphsItem->map.size; ++i) {
-        A1C_Pair* pair = &graphsItem->map.items[i];
-        if (pair->val.type == A1C_ItemType_map) {
-            // Update references in graphs arrays
-            A1C_Item* graphsArray = A1C_Map_get_cstr(&pair->val.map, "graphs");
-            if (graphsArray && graphsArray->type == A1C_ItemType_array) {
-                for (size_t j = 0; j < graphsArray->array.size; ++j) {
-                    A1C_Item* graphRef = A1C_Array_get(&graphsArray->array, j);
-                    if (graphRef && graphRef->type == A1C_ItemType_string) {
-                        StringView refView =
-                                StringView_initFromA1C(graphRef->string);
-                        std::string_view refName(refView.data, refView.size);
-                        if (refName == oldName) {
-                            if (!A1C_Item_string_copy(
-                                        graphRef,
-                                        newName.data(),
-                                        newName.length(),
-                                        arena)) {
-                                throw Exception(
-                                        "Failed to update graph reference");
-                            }
-                            Logger::log_c(
-                                    VERBOSE2,
-                                    "Updated graph reference from %.*s to %.*s in graph %.*s",
-                                    (int)oldName.size(),
-                                    oldName.data(),
-                                    (int)newName.size(),
-                                    newName.data(),
-                                    (int)pair->key.string.size,
-                                    pair->key.string.data);
-                        }
-                    }
-                }
-            }
-        }
-    }
 }
 
 enum class GraphFindStrategy {
@@ -205,27 +176,6 @@ A1C_Item* extractGraphsFromCbor(std::shared_ptr<const A1C_Item> root)
     return graphsItem;
 }
 
-const A1C_Item* findGraphByPrefix(
-        const std::string_view& serializedCompressor,
-        std::string_view targetGraphPrefix)
-{
-    auto [root, arena] =
-            decodeSerializedCompressorIntoCbor(serializedCompressor);
-    auto graphsItem = extractGraphsFromCbor(root);
-
-    auto result = findGraphInMap(
-            graphsItem, targetGraphPrefix, GraphFindStrategy::Prefix);
-
-    if (result.names.empty()) {
-        return nullptr;
-    }
-
-    auto exactResult = findGraphInMap(
-            graphsItem, result.names[0], GraphFindStrategy::Exact);
-
-    return exactResult.pair ? &exactResult.pair->val : nullptr;
-}
-
 } // anonymous namespace
 
 std::shared_ptr<const std::string_view> encodeCborAsSerialized(
@@ -315,98 +265,7 @@ bool hasTargetGraph(
             "In hasTargetGraph. targetGraphPrefix: %.*s",
             (int)targetGraphPrefix.size(),
             targetGraphPrefix.data());
-    const std::string serializedData = compressor.serialize();
-    return findGraphByPrefix(serializedData, targetGraphPrefix) != nullptr;
-}
-
-std::vector<std::string> extractSuccessorsFromCbor(
-        const std::string_view& cborStr,
-        const std::string& graphName)
-{
-    // Decode once and keep the arena alive
-    auto [root, arena] = decodeSerializedCompressorIntoCbor(cborStr);
-    auto graphsItem    = extractGraphsFromCbor(root);
-
-    // Find the exact graph using the same decoded data
-    auto exactResult =
-            findGraphInMap(graphsItem, graphName, GraphFindStrategy::Exact);
-
-    if (!exactResult.pair) {
-        throw Exception("Could not find exact graph named '" + graphName + "'");
-    }
-
-    const A1C_Item* targetGraph = &exactResult.pair->val;
-
-    // Get the "graphs" array from the target graph (contains successor graph
-    // names)
-    A1C_Item const* const graphsArray =
-            A1C_Map_get_cstr(&targetGraph->map, "graphs");
-    if (!graphsArray || graphsArray->type != A1C_ItemType_array) {
-        throw Exception(
-                "'" + graphName
-                + "' does not contain 'graphs' key or it's not an array");
-    }
-
-    std::vector<std::string> successorsFromSerialization;
-    for (size_t i = 0; i < graphsArray->array.size; ++i) {
-        A1C_Item const* const item = A1C_Array_get(&graphsArray->array, i);
-        if (item && item->type == A1C_ItemType_string) {
-            StringView successorView = StringView_initFromA1C(item->string);
-            successorsFromSerialization.emplace_back(
-                    successorView.data, successorView.size);
-        }
-    }
-    return successorsFromSerialization;
-}
-
-std::vector<std::string> extractNodesFromCbor(
-        const std::string_view& cborStr,
-        const std::string& targetGraphPrefix)
-{
-    // Decode once and keep the arena alive
-    auto [root, arena] = decodeSerializedCompressorIntoCbor(cborStr);
-    auto graphsItem    = extractGraphsFromCbor(root);
-
-    // Find all graphs with the prefix
-    auto result = findGraphInMap(
-            graphsItem, targetGraphPrefix, GraphFindStrategy::Prefix);
-
-    if (result.names.empty()) {
-        throw Exception(
-                "JSON does not contain any graph with name starting with '"
-                + targetGraphPrefix + "'");
-    }
-
-    // Find the exact graph using the same decoded data
-    auto exactResult = findGraphInMap(
-            graphsItem, result.names[0], GraphFindStrategy::Exact);
-
-    if (!exactResult.pair) {
-        throw Exception(
-                "Could not find exact graph for prefix '" + targetGraphPrefix
-                + "'");
-    }
-
-    const A1C_Item* targetGraph = &exactResult.pair->val;
-
-    // Get the "nodes" array from the target graph
-    A1C_Item const* const nodesArray =
-            A1C_Map_get_cstr(&targetGraph->map, "nodes");
-    if (!nodesArray || nodesArray->type != A1C_ItemType_array) {
-        throw Exception(
-                "'" + targetGraphPrefix
-                + "' does not contain 'nodes' key or it's not an array");
-    }
-
-    std::vector<std::string> nodesFromSerialization;
-    for (size_t i = 0; i < nodesArray->array.size; ++i) {
-        A1C_Item const* const item = A1C_Array_get(&nodesArray->array, i);
-        if (item && item->type == A1C_ItemType_string) {
-            StringView nodeView = StringView_initFromA1C(item->string);
-            nodesFromSerialization.emplace_back(nodeView.data, nodeView.size);
-        }
-    }
-    return nodesFromSerialization;
+    return !findAllGraphsWithPrefix(compressor, targetGraphPrefix).empty();
 }
 
 std::shared_ptr<const std::string_view> createSharedStringView(std::string str)
@@ -426,55 +285,30 @@ std::vector<std::string> findAllGraphsWithPrefix(
     return result.names;
 }
 
-std::string renameGraphInCompressor(
-        const std::string_view serializedCompressor,
-        std::string_view oldGraphName,
-        std::string_view newGraphName)
+std::vector<GraphID> findAllGraphsWithPrefix(
+        const Compressor& compressor,
+        poly::string_view prefix)
 {
-    auto [root, arena] =
-            decodeSerializedCompressorIntoCbor(serializedCompressor);
-    auto graphsItem = extractGraphsFromCbor(root);
+    return findGraphsWhere(
+            compressor, [&prefix](const Compressor& c, GraphID g) {
+                auto graphName = ZL_Compressor_Graph_getName(c.get(), g);
+                return getGraphBasePrefix(graphName) == prefix;
+            });
+}
 
-    // Verify the old graph exists
-    auto targetGraph =
-            findGraphInMap(graphsItem, oldGraphName, GraphFindStrategy::Exact);
-    if (!targetGraph.pair) {
-        throw Exception(
-                "Could not find target graph '" + std::string(oldGraphName)
-                + "' in the graphs map");
-    }
+std::vector<GraphID> getCustomGraphs(
+        const Compressor& compressor,
+        GraphID graph)
+{
+    auto graphs = ZL_Compressor_Graph_getCustomGraphs(compressor.get(), graph);
+    return { graphs.graphids, graphs.graphids + graphs.nbGraphIDs };
+}
 
-    A1C_Arena a1cArena = A1C_Arena_wrap(arena.get());
-    replaceGraphNameReferences(
-            graphsItem, oldGraphName, newGraphName, &a1cArena);
-
-    // Update the "start" field if it points to the old graph name
-    A1C_Item* startField = A1C_Map_get_cstr(&root->map, "start");
-    if (startField && startField->type == A1C_ItemType_string) {
-        StringView currentStartView =
-                StringView_initFromA1C(startField->string);
-        std::string_view currentStart(
-                currentStartView.data, currentStartView.size);
-        if (currentStart == oldGraphName) {
-            if (!A1C_Item_string_copy(
-                        startField,
-                        newGraphName.data(),
-                        newGraphName.length(),
-                        &a1cArena)) {
-                throw Exception("Failed to update start field");
-            }
-            Logger::log_c(
-                    VERBOSE2,
-                    "Updated start field from '%.*s' to '%.*s'",
-                    (int)oldGraphName.size(),
-                    oldGraphName.data(),
-                    (int)newGraphName.size(),
-                    newGraphName.data());
-        }
-    }
-
-    auto serializedResult = encodeCborAsSerialized(root.get());
-    return std::string(*serializedResult);
+/// @returns The custom nodes of @p graphid
+std::vector<NodeID> getCustomNodes(const Compressor& compressor, GraphID graph)
+{
+    auto nodes = ZL_Compressor_Graph_getCustomNodes(compressor.get(), graph);
+    return { nodes.nodeids, nodes.nodeids + nodes.nbNodeIDs };
 }
 
 std::string replaceBaseGraphInCompressor(
@@ -536,55 +370,6 @@ std::string replaceBaseGraphInCompressor(
 
     auto serializedResult = encodeCborAsSerialized(root.get());
     return std::string(*serializedResult);
-}
-
-/**
- * @brief Gets the maximum ID from all graphs with '#' in the name.
- *
- * Serialized graph definions are stored in the format {name}#{id}, where
- * {name} is the graph name and {id} is a positive integer. The IDs are unique
- * across all graphs of all names. {name} can be empty.
-
- * This function iterates through all graphs, extracts the suffix after the
- * '#' and returns the maximum value found. Graphs without '#' are skipped.
- *
- * @param serializedCompressor The serialized compressor containing the graphs
- * @return int The maximum ID found, or 0 if no graphs with '#' exist
- */
-int getMaximumIdFromSerialized(std::string_view serializedCompressor)
-{
-    auto [root, arena] =
-            decodeSerializedCompressorIntoCbor(serializedCompressor);
-    auto graphsItem = extractGraphsFromCbor(root);
-
-    auto extractId = [](const A1C_Pair& pair) -> int {
-        if (pair.key.type != A1C_ItemType_string) {
-            return 0;
-        }
-
-        std::string graphName(pair.key.string.data, pair.key.string.size);
-        size_t hashPos = graphName.find('#');
-        if (hashPos != std::string::npos && hashPos + 1 < graphName.length()) {
-            std::string suffix = graphName.substr(hashPos + 1);
-            try {
-                return std::stoi(suffix);
-            } catch (const std::exception&) {
-                // Skip invalid suffixes
-                return 0;
-            }
-        }
-        return 0;
-    };
-
-    A1C_Pair* items = graphsItem->map.items;
-    size_t size     = graphsItem->map.size;
-    auto maxElement = std::max_element(
-            items,
-            items + size,
-            [&extractId](const A1C_Pair& a, const A1C_Pair& b) {
-                return extractId(a) < extractId(b);
-            });
-    return (maxElement != items + size) ? extractId(*maxElement) : 0;
 }
 
 } // namespace openzl::training::graph_mutation

--- a/tools/training/graph_mutation/graph_mutation_utils.h
+++ b/tools/training/graph_mutation/graph_mutation_utils.h
@@ -29,81 +29,11 @@ namespace openzl::training::graph_mutation {
 std::shared_ptr<const std::string_view> createSharedStringView(std::string str);
 
 /**
- * @brief Extracts successor graph names from a CBOR string for a specified
- * graph.
- *
- * @param cborStr The CBOR string to parse.
- * @param graphName The exact name of the graph whose successors
- * to extract.
- * @return A vector of successor graph names.
- */
-std::vector<std::string> extractSuccessorsFromCbor(
-        const std::string_view& cborStr,
-        const std::string& graphName);
-
-/**
- * @brief Extracts node names from a CBOR string for a specified
- * graph.
- *
- * @param cborStr The CBOR string to parse.
- * @param targetGraphPrefix The base name of the graph whose successors
- * to extract.
- * @return A vector of successor graph names.
- */
-std::vector<std::string> extractNodesFromCbor(
-        const std::string_view& cborStr,
-        const std::string& targetGraphPrefix);
-
-/**
- * @brief Replaces a graph's parameters in a compressor with new local
- * parameters.
- *
- * This function modifies the compressor by updating the specified graph with
- * new local parameters. It serializes the compressor, modifies the CBOR
- * representation, and then returns the serialized modified compressor.
- *
- * @param serializedCompressor The serialized compressor to modify.
- * @param localParams The new local parameters to apply.
- * @param graphName The name of the graph to modify.
- * @return std::shared_ptr<const std::string_view> The serialized modified
- * compressor as CBOR data.
- */
-std::shared_ptr<const std::string_view> replaceGraphInCompressor(
-        std::string_view serializedCompressor,
-        const ZL_LocalParams& localParams,
-        const std::string& graphName);
-
-/**
  * @brief Checks if a compressor contains a graph with a specific prefix.
  */
 bool hasTargetGraph(
         const Compressor& compressor,
         poly::string_view targetGraphPrefix);
-
-/**
- * @brief Renames a graph throughout the compressor by updating all references
- * and the start field.
- *
- * This function performs a comprehensive rename of a graph by:
- * 1. Updating all references to the old graph name in other graphs' dependency
- * arrays
- * 2. Updating the compressor's start field if it points to the old graph name
- *
- * Note: This function does not rename the actual graph definition key - it
- * assumes the graph has already been renamed at the definition level and only
- * updates references.
- *
- * @param serializedCompressor The serialized compressor data to modify
- * @param oldGraphName The current name of the graph to rename references from
- * @param newGraphName The new name to use in all references
- * @return std::string The updated serialized compressor with renamed references
- * @throws std::runtime_error If the old graph cannot be found or update
- * operations fail
- */
-std::string renameGraphInCompressor(
-        const std::string_view serializedCompressor,
-        std::string_view oldGraphName,
-        std::string_view newGraphName);
 
 /**
  * @brief Replaces the base graph of a specific parameterized graph.
@@ -162,29 +92,26 @@ std::shared_ptr<const std::string_view> encodeCborAsSerialized(
  * matches the given prefix. A serialized compressor is a CBOR-encoded data
  * structure containing compression graph definitions.
  *
- * @param serializedCompressor The serialized compressor containing the CBOR
- * data.
+ * @param compressor The compressor to search.
  * @param prefix The prefix to search for in graph names.
  * @return std::vector<std::string> A vector of graph names that match the
  * prefix.
  */
+std::vector<GraphID> findAllGraphsWithPrefix(
+        const Compressor& compressor,
+        poly::string_view prefix);
+
+// Will be deleted by a future diff once all usage is migrated
 std::vector<std::string> findAllGraphsWithPrefix(
         std::string_view serializedCompressor,
         const std::string& prefix);
 
-/**
- * @brief Gets the maximum ID from all graphs with '#' suffix in a serialized
- * compressor.
- *
- * This function decodes the serialized compressor into a CBOR structure and
- * finds the maximum ID from all graphs that have a '#' suffix. The ID is
- * extracted from the suffix after the '#' character, which is guaranteed to
- * be a positive integer. Graphs without '#' are skipped.
- *
- * @param serializedCompressor The serialized compressor containing the CBOR
- * data.
- * @return int The maximum ID found, or 0 if no graphs with '#' suffix exist.
- */
-int getMaximumIdFromSerialized(std::string_view serializedCompressor);
+/// @returns the custom graphs of @p graphid
+std::vector<GraphID> getCustomGraphs(
+        const Compressor& compressor,
+        GraphID graph);
+
+/// @returns The custom nodes of @p graphid
+std::vector<NodeID> getCustomNodes(const Compressor& compressor, GraphID graph);
 
 } // namespace openzl::training::graph_mutation


### PR DESCRIPTION
Summary:

Update clustering training to stop querying & mutating the serialized graph. Instead do all queries and modifications through the `Compressor` directly.

Reviewed By: kevinjzhang

Differential Revision: D103275004


