### PR TITLE
Add ZL_Compressor_overrideBaseGraph (#715)

### DIFF
--- a/src/openzl/compress/cgraph.c
+++ b/src/openzl/compress/cgraph.c
@@ -858,6 +858,16 @@ ZL_Report ZL_Compressor_overrideGraphParams(
     return ZL_returnSuccess();
 }
 
+ZL_Report ZL_Compressor_overrideBaseGraph(
+        ZL_Compressor* compressor,
+        ZL_GraphID graph,
+        ZL_GraphID newBaseGraph)
+{
+    ZL_RESULT_DECLARE_SCOPE(size_t, compressor);
+    ZL_ERR_IF_ERR(GM_overrideBaseGraph(compressor->gm, graph, newBaseGraph));
+    return ZL_returnSuccess();
+}
+
 ZL_GraphID ZL_Compressor_registerParameterizedGraph(
         ZL_Compressor* compressor,
         const ZL_ParameterizedGraphDesc* desc)

--- a/src/openzl/compress/cgraph.h
+++ b/src/openzl/compress/cgraph.h
@@ -112,6 +112,27 @@ ZL_Report ZL_Compressor_overrideGraphParams(
         const ZL_GraphParameters* gp);
 
 /**
+ * Warning: This is part of experimental API for compressor mutation.
+ *
+ * Requires that:
+ * @p graph is a parameterized graph registered in @p compressor
+ * @p newBaseGraph is a static graph registered in @p compressor
+ * @p newBaseGraph is not a parameterization of @p graph
+ *
+ * Replaces the base graph of the parameterized graph @p graph with @p
+ * newBaseGraph and clears the custom nodes, custom graphs, and local params.
+ *
+ * @warning All parameterizations are cleared because they applied to the old
+ * base graph and do not apply to @p newBaseGraph.
+ *
+ * @returns success, or an error if the requirements are not met.
+ */
+ZL_Report ZL_Compressor_overrideBaseGraph(
+        ZL_Compressor* compressor,
+        ZL_GraphID graph,
+        ZL_GraphID newBaseGraph);
+
+/**
  * Look up a previously loaded dict by its ZL_DictID.
  * @param matDesc must match the materializer used when the dict was loaded.
  * @returns the dict, or NULL if no dict with this ID has been loaded.

--- a/src/openzl/compress/graphmgr.c
+++ b/src/openzl/compress/graphmgr.c
@@ -583,6 +583,130 @@ ZL_Report GM_overrideGraphParams(
     return ZL_returnSuccess();
 }
 
+/// @returns An error if the graph @p haystack recursively depends on @p needle
+///          through parameterization.
+/// @pre both are valid graphs
+static ZL_Report GM_checkDoesNotDependOn(
+        const GraphsMgr* gm,
+        ZL_GraphID needle,
+        ZL_GraphID haystack)
+{
+    ZL_RESULT_DECLARE_SCOPE_REPORT(gm->opCtx);
+
+    ZL_ASSERT(GM_isValidGraphID(gm, haystack));
+    ZL_ASSERT(GM_isValidGraphID(gm, needle));
+
+    size_t count = 0;
+    for (;;) {
+        // Check if haystack (recursively) depends on needle.
+        ZL_ERR_IF_EQ(
+                haystack.gid,
+                needle.gid,
+                graph_invalid,
+                "Would introduce infinite loop");
+
+        // There are at most ZL_ENCODER_GRAPH_LIMIT graphs in a compressor. If
+        // this limit is surpassed, we must be in some sort of infinite loop.
+        // This is unexpected, because it means the graph was already invalid.
+        ZL_ERR_IF_GT(
+                count++,
+                ZL_ENCODER_GRAPH_LIMIT,
+                graph_invalid,
+                "Would introuce infinite loop");
+
+        if (GR_isStandardGraph(haystack)) {
+            // Standard graphs aren't parameterized graphs
+            break;
+        }
+        const Graph_Desc_internal* desc =
+                &VECTOR_AT(gm->gdv, GM_GraphID_to_lgid(haystack));
+        if (desc->originalGraphType != ZL_GraphType_parameterized) {
+            // Not a parameterized graph
+            break;
+        }
+
+        // Iteratively check the base graph of the parameterized graph
+        haystack = desc->baseGraphID;
+    }
+
+    return ZL_returnSuccess();
+}
+
+/// @returns an error if @p graph1 is not compatible with @p graph0.
+/// @note Cannot catch all possible incompatibilities, but will catch
+/// if it is statically incompatible. Other incompatibilities will be
+/// caught at runtime.
+static ZL_Report GM_checkInputTypesAreCompatible(
+        const GraphsMgr* gm,
+        ZL_GraphID graph0,
+        ZL_GraphID graph1)
+{
+    ZL_RESULT_DECLARE_SCOPE_REPORT(gm->opCtx);
+
+    GM_GraphMetadata meta0 = GM_getGraphMetadata(gm, graph0);
+    GM_GraphMetadata meta1 = GM_getGraphMetadata(gm, graph1);
+
+    ZL_ERR_IF_NE(
+            meta0.nbInputs,
+            meta1.nbInputs,
+            graph_invalid,
+            "Graphs have different number of inputs");
+    for (size_t i = 0; i < meta0.nbInputs; ++i) {
+        ZL_ERR_IF_EQ(
+                meta0.inputTypeMasks[i] & meta1.inputTypeMasks[i],
+                0,
+                graph_invalid,
+                "Input %zu types are not compatible",
+                i);
+    }
+
+    return ZL_returnSuccess();
+}
+
+ZL_Report
+GM_overrideBaseGraph(GraphsMgr* gm, ZL_GraphID graph, ZL_GraphID newBaseGraph)
+{
+    ZL_ASSERT_NN(gm);
+    ZL_RESULT_DECLARE_SCOPE(size_t, gm->opCtx);
+
+    ZL_ERR_IF(
+            GR_isStandardGraph(graph),
+            graph_invalid,
+            "Cannot replace standard graph");
+    ZL_ERR_IF_NOT(
+            GM_isValidGraphID(gm, graph), graph_invalid, "Graph is invalid");
+    ZL_ERR_IF_NOT(
+            GM_isValidGraphID(gm, newBaseGraph),
+            graph_invalid,
+            "New base graph is invalid");
+
+    ZL_ERR_IF_ERR(GM_checkInputTypesAreCompatible(gm, graph, newBaseGraph));
+
+    ZL_IDType const lid = GM_GraphID_to_lgid(graph);
+    // Check that the graphs is a parameterized graph
+    ZL_ERR_IF_NE(
+            VECTOR_AT(gm->gdv, lid).originalGraphType,
+            ZL_GraphType_parameterized,
+            graph_invalid,
+            "Graph is not parameterized");
+
+    // Validate that newBaseGraph does not depend on graph
+    ZL_ERR_IF_ERR(GM_checkDoesNotDependOn(
+            gm, /* needle */ graph, /* haystack */ newBaseGraph));
+    // Set the new base graph and check for infinite loops
+    VECTOR_AT(gm->gdv, lid).baseGraphID = newBaseGraph;
+
+    // Clear the custom graphs, custom nodes, and local params
+    VECTOR_AT(gm->gdv, lid).migd.customGraphs   = NULL;
+    VECTOR_AT(gm->gdv, lid).migd.nbCustomGraphs = 0;
+    VECTOR_AT(gm->gdv, lid).migd.customNodes    = NULL;
+    VECTOR_AT(gm->gdv, lid).migd.nbCustomNodes  = 0;
+    ZL_LocalParams* localParams = &VECTOR_AT(gm->gdv, lid).migd.localParams;
+    memset(localParams, 0, sizeof(*localParams));
+
+    return ZL_returnSuccess();
+}
+
 ZL_RESULT_OF(ZL_GraphID)
 GM_registerParameterizedGraph(
         GraphsMgr* gm,
@@ -648,8 +772,8 @@ GM_registerParameterizedGraph(
     if (desc->name != NULL) {
         miDesc.name = desc->name;
     } else {
-        // Use the name prefix rather than the unique name, because this graph
-        // needs a new non-anchor name.
+        // Use the name prefix rather than the unique name, because this
+        // graph needs a new non-anchor name.
         ZL_Name name = GM_getGraphMetadata(gm, desc->graph).name;
         miDesc.name  = ZL_Name_prefix(&name);
     }
@@ -720,8 +844,8 @@ static ZL_RESULT_OF(ZL_GraphID) GM_registerSegmenter_internal(
     ZL_ERR_IF_ERR(GM_transferLocalParameters(gm, &gdi.segDesc.localParams));
     // Materialize params if materializer is provided (with deduplication)
     if (segDesc->materializer.materializeFn != NULL) {
-        // Validate provided params don't contain the paramId reserved for the
-        // materializer
+        // Validate provided params don't contain the paramId reserved for
+        // the materializer
         ZL_ERR_IF_ERR(MPM_validateMaterializedParamId(
                 &gdi.segDesc.localParams, segDesc->materializer.paramId));
         // Add the materialized object to refParams
@@ -772,9 +896,9 @@ ZL_GraphID GM_getLastRegisteredGraph(const GraphsMgr* gm)
             VECTOR_SIZE(gm->gdv));
     ZL_ASSERT_NN(gm);
     if (VECTOR_SIZE(gm->gdv) == 0) {
-        // Note(@Cyan): this scenario only happens when no custom graph has been
-        // registered yet. Another option here could be to return the most
-        // generic standard graph instead.
+        // Note(@Cyan): this scenario only happens when no custom graph has
+        // been registered yet. Another option here could be to return the
+        // most generic standard graph instead.
         return ZL_GRAPH_ILLEGAL;
     }
     // The last registered graph is the last element in the vector

--- a/src/openzl/compress/graphmgr.h
+++ b/src/openzl/compress/graphmgr.h
@@ -139,6 +139,10 @@ ZL_Report GM_overrideGraphParams(
         ZL_GraphID targetGraph,
         const ZL_GraphParameters* gp);
 
+/// @see ZL_Compressor_overrideBaseGraph
+ZL_Report
+GM_overrideBaseGraph(GraphsMgr* gm, ZL_GraphID graph, ZL_GraphID newBaseGraph);
+
 ZL_END_C_DECLS
 
 #endif // ZSTRONG_COMPRESS_GRAPHMGR_H

--- a/tests/unittest/compress/CompressorUnitTest.cpp
+++ b/tests/unittest/compress/CompressorUnitTest.cpp
@@ -1784,6 +1784,127 @@ TEST_F(CompressorTest, ReplaceGraphParamsOnlyWhenParamExists)
 }
 
 // =============================================================================
+// Base Graph Replacement Tests
+// =============================================================================
+
+TEST_F(CompressorTest, OverrideBaseGraph)
+{
+    auto baseGraph = ZL_Compressor_registerStaticGraph_fromNode1o(
+            compressor_.get(), ZL_NODE_DELTA_INT, ZL_GRAPH_ZSTD);
+    ZL_GraphID customGraphs[1]          = { ZL_GRAPH_ZSTD };
+    ZL_NodeID customNodes[1]            = { ZL_NODE_ZIGZAG };
+    ZL_ParameterizedGraphDesc paramDesc = {
+        .graph          = baseGraph,
+        .customGraphs   = customGraphs,
+        .nbCustomGraphs = 1,
+        .customNodes    = customNodes,
+        .nbCustomNodes  = 1,
+        .localParams    = &localParams_,
+    };
+    auto paramGraph = ZL_Compressor_registerParameterizedGraph(
+            compressor_.get(), &paramDesc);
+    ASSERT_NE(paramGraph, ZL_GRAPH_ILLEGAL);
+
+    // Verify initial state
+    EXPECT_EQ(
+            ZL_Compressor_Graph_getBaseGraphID(compressor_.get(), paramGraph),
+            baseGraph);
+    EXPECT_EQ(
+            ZL_Compressor_Graph_getCustomGraphs(compressor_.get(), paramGraph)
+                    .nbGraphIDs,
+            1u);
+    EXPECT_EQ(
+            ZL_Compressor_Graph_getCustomNodes(compressor_.get(), paramGraph)
+                    .nbNodeIDs,
+            1u);
+
+    // Override with a new base graph
+    auto newBaseGraph = ZL_Compressor_registerStaticGraph_fromNode1o(
+            compressor_.get(), ZL_NODE_ZIGZAG, ZL_GRAPH_ZSTD);
+    EXPECT_ZS_VALID(ZL_Compressor_overrideBaseGraph(
+            compressor_.get(), paramGraph, newBaseGraph));
+
+    // Base graph should be updated
+    EXPECT_EQ(
+            ZL_Compressor_Graph_getBaseGraphID(compressor_.get(), paramGraph),
+            newBaseGraph);
+
+    // Custom graphs, custom nodes, and local params should be cleared
+    EXPECT_EQ(
+            ZL_Compressor_Graph_getCustomGraphs(compressor_.get(), paramGraph)
+                    .nbGraphIDs,
+            0u);
+    EXPECT_EQ(
+            ZL_Compressor_Graph_getCustomNodes(compressor_.get(), paramGraph)
+                    .nbNodeIDs,
+            0u);
+    expectParamsEmpty(
+            ZL_Compressor_Graph_getLocalParams(compressor_.get(), paramGraph));
+
+    // Graph type should still be parameterized
+    EXPECT_EQ(
+            ZL_GraphType_parameterized,
+            ZL_Compressor_getGraphType(compressor_.get(), paramGraph));
+}
+
+TEST_F(CompressorTest, OverrideBaseGraphRejectsStandardGraph)
+{
+    EXPECT_ZS_ERROR(ZL_Compressor_overrideBaseGraph(
+            compressor_.get(), ZL_GRAPH_FIELD_LZ, ZL_GRAPH_ZSTD));
+}
+
+TEST_F(CompressorTest, OverrideBaseGraphRejectsNonParameterizedGraph)
+{
+    auto staticGraph = ZL_Compressor_registerStaticGraph_fromNode1o(
+            compressor_.get(), ZL_NODE_DELTA_INT, ZL_GRAPH_ZSTD);
+    auto newBaseGraph = ZL_Compressor_registerStaticGraph_fromNode1o(
+            compressor_.get(), ZL_NODE_ZIGZAG, ZL_GRAPH_ZSTD);
+    EXPECT_ZS_ERROR(ZL_Compressor_overrideBaseGraph(
+            compressor_.get(), staticGraph, newBaseGraph));
+}
+
+TEST_F(CompressorTest, OverrideBaseGraphRejectsInvalidGraph)
+{
+    auto baseGraph = ZL_Compressor_registerStaticGraph_fromNode1o(
+            compressor_.get(), ZL_NODE_DELTA_INT, ZL_GRAPH_ZSTD);
+    auto paramGraph = makeParameterizedGraph();
+
+    EXPECT_ZS_ERROR(ZL_Compressor_overrideBaseGraph(
+            compressor_.get(), ZL_GRAPH_ILLEGAL, baseGraph));
+    EXPECT_ZS_ERROR(ZL_Compressor_overrideBaseGraph(
+            compressor_.get(), paramGraph, ZL_GRAPH_ILLEGAL));
+}
+
+TEST_F(CompressorTest, OverrideBaseGraphRejectsInfiniteLoop)
+{
+    auto paramGraph1 = makeParameterizedGraph();
+    auto paramGraph2 = compressor_.parameterizeGraph(
+            paramGraph1, openzl::GraphParameters{});
+    ASSERT_NE(paramGraph2, ZL_GRAPH_ILLEGAL);
+
+    // paramGraph2's base is paramGraph1. Setting paramGraph1's base to
+    // paramGraph2 would create a cycle.
+    EXPECT_ZS_ERROR(ZL_Compressor_overrideBaseGraph(
+            compressor_.get(), paramGraph1, paramGraph2));
+}
+
+TEST_F(CompressorTest, OverrideBaseGraphRejectsSelfLoop)
+{
+    auto paramGraph = makeParameterizedGraph();
+    EXPECT_ZS_ERROR(ZL_Compressor_overrideBaseGraph(
+            compressor_.get(), paramGraph, paramGraph));
+}
+
+TEST_F(CompressorTest, OverrideBaseGraphRejectsIncompatibleInputTypes)
+{
+    auto paramGraph = makeParameterizedGraph();
+    auto multiInput = makeMultiInputGraph(false);
+
+    EXPECT_ZS_ERROR(ZL_Compressor_overrideBaseGraph(
+            compressor_.get(), paramGraph, multiInput));
+}
+
+// =============================================================================
 // Materialization Tests
 // =============================================================================
 

--- a/tools/ml_selector/ml_selector_trainer.cpp
+++ b/tools/ml_selector/ml_selector_trainer.cpp
@@ -557,10 +557,10 @@ std::shared_ptr<const std::string_view> trainMLSelectorGraph(
     (void)trainParams;
 
     // Find the ML selector graph by prefix
-    auto mlSelectorGraphNames = graph_mutation::findAllGraphsWithPrefix(
-            compressor.serialize(), ML_SELECTOR_GRAPH_NAME);
+    auto mlSelectorGraphs = graph_mutation::findAllGraphsWithPrefix(
+            compressor, ML_SELECTOR_GRAPH_NAME);
 
-    if (mlSelectorGraphNames.empty()) {
+    if (mlSelectorGraphs.empty()) {
         throw std::runtime_error(
                 "Error finding ML selector graph with prefix '"
                 + ML_SELECTOR_GRAPH_NAME + "'");
@@ -577,11 +577,13 @@ std::shared_ptr<const std::string_view> trainMLSelectorGraph(
      * outputs become inputs for downstream selectors, which can then be
      * trained in subsequent passes.
      */
-    while (trainedMlSelectors.size() < mlSelectorGraphNames.size()
+    while (trainedMlSelectors.size() < mlSelectorGraphs.size()
            && trainedAnyThisPass) {
         trainedAnyThisPass = false;
 
-        for (auto& mlSelectorGraphName : mlSelectorGraphNames) {
+        for (auto mlSelectorGraph : mlSelectorGraphs) {
+            std::string mlSelectorGraphName = ZL_Compressor_Graph_getName(
+                    compressor.get(), mlSelectorGraph);
             if (trainedMlSelectors.count(mlSelectorGraphName) > 0) {
                 continue;
             }
@@ -595,9 +597,6 @@ std::shared_ptr<const std::string_view> trainMLSelectorGraph(
             if (mlSelectorInputs.empty()) {
                 continue;
             }
-
-            const ZL_GraphID mlSelectorGraph =
-                    compressor.getGraph(mlSelectorGraphName).value();
 
             const auto successors = ZL_Compressor_Graph_getCustomGraphs(
                     compressor.get(), mlSelectorGraph);
@@ -640,11 +639,11 @@ std::shared_ptr<const std::string_view> trainMLSelectorGraph(
     }
 
     // Warn if some mlSelectors were left untrained
-    if (trainedMlSelectors.size() < mlSelectorGraphNames.size()) {
+    if (trainedMlSelectors.size() < mlSelectorGraphs.size()) {
         Logger::log(
                 WARNINGS,
                 "Warning: ",
-                mlSelectorGraphNames.size() - trainedMlSelectors.size(),
+                mlSelectorGraphs.size() - trainedMlSelectors.size(),
                 " mlSelector(s) could not be trained - no inputs captured.");
     }
 

--- a/tools/training/ace/ace.cpp
+++ b/tools/training/ace/ace.cpp
@@ -86,17 +86,13 @@ std::vector<std::shared_ptr<const std::string_view>> ACETrainer::train(
     auto compressor = makeCompressor();
     auto cctx       = refCCtxForTraining(compressor);
 
-    // We need to create a new serialized compressor because compressor
-    // will have different graph IDs from serializedCompressorInput
-    std::string serializedUntrainedCompressor        = compressor.serialize();
-    const std::vector<std::string> autoBackendGraphs = findAllGraphsWithPrefix(
-            serializedUntrainedCompressor, ACE_GRAPH_NAME);
-
-    if (makeCompressor().serialize() != serializedUntrainedCompressor) {
-        // HACK: This is not a strong guarantee that the library provides, so
-        // make sure to check it. Ultimately we need the ability to clone
-        // compressors.
-        throw std::logic_error("Deserialization is not determinsitic!");
+    const std::vector<GraphID> autoBackendGraphIDs =
+            findAllGraphsWithPrefix(compressor, ACE_GRAPH_NAME);
+    std::vector<std::string> autoBackendGraphs;
+    autoBackendGraphs.reserve(autoBackendGraphIDs.size());
+    for (const auto& graphID : autoBackendGraphIDs) {
+        autoBackendGraphs.emplace_back(
+                ZL_Compressor_Graph_getName(compressor.get(), graphID));
     }
 
     Logger::log(

--- a/tools/training/ace/ace_combination.cpp
+++ b/tools/training/ace/ace_combination.cpp
@@ -1,5 +1,6 @@
 #include <set>
 
+#include "openzl/compress/cgraph.h"
 #include "openzl/zl_reflection.h"
 #include "tools/logger/Logger.h"
 #include "tools/training/ace/ace_combination.h"
@@ -37,21 +38,17 @@ std::shared_ptr<const std::string_view> runReplacements(
     }
 
     // Replace each backend graph with the new GraphID
-    std::string serializedForReplacements = compressor.serialize();
     for (const auto& [backendGraph, newGraphId] : newGraphIds) {
-        auto result = replaceBaseGraphInCompressor(
-                serializedForReplacements,
-                backendGraph,
-                ZL_Compressor_Graph_getName(compressor.get(), newGraphId));
-
-        serializedForReplacements = std::string(result.begin(), result.end());
+        auto backendGraphId = compressor.getGraph(backendGraph);
+        compressor.unwrap(ZL_Compressor_overrideBaseGraph(
+                compressor.get(), backendGraphId.value(), newGraphId));
     }
 
-    auto json = Compressor::convertSerializedToJson(serializedForReplacements);
+    auto serialized = compressor.serialize();
+    auto json       = Compressor::convertSerializedToJson(serialized);
     Logger::log(VERBOSE3, "Graph with trained ACE successors: ", json);
 
-    return graph_mutation::createSharedStringView(
-            std::move(serializedForReplacements));
+    return graph_mutation::createSharedStringView(std::move(serialized));
 }
 
 /**

--- a/tools/training/ace/ace_combination.cpp
+++ b/tools/training/ace/ace_combination.cpp
@@ -282,10 +282,16 @@ std::vector<std::shared_ptr<const std::string_view>> getCombinedCompressors(
     auto compressor = makeCompressor();
     auto cctx       = refCCtxForTraining(compressor);
     auto serialized = compressor.serialize();
-    /// Get the ACECompressor for each backend graph from the
-    /// trainedSerializedCompressor
-    const std::vector<std::string> autoBackendGraphs =
-            findAllGraphsWithPrefix(serialized, ACE_GRAPH_NAME);
+
+    /// Get the ACECompressor for each backend graph from the compressor
+    const std::vector<GraphID> autoBackendGraphIDs =
+            findAllGraphsWithPrefix(compressor, ACE_GRAPH_NAME);
+    std::vector<std::string> autoBackendGraphs;
+    autoBackendGraphs.reserve(autoBackendGraphIDs.size());
+    for (const auto& graphID : autoBackendGraphIDs) {
+        autoBackendGraphs.emplace_back(
+                ZL_Compressor_Graph_getName(compressor.get(), graphID));
+    }
 
     // Note this is done a second time (is it worth caching the flattened
     // samples)

--- a/tools/training/clustering/clustering_graph_trainer.cpp
+++ b/tools/training/clustering/clustering_graph_trainer.cpp
@@ -3,6 +3,7 @@
 #include <vector>
 
 #include "openzl/common/allocation.h"
+#include "openzl/compress/cgraph.h"
 #include "openzl/compress/graphs/generic_clustering_graph.h"
 #include "openzl/cpp/CCtx.hpp"
 #include "openzl/cpp/Exception.hpp"
@@ -31,18 +32,14 @@ namespace {
  * NOTE: this function does not swap this new clustering graph into the
  * original graph, it just registers it on the compressor.
  */
-std::string addAceSuccessors(
-        Compressor& compressor,
-        ZL_GraphID trainedClusteringGraphID)
+void setAceSuccessors(Compressor& compressor, GraphID trainedClusteringGraphID)
 {
     // Add the same number of ACE successors as there are clustering
     // successors
-    auto numClusteringSuccessors =
-            extractSuccessorsFromCbor(
-                    compressor.serialize(),
-                    ZL_Compressor_Graph_getName(
-                            compressor.get(), trainedClusteringGraphID))
-                    .size();
+    const size_t numClusteringSuccessors =
+            ZL_Compressor_Graph_getCustomGraphs(
+                    compressor.get(), trainedClusteringGraphID)
+                    .nbGraphIDs;
 
     std::vector<ZL_GraphID> aceGraphIds;
     aceGraphIds.reserve(numClusteringSuccessors);
@@ -50,24 +47,13 @@ std::string addAceSuccessors(
         aceGraphIds.push_back(ZL_Compressor_buildACEGraph(compressor.get()));
     }
 
-    // Create and register new clustering graph with the ACE successors
-    auto localParams = ZL_Compressor_Graph_getLocalParams(
-            compressor.get(), trainedClusteringGraphID);
-
-    ZL_ParameterizedGraphDesc const newClusteringGraphDesc = {
-        .graph          = trainedClusteringGraphID,
+    ZL_GraphParameters params = {
         .customGraphs   = aceGraphIds.data(),
         .nbCustomGraphs = aceGraphIds.size(),
-        .localParams    = &localParams
     };
 
-    // Replace original clustering graph with the new one
-    auto clusterGraphWithAceSuccessorsID =
-            ZL_Compressor_registerParameterizedGraph(
-                    compressor.get(), &newClusteringGraphDesc);
-
-    return ZL_Compressor_Graph_getName(
-            compressor.get(), clusterGraphWithAceSuccessorsID);
+    compressor.unwrap(ZL_Compressor_overrideGraphParams(
+            compressor.get(), trainedClusteringGraphID, &params));
 }
 
 /**
@@ -80,33 +66,22 @@ ZL_GraphID clusterSuccessors(
         const std::vector<MultiInput>& inputs,
         Compressor& compressor,
         const TrainParams& trainParams,
-        const std::string& clusteringGraphUniqueNameUntrained)
+        GraphID clusteringGraphUniqueIDUntrained)
 {
-    auto cctx                                = refCCtxForTraining(compressor);
-    const auto serializedCompressorUntrained = compressor.serialize();
+    auto cctx = refCCtxForTraining(compressor);
+
+    const std::string clusteringGraphUniqueNameUntrained =
+            ZL_Compressor_Graph_getName(
+                    compressor.get(), clusteringGraphUniqueIDUntrained);
 
     // Get successors for training
-    auto successorsFromSerialization = extractSuccessorsFromCbor(
-            serializedCompressorUntrained, clusteringGraphUniqueNameUntrained);
-    std::vector<ZL_GraphID> successorsVec;
-    successorsVec.reserve(successorsFromSerialization.size());
-    for (const auto& successor : successorsFromSerialization) {
-        ZL_GraphID graphId =
-                ZL_Compressor_getGraph(compressor.get(), successor.c_str());
-        successorsVec.push_back(graphId);
-    }
+    const auto successorsVec =
+            getCustomGraphs(compressor, clusteringGraphUniqueIDUntrained);
 
     // Get clustering codecs for training
-    auto nodesFromSerialization = extractNodesFromCbor(
-            serializedCompressorUntrained, CLUSTERING_GRAPH_NAME);
+    std::vector<ZL_NodeID> clusteringCodecs =
+            getCustomNodes(compressor, clusteringGraphUniqueIDUntrained);
 
-    std::vector<ZL_NodeID> clusteringCodecs;
-    clusteringCodecs.reserve(nodesFromSerialization.size());
-    for (const auto& node : nodesFromSerialization) {
-        ZL_NodeID nodeID =
-                ZL_Compressor_getNode(compressor.get(), node.c_str());
-        clusteringCodecs.push_back(nodeID);
-    }
     auto samples = collectInputStreamsForGraph(
             inputs, clusteringGraphUniqueNameUntrained, cctx);
     Logger::log_c(
@@ -137,17 +112,50 @@ ZL_GraphID clusterSuccessors(
  * Get the unique name of the clustering graph in the compressor's
  * graph. There is expected to be exactly one clustering graph.
  */
-std::string getClusteringGraphUniqueName(Compressor& compressor)
+ZL_GraphID getClusteringGraphUniqueID(const Compressor& compressor)
 {
-    auto clusteringGraphNames = findAllGraphsWithPrefix(
-            compressor.serialize(), CLUSTERING_GRAPH_NAME);
-    if (clusteringGraphNames.size() != 1) {
+    auto clusteringGraphs =
+            findAllGraphsWithPrefix(compressor, CLUSTERING_GRAPH_NAME);
+    if (clusteringGraphs.size() != 1) {
         throw Exception(
                 "Graph must contain a single clustering graph, instead it contains "
-                + std::to_string(clusteringGraphNames.size())
+                + std::to_string(clusteringGraphs.size())
                 + " clustering graphs");
     }
-    return clusteringGraphNames[0];
+    auto baseGraph = ZL_Compressor_Graph_getBaseGraphID(
+            compressor.get(), clusteringGraphs[0]);
+    if (baseGraph != ZL_GRAPH_CLUSTERING) {
+        throw Exception(
+                "Clustering graph is not a parameterized version of ZL_GRAPH_CLUSTERING");
+    }
+
+    return clusteringGraphs[0];
+}
+
+void overrideClusteringGraphParams(
+        Compressor& compressor,
+        GraphID untrainedGraph,
+        GraphID trainedGraph)
+{
+    assert(ZL_Compressor_Graph_getBaseGraphID(compressor.get(), untrainedGraph)
+           == ZL_GRAPH_CLUSTERING);
+    assert(ZL_Compressor_Graph_getBaseGraphID(compressor.get(), trainedGraph)
+           == ZL_GRAPH_CLUSTERING);
+
+    auto graphs = getCustomGraphs(compressor, trainedGraph);
+    auto nodes  = getCustomNodes(compressor, trainedGraph);
+    auto localParams =
+            ZL_Compressor_Graph_getLocalParams(compressor.get(), trainedGraph);
+
+    const ZL_GraphParameters params = {
+        .customGraphs   = graphs.data(),
+        .nbCustomGraphs = graphs.size(),
+        .customNodes    = nodes.data(),
+        .nbCustomNodes  = nodes.size(),
+        .localParams    = &localParams,
+    };
+    compressor.unwrap(ZL_Compressor_overrideGraphParams(
+            compressor.get(), untrainedGraph, &params));
 }
 
 } // namespace
@@ -159,33 +167,32 @@ std::shared_ptr<const std::string_view> trainClusteringGraph(
 {
     // Get name of untrained clustering graph which will be replaced in the
     // final trained graph
-    const auto clusteringGraphUniqueNameUntrained =
-            getClusteringGraphUniqueName(compressor);
+    const auto clusteringGraphUniqueIDUntrained =
+            getClusteringGraphUniqueID(compressor);
 
     // Cluster successors (or don't cluster)
     ZL_GraphID trainedClusteringGraphID = trainParams.noClustering
-            ? ZL_Compressor_getGraph(
-                      compressor.get(),
-                      clusteringGraphUniqueNameUntrained.c_str())
+            ? clusteringGraphUniqueIDUntrained
             : clusterSuccessors(
                       inputs,
                       compressor,
                       trainParams,
-                      clusteringGraphUniqueNameUntrained);
+                      clusteringGraphUniqueIDUntrained);
 
-    // Replace default successors with ACE successors or keep original name
-    const std::string clusteringGraphUniqueNameFinal =
-            trainParams.noAceSuccessors
-            ? ZL_Compressor_Graph_getName(
-                      compressor.get(), trainedClusteringGraphID)
-            : addAceSuccessors(compressor, trainedClusteringGraphID);
+    if (!trainParams.noAceSuccessors) {
+        // Replace default successors with ACE successors by overriding
+        // graph parameters
+        setAceSuccessors(compressor, trainedClusteringGraphID);
+    }
 
     // Replace original clustering graph with the new one that uses
-    // clustering and/or ACE successors
-    return createSharedStringView(renameGraphInCompressor(
-            compressor.serialize(),
-            clusteringGraphUniqueNameUntrained,
-            clusteringGraphUniqueNameFinal));
+    // clustering and/or ACE successors by overriding graph parameters
+    overrideClusteringGraphParams(
+            compressor,
+            clusteringGraphUniqueIDUntrained,
+            trainedClusteringGraphID);
+
+    return createSharedStringView(compressor.serialize());
 }
 
 } // namespace openzl::training

--- a/tools/training/graph_mutation/graph_mutation_utils.cpp
+++ b/tools/training/graph_mutation/graph_mutation_utils.cpp
@@ -1,11 +1,8 @@
 // Copyright (c) Meta Platforms, Inc. and affiliates.
 
-#include <algorithm>
 #include <memory>
 #include <string>
 
-#include "openzl/common/a1cbor_helpers.h"
-#include "openzl/common/allocation.h"
 #include "openzl/cpp/Compressor.hpp"
 #include "openzl/zl_reflection.h"
 
@@ -47,7 +44,7 @@ std::vector<GraphID> findGraphsWhere(const Compressor& compressor, Fn&& fn)
     return state.result;
 }
 
-/*
+/**
  * @brief A wrapper class for a CBOR data bundle.
  */
 struct CborDataBundle {
@@ -66,145 +63,7 @@ struct CborDataBundle {
     }
 };
 
-/**
- * @brief Gets the start graph name from the root item.
- *
- * This function extracts the name of the starting graph from the root CBOR
- * item. It checks for a valid "start" field in the root map and returns its
- * value.
- * @param root The root CBOR item containing the start graph name
- * @return std::string The name of the start graph
- * @throws std::runtime_error If the start graph name cannot be found
- */
-std::string getStartGraphName(const A1C_Item* root)
-{
-    A1C_Item* startField = A1C_Map_get_cstr(&root->map, "start");
-    if (!startField || startField->type != A1C_ItemType_string) {
-        throw Exception("No valid start key found in the graph");
-    }
-
-    return std::string(startField->string.data, startField->string.size);
-}
-
-enum class GraphFindStrategy {
-    Exact, // Find by exact name match
-    Prefix // Find all graphs with matching prefix
-};
-
-struct GraphFindResult {
-    A1C_Pair* pair = nullptr;       // For exact name searches
-    std::vector<std::string> names; // For all-with-prefix searches
-
-    explicit operator bool() const
-    {
-        return pair != nullptr || !names.empty();
-    }
-};
-
-/**
- * @brief Find graphs (exact name or prefix) in the graphs map.
- *
- * @param graphsItem The graphs map item (must be valid)
- * @param searchTerm The name or prefix to search for
- * @param strategy The search strategy to use
- * @return GraphFindResult containing the results based on strategy
- */
-GraphFindResult findGraphInMap(
-        A1C_Item* graphsItem,
-        std::string_view searchTerm,
-        GraphFindStrategy strategy)
-{
-    GraphFindResult result;
-
-    for (size_t i = 0; i < graphsItem->map.size; ++i) {
-        A1C_Pair* pair = &graphsItem->map.items[i];
-        if (pair->key.type != A1C_ItemType_string) {
-            continue;
-        }
-
-        StringView keyView = StringView_initFromA1C(pair->key.string);
-        std::string_view keySv(keyView.data, keyView.size);
-
-        bool matches = false;
-        switch (strategy) {
-            case GraphFindStrategy::Exact:
-                matches = (keySv == searchTerm);
-                break;
-            case GraphFindStrategy::Prefix:
-                matches =
-                        (getGraphBasePrefix(keySv) == std::string(searchTerm));
-                break;
-        }
-
-        if (matches) {
-            if (pair->val.type != A1C_ItemType_map) {
-                if (strategy == GraphFindStrategy::Exact) {
-                    throw Exception(
-                            "Graph '" + std::string(searchTerm)
-                            + "' is not a valid map");
-                }
-                continue; // Skip invalid graphs for prefix searches
-            }
-
-            switch (strategy) {
-                case GraphFindStrategy::Exact:
-                    Logger::log_c(
-                            VERBOSE2,
-                            "Found target graph: %.*s",
-                            (int)keySv.size(),
-                            keySv.data());
-                    result.pair = pair;
-                    return result; // Return immediately for exact match
-
-                case GraphFindStrategy::Prefix:
-                    result.names.emplace_back(keySv);
-                    break; // Continue searching for all matches
-            }
-        }
-    }
-
-    return result;
-}
-
-A1C_Item* extractGraphsFromCbor(std::shared_ptr<const A1C_Item> root)
-{
-    A1C_Item* graphsItem = A1C_Map_get_cstr(&root->map, "graphs");
-    if (!graphsItem || graphsItem->type != A1C_ItemType_map) {
-        throw Exception("Could not find valid 'graphs' map in root");
-    }
-
-    return graphsItem;
-}
-
 } // anonymous namespace
-
-std::shared_ptr<const std::string_view> encodeCborAsSerialized(
-        const A1C_Item* root)
-{
-    size_t cborSize = A1C_Item_encodedSize(root);
-    if (cborSize == 0) {
-        throw Exception("Failed to determine CBOR size");
-    }
-
-    std::string cborBuffer;
-    cborBuffer.resize(cborSize);
-
-    A1C_Error error;
-    size_t bytesWritten = A1C_Item_encode(
-            root,
-            reinterpret_cast<uint8_t*>(cborBuffer.data()),
-            cborSize,
-            &error);
-    if (bytesWritten == 0) {
-        throw Exception(
-                "Failed to encode CBOR: "
-                + std::string(A1C_ErrorType_getString(error.type)));
-    }
-
-    cborBuffer.resize(bytesWritten);
-
-    return CborDataBundle::create(std::move(cborBuffer));
-}
 
 /**
  * @brief Extracts the base name of a graph by splitting at '#' character.
@@ -219,41 +78,6 @@ std::string_view getGraphBasePrefix(std::string_view graphName)
         return graphName.substr(0, hashPos);
     }
     return graphName;
-}
-
-std::tuple<std::shared_ptr<const A1C_Item>, std::shared_ptr<Arena>>
-decodeSerializedCompressorIntoCbor(const std::string_view serialized)
-{
-    auto arena = std::shared_ptr<Arena>(
-            ALLOC_HeapArena_create(), ALLOC_Arena_freeArena);
-    const A1C_Arena a1cArena = A1C_Arena_wrap(arena.get());
-
-    A1C_Decoder decoder;
-    const A1C_DecoderConfig config = { .maxDepth            = 0,
-                                       .limitBytes          = 0,
-                                       .referenceSource     = true,
-                                       .rejectUnknownSimple = true };
-    A1C_Decoder_init(&decoder, a1cArena, config);
-
-    const A1C_Item* root = A1C_Decoder_decode(
-            &decoder,
-            reinterpret_cast<const uint8_t*>(serialized.data()),
-            serialized.size());
-
-    if (!root) {
-        throw Exception("Failed to parse CBOR data");
-    }
-
-    if (root->type != A1C_ItemType_map) {
-        throw Exception("Root is not a map");
-    }
-
-    auto rootPtr =
-            std::shared_ptr<const A1C_Item>(root, [arena](const A1C_Item*) {
-                // The arena will be destroyed when this deleter is called
-            });
-
-    return std::make_tuple(rootPtr, arena);
 }
 
 bool hasTargetGraph(
@@ -297,67 +121,6 @@ std::vector<NodeID> getCustomNodes(const Compressor& compressor, GraphID graph)
 {
     auto nodes = ZL_Compressor_Graph_getCustomNodes(compressor.get(), graph);
     return { nodes.nodeids, nodes.nodeids + nodes.nbNodeIDs };
-}
-
-std::string replaceBaseGraphInCompressor(
-        const std::string_view serializedCompressor,
-        const std::string& parameterizedGraphName,
-        const std::string& newBaseGraphName)
-{
-    auto [root, arena] =
-            decodeSerializedCompressorIntoCbor(serializedCompressor);
-    auto graphsItem = extractGraphsFromCbor(root);
-
-    // Find the parameterized graph by exact name
-    auto targetGraph = findGraphInMap(
-            graphsItem, parameterizedGraphName, GraphFindStrategy::Exact);
-    if (!targetGraph.pair) {
-        throw Exception(
-                "Could not find parameterized graph '" + parameterizedGraphName
-                + "' in the graphs map");
-    }
-
-    if (targetGraph.pair->val.type != A1C_ItemType_map) {
-        throw Exception("Invalid parameterized graph");
-    }
-    auto type = A1C_Map_get_cstr(&targetGraph.pair->val.map, "type");
-    if (!type || type->type != A1C_ItemType_string) {
-        throw Exception("Invalid parameterized graph");
-    }
-    if (poly::string_view(type->string.data, type->string.size)
-        != "parameterized") {
-        throw Exception("Invalid parameterized graph");
-    }
-
-    A1C_Arena a1cArena = A1C_Arena_wrap(arena.get());
-    A1C_Pair* map      = A1C_Item_map(&targetGraph.pair->val, 4, &a1cArena);
-    if (map == nullptr) {
-        throw std::bad_alloc();
-    }
-    A1C_Item_string_refCStr(&map[0].key, "type");
-    A1C_Item_string_refCStr(&map[0].val, "parameterized");
-    A1C_Item_string_refCStr(&map[1].key, "base");
-    if (!A1C_Item_string_cstr(
-                &map[1].val, newBaseGraphName.c_str(), &a1cArena)) {
-        throw std::bad_alloc();
-    }
-    A1C_Item_string_refCStr(&map[2].key, "graphs");
-    if (A1C_Item_array(&map[2].val, 0, &a1cArena) == nullptr) {
-        throw std::bad_alloc();
-    }
-    A1C_Item_string_refCStr(&map[3].key, "nodes");
-    if (A1C_Item_array(&map[3].val, 0, &a1cArena) == nullptr) {
-        throw std::bad_alloc();
-    }
-
-    Logger::log_c(
-            VERBOSE2,
-            "Updated base field of graph '%s' to '%s'",
-            parameterizedGraphName.c_str(),
-            newBaseGraphName.c_str());
-
-    auto serializedResult = encodeCborAsSerialized(root.get());
-    return std::string(*serializedResult);
 }
 
 } // namespace openzl::training::graph_mutation

--- a/tools/training/graph_mutation/graph_mutation_utils.cpp
+++ b/tools/training/graph_mutation/graph_mutation_utils.cpp
@@ -273,18 +273,6 @@ std::shared_ptr<const std::string_view> createSharedStringView(std::string str)
     return CborDataBundle::create(std::move(str));
 }
 
-std::vector<std::string> findAllGraphsWithPrefix(
-        std::string_view serializedCompressor,
-        const std::string& prefix)
-{
-    auto [root, arena] =
-            decodeSerializedCompressorIntoCbor(serializedCompressor);
-    auto graphsItem = extractGraphsFromCbor(root);
-
-    auto result = findGraphInMap(graphsItem, prefix, GraphFindStrategy::Prefix);
-    return result.names;
-}
-
 std::vector<GraphID> findAllGraphsWithPrefix(
         const Compressor& compressor,
         poly::string_view prefix)

--- a/tools/training/graph_mutation/graph_mutation_utils.cpp
+++ b/tools/training/graph_mutation/graph_mutation_utils.cpp
@@ -7,6 +7,7 @@
 #include "openzl/common/a1cbor_helpers.h"
 #include "openzl/common/allocation.h"
 #include "openzl/cpp/Compressor.hpp"
+#include "openzl/zl_reflection.h"
 
 #include "tools/logger/Logger.h"
 #include "tools/training/graph_mutation/graph_mutation_utils.h"
@@ -16,6 +17,35 @@ namespace openzl::training::graph_mutation {
 using namespace tools::logger;
 
 namespace {
+
+template <typename Fn>
+std::vector<GraphID> findGraphsWhere(const Compressor& compressor, Fn&& fn)
+{
+    struct State {
+        Fn& fn;
+        std::vector<GraphID> result{};
+    };
+    State state{ fn };
+
+    auto callback = [](void* opaque,
+                       const ZL_Compressor* c,
+                       ZL_GraphID graph) noexcept {
+        const CompressorRef cref(const_cast<ZL_Compressor*>(c));
+        auto& s = *static_cast<State*>(opaque);
+        try {
+            if (s.fn(cref, graph)) {
+                s.result.push_back(graph);
+            }
+        } catch (...) {
+            return ZL_returnError(ZL_ErrorCode_GENERIC);
+        }
+        return ZL_returnSuccess();
+    };
+
+    compressor.unwrap(
+            ZL_Compressor_forEachGraph(compressor.get(), callback, &state));
+    return state.result;
+}
 
 /*
  * @brief A wrapper class for a CBOR data bundle.
@@ -54,65 +84,6 @@ std::string getStartGraphName(const A1C_Item* root)
     }
 
     return std::string(startField->string.data, startField->string.size);
-}
-
-/**
- * @brief Replaces all references to a graph name in other graphs' dependency
- * arrays.
- *
- * Scans through all graphs in the compressor and updates any references to the
- * old graph name found in their "graphs" arrays (dependency lists). This
- * function only updates references - it does not modify the original graph
- * definition key, the start graph field, or base graph references.
- *
- * @param graphsItem The CBOR item containing all graphs map
- * @param oldName The old graph name to find and replace in references
- * @param newName The new graph name to substitute in references
- * @param arena The memory arena for CBOR string operations
- */
-void replaceGraphNameReferences(
-        A1C_Item* graphsItem,
-        std::string_view oldName,
-        std::string_view newName,
-        A1C_Arena* arena)
-{
-    // Update all references to the old graph name in all graphs
-    for (size_t i = 0; i < graphsItem->map.size; ++i) {
-        A1C_Pair* pair = &graphsItem->map.items[i];
-        if (pair->val.type == A1C_ItemType_map) {
-            // Update references in graphs arrays
-            A1C_Item* graphsArray = A1C_Map_get_cstr(&pair->val.map, "graphs");
-            if (graphsArray && graphsArray->type == A1C_ItemType_array) {
-                for (size_t j = 0; j < graphsArray->array.size; ++j) {
-                    A1C_Item* graphRef = A1C_Array_get(&graphsArray->array, j);
-                    if (graphRef && graphRef->type == A1C_ItemType_string) {
-                        StringView refView =
-                                StringView_initFromA1C(graphRef->string);
-                        std::string_view refName(refView.data, refView.size);
-                        if (refName == oldName) {
-                            if (!A1C_Item_string_copy(
-                                        graphRef,
-                                        newName.data(),
-                                        newName.length(),
-                                        arena)) {
-                                throw Exception(
-                                        "Failed to update graph reference");
-                            }
-                            Logger::log_c(
-                                    VERBOSE2,
-                                    "Updated graph reference from %.*s to %.*s in graph %.*s",
-                                    (int)oldName.size(),
-                                    oldName.data(),
-                                    (int)newName.size(),
-                                    newName.data(),
-                                    (int)pair->key.string.size,
-                                    pair->key.string.data);
-                        }
-                    }
-                }
-            }
-        }
-    }
 }
 
 enum class GraphFindStrategy {
@@ -205,27 +176,6 @@ A1C_Item* extractGraphsFromCbor(std::shared_ptr<const A1C_Item> root)
     return graphsItem;
 }
 
-const A1C_Item* findGraphByPrefix(
-        const std::string_view& serializedCompressor,
-        std::string_view targetGraphPrefix)
-{
-    auto [root, arena] =
-            decodeSerializedCompressorIntoCbor(serializedCompressor);
-    auto graphsItem = extractGraphsFromCbor(root);
-
-    auto result = findGraphInMap(
-            graphsItem, targetGraphPrefix, GraphFindStrategy::Prefix);
-
-    if (result.names.empty()) {
-        return nullptr;
-    }
-
-    auto exactResult = findGraphInMap(
-            graphsItem, result.names[0], GraphFindStrategy::Exact);
-
-    return exactResult.pair ? &exactResult.pair->val : nullptr;
-}
-
 } // anonymous namespace
 
 std::shared_ptr<const std::string_view> encodeCborAsSerialized(
@@ -315,98 +265,7 @@ bool hasTargetGraph(
             "In hasTargetGraph. targetGraphPrefix: %.*s",
             (int)targetGraphPrefix.size(),
             targetGraphPrefix.data());
-    const std::string serializedData = compressor.serialize();
-    return findGraphByPrefix(serializedData, targetGraphPrefix) != nullptr;
-}
-
-std::vector<std::string> extractSuccessorsFromCbor(
-        const std::string_view& cborStr,
-        const std::string& graphName)
-{
-    // Decode once and keep the arena alive
-    auto [root, arena] = decodeSerializedCompressorIntoCbor(cborStr);
-    auto graphsItem    = extractGraphsFromCbor(root);
-
-    // Find the exact graph using the same decoded data
-    auto exactResult =
-            findGraphInMap(graphsItem, graphName, GraphFindStrategy::Exact);
-
-    if (!exactResult.pair) {
-        throw Exception("Could not find exact graph named '" + graphName + "'");
-    }
-
-    const A1C_Item* targetGraph = &exactResult.pair->val;
-
-    // Get the "graphs" array from the target graph (contains successor graph
-    // names)
-    A1C_Item const* const graphsArray =
-            A1C_Map_get_cstr(&targetGraph->map, "graphs");
-    if (!graphsArray || graphsArray->type != A1C_ItemType_array) {
-        throw Exception(
-                "'" + graphName
-                + "' does not contain 'graphs' key or it's not an array");
-    }
-
-    std::vector<std::string> successorsFromSerialization;
-    for (size_t i = 0; i < graphsArray->array.size; ++i) {
-        A1C_Item const* const item = A1C_Array_get(&graphsArray->array, i);
-        if (item && item->type == A1C_ItemType_string) {
-            StringView successorView = StringView_initFromA1C(item->string);
-            successorsFromSerialization.emplace_back(
-                    successorView.data, successorView.size);
-        }
-    }
-    return successorsFromSerialization;
-}
-
-std::vector<std::string> extractNodesFromCbor(
-        const std::string_view& cborStr,
-        const std::string& targetGraphPrefix)
-{
-    // Decode once and keep the arena alive
-    auto [root, arena] = decodeSerializedCompressorIntoCbor(cborStr);
-    auto graphsItem    = extractGraphsFromCbor(root);
-
-    // Find all graphs with the prefix
-    auto result = findGraphInMap(
-            graphsItem, targetGraphPrefix, GraphFindStrategy::Prefix);
-
-    if (result.names.empty()) {
-        throw Exception(
-                "JSON does not contain any graph with name starting with '"
-                + targetGraphPrefix + "'");
-    }
-
-    // Find the exact graph using the same decoded data
-    auto exactResult = findGraphInMap(
-            graphsItem, result.names[0], GraphFindStrategy::Exact);
-
-    if (!exactResult.pair) {
-        throw Exception(
-                "Could not find exact graph for prefix '" + targetGraphPrefix
-                + "'");
-    }
-
-    const A1C_Item* targetGraph = &exactResult.pair->val;
-
-    // Get the "nodes" array from the target graph
-    A1C_Item const* const nodesArray =
-            A1C_Map_get_cstr(&targetGraph->map, "nodes");
-    if (!nodesArray || nodesArray->type != A1C_ItemType_array) {
-        throw Exception(
-                "'" + targetGraphPrefix
-                + "' does not contain 'nodes' key or it's not an array");
-    }
-
-    std::vector<std::string> nodesFromSerialization;
-    for (size_t i = 0; i < nodesArray->array.size; ++i) {
-        A1C_Item const* const item = A1C_Array_get(&nodesArray->array, i);
-        if (item && item->type == A1C_ItemType_string) {
-            StringView nodeView = StringView_initFromA1C(item->string);
-            nodesFromSerialization.emplace_back(nodeView.data, nodeView.size);
-        }
-    }
-    return nodesFromSerialization;
+    return !findAllGraphsWithPrefix(compressor, targetGraphPrefix).empty();
 }
 
 std::shared_ptr<const std::string_view> createSharedStringView(std::string str)
@@ -426,55 +285,30 @@ std::vector<std::string> findAllGraphsWithPrefix(
     return result.names;
 }
 
-std::string renameGraphInCompressor(
-        const std::string_view serializedCompressor,
-        std::string_view oldGraphName,
-        std::string_view newGraphName)
+std::vector<GraphID> findAllGraphsWithPrefix(
+        const Compressor& compressor,
+        poly::string_view prefix)
 {
-    auto [root, arena] =
-            decodeSerializedCompressorIntoCbor(serializedCompressor);
-    auto graphsItem = extractGraphsFromCbor(root);
+    return findGraphsWhere(
+            compressor, [&prefix](const Compressor& c, GraphID g) {
+                auto graphName = ZL_Compressor_Graph_getName(c.get(), g);
+                return getGraphBasePrefix(graphName) == prefix;
+            });
+}
 
-    // Verify the old graph exists
-    auto targetGraph =
-            findGraphInMap(graphsItem, oldGraphName, GraphFindStrategy::Exact);
-    if (!targetGraph.pair) {
-        throw Exception(
-                "Could not find target graph '" + std::string(oldGraphName)
-                + "' in the graphs map");
-    }
+std::vector<GraphID> getCustomGraphs(
+        const Compressor& compressor,
+        GraphID graph)
+{
+    auto graphs = ZL_Compressor_Graph_getCustomGraphs(compressor.get(), graph);
+    return { graphs.graphids, graphs.graphids + graphs.nbGraphIDs };
+}
 
-    A1C_Arena a1cArena = A1C_Arena_wrap(arena.get());
-    replaceGraphNameReferences(
-            graphsItem, oldGraphName, newGraphName, &a1cArena);
-
-    // Update the "start" field if it points to the old graph name
-    A1C_Item* startField = A1C_Map_get_cstr(&root->map, "start");
-    if (startField && startField->type == A1C_ItemType_string) {
-        StringView currentStartView =
-                StringView_initFromA1C(startField->string);
-        std::string_view currentStart(
-                currentStartView.data, currentStartView.size);
-        if (currentStart == oldGraphName) {
-            if (!A1C_Item_string_copy(
-                        startField,
-                        newGraphName.data(),
-                        newGraphName.length(),
-                        &a1cArena)) {
-                throw Exception("Failed to update start field");
-            }
-            Logger::log_c(
-                    VERBOSE2,
-                    "Updated start field from '%.*s' to '%.*s'",
-                    (int)oldGraphName.size(),
-                    oldGraphName.data(),
-                    (int)newGraphName.size(),
-                    newGraphName.data());
-        }
-    }
-
-    auto serializedResult = encodeCborAsSerialized(root.get());
-    return std::string(*serializedResult);
+/// @returns The custom nodes of @p graphid
+std::vector<NodeID> getCustomNodes(const Compressor& compressor, GraphID graph)
+{
+    auto nodes = ZL_Compressor_Graph_getCustomNodes(compressor.get(), graph);
+    return { nodes.nodeids, nodes.nodeids + nodes.nbNodeIDs };
 }
 
 std::string replaceBaseGraphInCompressor(
@@ -536,55 +370,6 @@ std::string replaceBaseGraphInCompressor(
 
     auto serializedResult = encodeCborAsSerialized(root.get());
     return std::string(*serializedResult);
-}
-
-/**
- * @brief Gets the maximum ID from all graphs with '#' in the name.
- *
- * Serialized graph definions are stored in the format {name}#{id}, where
- * {name} is the graph name and {id} is a positive integer. The IDs are unique
- * across all graphs of all names. {name} can be empty.
-
- * This function iterates through all graphs, extracts the suffix after the
- * '#' and returns the maximum value found. Graphs without '#' are skipped.
- *
- * @param serializedCompressor The serialized compressor containing the graphs
- * @return int The maximum ID found, or 0 if no graphs with '#' exist
- */
-int getMaximumIdFromSerialized(std::string_view serializedCompressor)
-{
-    auto [root, arena] =
-            decodeSerializedCompressorIntoCbor(serializedCompressor);
-    auto graphsItem = extractGraphsFromCbor(root);
-
-    auto extractId = [](const A1C_Pair& pair) -> int {
-        if (pair.key.type != A1C_ItemType_string) {
-            return 0;
-        }
-
-        std::string graphName(pair.key.string.data, pair.key.string.size);
-        size_t hashPos = graphName.find('#');
-        if (hashPos != std::string::npos && hashPos + 1 < graphName.length()) {
-            std::string suffix = graphName.substr(hashPos + 1);
-            try {
-                return std::stoi(suffix);
-            } catch (const std::exception&) {
-                // Skip invalid suffixes
-                return 0;
-            }
-        }
-        return 0;
-    };
-
-    A1C_Pair* items = graphsItem->map.items;
-    size_t size     = graphsItem->map.size;
-    auto maxElement = std::max_element(
-            items,
-            items + size,
-            [&extractId](const A1C_Pair& a, const A1C_Pair& b) {
-                return extractId(a) < extractId(b);
-            });
-    return (maxElement != items + size) ? extractId(*maxElement) : 0;
 }
 
 } // namespace openzl::training::graph_mutation

--- a/tools/training/graph_mutation/graph_mutation_utils.h
+++ b/tools/training/graph_mutation/graph_mutation_utils.h
@@ -101,11 +101,6 @@ std::vector<GraphID> findAllGraphsWithPrefix(
         const Compressor& compressor,
         poly::string_view prefix);
 
-// Will be deleted by a future diff once all usage is migrated
-std::vector<std::string> findAllGraphsWithPrefix(
-        std::string_view serializedCompressor,
-        const std::string& prefix);
-
 /// @returns the custom graphs of @p graphid
 std::vector<GraphID> getCustomGraphs(
         const Compressor& compressor,

--- a/tools/training/graph_mutation/graph_mutation_utils.h
+++ b/tools/training/graph_mutation/graph_mutation_utils.h
@@ -36,26 +36,6 @@ bool hasTargetGraph(
         poly::string_view targetGraphPrefix);
 
 /**
- * @brief Replaces the base graph of a specific parameterized graph.
- *
- * This function updates the "base" field of a specific parameterized graph
- * to point to a new base graph. Unlike replaceGraphInCompressor2, this only
- * modifies the base field of the specified graph and does not update other
- * references throughout the compressor. It also clears the other fields of
- * the parameterized graph.
- *
- * @param serializedCompressor The serialized compressor to modify.
- * @param parameterizedGraphName The name of the parameterized graph whose
- * base should be updated.
- * @param newBaseGraphName The name of the new base graph to reference.
- * @return The serialized modified compressor as CBOR data.
- */
-std::string replaceBaseGraphInCompressor(
-        const std::string_view serializedCompressor,
-        const std::string& parameterizedGraphName,
-        const std::string& newBaseGraphName);
-
-/**
  * @brief Extracts the base name of a graph by splitting at '#'
  * character.
  *
@@ -63,26 +43,6 @@ std::string replaceBaseGraphInCompressor(
  * @return The base name (prefix before '#')
  */
 std::string_view getGraphBasePrefix(std::string_view graphName);
-
-/**
- * @brief Decodes a serialized compressor into a CBOR structure.
- *
- * @param serialized The serialized compressor to decode.
- * @return A tuple containing the root CBOR item and the arena used to decode
- */
-std::tuple<std::shared_ptr<const A1C_Item>, std::shared_ptr<Arena>>
-decodeSerializedCompressorIntoCbor(const std::string_view serialized);
-
-/**
- * @brief Encodes a CBOR item into serialized binary data.
- *
- * @param root The CBOR item to encode
- * @return std::shared_ptr<const std::string_view> A shared pointer to a string
- * view containing the serialized binary data
- * @throws std::runtime_error If encoding fails
- */
-std::shared_ptr<const std::string_view> encodeCborAsSerialized(
-        const A1C_Item* root);
 
 /**
  * @brief Finds all graphs with a specific prefix in a serialized compressor.

--- a/tools/training/graph_mutation/graph_mutation_utils.h
+++ b/tools/training/graph_mutation/graph_mutation_utils.h
@@ -29,81 +29,11 @@ namespace openzl::training::graph_mutation {
 std::shared_ptr<const std::string_view> createSharedStringView(std::string str);
 
 /**
- * @brief Extracts successor graph names from a CBOR string for a specified
- * graph.
- *
- * @param cborStr The CBOR string to parse.
- * @param graphName The exact name of the graph whose successors
- * to extract.
- * @return A vector of successor graph names.
- */
-std::vector<std::string> extractSuccessorsFromCbor(
-        const std::string_view& cborStr,
-        const std::string& graphName);
-
-/**
- * @brief Extracts node names from a CBOR string for a specified
- * graph.
- *
- * @param cborStr The CBOR string to parse.
- * @param targetGraphPrefix The base name of the graph whose successors
- * to extract.
- * @return A vector of successor graph names.
- */
-std::vector<std::string> extractNodesFromCbor(
-        const std::string_view& cborStr,
-        const std::string& targetGraphPrefix);
-
-/**
- * @brief Replaces a graph's parameters in a compressor with new local
- * parameters.
- *
- * This function modifies the compressor by updating the specified graph with
- * new local parameters. It serializes the compressor, modifies the CBOR
- * representation, and then returns the serialized modified compressor.
- *
- * @param serializedCompressor The serialized compressor to modify.
- * @param localParams The new local parameters to apply.
- * @param graphName The name of the graph to modify.
- * @return std::shared_ptr<const std::string_view> The serialized modified
- * compressor as CBOR data.
- */
-std::shared_ptr<const std::string_view> replaceGraphInCompressor(
-        std::string_view serializedCompressor,
-        const ZL_LocalParams& localParams,
-        const std::string& graphName);
-
-/**
  * @brief Checks if a compressor contains a graph with a specific prefix.
  */
 bool hasTargetGraph(
         const Compressor& compressor,
         poly::string_view targetGraphPrefix);
-
-/**
- * @brief Renames a graph throughout the compressor by updating all references
- * and the start field.
- *
- * This function performs a comprehensive rename of a graph by:
- * 1. Updating all references to the old graph name in other graphs' dependency
- * arrays
- * 2. Updating the compressor's start field if it points to the old graph name
- *
- * Note: This function does not rename the actual graph definition key - it
- * assumes the graph has already been renamed at the definition level and only
- * updates references.
- *
- * @param serializedCompressor The serialized compressor data to modify
- * @param oldGraphName The current name of the graph to rename references from
- * @param newGraphName The new name to use in all references
- * @return std::string The updated serialized compressor with renamed references
- * @throws std::runtime_error If the old graph cannot be found or update
- * operations fail
- */
-std::string renameGraphInCompressor(
-        const std::string_view serializedCompressor,
-        std::string_view oldGraphName,
-        std::string_view newGraphName);
 
 /**
  * @brief Replaces the base graph of a specific parameterized graph.
@@ -162,29 +92,26 @@ std::shared_ptr<const std::string_view> encodeCborAsSerialized(
  * matches the given prefix. A serialized compressor is a CBOR-encoded data
  * structure containing compression graph definitions.
  *
- * @param serializedCompressor The serialized compressor containing the CBOR
- * data.
+ * @param compressor The compressor to search.
  * @param prefix The prefix to search for in graph names.
  * @return std::vector<std::string> A vector of graph names that match the
  * prefix.
  */
+std::vector<GraphID> findAllGraphsWithPrefix(
+        const Compressor& compressor,
+        poly::string_view prefix);
+
+// Will be deleted by a future diff once all usage is migrated
 std::vector<std::string> findAllGraphsWithPrefix(
         std::string_view serializedCompressor,
         const std::string& prefix);
 
-/**
- * @brief Gets the maximum ID from all graphs with '#' suffix in a serialized
- * compressor.
- *
- * This function decodes the serialized compressor into a CBOR structure and
- * finds the maximum ID from all graphs that have a '#' suffix. The ID is
- * extracted from the suffix after the '#' character, which is guaranteed to
- * be a positive integer. Graphs without '#' are skipped.
- *
- * @param serializedCompressor The serialized compressor containing the CBOR
- * data.
- * @return int The maximum ID found, or 0 if no graphs with '#' suffix exist.
- */
-int getMaximumIdFromSerialized(std::string_view serializedCompressor);
+/// @returns the custom graphs of @p graphid
+std::vector<GraphID> getCustomGraphs(
+        const Compressor& compressor,
+        GraphID graph);
+
+/// @returns The custom nodes of @p graphid
+std::vector<NodeID> getCustomNodes(const Compressor& compressor, GraphID graph);
 
 } // namespace openzl::training::graph_mutation

--- a/tools/training/tests/test_sample_collection.cpp
+++ b/tools/training/tests/test_sample_collection.cpp
@@ -3,6 +3,7 @@
 #include <gtest/gtest.h>
 
 #include "openzl/codecs/zl_clustering.h"
+#include "openzl/zl_reflection.h"
 #include "tools/training/graph_mutation/graph_mutation_utils.h"
 #include "tools/training/sample_collection/training_sample_collector.h"
 
@@ -60,10 +61,11 @@ TEST_F(TestSampleCollection, BasicSampleCollection)
     std::vector<MultiInput> mi_samples            = getMISamples(samples);
 
     // Get all the clustering instances (we expect 1)
-    auto serialized = compressor_.serialize();
-    auto names =
-            graph_mutation::findAllGraphsWithPrefix(serialized, "zl.cluster");
-    ASSERT_EQ(names.size(), 1);
+    auto graphs =
+            graph_mutation::findAllGraphsWithPrefix(compressor_, "zl.cluster");
+    ASSERT_EQ(graphs.size(), 1);
+    std::vector<std::string> names = { ZL_Compressor_Graph_getName(
+            compressor_.get(), graphs[0]) };
 
     // Collect the input streams for the clustering instance
     auto inputs = collectInputStreamsForGraphs(mi_samples, names, cctx_);


### PR DESCRIPTION
Summary:

Add `ZL_Compressor_overrideBaseGraph()` and use it in ACE instead of `replaceBaseGraphInCompressor()` and delete `replaceBaseGraphInCompressor()`.

Reviewed By: kevinjzhang

Differential Revision: D103275002


