### PR TITLE
Handle missing repetition/definition levels

### DIFF
--- a/custom_parsers/parquet/parquet_lexer.cpp
+++ b/custom_parsers/parquet/parquet_lexer.cpp
@@ -95,6 +95,30 @@ lexFooter(ZL_ParquetLexer* lexer, ZL_ParquetToken* out, ZL_ErrorContext* errCtx)
     return ZL_returnSuccess();
 }
 
+/// Consume one RLE-encoded level block (4-byte LE size prefix + data) from the
+/// current lexer position and shrink the page's remaining value-byte budget
+/// accordingly.
+ZL_Report consumeLevelData(
+        ZL_ParquetLexer* lexer,
+        ZL_ParquetToken* out,
+        Encoding encoding,
+        ZL_ErrorContext* errCtx)
+{
+    ZL_RESULT_DECLARE_SCOPE_REPORT(errCtx);
+    ZL_ERR_IF_NE((int)encoding, (int)Encoding::RLE, node_invalid_input);
+    ZL_ERR_IF_LT(getRemaining(lexer), 4, node_invalid_input);
+    auto size = ZL_readLE32(lexer->currPtr);
+    lexer->currPtr += 4;
+    out->size += 4;
+    ZL_ERR_IF_LT(getRemaining(lexer), size, node_invalid_input);
+    lexer->currPtr += size;
+    out->size += size;
+    ZL_ERR_IF_LT(
+            (size_t)lexer->pageHeader->numBytes, size + 4, node_invalid_input);
+    lexer->pageHeader->numBytes -= size + 4;
+    return ZL_returnSuccess();
+}
+
 ZL_Report lexPageHeader(
         ZL_ParquetLexer* lexer,
         ZL_ParquetToken* out,
@@ -119,30 +143,20 @@ ZL_Report lexPageHeader(
     }
 
     // If we are in a data page, include the repetition and definition levels in
-    // the header
+    // the header (if present).
     if (lexer->pageHeader->pageType == PageType::DATA_PAGE) {
-        ZL_ERR_IF_NE(
-                (int)lexer->pageHeader->rl_encoding,
-                (int)Encoding::RLE,
-                node_invalid_input);
-        ZL_ERR_IF_NE(
-                (int)lexer->pageHeader->dl_encoding,
-                (int)Encoding::RLE,
-                node_invalid_input);
-        // Repetition and Definition levels
-        ZL_ERR_IF_LT(getRemaining(lexer), 4, node_invalid_input);
-        auto size = ZL_readLE32(lexer->currPtr);
-        advance(4);
-        ZL_ERR_IF_LT(getRemaining(lexer), size, node_invalid_input);
-        advance(size);
+        auto& chunkMeta = getChunkMeta(lexer);
+        auto schemaMeta = getSchemaMeta(lexer, chunkMeta.path_in_schema);
+        ZL_ERR_IF_NULL(schemaMeta, GENERIC, "Unknown schema path");
 
-        // Adjust the expected data page bytes
-        ZL_ERR_IF_LT(
-
-                (size_t)lexer->pageHeader->numBytes,
-                size + 4,
-                node_invalid_input);
-        lexer->pageHeader->numBytes -= size + 4;
+        if (schemaMeta->hasRepetitionLevels) {
+            ZL_ERR_IF_ERR(consumeLevelData(
+                    lexer, out, lexer->pageHeader->rl_encoding, errCtx));
+        }
+        if (schemaMeta->hasDefinitionLevels) {
+            ZL_ERR_IF_ERR(consumeLevelData(
+                    lexer, out, lexer->pageHeader->dl_encoding, errCtx));
+        }
     }
 
     lexer->chunkLexed += out->size;

--- a/custom_parsers/parquet/parquet_metadata.cpp
+++ b/custom_parsers/parquet/parquet_metadata.cpp
@@ -2,6 +2,7 @@
 
 #include "parquet_metadata.h"
 
+#include <stack>
 #include <stdexcept>
 #include <tuple>
 
@@ -271,12 +272,35 @@ uint32_t readDataPageHeader(ThriftCompactReader& reader, PageHeader& header)
     return read;
 }
 
+enum class RepetitionType : uint32_t {
+    REQUIRED = 0,
+    OPTIONAL = 1,
+    REPEATED = 2,
+};
+
+RepetitionType getRepetitionType(int32_t val)
+{
+    switch (val) {
+        case 0:
+            return RepetitionType::REQUIRED;
+        case 1:
+            return RepetitionType::OPTIONAL;
+        case 2:
+            return RepetitionType::REPEATED;
+        default:
+            throw std::runtime_error("Invalid Parquet Repetition Type!");
+    }
+}
+
 struct SchemaElement {
     std::string name;
     bool isLeaf = false;
     /// Populated for leaf nodes
     DataType type;
     int32_t typeWidth = 0;
+    /// Repetition type of this element. Defaults to REQUIRED, which is the
+    /// default for the root element in the parquet schema.
+    RepetitionType repetitionType = RepetitionType::REQUIRED;
 
     // Populated for non-leaf nodes
     int32_t numChildren = 0;
@@ -309,6 +333,13 @@ uint32_t readSchemaElement(ThriftCompactReader& reader, SchemaElement& e)
                 read += reader.readI32(e.typeWidth);
                 break;
             }
+            case 3: /* Repetition Type */ {
+                throwIfTTypeNE(type, TType::T_I32);
+                int32_t reptype;
+                read += reader.readI32(reptype);
+                e.repetitionType = getRepetitionType(reptype);
+                break;
+            }
             case 4: /* Name */ {
                 throwIfTTypeNE(type, TType::T_STRING);
                 read += reader.readString(e.name);
@@ -335,31 +366,40 @@ void populateSchemaMetadata(
     if (schemaElements.empty()) {
         return;
     }
-    std::stack<std::tuple<int32_t, SchemaPath>> paths(
-            { std::tuple(schemaElements.front().numChildren, SchemaPath()) });
+    // Stack tuple: remaining children under this parent, the parent's path,
+    // and whether any ancestor on this path is OPTIONAL/REPEATED (definition
+    // levels) or REPEATED (repetition levels).
+    std::stack<std::tuple<int32_t, SchemaPath, bool, bool>> paths;
+    paths.emplace(
+            schemaElements.front().numChildren, SchemaPath(), false, false);
     schemaElements.erase(schemaElements.begin());
 
     for (auto& e : schemaElements) {
         if (paths.empty()) {
             throw std::runtime_error("Invalid schema!");
         }
-        auto& [numChildren, parentPath] = paths.top();
-        auto path                       = parentPath;
+        auto& [numChildren, parentPath, parentHasDef, parentHasRep] =
+                paths.top();
+        auto path = parentPath;
         path.push_back(e.name);
-        numChildren -= 1;
-
-        if (numChildren == 0) {
-            paths.pop();
+        bool hasDef =
+                parentHasDef || (e.repetitionType != RepetitionType::REQUIRED);
+        bool hasRep =
+                parentHasRep || (e.repetitionType == RepetitionType::REPEATED);
+        if (--numChildren == 0) {
+            paths.pop(); // invalidates parent* references above
         }
 
         if (!e.isLeaf) {
-            paths.emplace(e.numChildren, path);
+            paths.emplace(e.numChildren, path, hasDef, hasRep);
             continue;
         }
 
         SchemaMetadata m = {
-            .type      = e.type,
-            .typeWidth = (uint32_t)e.typeWidth,
+            .type                = e.type,
+            .typeWidth           = (uint32_t)e.typeWidth,
+            .hasDefinitionLevels = hasDef,
+            .hasRepetitionLevels = hasRep,
         };
 
         auto it = schemaMetadata.emplace(SchemaPath(path), m);

--- a/custom_parsers/parquet/parquet_metadata.h
+++ b/custom_parsers/parquet/parquet_metadata.h
@@ -36,6 +36,12 @@ struct SchemaMetadata {
     DataType type = (DataType)-1;
     /// The size of the data type in bytes
     uint32_t typeWidth = 0;
+    /// True when this leaf has any OPTIONAL or REPEATED ancestor; data pages
+    /// for the column then contain a definition-level block.
+    bool hasDefinitionLevels = false;
+    /// True when this leaf has any REPEATED ancestor; data pages for the
+    /// column then contain a repetition-level block.
+    bool hasRepetitionLevels = false;
 };
 
 struct FileMetadata {

--- a/custom_parsers/parquet/tests/fuzz_utils.h
+++ b/custom_parsers/parquet/tests/fuzz_utils.h
@@ -53,7 +53,7 @@ std::shared_ptr<arrow::Field> gen_arrow_field(
         type = arrow::struct_(fields);
     }
 
-    return arrow::field(std::move(name), std::move(type));
+    return arrow::field(std::move(name), std::move(type), f.coin("nullable"));
 };
 
 template <typename Mode>
@@ -71,12 +71,15 @@ std::shared_ptr<arrow::Schema> gen_arrow_schema(
 };
 
 template <typename Mode, typename T>
-std::vector<std::optional<T>>
-gen_vec(StructuredFDP<Mode>& f, std::string& name, size_t numElts)
+std::vector<std::optional<T>> gen_vec(
+        StructuredFDP<Mode>& f,
+        std::string& name,
+        size_t numElts,
+        bool nullable)
 {
     std::vector<std::optional<T>> vec(numElts);
     for (size_t i = 0; i < numElts; ++i) {
-        if (!f.has_more_data() || f.coin("null")) {
+        if (nullable && (!f.has_more_data() || f.coin("null"))) {
             vec[i] = std::nullopt;
         } else {
             vec[i] = Uniform<T>().gen(name, f);
@@ -90,11 +93,12 @@ std::vector<std::optional<std::string>> gen_str_vec(
         StructuredFDP<Mode>& f,
         std::string& name,
         size_t numElts,
-        LenDist lenDist)
+        LenDist lenDist,
+        bool nullable)
 {
     std::vector<std::optional<std::string>> vec(numElts);
     for (size_t i = 0; i < numElts; ++i) {
-        if (!f.has_more_data() || f.coin("null")) {
+        if (nullable && (!f.has_more_data() || f.coin("null"))) {
             vec[i] = std::nullopt;
         } else {
             vec[i] = openzl::tests::gen_str(f, name, lenDist);
@@ -111,24 +115,32 @@ std::shared_ptr<arrow::Array> gen_array_from_field(
 {
     auto type     = field->type();
     auto typeName = type->name();
+    bool nullable = field->nullable();
 
     if (typeName == "bool") {
-        return to_arrow_array(gen_vec<Mode, bool>(f, typeName, numElts));
-    } else if (typeName == "int32") {
-        return to_arrow_array(gen_vec<Mode, int32_t>(f, typeName, numElts));
-    } else if (typeName == "int64") {
-        return to_arrow_array(gen_vec<Mode, int64_t>(f, typeName, numElts));
-    } else if (typeName == "float") {
-        return to_arrow_array(gen_vec<Mode, float>(f, typeName, numElts));
-    } else if (typeName == "double") {
-        return to_arrow_array(gen_vec<Mode, double>(f, typeName, numElts));
-    } else if (typeName == "utf8") {
         return to_arrow_array(
-                gen_str_vec(f, typeName, numElts, Range<size_t>(1, 100)));
+                gen_vec<Mode, bool>(f, typeName, numElts, nullable));
+    } else if (typeName == "int32") {
+        return to_arrow_array(
+                gen_vec<Mode, int32_t>(f, typeName, numElts, nullable));
+    } else if (typeName == "int64") {
+        return to_arrow_array(
+                gen_vec<Mode, int64_t>(f, typeName, numElts, nullable));
+    } else if (typeName == "float") {
+        return to_arrow_array(
+                gen_vec<Mode, float>(f, typeName, numElts, nullable));
+    } else if (typeName == "double") {
+        return to_arrow_array(
+                gen_vec<Mode, double>(f, typeName, numElts, nullable));
+    } else if (typeName == "utf8") {
+        return to_arrow_array(gen_str_vec(
+                f, typeName, numElts, Range<size_t>(1, 100), nullable));
     } else if (typeName == "fixed_size_binary") {
         auto width = type->byte_width();
         return to_arrow_array(
-                gen_str_vec(f, typeName, numElts, Const<size_t>(width)), width);
+                gen_str_vec(
+                        f, typeName, numElts, Const<size_t>(width), nullable),
+                width);
     } else if (typeName == "struct") {
         std::vector<std::shared_ptr<arrow::Array>> arrays;
         for (const auto& childField : field->type()->fields()) {

--- a/custom_parsers/parquet/tests/test_parquet_lexer.cpp
+++ b/custom_parsers/parquet/tests/test_parquet_lexer.cpp
@@ -19,15 +19,15 @@ namespace parquet {
 namespace testing {
 
 namespace {
-std::shared_ptr<arrow::Table> generate_table()
+std::shared_ptr<arrow::Table> generate_table(bool nullable = true)
 {
     auto i64array = to_arrow_array<int64_t>({ 100, 200, 300, 400, 500 });
     auto strarray = to_arrow_array<std::string>(
             { "hello", "world", "my", "name", "is" });
 
     std::shared_ptr<arrow::Schema> schema = arrow::schema(
-            { arrow::field("int", arrow::int64()),
-              arrow::field("str", arrow::utf8()) });
+            { arrow::field("int", arrow::int64(), nullable),
+              arrow::field("str", arrow::utf8(), nullable) });
 
     return arrow::Table::Make(schema, { i64array, strarray });
 }
@@ -172,6 +172,34 @@ TEST(ParquetLexerTest, TestLexValidParquet)
     EXPECT_NE(lexer, nullptr);
 
     auto input = to_canonical_parquet(generate_table(), 3);
+
+    ZL_REQUIRE_SUCCESS(
+            ZL_ParquetLexer_init(lexer, input.data(), input.size(), nullptr));
+
+    auto tokens = std::vector<ZL_ParquetToken>(15);
+
+    auto const res =
+            ZL_ParquetLexer_lex(lexer, tokens.data(), tokens.size(), nullptr);
+    EXPECT_FALSE(ZL_isError(res));
+    EXPECT_TRUE(ZL_ParquetLexer_finished(lexer));
+    auto const numTokens = ZL_validResult(res);
+    EXPECT_LT(numTokens, tokens.size());
+    tokens.resize(numTokens);
+
+    std::vector<Column> columns = { { { "int" }, ZL_Type_numeric, 8 },
+                                    { { "str" }, ZL_Type_serial, 1 } };
+
+    validateTokens(tokens, input, columns, 2);
+
+    ZL_ParquetLexer_free(lexer);
+}
+
+TEST(ParquetLexerTest, TestLexRequiredParquet)
+{
+    auto lexer = ZL_ParquetLexer_create();
+    EXPECT_NE(lexer, nullptr);
+
+    auto input = to_canonical_parquet(generate_table(false /* nullable */), 3);
 
     ZL_REQUIRE_SUCCESS(
             ZL_ParquetLexer_init(lexer, input.data(), input.size(), nullptr));


### PR DESCRIPTION
Summary:
Per the parquet spec, definition/repetition level blocks are omitted from data pages when the column has no `OPTIONAL`/`REPEATED` ancestor. We did not previously handle this case, causing parsing of Parquet files with required columns to fail.

This diff adds tracking of `hasDefinitionLevels` / `hasRepetitionLevels` per leaf in the schema metadata, and consume the repetition/definition blocks independently in the lexer only when present.

Differential Revision: D103245483


