### PR TITLE
Opt into longer initialization timeouts for all fuzzers

### DIFF
--- a/defs.bzl
+++ b/defs.bzl
@@ -200,6 +200,11 @@ ZS_FUZZ_METADATA = Metadata(
 )
 
 _DEFAULT_HARNESS_CONFIG = {
+    # Set 10 minute initialization timeout to avoid AFL initialization
+    # timeouts.
+    "environment": {
+        "AFL_FORKSRV_INIT_TMOUT": "600000",
+    },
     # Set 1 minute timeout on inputs, rather than the 10 second default
     "perInputTimeout": 60,
 }


### PR DESCRIPTION
Summary: I also just saw some timeouts in non-version-test fuzzers, so opt into the 10 minute initialization timeout globally. Hopefully, some of the other speedups will also help, but I don't want to be spammed by this issue.

Differential Revision: D103449503


