### PR TITLE
Fix fuzzer input generation issues (#720)

### DIFF
--- a/tests/fuzz/OpenZLComponentFuzzer.cpp
+++ b/tests/fuzz/OpenZLComponentFuzzer.cpp
@@ -199,8 +199,10 @@ FUZZ(OpenZLComponentFuzzer, FuzzRoundTrip)
                 formatVersion);
     }
 
-    const size_t size = gen.usize_range(
-            "input_size", 1, std::max(size_t(1), gen.num_remaining_bytes()));
+    // Assume 4 bytes required per input byte
+    const size_t maxInputSize =
+            std::max<size_t>(1, gen.num_remaining_bytes() / 4);
+    const size_t size = gen.usize_range("input_size", 1, maxInputSize);
     auto inputs = component->generateInputs(gen, 1, size, compressor, graph);
     for (const auto& input : inputs) {
         try {

--- a/tests/registry/components/CompressSmallLengths.cpp
+++ b/tests/registry/components/CompressSmallLengths.cpp
@@ -145,7 +145,7 @@ class CompressSmallLengthsComponent : public OpenZLComponent {
     std::vector<std::unique_ptr<OpenZLInput>> generateInputs(
             datagen::DataGen& gen,
             size_t num,
-            size_t maxInputSize,
+            size_t maxInputSizeBytes,
             const Compressor&,
             GraphID) const override
     {
@@ -154,7 +154,9 @@ class CompressSmallLengthsComponent : public OpenZLComponent {
         for (size_t i = 0; i < num; ++i) {
             // Widths >= 2 (sentinel_byte rejects 1-byte inputs)
             const auto widthChoice = gen.usize_range("width", 0, 3);
-            auto inputSize = gen.usize_range("input_size", 0, maxInputSize);
+            // Divide by element width to get the max number of elements
+            auto maxInputSize = maxInputSizeBytes / (1u << widthChoice);
+            auto inputSize    = gen.usize_range("input_size", 0, maxInputSize);
             switch (widthChoice) {
                 case 0:
                     inputs.push_back(makeInput<uint8_t>(gen, inputSize));

--- a/tests/registry/components/MuxLengths.cpp
+++ b/tests/registry/components/MuxLengths.cpp
@@ -192,7 +192,7 @@ class MuxLengthsComponent : public OpenZLComponent {
     std::vector<std::unique_ptr<OpenZLInput>> generateInputs(
             datagen::DataGen& gen,
             size_t num,
-            size_t maxInputSize,
+            size_t maxInputSizeBytes,
             const Compressor& compressor,
             GraphID graphID) const override
     {
@@ -202,9 +202,12 @@ class MuxLengthsComponent : public OpenZLComponent {
         inputs.reserve(num);
         for (size_t i = 0; i < num; ++i) {
             auto widthChoice = gen.usize_range("width", 0, 3);
-            auto inputSize   = gen.usize_range("inputSize", 0, maxInputSize);
-            auto llSmallProb = gen.f32_range("llSmallProb", 0, 1);
-            auto mlSmallProb = gen.f32_range("mlSmallProb", 0, 1);
+            // Divide by element width to get the max number of elements.
+            // Note that there are two input streams to mux lengths.
+            auto maxInputSize = maxInputSizeBytes / (2 * (1u << widthChoice));
+            auto inputSize    = gen.usize_range("inputSize", 0, maxInputSize);
+            auto llSmallProb  = gen.f32_range("llSmallProb", 0, 1);
+            auto mlSmallProb  = gen.f32_range("mlSmallProb", 0, 1);
             switch (widthChoice) {
                 case 0:
                     inputs.push_back(

--- a/tests/registry/components/SentinelByte.cpp
+++ b/tests/registry/components/SentinelByte.cpp
@@ -78,7 +78,7 @@ class SentinelByteComponent : public OpenZLComponent {
     std::vector<std::unique_ptr<OpenZLInput>> generateInputs(
             datagen::DataGen& gen,
             size_t num,
-            size_t maxInputSize,
+            size_t maxInputSizeBytes,
             const Compressor&,
             GraphID) const override
     {
@@ -88,7 +88,9 @@ class SentinelByteComponent : public OpenZLComponent {
             // Only widths >= 2 (sentinel_byte rejects 1-byte inputs)
             const auto widthChoice = gen.usize_range("width", 0, 2);
             const auto smallProb   = gen.f32_range("small_prob", 0.0, 1.0);
-            auto inputSize = gen.usize_range("input_size", 0, maxInputSize);
+            // Divide by element width to get the max number of elements
+            auto maxInputSize = maxInputSizeBytes / (2u << widthChoice);
+            auto inputSize    = gen.usize_range("input_size", 0, maxInputSize);
             switch (widthChoice) {
                 case 0:
                     inputs.push_back(


### PR DESCRIPTION
Summary:

Fuzzers were failing because we were consuming too much data after the end of the input. This was for two reasons:

1. Many fuzzers use more than 1 byte of entropy for each byte of input data produced. So divide `num_remaining_bytes()` by 4.
2. Some components, namely `MuxLengths`, was treating `maxInputSize` as a number of elements, rather than a number of bytes. Fix that.
3. Claude also found two other components `SentinelByte` and `CompressSmallLengths` that had the same issue, so proactively fix it.

Differential Revision: D103685305


