### PR TITLE
Add VS Code syntax highlighting extension for SDDL files

### DIFF
--- a/contrib/sddl-syntax-highlighting/README.md
+++ b/contrib/sddl-syntax-highlighting/README.md
@@ -1,0 +1,26 @@
+# SDDL Syntax Highlighting (VS Code)
+
+A minimal VS Code extension providing TextMate syntax highlighting for OpenZL
+SDDL2 (`.sddl`) files.
+
+## Install (development)
+
+Symlink this directory into your user extensions folder:
+
+```bash
+ln -s "$(pwd)" ~/.vscode/extensions/openzl.sddl-syntax-0.1.0
+```
+
+> **Meta internal users:** Use
+> `~/.vscode-fb-stable/extensions/` instead
+
+Reload VS Code (`Cmd/Ctrl+Shift+P` → "Developer: Reload Window"). Open any
+`.sddl` file to verify — the status bar should show "SDDL".
+
+## Maintenance
+
+The token set must stay in sync with the SDDL2 tokenizer. The single source of
+truth is `tools/sddl2/compiler/Syntax.cpp` (the `strs_to_syms` table) plus the
+lexer rules in `tools/sddl2/compiler/tokenizer/Tokenizer.cpp`. When new
+keywords or types are added there, add matching patterns to
+`syntaxes/sddl.tmLanguage.json`.

--- a/contrib/sddl-syntax-highlighting/language-configuration.json
+++ b/contrib/sddl-syntax-highlighting/language-configuration.json
@@ -1,0 +1,20 @@
+{
+  "comments": {
+    "lineComment": "#"
+  },
+  "brackets": [
+    ["{", "}"],
+    ["[", "]"],
+    ["(", ")"]
+  ],
+  "autoClosingPairs": [
+    { "open": "{", "close": "}" },
+    { "open": "[", "close": "]" },
+    { "open": "(", "close": ")" }
+  ],
+  "surroundingPairs": [
+    ["{", "}"],
+    ["[", "]"],
+    ["(", ")"]
+  ]
+}

--- a/contrib/sddl-syntax-highlighting/package.json
+++ b/contrib/sddl-syntax-highlighting/package.json
@@ -1,0 +1,35 @@
+{
+  "name": "sddl-syntax",
+  "displayName": "SDDL Syntax Highlighting",
+  "description": "Syntax highlighting for OpenZL SDDL2 (Simple Data Description Language) files.",
+  "version": "0.1.0",
+  "publisher": "openzl",
+  "engines": {
+    "vscode": "^1.60.0"
+  },
+  "categories": [
+    "Programming Languages"
+  ],
+  "contributes": {
+    "languages": [
+      {
+        "id": "sddl",
+        "aliases": [
+          "SDDL",
+          "sddl"
+        ],
+        "extensions": [
+          ".sddl"
+        ],
+        "configuration": "./language-configuration.json"
+      }
+    ],
+    "grammars": [
+      {
+        "language": "sddl",
+        "scopeName": "source.sddl",
+        "path": "./syntaxes/sddl.tmLanguage.json"
+      }
+    ]
+  }
+}

--- a/contrib/sddl-syntax-highlighting/syntaxes/sddl.tmLanguage.json
+++ b/contrib/sddl-syntax-highlighting/syntaxes/sddl.tmLanguage.json
@@ -1,0 +1,147 @@
+{
+  "$schema": "https://raw.githubusercontent.com/martinring/tmlanguage/master/tmlanguage.json",
+  "name": "SDDL",
+  "scopeName": "source.sddl",
+  "fileTypes": ["sddl"],
+  "patterns": [
+    { "include": "#comments" },
+    { "include": "#numbers" },
+    { "include": "#keywords" },
+    { "include": "#builtin-functions" },
+    { "include": "#builtin-types" },
+    { "include": "#operators" },
+    { "include": "#punctuation" },
+    { "include": "#user-types" },
+    { "include": "#identifiers" }
+  ],
+  "repository": {
+    "comments": {
+      "patterns": [
+        {
+          "name": "comment.line.number-sign.sddl",
+          "begin": "#",
+          "end": "$",
+          "beginCaptures": {
+            "0": { "name": "punctuation.definition.comment.sddl" }
+          }
+        }
+      ]
+    },
+    "numbers": {
+      "patterns": [
+        {
+          "name": "constant.numeric.hex.sddl",
+          "match": "\\b0[xX][0-9a-fA-F]+\\b"
+        },
+        {
+          "name": "constant.numeric.octal.sddl",
+          "match": "\\b0[0-7]+\\b"
+        },
+        {
+          "name": "constant.numeric.decimal.sddl",
+          "match": "\\b(0|[1-9][0-9]*)\\b"
+        }
+      ]
+    },
+    "keywords": {
+      "patterns": [
+        {
+          "name": "storage.type.record.sddl",
+          "match": "\\brecord\\b"
+        },
+        {
+          "name": "keyword.control.conditional.sddl",
+          "match": "\\bwhen\\b"
+        },
+        {
+          "name": "keyword.control.sddl",
+          "match": "\\bexpect\\b"
+        }
+      ]
+    },
+    "builtin-functions": {
+      "patterns": [
+        {
+          "name": "support.function.builtin.sddl",
+          "match": "\\b(sizeof|abs)\\b"
+        }
+      ]
+    },
+    "builtin-types": {
+      "patterns": [
+        {
+          "name": "support.type.builtin.sddl",
+          "match": "\\b(Byte|Bytes|Int8|UInt8|Int16LE|Int16BE|UInt16LE|UInt16BE|Int32LE|Int32BE|UInt32LE|UInt32BE|Int64LE|Int64BE|UInt64LE|UInt64BE|Float16LE|Float16BE|Float32LE|Float32BE|Float64LE|Float64BE|BFloat16LE|BFloat16BE)\\b"
+        }
+      ]
+    },
+    "operators": {
+      "patterns": [
+        {
+          "name": "keyword.operator.comparison.sddl",
+          "match": "==|!=|<=|>=|<|>"
+        },
+        {
+          "name": "keyword.operator.logical.sddl",
+          "match": "&&|\\|\\||!(?!=)"
+        },
+        {
+          "name": "keyword.operator.bitwise.sddl",
+          "match": "(?<!&)&(?!&)|(?<!\\|)\\|(?!\\|)|\\^|~"
+        },
+        {
+          "name": "keyword.operator.arithmetic.sddl",
+          "match": "\\+|-|\\*|/|%"
+        },
+        {
+          "name": "keyword.operator.assignment.sddl",
+          "match": "="
+        },
+        {
+          "name": "keyword.operator.assignment.consume.sddl",
+          "match": ":"
+        }
+      ]
+    },
+    "punctuation": {
+      "patterns": [
+        {
+          "name": "punctuation.accessor.sddl",
+          "match": "\\."
+        },
+        {
+          "name": "punctuation.separator.comma.sddl",
+          "match": ","
+        },
+        {
+          "name": "punctuation.section.braces.sddl",
+          "match": "[{}]"
+        },
+        {
+          "name": "punctuation.section.brackets.sddl",
+          "match": "[\\[\\]]"
+        },
+        {
+          "name": "punctuation.section.parens.sddl",
+          "match": "[()]"
+        }
+      ]
+    },
+    "user-types": {
+      "patterns": [
+        {
+          "name": "support.type.sddl",
+          "match": "\\b[A-Z][A-Za-z0-9_]*[a-z][A-Za-z0-9_]*\\b"
+        }
+      ]
+    },
+    "identifiers": {
+      "patterns": [
+        {
+          "name": "variable.other.sddl",
+          "match": "\\b[A-Za-z_][A-Za-z0-9_]*\\b"
+        }
+      ]
+    }
+  }
+}


### PR DESCRIPTION
Summary:
Add a minimal VS Code extension that provides TextMate syntax highlighting for OpenZL SDDL2 (`.sddl`) files.

This makes `.sddl` files easier to read and write by colorizing keywords, builtin types, builtin functions, operators, numeric literals, and comments. The extension is intended to be installed locally via a symlink (see README); it is not published.

Reviewed By: Cyan4973

Differential Revision: D103065790


