### PR TITLE
Introduce SDDL2 Result types

### DIFF
--- a/src/openzl/compress/graphs/sddl2/sddl2.c
+++ b/src/openzl/compress/graphs/sddl2/sddl2.c
@@ -264,13 +264,13 @@ static ZL_Report sddl2_flatten_field_sizes(
                     graph, type.struct_data->members[i], field_sizes, index));
         }
     } else {
-        size_t field_size;
-        ZL_ERR_IF_NE(
-                SDDL2_Type_size(type, &field_size),
-                SDDL2_OK,
+        SDDL2_RESULT_OF(size_t) const field_size_report = SDDL2_Type_size(type);
+        ZL_ERR_IF(
+                SDDL2_isError(field_size_report),
                 GENERIC,
                 "Failed to compute size for type kind %d",
                 (int)type.kind);
+        size_t const field_size = SDDL2_value(field_size_report);
 
         field_sizes[(*index)++] = field_size;
     }
@@ -672,13 +672,14 @@ static ZL_Report sddl2_apply_type_conversion(
 
     // Determine primitive element size in bytes (not including width)
     // For array types, we convert the base element, not the full array
-    size_t element_size;
-    ZL_ERR_IF_NE(
-            SDDL2_kind_size(type.kind, &element_size),
-            SDDL2_OK,
+    SDDL2_RESULT_OF(size_t)
+    const element_size_report = SDDL2_kind_size(type.kind);
+    ZL_ERR_IF(
+            SDDL2_isError(element_size_report),
             GENERIC,
             "Invalid SDDL2 type kind %d for segment (unsupported type)",
             (int)type.kind);
+    size_t const element_size = SDDL2_value(element_size_report);
 
     // Determine endianness
     bool is_little_endian;
@@ -1171,13 +1172,12 @@ static ZL_Report sddl2_get_chunk_split_unit_size(
 
     // Primitive kinds, including BYTES, split on their element size.
     // BYTES intentionally uses 1-byte units so raw byte spans can chunk.
-    size_t unitBytes;
-    ZL_ERR_IF_NE(
-            SDDL2_kind_size(type.kind, &unitBytes),
-            SDDL2_OK,
+    SDDL2_RESULT_OF(size_t) const unitBytes_report = SDDL2_kind_size(type.kind);
+    ZL_ERR_IF(
+            SDDL2_isError(unitBytes_report),
             GENERIC,
             "Failed to derive a split unit size for SDDL2 segment chunking");
-    return ZL_returnValue(unitBytes);
+    return ZL_returnValue(SDDL2_value(unitBytes_report));
 }
 
 typedef struct {

--- a/src/openzl/compress/graphs/sddl2/sddl2_error.h
+++ b/src/openzl/compress/graphs/sddl2/sddl2_error.h
@@ -5,11 +5,17 @@
  *
  * Provides:
  * - SDDL2_Error enum - Unified error codes for all VM operations
+ * - SDDL2_RESULT_OF(type) - Generic Result type macro
  * - SDDL2_TRY() macro - Propagate errors up the call stack
  */
 
 #ifndef SDDL2_ERROR_H
 #define SDDL2_ERROR_H
+
+#include <stddef.h> // size_t
+
+#include "openzl/zl_macro_helpers.h" // ZS_MACRO_CONCAT
+#include "openzl/zl_portability.h"   // ZL_NODISCARD
 
 #if defined(__cplusplus)
 extern "C" {
@@ -39,28 +45,71 @@ typedef enum {
 } SDDL2_Error;
 
 /* ============================================================================
+ * SDDL2_RESULT_OF - Generic Result Type
+ * ============================================================================
+ *
+ * Creates a Result type that bundles a value with an error code.
+ * Eliminates out parameters and triggers warnings if return value is ignored.
+ *
+ * Usage:
+ *   SDDL2_RESULT_DECLARE_TYPE(size_t);  // declare once
+ *
+ *   SDDL2_RESULT_OF(size_t) result = some_function();
+ *   if (SDDL2_isError(result)) { handle_error(SDDL2_error(result)); }
+ *   size_t value = SDDL2_value(result);
+ */
+
+#define SDDL2_RESULT_OF(type) ZS_MACRO_CONCAT(SDDL2_Result_, type)
+
+#define SDDL2_RESULT_DECLARE_TYPE(type) \
+    typedef struct ZL_NODISCARD {       \
+        SDDL2_Error _code;              \
+        type _value;                    \
+    } SDDL2_RESULT_OF(type)
+
+/* Generic accessors */
+#define SDDL2_isError(result) ((result)._code != SDDL2_OK)
+#define SDDL2_error(result) ((result)._code)
+#define SDDL2_value(result) ((result)._value)
+
+/* Generic constructors */
+#if defined(__cplusplus)
+#    define SDDL2_success(type, val) (SDDL2_RESULT_OF(type){ SDDL2_OK, (val) })
+#    define SDDL2_failure(type, err) (SDDL2_RESULT_OF(type){ (err), {} })
+#else
+#    define SDDL2_success(type, val) \
+        ((SDDL2_RESULT_OF(type)){ ._code = SDDL2_OK, ._value = (val) })
+#    define SDDL2_failure(type, err) ((SDDL2_RESULT_OF(type)){ ._code = (err) })
+#endif
+
+/* Pre-declare size_t Result type (used in public API) */
+SDDL2_RESULT_DECLARE_TYPE(size_t);
+
+/* ============================================================================
  * Error Handling Macros
  * ========================================================================= */
 
 /**
- * Try an operation, return on failure.
- *
- * Usage:
- *   SDDL2_TRY(pop_i64(stack, &value));
- *   SDDL2_TRY(SDDL2_Stack_push(&stack, result));
- *
- * Expands to:
- *   do {
- *       SDDL2_Error _err = (operation);
- *       if (_err != SDDL2_OK)
- *           return _err;
- *   } while (0)
+ * Try an operation that returns SDDL2_Error, return on failure.
  */
 #define SDDL2_TRY(operation)            \
     do {                                \
         SDDL2_Error _err = (operation); \
         if (_err != SDDL2_OK)           \
             return _err;                \
+    } while (0)
+
+/**
+ * Declare a variable and assign the result value, or return on error.
+ * Use in functions that return SDDL2_Error.
+ */
+#define SDDL2_TRY_LET(type, var, operation)          \
+    type var;                                        \
+    do {                                             \
+        SDDL2_RESULT_OF(type) _result = (operation); \
+        if (SDDL2_isError(_result))                  \
+            return SDDL2_error(_result);             \
+        (var) = SDDL2_value(_result);                \
     } while (0)
 
 #if defined(__cplusplus)

--- a/src/openzl/compress/graphs/sddl2/sddl2_vm.c
+++ b/src/openzl/compress/graphs/sddl2/sddl2_vm.c
@@ -93,15 +93,13 @@ void sddl2_fallback_free(void* ptr)
  * Handles both primitive types and complex structures.
  * ========================================================================= */
 
-SDDL2_Error SDDL2_kind_size(SDDL2_Type_kind kind, size_t* out_size)
+SDDL2_RESULT_OF(size_t) SDDL2_kind_size(SDDL2_Type_kind kind)
 {
-    *out_size = (size_t)-1; // Initialize to invalid value
     switch (kind) {
         case SDDL2_TYPE_U8:
         case SDDL2_TYPE_I8:
         case SDDL2_TYPE_F8:
-            *out_size = 1;
-            return SDDL2_OK;
+            return SDDL2_success(size_t, 1);
         case SDDL2_TYPE_U16LE:
         case SDDL2_TYPE_U16BE:
         case SDDL2_TYPE_I16LE:
@@ -110,48 +108,44 @@ SDDL2_Error SDDL2_kind_size(SDDL2_Type_kind kind, size_t* out_size)
         case SDDL2_TYPE_F16BE:
         case SDDL2_TYPE_BF16LE:
         case SDDL2_TYPE_BF16BE:
-            *out_size = 2;
-            return SDDL2_OK;
+            return SDDL2_success(size_t, 2);
         case SDDL2_TYPE_U32LE:
         case SDDL2_TYPE_U32BE:
         case SDDL2_TYPE_I32LE:
         case SDDL2_TYPE_I32BE:
         case SDDL2_TYPE_F32LE:
         case SDDL2_TYPE_F32BE:
-            *out_size = 4;
-            return SDDL2_OK;
+            return SDDL2_success(size_t, 4);
         case SDDL2_TYPE_U64LE:
         case SDDL2_TYPE_U64BE:
         case SDDL2_TYPE_I64LE:
         case SDDL2_TYPE_I64BE:
         case SDDL2_TYPE_F64LE:
         case SDDL2_TYPE_F64BE:
-            *out_size = 8;
-            return SDDL2_OK;
+            return SDDL2_success(size_t, 8);
         case SDDL2_TYPE_BYTES:
-            *out_size = 1;
-            return SDDL2_OK;
+            return SDDL2_success(size_t, 1);
         case SDDL2_TYPE_STRUCTURE:
-            return SDDL2_TYPE_MISMATCH;
         default:
-            return SDDL2_TYPE_MISMATCH;
+            return SDDL2_failure(size_t, SDDL2_TYPE_MISMATCH);
     }
 }
 
-SDDL2_Error SDDL2_Type_size(SDDL2_Type type, size_t* out_size)
+SDDL2_RESULT_OF(size_t) SDDL2_Type_size(SDDL2_Type type)
 {
     if (type.kind == SDDL2_TYPE_STRUCTURE) {
         if (type.struct_data == NULL) {
-            return SDDL2_TYPE_MISMATCH;
+            return SDDL2_failure(size_t, SDDL2_TYPE_MISMATCH);
         }
-        *out_size = type.struct_data->total_size_bytes * type.width;
-        return SDDL2_OK;
+        return SDDL2_success(
+                size_t, type.struct_data->total_size_bytes* type.width);
     }
 
-    size_t ks;
-    SDDL2_TRY(SDDL2_kind_size(type.kind, &ks));
-    *out_size = ks * type.width;
-    return SDDL2_OK;
+    SDDL2_RESULT_OF(size_t) ks = SDDL2_kind_size(type.kind);
+    if (SDDL2_isError(ks)) {
+        return ks;
+    }
+    return SDDL2_success(size_t, SDDL2_value(ks) * type.width);
 }
 
 /* ============================================================================
@@ -204,27 +198,30 @@ SDDL2_Value SDDL2_Value_type(SDDL2_Type type)
  * Internal helper functions that encapsulate common stack operation patterns:
  * - pop_i64(): Pop and validate I64 value
  * - pop_positive_i64(): Pop and validate positive I64, convert to size_t
- * - pop_binary_i64(): Pop two I64 values for binary operations
  * - pop_tag(), pop_type(): Type-specific pop operations
  * - push_i64(): Push I64 result
  * These reduce boilerplate and ensure consistent type checking.
  * ========================================================================= */
 
+/* Result types for internal use (not in public header) */
+SDDL2_RESULT_DECLARE_TYPE(int64_t);
+SDDL2_RESULT_DECLARE_TYPE(uint32_t);
+SDDL2_RESULT_DECLARE_TYPE(SDDL2_Type);
+
 /**
  * Pop a single I64 value from stack with type checking.
  * Common pattern for unary operations and address calculations.
  */
-static inline SDDL2_Error pop_i64(SDDL2_Stack* stack, int64_t* out)
+static inline SDDL2_RESULT_OF(int64_t) pop_i64(SDDL2_Stack* stack)
 {
-    SDDL2_Value val;
-    SDDL2_TRY(SDDL2_Stack_pop(stack, &val));
-
-    if (val.kind != SDDL2_VALUE_I64) {
-        return SDDL2_TYPE_MISMATCH;
+    SDDL2_RESULT_OF(SDDL2_Value) r = SDDL2_Stack_pop(stack);
+    if (SDDL2_isError(r)) {
+        return SDDL2_failure(int64_t, SDDL2_error(r));
     }
-
-    *out = val.value.as_i64;
-    return SDDL2_OK;
+    if (SDDL2_value(r).kind != SDDL2_VALUE_I64) {
+        return SDDL2_failure(int64_t, SDDL2_TYPE_MISMATCH);
+    }
+    return SDDL2_success(int64_t, SDDL2_value(r).value.as_i64);
 }
 
 /**
@@ -232,72 +229,46 @@ static inline SDDL2_Error pop_i64(SDDL2_Stack* stack, int64_t* out)
  * Common pattern for count/size operations (>= 0).
  * Used by type.fixed_array and type.structure for element/member counts.
  */
-static inline SDDL2_Error pop_positive_i64(SDDL2_Stack* stack, size_t* out)
+static inline SDDL2_RESULT_OF(size_t) pop_positive_i64(SDDL2_Stack* stack)
 {
-    SDDL2_Value val;
-    SDDL2_TRY(SDDL2_Stack_pop(stack, &val));
-
-    if (val.kind != SDDL2_VALUE_I64) {
-        return SDDL2_TYPE_MISMATCH;
+    SDDL2_RESULT_OF(int64_t) r = pop_i64(stack);
+    if (SDDL2_isError(r)) {
+        return SDDL2_failure(size_t, SDDL2_error(r));
     }
-
-    if (val.value.as_i64 < 0) {
-        return SDDL2_TYPE_MISMATCH;
+    if (SDDL2_value(r) < 0) {
+        return SDDL2_failure(size_t, SDDL2_TYPE_MISMATCH);
     }
-
-    *out = (size_t)val.value.as_i64;
-    return SDDL2_OK;
-}
-
-/**
- * Pop two I64 values from stack with type checking (b first, then a).
- * Common pattern for binary arithmetic operations.
- * Stack order: ... a b [top] → pops b, then a
- */
-static inline SDDL2_Error
-pop_binary_i64(SDDL2_Stack* stack, int64_t* a_out, int64_t* b_out)
-{
-    int64_t b, a;
-
-    // Pop in reverse order: b (top), then a
-    SDDL2_TRY(pop_i64(stack, &b));
-    SDDL2_TRY(pop_i64(stack, &a));
-
-    *a_out = a;
-    *b_out = b;
-    return SDDL2_OK;
+    return SDDL2_success(size_t, (size_t)SDDL2_value(r));
 }
 
 /**
  * Pop a Tag value from stack with type checking.
  */
-static inline SDDL2_Error pop_tag(SDDL2_Stack* stack, uint32_t* out)
+static inline SDDL2_RESULT_OF(uint32_t) pop_tag(SDDL2_Stack* stack)
 {
-    SDDL2_Value val;
-    SDDL2_TRY(SDDL2_Stack_pop(stack, &val));
-
-    if (val.kind != SDDL2_VALUE_TAG) {
-        return SDDL2_TYPE_MISMATCH;
+    SDDL2_RESULT_OF(SDDL2_Value) r = SDDL2_Stack_pop(stack);
+    if (SDDL2_isError(r)) {
+        return SDDL2_failure(uint32_t, SDDL2_error(r));
     }
-
-    *out = val.value.as_tag;
-    return SDDL2_OK;
+    if (SDDL2_value(r).kind != SDDL2_VALUE_TAG) {
+        return SDDL2_failure(uint32_t, SDDL2_TYPE_MISMATCH);
+    }
+    return SDDL2_success(uint32_t, SDDL2_value(r).value.as_tag);
 }
 
 /**
  * Pop a Type value from stack with type checking.
  */
-static inline SDDL2_Error pop_type(SDDL2_Stack* stack, SDDL2_Type* out)
+static inline SDDL2_RESULT_OF(SDDL2_Type) pop_type(SDDL2_Stack* stack)
 {
-    SDDL2_Value val;
-    SDDL2_TRY(SDDL2_Stack_pop(stack, &val));
-
-    if (val.kind != SDDL2_VALUE_TYPE) {
-        return SDDL2_TYPE_MISMATCH;
+    SDDL2_RESULT_OF(SDDL2_Value) r = SDDL2_Stack_pop(stack);
+    if (SDDL2_isError(r)) {
+        return SDDL2_failure(SDDL2_Type, SDDL2_error(r));
     }
-
-    *out = val.value.as_type;
-    return SDDL2_OK;
+    if (SDDL2_value(r).kind != SDDL2_VALUE_TYPE) {
+        return SDDL2_failure(SDDL2_Type, SDDL2_TYPE_MISMATCH);
+    }
+    return SDDL2_success(SDDL2_Type, SDDL2_value(r).value.as_type);
 }
 
 /**
@@ -321,12 +292,10 @@ static inline SDDL2_Error push_i64(SDDL2_Stack* stack, int64_t value)
 SDDL2_Error SDDL2_op_type_fixed_array(SDDL2_Stack* stack)
 {
     // Pop array count (must be positive)
-    size_t array_count;
-    SDDL2_TRY(pop_positive_i64(stack, &array_count));
+    SDDL2_TRY_LET(size_t, array_count, pop_positive_i64(stack));
 
     // Pop the base type from stack
-    SDDL2_Type base_type;
-    SDDL2_TRY(pop_type(stack, &base_type));
+    SDDL2_TRY_LET(SDDL2_Type, base_type, pop_type(stack));
 
     // Create new type with multiplied width
     SDDL2_Type array_type = base_type;
@@ -349,8 +318,7 @@ SDDL2_Error SDDL2_op_type_structure(
         void* alloc_ctx)
 {
     // Pop member count (must be positive)
-    size_t member_count;
-    SDDL2_TRY(pop_positive_i64(stack, &member_count));
+    SDDL2_TRY_LET(size_t, member_count, pop_positive_i64(stack));
 
     // Calculate allocation size for structure data
     // size = sizeof(header) + member_count * sizeof(SDDL2_Type)
@@ -379,23 +347,25 @@ SDDL2_Error SDDL2_op_type_structure(
     for (size_t i = 0; i < member_count; i++) {
         size_t index = member_count - 1 - i; // Reverse index
 
-        SDDL2_Error err = pop_type(stack, &struct_data->members[index]);
-        if (err != SDDL2_OK) {
+        SDDL2_RESULT_OF(SDDL2_Type) type_result = pop_type(stack);
+        if (SDDL2_isError(type_result)) {
             // When *not* in arena mode (i.e. during tests),
             // it's necessary to free() here to avoid memory leaks
             sddl2_free(struct_data, alloc_fn);
-            return err;
+            return SDDL2_error(type_result);
         }
+        struct_data->members[index] = SDDL2_value(type_result);
     }
 
     // Compute total size by summing all member sizes
     for (size_t i = 0; i < member_count; i++) {
-        size_t member_size;
-        if (SDDL2_Type_size(struct_data->members[i], &member_size)
-            != SDDL2_OK) {
+        SDDL2_RESULT_OF(size_t)
+        const member_size_report = SDDL2_Type_size(struct_data->members[i]);
+        if (SDDL2_isError(member_size_report)) {
             sddl2_free(struct_data, alloc_fn);
-            return SDDL2_TYPE_MISMATCH;
+            return SDDL2_error(member_size_report);
         }
+        size_t const member_size = SDDL2_value(member_size_report);
 
         // Check for size overflow when adding member_size
         if (ZL_overflowAddST(
@@ -420,11 +390,8 @@ SDDL2_Error SDDL2_op_type_structure(
 SDDL2_Error SDDL2_op_type_sizeof(SDDL2_Stack* stack)
 {
     // Pop the type
-    SDDL2_Type type;
-    SDDL2_TRY(pop_type(stack, &type));
-
-    size_t size;
-    SDDL2_TRY(SDDL2_Type_size(type, &size));
+    SDDL2_TRY_LET(SDDL2_Type, type, pop_type(stack));
+    SDDL2_TRY_LET(size_t, size, SDDL2_Type_size(type));
     return push_i64(stack, (int64_t)size);
 }
 
@@ -500,8 +467,8 @@ SDDL2_op_add(SDDL2_Stack* stack, SDDL2_Trace_buffer* trace, size_t pc)
     (void)trace;
     (void)pc;
 
-    int64_t a, b;
-    SDDL2_TRY(pop_binary_i64(stack, &a, &b));
+    SDDL2_TRY_LET(int64_t, b, pop_i64(stack));
+    SDDL2_TRY_LET(int64_t, a, pop_i64(stack));
 
     if (add_would_overflow(a, b)) {
         return SDDL2_MATH_OVERFLOW;
@@ -516,8 +483,8 @@ SDDL2_op_sub(SDDL2_Stack* stack, SDDL2_Trace_buffer* trace, size_t pc)
     (void)trace;
     (void)pc;
 
-    int64_t a, b;
-    SDDL2_TRY(pop_binary_i64(stack, &a, &b));
+    SDDL2_TRY_LET(int64_t, b, pop_i64(stack));
+    SDDL2_TRY_LET(int64_t, a, pop_i64(stack));
 
     if (sub_would_overflow(a, b)) {
         return SDDL2_MATH_OVERFLOW;
@@ -532,8 +499,8 @@ SDDL2_op_mul(SDDL2_Stack* stack, SDDL2_Trace_buffer* trace, size_t pc)
     (void)trace;
     (void)pc;
 
-    int64_t a, b;
-    SDDL2_TRY(pop_binary_i64(stack, &a, &b));
+    SDDL2_TRY_LET(int64_t, b, pop_i64(stack));
+    SDDL2_TRY_LET(int64_t, a, pop_i64(stack));
 
     if (mul_would_overflow(a, b)) {
         return SDDL2_MATH_OVERFLOW;
@@ -548,8 +515,8 @@ SDDL2_op_div(SDDL2_Stack* stack, SDDL2_Trace_buffer* trace, size_t pc)
     (void)trace;
     (void)pc;
 
-    int64_t a, b;
-    SDDL2_TRY(pop_binary_i64(stack, &a, &b));
+    SDDL2_TRY_LET(int64_t, b, pop_i64(stack));
+    SDDL2_TRY_LET(int64_t, a, pop_i64(stack));
 
     // Divide by zero check
     if (b == 0) {
@@ -570,8 +537,8 @@ SDDL2_op_mod(SDDL2_Stack* stack, SDDL2_Trace_buffer* trace, size_t pc)
     (void)trace;
     (void)pc;
 
-    int64_t a, b;
-    SDDL2_TRY(pop_binary_i64(stack, &a, &b));
+    SDDL2_TRY_LET(int64_t, b, pop_i64(stack));
+    SDDL2_TRY_LET(int64_t, a, pop_i64(stack));
 
     // Divide by zero check
     if (b == 0) {
@@ -587,8 +554,7 @@ SDDL2_op_abs(SDDL2_Stack* stack, SDDL2_Trace_buffer* trace, size_t pc)
     (void)trace;
     (void)pc;
 
-    int64_t a;
-    SDDL2_TRY(pop_i64(stack, &a));
+    SDDL2_TRY_LET(int64_t, a, pop_i64(stack));
 
     // Check for INT64_MIN (abs(INT64_MIN) overflows)
     if (a == INT64_MIN) {
@@ -604,8 +570,7 @@ SDDL2_op_neg(SDDL2_Stack* stack, SDDL2_Trace_buffer* trace, size_t pc)
     (void)trace;
     (void)pc;
 
-    int64_t a;
-    SDDL2_TRY(pop_i64(stack, &a));
+    SDDL2_TRY_LET(int64_t, a, pop_i64(stack));
 
     // Check for INT64_MIN (negation overflows)
     if (a == INT64_MIN) {
@@ -644,8 +609,8 @@ static void SDDL2_log_unary_op(
 SDDL2_Error
 SDDL2_op_eq(SDDL2_Stack* stack, SDDL2_Trace_buffer* trace, size_t pc)
 {
-    int64_t a, b;
-    SDDL2_TRY(pop_binary_i64(stack, &a, &b));
+    SDDL2_TRY_LET(int64_t, b, pop_i64(stack));
+    SDDL2_TRY_LET(int64_t, a, pop_i64(stack));
     int64_t result = (a == b);
     SDDL2_log_binary_op("cmp.eq", "==", a, b, result, trace, pc);
     return push_i64(stack, result);
@@ -654,8 +619,8 @@ SDDL2_op_eq(SDDL2_Stack* stack, SDDL2_Trace_buffer* trace, size_t pc)
 SDDL2_Error
 SDDL2_op_ne(SDDL2_Stack* stack, SDDL2_Trace_buffer* trace, size_t pc)
 {
-    int64_t a, b;
-    SDDL2_TRY(pop_binary_i64(stack, &a, &b));
+    SDDL2_TRY_LET(int64_t, b, pop_i64(stack));
+    SDDL2_TRY_LET(int64_t, a, pop_i64(stack));
     int64_t result = (a != b);
     SDDL2_log_binary_op("cmp.ne", "!=", a, b, result, trace, pc);
     return push_i64(stack, result);
@@ -664,8 +629,8 @@ SDDL2_op_ne(SDDL2_Stack* stack, SDDL2_Trace_buffer* trace, size_t pc)
 SDDL2_Error
 SDDL2_op_lt(SDDL2_Stack* stack, SDDL2_Trace_buffer* trace, size_t pc)
 {
-    int64_t a, b;
-    SDDL2_TRY(pop_binary_i64(stack, &a, &b));
+    SDDL2_TRY_LET(int64_t, b, pop_i64(stack));
+    SDDL2_TRY_LET(int64_t, a, pop_i64(stack));
     int64_t result = (a < b);
     SDDL2_log_binary_op("cmp.lt", "<", a, b, result, trace, pc);
     return push_i64(stack, result);
@@ -674,8 +639,8 @@ SDDL2_op_lt(SDDL2_Stack* stack, SDDL2_Trace_buffer* trace, size_t pc)
 SDDL2_Error
 SDDL2_op_le(SDDL2_Stack* stack, SDDL2_Trace_buffer* trace, size_t pc)
 {
-    int64_t a, b;
-    SDDL2_TRY(pop_binary_i64(stack, &a, &b));
+    SDDL2_TRY_LET(int64_t, b, pop_i64(stack));
+    SDDL2_TRY_LET(int64_t, a, pop_i64(stack));
     int64_t result = (a <= b);
     SDDL2_log_binary_op("cmp.le", "<=", a, b, result, trace, pc);
     return push_i64(stack, result);
@@ -684,8 +649,8 @@ SDDL2_op_le(SDDL2_Stack* stack, SDDL2_Trace_buffer* trace, size_t pc)
 SDDL2_Error
 SDDL2_op_gt(SDDL2_Stack* stack, SDDL2_Trace_buffer* trace, size_t pc)
 {
-    int64_t a, b;
-    SDDL2_TRY(pop_binary_i64(stack, &a, &b));
+    SDDL2_TRY_LET(int64_t, b, pop_i64(stack));
+    SDDL2_TRY_LET(int64_t, a, pop_i64(stack));
     int64_t result = (a > b);
     SDDL2_log_binary_op("cmp.gt", ">", a, b, result, trace, pc);
     return push_i64(stack, result);
@@ -694,8 +659,8 @@ SDDL2_op_gt(SDDL2_Stack* stack, SDDL2_Trace_buffer* trace, size_t pc)
 SDDL2_Error
 SDDL2_op_ge(SDDL2_Stack* stack, SDDL2_Trace_buffer* trace, size_t pc)
 {
-    int64_t a, b;
-    SDDL2_TRY(pop_binary_i64(stack, &a, &b));
+    SDDL2_TRY_LET(int64_t, b, pop_i64(stack));
+    SDDL2_TRY_LET(int64_t, a, pop_i64(stack));
     int64_t result = (a >= b);
     SDDL2_log_binary_op("cmp.ge", ">=", a, b, result, trace, pc);
     return push_i64(stack, result);
@@ -715,8 +680,8 @@ SDDL2_op_ge(SDDL2_Stack* stack, SDDL2_Trace_buffer* trace, size_t pc)
 SDDL2_Error
 SDDL2_op_bit_and(SDDL2_Stack* stack, SDDL2_Trace_buffer* trace, size_t pc)
 {
-    int64_t a, b;
-    SDDL2_TRY(pop_binary_i64(stack, &a, &b));
+    SDDL2_TRY_LET(int64_t, b, pop_i64(stack));
+    SDDL2_TRY_LET(int64_t, a, pop_i64(stack));
     int64_t result = (a & b);
     SDDL2_log_binary_op("math.bit_and", "&", a, b, result, trace, pc);
     return push_i64(stack, result);
@@ -725,8 +690,8 @@ SDDL2_op_bit_and(SDDL2_Stack* stack, SDDL2_Trace_buffer* trace, size_t pc)
 SDDL2_Error
 SDDL2_op_bit_or(SDDL2_Stack* stack, SDDL2_Trace_buffer* trace, size_t pc)
 {
-    int64_t a, b;
-    SDDL2_TRY(pop_binary_i64(stack, &a, &b));
+    SDDL2_TRY_LET(int64_t, b, pop_i64(stack));
+    SDDL2_TRY_LET(int64_t, a, pop_i64(stack));
     int64_t result = (a | b);
     SDDL2_log_binary_op("math.bit_or", "|", a, b, result, trace, pc);
     return push_i64(stack, result);
@@ -735,8 +700,8 @@ SDDL2_op_bit_or(SDDL2_Stack* stack, SDDL2_Trace_buffer* trace, size_t pc)
 SDDL2_Error
 SDDL2_op_bit_xor(SDDL2_Stack* stack, SDDL2_Trace_buffer* trace, size_t pc)
 {
-    int64_t a, b;
-    SDDL2_TRY(pop_binary_i64(stack, &a, &b));
+    SDDL2_TRY_LET(int64_t, b, pop_i64(stack));
+    SDDL2_TRY_LET(int64_t, a, pop_i64(stack));
     int64_t result = (a ^ b);
     SDDL2_log_binary_op("math.bit_xor", "^", a, b, result, trace, pc);
     return push_i64(stack, result);
@@ -745,8 +710,7 @@ SDDL2_op_bit_xor(SDDL2_Stack* stack, SDDL2_Trace_buffer* trace, size_t pc)
 SDDL2_Error
 SDDL2_op_bit_not(SDDL2_Stack* stack, SDDL2_Trace_buffer* trace, size_t pc)
 {
-    int64_t a;
-    SDDL2_TRY(pop_i64(stack, &a));
+    SDDL2_TRY_LET(int64_t, a, pop_i64(stack));
     int64_t result = (~a);
     SDDL2_log_unary_op("math.bit_not", "~", a, result, trace, pc);
     return push_i64(stack, result);
@@ -766,8 +730,8 @@ SDDL2_op_bit_not(SDDL2_Stack* stack, SDDL2_Trace_buffer* trace, size_t pc)
 SDDL2_Error
 SDDL2_op_and(SDDL2_Stack* stack, SDDL2_Trace_buffer* trace, size_t pc)
 {
-    int64_t a, b;
-    SDDL2_TRY(pop_binary_i64(stack, &a, &b));
+    SDDL2_TRY_LET(int64_t, b, pop_i64(stack));
+    SDDL2_TRY_LET(int64_t, a, pop_i64(stack));
     int64_t result = (a && b);
     SDDL2_log_binary_op("logic.and", "&&", a, b, result, trace, pc);
     return push_i64(stack, result);
@@ -776,8 +740,8 @@ SDDL2_op_and(SDDL2_Stack* stack, SDDL2_Trace_buffer* trace, size_t pc)
 SDDL2_Error
 SDDL2_op_or(SDDL2_Stack* stack, SDDL2_Trace_buffer* trace, size_t pc)
 {
-    int64_t a, b;
-    SDDL2_TRY(pop_binary_i64(stack, &a, &b));
+    SDDL2_TRY_LET(int64_t, b, pop_i64(stack));
+    SDDL2_TRY_LET(int64_t, a, pop_i64(stack));
     int64_t result = (a || b);
     SDDL2_log_binary_op("logic.or", "||", a, b, result, trace, pc);
     return push_i64(stack, result);
@@ -786,8 +750,8 @@ SDDL2_op_or(SDDL2_Stack* stack, SDDL2_Trace_buffer* trace, size_t pc)
 SDDL2_Error
 SDDL2_op_xor(SDDL2_Stack* stack, SDDL2_Trace_buffer* trace, size_t pc)
 {
-    int64_t a, b;
-    SDDL2_TRY(pop_binary_i64(stack, &a, &b));
+    SDDL2_TRY_LET(int64_t, b, pop_i64(stack));
+    SDDL2_TRY_LET(int64_t, a, pop_i64(stack));
     int64_t result = ((a && !b) || (!a && b));
     SDDL2_log_binary_op("logic.xor", "^^", a, b, result, trace, pc);
     return push_i64(stack, result);
@@ -796,8 +760,7 @@ SDDL2_op_xor(SDDL2_Stack* stack, SDDL2_Trace_buffer* trace, size_t pc)
 SDDL2_Error
 SDDL2_op_not(SDDL2_Stack* stack, SDDL2_Trace_buffer* trace, size_t pc)
 {
-    int64_t a;
-    SDDL2_TRY(pop_i64(stack, &a));
+    SDDL2_TRY_LET(int64_t, a, pop_i64(stack));
     int64_t result = (!a);
     SDDL2_log_unary_op("logic.not", "!", a, result, trace, pc);
     return push_i64(stack, result);
@@ -819,8 +782,7 @@ SDDL2_op_drop(SDDL2_Stack* stack, SDDL2_Trace_buffer* trace, size_t pc)
     (void)trace;
     (void)pc;
 
-    SDDL2_Value val;
-    return SDDL2_Stack_pop(stack, &val);
+    return SDDL2_error(SDDL2_Stack_pop(stack));
 }
 
 SDDL2_Error
@@ -829,12 +791,10 @@ SDDL2_op_stack_drop_if(SDDL2_Stack* stack, SDDL2_Trace_buffer* trace, size_t pc)
     (void)trace;
     (void)pc;
 
-    int64_t condition;
-    SDDL2_TRY(pop_i64(stack, &condition));
+    SDDL2_TRY_LET(int64_t, condition, pop_i64(stack));
 
     if (condition != 0) {
-        SDDL2_Value val;
-        return SDDL2_Stack_pop(stack, &val);
+        return SDDL2_error(SDDL2_Stack_pop(stack));
     }
 
     return SDDL2_OK;
@@ -842,11 +802,8 @@ SDDL2_op_stack_drop_if(SDDL2_Stack* stack, SDDL2_Trace_buffer* trace, size_t pc)
 
 SDDL2_Error SDDL2_op_jump_if(SDDL2_Stack* stack, size_t* out_skip_count)
 {
-    int64_t condition;
-    SDDL2_TRY(pop_i64(stack, &condition));
-
-    size_t n;
-    SDDL2_TRY(pop_positive_i64(stack, &n));
+    SDDL2_TRY_LET(int64_t, condition, pop_i64(stack));
+    SDDL2_TRY_LET(size_t, n, pop_positive_i64(stack));
 
     if (condition != 0) {
         *out_skip_count = n;
@@ -911,15 +868,13 @@ SDDL2_Error SDDL2_op_var_store(
     (void)trace;
     (void)pc;
 
-    int64_t reg_index;
-    SDDL2_TRY(pop_i64(stack, &reg_index));
+    SDDL2_TRY_LET(int64_t, reg_index, pop_i64(stack));
 
     if (reg_index < 0 || reg_index >= SDDL2_VAR_REGISTER_COUNT) {
         return SDDL2_LOAD_BOUNDS;
     }
 
-    SDDL2_Value val;
-    SDDL2_TRY(SDDL2_Stack_pop(stack, &val));
+    SDDL2_TRY_LET(SDDL2_Value, val, SDDL2_Stack_pop(stack));
 
     regs->values[reg_index]   = val;
     regs->occupied[reg_index] = 1;
@@ -936,8 +891,7 @@ SDDL2_Error SDDL2_op_var_load(
     (void)trace;
     (void)pc;
 
-    int64_t reg_index;
-    SDDL2_TRY(pop_i64(stack, &reg_index));
+    SDDL2_TRY_LET(int64_t, reg_index, pop_i64(stack));
 
     if (reg_index < 0 || reg_index >= SDDL2_VAR_REGISTER_COUNT) {
         return SDDL2_LOAD_BOUNDS;
@@ -966,8 +920,7 @@ static void SDDL2_log_expect_true_failure(
 
 SDDL2_Error SDDL2_op_expect_true(SDDL2_Stack* stack, SDDL2_Trace_buffer* trace)
 {
-    int64_t value;
-    SDDL2_TRY(pop_i64(stack, &value));
+    SDDL2_TRY_LET(int64_t, value, pop_i64(stack));
 
     if (value == 0) {
         SDDL2_log_expect_true_failure(trace, stack);
@@ -1050,8 +1003,7 @@ static void SDDL2_log_load(const char* op_name, int64_t addr, int64_t value);
     SDDL2_Error SDDL2_op_load_##name(                             \
             SDDL2_Stack* stack, const SDDL2_Input_cursor* buffer) \
     {                                                             \
-        int64_t addr;                                             \
-        SDDL2_TRY(pop_i64(stack, &addr));                         \
+        SDDL2_TRY_LET(int64_t, addr, pop_i64(stack));             \
         SDDL2_TRY(check_load_bounds(buffer, addr, size));         \
         const uint8_t* bytes = (const uint8_t*)buffer->data;      \
         int64_t value        = (int64_t)(read_expr);              \
@@ -1324,8 +1276,7 @@ static SDDL2_Error segment_create_internal(
     // Calculate actual size in bytes
     // total_type_size = size of one instance of the type (including width)
     // segment_size = element_count × total_type_size
-    size_t total_type_size;
-    SDDL2_TRY(SDDL2_Type_size(type, &total_type_size));
+    SDDL2_TRY_LET(size_t, total_type_size, SDDL2_Type_size(type));
 
     // Check for overflow in element_count * total_type_size multiplication
     size_t size_bytes;
@@ -1397,8 +1348,7 @@ SDDL2_Error SDDL2_op_segment_create_unspecified(
         SDDL2_Segment_list* segments)
 {
     // Pop size from stack
-    int64_t size_i64;
-    SDDL2_TRY(pop_i64(stack, &size_i64));
+    SDDL2_TRY_LET(int64_t, size_i64, pop_i64(stack));
 
     // Validate size (must be non-negative)
     if (size_i64 < 0) {
@@ -1672,15 +1622,10 @@ SDDL2_Error SDDL2_op_segment_create_tagged(
         SDDL2_Segment_list* segments,
         SDDL2_Tag_registry* registry)
 {
-    // Pop size, type, and tag from stack (size on top, type middle, tag bottom)
-    int64_t size_i64;
-    SDDL2_Type type;
-    uint32_t tag;
-
     // Pop in reverse order: size (top), type, tag (bottom)
-    SDDL2_TRY(pop_i64(stack, &size_i64));
-    SDDL2_TRY(pop_type(stack, &type));
-    SDDL2_TRY(pop_tag(stack, &tag));
+    SDDL2_TRY_LET(int64_t, size_i64, pop_i64(stack));
+    SDDL2_TRY_LET(SDDL2_Type, type, pop_type(stack));
+    SDDL2_TRY_LET(uint32_t, tag, pop_tag(stack));
 
     // Validate size (must be non-negative)
     if (size_i64 < 0) {

--- a/src/openzl/compress/graphs/sddl2/sddl2_vm.h
+++ b/src/openzl/compress/graphs/sddl2/sddl2_vm.h
@@ -133,6 +133,9 @@ typedef struct {
     } value;
 } SDDL2_Value;
 
+/* Declare Result type for SDDL2_Value */
+SDDL2_RESULT_DECLARE_TYPE(SDDL2_Value);
+
 /* ============================================================================
  * Stack Structure
  * ========================================================================= */
@@ -441,13 +444,12 @@ static inline SDDL2_Error SDDL2_Stack_push(
  * NOTE: Kept as inline for performance - this is on the hot path,
  * called for every VM instruction that consumes a value.
  */
-static inline SDDL2_Error SDDL2_Stack_pop(SDDL2_Stack* stack, SDDL2_Value* out)
+static inline SDDL2_RESULT_OF(SDDL2_Value) SDDL2_Stack_pop(SDDL2_Stack* stack)
 {
     if (stack->top == 0) {
-        return SDDL2_STACK_UNDERFLOW;
+        return SDDL2_failure(SDDL2_Value, SDDL2_STACK_UNDERFLOW);
     }
-    *out = stack->items[--stack->top];
-    return SDDL2_OK;
+    return SDDL2_success(SDDL2_Value, stack->items[--stack->top]);
 }
 
 /**
@@ -479,18 +481,16 @@ SDDL2_Value SDDL2_Value_type(SDDL2_Type type);
  * ========================================================================= */
 
 /**
- * Get the size in bytes of a single element of the given type kind (primitive
- * size). Returns 1 for BYTES (raw bytes with no known interpretation).
- * Returns SDDL2_TYPE_MISMATCH for unknown/invalid type kinds and for STRUCTURE.
+ * Get the size in bytes of a single element of the given type kind.
+ * Returns SDDL2_TYPE_MISMATCH for unknown/invalid kinds and STRUCTURE.
  */
-SDDL2_Error SDDL2_kind_size(SDDL2_Type_kind kind, size_t* out_size);
+SDDL2_RESULT_OF(size_t) SDDL2_kind_size(SDDL2_Type_kind kind);
 
 /**
- * Get the total size in bytes of a type (including width).
- * Calculates: element_size × type.width
+ * Get the total size in bytes of a type (element_size × width).
  * Returns SDDL2_TYPE_MISMATCH for invalid types.
  */
-SDDL2_Error SDDL2_Type_size(SDDL2_Type type, size_t* out_size);
+SDDL2_RESULT_OF(size_t) SDDL2_Type_size(SDDL2_Type type);
 
 /* ============================================================================
  * Type Operations

--- a/tests/compress/graphs/sddl2/test_sddl2_stack_depth.cpp
+++ b/tests/compress/graphs/sddl2/test_sddl2_stack_depth.cpp
@@ -80,8 +80,8 @@ TEST_F(SDDL2StackDepthTest, PushStackDepthAfterPop)
     }
 
     SDDL2_Value val;
-    ASSERT_EQ(SDDL2_Stack_pop(stack_, &val), SDDL2_OK);
-    ASSERT_EQ(SDDL2_Stack_pop(stack_, &val), SDDL2_OK);
+    ASSERT_EQ(popValue(stack_, &val), SDDL2_OK);
+    ASSERT_EQ(popValue(stack_, &val), SDDL2_OK);
 
     ASSERT_EQ(SDDL2_op_push_stack_depth(stack_), SDDL2_OK);
     popAndVerifyI64(stack_, 3);

--- a/tests/compress/graphs/sddl2/test_sddl2_stack_drop_if.cpp
+++ b/tests/compress/graphs/sddl2/test_sddl2_stack_drop_if.cpp
@@ -47,7 +47,7 @@ TEST_F(SDDL2StackDropIfTest, DropIfFalseBasic)
     EXPECT_EQ(stack_->top, 1u);
 
     SDDL2_Value result;
-    ASSERT_EQ(SDDL2_Stack_pop(stack_, &result), SDDL2_OK);
+    ASSERT_EQ(popValue(stack_, &result), SDDL2_OK);
     EXPECT_EQ(result.kind, SDDL2_VALUE_I64);
     EXPECT_EQ(result.value.as_i64, 42);
 }
@@ -107,7 +107,7 @@ TEST_F(SDDL2StackDropIfTest, DropIfPreservesValueType)
 
     // Verify Tag value is preserved
     SDDL2_Value result;
-    ASSERT_EQ(SDDL2_Stack_pop(stack_, &result), SDDL2_OK);
+    ASSERT_EQ(popValue(stack_, &result), SDDL2_OK);
     EXPECT_EQ(result.kind, SDDL2_VALUE_TAG);
     EXPECT_EQ(result.value.as_tag, 999u);
 }
@@ -159,8 +159,8 @@ TEST_F(SDDL2StackDropIfTest, DropIfMultipleValuesOnStack)
     EXPECT_EQ(stack_->top, 2u);
 
     SDDL2_Value v1, v2;
-    ASSERT_EQ(SDDL2_Stack_pop(stack_, &v1), SDDL2_OK);
-    ASSERT_EQ(SDDL2_Stack_pop(stack_, &v2), SDDL2_OK);
+    ASSERT_EQ(popValue(stack_, &v1), SDDL2_OK);
+    ASSERT_EQ(popValue(stack_, &v2), SDDL2_OK);
     EXPECT_EQ(v1.value.as_i64, 20);
     EXPECT_EQ(v2.value.as_i64, 10);
 }
@@ -180,9 +180,9 @@ TEST_F(SDDL2StackDropIfTest, DropIfLeavesStackUnchangedWhenFalse)
     EXPECT_EQ(stack_->top, 3u);
 
     SDDL2_Value v1, v2, v3;
-    ASSERT_EQ(SDDL2_Stack_pop(stack_, &v1), SDDL2_OK);
-    ASSERT_EQ(SDDL2_Stack_pop(stack_, &v2), SDDL2_OK);
-    ASSERT_EQ(SDDL2_Stack_pop(stack_, &v3), SDDL2_OK);
+    ASSERT_EQ(popValue(stack_, &v1), SDDL2_OK);
+    ASSERT_EQ(popValue(stack_, &v2), SDDL2_OK);
+    ASSERT_EQ(popValue(stack_, &v3), SDDL2_OK);
     EXPECT_EQ(v1.value.as_i64, 30);
     EXPECT_EQ(v2.value.as_i64, 20);
     EXPECT_EQ(v3.value.as_i64, 10);

--- a/tests/compress/graphs/sddl2/test_sddl2_structure_segment.cpp
+++ b/tests/compress/graphs/sddl2/test_sddl2_structure_segment.cpp
@@ -56,7 +56,7 @@ TEST_F(SDDL2StructureSegmentTest, SingleStructureSegment)
 
     // Pop the structure type, then push tag/type/size for segment creation
     SDDL2_Value struct_val;
-    ASSERT_EQ(SDDL2_Stack_pop(stack_, &struct_val), SDDL2_OK);
+    ASSERT_EQ(popValue(stack_, &struct_val), SDDL2_OK);
 
     ASSERT_EQ(SDDL2_Stack_push(stack_, SDDL2_Value_tag(100)), SDDL2_OK);
     ASSERT_EQ(SDDL2_Stack_push(stack_, struct_val), SDDL2_OK);
@@ -109,7 +109,7 @@ TEST_F(SDDL2StructureSegmentTest, ArrayOfStructuresSegment)
     ASSERT_EQ(SDDL2_op_type_fixed_array(stack_), SDDL2_OK);
 
     SDDL2_Value array_val;
-    ASSERT_EQ(SDDL2_Stack_pop(stack_, &array_val), SDDL2_OK);
+    ASSERT_EQ(popValue(stack_, &array_val), SDDL2_OK);
     ASSERT_EQ(array_val.value.as_type.width, 10u);
 
     // Push tag/type/size for segment creation
@@ -159,7 +159,7 @@ TEST_F(SDDL2StructureSegmentTest, MultipleStructureSegments)
     ASSERT_EQ(SDDL2_op_type_structure(stack_, alloc_fn, alloc_ctx_), SDDL2_OK);
 
     SDDL2_Value struct1_val;
-    ASSERT_EQ(SDDL2_Stack_pop(stack_, &struct1_val), SDDL2_OK);
+    ASSERT_EQ(popValue(stack_, &struct1_val), SDDL2_OK);
 
     ASSERT_EQ(SDDL2_Stack_push(stack_, SDDL2_Value_tag(100)), SDDL2_OK);
     ASSERT_EQ(SDDL2_Stack_push(stack_, struct1_val), SDDL2_OK);
@@ -177,7 +177,7 @@ TEST_F(SDDL2StructureSegmentTest, MultipleStructureSegments)
     ASSERT_EQ(SDDL2_op_type_structure(stack_, alloc_fn, alloc_ctx_), SDDL2_OK);
 
     SDDL2_Value struct2_val;
-    ASSERT_EQ(SDDL2_Stack_pop(stack_, &struct2_val), SDDL2_OK);
+    ASSERT_EQ(popValue(stack_, &struct2_val), SDDL2_OK);
 
     ASSERT_EQ(SDDL2_Stack_push(stack_, SDDL2_Value_tag(200)), SDDL2_OK);
     ASSERT_EQ(SDDL2_Stack_push(stack_, struct2_val), SDDL2_OK);
@@ -230,7 +230,7 @@ TEST_F(SDDL2StructureSegmentTest, SegmentMergingSameStructure)
     ASSERT_EQ(SDDL2_op_type_structure(stack_, alloc_fn, alloc_ctx_), SDDL2_OK);
 
     SDDL2_Value struct_val;
-    ASSERT_EQ(SDDL2_Stack_pop(stack_, &struct_val), SDDL2_OK);
+    ASSERT_EQ(popValue(stack_, &struct_val), SDDL2_OK);
 
     // First segment: tag=100, 5 instances = 15 bytes
     ASSERT_EQ(SDDL2_Stack_push(stack_, SDDL2_Value_tag(100)), SDDL2_OK);

--- a/tests/compress/graphs/sddl2/test_sddl2_type_fixed_array.cpp
+++ b/tests/compress/graphs/sddl2/test_sddl2_type_fixed_array.cpp
@@ -25,7 +25,7 @@ TEST_F(SDDL2TypeFixedArrayTest, BasicArrayType)
     EXPECT_EQ(SDDL2_Stack_depth(stack_), 1);
 
     SDDL2_Value result;
-    ASSERT_EQ(SDDL2_Stack_pop(stack_, &result), SDDL2_OK);
+    ASSERT_EQ(popValue(stack_, &result), SDDL2_OK);
     EXPECT_EQ(result.kind, SDDL2_VALUE_TYPE);
     EXPECT_EQ(result.value.as_type.kind, SDDL2_TYPE_U32LE);
     EXPECT_EQ(result.value.as_type.width, 10);
@@ -46,7 +46,7 @@ TEST_F(SDDL2TypeFixedArrayTest, NestedArrays)
     ASSERT_EQ(SDDL2_op_type_fixed_array(stack_), SDDL2_OK);
 
     SDDL2_Value result;
-    ASSERT_EQ(SDDL2_Stack_pop(stack_, &result), SDDL2_OK);
+    ASSERT_EQ(popValue(stack_, &result), SDDL2_OK);
     EXPECT_EQ(result.kind, SDDL2_VALUE_TYPE);
     EXPECT_EQ(result.value.as_type.kind, SDDL2_TYPE_I16LE);
     EXPECT_EQ(result.value.as_type.width, 15); // 5 * 3
@@ -62,7 +62,7 @@ TEST_F(SDDL2TypeFixedArrayTest, ArrayCountOne)
     ASSERT_EQ(SDDL2_op_type_fixed_array(stack_), SDDL2_OK);
 
     SDDL2_Value result;
-    ASSERT_EQ(SDDL2_Stack_pop(stack_, &result), SDDL2_OK);
+    ASSERT_EQ(popValue(stack_, &result), SDDL2_OK);
     EXPECT_EQ(result.kind, SDDL2_VALUE_TYPE);
     EXPECT_EQ(result.value.as_type.kind, SDDL2_TYPE_F32BE);
     EXPECT_EQ(result.value.as_type.width, 7); // 7 * 1
@@ -77,7 +77,7 @@ TEST_F(SDDL2TypeFixedArrayTest, ZeroWidthArray)
     ASSERT_EQ(SDDL2_op_type_fixed_array(stack_), SDDL2_OK);
 
     SDDL2_Value result;
-    ASSERT_EQ(SDDL2_Stack_pop(stack_, &result), SDDL2_OK);
+    ASSERT_EQ(popValue(stack_, &result), SDDL2_OK);
     EXPECT_EQ(result.kind, SDDL2_VALUE_TYPE);
     EXPECT_EQ(result.value.as_type.kind, SDDL2_TYPE_U8);
     EXPECT_EQ(result.value.as_type.width, 0);
@@ -94,7 +94,7 @@ TEST_F(SDDL2TypeFixedArrayTest, MaxSafeValue)
     ASSERT_EQ(SDDL2_op_type_fixed_array(stack_), SDDL2_OK);
 
     SDDL2_Value result;
-    ASSERT_EQ(SDDL2_Stack_pop(stack_, &result), SDDL2_OK);
+    ASSERT_EQ(popValue(stack_, &result), SDDL2_OK);
     EXPECT_EQ(result.value.as_type.width, UINT32_MAX);
 }
 
@@ -117,7 +117,7 @@ TEST_F(SDDL2TypeFixedArrayTest, AllTypeKinds)
         ASSERT_EQ(SDDL2_op_type_fixed_array(stack_), SDDL2_OK);
 
         SDDL2_Value result;
-        ASSERT_EQ(SDDL2_Stack_pop(stack_, &result), SDDL2_OK);
+        ASSERT_EQ(popValue(stack_, &result), SDDL2_OK);
         EXPECT_EQ(result.value.as_type.kind, types[i]);
         EXPECT_EQ(result.value.as_type.width, 10); // 2 * 5
     }

--- a/tests/compress/graphs/sddl2/test_sddl2_type_sizeof.cpp
+++ b/tests/compress/graphs/sddl2/test_sddl2_type_sizeof.cpp
@@ -62,7 +62,7 @@ TEST_F(SDDL2TypeSizeofTest, VariousPrimitives)
         ASSERT_EQ(SDDL2_op_type_sizeof(stack_), SDDL2_OK);
 
         SDDL2_Value result;
-        ASSERT_EQ(SDDL2_Stack_pop(stack_, &result), SDDL2_OK);
+        ASSERT_EQ(popValue(stack_, &result), SDDL2_OK);
         EXPECT_EQ(result.kind, SDDL2_VALUE_I64);
         EXPECT_EQ(result.value.as_i64, tc.expected_size) << "kind=" << tc.kind;
     }

--- a/tests/compress/graphs/sddl2/test_sddl2_var.cpp
+++ b/tests/compress/graphs/sddl2/test_sddl2_var.cpp
@@ -122,7 +122,7 @@ TEST_F(SDDL2VarTest, LoadTag)
     ASSERT_EQ(SDDL2_Stack_push(stack_, SDDL2_Value_i64(5)), SDDL2_OK);
     ASSERT_EQ(SDDL2_op_var_load(stack_, NULL, 0, &regs_), SDDL2_OK);
     SDDL2_Value result;
-    ASSERT_EQ(SDDL2_Stack_pop(stack_, &result), SDDL2_OK);
+    ASSERT_EQ(popValue(stack_, &result), SDDL2_OK);
     EXPECT_EQ(result.kind, SDDL2_VALUE_TAG);
     EXPECT_EQ(result.value.as_tag, 100u);
 }
@@ -137,7 +137,7 @@ TEST_F(SDDL2VarTest, LoadType)
     ASSERT_EQ(SDDL2_Stack_push(stack_, SDDL2_Value_i64(10)), SDDL2_OK);
     ASSERT_EQ(SDDL2_op_var_load(stack_, NULL, 0, &regs_), SDDL2_OK);
     SDDL2_Value result;
-    ASSERT_EQ(SDDL2_Stack_pop(stack_, &result), SDDL2_OK);
+    ASSERT_EQ(popValue(stack_, &result), SDDL2_OK);
     EXPECT_EQ(result.kind, SDDL2_VALUE_TYPE);
     EXPECT_EQ(result.value.as_type.kind, SDDL2_TYPE_I32LE);
     EXPECT_EQ(result.value.as_type.width, 1u);

--- a/tests/compress/graphs/sddl2/test_sddl2_vm.cpp
+++ b/tests/compress/graphs/sddl2/test_sddl2_vm.cpp
@@ -39,13 +39,13 @@ TEST_F(SDDL2VmTest, StackPushPop)
 
     // Pop and verify Tag
     SDDL2_Value popped;
-    ASSERT_EQ(SDDL2_Stack_pop(stack_, &popped), SDDL2_OK);
+    ASSERT_EQ(popValue(stack_, &popped), SDDL2_OK);
     EXPECT_EQ(popped.kind, SDDL2_VALUE_TAG);
     EXPECT_EQ(popped.value.as_tag, 100u);
     EXPECT_EQ(SDDL2_Stack_depth(stack_), 1u);
 
     // Pop and verify I64
-    ASSERT_EQ(SDDL2_Stack_pop(stack_, &popped), SDDL2_OK);
+    ASSERT_EQ(popValue(stack_, &popped), SDDL2_OK);
     EXPECT_EQ(popped.kind, SDDL2_VALUE_I64);
     EXPECT_EQ(popped.value.as_i64, 42);
     EXPECT_EQ(SDDL2_Stack_depth(stack_), 0u);
@@ -54,7 +54,7 @@ TEST_F(SDDL2VmTest, StackPushPop)
 TEST_F(SDDL2VmTest, StackUnderflow)
 {
     SDDL2_Value v;
-    EXPECT_EQ(SDDL2_Stack_pop(stack_, &v), SDDL2_STACK_UNDERFLOW);
+    EXPECT_EQ(popValue(stack_, &v), SDDL2_STACK_UNDERFLOW);
     EXPECT_EQ(SDDL2_Stack_peek(stack_, &v), SDDL2_STACK_UNDERFLOW);
 }
 

--- a/tests/compress/graphs/sddl2/test_sddl2_vm_kind_size.cpp
+++ b/tests/compress/graphs/sddl2/test_sddl2_vm_kind_size.cpp
@@ -80,12 +80,14 @@ TEST(SDDL2KindSizeTest, EightByteTypes)
 
 TEST(SDDL2KindSizeTest, InvalidTypeReturnsError)
 {
-    size_t out;
-    EXPECT_NE(SDDL2_kind_size(SDDL2_Type_kind(9999), &out), SDDL2_OK);
+    SDDL2_RESULT_OF(size_t) result = SDDL2_kind_size(SDDL2_Type_kind(9999));
+    EXPECT_TRUE(SDDL2_isError(result));
+    EXPECT_EQ(SDDL2_error(result), SDDL2_TYPE_MISMATCH);
 }
 
 TEST(SDDL2KindSizeTest, StructReturnsError)
 {
-    size_t out;
-    EXPECT_NE(SDDL2_kind_size(SDDL2_TYPE_STRUCTURE, &out), SDDL2_OK);
+    SDDL2_RESULT_OF(size_t) result = SDDL2_kind_size(SDDL2_TYPE_STRUCTURE);
+    EXPECT_TRUE(SDDL2_isError(result));
+    EXPECT_EQ(SDDL2_error(result), SDDL2_TYPE_MISMATCH);
 }

--- a/tests/compress/graphs/sddl2/test_sddl2_vm_type_structure.cpp
+++ b/tests/compress/graphs/sddl2/test_sddl2_vm_type_structure.cpp
@@ -50,7 +50,7 @@ TEST_F(SDDL2VmTypeStructureTest, SimpleStructure)
     EXPECT_EQ(SDDL2_Stack_depth(stack_), 1u);
 
     SDDL2_Value result{};
-    ASSERT_EQ(SDDL2_Stack_pop(stack_, &result), SDDL2_OK);
+    ASSERT_EQ(popValue(stack_, &result), SDDL2_OK);
     EXPECT_EQ(result.kind, SDDL2_VALUE_TYPE);
     EXPECT_EQ(result.value.as_type.kind, SDDL2_TYPE_STRUCTURE);
     EXPECT_EQ(result.value.as_type.width, 1u);
@@ -90,7 +90,7 @@ TEST_F(SDDL2VmTypeStructureTest, StructureWithArrays)
     ASSERT_EQ(SDDL2_op_type_structure(stack_, alloc_fn, alloc_ctx_), SDDL2_OK);
 
     SDDL2_Value result{};
-    ASSERT_EQ(SDDL2_Stack_pop(stack_, &result), SDDL2_OK);
+    ASSERT_EQ(popValue(stack_, &result), SDDL2_OK);
 
     SDDL2_Struct_data* struct_data = result.value.as_type.struct_data;
     EXPECT_EQ(struct_data->total_size_bytes, 43u);
@@ -118,7 +118,7 @@ TEST_F(SDDL2VmTypeStructureTest, ArrayOfStructures)
     ASSERT_EQ(SDDL2_op_type_fixed_array(stack_), SDDL2_OK);
 
     SDDL2_Value result{};
-    ASSERT_EQ(SDDL2_Stack_pop(stack_, &result), SDDL2_OK);
+    ASSERT_EQ(popValue(stack_, &result), SDDL2_OK);
     EXPECT_EQ(result.value.as_type.kind, SDDL2_TYPE_STRUCTURE);
     EXPECT_EQ(result.value.as_type.width, 10u);
 
@@ -136,7 +136,7 @@ TEST_F(SDDL2VmTypeStructureTest, ZeroMemberStructure)
     ASSERT_EQ(SDDL2_op_type_structure(stack_, alloc_fn, alloc_ctx_), SDDL2_OK);
 
     SDDL2_Value result{};
-    ASSERT_EQ(SDDL2_Stack_pop(stack_, &result), SDDL2_OK);
+    ASSERT_EQ(popValue(stack_, &result), SDDL2_OK);
     EXPECT_EQ(result.kind, SDDL2_VALUE_TYPE);
     EXPECT_EQ(result.value.as_type.kind, SDDL2_TYPE_STRUCTURE);
     EXPECT_EQ(result.value.as_type.width, 1u);

--- a/tests/compress/graphs/sddl2/utils.h
+++ b/tests/compress/graphs/sddl2/utils.h
@@ -140,24 +140,38 @@ class SDDL2StackTestCustomCapacity : public SDDL2TestBase {
 
 using SDDL2StackTest = SDDL2StackTestCustomCapacity<100>;
 
-static size_t getKindSize(SDDL2_Type_kind kind)
+inline size_t getKindSize(SDDL2_Type_kind kind)
 {
-    size_t out = 0;
-    EXPECT_EQ(SDDL2_kind_size(kind, &out), SDDL2_OK);
-    return out;
+    SDDL2_RESULT_OF(size_t) result = SDDL2_kind_size(kind);
+    EXPECT_FALSE(SDDL2_isError(result));
+    return SDDL2_value(result);
 }
 
-static size_t getTypeSize(SDDL2_Type type)
+inline size_t getTypeSize(SDDL2_Type type)
 {
-    size_t out = 0;
-    EXPECT_EQ(SDDL2_Type_size(type, &out), SDDL2_OK);
-    return out;
+    SDDL2_RESULT_OF(size_t) result = SDDL2_Type_size(type);
+    EXPECT_FALSE(SDDL2_isError(result));
+    return SDDL2_value(result);
+}
+
+/**
+ * Pop helper that extracts value into out parameter.
+ * Provides compatibility with old API for tests.
+ */
+inline SDDL2_Error popValue(SDDL2_Stack* stack, SDDL2_Value* out)
+{
+    SDDL2_RESULT_OF(SDDL2_Value) result = SDDL2_Stack_pop(stack);
+    if (SDDL2_isError(result)) {
+        return SDDL2_error(result);
+    }
+    *out = SDDL2_value(result);
+    return SDDL2_OK;
 }
 
 static void popAndVerifyI64(SDDL2_Stack* stack, int64_t expected)
 {
     SDDL2_Value result;
-    ASSERT_EQ(SDDL2_Stack_pop(stack, &result), SDDL2_OK);
+    ASSERT_EQ(popValue(stack, &result), SDDL2_OK);
     EXPECT_EQ(result.kind, SDDL2_VALUE_I64);
     EXPECT_EQ(result.value.as_i64, expected);
 }


### PR DESCRIPTION
Summary:
Replace out-parameter error handling with Result types that bundle values with error codes. This prevents bugs from uninitialized outputs and uses ZL_NODISCARD to catch ignored errors at compile time.

New SDDL2_RESULT_OF(type) macro creates Result structs with accessor macros (SDDL2_isError, SDDL2_error, SDDL2_value) and constructors (SDDL2_success, SDDL2_failure).

API changes:
- SDDL2_kind_size(), SDDL2_Type_size() now return SDDL2_RESULT_OF(size_t)
- SDDL2_Stack_pop() now returns SDDL2_RESULT_OF(SDDL2_Value)
- Internal pop_* helpers now return Result types
- Added SDDL2_TRY_LET for concise error propagation

Updated all call sites in sddl2.c, sddl2_vm.c, and tests.

Reviewed By: Cyan4973

Differential Revision: D103698980


