### PR TITLE
Fix xgboost MinGW build issue (#727)

### DIFF
--- a/.github/workflows/windows-ci.yml
+++ b/.github/workflows/windows-ci.yml
@@ -208,6 +208,8 @@ jobs:
           echo "=== Testing $CC $CXX ${{ matrix.msystem }} ==="
           CFLAGS=-Werror make lib V=1
           CFLAGS=-Werror CXXFLAGS=-Werror make test V=1
+          echo "=== Building with make -j ==="
+          make -j V=1
           echo "=== Build and test completed successfully ==="
 
 

--- a/Makefile
+++ b/Makefile
@@ -491,8 +491,9 @@ XGBOOST_CMAKE_PLATFORM :=
 XGBOOST_LDFLAGS :=
 XGBOOST_LDLIBS :=
 ifneq (,$(filter $(SMALL_CMD_LINE),$(UNAME)))
-    # MinGW/MSYS: Link ws2_32 for Windows socket functions
-    XGBOOST_CMAKE_PLATFORM := -DCMAKE_CXX_STANDARD_LIBRARIES="-lws2_32" \
+    # MinGW/MSYS: Use Unix Makefiles generator and link ws2_32 for Windows socket functions
+    XGBOOST_CMAKE_PLATFORM := -G "Unix Makefiles" \
+        -DCMAKE_CXX_STANDARD_LIBRARIES="-lws2_32" \
         -DCMAKE_SHARED_LINKER_FLAGS="-lws2_32"
     XGBOOST_LDFLAGS += -L$(abspath $(XGBOOST_LIBDIR))
     XGBOOST_LDLIBS += -lws2_32
@@ -535,7 +536,11 @@ endif
 $(LIBXGBOOST_A) : MAKEOVERRIDES=
 $(LIBXGBOOST_A) : $(XGBOOST_HEADER)
 	$(MKDIR) -p $(XGBOOST_LIBDIR)
-	cd deps/xgboost && mkdir -p build && cd build && cmake .. -DBUILD_STATIC_LIB=ON -DUSE_OPENMP=OFF -DCMAKE_ARCHIVE_OUTPUT_DIRECTORY=$(abspath $(XGBOOST_LIBDIR)) && $(MAKE)
+	cd deps/xgboost && mkdir -p build && cd build && cmake .. -DBUILD_STATIC_LIB=ON -DUSE_OPENMP=OFF -DCMAKE_ARCHIVE_OUTPUT_DIRECTORY=$(abspath $(XGBOOST_LIBDIR)) $(XGBOOST_CMAKE_PLATFORM) && $(MAKE)
+	# xgboost's CMakeLists.txt strips the 'lib' prefix on Windows; rename to match expected name
+	@if [ -f $(XGBOOST_LIBDIR)/xgboost.a ] && [ ! -f $(XGBOOST_LIBDIR)/libxgboost.a ]; then \
+		mv $(XGBOOST_LIBDIR)/xgboost.a $(XGBOOST_LIBDIR)/libxgboost.a; \
+	fi
 
 # libdmlc.a is built as part of xgboost static build
 $(LIBDMLC_A): $(LIBXGBOOST_A)

--- a/build-scripts/cmake/WINDOWS_BUILD.md
+++ b/build-scripts/cmake/WINDOWS_BUILD.md
@@ -56,6 +56,7 @@ cmake --build build --config Release
 ### MinGW-w64
 
 - Via MSYS2: `pacman -S mingw-w64-x86_64-gcc`
+  - For `zli` and test targets: also install `mingw-w64-x86_64-cmake`
 - Via w64devkit: Download from <https://github.com/skeeto/w64devkit>
 
 ## Examples


### PR DESCRIPTION
Summary:

Fix `make -j1` build on MSYS2/MinGW by specifying the "Unix Makefiles" CMake generator (otherwise CMake may pick Ninja or NMake on Windows)

Reviewed By: Cyan4973

Differential Revision: D103741888


