### PR TITLE
Base ZL_DictLoader with materializer registry (#728)

### DIFF
--- a/include/openzl/zl_decompress.h
+++ b/include/openzl/zl_decompress.h
@@ -8,6 +8,7 @@
 #include "openzl/zl_errors.h"        // ZL_Report, ZL_isError()
 #include "openzl/zl_introspection.h" // ZL_DecompressIntrospectionHooks
 #include "openzl/zl_opaque_types.h"  // ZL_DCtx
+#include "openzl/zl_opaque_types.h"  // ZL_DictLoader, ZL_FatBundleDictLoader
 #include "openzl/zl_output.h"
 
 #if defined(__cplusplus)
@@ -82,6 +83,14 @@ ZL_DCtx* ZL_DCtx_create(void);
  * @param dctx Decompression context to free
  */
 void ZL_DCtx_free(ZL_DCtx* dctx);
+
+/**
+ * @brief Attach a dict loader to the decompression context.
+ *
+ * The dict loader is referenced (not owned) by the DCtx. The caller must
+ * ensure the dict loader outlives the DCtx.
+ */
+void ZL_DCtx_refDictLoader(ZL_DCtx* dctx, ZL_DictLoader* loader);
 
 /**
  * @brief Global decompression parameters.

--- a/include/openzl/zl_dictloader.h
+++ b/include/openzl/zl_dictloader.h
@@ -1,0 +1,136 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#ifndef OPENZL_ZL_DICTLOADER_H
+#define OPENZL_ZL_DICTLOADER_H
+
+#include <stddef.h> // size_t
+
+#include "openzl/zl_dict.h" // ZL_BundleInfo, ZL_DictBundle, ZL_DictBundleConstPtr
+#include "openzl/zl_errors.h"       // ZL_RESULT_OF
+#include "openzl/zl_materializer.h" // ZL_MaterializerDesc
+#include "openzl/zl_opaque_types.h" // ZL_Dict, ZL_FatBundleDictLoader
+
+#if defined(__cplusplus)
+extern "C" {
+#endif
+
+/*
+ * =============================== ZL_DictLoader ===============================
+ *
+ * The ZL_DictLoader is responsible for fetching and (de)materializing dicts and
+ * bundles. It is used by the ZL_DCtx to provide dictionary functionality. Refer
+ * to ZL_DCtx_refDictLoader() for usage.
+ *
+ * The fetching APIs are provided unimplemented to enable you to customize blob
+ * sources and caching behavior. (A simple reference implementation is also
+ * provided in ZL_FatBundleDictLoader. This is sufficient for use with the
+ * trainer.)
+ *
+ * WARNING: The dict loader function implementations are required to be
+ * thread-safe. It is expected that the same dict loader can be used by multiple
+ * threads.
+ *
+ * Before usage, custom codecs must have their de/materializers registered with
+ * the ZL_DictLoader.
+ *
+ * ** NOTE: The ZL_DictLoader is not used at compression time. The ZL_Compressor
+ * assumes the responsibility of dict loading. Register compression-time
+ * materialization instructions with the ZL_MIEncoderDesc and provide the raw
+ * blobs to the ZL_Compressor using ZL_Compressor_useDict().
+ */
+
+typedef struct {
+    /**
+     * Fetch a dict bundle by its ID. Implementors are required to keep
+     * materialized bundles and dicts alive for the lifetime of the
+     * ZL_DictLoaderDesc. This should be accomplished using custom state defined
+     * by @p opaque .
+     */
+    ZL_RESULT_OF(ZL_DictBundleConstPtr) (
+            *fetchDictBundle)(ZL_DictLoader* loader, const ZL_BundleID* id);
+
+    /**
+     * The ZL_DictLoader will take ownership of this pointer. Ensure the
+     * freeFn properly dematerializes any materialized dicts.
+     */
+    ZL_OpaquePtr opaque;
+} ZL_DictLoaderDesc;
+
+ZL_DictLoader* ZL_DictLoader_create(const ZL_DictLoaderDesc* desc);
+void ZL_DictLoader_free(ZL_DictLoader* loader);
+
+/**
+ * Fetch the opaque pointer provided to ZL_DictLoader_create() via the
+ * @p ZL_DictLoaderDesc
+ */
+void* ZL_DictLoader_getOpaque(const ZL_DictLoader* loader);
+
+/**
+ * Registers a dict materialization function for a particular custom codec. By
+ * "materialization", we mean a function to turn a serialized string into an
+ * in-memory object. By "dematerialization" we mean a function to free the
+ * memory associated with a materialized object. Materialization is similar to
+ * deserialization, but dematerialization does not produce any artifacts, unlike
+ * serialization.
+ *
+ * Codecs that support dictionaries may fetch the materialized object (if any)
+ * at both compression time and decompression time using ZL_Encoder_getDict()
+ * and ZL_Decoder_getDict() respectively.
+ *
+ * The loader takes unconditional ownership of the materializer opaque pointer
+ * and will free it upon destruction or failed registrations.
+ *
+ * WARNING: This function is not thread-safe!
+ *
+ * @returns an error if registration fails, for instance if the materializer is
+ * invalid or an attempt is made to double-register a materializer.
+ */
+ZL_Report ZL_DictLoader_registerMaterializer(
+        ZL_DictLoader* loader,
+        ZL_IDType codecID,
+        const ZL_MaterializerDesc2* materializer);
+
+/**
+ * Materializes a raw dict blob using the materializer registered for
+ * @p codecID. The loader manages the ZL_Materializer lifecycle internally.
+ * Persistent allocations made by the materializer are owned by the loader.
+ *
+ * WARNING: This function is not thread-safe!
+ *
+ * @param loader The dict loader.
+ * @param codecID Codec to look up.
+ * @param isCustomCodec true if @p codecID refers to a custom codec.
+ * @param src Pointer to the raw dict blob.
+ * @param srcSize Size of the raw dict blob in bytes.
+ * @returns The materialized object pointer, or an error.
+ */
+ZL_RESULT_OF(ZL_VoidPtr)
+ZL_DictLoader_materialize(
+        ZL_DictLoader* loader,
+        ZL_IDType codecID,
+        bool isCustomCodec,
+        const void* src,
+        size_t srcSize);
+
+/**
+ * Dematerializes (frees non-arena resources of) a previously materialized
+ * object. If the materializer is not found or @p materialized is NULL, this
+ * is a no-op.
+ *
+ * WARNING: This function is not thread-safe!
+ *
+ * @param loader The dict loader.
+ * @param codecID Codec to look up.
+ * @param isCustomCodec true if @p codecID refers to a custom codec.
+ * @param materialized The object to dematerialize.
+ */
+void ZL_DictLoader_dematerialize(
+        ZL_DictLoader* loader,
+        ZL_IDType codecID,
+        bool isCustomCodec,
+        void* materialized);
+#if defined(__cplusplus)
+} // extern "C"
+#endif
+
+#endif // OPENZL_ZL_DICTLOADER_H

--- a/src/openzl/decompress/decompress2.c
+++ b/src/openzl/decompress/decompress2.c
@@ -88,6 +88,7 @@ struct ZL_DCtx_s {
     ZL_OperationContext opCtx;
     GDParams requestedGDParams; // As user-selected at DCtx level
     GDParams appliedGDParams;   // Used at decompression time; DCtx > default
+    ZL_DictLoader* dictLoader;  // Referenced, not owned
 }; // typedef'd to ZL_DCtx within zs2_decompress.h
 
 // --------------------------
@@ -200,6 +201,12 @@ ZL_Report DCTX_registerDecoderFusion(
 void DCTX_clearDecoderFusions(ZL_DCtx* dctx)
 {
     ZL_DecoderFusionState_clearFusions(&dctx->fusion);
+}
+
+void ZL_DCtx_refDictLoader(ZL_DCtx* dctx, ZL_DictLoader* loader)
+{
+    ZL_ASSERT_NN(dctx);
+    dctx->dictLoader = loader;
 }
 
 ZL_Report ZL_DCtx_setParameter(ZL_DCtx* dctx, ZL_DParam gdparam, int value)

--- a/src/openzl/dict/dictloader.c
+++ b/src/openzl/dict/dictloader.c
@@ -1,0 +1,285 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#include "openzl/dict/dictloader.h"
+
+#include <stdlib.h>
+
+#include "openzl/common/allocation.h"
+#include "openzl/common/assertion.h"
+#include "openzl/dict/dict_constants.h"
+#include "openzl/dict/materializer_ctx.h"
+#include "openzl/zl_errors.h"
+
+static void DictLoader_freeOpaquePtr(const ZL_OpaquePtr* opaque)
+{
+    if (opaque->freeFn != NULL) {
+        opaque->freeFn(opaque->freeOpaquePtr, opaque->ptr);
+    }
+}
+
+size_t DL_MatMap_hash(const PublicTransformInfo* key)
+{
+    size_t h = (size_t)key->trt;
+    h        = h * 31 + (size_t)key->trid;
+
+    return h;
+}
+
+bool DL_MatMap_eq(
+        const PublicTransformInfo* lhs,
+        const PublicTransformInfo* rhs)
+{
+    return lhs->trt == rhs->trt && lhs->trid == rhs->trid;
+}
+
+ZL_DictLoader* ZL_DictLoader_create(const ZL_DictLoaderDesc* desc)
+{
+    if (desc == NULL || desc->fetchDictBundle == NULL) {
+        return NULL;
+    }
+
+    ZL_DictLoader* loader = (ZL_DictLoader*)ZL_calloc(sizeof(ZL_DictLoader));
+    if (loader == NULL) {
+        return NULL;
+    }
+
+    loader->desc          = *desc;
+    loader->materializers = DL_MatMap_create(ZL_MAX_DICTS_PER_BUNDLE);
+
+    loader->persistentArena = ALLOC_HeapArena_create();
+    if (loader->persistentArena == NULL) {
+        ZL_DictLoader_free(loader);
+        return NULL;
+    }
+    loader->scratchArena = ALLOC_StackArena_create();
+    if (loader->scratchArena == NULL) {
+        ZL_DictLoader_free(loader);
+        return NULL;
+    }
+
+    if (ZL_isError(DictLoader_registerStandardMaterializers(loader))) {
+        ZL_DictLoader_free(loader);
+        return NULL;
+    }
+
+    return loader;
+}
+
+void ZL_DictLoader_free(ZL_DictLoader* loader)
+{
+    if (loader == NULL) {
+        return;
+    }
+
+    if (loader->desc.opaque.freeFn != NULL) {
+        loader->desc.opaque.freeFn(
+                loader->desc.opaque.freeOpaquePtr, loader->desc.opaque.ptr);
+    }
+
+    DL_MatMap_Iter iter = DL_MatMap_iter(&loader->materializers);
+    const DL_MatMap_Entry* entry;
+    while ((entry = DL_MatMap_Iter_next(&iter)) != NULL) {
+        DictLoader_freeOpaquePtr(&entry->val.opaque);
+    }
+
+    DL_MatMap_destroy(&loader->materializers);
+
+    if (loader->scratchArena != NULL) {
+        ALLOC_Arena_freeArena(loader->scratchArena);
+    }
+    if (loader->persistentArena != NULL) {
+        ALLOC_Arena_freeArena(loader->persistentArena);
+    }
+
+    ZL_free(loader);
+}
+
+void* ZL_DictLoader_getOpaque(const ZL_DictLoader* loader)
+{
+    ZL_ASSERT_NN(loader);
+
+    return loader->desc.opaque.ptr;
+}
+
+static ZL_Report DictLoader_registerMaterializer_inner(
+        ZL_DictLoader* loader,
+        ZL_IDType codecID,
+        const ZL_MaterializerDesc2* materializer)
+{
+    ZL_RESULT_DECLARE_SCOPE_REPORT(NULL);
+    ZL_ERR_IF_NULL(loader, GENERIC);
+    ZL_ERR_IF_NULL(materializer, GENERIC);
+    ZL_ERR_IF_NULL(
+            materializer->materializeFn,
+            GENERIC,
+            "materializer must have a materializeFn");
+    ZL_ERR_IF_NULL(
+            materializer->dematerializeFn,
+            GENERIC,
+            "materializer must have a dematerializeFn. If no dematerialization is needed, use ZL_NOOP_DEMATERIALIZE");
+
+    PublicTransformInfo const key = { .trt = trt_custom, .trid = codecID };
+
+    if (DL_MatMap_contains(&loader->materializers, &key)) {
+        ZL_ERR(GENERIC,
+               "materializer already registered for (custom) codec %u",
+               codecID);
+    }
+
+    DL_MatMap_Entry entry = { .key = key, .val = *materializer };
+    DL_MatMap_Insert ins  = DL_MatMap_insert(&loader->materializers, &entry);
+    ZL_ERR_IF(ins.badAlloc, allocation);
+
+    return ZL_returnSuccess();
+}
+
+ZL_Report ZL_DictLoader_registerMaterializer(
+        ZL_DictLoader* loader,
+        ZL_IDType codecID,
+        const ZL_MaterializerDesc2* materializer)
+{
+    ZL_Report report = DictLoader_registerMaterializer_inner(
+            loader, codecID, materializer);
+    if (ZL_isError(report) && materializer != NULL) {
+        DictLoader_freeOpaquePtr(&materializer->opaque);
+    }
+    return report;
+}
+
+const ZL_MaterializerDesc2* DictLoader_getMaterializer(
+        const ZL_DictLoader* loader,
+        ZL_IDType codecID,
+        bool isCustomCodec)
+{
+    ZL_ASSERT_NN(loader);
+
+    PublicTransformInfo const key = { .trt  = isCustomCodec ? trt_custom
+                                                            : trt_standard,
+                                      .trid = codecID };
+    const DL_MatMap_Entry* entry = DL_MatMap_find(&loader->materializers, &key);
+    if (entry == NULL) {
+        return NULL;
+    }
+
+    return &entry->val;
+}
+
+static ZL_Report DictLoader_registerStandardMaterializer(
+        ZL_DictLoader* loader,
+        ZL_NodeID codecID,
+        ZL_MaterializerDesc2* mat)
+{
+    ZL_RESULT_DECLARE_SCOPE_REPORT(NULL);
+    ZL_ASSERT_NN(loader);
+    ZL_ERR_IF_NULL(mat, GENERIC);
+
+    ZL_ERR_IF_NULL(
+            mat->materializeFn,
+            logicError,
+            "materializer must have a materializeFn");
+    ZL_ERR_IF_NULL(
+            mat->dematerializeFn,
+            logicError,
+            "materializer must have a dematerializeFn");
+    ZL_ERR_IF_NN(
+            mat->opaque.ptr,
+            logicError,
+            "standard materializer must not have an opaque ptr");
+
+    PublicTransformInfo const key = { .trt  = trt_standard,
+                                      .trid = codecID.nid };
+    DL_MatMap_Entry entry         = { .key = key, .val = *mat };
+    DL_MatMap_Insert ins = DL_MatMap_insert(&loader->materializers, &entry);
+    ZL_ERR_IF(ins.badAlloc, allocation);
+
+    return ZL_returnSuccess();
+}
+
+const ZL_DictBundle* DictLoader_getDictBundle(
+        ZL_DictLoader* loader,
+        const ZL_BundleID* id)
+{
+    ZL_ASSERT_NN(loader);
+    ZL_ASSERT_NN(id);
+
+    ZL_RESULT_OF(ZL_DictBundleConstPtr)
+    res = loader->desc.fetchDictBundle(loader, id);
+    if (ZL_RES_isError(res)) {
+        return NULL;
+    }
+    return ZL_RES_value(res);
+}
+
+ZL_RESULT_OF(ZL_VoidPtr)
+ZL_DictLoader_materialize(
+        ZL_DictLoader* loader,
+        ZL_IDType codecID,
+        bool isCustomCodec,
+        const void* src,
+        size_t srcSize)
+{
+    ZL_RESULT_DECLARE_SCOPE(ZL_VoidPtr, NULL);
+    ZL_ERR_IF_NULL(loader, GENERIC);
+    ZL_ERR_IF_NULL(src, GENERIC);
+
+    const ZL_MaterializerDesc2* matDesc =
+            DictLoader_getMaterializer(loader, codecID, isCustomCodec);
+    ZL_ERR_IF_NULL(
+            matDesc,
+            dict_materialization,
+            "no materializer registered for codec %u",
+            codecID);
+
+    ZL_ASSERT_EQ(ALLOC_Arena_memUsed(loader->scratchArena), 0);
+
+    ZL_Materializer matCtx = {
+        .persistentArena = loader->persistentArena,
+        .scratchArena    = loader->scratchArena,
+        .opaquePtr       = matDesc->opaque.ptr,
+        .opCtx           = NULL,
+    };
+    ZL_RESULT_OF(ZL_VoidPtr)
+    result = matDesc->materializeFn(&matCtx, src, srcSize);
+    ALLOC_Arena_freeAll(loader->scratchArena);
+
+    return result;
+}
+
+void ZL_DictLoader_dematerialize(
+        ZL_DictLoader* loader,
+        ZL_IDType codecID,
+        bool isCustomCodec,
+        void* materialized)
+{
+    if (loader == NULL || materialized == NULL) {
+        return;
+    }
+
+    const ZL_MaterializerDesc2* matDesc =
+            DictLoader_getMaterializer(loader, codecID, isCustomCodec);
+    if (matDesc == NULL) {
+        return;
+    }
+
+    ZL_Materializer matCtx = {
+        .persistentArena = NULL,
+        .scratchArena    = NULL,
+        .opaquePtr       = matDesc->opaque.ptr,
+        .opCtx           = NULL,
+    };
+    matDesc->dematerializeFn(&matCtx, materialized);
+}
+
+ZL_Report DictLoader_registerStandardMaterializers(ZL_DictLoader* loader)
+{
+    ZL_RESULT_DECLARE_SCOPE_REPORT(NULL);
+    ZL_ERR_IF_NULL(loader, GENERIC);
+
+    // TODO: register standard codec materializers (e.g. zstd)
+    // ZL_ERR_IF_ERR(DictLoader_registerStandardMaterializer(
+    //         loader,
+    //         ZL_MAKE_NODE_ID(ZL_PrivateStandardNodeID_zstd),
+    //         ZL_Zstd_materializer));
+
+    return ZL_returnSuccess();
+}

--- a/src/openzl/dict/dictloader.h
+++ b/src/openzl/dict/dictloader.h
@@ -1,0 +1,58 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#ifndef OPENZL_DICT_DICTLOADER_H
+#define OPENZL_DICT_DICTLOADER_H
+
+#include "openzl/common/allocation.h"  // Arena
+#include "openzl/common/map.h"         // ZL_DECLARE_CUSTOM_MAP_TYPE
+#include "openzl/common/wire_format.h" // PublicTransformInfo
+#include "openzl/zl_dictloader.h"
+
+#if defined(__cplusplus)
+extern "C" {
+#endif
+
+// Map: PublicTransformInfo -> ZL_MaterializerDesc2
+size_t DL_MatMap_hash(const PublicTransformInfo* key);
+bool DL_MatMap_eq(
+        const PublicTransformInfo* lhs,
+        const PublicTransformInfo* rhs);
+ZL_DECLARE_CUSTOM_MAP_TYPE(
+        DL_MatMap,
+        PublicTransformInfo,
+        ZL_MaterializerDesc2);
+
+struct ZL_DictLoader_s {
+    ZL_DictLoaderDesc desc;
+    DL_MatMap materializers;
+    Arena* persistentArena;
+    Arena* scratchArena;
+};
+
+/**
+ * Registers materializers for all standard (built-in) codecs that support
+ * dictionaries (e.g. zstd). ZL_DictLoader_create calls this once after creating
+ * a ZL_DictLoader.
+ */
+ZL_Report DictLoader_registerStandardMaterializers(ZL_DictLoader* loader);
+
+/**
+ * @returns the ZL_MaterializerDesc2 registered with @p codecID or NULL if no
+ * materializer has been registered with that ID.
+ */
+const ZL_MaterializerDesc2* DictLoader_getMaterializer(
+        const ZL_DictLoader* loader,
+        ZL_IDType codecID,
+        bool isCustomCodec);
+/**
+ * Trampoline to the underlying ZL_DictLoaderDesc.
+ */
+const ZL_DictBundle* DictLoader_getDictBundle(
+        ZL_DictLoader* loader,
+        const ZL_BundleID* id);
+
+#if defined(__cplusplus)
+} // extern "C"
+#endif
+
+#endif // OPENZL_DICT_DICTLOADER_H


### PR DESCRIPTION
Summary:

Introduce the `ZL_DictLoader`, an interface for providing dict bundles to the DCtx. The expectation is that implementors fill out the provided `fetchDictBundle` function using the helpers provided. A reference implementation will be provided in the next diff.

Reviewed By: terrelln

Differential Revision: D101225754


