### PR TITLE
Fix OOB column-chunk access when chunkRemaining hits zero

### DIFF
--- a/custom_parsers/parquet/parquet_lexer.cpp
+++ b/custom_parsers/parquet/parquet_lexer.cpp
@@ -272,6 +272,10 @@ lexOne(ZL_ParquetLexer* lexer, ZL_ParquetToken* out, ZL_ErrorContext* errCtx)
     ZL_ERR_IF_LT(chunkRemaining, 0, node_invalid_input);
     ZL_ERR_IF_LT(
             getRemaining(lexer), (size_t)chunkRemaining, node_invalid_input);
+    ZL_ERR_IF_GE(
+            lexer->chunkIdx,
+            lexer->fileMetadata->columnChunks.size(),
+            node_invalid_input);
 
     if (!lexer->pageHeader) {
         return lexPageHeader(lexer, out, errCtx);


### PR DESCRIPTION
Summary: Add a bounds check immediately after the chunk-advance so that a malformed input which lands `chunkIdx` past the end of the column-chunk vector is rejected with `node_invalid_input` instead of aborting.

Differential Revision: D103844843


