### PR TITLE
add base64 enc/dec utility to src/openzl/common (#735)

### DIFF
--- a/src/openzl/shared/a1cbor.c
+++ b/src/openzl/shared/a1cbor.c
@@ -6,6 +6,8 @@
 #include <stdio.h>
 #include <string.h>
 
+#include "openzl/shared/base64.h"
+
 #include "./utils.h"
 
 ////////////////////////////////////////
@@ -146,52 +148,6 @@ static uint64_t A1C_bigEndian64(uint64_t value)
             return 0;       \
         }                   \
     } while (0)
-
-const char A1C_kBase64Map[] = {
-    'A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', 'I', 'J', 'K', 'L', 'M',
-    'N', 'O', 'P', 'Q', 'R', 'S', 'T', 'U', 'V', 'W', 'X', 'Y', 'Z',
-    'a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j', 'k', 'l', 'm',
-    'n', 'o', 'p', 'q', 'r', 's', 't', 'u', 'v', 'w', 'x', 'y', 'z',
-    '0', '1', '2', '3', '4', '5', '6', '7', '8', '9', '+', '/'
-};
-
-static ZL_MAYBE_UNUSED_FUNCTION size_t A1C_base64EncodedSize(size_t srcSize)
-{
-    size_t encodedSize = (srcSize / 3) * 4;
-    if (srcSize % 3 != 0) {
-        encodedSize += 4;
-    }
-    return encodedSize;
-}
-
-static size_t A1C_base64Encode(char* dst, const uint8_t* src, size_t srcSize)
-{
-    const char* const dstBegin  = dst;
-    const uint8_t* const srcEnd = src + srcSize;
-    for (; (srcEnd - src) >= 3; src += 3, dst += 4) {
-        dst[0] = A1C_kBase64Map[src[0] >> 2];
-        dst[1] = A1C_kBase64Map[((src[0] & 0x03) << 4) + ((src[1] >> 4))];
-        dst[2] = A1C_kBase64Map[((src[1] & 0x0f) << 2) + ((src[2] >> 6))];
-        dst[3] = A1C_kBase64Map[src[2] & 0x3f];
-    }
-
-    if (src < srcEnd) {
-        assert(src + 1 == srcEnd || src + 2 == srcEnd);
-        dst[0] = A1C_kBase64Map[src[0] >> 2];
-        if (src + 1 == srcEnd) {
-            dst[1] = A1C_kBase64Map[(src[0] & 0x03) << 4];
-            dst[2] = '=';
-        } else {
-            dst[1] = A1C_kBase64Map[((src[0] & 0x03) << 4) + (src[1] >> 4)];
-            dst[2] = A1C_kBase64Map[(src[1] & 0x0f) << 2];
-        }
-        dst[3] = '=';
-        dst += 4;
-    }
-    const size_t dstSize = (size_t)(dst - dstBegin);
-    assert(dstSize == A1C_base64EncodedSize(srcSize));
-    return dstSize;
-}
 
 ////////////////////////////////////////
 // Errors
@@ -1719,8 +1675,13 @@ A1C_Encoder_jsonBytes(A1C_Encoder* encoder, const A1C_Item* item)
             if (toEncode > 192) {
                 toEncode = 192;
             }
-            assert(A1C_base64EncodedSize(toEncode) <= sizeof(buffer));
-            const size_t base64Size = A1C_base64Encode(buffer, data, toEncode);
+            assert(ZL_base64EncodedSize(toEncode) <= sizeof(buffer));
+            ZL_Report b64Report =
+                    ZL_base64Encode(buffer, sizeof(buffer), data, toEncode);
+            if (ZL_isError(b64Report)) {
+                return false;
+            }
+            const size_t base64Size = ZL_validResult(b64Report);
             A1C_RET_IF_ERR(A1C_Encoder_write(encoder, buffer, base64Size));
             data += toEncode;
         }

--- a/src/openzl/shared/base64.c
+++ b/src/openzl/shared/base64.c
@@ -1,0 +1,119 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#include "openzl/shared/base64.h"
+
+static const char kBase64Map[] = {
+    'A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', 'I', 'J', 'K', 'L', 'M',
+    'N', 'O', 'P', 'Q', 'R', 'S', 'T', 'U', 'V', 'W', 'X', 'Y', 'Z',
+    'a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j', 'k', 'l', 'm',
+    'n', 'o', 'p', 'q', 'r', 's', 't', 'u', 'v', 'w', 'x', 'y', 'z',
+    '0', '1', '2', '3', '4', '5', '6', '7', '8', '9', '+', '/'
+};
+
+/* Decode table: valid base64 chars map to their 6-bit value + 1.
+ * Invalid chars map to 0, which lets us detect them during decoding. */
+static const uint8_t kBase64DecodeMap[256] = {
+    ['A'] = 1,  ['B'] = 2,  ['C'] = 3,  ['D'] = 4,  ['E'] = 5,  ['F'] = 6,
+    ['G'] = 7,  ['H'] = 8,  ['I'] = 9,  ['J'] = 10, ['K'] = 11, ['L'] = 12,
+    ['M'] = 13, ['N'] = 14, ['O'] = 15, ['P'] = 16, ['Q'] = 17, ['R'] = 18,
+    ['S'] = 19, ['T'] = 20, ['U'] = 21, ['V'] = 22, ['W'] = 23, ['X'] = 24,
+    ['Y'] = 25, ['Z'] = 26, ['a'] = 27, ['b'] = 28, ['c'] = 29, ['d'] = 30,
+    ['e'] = 31, ['f'] = 32, ['g'] = 33, ['h'] = 34, ['i'] = 35, ['j'] = 36,
+    ['k'] = 37, ['l'] = 38, ['m'] = 39, ['n'] = 40, ['o'] = 41, ['p'] = 42,
+    ['q'] = 43, ['r'] = 44, ['s'] = 45, ['t'] = 46, ['u'] = 47, ['v'] = 48,
+    ['w'] = 49, ['x'] = 50, ['y'] = 51, ['z'] = 52, ['0'] = 53, ['1'] = 54,
+    ['2'] = 55, ['3'] = 56, ['4'] = 57, ['5'] = 58, ['6'] = 59, ['7'] = 60,
+    ['8'] = 61, ['9'] = 62, ['+'] = 63, ['/'] = 64,
+};
+
+size_t ZL_base64EncodedSize(size_t srcSize)
+{
+    size_t encodedSize = (srcSize / 3) * 4;
+    if (srcSize % 3 != 0) {
+        encodedSize += 4;
+    }
+    return encodedSize;
+}
+
+ZL_Report
+ZL_base64Encode(char* dst, size_t dstCap, const uint8_t* src, size_t srcSize)
+{
+    ZL_RESULT_DECLARE_SCOPE_REPORT(NULL);
+    if (srcSize == 0) {
+        return ZL_returnValue(0);
+    }
+    const size_t encodedSize = ZL_base64EncodedSize(srcSize);
+    ZL_ERR_IF(dstCap < encodedSize, dstCapacity_tooSmall);
+
+    char* const dstBegin     = dst;
+    const uint8_t* const end = src + srcSize;
+    for (; (end - src) >= 3; src += 3, dst += 4) {
+        dst[0] = kBase64Map[src[0] >> 2];
+        dst[1] = kBase64Map[((src[0] & 0x03) << 4) + (src[1] >> 4)];
+        dst[2] = kBase64Map[((src[1] & 0x0f) << 2) + (src[2] >> 6)];
+        dst[3] = kBase64Map[src[2] & 0x3f];
+    }
+
+    if (src < end) {
+        dst[0] = kBase64Map[src[0] >> 2];
+        if (src + 1 == end) {
+            dst[1] = kBase64Map[(src[0] & 0x03) << 4];
+            dst[2] = '=';
+        } else {
+            dst[1] = kBase64Map[((src[0] & 0x03) << 4) + (src[1] >> 4)];
+            dst[2] = kBase64Map[(src[1] & 0x0f) << 2];
+        }
+        dst[3] = '=';
+        dst += 4;
+    }
+
+    return ZL_returnValue((size_t)(dst - dstBegin));
+}
+
+ZL_Report
+ZL_base64Decode(uint8_t* dst, size_t dstCap, const char* src, size_t srcSize)
+{
+    ZL_RESULT_DECLARE_SCOPE_REPORT(NULL);
+    if (srcSize == 0) {
+        return ZL_returnValue(0);
+    }
+    ZL_ERR_IF(srcSize % 4 != 0, corruption);
+
+    size_t pad = 0;
+    if (src[srcSize - 1] == '=') {
+        pad++;
+    }
+    if (srcSize >= 2 && src[srcSize - 2] == '=') {
+        pad++;
+    }
+
+    const size_t decodedSize = (srcSize / 4) * 3 - pad;
+    ZL_ERR_IF(decodedSize > dstCap, dstCapacity_tooSmall);
+
+    size_t di = 0;
+    for (size_t i = 0; i < srcSize; i += 4) {
+        const int isLastBlock = (i + 4 == srcSize);
+        const uint8_t ra      = kBase64DecodeMap[(uint8_t)src[i]];
+        const uint8_t rb      = kBase64DecodeMap[(uint8_t)src[i + 1]];
+        const uint8_t rc      = (isLastBlock && src[i + 2] == '=')
+                     ? 1
+                     : kBase64DecodeMap[(uint8_t)src[i + 2]];
+        const uint8_t rd      = (isLastBlock && src[i + 3] == '=')
+                     ? 1
+                     : kBase64DecodeMap[(uint8_t)src[i + 3]];
+        ZL_ERR_IF(ra == 0 || rb == 0 || rc == 0 || rd == 0, corruption);
+        const uint8_t a = ra - 1;
+        const uint8_t b = rb - 1;
+        const uint8_t c = rc - 1;
+        const uint8_t d = rd - 1;
+        dst[di++]       = (uint8_t)((a << 2) | (b >> 4));
+        if (di < decodedSize) {
+            dst[di++] = (uint8_t)((b << 4) | (c >> 2));
+        }
+        if (di < decodedSize) {
+            dst[di++] = (uint8_t)((c << 6) | d);
+        }
+    }
+
+    return ZL_returnValue(decodedSize);
+}

--- a/src/openzl/shared/base64.h
+++ b/src/openzl/shared/base64.h
@@ -1,0 +1,54 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#ifndef OPENZL_SHARED_BASE64_H
+#define OPENZL_SHARED_BASE64_H
+
+#include <stddef.h>
+#include <stdint.h>
+
+#include "openzl/zl_errors.h"
+
+#if defined(__cplusplus)
+extern "C" {
+#endif
+
+/**
+ * Returns the number of bytes needed to hold the base64-encoded form
+ * of @p srcSize bytes of input (without a null terminator).
+ */
+size_t ZL_base64EncodedSize(size_t srcSize);
+
+/**
+ * Base64-encode @p srcSize bytes from @p src into @p dst.
+ *
+ * @param dst      Destination buffer.
+ * @param dstCap   Capacity of the destination buffer in bytes.
+ * @param src      Source data to encode.
+ * @param srcSize  Number of source bytes.
+ *
+ * @returns a ZL_Report containing the number of bytes written on success,
+ *          or an error if @p dstCap is too small.
+ */
+ZL_Report
+ZL_base64Encode(char* dst, size_t dstCap, const uint8_t* src, size_t srcSize);
+
+/**
+ * Decode a base64-encoded string.
+ *
+ * @param dst      Destination buffer for decoded bytes.
+ * @param dstCap   Capacity of the destination buffer in bytes.
+ * @param src      Base64-encoded input.
+ * @param srcSize  Length of the input in bytes (must be a multiple of 4).
+ *
+ * @returns a ZL_Report containing the number of decoded bytes written on
+ *          success, or an error on bad length, insufficient capacity, or
+ * invalid characters.
+ */
+ZL_Report
+ZL_base64Decode(uint8_t* dst, size_t dstCap, const char* src, size_t srcSize);
+
+#if defined(__cplusplus)
+} // extern "C"
+#endif
+
+#endif // OPENZL_SHARED_BASE64_H

--- a/tests/unittest/common/Base64Test.cpp
+++ b/tests/unittest/common/Base64Test.cpp
@@ -1,0 +1,187 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#include <gtest/gtest.h>
+
+#include <cstring>
+#include <string>
+#include <string_view>
+#include <vector>
+
+#include "openzl/shared/base64.h"
+
+namespace openzl::tests {
+
+// RFC 4648 §10 test vectors
+struct RFC4648Vector {
+    std::string_view plain;
+    std::string_view encoded;
+};
+
+static const RFC4648Vector kRFC4648Vectors[] = {
+    { "", "" },
+    { "f", "Zg==" },
+    { "fo", "Zm8=" },
+    { "foo", "Zm9v" },
+    { "foob", "Zm9vYg==" },
+    { "fooba", "Zm9vYmE=" },
+    { "foobar", "Zm9vYmFy" },
+};
+
+TEST(Base64Test, RFC4648RoundTrip)
+{
+    for (const auto& vec : kRFC4648Vectors) {
+        // Encode
+        const size_t encSize = ZL_base64EncodedSize(vec.plain.size());
+        ASSERT_EQ(encSize, vec.encoded.size())
+                << "EncodedSize mismatch for \"" << vec.plain << "\"";
+
+        std::vector<char> encBuf(encSize + 1);
+        const ZL_Report encReport = ZL_base64Encode(
+                encBuf.data(),
+                encBuf.size(),
+                reinterpret_cast<const uint8_t*>(vec.plain.data()),
+                vec.plain.size());
+        ASSERT_FALSE(ZL_isError(encReport))
+                << "Encode failed for \"" << vec.plain << "\"";
+        const size_t written = ZL_validResult(encReport);
+        ASSERT_EQ(written, vec.encoded.size())
+                << "Encode length mismatch for \"" << vec.plain << "\"";
+        EXPECT_EQ(std::string_view(encBuf.data(), written), vec.encoded)
+                << "Encode output mismatch for \"" << vec.plain << "\"";
+
+        // Decode
+        std::vector<uint8_t> decBuf(vec.plain.size() + 1);
+        const ZL_Report decReport = ZL_base64Decode(
+                decBuf.data(),
+                decBuf.size(),
+                vec.encoded.data(),
+                vec.encoded.size());
+        ASSERT_FALSE(ZL_isError(decReport))
+                << "Decode failed for \"" << vec.encoded << "\"";
+        const size_t decoded = ZL_validResult(decReport);
+        ASSERT_EQ(decoded, vec.plain.size())
+                << "Decode length mismatch for \"" << vec.encoded << "\"";
+        EXPECT_EQ(
+                std::string_view(
+                        reinterpret_cast<char*>(decBuf.data()), decoded),
+                vec.plain)
+                << "Decode output mismatch for \"" << vec.encoded << "\"";
+    }
+}
+
+TEST(Base64Test, EncodedSize)
+{
+    EXPECT_EQ(ZL_base64EncodedSize(0), 0);
+    EXPECT_EQ(ZL_base64EncodedSize(1), 4);
+    EXPECT_EQ(ZL_base64EncodedSize(2), 4);
+    EXPECT_EQ(ZL_base64EncodedSize(3), 4);
+    EXPECT_EQ(ZL_base64EncodedSize(4), 8);
+    EXPECT_EQ(ZL_base64EncodedSize(6), 8);
+    EXPECT_EQ(ZL_base64EncodedSize(7), 12);
+}
+
+TEST(Base64Test, EncodeRejectsInsufficientCapacity)
+{
+    const uint8_t src[]  = "foo";
+    const size_t srcSize = 3;
+    const size_t needed  = ZL_base64EncodedSize(srcSize);
+
+    // One byte too small
+    std::vector<char> buf(needed);
+    EXPECT_TRUE(
+            ZL_isError(ZL_base64Encode(buf.data(), needed - 1, src, srcSize)));
+
+    // Exact size succeeds
+    ZL_Report report = ZL_base64Encode(buf.data(), needed, src, srcSize);
+    ASSERT_FALSE(ZL_isError(report));
+    EXPECT_EQ(ZL_validResult(report), needed);
+}
+
+TEST(Base64Test, DecodeRejectsInsufficientCapacity)
+{
+    const char* encoded     = "Zm9v"; // "foo"
+    const size_t encodedLen = 4;
+
+    // Decoded size is 3; capacity of 2 should fail
+    uint8_t buf[3];
+    EXPECT_TRUE(ZL_isError(ZL_base64Decode(buf, 2, encoded, encodedLen)));
+
+    // Exact capacity succeeds
+    ZL_Report report = ZL_base64Decode(buf, 3, encoded, encodedLen);
+    ASSERT_FALSE(ZL_isError(report));
+    EXPECT_EQ(ZL_validResult(report), 3);
+}
+
+TEST(Base64Test, DecodeRejectsInvalidLength)
+{
+    uint8_t buf[16];
+    // Lengths that aren't multiples of 4 should return error
+    EXPECT_TRUE(ZL_isError(ZL_base64Decode(buf, sizeof(buf), "Z", 1)));
+    EXPECT_TRUE(ZL_isError(ZL_base64Decode(buf, sizeof(buf), "Zm", 2)));
+    EXPECT_TRUE(ZL_isError(ZL_base64Decode(buf, sizeof(buf), "Zm9", 3)));
+    // Multiple of 4 succeeds
+    EXPECT_FALSE(ZL_isError(ZL_base64Decode(buf, sizeof(buf), "Zm9v", 4)));
+}
+
+TEST(Base64Test, DecodeRejectsMidStreamPadding)
+{
+    uint8_t buf[16];
+    EXPECT_TRUE(ZL_isError(ZL_base64Decode(buf, sizeof(buf), "Zm==Zm9v", 8)));
+    EXPECT_TRUE(ZL_isError(ZL_base64Decode(buf, sizeof(buf), "Zg==Zg==", 8)));
+    EXPECT_TRUE(ZL_isError(ZL_base64Decode(buf, sizeof(buf), "Zm8=Zm8=", 8)));
+}
+
+TEST(Base64Test, DecodeRejectsInvalidChars)
+{
+    uint8_t buf[3];
+    // Invalid characters should return an error
+    EXPECT_TRUE(ZL_isError(ZL_base64Decode(buf, sizeof(buf), "!m9v", 4)));
+    EXPECT_TRUE(ZL_isError(ZL_base64Decode(buf, sizeof(buf), "Zm\x019", 4)));
+    EXPECT_TRUE(ZL_isError(ZL_base64Decode(buf, sizeof(buf), "Zm9@", 4)));
+
+    // Valid input succeeds
+    ZL_Report report = ZL_base64Decode(buf, sizeof(buf), "Zm9v", 4);
+    ASSERT_FALSE(ZL_isError(report));
+    EXPECT_EQ(ZL_validResult(report), 3);
+}
+
+TEST(Base64Test, EmptyInput)
+{
+    // Encoding empty input produces empty output (value 0, not error)
+    char encBuf[1]      = { 'X' };
+    ZL_Report encReport = ZL_base64Encode(encBuf, sizeof(encBuf), nullptr, 0);
+    ASSERT_FALSE(ZL_isError(encReport));
+    EXPECT_EQ(ZL_validResult(encReport), 0);
+
+    // Decoding empty input returns success with value 0
+    uint8_t decBuf[1]   = { 0xFF };
+    ZL_Report decReport = ZL_base64Decode(decBuf, sizeof(decBuf), "", 0);
+    ASSERT_FALSE(ZL_isError(decReport));
+    EXPECT_EQ(ZL_validResult(decReport), 0);
+}
+
+TEST(Base64Test, BinaryRoundTrip)
+{
+    // Roundtrip all 256 byte values
+    uint8_t src[256];
+    for (int i = 0; i < 256; ++i) {
+        src[i] = static_cast<uint8_t>(i);
+    }
+
+    const size_t encSize = ZL_base64EncodedSize(sizeof(src));
+    std::vector<char> encBuf(encSize);
+    ZL_Report encReport =
+            ZL_base64Encode(encBuf.data(), encBuf.size(), src, sizeof(src));
+    ASSERT_FALSE(ZL_isError(encReport));
+    const size_t written = ZL_validResult(encReport);
+    ASSERT_EQ(written, encSize);
+
+    uint8_t decoded[256];
+    ZL_Report decReport =
+            ZL_base64Decode(decoded, sizeof(decoded), encBuf.data(), written);
+    ASSERT_FALSE(ZL_isError(decReport));
+    ASSERT_EQ(ZL_validResult(decReport), sizeof(src));
+    EXPECT_EQ(std::memcmp(src, decoded, sizeof(src)), 0);
+}
+
+} // namespace openzl::tests


### PR DESCRIPTION
Summary:

Add a reusable base64 encoding/decoding utility to `src/openzl/common/base64.{h,c}`.
The implementation mirrors the one in `a1cbor.c` but both `ZL_base64Encode` and
`ZL_base64Decode` accept an explicit `dstCap` argument to prevent buffer overruns.
A `ZL_base64EncodedSize` helper is also provided.

The new files are automatically picked up by the `:common` BUCK target via its
`glob(["src/openzl/common/**/*.c"])` pattern.

Differential Revision: D101713364


