### PR TITLE
Fix flaky ParquetChunkedTest.test_chunk_size_affects_output

### DIFF
--- a/cli/tests/cli_integration_tests.py
+++ b/cli/tests/cli_integration_tests.py
@@ -522,9 +522,19 @@ class ParquetChunkedTest(ParquetTest):
             extra_args="--chunk-size 2M",
         )
 
+        # Compare bytewise rather than by file size: ACE training has
+        # structural non-determinism that can produce two trained compressors
+        # of identical byte count even when their contents differ. The
+        # invariant we actually care about is that the chunk-size parameter
+        # was baked into the serialized compressor — which guarantees the
+        # *bytes* differ, but not the size.
+        with open(default_trained, "rb") as f:
+            default_bytes = f.read()
+        with open(chunked_trained, "rb") as f:
+            chunked_bytes = f.read()
         self.assertNotEqual(
-            os.path.getsize(default_trained),
-            os.path.getsize(chunked_trained),
+            default_bytes,
+            chunked_bytes,
             "Trained compressors should differ when --chunk-size is changed",
         )
 


### PR DESCRIPTION
Summary:
The test checks that two trained compressors with different chunk sizes produce different `.zlc` files. 
The previous version compared file sizes, but `ACE` training is non-deterministic, and two runs can produce different artifacts but with identical size, which trips the assertion as a false positive. This is rare but can happen in CI, making CI signal flaky.

Switch to a bytewise comparison, which must always be true.

Differential Revision: D103963402


