### PR TITLE
Static assert 64-bit platforms

### DIFF
--- a/src/openzl/common/allocation.c
+++ b/src/openzl/common/allocation.c
@@ -196,6 +196,10 @@ typedef struct {
 static void*
 ALLOC_HeapArena_allocImpl(HeapArena* arena, HeapMeta* meta, size_t size)
 {
+    ZL_STATIC_ASSERT(
+            sizeof(size_t) == 8,
+            "OpenZL currently only supports 64-bit platforms");
+
     if (meta == NULL) {
         return NULL;
     }


### PR DESCRIPTION
Summary: We don't test on 32-bit platforms yet, so static assert that it isn't supported in one known place where we don't support 32-bits.

Differential Revision: D104076319


