### PR TITLE
Add between() built-in (#743)

### DIFF
--- a/doc/mkdocs/doc/sddl/core-concepts.md
+++ b/doc/mkdocs/doc/sddl/core-concepts.md
@@ -175,7 +175,7 @@ row_bytes = 4 * ((width + 3) / 4)
 
 ## Built-in Functions
 
-SDDL provides two built-in functions:
+SDDL provides three built-in functions:
 
 **`sizeof`** returns the size in bytes of a type. Only works on types with statically known sizes:
 
@@ -189,6 +189,13 @@ expect sizeof(StarEntry(STNUM, MPROP, NMAG)) == header.NBENT
 ```sddl
 count = abs(header.signed_count)
 magnitudes: Int16LE[abs(NMAG)]
+```
+
+**`between(l, x, h)`** returns `1` if `l <= x <= h` and `0` otherwise. Useful inside `expect` for range checks:
+
+```sddl
+expect between(1, header.version, 3)
+expect between(0, count, max_count)
 ```
 
 ## Comments

--- a/doc/mkdocs/doc/sddl/reference.md
+++ b/doc/mkdocs/doc/sddl/reference.md
@@ -113,6 +113,7 @@ expect condition
 |----------|-------------|
 | `sizeof(Type)` | Size in bytes (static types only) |
 | `abs(expr)` | Absolute value |
+| `between(l, x, h)` | `1` if `l <= x <= h`, else `0` |
 
 ## Comments
 

--- a/tests/compress/graphs/sddl2/test_sddl2_code_execution.cpp
+++ b/tests/compress/graphs/sddl2/test_sddl2_code_execution.cpp
@@ -37,6 +37,19 @@ class SDDL2CodeExecutionTest : public SDDL2TestBase {
                 expected_segment_sizes);
     }
 
+    template <typename T>
+    void expect_failure(
+            const std::string& code,
+            const std::vector<T>& input,
+            SDDL2_Error expected_error)
+    {
+        EXPECT_EQ(
+                run(code,
+                    reinterpret_cast<const uint8_t*>(input.data()),
+                    input.size() * sizeof(T)),
+                expected_error);
+    }
+
    private:
     void expect_success(
             const std::string& code,
@@ -692,6 +705,93 @@ TEST_F(SDDL2CodeExecutionTest, BitwiseOperations)
         expect (~0) == -1
     )";
 
+    expect_success(prog, input, expected_sizes);
+}
+
+// ============================================================================
+// Between Built-in
+// ============================================================================
+
+TEST_F(SDDL2CodeExecutionTest, BetweenConstantsAllInRange)
+{
+    const auto prog = R"(
+        expect between(0, 5, 10)
+        expect between(-5, 0, 5)
+        expect between(0, 0, 0)
+        expect between(-100, -50, -1)
+    )";
+    expect_success(prog, std::vector<uint8_t>{}, {});
+}
+
+TEST_F(SDDL2CodeExecutionTest, BetweenRuntimeValuesInRange)
+{
+    const std::vector<size_t> expected_sizes = { 4 };
+    const std::vector<uint8_t> input         = {
+        0x32,
+        0x00,
+        0x00,
+        0x00, // x = 50
+    };
+
+    const auto prog = R"(
+        x: Int32LE
+        expect between(0, x, 100)
+    )";
+    expect_success(prog, input, expected_sizes);
+}
+
+TEST_F(SDDL2CodeExecutionTest, BetweenRuntimeValuesAtBoundaries)
+{
+    const std::vector<size_t> expected_sizes = { 4, 4 };
+    const std::vector<uint8_t> input         = {
+        0x00, 0x00, 0x00, 0x00, // lo = 0
+        0x64, 0x00, 0x00, 0x00, // hi = 100
+    };
+
+    const auto prog = R"(
+        lo: Int32LE
+        hi: Int32LE
+        # val == lo
+        expect between(lo, lo, hi)
+        # val == hi
+        expect between(lo, hi, hi)
+    )";
+    expect_success(prog, input, expected_sizes);
+}
+
+TEST_F(SDDL2CodeExecutionTest, BetweenRuntimeValueBelowRangeFails)
+{
+    const std::vector<uint8_t> input = { 0xFF, 0xFF, 0xFF, 0xFF };
+    const auto prog                  = R"(
+        x: Int32LE
+        expect between(0, x, 100)
+    )";
+    expect_failure(prog, input, SDDL2_VALIDATION_FAILED);
+}
+
+TEST_F(SDDL2CodeExecutionTest, BetweenRuntimeValueAboveRangeFails)
+{
+    const std::vector<uint8_t> input = { 0x65, 0x00, 0x00, 0x00 };
+    const auto prog                  = R"(
+        x: Int32LE
+        expect between(0, x, 100)
+    )";
+    expect_failure(prog, input, SDDL2_VALIDATION_FAILED);
+}
+
+TEST_F(SDDL2CodeExecutionTest, BetweenWithExpressions)
+{
+    const std::vector<size_t> expected_sizes = { 4, 4 };
+    const std::vector<uint8_t> input         = {
+        0x05, 0x00, 0x00, 0x00, // a = 5
+        0x03, 0x00, 0x00, 0x00, // b = 3
+    };
+    // Exercises that lo/val/hi can be arbitrary numeric expressions.
+    const auto prog = R"(
+        a: Int32LE
+        b: Int32LE
+        expect between(b - 1, a - b, a + b)
+    )";
     expect_success(prog, input, expected_sizes);
 }
 

--- a/tools/sddl2/compiler/Syntax.cpp
+++ b/tools/sddl2/compiler/Syntax.cpp
@@ -78,6 +78,7 @@ static const std::map<Symbol, poly::string_view> syms_to_debug_strs{
     { Symbol::DIV, "DIV" },
     { Symbol::MOD, "MOD" },
     { Symbol::ABS, "ABS" },
+    { Symbol::BETWEEN, "BETWEEN" },
 
     { Symbol::BIT_AND, "BIT_AND" },
     { Symbol::BIT_OR, "BIT_OR" },
@@ -152,6 +153,7 @@ const std::vector<std::pair<poly::string_view, Symbol>> strs_to_syms{
     { "/", Symbol::DIV },
     { "%", Symbol::MOD },
     { "abs", Symbol::ABS },
+    { "between", Symbol::BETWEEN },
     { "&&", Symbol::LOG_AND },
     { "||", Symbol::LOG_OR },
     { "!", Symbol::LOG_NOT },

--- a/tools/sddl2/compiler/Syntax.h
+++ b/tools/sddl2/compiler/Syntax.h
@@ -46,6 +46,7 @@ enum class Symbol {
     DIV,
     MOD,
     ABS,
+    BETWEEN,
 
     // Bitwise Operators
     BIT_AND,

--- a/tools/sddl2/compiler/parser/AST.h
+++ b/tools/sddl2/compiler/parser/AST.h
@@ -426,6 +426,14 @@ class Codegen {
         return op(Op::ABS, std::move(arg));
     }
 
+    ASTPtr between(ASTPtr low, ASTPtr val, ASTPtr high) const
+    {
+        auto low_op  = op(Op::LE, std::move(low), val);
+        auto high_op = op(Op::LE, std::move(val), std::move(high));
+
+        return op(Op::LOG_AND, std::move(low_op), std::move(high_op));
+    }
+
     ASTPtr assign(ASTPtr lhs, ASTPtr rhs) const
     {
         return op(Op::ASSIGN, std::move(lhs), std::move(rhs));

--- a/tools/sddl2/compiler/parser/Grammar.cpp
+++ b/tools/sddl2/compiler/parser/Grammar.cpp
@@ -553,6 +553,36 @@ class WhenRule : public GrammarRule {
     }
 };
 
+/**
+ * Helper: parses the inner argument list of a builtin function call and
+ * verifies the expected arity. Returns the inner args. Throws ParseError on
+ * shape mismatch.
+ */
+const ASTVec& expect_builtin_func_args(
+        const ASTPtr& op,
+        Symbol sym,
+        const ASTPtr& paren_list,
+        size_t expected_arity)
+{
+    const auto* list = some(paren_list).as_list();
+    if (list == nullptr) {
+        throw ParseError(
+                some(op).loc(),
+                std::string{ sym_to_repr_str(sym) }
+                        + "() requires a paren list.");
+    }
+
+    const auto& inner_args = list->nodes();
+    if (inner_args.size() != expected_arity) {
+        throw ParseError(
+                some(op).loc(),
+                std::string{ sym_to_repr_str(sym) } + "() requires exactly "
+                        + std::to_string(expected_arity) + " argument"
+                        + (expected_arity == 1 ? "" : "s") + ".");
+    }
+    return inner_args;
+}
+
 class BuiltinFuncRule : public GrammarRule {
    public:
     explicit BuiltinFuncRule(Symbol sym, Op result_op)
@@ -567,28 +597,37 @@ class BuiltinFuncRule : public GrammarRule {
    private:
     ASTPtr do_gen(ASTPtr op, ArgsVec args) const override
     {
-        auto& paren_list = args.at(0);
-        const auto* list = some(paren_list).as_list();
-        if (list == nullptr) {
-            throw ParseError(
-                    some(op).loc(),
-                    std::string{ sym_to_repr_str(this->sym()) }
-                            + "() requires a paren list.");
-        }
-
-        const auto& inner_args = list->nodes();
-        if (inner_args.size() != 1) {
-            throw ParseError(
-                    some(op).loc(),
-                    std::string{ sym_to_repr_str(this->sym()) }
-                            + "() requires exactly 1 argument.");
-        }
-
+        const auto& inner_args =
+                expect_builtin_func_args(op, this->sym(), args.at(0), 1);
         return std::make_shared<ASTOp>(
                 op->loc(), result_op_, ArgsVec{ inner_args.at(0) });
     }
 
     const Op result_op_;
+};
+
+class BetweenRule : public GrammarRule {
+   public:
+    BetweenRule()
+            : GrammarRule(
+                      Symbol::BETWEEN,
+                      Precedence::ACCESS,
+                      std::vector<ArgType>({ ArgType::LIST_PAREN }))
+    {
+    }
+
+   private:
+    ASTPtr do_gen(ASTPtr op, ArgsVec args) const override
+    {
+        const auto& inner_args =
+                expect_builtin_func_args(op, this->sym(), args.at(0), 3);
+        const auto& loc   = op->loc();
+        const auto& low   = inner_args[0];
+        const auto& value = inner_args[1];
+        const auto& high  = inner_args[2];
+
+        return Codegen{ loc }.between(low, value, high);
+    }
 };
 
 template <typename RuleT, typename... Args>
@@ -617,6 +656,7 @@ const std::vector<std::unique_ptr<const GrammarRule>> grammar_rules{ []() {
     add_rule<BuiltinFuncRule>(r, Symbol::SIZEOF, Op::SIZEOF);
     add_rule<WhenRule>(r);
     add_rule<BuiltinFuncRule>(r, Symbol::ABS, Op::ABS);
+    add_rule<BetweenRule>(r);
 
     add_rule<BinaryOpRule>(r, Symbol::ASSIGN, Precedence::ASSIGNMENT);
     add_rule<BinaryOpRule>(r, Symbol::ASSUME, Precedence::ASSIGNMENT);

--- a/tools/sddl2/compiler/tests/OptimizerTest.cpp
+++ b/tools/sddl2/compiler/tests/OptimizerTest.cpp
@@ -248,4 +248,20 @@ TEST_F(OptimizerTest, AbsConstFold)
     expect_ast(prog, expected);
 }
 
+TEST_F(OptimizerTest, BetweenConstFold)
+{
+    const auto prog     = R"(
+        expect between(0, 5, 10) == 1
+        expect between(0, -1, 10) == 0
+        expect between(0, 11, 10) == 0
+        expect between(5, 5, 5) == 1
+    )";
+    const auto cg       = Codegen();
+    const auto expected = std::vector<ASTPtr>({ cg.expect(cg.num(1)),
+                                                cg.expect(cg.num(1)),
+                                                cg.expect(cg.num(1)),
+                                                cg.expect(cg.num(1)) });
+    expect_ast(prog, expected);
+}
+
 } // namespace openzl::sddl2::tests

--- a/tools/sddl2/compiler/tests/ParserTest.cpp
+++ b/tools/sddl2/compiler/tests/ParserTest.cpp
@@ -368,6 +368,28 @@ TEST_F(ParserTest, WhenBlockAST)
     expect_ast(prog, expected);
 }
 
+TEST_F(ParserTest, BetweenAST)
+{
+    const auto prog = R"(
+        expect between(1, 2, 3)
+    )";
+
+    const auto cg       = Codegen();
+    const auto expected = std::vector<ASTPtr>({
+            cg.expect(cg.between(cg.num(1), cg.num(2), cg.num(3))),
+    });
+    expect_ast(prog, expected);
+}
+
+TEST_F(ParserTest, BetweenWrongArity)
+{
+    expect_error(
+            "expect between(1, 2)\n", "between() requires exactly 3 arguments");
+    expect_error(
+            "expect between(1, 2, 3, 4)\n",
+            "between() requires exactly 3 arguments");
+}
+
 TEST_F(ParserTest, WhenBlockInRecordAST)
 {
     const auto prog = R"(

--- a/tools/sddl2/compiler/tests/SemanticAnalyzerTest.cpp
+++ b/tools/sddl2/compiler/tests/SemanticAnalyzerTest.cpp
@@ -341,6 +341,13 @@ TEST_F(SemanticAnalyzerTest, AbsFieldType)
     expect_error(prog, "numeric");
 }
 
+TEST_F(SemanticAnalyzerTest, BetweenFieldType)
+{
+    expect_error("tmp = between(Int32LE, 0, 10)\n", "numeric");
+    expect_error("tmp = between(0, Int32LE, 10)\n", "numeric");
+    expect_error("tmp = between(0, 5, Int32LE)\n", "numeric");
+}
+
 TEST_F(SemanticAnalyzerTest, MemberAccessOnConditionalField)
 {
     const auto prog = R"(


### PR DESCRIPTION
Summary:

Implements the `between(l, x, h)` math built-in for SDDL. Desugared at parse time to `(l <= val) && (val <= h)` so no new opcode, semantic-analyzer case, optimizer rule, or codegen case is needed.

Reviewed By: Cyan4973

Differential Revision: D104239885


