### PR TITLE
Add library version requirements for codecs and node (#746)

### DIFF
--- a/include/openzl/zl_reflection.h
+++ b/include/openzl/zl_reflection.h
@@ -329,6 +329,22 @@ ZL_Report ZL_Compressor_Node_getDictIndex(
         ZL_NodeID node);
 
 /**
+ * @returns The minimum library version to deserialize a compressor containing
+ * this node, or an error if the node is not a valid standard node.
+ */
+ZL_Report ZL_Compressor_Node_getMinLibraryVersion(
+        const ZL_Compressor* compressor,
+        ZL_NodeID node);
+
+/**
+ * @returns The minimum library version to deserialize a compressor containing
+ * this standard graph, or an error if the graph ID is out of bounds.
+ */
+ZL_Report ZL_Compressor_Graph_getMinLibraryVersion(
+        const ZL_Compressor* compressor,
+        ZL_GraphID gid);
+
+/**
  * @returns The MParam ID associated with the @p node or ZL_MPARAM_ID_NULL if no
  * MParam is associated.
  */

--- a/src/openzl/codecs/encoder_registry.c
+++ b/src/openzl/codecs/encoder_registry.c
@@ -45,20 +45,32 @@
 
 // Set _minFormatVersion to the value of ZL_MAX_FORMAT_VERSION
 // at the time you add the transform.
-#define REGISTER_TRANSFORM(_nid, _strid, _minFormatVersion, _macro) \
-    REGISTER_DEPRECATED_TRANSFORM(                                  \
-            _nid, _strid, _minFormatVersion, ZL_MAX_FORMAT_VERSION, _macro)
+#define REGISTER_TRANSFORM(                                      \
+        _nid, _strid, _minFormatVersion, _reqLibVersion, _macro) \
+    REGISTER_DEPRECATED_TRANSFORM(                               \
+            _nid,                                                \
+            _strid,                                              \
+            _minFormatVersion,                                   \
+            ZL_MAX_FORMAT_VERSION,                               \
+            _reqLibVersion,                                      \
+            _macro)
 
 /// Registers deprecated transforms that are no longer allowed to be used.
 /// Formats in the range [_minFormatVerison, _maxFormatVersion] support the
 /// transform.
-#define REGISTER_DEPRECATED_TRANSFORM(                              \
-        _nid, _strid, _minFormatVersion, _maxFormatVersion, _macro) \
+#define REGISTER_DEPRECATED_TRANSFORM( \
+        _nid,                          \
+        _strid,                        \
+        _minFormatVersion,             \
+        _maxFormatVersion,             \
+        _reqLibVersion,                \
+        _macro)                        \
     [_nid] = {                                                      \
     .nodetype = node_internalTransform,                             \
     .publicIDtype = trt_standard,                                   \
     .minFormatVersion = (_minFormatVersion),                        \
     .maxFormatVersion = (_maxFormatVersion),                        \
+    .minLibraryVersion = (_reqLibVersion),                          \
     .transformDesc = {                                              \
         .publicDesc = _macro(_strid),                               \
     },                                                              \
@@ -66,96 +78,96 @@
 
 // clang-format off
 const CNode ER_standardNodes[STANDARD_ENCODERS_NB] = {
-    [ZL_StandardNodeID_illegal] = { .nodetype = node_illegal, .minFormatVersion=ZL_MIN_FORMAT_VERSION, .maxFormatVersion=ZL_MAX_FORMAT_VERSION },
-    REGISTER_TRANSFORM(ZL_StandardNodeID_delta_int, ZL_StandardTransformID_delta_int, 3, EI_DELTA_INT),
-    REGISTER_TRANSFORM(ZL_StandardNodeID_transpose_split, ZL_StandardTransformID_transpose_split, 11, EI_TRANSPOSE_SPLIT),
-    REGISTER_TRANSFORM(ZL_StandardNodeID_zigzag, ZL_StandardTransformID_zigzag, 3, EI_ZIGZAG_NUM),
-    REGISTER_TRANSFORM(ZL_StandardNodeID_dispatchN_byTag, ZL_StandardTransformID_dispatchN_byTag, 9, EI_DISPATCHNBYTAG),
-    REGISTER_TRANSFORM(ZL_StandardNodeID_float32_deconstruct, ZL_StandardTransformID_float_deconstruct, 4, EI_FLOAT32_DECONSTRUCT),
-    REGISTER_TRANSFORM(ZL_StandardNodeID_bfloat16_deconstruct, ZL_StandardTransformID_float_deconstruct, 5, EI_BFLOAT16_DECONSTRUCT),
-    REGISTER_TRANSFORM(ZL_StandardNodeID_float16_deconstruct, ZL_StandardTransformID_float_deconstruct, 5, EI_FLOAT16_DECONSTRUCT),
-    REGISTER_TRANSFORM(ZL_StandardNodeID_field_lz, ZL_StandardTransformID_field_lz, 3, EI_FIELD_LZ),
+    [ZL_StandardNodeID_illegal] = { .nodetype = node_illegal, .minFormatVersion=ZL_MIN_FORMAT_VERSION, .maxFormatVersion=ZL_MAX_FORMAT_VERSION, .minLibraryVersion=200 },
+    REGISTER_TRANSFORM(ZL_StandardNodeID_delta_int, ZL_StandardTransformID_delta_int, 3, 200, EI_DELTA_INT),
+    REGISTER_TRANSFORM(ZL_StandardNodeID_transpose_split, ZL_StandardTransformID_transpose_split, 11, 200, EI_TRANSPOSE_SPLIT),
+    REGISTER_TRANSFORM(ZL_StandardNodeID_zigzag, ZL_StandardTransformID_zigzag, 3, 200, EI_ZIGZAG_NUM),
+    REGISTER_TRANSFORM(ZL_StandardNodeID_dispatchN_byTag, ZL_StandardTransformID_dispatchN_byTag, 9, 200, EI_DISPATCHNBYTAG),
+    REGISTER_TRANSFORM(ZL_StandardNodeID_float32_deconstruct, ZL_StandardTransformID_float_deconstruct, 4, 200, EI_FLOAT32_DECONSTRUCT),
+    REGISTER_TRANSFORM(ZL_StandardNodeID_bfloat16_deconstruct, ZL_StandardTransformID_float_deconstruct, 5, 200, EI_BFLOAT16_DECONSTRUCT),
+    REGISTER_TRANSFORM(ZL_StandardNodeID_float16_deconstruct, ZL_StandardTransformID_float_deconstruct, 5, 200, EI_FLOAT16_DECONSTRUCT),
+    REGISTER_TRANSFORM(ZL_StandardNodeID_field_lz, ZL_StandardTransformID_field_lz, 3, 200, EI_FIELD_LZ),
 
     // Conversion operations
-    REGISTER_TRANSFORM(ZL_StandardNodeID_convert_serial_to_struct, ZL_StandardTransformID_convert_serial_to_struct, 3, EI_CONVERT_SERIAL_TO_STRUCT),
-    REGISTER_TRANSFORM(ZL_StandardNodeID_convert_serial_to_struct2, ZL_StandardTransformID_convert_serial_to_struct, 3, EI_CONVERT_SERIAL_TO_STRUCT2),
-    REGISTER_TRANSFORM(ZL_StandardNodeID_convert_serial_to_struct4, ZL_StandardTransformID_convert_serial_to_struct, 3, EI_CONVERT_SERIAL_TO_STRUCT4),
-    REGISTER_TRANSFORM(ZL_StandardNodeID_convert_serial_to_struct8, ZL_StandardTransformID_convert_serial_to_struct, 3, EI_CONVERT_SERIAL_TO_STRUCT8),
-    REGISTER_TRANSFORM(ZL_StandardNodeID_convert_struct_to_serial,  ZL_StandardTransformID_convert_struct_to_serial, 3, EI_CONVERT_STRUCT_TO_SERIAL),
-    REGISTER_TRANSFORM(ZL_StandardNodeID_convert_struct_to_num_le, ZL_StandardTransformID_convert_struct_to_num_le, 3, EI_CONVERT_STRUCT_TO_NUM_LE),
-    REGISTER_TRANSFORM(ZL_StandardNodeID_convert_struct_to_num_be, ZL_StandardTransformID_convert_struct_to_num_be, 21, EI_CONVERT_STRUCT_TO_NUM_BE),
-    REGISTER_TRANSFORM(ZL_StandardNodeID_convert_num_to_struct_le, ZL_StandardTransformID_convert_num_to_struct_le, 3, EI_CONVERT_NUM_TO_STRUCT_LE),
-    REGISTER_TRANSFORM(ZL_StandardNodeID_convert_serial_to_num8,  ZL_StandardTransformID_convert_serial_to_num_le, 3, EI_CONVERT_SERIAL_TO_NUM8),
-    REGISTER_TRANSFORM(ZL_StandardNodeID_convert_serial_to_num_le16, ZL_StandardTransformID_convert_serial_to_num_le, 3, EI_CONVERT_SERIAL_TO_NUM_LE16),
-    REGISTER_TRANSFORM(ZL_StandardNodeID_convert_serial_to_num_le32, ZL_StandardTransformID_convert_serial_to_num_le, 3, EI_CONVERT_SERIAL_TO_NUM_LE32),
-    REGISTER_TRANSFORM(ZL_StandardNodeID_convert_serial_to_num_le64, ZL_StandardTransformID_convert_serial_to_num_le, 3, EI_CONVERT_SERIAL_TO_NUM_LE64),
-    REGISTER_TRANSFORM(ZL_StandardNodeID_convert_serial_to_num_be16, ZL_StandardTransformID_convert_serial_to_num_be, 21, EI_CONVERT_SERIAL_TO_NUM_BE16),
-    REGISTER_TRANSFORM(ZL_StandardNodeID_convert_serial_to_num_be32, ZL_StandardTransformID_convert_serial_to_num_be, 21, EI_CONVERT_SERIAL_TO_NUM_BE32),
-    REGISTER_TRANSFORM(ZL_StandardNodeID_convert_serial_to_num_be64, ZL_StandardTransformID_convert_serial_to_num_be, 21, EI_CONVERT_SERIAL_TO_NUM_BE64),
-    REGISTER_TRANSFORM(ZL_StandardNodeID_convert_num_to_serial_le,   ZL_StandardTransformID_convert_num_to_serial_le, 3, EI_CONVERT_NUM_TO_SERIAL_LE),
-    REGISTER_TRANSFORM(ZL_StandardNodeID_separate_string_components, ZL_StandardTransformID_separate_string_components, 10, EI_SEPARATE_VSF_COMPONENTS),
-    REGISTER_TRANSFORM(ZL_StandardNodeID_parse_int, ZL_StandardTransformID_parse_int, 19, EI_PARSE_INT),
+    REGISTER_TRANSFORM(ZL_StandardNodeID_convert_serial_to_struct, ZL_StandardTransformID_convert_serial_to_struct, 3, 200, EI_CONVERT_SERIAL_TO_STRUCT),
+    REGISTER_TRANSFORM(ZL_StandardNodeID_convert_serial_to_struct2, ZL_StandardTransformID_convert_serial_to_struct, 3, 200, EI_CONVERT_SERIAL_TO_STRUCT2),
+    REGISTER_TRANSFORM(ZL_StandardNodeID_convert_serial_to_struct4, ZL_StandardTransformID_convert_serial_to_struct, 3, 200, EI_CONVERT_SERIAL_TO_STRUCT4),
+    REGISTER_TRANSFORM(ZL_StandardNodeID_convert_serial_to_struct8, ZL_StandardTransformID_convert_serial_to_struct, 3, 200, EI_CONVERT_SERIAL_TO_STRUCT8),
+    REGISTER_TRANSFORM(ZL_StandardNodeID_convert_struct_to_serial,  ZL_StandardTransformID_convert_struct_to_serial, 3, 200, EI_CONVERT_STRUCT_TO_SERIAL),
+    REGISTER_TRANSFORM(ZL_StandardNodeID_convert_struct_to_num_le, ZL_StandardTransformID_convert_struct_to_num_le, 3, 200, EI_CONVERT_STRUCT_TO_NUM_LE),
+    REGISTER_TRANSFORM(ZL_StandardNodeID_convert_struct_to_num_be, ZL_StandardTransformID_convert_struct_to_num_be, 21, 200, EI_CONVERT_STRUCT_TO_NUM_BE),
+    REGISTER_TRANSFORM(ZL_StandardNodeID_convert_num_to_struct_le, ZL_StandardTransformID_convert_num_to_struct_le, 3, 200, EI_CONVERT_NUM_TO_STRUCT_LE),
+    REGISTER_TRANSFORM(ZL_StandardNodeID_convert_serial_to_num8,  ZL_StandardTransformID_convert_serial_to_num_le, 3, 200, EI_CONVERT_SERIAL_TO_NUM8),
+    REGISTER_TRANSFORM(ZL_StandardNodeID_convert_serial_to_num_le16, ZL_StandardTransformID_convert_serial_to_num_le, 3, 200, EI_CONVERT_SERIAL_TO_NUM_LE16),
+    REGISTER_TRANSFORM(ZL_StandardNodeID_convert_serial_to_num_le32, ZL_StandardTransformID_convert_serial_to_num_le, 3, 200, EI_CONVERT_SERIAL_TO_NUM_LE32),
+    REGISTER_TRANSFORM(ZL_StandardNodeID_convert_serial_to_num_le64, ZL_StandardTransformID_convert_serial_to_num_le, 3, 200, EI_CONVERT_SERIAL_TO_NUM_LE64),
+    REGISTER_TRANSFORM(ZL_StandardNodeID_convert_serial_to_num_be16, ZL_StandardTransformID_convert_serial_to_num_be, 21, 200, EI_CONVERT_SERIAL_TO_NUM_BE16),
+    REGISTER_TRANSFORM(ZL_StandardNodeID_convert_serial_to_num_be32, ZL_StandardTransformID_convert_serial_to_num_be, 21, 200, EI_CONVERT_SERIAL_TO_NUM_BE32),
+    REGISTER_TRANSFORM(ZL_StandardNodeID_convert_serial_to_num_be64, ZL_StandardTransformID_convert_serial_to_num_be, 21, 200, EI_CONVERT_SERIAL_TO_NUM_BE64),
+    REGISTER_TRANSFORM(ZL_StandardNodeID_convert_num_to_serial_le,   ZL_StandardTransformID_convert_num_to_serial_le, 3, 200, EI_CONVERT_NUM_TO_SERIAL_LE),
+    REGISTER_TRANSFORM(ZL_StandardNodeID_separate_string_components, ZL_StandardTransformID_separate_string_components, 10, 200, EI_SEPARATE_VSF_COMPONENTS),
+    REGISTER_TRANSFORM(ZL_StandardNodeID_parse_int, ZL_StandardTransformID_parse_int, 19, 200, EI_PARSE_INT),
 
-    REGISTER_TRANSFORM(ZL_StandardNodeID_bitunpack, ZL_StandardTransformID_bitunpack, 6, EI_BITUNPACK),
-    REGISTER_TRANSFORM(ZL_StandardNodeID_range_pack, ZL_StandardTransformID_range_pack, 8, EI_RANGE_PACK),
-    REGISTER_TRANSFORM(ZL_StandardNodeID_merge_sorted, ZL_StandardTransformID_merge_sorted, 9, EI_MERGE_SORTED),
-    REGISTER_TRANSFORM(ZL_StandardNodeID_prefix, ZL_StandardTransformID_prefix, 11, EI_PREFIX),
-    REGISTER_TRANSFORM(ZL_StandardNodeID_divide_by, ZL_StandardTransformID_divide_by, 16, EI_DIVIDE_BY_INT),
-    REGISTER_TRANSFORM(ZL_StandardNodeID_dispatch_string, ZL_StandardTransformID_dispatch_string, 16, EI_DISPATCH_STRING),
-    REGISTER_TRANSFORM(ZL_StandardNodeID_concat_serial, ZL_StandardTransformID_concat_serial, 16, EI_CONCAT_SERIAL),
-    REGISTER_TRANSFORM(ZL_StandardNodeID_concat_num, ZL_StandardTransformID_concat_num, 17, EI_CONCAT_NUM),
-    REGISTER_TRANSFORM(ZL_StandardNodeID_concat_struct, ZL_StandardTransformID_concat_struct, 17, EI_CONCAT_STRUCT),
-    REGISTER_TRANSFORM(ZL_StandardNodeID_concat_string, ZL_StandardTransformID_concat_string, 18, EI_CONCAT_STRING),
-    REGISTER_TRANSFORM(ZL_StandardNodeID_dedup_num, ZL_StandardTransformID_dedup_num, 16, EI_DEDUP_NUM),
-    REGISTER_TRANSFORM(ZL_StandardNodeID_interleave_string, ZL_StandardTransformID_interleave_string, 20, EI_INTERLEAVE_STRING),
-    REGISTER_TRANSFORM(ZL_StandardNodeID_tokenize_struct, ZL_StandardTransformID_tokenize_fixed, 8, EI_TOKENIZE_STRUCT),
-    REGISTER_TRANSFORM(ZL_StandardNodeID_tokenize_numeric, ZL_StandardTransformID_tokenize_numeric, 8, EI_TOKENIZE_NUMERIC),
-    REGISTER_TRANSFORM(ZL_StandardNodeID_tokenize_string, ZL_StandardTransformID_tokenize_string, 11, EI_TOKENIZE_STRING),
-    REGISTER_TRANSFORM(ZL_StandardNodeID_quantize_offsets, ZL_StandardTransformID_quantize_offsets, 3, EI_QUANTIZE_OFFSETS),
-    REGISTER_TRANSFORM(ZL_StandardNodeID_quantize_lengths, ZL_StandardTransformID_quantize_lengths, 3, EI_QUANTIZE_LENGTHS),
-    REGISTER_TRANSFORM(ZL_StandardNodeID_bitsplit_top8, ZL_StandardTransformID_bitSplit, 24, EI_BITSPLIT_TOP8),
-    REGISTER_TRANSFORM(ZL_StandardNodeID_bitsplit_fp, ZL_StandardTransformID_bitSplit, 24, EI_BITSPLIT_FP),
-    REGISTER_TRANSFORM(ZL_StandardNodeID_bitsplit_bf16, ZL_StandardTransformID_bitSplit, 24, EI_BITSPLIT_BF16),
-    REGISTER_TRANSFORM(ZL_StandardNodeID_partition, ZL_StandardTransformID_partition, 24, EI_PARTITION),
-    REGISTER_TRANSFORM(ZL_StandardNodeID_split_byrange, ZL_StandardTransformID_splitn_num, 24, EI_SPLIT_BYRANGE),
-    REGISTER_TRANSFORM(ZL_StandardNodeID_sentinel_byte, ZL_StandardTransformID_sentinel, 24, EI_SENTINEL_BYTE),
-    REGISTER_TRANSFORM(ZL_StandardNodeID_sentinel_num, ZL_StandardTransformID_sentinel, 24, EI_SENTINEL),
-    REGISTER_TRANSFORM(ZL_StandardNodeID_lz, ZL_StandardTransformID_lz, 24, EI_LZ),
-    REGISTER_TRANSFORM(ZL_StandardNodeID_mux_lengths, ZL_StandardTransformID_mux_lengths, 24, EI_MUX_LENGTHS),
+    REGISTER_TRANSFORM(ZL_StandardNodeID_bitunpack, ZL_StandardTransformID_bitunpack, 6, 200, EI_BITUNPACK),
+    REGISTER_TRANSFORM(ZL_StandardNodeID_range_pack, ZL_StandardTransformID_range_pack, 8, 200, EI_RANGE_PACK),
+    REGISTER_TRANSFORM(ZL_StandardNodeID_merge_sorted, ZL_StandardTransformID_merge_sorted, 9, 200, EI_MERGE_SORTED),
+    REGISTER_TRANSFORM(ZL_StandardNodeID_prefix, ZL_StandardTransformID_prefix, 11, 200, EI_PREFIX),
+    REGISTER_TRANSFORM(ZL_StandardNodeID_divide_by, ZL_StandardTransformID_divide_by, 16, 200, EI_DIVIDE_BY_INT),
+    REGISTER_TRANSFORM(ZL_StandardNodeID_dispatch_string, ZL_StandardTransformID_dispatch_string, 16, 200, EI_DISPATCH_STRING),
+    REGISTER_TRANSFORM(ZL_StandardNodeID_concat_serial, ZL_StandardTransformID_concat_serial, 16, 200, EI_CONCAT_SERIAL),
+    REGISTER_TRANSFORM(ZL_StandardNodeID_concat_num, ZL_StandardTransformID_concat_num, 17, 200, EI_CONCAT_NUM),
+    REGISTER_TRANSFORM(ZL_StandardNodeID_concat_struct, ZL_StandardTransformID_concat_struct, 17, 200, EI_CONCAT_STRUCT),
+    REGISTER_TRANSFORM(ZL_StandardNodeID_concat_string, ZL_StandardTransformID_concat_string, 18, 200, EI_CONCAT_STRING),
+    REGISTER_TRANSFORM(ZL_StandardNodeID_dedup_num, ZL_StandardTransformID_dedup_num, 16, 200, EI_DEDUP_NUM),
+    REGISTER_TRANSFORM(ZL_StandardNodeID_interleave_string, ZL_StandardTransformID_interleave_string, 20, 200, EI_INTERLEAVE_STRING),
+    REGISTER_TRANSFORM(ZL_StandardNodeID_tokenize_struct, ZL_StandardTransformID_tokenize_fixed, 8, 200, EI_TOKENIZE_STRUCT),
+    REGISTER_TRANSFORM(ZL_StandardNodeID_tokenize_numeric, ZL_StandardTransformID_tokenize_numeric, 8, 200, EI_TOKENIZE_NUMERIC),
+    REGISTER_TRANSFORM(ZL_StandardNodeID_tokenize_string, ZL_StandardTransformID_tokenize_string, 11, 200, EI_TOKENIZE_STRING),
+    REGISTER_TRANSFORM(ZL_StandardNodeID_quantize_offsets, ZL_StandardTransformID_quantize_offsets, 3, 200, EI_QUANTIZE_OFFSETS),
+    REGISTER_TRANSFORM(ZL_StandardNodeID_quantize_lengths, ZL_StandardTransformID_quantize_lengths, 3, 200, EI_QUANTIZE_LENGTHS),
+    REGISTER_TRANSFORM(ZL_StandardNodeID_bitsplit_top8, ZL_StandardTransformID_bitSplit, 24, 200, EI_BITSPLIT_TOP8),
+    REGISTER_TRANSFORM(ZL_StandardNodeID_bitsplit_fp, ZL_StandardTransformID_bitSplit, 24, 200, EI_BITSPLIT_FP),
+    REGISTER_TRANSFORM(ZL_StandardNodeID_bitsplit_bf16, ZL_StandardTransformID_bitSplit, 24, 200, EI_BITSPLIT_BF16),
+    REGISTER_TRANSFORM(ZL_StandardNodeID_partition, ZL_StandardTransformID_partition, 24, 200, EI_PARTITION),
+    REGISTER_TRANSFORM(ZL_StandardNodeID_split_byrange, ZL_StandardTransformID_splitn_num, 24, 200, EI_SPLIT_BYRANGE),
+    REGISTER_TRANSFORM(ZL_StandardNodeID_sentinel_byte, ZL_StandardTransformID_sentinel, 24, 200, EI_SENTINEL_BYTE),
+    REGISTER_TRANSFORM(ZL_StandardNodeID_sentinel_num, ZL_StandardTransformID_sentinel, 24, 200, EI_SENTINEL),
+    REGISTER_TRANSFORM(ZL_StandardNodeID_lz, ZL_StandardTransformID_lz, 24, 200, EI_LZ),
+    REGISTER_TRANSFORM(ZL_StandardNodeID_mux_lengths, ZL_StandardTransformID_mux_lengths, 24, 200, EI_MUX_LENGTHS),
 
     // Private Nodes
-    REGISTER_TRANSFORM(ZL_PrivateStandardNodeID_set_string_lens,           ZL_StandardTransformID_convert_serial_string, 10, EI_SETSTRINGLENS),
-    REGISTER_TRANSFORM(ZL_PrivateStandardNodeID_fse_v2, ZL_StandardTransformID_fse_v2, 15, EI_FSE_V2),
-    REGISTER_TRANSFORM(ZL_PrivateStandardNodeID_huffman_v2, ZL_StandardTransformID_huffman_v2, 15, EI_HUFFMAN_V2),
-    REGISTER_TRANSFORM(ZL_PrivateStandardNodeID_huffman_struct_v2, ZL_StandardTransformID_huffman_struct_v2, 15, EI_HUFFMAN_STRUCT_V2),
-    REGISTER_TRANSFORM(ZL_PrivateStandardNodeID_fse_ncount, ZL_StandardTransformID_fse_ncount, 15, EI_FSE_NCOUNT),
-    REGISTER_TRANSFORM(ZL_PrivateStandardNodeID_zstd, ZL_StandardTransformID_zstd, 3, EI_ZSTD),
-    REGISTER_TRANSFORM(ZL_PrivateStandardNodeID_bitpack_serial, ZL_StandardTransformID_bitpack_serial, 3, EI_BITPACK_SERIALIZED),
-    REGISTER_TRANSFORM(ZL_PrivateStandardNodeID_bitpack_int, ZL_StandardTransformID_bitpack_int, 3, EI_BITPACK_INTEGER),
-    REGISTER_TRANSFORM(ZL_PrivateStandardNodeID_flatpack, ZL_StandardTransformID_flatpack, 3, EI_FLATPACK),
-    REGISTER_TRANSFORM(ZL_PrivateStandardNodeID_splitN, ZL_StandardTransformID_splitn, 9, EI_SPLITN),
-    REGISTER_TRANSFORM(ZL_PrivateStandardNodeID_splitN_struct, ZL_StandardTransformID_splitn_struct, 15, EI_SPLITN_STRUCT),
-    REGISTER_TRANSFORM(ZL_PrivateStandardNodeID_splitN_num, ZL_StandardTransformID_splitn_num, 15, EI_SPLITN_NUM),
-    REGISTER_TRANSFORM(ZL_PrivateStandardNodeID_split_by_struct, ZL_StandardTransformID_splitByStruct, ZL_StandardTransformMinVersion_splitByStruct, EI_SPLITBYSTRUCT),
-    REGISTER_TRANSFORM(ZL_PrivateStandardNodeID_constant_serial, ZL_StandardTransformID_constant_serial, 11, EI_CONSTANT_SERIALIZED),
-    REGISTER_TRANSFORM(ZL_PrivateStandardNodeID_constant_fixed, ZL_StandardTransformID_constant_fixed, 11, EI_CONSTANT_FIXED),
-    REGISTER_TRANSFORM(ZL_PrivateStandardNodeID_tokenize_sorted, ZL_StandardTransformID_tokenize_numeric, 8, EI_TOKENIZE_SORTED),
-    REGISTER_TRANSFORM(ZL_PrivateStandardNodeID_tokenize_string_sorted, ZL_StandardTransformID_tokenize_string, 11, EI_TOKENIZE_VSF_SORTED),
-    REGISTER_TRANSFORM(ZL_PrivateStandardNodeID_dedup_num_trusted, ZL_StandardTransformID_dedup_num, 16, EI_DEDUP_NUM_TRUSTED),
-    REGISTER_TRANSFORM(ZL_PrivateStandardNodeID_lz4, ZL_StandardTransformID_lz4, 23, EI_LZ4),
-    REGISTER_TRANSFORM(ZL_PrivateStandardNodeID_bitSplit, ZL_StandardTransformID_bitSplit, 24, EI_BITSPLIT),
+    REGISTER_TRANSFORM(ZL_PrivateStandardNodeID_set_string_lens,           ZL_StandardTransformID_convert_serial_string, 10, 200, EI_SETSTRINGLENS),
+    REGISTER_TRANSFORM(ZL_PrivateStandardNodeID_fse_v2, ZL_StandardTransformID_fse_v2, 15, 200, EI_FSE_V2),
+    REGISTER_TRANSFORM(ZL_PrivateStandardNodeID_huffman_v2, ZL_StandardTransformID_huffman_v2, 15, 200, EI_HUFFMAN_V2),
+    REGISTER_TRANSFORM(ZL_PrivateStandardNodeID_huffman_struct_v2, ZL_StandardTransformID_huffman_struct_v2, 15, 200, EI_HUFFMAN_STRUCT_V2),
+    REGISTER_TRANSFORM(ZL_PrivateStandardNodeID_fse_ncount, ZL_StandardTransformID_fse_ncount, 15, 200, EI_FSE_NCOUNT),
+    REGISTER_TRANSFORM(ZL_PrivateStandardNodeID_zstd, ZL_StandardTransformID_zstd, 3, 200, EI_ZSTD),
+    REGISTER_TRANSFORM(ZL_PrivateStandardNodeID_bitpack_serial, ZL_StandardTransformID_bitpack_serial, 3, 200, EI_BITPACK_SERIALIZED),
+    REGISTER_TRANSFORM(ZL_PrivateStandardNodeID_bitpack_int, ZL_StandardTransformID_bitpack_int, 3, 200, EI_BITPACK_INTEGER),
+    REGISTER_TRANSFORM(ZL_PrivateStandardNodeID_flatpack, ZL_StandardTransformID_flatpack, 3, 200, EI_FLATPACK),
+    REGISTER_TRANSFORM(ZL_PrivateStandardNodeID_splitN, ZL_StandardTransformID_splitn, 9, 200, EI_SPLITN),
+    REGISTER_TRANSFORM(ZL_PrivateStandardNodeID_splitN_struct, ZL_StandardTransformID_splitn_struct, 15, 200, EI_SPLITN_STRUCT),
+    REGISTER_TRANSFORM(ZL_PrivateStandardNodeID_splitN_num, ZL_StandardTransformID_splitn_num, 15, 200, EI_SPLITN_NUM),
+    REGISTER_TRANSFORM(ZL_PrivateStandardNodeID_split_by_struct, ZL_StandardTransformID_splitByStruct, ZL_StandardTransformMinVersion_splitByStruct, 200, EI_SPLITBYSTRUCT),
+    REGISTER_TRANSFORM(ZL_PrivateStandardNodeID_constant_serial, ZL_StandardTransformID_constant_serial, 11, 200, EI_CONSTANT_SERIALIZED),
+    REGISTER_TRANSFORM(ZL_PrivateStandardNodeID_constant_fixed, ZL_StandardTransformID_constant_fixed, 11, 200, EI_CONSTANT_FIXED),
+    REGISTER_TRANSFORM(ZL_PrivateStandardNodeID_tokenize_sorted, ZL_StandardTransformID_tokenize_numeric, 8, 200, EI_TOKENIZE_SORTED),
+    REGISTER_TRANSFORM(ZL_PrivateStandardNodeID_tokenize_string_sorted, ZL_StandardTransformID_tokenize_string, 11, 200, EI_TOKENIZE_VSF_SORTED),
+    REGISTER_TRANSFORM(ZL_PrivateStandardNodeID_dedup_num_trusted, ZL_StandardTransformID_dedup_num, 16, 200, EI_DEDUP_NUM_TRUSTED),
+    REGISTER_TRANSFORM(ZL_PrivateStandardNodeID_lz4, ZL_StandardTransformID_lz4, 23, 200, EI_LZ4),
+    REGISTER_TRANSFORM(ZL_PrivateStandardNodeID_bitSplit, ZL_StandardTransformID_bitSplit, 24, 200, EI_BITSPLIT),
 
     // Deprecated Nodes
-    REGISTER_DEPRECATED_TRANSFORM(ZL_PrivateStandardNodeID_rolz_deprecated, ZL_StandardTransformID_rolz, 3, 12, EI_ROLZ),
-    REGISTER_DEPRECATED_TRANSFORM(ZL_PrivateStandardNodeID_fastlz_deprecated, ZL_StandardTransformID_fastlz, 3, 12, EI_FASTLZ),
-    REGISTER_DEPRECATED_TRANSFORM(ZL_PrivateStandardNodeID_fse_deprecated, ZL_StandardTransformID_fse_deprecated, 3, 14, EI_FSE),
-    REGISTER_DEPRECATED_TRANSFORM(ZL_PrivateStandardNodeID_huffman_deprecated, ZL_StandardTransformID_huffman_deprecated, 3, 14, EI_HUFFMAN),
-    REGISTER_DEPRECATED_TRANSFORM(ZL_PrivateStandardNodeID_huffman_fixed_deprecated, ZL_StandardTransformID_huffman_fixed_deprecated, 3, 14, EI_HUFFMAN_FIXED),
-    REGISTER_DEPRECATED_TRANSFORM(ZL_PrivateStandardNodeID_zstd_fixed_deprecated, ZL_StandardTransformID_zstd_fixed, 3, 10, EI_ZSTD_FIXED),
-    REGISTER_DEPRECATED_TRANSFORM(ZL_PrivateStandardNodeID_transpose_deprecated, ZL_StandardTransformID_transpose, 3, 10, EI_TRANSPOSE),
-    REGISTER_DEPRECATED_TRANSFORM(ZL_PrivateStandardNodeID_transpose_split2_deprecated, ZL_StandardTransformID_transpose_split2, 3, 10, EI_TRANSPOSE_SPLIT2),
-    REGISTER_DEPRECATED_TRANSFORM(ZL_PrivateStandardNodeID_transpose_split4_deprecated, ZL_StandardTransformID_transpose_split4, 3, 10, EI_TRANSPOSE_SPLIT4),
-    REGISTER_DEPRECATED_TRANSFORM(ZL_PrivateStandardNodeID_transpose_split8_deprecated, ZL_StandardTransformID_transpose_split8, 3, 10, EI_TRANSPOSE_SPLIT8),
+    REGISTER_DEPRECATED_TRANSFORM(ZL_PrivateStandardNodeID_rolz_deprecated, ZL_StandardTransformID_rolz, 3, 12, 200, EI_ROLZ),
+    REGISTER_DEPRECATED_TRANSFORM(ZL_PrivateStandardNodeID_fastlz_deprecated, ZL_StandardTransformID_fastlz, 3, 12, 200, EI_FASTLZ),
+    REGISTER_DEPRECATED_TRANSFORM(ZL_PrivateStandardNodeID_fse_deprecated, ZL_StandardTransformID_fse_deprecated, 3, 14, 200, EI_FSE),
+    REGISTER_DEPRECATED_TRANSFORM(ZL_PrivateStandardNodeID_huffman_deprecated, ZL_StandardTransformID_huffman_deprecated, 3, 14, 200, EI_HUFFMAN),
+    REGISTER_DEPRECATED_TRANSFORM(ZL_PrivateStandardNodeID_huffman_fixed_deprecated, ZL_StandardTransformID_huffman_fixed_deprecated, 3, 14, 200, EI_HUFFMAN_FIXED),
+    REGISTER_DEPRECATED_TRANSFORM(ZL_PrivateStandardNodeID_zstd_fixed_deprecated, ZL_StandardTransformID_zstd_fixed, 3, 10, 200, EI_ZSTD_FIXED),
+    REGISTER_DEPRECATED_TRANSFORM(ZL_PrivateStandardNodeID_transpose_deprecated, ZL_StandardTransformID_transpose, 3, 10, 200, EI_TRANSPOSE),
+    REGISTER_DEPRECATED_TRANSFORM(ZL_PrivateStandardNodeID_transpose_split2_deprecated, ZL_StandardTransformID_transpose_split2, 3, 10, 200, EI_TRANSPOSE_SPLIT2),
+    REGISTER_DEPRECATED_TRANSFORM(ZL_PrivateStandardNodeID_transpose_split4_deprecated, ZL_StandardTransformID_transpose_split4, 3, 10, 200, EI_TRANSPOSE_SPLIT4),
+    REGISTER_DEPRECATED_TRANSFORM(ZL_PrivateStandardNodeID_transpose_split8_deprecated, ZL_StandardTransformID_transpose_split8, 3, 10, 200, EI_TRANSPOSE_SPLIT8),
 };
 // clang-format on
 

--- a/src/openzl/compress/cgraph.c
+++ b/src/openzl/compress/cgraph.c
@@ -1,7 +1,8 @@
 // Copyright (c) Meta Platforms, Inc. and affiliates.
 
 #include "openzl/compress/cgraph.h"
-#include "openzl/common/allocation.h" // ZL_malloc, ZL_free
+#include "openzl/codecs/encoder_registry.h" // ER_standardNodes, STANDARD_ENCODERS_NB
+#include "openzl/common/allocation.h"       // ZL_malloc, ZL_free
 #include "openzl/common/assertion.h"
 #include "openzl/common/errors_internal.h" // ZS2_RET_IF_ERR
 #include "openzl/common/opaque.h"
@@ -1364,6 +1365,38 @@ ZL_Report ZL_Compressor_Node_getDictIndex(
         return ZL_returnError(ZL_ErrorCode_dictNoRecord);
     }
     return ZL_returnValue(index);
+}
+
+ZL_Report ZL_Compressor_Node_getMinLibraryVersion(
+        const ZL_Compressor* compressor,
+        ZL_NodeID node)
+{
+    (void)compressor;
+    ZL_RESULT_DECLARE_SCOPE_REPORT(NULL);
+    ZL_ERR_IF_GE(
+            node.nid,
+            STANDARD_ENCODERS_NB,
+            parameter_invalid,
+            "node ID out of bounds");
+    ZL_ERR_IF(
+            ER_standardNodes[node.nid].nodetype == node_illegal,
+            node_invalid,
+            "node is not a valid standard node");
+    return ZL_returnValue(ER_standardNodes[node.nid].minLibraryVersion);
+}
+
+ZL_Report ZL_Compressor_Graph_getMinLibraryVersion(
+        const ZL_Compressor* compressor,
+        ZL_GraphID gid)
+{
+    (void)compressor;
+    ZL_RESULT_DECLARE_SCOPE_REPORT(NULL);
+    ZL_ERR_IF_GE(
+            gid.gid,
+            ZL_PrivateStandardGraphID_end,
+            parameter_invalid,
+            "graph ID out of bounds");
+    return ZL_returnValue(GR_standardGraphs[gid.gid].gdi.minLibraryVersion);
 }
 
 const void* CGRAPH_getDictObj(const ZL_Compressor* cgraph, size_t dictOffset)

--- a/src/openzl/compress/cnode.h
+++ b/src/openzl/compress/cnode.h
@@ -46,6 +46,10 @@ typedef struct {
     /// This field records that reference to the node from which this node was
     /// created. Set to ZL_NODE_ILLEGAL when there is no such base node.
     ZL_NodeID baseNodeID;
+    /// The minimum library version required for compressor deserializers to
+    /// recognize this node and use this component for compression in the
+    /// expected manner.
+    unsigned minLibraryVersion;
 } CNode;
 
 /// @returns the local parameters for the @p cnode

--- a/src/openzl/compress/graph_registry.c
+++ b/src/openzl/compress/graph_registry.c
@@ -46,7 +46,8 @@
 // because these sources are not considered "constant" by the C standard.
 // For the same reason, they can't be checked at compile using static_assert(),
 // but are checked at runtime (in debug mode) with GR_validate().
-#define REGISTER_STATIC_GRAPH(id, _gname, intype, hnid, dstlist) \
+#define REGISTER_STATIC_GRAPH(                             \
+        id, _gname, intype, hnid, dstlist, _reqLibVersion) \
     [id] = {                                                                 \
         .type = GR_dynamicGraph,                                             \
         .gdi  = {                                                            \
@@ -60,10 +61,11 @@
                 .customGraphs     = dstlist,                                 \
             },                                                               \
             .baseGraphID = ZL_GRAPH_ILLEGAL,                                 \
+            .minLibraryVersion = (_reqLibVersion),                            \
         },                                                                   \
     }
 
-#define REGISTER_SELECTOR(id, _sname, _selectF, _intypes) \
+#define REGISTER_SELECTOR(id, _sname, _selectF, _intypes, _reqLibVersion) \
     [id] = {                                                           \
         .type = GR_dynamicGraph,                                       \
         .gdi  = {                                                      \
@@ -75,10 +77,11 @@
             },                                                         \
             .privateParam = &(GR_SelectorFunction){ _selectF},         \
             .baseGraphID = ZL_GRAPH_ILLEGAL,                           \
+            .minLibraryVersion = (_reqLibVersion),                      \
         },                                                             \
     }
 
-#define REGISTER_DYNAMIC_GRAPH(id, _gname, _intype, _graph_f) \
+#define REGISTER_DYNAMIC_GRAPH(id, _gname, _intype, _graph_f, _reqLibVersion) \
     [id] = {                                                                \
         .type = GR_dynamicGraph,                                            \
         .gdi  = {                                                           \
@@ -89,28 +92,31 @@
                 .nbInputs         = 1,                                      \
             },                                                              \
             .baseGraphID = ZL_GRAPH_ILLEGAL,                                \
+            .minLibraryVersion = (_reqLibVersion),                           \
         },                                                                  \
     }
 
-#define REGISTER_MIGRAPH(id, _gdesc) \
+#define REGISTER_MIGRAPH(id, _gdesc, _reqLibVersion) \
     [id] = {                                  \
         .type = GR_dynamicGraph,              \
         .gdi  = {                             \
             .migd = _gdesc,                   \
             .baseGraphID = ZL_GRAPH_ILLEGAL,  \
+            .minLibraryVersion = (_reqLibVersion), \
         },                                    \
     }
 
-#define REGISTER_SEGMENTER(id, _sdesc) \
+#define REGISTER_SEGMENTER(id, _sdesc, _reqLibVersion) \
     [id] = {                                 \
         .type = GR_segmenter,                \
         .gdi  = {                            \
             .segDesc = _sdesc,               \
             .baseGraphID = ZL_GRAPH_ILLEGAL, \
+            .minLibraryVersion = (_reqLibVersion), \
         },                                   \
     }
 
-#define REGISTER_SPECIAL(id, _name, _type) \
+#define REGISTER_SPECIAL(id, _name, _type, _reqLibVersion) \
     [id] = {                                                              \
         .type = _type,                                                    \
         .gdi  = {                                                         \
@@ -120,92 +126,93 @@
                 .nbInputs         = 1,                                    \
             },                                                            \
             .baseGraphID = ZL_GRAPH_ILLEGAL,                              \
+            .minLibraryVersion = (_reqLibVersion),                         \
         },                                                                \
     }
 
 // clang-format off
 const InternalGraphDesc GR_standardGraphs[ZL_PrivateStandardGraphID_end] = {
     // note: serial_store is effectively a special action
-    REGISTER_SPECIAL(ZL_PrivateStandardGraphID_serial_store, "!zl.private.serial_store", GR_store ),
+    REGISTER_SPECIAL(ZL_PrivateStandardGraphID_serial_store, "!zl.private.serial_store", GR_store, 200 ),
 
     // Public graphs
-    REGISTER_MIGRAPH(ZL_StandardGraphID_store, MIGRAPH_STORE),
-    REGISTER_DYNAMIC_GRAPH(ZL_StandardGraphID_fse, "!zl.fse", ZL_Type_serial, EI_fseDynamicGraph),
-    REGISTER_DYNAMIC_GRAPH(ZL_StandardGraphID_huffman, "!zl.huffman", ZL_Type_serial | ZL_Type_struct | ZL_Type_numeric, EI_huffmanDynamicGraph),
-    REGISTER_DYNAMIC_GRAPH(ZL_StandardGraphID_entropy, "!zl.entropy", ZL_Type_serial | ZL_Type_struct | ZL_Type_numeric, EI_entropyDynamicGraph),
-    REGISTER_SELECTOR(ZL_StandardGraphID_constant, "!zl.constant", SI_selector_constant, ZL_Type_serial | ZL_Type_struct | ZL_Type_numeric),
-    REGISTER_STATIC_GRAPH(ZL_StandardGraphID_zstd, "!zl.zstd", ZL_Type_serial, ZL_PrivateStandardNodeID_zstd, _1_SUCCESSOR(ZL_PrivateStandardGraphID_serial_store) ),
-    REGISTER_SELECTOR(ZL_StandardGraphID_bitpack, "!zl.bitpack", SI_selector_bitpack, ZL_Type_serial | ZL_Type_numeric),
-    REGISTER_STATIC_GRAPH(ZL_StandardGraphID_flatpack, "!zl.flatpack", ZL_Type_serial, ZL_PrivateStandardNodeID_flatpack, _2_SUCCESSORS(ZL_PrivateStandardGraphID_serial_store, ZL_PrivateStandardGraphID_serial_store) ),
-    REGISTER_DYNAMIC_GRAPH(ZL_StandardGraphID_field_lz, "!zl.field_lz", ZL_Type_struct | ZL_Type_numeric, EI_fieldLzDynGraph),
-    REGISTER_DYNAMIC_GRAPH(ZL_StandardGraphID_lz, "!zl.lz", ZL_Type_serial, EI_lzDynGraph),
-    REGISTER_MIGRAPH(ZL_StandardGraphID_compress_generic, MIGRAPH_COMPRESS),
-    REGISTER_SELECTOR(ZL_StandardGraphID_select_generic_lz_backend, "!zl.select_generic_lz_backend", SI_selector_genericLZ, ZL_Type_serial),
-    REGISTER_SEGMENTER(ZL_StandardGraphID_segment_numeric, SEGM_NUMERIC_DESC),
-    REGISTER_STATIC_GRAPH(ZL_PrivateStandardGraphID_interpret_num8_compress,  "!zl.private.interpret_num8_compress",  ZL_Type_serial, ZL_StandardNodeID_convert_serial_to_num8,     _1_SUCCESSOR(ZL_PrivateStandardGraphID_numeric_compress)),
-    REGISTER_STATIC_GRAPH(ZL_PrivateStandardGraphID_interpret_num16_compress, "!zl.private.interpret_num16_compress", ZL_Type_serial, ZL_StandardNodeID_convert_serial_to_num_le16, _1_SUCCESSOR(ZL_PrivateStandardGraphID_numeric_compress)),
-    REGISTER_STATIC_GRAPH(ZL_PrivateStandardGraphID_interpret_num32_compress, "!zl.private.interpret_num32_compress", ZL_Type_serial, ZL_StandardNodeID_convert_serial_to_num_le32, _1_SUCCESSOR(ZL_PrivateStandardGraphID_numeric_compress)),
-    REGISTER_STATIC_GRAPH(ZL_PrivateStandardGraphID_interpret_num64_compress, "!zl.private.interpret_num64_compress", ZL_Type_serial, ZL_StandardNodeID_convert_serial_to_num_le64, _1_SUCCESSOR(ZL_PrivateStandardGraphID_numeric_compress)),
-    REGISTER_SEGMENTER(ZL_StandardGraphID_segment_num8_from_serial,  SEGM_NUM_FROM_SERIAL_DESC(1, 8,  ZL_PrivateStandardGraphID_interpret_num8_compress)),
-    REGISTER_SEGMENTER(ZL_StandardGraphID_segment_num16_from_serial, SEGM_NUM_FROM_SERIAL_DESC(2, 16, ZL_PrivateStandardGraphID_interpret_num16_compress)),
-    REGISTER_SEGMENTER(ZL_StandardGraphID_segment_num32_from_serial, SEGM_NUM_FROM_SERIAL_DESC(4, 32, ZL_PrivateStandardGraphID_interpret_num32_compress)),
-    REGISTER_SEGMENTER(ZL_StandardGraphID_segment_num64_from_serial, SEGM_NUM_FROM_SERIAL_DESC(8, 64, ZL_PrivateStandardGraphID_interpret_num64_compress)),
-    REGISTER_SEGMENTER(ZL_StandardGraphID_segment_serial, SEGM_SERIAL_DESC),
-    REGISTER_SELECTOR(ZL_StandardGraphID_select_numeric, "!zl.select_numeric", SI_selector_numeric, ZL_Type_numeric),
-    REGISTER_MIGRAPH(ZL_StandardGraphID_clustering, MIGRAPH_CLUSTERING),
-    REGISTER_DYNAMIC_GRAPH(ZL_StandardGraphID_simple_data_description_language, "!zl.sddl", ZL_Type_serial, ZL_SDDL_dynGraph),
-    REGISTER_SEGMENTER(ZL_StandardGraphID_simple_data_description_language_v2, SEGM_SDDL2_DESC),
-    REGISTER_MIGRAPH(ZL_StandardGraphID_try_parse_int, MIGRAPH_TRY_PARSE_INT),
-    REGISTER_STATIC_GRAPH(ZL_StandardGraphID_lz4, "!zl.lz4", ZL_Type_serial, ZL_PrivateStandardNodeID_lz4, _1_SUCCESSOR(ZL_PrivateStandardGraphID_serial_store)),
-    REGISTER_DYNAMIC_GRAPH(ZL_StandardGraphID_partition_bitpack, "!zl.partition_bitpack", ZL_Type_numeric, EI_partitionBitpackDynGraph),
-    REGISTER_DYNAMIC_GRAPH(ZL_StandardGraphID_ml_selector,"!zl.ml_selector", ZL_Type_numeric, ZL_MLSel_dynGraph),
-    REGISTER_MIGRAPH(ZL_PrivateStandardGraphID_merge_sorted, MIGRAPH_MERGE_SORTED),
-    REGISTER_MIGRAPH(ZL_PrivateStandardGraphID_transpose_split, MIGRAPH_TRANSPOSE_SPLIT),
+    REGISTER_MIGRAPH(ZL_StandardGraphID_store, MIGRAPH_STORE, 200),
+    REGISTER_DYNAMIC_GRAPH(ZL_StandardGraphID_fse, "!zl.fse", ZL_Type_serial, EI_fseDynamicGraph, 200),
+    REGISTER_DYNAMIC_GRAPH(ZL_StandardGraphID_huffman, "!zl.huffman", ZL_Type_serial | ZL_Type_struct | ZL_Type_numeric, EI_huffmanDynamicGraph, 200),
+    REGISTER_DYNAMIC_GRAPH(ZL_StandardGraphID_entropy, "!zl.entropy", ZL_Type_serial | ZL_Type_struct | ZL_Type_numeric, EI_entropyDynamicGraph, 200),
+    REGISTER_SELECTOR(ZL_StandardGraphID_constant, "!zl.constant", SI_selector_constant, ZL_Type_serial | ZL_Type_struct | ZL_Type_numeric, 200),
+    REGISTER_STATIC_GRAPH(ZL_StandardGraphID_zstd, "!zl.zstd", ZL_Type_serial, ZL_PrivateStandardNodeID_zstd, _1_SUCCESSOR(ZL_PrivateStandardGraphID_serial_store), 200 ),
+    REGISTER_SELECTOR(ZL_StandardGraphID_bitpack, "!zl.bitpack", SI_selector_bitpack, ZL_Type_serial | ZL_Type_numeric, 200),
+    REGISTER_STATIC_GRAPH(ZL_StandardGraphID_flatpack, "!zl.flatpack", ZL_Type_serial, ZL_PrivateStandardNodeID_flatpack, _2_SUCCESSORS(ZL_PrivateStandardGraphID_serial_store, ZL_PrivateStandardGraphID_serial_store), 200 ),
+    REGISTER_DYNAMIC_GRAPH(ZL_StandardGraphID_field_lz, "!zl.field_lz", ZL_Type_struct | ZL_Type_numeric, EI_fieldLzDynGraph, 200),
+    REGISTER_DYNAMIC_GRAPH(ZL_StandardGraphID_lz, "!zl.lz", ZL_Type_serial, EI_lzDynGraph, 200),
+    REGISTER_MIGRAPH(ZL_StandardGraphID_compress_generic, MIGRAPH_COMPRESS, 200),
+    REGISTER_SELECTOR(ZL_StandardGraphID_select_generic_lz_backend, "!zl.select_generic_lz_backend", SI_selector_genericLZ, ZL_Type_serial, 200),
+    REGISTER_SEGMENTER(ZL_StandardGraphID_segment_numeric, SEGM_NUMERIC_DESC, 200),
+    REGISTER_STATIC_GRAPH(ZL_PrivateStandardGraphID_interpret_num8_compress,  "!zl.private.interpret_num8_compress",  ZL_Type_serial, ZL_StandardNodeID_convert_serial_to_num8,     _1_SUCCESSOR(ZL_PrivateStandardGraphID_numeric_compress), 200),
+    REGISTER_STATIC_GRAPH(ZL_PrivateStandardGraphID_interpret_num16_compress, "!zl.private.interpret_num16_compress", ZL_Type_serial, ZL_StandardNodeID_convert_serial_to_num_le16, _1_SUCCESSOR(ZL_PrivateStandardGraphID_numeric_compress), 200),
+    REGISTER_STATIC_GRAPH(ZL_PrivateStandardGraphID_interpret_num32_compress, "!zl.private.interpret_num32_compress", ZL_Type_serial, ZL_StandardNodeID_convert_serial_to_num_le32, _1_SUCCESSOR(ZL_PrivateStandardGraphID_numeric_compress), 200),
+    REGISTER_STATIC_GRAPH(ZL_PrivateStandardGraphID_interpret_num64_compress, "!zl.private.interpret_num64_compress", ZL_Type_serial, ZL_StandardNodeID_convert_serial_to_num_le64, _1_SUCCESSOR(ZL_PrivateStandardGraphID_numeric_compress), 200),
+    REGISTER_SEGMENTER(ZL_StandardGraphID_segment_num8_from_serial,  SEGM_NUM_FROM_SERIAL_DESC(1, 8,  ZL_PrivateStandardGraphID_interpret_num8_compress), 200),
+    REGISTER_SEGMENTER(ZL_StandardGraphID_segment_num16_from_serial, SEGM_NUM_FROM_SERIAL_DESC(2, 16, ZL_PrivateStandardGraphID_interpret_num16_compress), 200),
+    REGISTER_SEGMENTER(ZL_StandardGraphID_segment_num32_from_serial, SEGM_NUM_FROM_SERIAL_DESC(4, 32, ZL_PrivateStandardGraphID_interpret_num32_compress), 200),
+    REGISTER_SEGMENTER(ZL_StandardGraphID_segment_num64_from_serial, SEGM_NUM_FROM_SERIAL_DESC(8, 64, ZL_PrivateStandardGraphID_interpret_num64_compress), 200),
+    REGISTER_SEGMENTER(ZL_StandardGraphID_segment_serial, SEGM_SERIAL_DESC, 200),
+    REGISTER_SELECTOR(ZL_StandardGraphID_select_numeric, "!zl.select_numeric", SI_selector_numeric, ZL_Type_numeric, 200),
+    REGISTER_MIGRAPH(ZL_StandardGraphID_clustering, MIGRAPH_CLUSTERING, 200),
+    REGISTER_DYNAMIC_GRAPH(ZL_StandardGraphID_simple_data_description_language, "!zl.sddl", ZL_Type_serial, ZL_SDDL_dynGraph, 200),
+    REGISTER_SEGMENTER(ZL_StandardGraphID_simple_data_description_language_v2, SEGM_SDDL2_DESC, 200),
+    REGISTER_MIGRAPH(ZL_StandardGraphID_try_parse_int, MIGRAPH_TRY_PARSE_INT, 200),
+    REGISTER_STATIC_GRAPH(ZL_StandardGraphID_lz4, "!zl.lz4", ZL_Type_serial, ZL_PrivateStandardNodeID_lz4, _1_SUCCESSOR(ZL_PrivateStandardGraphID_serial_store), 200),
+    REGISTER_DYNAMIC_GRAPH(ZL_StandardGraphID_partition_bitpack, "!zl.partition_bitpack", ZL_Type_numeric, EI_partitionBitpackDynGraph, 200),
+    REGISTER_DYNAMIC_GRAPH(ZL_StandardGraphID_ml_selector,"!zl.ml_selector", ZL_Type_numeric, ZL_MLSel_dynGraph, 200),
+    REGISTER_MIGRAPH(ZL_PrivateStandardGraphID_merge_sorted, MIGRAPH_MERGE_SORTED, 200),
+    REGISTER_MIGRAPH(ZL_PrivateStandardGraphID_transpose_split, MIGRAPH_TRANSPOSE_SPLIT, 200),
 
     // Private graphs
-    REGISTER_SELECTOR(ZL_PrivateStandardGraphID_store1, "!zl.private.store1", SI_selector_store, ZL_Type_any),
-    REGISTER_STATIC_GRAPH(ZL_PrivateStandardGraphID_string_store, "!zl.private.string_store", ZL_Type_string, ZL_StandardNodeID_separate_string_components, _2_SUCCESSORS(ZL_PrivateStandardGraphID_serial_store, ZL_PrivateStandardGraphID_serial_store) ),
+    REGISTER_SELECTOR(ZL_PrivateStandardGraphID_store1, "!zl.private.store1", SI_selector_store, ZL_Type_any, 200),
+    REGISTER_STATIC_GRAPH(ZL_PrivateStandardGraphID_string_store, "!zl.private.string_store", ZL_Type_string, ZL_StandardNodeID_separate_string_components, _2_SUCCESSORS(ZL_PrivateStandardGraphID_serial_store, ZL_PrivateStandardGraphID_serial_store), 200 ),
 
-    REGISTER_SELECTOR(ZL_PrivateStandardGraphID_compress1, "!zl.private.compress2", SI_selector_compress, ZL_Type_any),
-    REGISTER_SELECTOR(ZL_PrivateStandardGraphID_serial_compress, "!zl.private.serial_compress", SI_selector_compress_serial, ZL_Type_serial),
-    REGISTER_SELECTOR(ZL_PrivateStandardGraphID_struct_compress, "!zl.private.struct_compress", SI_selector_compress_struct, ZL_Type_struct),
-    REGISTER_SELECTOR(ZL_PrivateStandardGraphID_numeric_compress, "!zl.private.numeric_compress", SI_selector_compress_numeric, ZL_Type_numeric),
-    REGISTER_SELECTOR(ZL_PrivateStandardGraphID_string_compress, "!zl.private.string_compress", SI_selector_compress_string, ZL_Type_string),
-    REGISTER_STATIC_GRAPH(ZL_PrivateStandardGraphID_string_separate_compress, "!zl.private.string_separate_compress", ZL_Type_string, ZL_StandardNodeID_separate_string_components, _2_SUCCESSORS(ZL_PrivateStandardGraphID_serial_compress, ZL_PrivateStandardGraphID_numeric_compress) ),
+    REGISTER_SELECTOR(ZL_PrivateStandardGraphID_compress1, "!zl.private.compress2", SI_selector_compress, ZL_Type_any, 200),
+    REGISTER_SELECTOR(ZL_PrivateStandardGraphID_serial_compress, "!zl.private.serial_compress", SI_selector_compress_serial, ZL_Type_serial, 200),
+    REGISTER_SELECTOR(ZL_PrivateStandardGraphID_struct_compress, "!zl.private.struct_compress", SI_selector_compress_struct, ZL_Type_struct, 200),
+    REGISTER_SELECTOR(ZL_PrivateStandardGraphID_numeric_compress, "!zl.private.numeric_compress", SI_selector_compress_numeric, ZL_Type_numeric, 200),
+    REGISTER_SELECTOR(ZL_PrivateStandardGraphID_string_compress, "!zl.private.string_compress", SI_selector_compress_string, ZL_Type_string, 200),
+    REGISTER_STATIC_GRAPH(ZL_PrivateStandardGraphID_string_separate_compress, "!zl.private.string_separate_compress", ZL_Type_string, ZL_StandardNodeID_separate_string_components, _2_SUCCESSORS(ZL_PrivateStandardGraphID_serial_compress, ZL_PrivateStandardGraphID_numeric_compress), 200 ),
 
-    REGISTER_STATIC_GRAPH(ZL_PrivateStandardGraphID_bitpack_serial, "!zl.private.bitpack_serial", ZL_Type_serial, ZL_PrivateStandardNodeID_bitpack_serial, _1_SUCCESSOR(ZL_PrivateStandardGraphID_serial_store) ),
-    REGISTER_STATIC_GRAPH(ZL_PrivateStandardGraphID_bitpack_int, "!zl.private.bitpack_int", ZL_Type_numeric, ZL_PrivateStandardNodeID_bitpack_int, _1_SUCCESSOR(ZL_PrivateStandardGraphID_serial_store) ),
+    REGISTER_STATIC_GRAPH(ZL_PrivateStandardGraphID_bitpack_serial, "!zl.private.bitpack_serial", ZL_Type_serial, ZL_PrivateStandardNodeID_bitpack_serial, _1_SUCCESSOR(ZL_PrivateStandardGraphID_serial_store), 200 ),
+    REGISTER_STATIC_GRAPH(ZL_PrivateStandardGraphID_bitpack_int, "!zl.private.bitpack_int", ZL_Type_numeric, ZL_PrivateStandardNodeID_bitpack_int, _1_SUCCESSOR(ZL_PrivateStandardGraphID_serial_store), 200 ),
 
-    REGISTER_STATIC_GRAPH(ZL_PrivateStandardGraphID_constant_serial, "!zl.private.constant_serial", ZL_Type_serial, ZL_PrivateStandardNodeID_constant_serial, _1_SUCCESSOR(ZL_PrivateStandardGraphID_serial_store) ),
-    REGISTER_STATIC_GRAPH(ZL_PrivateStandardGraphID_constant_fixed, "!zl.private.constant_fixed", ZL_Type_struct, ZL_PrivateStandardNodeID_constant_fixed, _1_SUCCESSOR(ZL_PrivateStandardGraphID_serial_store) ),
+    REGISTER_STATIC_GRAPH(ZL_PrivateStandardGraphID_constant_serial, "!zl.private.constant_serial", ZL_Type_serial, ZL_PrivateStandardNodeID_constant_serial, _1_SUCCESSOR(ZL_PrivateStandardGraphID_serial_store), 200 ),
+    REGISTER_STATIC_GRAPH(ZL_PrivateStandardGraphID_constant_fixed, "!zl.private.constant_fixed", ZL_Type_struct, ZL_PrivateStandardNodeID_constant_fixed, _1_SUCCESSOR(ZL_PrivateStandardGraphID_serial_store), 200 ),
 
-    REGISTER_STATIC_GRAPH(ZL_PrivateStandardGraphID_fse_ncount, "!zl.private.fse_ncount", ZL_Type_numeric, ZL_PrivateStandardNodeID_fse_ncount, _1_SUCCESSOR(ZL_PrivateStandardGraphID_serial_store) ),
+    REGISTER_STATIC_GRAPH(ZL_PrivateStandardGraphID_fse_ncount, "!zl.private.fse_ncount", ZL_Type_numeric, ZL_PrivateStandardNodeID_fse_ncount, _1_SUCCESSOR(ZL_PrivateStandardGraphID_serial_store), 200 ),
 
-    REGISTER_DYNAMIC_GRAPH(ZL_PrivateStandardGraphID_field_lz_literals, "!zl.private.field_lz_literals", ZL_Type_struct, EI_fieldLzLiteralsDynGraph),
-    REGISTER_SELECTOR(ZL_PrivateStandardGraphID_field_lz_literals_channel, "!zl.private.field_lz_literals_channel", SI_fieldLzLiteralsChannelSelector, ZL_Type_serial),
+    REGISTER_DYNAMIC_GRAPH(ZL_PrivateStandardGraphID_field_lz_literals, "!zl.private.field_lz_literals", ZL_Type_struct, EI_fieldLzLiteralsDynGraph, 200),
+    REGISTER_SELECTOR(ZL_PrivateStandardGraphID_field_lz_literals_channel, "!zl.private.field_lz_literals_channel", SI_fieldLzLiteralsChannelSelector, ZL_Type_serial, 200),
 
-    REGISTER_STATIC_GRAPH(ZL_PrivateStandardGraphID_delta_huffman_internal, "!zl.private.delta_huffman_internal", ZL_Type_numeric, ZL_StandardNodeID_delta_int, _1_SUCCESSOR(ZL_StandardGraphID_huffman) ),
-    REGISTER_STATIC_GRAPH(ZL_PrivateStandardGraphID_delta_flatpack_internal, "!zl.private.flatpack_internal", ZL_Type_numeric, ZL_StandardNodeID_delta_int, _1_SUCCESSOR(ZL_StandardGraphID_flatpack) ),
-    REGISTER_STATIC_GRAPH(ZL_PrivateStandardGraphID_delta_zstd_internal, "!zl.private.zstd_internal", ZL_Type_numeric, ZL_StandardNodeID_delta_int, _1_SUCCESSOR(ZL_StandardGraphID_zstd) ),
+    REGISTER_STATIC_GRAPH(ZL_PrivateStandardGraphID_delta_huffman_internal, "!zl.private.delta_huffman_internal", ZL_Type_numeric, ZL_StandardNodeID_delta_int, _1_SUCCESSOR(ZL_StandardGraphID_huffman), 200 ),
+    REGISTER_STATIC_GRAPH(ZL_PrivateStandardGraphID_delta_flatpack_internal, "!zl.private.flatpack_internal", ZL_Type_numeric, ZL_StandardNodeID_delta_int, _1_SUCCESSOR(ZL_StandardGraphID_flatpack), 200 ),
+    REGISTER_STATIC_GRAPH(ZL_PrivateStandardGraphID_delta_zstd_internal, "!zl.private.zstd_internal", ZL_Type_numeric, ZL_StandardNodeID_delta_int, _1_SUCCESSOR(ZL_StandardGraphID_zstd), 200 ),
 
-    REGISTER_STATIC_GRAPH(ZL_PrivateStandardGraphID_delta_huffman, "!zl.private.delta_huffman", ZL_Type_serial, ZL_StandardNodeID_convert_serial_to_num8, _1_SUCCESSOR(ZL_PrivateStandardGraphID_delta_huffman_internal) ),
-    REGISTER_STATIC_GRAPH(ZL_PrivateStandardGraphID_delta_flatpack, "!zl.private.delta_flatpack", ZL_Type_serial, ZL_StandardNodeID_convert_serial_to_num8, _1_SUCCESSOR(ZL_PrivateStandardGraphID_delta_flatpack_internal) ),
-    REGISTER_STATIC_GRAPH(ZL_PrivateStandardGraphID_delta_zstd, "!zl.private.delta_zstd", ZL_Type_serial, ZL_StandardNodeID_convert_serial_to_num8, _1_SUCCESSOR(ZL_PrivateStandardGraphID_delta_zstd_internal) ),
+    REGISTER_STATIC_GRAPH(ZL_PrivateStandardGraphID_delta_huffman, "!zl.private.delta_huffman", ZL_Type_serial, ZL_StandardNodeID_convert_serial_to_num8, _1_SUCCESSOR(ZL_PrivateStandardGraphID_delta_huffman_internal), 200 ),
+    REGISTER_STATIC_GRAPH(ZL_PrivateStandardGraphID_delta_flatpack, "!zl.private.delta_flatpack", ZL_Type_serial, ZL_StandardNodeID_convert_serial_to_num8, _1_SUCCESSOR(ZL_PrivateStandardGraphID_delta_flatpack_internal), 200 ),
+    REGISTER_STATIC_GRAPH(ZL_PrivateStandardGraphID_delta_zstd, "!zl.private.delta_zstd", ZL_Type_serial, ZL_StandardNodeID_convert_serial_to_num8, _1_SUCCESSOR(ZL_PrivateStandardGraphID_delta_zstd_internal), 200 ),
 
-    REGISTER_STATIC_GRAPH(ZL_PrivateStandardGraphID_delta_field_lz, "!zl.private.delta_field_lz", ZL_Type_numeric, ZL_StandardNodeID_delta_int, _1_SUCCESSOR(ZL_StandardGraphID_field_lz) ),
-    REGISTER_STATIC_GRAPH(ZL_PrivateStandardGraphID_range_pack, "!zl.private.range_pack", ZL_Type_numeric, ZL_StandardNodeID_range_pack, _1_SUCCESSOR(ZL_StandardGraphID_field_lz) ),
-    REGISTER_STATIC_GRAPH(ZL_PrivateStandardGraphID_range_pack_zstd, "!zl.private.range_pack_zstd", ZL_Type_numeric, ZL_StandardNodeID_range_pack, _1_SUCCESSOR(ZL_StandardGraphID_zstd) ),
-    REGISTER_STATIC_GRAPH(ZL_PrivateStandardGraphID_tokenize_delta_field_lz, "!zl.private.tokenize_delta_field_lz", ZL_Type_numeric, ZL_PrivateStandardNodeID_tokenize_sorted, _2_SUCCESSORS(ZL_PrivateStandardGraphID_delta_field_lz, ZL_StandardGraphID_field_lz) ),
+    REGISTER_STATIC_GRAPH(ZL_PrivateStandardGraphID_delta_field_lz, "!zl.private.delta_field_lz", ZL_Type_numeric, ZL_StandardNodeID_delta_int, _1_SUCCESSOR(ZL_StandardGraphID_field_lz), 200 ),
+    REGISTER_STATIC_GRAPH(ZL_PrivateStandardGraphID_range_pack, "!zl.private.range_pack", ZL_Type_numeric, ZL_StandardNodeID_range_pack, _1_SUCCESSOR(ZL_StandardGraphID_field_lz), 200 ),
+    REGISTER_STATIC_GRAPH(ZL_PrivateStandardGraphID_range_pack_zstd, "!zl.private.range_pack_zstd", ZL_Type_numeric, ZL_StandardNodeID_range_pack, _1_SUCCESSOR(ZL_StandardGraphID_zstd), 200 ),
+    REGISTER_STATIC_GRAPH(ZL_PrivateStandardGraphID_tokenize_delta_field_lz, "!zl.private.tokenize_delta_field_lz", ZL_Type_numeric, ZL_PrivateStandardNodeID_tokenize_sorted, _2_SUCCESSORS(ZL_PrivateStandardGraphID_delta_field_lz, ZL_StandardGraphID_field_lz), 200 ),
 
-    REGISTER_DYNAMIC_GRAPH(ZL_PrivateStandardGraphID_split_serial, "!zl.private.split_serial", ZL_Type_serial, ZL_splitFnGraph),
-    REGISTER_DYNAMIC_GRAPH(ZL_PrivateStandardGraphID_split_struct, "!zl.private.split_struct", ZL_Type_struct, ZL_splitFnGraph),
-    REGISTER_DYNAMIC_GRAPH(ZL_PrivateStandardGraphID_split_numeric, "!zl.private.split_numeric", ZL_Type_numeric, ZL_splitFnGraph),
-    REGISTER_DYNAMIC_GRAPH(ZL_PrivateStandardGraphID_split_string, "!zl.private.split_string", ZL_Type_string, ZL_splitFnGraph),
-    REGISTER_DYNAMIC_GRAPH(ZL_PrivateStandardGraphID_sddl2_chunk, "!zl.private.sddl2_chunk", ZL_Type_serial, SDDL2_replayChunk),
+    REGISTER_DYNAMIC_GRAPH(ZL_PrivateStandardGraphID_split_serial, "!zl.private.split_serial", ZL_Type_serial, ZL_splitFnGraph, 200),
+    REGISTER_DYNAMIC_GRAPH(ZL_PrivateStandardGraphID_split_struct, "!zl.private.split_struct", ZL_Type_struct, ZL_splitFnGraph, 200),
+    REGISTER_DYNAMIC_GRAPH(ZL_PrivateStandardGraphID_split_numeric, "!zl.private.split_numeric", ZL_Type_numeric, ZL_splitFnGraph, 200),
+    REGISTER_DYNAMIC_GRAPH(ZL_PrivateStandardGraphID_split_string, "!zl.private.split_string", ZL_Type_string, ZL_splitFnGraph, 200),
+    REGISTER_DYNAMIC_GRAPH(ZL_PrivateStandardGraphID_sddl2_chunk, "!zl.private.sddl2_chunk", ZL_Type_serial, SDDL2_replayChunk, 200),
 
-    REGISTER_MIGRAPH(ZL_PrivateStandardGraphID_n_to_n, MIGRAPH_N_TO_N),
+    REGISTER_MIGRAPH(ZL_PrivateStandardGraphID_n_to_n, MIGRAPH_N_TO_N, 200),
     
-    REGISTER_DYNAMIC_GRAPH(ZL_PrivateStandardGraphID_compress_small_lengths, "!zl.compress_small_lengths", ZL_Type_numeric, ZL_compressSmallLengthsGraph),
+    REGISTER_DYNAMIC_GRAPH(ZL_PrivateStandardGraphID_compress_small_lengths, "!zl.compress_small_lengths", ZL_Type_numeric, ZL_compressSmallLengthsGraph, 200),
 };
 // clang-format on
 

--- a/src/openzl/compress/graph_registry.h
+++ b/src/openzl/compress/graph_registry.h
@@ -52,6 +52,10 @@ typedef struct {
     /// This field records that reference to the graph from which this graph
     /// was created. Set to ZL_GRAPH_ILLEGAL when there is no such graph.
     ZL_GraphID baseGraphID;
+    /// The minimum library version required for compressor deserializers to
+    /// recognize this graph and use this component for compression in the
+    /// expected manner.
+    unsigned minLibraryVersion;
 } Graph_Desc_internal;
 
 typedef struct {

--- a/tests/zstrong/test_reflection.cpp
+++ b/tests/zstrong/test_reflection.cpp
@@ -2,9 +2,16 @@
 
 #include <gtest/gtest.h>
 
+#include "openzl/codecs/encoder_registry.h"
+#include "openzl/codecs/zl_delta.h"
+#include "openzl/codecs/zl_field_lz.h"
+#include "openzl/codecs/zl_store.h"
+#include "openzl/codecs/zl_zstd.h"
 #include "openzl/common/assertion.h"
 #include "openzl/common/errors_internal.h"
 #include "openzl/common/wire_format.h"
+#include "openzl/compress/graph_registry.h"
+#include "openzl/compress/private_nodes.h"
 #include "openzl/zl_compress.h"
 #include "openzl/zl_compressor.h"
 #include "openzl/zl_reflection.h"
@@ -142,4 +149,60 @@ TEST_F(ReflectionTest, Conversion)
     const auto storedStream =
             ZL_ReflectionCtx_getStoredOutput_lastChunk(rctx_, 0u);
     ASSERT_EQ(streamContent(storedStream), "01234567");
+}
+
+TEST(VersionGetterTest, GraphVersionSucceedsForAllStandardGraphs)
+{
+    size_t nbGraphs = GR_getNbStandardGraphs();
+    std::vector<ZL_GraphID> graphs(nbGraphs);
+    GR_getAllStandardGraphIDs(graphs.data(), graphs.size());
+
+    for (const auto& gid : graphs) {
+        ZL_Report report =
+                ZL_Compressor_Graph_getMinLibraryVersion(nullptr, gid);
+        EXPECT_FALSE(ZL_isError(report))
+                << "Expected success for standard graph ID " << gid.gid;
+    }
+}
+
+TEST(VersionGetterTest,
+     GraphVersionReturnsParameterInvalidForOutOfBoundsGraphID)
+{
+    ZL_GraphID invalid = { .gid = 99999 };
+    ZL_Report report =
+            ZL_Compressor_Graph_getMinLibraryVersion(nullptr, invalid);
+    EXPECT_TRUE(ZL_isError(report));
+    EXPECT_EQ(ZL_errorCode(report), ZL_ErrorCode_parameter_invalid);
+}
+
+TEST(VersionGetterTest, NodeVersionSucceedsForAllStandardNodes)
+{
+    size_t nbNodes = ER_getNbStandardNodes();
+    std::vector<ZL_NodeID> nodes(nbNodes);
+    ER_getAllStandardNodeIDs(nodes.data(), nodes.size());
+
+    for (const auto& nid : nodes) {
+        ZL_Report report =
+                ZL_Compressor_Node_getMinLibraryVersion(nullptr, nid);
+        EXPECT_FALSE(ZL_isError(report))
+                << "Expected success for standard node ID " << nid.nid;
+    }
+}
+
+TEST(VersionGetterTest, NodeVersionReturnsParameterInvalidForOutOfBoundsID)
+{
+    ZL_NodeID invalid = { .nid = 99999 };
+    ZL_Report report =
+            ZL_Compressor_Node_getMinLibraryVersion(nullptr, invalid);
+    EXPECT_TRUE(ZL_isError(report));
+    EXPECT_EQ(ZL_errorCode(report), ZL_ErrorCode_parameter_invalid);
+}
+
+TEST(VersionGetterTest, NodeVersionReturnsNodeInvalidForIllegalNode)
+{
+    ZL_NodeID illegal = ZL_NODE_ILLEGAL;
+    ZL_Report report =
+            ZL_Compressor_Node_getMinLibraryVersion(nullptr, illegal);
+    EXPECT_TRUE(ZL_isError(report));
+    EXPECT_EQ(ZL_errorCode(report), ZL_ErrorCode_node_invalid);
 }


### PR DESCRIPTION
Summary:

This diff adds a required field `reqLibraryVersion` to  `Graph_Desc_internal` and `CNode` inside the graph and node registries. To provide and retrieve these values respectively:
- Updated macro definitions to require a version, and all uses of the macro to have version 200 (the current library version).
- Added `ZL_Compressor_Node_getRequiredLibraryVersion `and `ZL_Compressor_getRequiredLibraryVersion` are added to retrieve the required library version for a given graph or node.

The next diffs in the stack addresses the changes in compressor deserialization based on versioning and adds a markdown describing the policy for updating library versions of graphs and codecs.

Reviewed By: terrelln

Differential Revision: D102239347


