### PR TITLE
Mark unused code in builds with attribute (#748)

### DIFF
--- a/src/openzl/codecs/partition/decode_partition_bitpack_fusion.c
+++ b/src/openzl/codecs/partition/decode_partition_bitpack_fusion.c
@@ -11,13 +11,16 @@
 #include "openzl/shared/numeric_operations.h"
 #include "openzl/zl_input.h"
 #include "openzl/zl_output.h"
+#include "openzl/zl_portability.h"
 
 // ---------------------------------------------------------------------------
 // LUT builders: expand per-bucket base/mask arrays into packed 2-element LUTs
 // ---------------------------------------------------------------------------
 
 /// Build expanded LUT for nbBits=4: 2^4=16 raw entries -> 2^8=256 expanded.
-static void expandLUT4(const uint16_t* LUTx1, uint32_t LUTx2[256])
+ZL_UNUSED_ATTR static void expandLUT4(
+        const uint16_t* LUTx1,
+        uint32_t LUTx2[256])
 {
     for (size_t idx = 0; idx < 256; ++idx) {
         const size_t lo = idx & 0xF;
@@ -27,7 +30,9 @@ static void expandLUT4(const uint16_t* LUTx1, uint32_t LUTx2[256])
 }
 
 /// Build expanded LUT for nbBits=5: 2^5=32 raw entries -> 2^10=1024 expanded.
-static void expandLUT5(const uint16_t* LUTx1, uint32_t LUTx2[1024])
+ZL_UNUSED_ATTR static void expandLUT5(
+        const uint16_t* LUTx1,
+        uint32_t LUTx2[1024])
 {
     for (size_t idx = 0; idx < 1024; ++idx) {
         const size_t lo = idx & 31;

--- a/src/openzl/codecs/rolz/decode_fast_dec.c
+++ b/src/openzl/codecs/rolz/decode_fast_dec.c
@@ -134,7 +134,7 @@ static ZL_MAYBE_UNUSED_FUNCTION void dpr16(
 
 #    define _ 0xFF
 // clang-format off
-static uint8_t const ZL_ALIGNED(16) ZL_UNUSED shuffle[8][16] = {
+static uint8_t const ZL_ALIGNED(16) ZL_UNUSED_ATTR shuffle[8][16] = {
   { 0x00, 0x01, 0x02, 0x03, 0x00, 0x01, 0x02, 0x03, 0x00, 0x01, 0x02, 0x03, _, _, _, _ }, // 000
   { 0x04, 0x05, 0x06, 0x07, 0x04, 0x05, 0x06, 0x07, 0x04, 0x05, 0x06, 0x07, _, _, _, _ }, // 001
   { 0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x04, 0x05, 0x06, 0x07, _, _, _, _ }, // 010
@@ -147,7 +147,7 @@ static uint8_t const ZL_ALIGNED(16) ZL_UNUSED shuffle[8][16] = {
 
 #undef _
 #define _ 9
-static ZL_ALIGNED(32) int32_t const shuffle7[128][8] ZL_UNUSED  = {
+static ZL_ALIGNED(32) int32_t const shuffle7[128][8] ZL_UNUSED_ATTR  = {
   { 0, 0, 0, 0, 0, 0, 0, _ }, // 0000000
   { 1, 1, 1, 1, 1, 1, 1, _ }, // 1000000
   { 0, 1, 1, 1, 1, 1, 1, _ }, // 0100000

--- a/src/openzl/shared/clustering_compress.c
+++ b/src/openzl/shared/clustering_compress.c
@@ -3,7 +3,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include "openzl/shared/clustering.h"
-#include "openzl/shared/portability.h" // ZL_UNUSED
+#include "openzl/shared/portability.h" // ZL_UNUSED_ATTR
 
 #define kDumpGraph 1
 #define kGraphFile "clustering.dot"
@@ -182,7 +182,7 @@ static int64_t ZS_combineLoss(
     return combinedCost - separateCost;
 }
 
-static ZL_UNUSED void
+static ZL_UNUSED_ATTR void
 ZS_Histogram_compute(ZL_Histogram* hist, uint32_t maxSymbol, ZL_RC src)
 {
     uint8_t const* const ip = ZL_RC_ptr(&src);

--- a/src/openzl/shared/data_stats.c
+++ b/src/openzl/shared/data_stats.c
@@ -5,7 +5,7 @@
 #include "openzl/shared/bits.h"
 #include "openzl/shared/data_stats.h"
 #include "openzl/shared/histogram.h"
-#include "openzl/shared/portability.h" // ZL_UNUSED
+#include "openzl/shared/portability.h" // ZL_UNUSED_ATTR
 #include "openzl/shared/utils.h"
 #include "openzl/shared/varint.h"
 
@@ -209,7 +209,7 @@ unsigned int const* DataStatsU8_getHistogram(DataStatsU8* stats)
     RETURN_OR_CALC_LAZY(stats, histogram, DataStatsU8_calcHistogram(stats));
 }
 
-static ZL_UNUSED void DataStatsU8_calcDeltaHistogram(DataStatsU8* stats)
+static ZL_UNUSED_ATTR void DataStatsU8_calcDeltaHistogram(DataStatsU8* stats)
 {
     if (!stats->histogramInitialized) {
         DataStatsU8_calcHistograms(stats);

--- a/tests/codecs/test_sddl.cpp
+++ b/tests/codecs/test_sddl.cpp
@@ -6,6 +6,7 @@
 
 #include "openzl/compress/graphs/sddl/simple_data_description_language.h"
 #include "openzl/compress/graphs/sddl/simple_data_description_language_source_code.h"
+#include "openzl/zl_portability.h"
 
 #include "openzl/zl_reflection.h"
 
@@ -62,7 +63,9 @@ std::string iota(size_t len)
     return ret;
 }
 
-std::ostream& operator<<(std::ostream& os, const ZL_SDDL_Instructions& instrs)
+ZL_UNUSED_ATTR std::ostream& operator<<(
+        std::ostream& os,
+        const ZL_SDDL_Instructions& instrs)
 {
     static const std::map<ZL_Type, const char*> zl_type_names{
         { ZL_Type_serial, "ZL_Type_serial" },

--- a/tests/compress/graphs/sddl2/utils.h
+++ b/tests/compress/graphs/sddl2/utils.h
@@ -17,6 +17,7 @@
 #include "openzl/zl_config.h"
 #include "openzl/zl_graph_api.h"
 #include "openzl/zl_input.h"
+#include "openzl/zl_portability.h"
 
 namespace openzl {
 namespace sddl2 {
@@ -168,7 +169,7 @@ inline SDDL2_Error popValue(SDDL2_Stack* stack, SDDL2_Value* out)
     return SDDL2_OK;
 }
 
-static void popAndVerifyI64(SDDL2_Stack* stack, int64_t expected)
+ZL_UNUSED_ATTR static void popAndVerifyI64(SDDL2_Stack* stack, int64_t expected)
 {
     SDDL2_Value result;
     ASSERT_EQ(popValue(stack, &result), SDDL2_OK);

--- a/tests/round_trip/test_segmenter.cpp
+++ b/tests/round_trip/test_segmenter.cpp
@@ -24,6 +24,7 @@
 #include "openzl/zl_graph_api.h"  // ZL_FunctionGraphDesc
 #include "openzl/zl_input.h"
 #include "openzl/zl_opaque_types.h"
+#include "openzl/zl_portability.h"
 #include "openzl/zl_segmenter.h"
 #include "openzl/zl_selector.h"
 #include "openzl/zl_version.h" // ZL_MIN_FORMAT_VERSION
@@ -239,7 +240,9 @@ static ZL_GraphID permissiveGraph_asGraphF(ZL_Compressor* cgraph) noexcept
     return permissiveGraph(cgraph, g_failingGraph_forPermissive);
 }
 
-static size_t permissiveTest(ZL_GraphFn graphf, const char* testName)
+ZL_UNUSED_ATTR static size_t permissiveTest(
+        ZL_GraphFn graphf,
+        const char* testName)
 {
     printf("\n=========================== \n");
     printf(" Testing Permissive Mode \n");
@@ -347,7 +350,8 @@ PARSER_Result PARSER_analyzeChunk(PARSER_State* ps, const ZL_Input* input)
  * in this case it justs check that it received the expected value.
  * Input: Same as Segmenter ==> 1 Serial stream
  */
-ZL_Report test_PrivateGraphFn(ZL_Graph* graph, const void* payload)
+ZL_UNUSED_ATTR ZL_Report
+test_PrivateGraphFn(ZL_Graph* graph, const void* payload)
 {
     ZL_RESULT_DECLARE_SCOPE_REPORT(graph);
     PARSER_State ps = *(const PARSER_State*)payload;

--- a/tests/unittest/common/test_bitstream.cpp
+++ b/tests/unittest/common/test_bitstream.cpp
@@ -11,6 +11,7 @@
 #include "openzl/codecs/common/bitstream/ff_bitstream.h"
 #include "openzl/fse/bitstream.h"
 #include "openzl/zl_errors.h"
+#include "openzl/zl_portability.h"
 #include "tests/utils.h"
 
 namespace openzl {
@@ -547,7 +548,7 @@ void printResults(std::string name, std::function<BenchmarkResult()> bm)
     fprintf(stderr, "\n");
 }
 
-void benchmark(int argc, char** argv)
+ZL_UNUSED_ATTR void benchmark(int argc, char** argv)
 {
     (void)argc, (void)argv;
     auto zsBm = [](size_t maxBits) {


### PR DESCRIPTION
Summary:

Uses attributes to prevent build errors. Also move existing uses cases if `ZL_UNUSED` to `ZL_UNUSED_ATTR` as it is the dominant pattern in OpenZL.

Reviewed By: terrelln

Differential Revision: D104729484


