### PR TITLE
openzl: serialization_opts.dtoa_flags → .float_format

### DIFF
--- a/tools/BUCK
+++ b/tools/BUCK
@@ -43,7 +43,7 @@ zs_cxxlibrary(
     headers = ["zstrong_ml.h"],
     compiler_flags = ["-Wno-float-equal"],
     strict_conversions = False,
-    deps = ["//folly:base64"],
+    deps = [],
     exported_deps = [
         "gbt_predictor:zstrong_gbt_predictor",
         ":zstrong_cpp",

--- a/tools/zstrong_ml.cpp
+++ b/tools/zstrong_ml.cpp
@@ -540,8 +540,7 @@ folly::dynamic MLTrainingSample::toDynamic() const
 std::string MLTrainingSample::toJson() const
 {
     folly::json::serialization_opts opts;
-    opts.dtoa_flags = folly::DtoaFlags::EMIT_TRAILING_DECIMAL_POINT
-            | folly::DtoaFlags::EMIT_TRAILING_ZERO_AFTER_POINT;
+    opts.float_format = folly::json::FloatFormat::SHORTEST_TRAILING_DOT_ZERO;
 
     return folly::json::serialize(toDynamic(), opts);
 }
@@ -568,8 +567,7 @@ std::string MLTrainingSamplesToJson(
     }
 
     folly::json::serialization_opts opts;
-    opts.dtoa_flags = folly::DtoaFlags::EMIT_TRAILING_DECIMAL_POINT
-            | folly::DtoaFlags::EMIT_TRAILING_ZERO_AFTER_POINT;
+    opts.float_format = folly::json::FloatFormat::SHORTEST_TRAILING_DOT_ZERO;
     return folly::json::serialize(array, opts);
 }
 


### PR DESCRIPTION
Summary: Both prod/dev copies of zstrong_ml.cpp had `opts.dtoa_flags = EMIT_TRAILING_DECIMAL_POINT | EMIT_TRAILING_ZERO_AFTER_POINT` set in two functions each. Migrate all four sites to `opts.float_format = folly::json::FloatFormat::SHORTEST_TRAILING_DOT_ZERO`. Same fmt::format_to("{:#}", v) dispatch — behavior identical (D104712333).

Reviewed By: terrelln

Differential Revision: D104716183


