### PR TITLE
move public training API to return a TrainedCandidate struct

### DIFF
--- a/cli/commands/cmd_train.cpp
+++ b/cli/commands/cmd_train.cpp
@@ -86,9 +86,8 @@ int cmdTrain(const TrainArgs& args)
     Logger::log(INFO, "Benchmarking untrained compressor...");
     auto untrainedBenchmark = runCompressionBenchmarks(benchmarkArgs);
 
-    std::vector<std::shared_ptr<const std::string_view>>
-            serializedTrainedCompressors = openzl::training::train(
-                    benchmarkArgs.inputs, *args.compressor(), args.trainParams);
+    auto serializedTrainedCompressors = openzl::training::train(
+            benchmarkArgs.inputs, *args.compressor(), args.trainParams);
 
     poly::optional<tools::io::OutputFile> resultsCsv;
     if (args.trainParams.paretoFrontier) {
@@ -111,7 +110,7 @@ int cmdTrain(const TrainArgs& args)
         // Benchmark the trained compressor
         benchmarkArgs.setCompressor(
                 custom_parsers::createCompressorFromSerialized(
-                        *serializedTrainedCompressor));
+                        serializedTrainedCompressor.serializedCompressor));
         if (!args.trainParams.paretoFrontier) {
             Logger::log(INFO, "Benchmarking trained compressor...");
         }
@@ -142,14 +141,15 @@ int cmdTrain(const TrainArgs& args)
                     + std::to_string(i) + ".zc";
             auto output = tools::io::OutputFile(std::move(outputFilename));
             output.open();
-            output.write(*serializedTrainedCompressor);
+            output.write(serializedTrainedCompressor.serializedCompressor);
             output.close();
         } else {
             if (i != 0) {
                 throw std::logic_error("Must only have one trained compressor");
             }
             // Output file is already open
-            args.output->write(*serializedTrainedCompressor);
+            args.output->write(
+                    serializedTrainedCompressor.serializedCompressor);
             args.output->close();
         }
     }

--- a/contrib/lz-research/Compressor.cpp
+++ b/contrib/lz-research/Compressor.cpp
@@ -814,7 +814,8 @@ nlohmann::json OpenZLCompressor::train(
 
     nlohmann::json out = nlohmann::json::array();
     for (size_t idx = 0; idx < compressors.size(); ++idx) {
-        out.push_back(makeConfig(std::to_string(idx), *compressors[idx]));
+        out.push_back(makeConfig(
+                std::to_string(idx), compressors[idx].serializedCompressor));
     }
 
     return out;

--- a/contrib/openzl-demo/ext/openzl_demo.cpp
+++ b/contrib/openzl-demo/ext/openzl_demo.cpp
@@ -58,8 +58,8 @@ std::vector<nb::bytes> train(
     result.reserve(trainedCompressors.size());
     for (const auto& trainedCompressor : trainedCompressors) {
         result.emplace_back(
-                (const uint8_t*)trainedCompressor->data(),
-                trainedCompressor->size());
+                (const uint8_t*)trainedCompressor.serializedCompressor.data(),
+                trainedCompressor.serializedCompressor.size());
     }
     return result;
 }

--- a/examples/training.cpp
+++ b/examples/training.cpp
@@ -307,7 +307,8 @@ static void train_example(
     // --8<-- [start:compress]
     openzl::CCtx cctx;
     std::string out;
-    auto testCompressor = createCompressorFromSerialized(*serialized);
+    auto testCompressor =
+            createCompressorFromSerialized(serialized.serializedCompressor);
     // Try compressing every file provided
     for (const auto& inputPtr : *inputs) {
         cctx.setParameter(openzl::CParam::FormatVersion, ZL_MAX_FORMAT_VERSION);
@@ -326,7 +327,7 @@ static void train_example(
         std::cerr << "Error opening file for writing: " << outputPath
                   << std::endl;
     }
-    output << *serialized;
+    output << serialized.serializedCompressor;
     output.close();
 }
 

--- a/tools/ml_selector/tests/test_mlSelectorTrainer.cpp
+++ b/tools/ml_selector/tests/test_mlSelectorTrainer.cpp
@@ -286,12 +286,11 @@ class TestMLSelectorTrainer : public testing::Test {
         EXPECT_EQ(cBuffer, scBuffer);
     }
 
-    Compressor deserializeCompressor(
-            std::shared_ptr<const std::string_view>& serializedCompressor)
+    Compressor deserializeCompressor(std::string_view serializedCompressor)
     {
         Compressor mlCompressor;
         mlCompressor.setParameter(CParam::FormatVersion, ZL_MAX_FORMAT_VERSION);
-        mlCompressor.deserialize(*serializedCompressor.get());
+        mlCompressor.deserialize(serializedCompressor);
 
         return mlCompressor;
     }
@@ -331,7 +330,7 @@ TEST_F(TestMLSelectorTrainer, MultiClassSelection)
             multiInputs_, trainedCompressor_, trainParams_);
 
     // Deserialize the trained compressor
-    Compressor mlCompressor = deserializeCompressor(serializedCompressor);
+    Compressor mlCompressor = deserializeCompressor(*serializedCompressor);
 
     // Check that the ml selector graph selects the correct successor
     for (size_t i = 0; i < multiSuccessors_.size(); i++) {
@@ -351,7 +350,7 @@ TEST_F(TestMLSelectorTrainer, BinaryClassSelection)
             binaryInputs_, trainedCompressor_, trainParams_);
 
     // Deserialize the trained compressor
-    Compressor mlCompressor = deserializeCompressor(serializedCompressor);
+    Compressor mlCompressor = deserializeCompressor(*serializedCompressor);
 
     // Check that the ml selector graph selects the correct successor
     for (size_t i = 0; i < binarySuccessors_.size(); i++) {
@@ -371,7 +370,7 @@ TEST_F(TestMLSelectorTrainer, BinaryClassRoundTrip)
                     binaryInputs_, trainedCompressor_, trainParams_);
 
     Compressor mlCompressor =
-            deserializeCompressor(serializedBinaryClassCompressors);
+            deserializeCompressor(*serializedBinaryClassCompressors);
 
     // Make sure deserialized data is same as original data
     for (size_t i = 0; i < testData_.size(); i++) {
@@ -388,7 +387,7 @@ TEST_F(TestMLSelectorTrainer, MultiClassRoundTrip)
                     multiInputs_, trainedCompressor_, trainParams_);
 
     Compressor mlCompressor =
-            deserializeCompressor(serializedMultiClassCompressors);
+            deserializeCompressor(*serializedMultiClassCompressors);
 
     // Make sure deserialized data is same as original data
     for (size_t i = 0; i < testData_.size(); i++) {
@@ -403,8 +402,8 @@ TEST_F(TestMLSelectorTrainer, TrainRoundTrip)
     auto serializedCompressor = openzl::training::train(
             multiInputs_, trainedCompressor_, trainParams_);
 
-    Compressor mlCompressor =
-            deserializeCompressor(serializedCompressor.front());
+    Compressor mlCompressor = deserializeCompressor(
+            serializedCompressor.front().serializedCompressor);
 
     testRoundTrip(testData_.front(), mlCompressor);
 }
@@ -483,7 +482,7 @@ TEST_F(TestMLSelectorTrainer, TestAmbiguousData)
             trainData, trainedCompressor_, trainParams_);
 
     // Deserialize the trained compressor
-    Compressor mlCompressor = deserializeCompressor(serializedCompressor);
+    Compressor mlCompressor = deserializeCompressor(*serializedCompressor);
 
     // Check that the ml selector graph selects the correct successor
     std::vector<size_t> sizes          = {};

--- a/tools/protobuf/cli.cpp
+++ b/tools/protobuf/cli.cpp
@@ -373,7 +373,7 @@ int handleTrain(TrainArgs args)
     ZL_LOG(ALWAYS,
            "Writing trained compressor to %s",
            std::string(args.output->name()).c_str());
-    args.output->write(*serialized);
+    args.output->write(serialized.serializedCompressor);
 
     return 0;
 }

--- a/tools/training/tests/test_clustering_benchmarks.cpp
+++ b/tools/training/tests/test_clustering_benchmarks.cpp
@@ -31,8 +31,8 @@ class TestClusteringBenchmarks : public testing::Test {
         // Compress the data using the trained compressor
         CCtx cctx;
         cctx.setParameter(CParam::FormatVersion, ZL_MAX_FORMAT_VERSION);
-        auto newCompressor =
-                custom_parsers::createCompressorFromSerialized(*serialized[0]);
+        auto newCompressor = custom_parsers::createCompressorFromSerialized(
+                serialized[0].serializedCompressor);
         cctx.refCompressor(*newCompressor);
         size_t compressedSize   = 0;
         size_t uncompressedSize = 0;

--- a/tools/training/train.cpp
+++ b/tools/training/train.cpp
@@ -15,7 +15,7 @@ using namespace openzl::tools::logger;
 
 namespace openzl::training {
 
-std::vector<std::shared_ptr<const std::string_view>> train(
+std::vector<TrainedCandidate> train(
         const std::vector<MultiInput>& inputs,
         Compressor& compressor,
         const TrainParams& trainParams)
@@ -68,6 +68,14 @@ std::vector<std::shared_ptr<const std::string_view>> train(
                     Compressor::convertSerializedToJson(
                             *serializedTrainedCompressors[0]))
                     .c_str());
-    return serializedTrainedCompressors;
+
+    std::vector<TrainedCandidate> retval;
+    retval.reserve(serializedTrainedCompressors.size());
+    for (auto& trainedCompressor : serializedTrainedCompressors) {
+        retval.emplace_back(
+                TrainedCandidate{ .serializedCompressor =
+                                          std::string(*trainedCompressor) });
+    }
+    return retval;
 }
 } // namespace openzl::training

--- a/tools/training/train.h
+++ b/tools/training/train.h
@@ -8,6 +8,15 @@
 
 namespace openzl::training {
 
+/// Represents a trained compressor candidate produced by the training
+/// pipeline. Contains the serialized compressor bytes that can be
+/// deserialized into a full Compressor object. The serialized data is
+/// self-contained and safe to outlive the source Compressor.
+struct TrainedCandidate {
+    /// Owned serialized compressor bytes (CBOR-encoded).
+    std::string serializedCompressor;
+};
+
 /**
  * This function trains compressor graphs (clustering and/or ACE graphs).
  * It takes in a vector of buffer data, processes it through the training
@@ -19,12 +28,12 @@ namespace openzl::training {
  * @param maxThreads The maximum number of threads to use for training.
  * @param numSamples The number of samples to use for training (optional).
  *
- * @return A vector shared pointer to the trained serialized compressors.
+ * @return A vector of trained serialized compressors.
  *         If `trainParams.paretoFront` is false, the vector will contain a
  *         single compressor. Otherwise, it will contain a Pareto frontier
  *         of compressors.
  */
-std::vector<std::shared_ptr<const std::string_view>> train(
+std::vector<TrainedCandidate> train(
         const std::vector<MultiInput>& inputs,
         Compressor& compressor,
         const TrainParams& trainParams);


### PR DESCRIPTION
Summary: Some light refactoring to wrap our returned serial compressors in a struct. This is a precursor to returning and operating on trained candidates as a whole, including trained dict bundles.

Differential Revision: D104086124


