### PR TITLE
Fix LZ long-match encoding overflow (#753)

### DIFF
--- a/include/openzl/codecs/zl_lz.h
+++ b/include/openzl/codecs/zl_lz.h
@@ -26,8 +26,12 @@ extern "C" {
 /// (like LZ4) and control the parameters like compression level.
 #define ZL_GRAPH_LZ ZL_MAKE_GRAPH_ID(ZL_StandardGraphID_lz)
 
-/// The LZ encoder sets the metadata on this ID to the minimum possible
-/// match length emitted by the encoder.
+/// The LZ encoder sets the metadata on this ID to the minimum expected
+/// match length emitted by the encoder. There may be edge cases where
+/// the match length is shorter, but it will be extremely rare. The
+/// current cases are:
+/// - The literal length is >= 2^16, and a match length of 0 is emitted.
+/// - The match length is >= 2^16 and (ml % 2^16 < min_match_length)
 #define ZL_LZ_MIN_MATCH_LENGTH_METADATA_ID 77
 
 #if defined(__cplusplus)

--- a/src/openzl/codecs/lz/encode_lz_kernel.c
+++ b/src/openzl/codecs/lz/encode_lz_kernel.c
@@ -9,6 +9,16 @@
 #include "openzl/shared/mem.h"
 #include "openzl/shared/simd_wrapper.h"
 
+// OpenZL uses uint16_t to emit literal lengths and match lengths so they cannot
+// be longer than UINT16_MAX. In fuzzing build modes, instead limit to a shorter
+// length so the fuzzer can find bugs related to overflowing the maximum lengths
+// in small inputs.
+#ifdef FUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION
+#    define ZL_LZ_MAX_LENGTH 1024
+#else
+#    define ZL_LZ_MAX_LENGTH UINT16_MAX
+#endif
+
 #define ZL_LZ_HASH_LEN 7
 
 #define ZL_LZ_MATCH_OVER_LENGTH 16
@@ -43,8 +53,8 @@ static ptrdiff_t matchLength(
             return totalLength + length;
         }
         totalLength += 16;
-        if (ZL_UNLIKELY(totalLength > UINT16_MAX)) {
-            return UINT16_MAX;
+        if (ZL_UNLIKELY(totalLength > ZL_LZ_MAX_LENGTH)) {
+            return ZL_LZ_MAX_LENGTH;
         }
     }
 
@@ -61,9 +71,9 @@ size_t ZL_Lz_maxNumSequences(size_t srcSize)
         return 0;
     }
     // Each real match sequence consumes at least MIN_MATCH bytes.
-    // Each overflow no-op sequence consumes UINT16_MAX literal bytes.
+    // Each overflow no-op sequence consumes ZL_LZ_MAX_LENGTH literal bytes.
     // Add 2 for the trailing literal sequence and rounding.
-    return srcSize / ZL_LZ_MIN_MATCH + srcSize / UINT16_MAX + 2;
+    return srcSize / ZL_LZ_MIN_MATCH + srcSize / ZL_LZ_MAX_LENGTH + 2;
 }
 
 /**
@@ -129,8 +139,8 @@ void ZL_Lz_encode(
             }
 
             // Truncate match to fit in a uint16_t
-            if (ZL_UNLIKELY(ml > UINT16_MAX)) {
-                ml = UINT16_MAX;
+            if (ZL_UNLIKELY(ml > ZL_LZ_MAX_LENGTH)) {
+                ml = ZL_LZ_MAX_LENGTH;
             }
 
             // Copy literals
@@ -145,17 +155,17 @@ void ZL_Lz_encode(
             lits += ll;
 
             // Store the sequence
-            if (ZL_LIKELY(ll <= UINT16_MAX)) {
+            if (ZL_LIKELY(ll <= ZL_LZ_MAX_LENGTH)) {
                 litLens[seq] = (uint16_t)ll;
             } else {
                 // If the literal length is too large, split it into multiple
                 // sequences with match length 0 and offset 1.
-                while (ll > UINT16_MAX) {
-                    litLens[seq]   = UINT16_MAX;
+                while (ll > ZL_LZ_MAX_LENGTH) {
+                    litLens[seq]   = ZL_LZ_MAX_LENGTH;
                     matchLens[seq] = 0;
                     offsets[seq]   = 1;
                     ++seq;
-                    ll -= UINT16_MAX;
+                    ll -= ZL_LZ_MAX_LENGTH;
                 }
                 litLens[seq] = (uint16_t)ll;
             }

--- a/src/openzl/codecs/lz/encode_lz_kernel.c
+++ b/src/openzl/codecs/lz/encode_lz_kernel.c
@@ -53,9 +53,6 @@ static ptrdiff_t matchLength(
             return totalLength + length;
         }
         totalLength += 16;
-        if (ZL_UNLIKELY(totalLength > ZL_LZ_MAX_LENGTH)) {
-            return ZL_LZ_MAX_LENGTH;
-        }
     }
 
     while (inPos + totalLength < inEnd
@@ -70,9 +67,10 @@ size_t ZL_Lz_maxNumSequences(size_t srcSize)
     if (srcSize == 0) {
         return 0;
     }
-    // Each real match sequence consumes at least MIN_MATCH bytes.
-    // Each overflow no-op sequence consumes ZL_LZ_MAX_LENGTH literal bytes.
-    // Add 2 for the trailing literal sequence and rounding.
+    // Each real match sequence consumes at least MIN_MATCH bytes on average.
+    // Overflow matches may emit shorter sequences, but average to >=
+    // UINT16_MAX/2. Each overflow no-op sequence consumes ZL_LZ_MAX_LENGTH
+    // literal bytes. Add 2 for the trailing literal sequence and rounding.
     return srcSize / ZL_LZ_MIN_MATCH + srcSize / ZL_LZ_MAX_LENGTH + 2;
 }
 
@@ -138,11 +136,6 @@ void ZL_Lz_encode(
                 ++ml;
             }
 
-            // Truncate match to fit in a uint16_t
-            if (ZL_UNLIKELY(ml > ZL_LZ_MAX_LENGTH)) {
-                ml = ZL_LZ_MAX_LENGTH;
-            }
-
             // Copy literals
             size_t ll = (size_t)(inPos - inLitStart);
             assert(inPos + ZL_LZ_LIT_OVER_LENGTH <= (ptrdiff_t)srcSize);
@@ -169,9 +162,27 @@ void ZL_Lz_encode(
                 }
                 litLens[seq] = (uint16_t)ll;
             }
-            matchLens[seq] = (uint16_t)ml;
-            offsets[seq]   = (uint16_t)distance;
-            ++seq;
+            if (ZL_LIKELY(ml <= ZL_LZ_MAX_LENGTH)) {
+                matchLens[seq] = (uint16_t)ml;
+                offsets[seq]   = (uint16_t)distance;
+                ++seq;
+            } else {
+                // If the match length is too large, split it into multiple
+                // sequences. The final match length may be < ZL_LZ_MIN_MATCH
+                // but that is okay.
+                ptrdiff_t remainingMatchLength = ml;
+                while (remainingMatchLength > 0) {
+                    ptrdiff_t const bounded =
+                            ZL_MIN(remainingMatchLength, ZL_LZ_MAX_LENGTH);
+                    // litlens[seq] is already set
+                    matchLens[seq] = (uint16_t)bounded;
+                    offsets[seq]   = (uint16_t)distance;
+                    ++seq;
+
+                    remainingMatchLength -= bounded;
+                    litLens[seq] = 0;
+                }
+            }
 
             // Update the hash table with positions at the start and end of the
             // match.

--- a/tests/registry/components/Lz.cpp
+++ b/tests/registry/components/Lz.cpp
@@ -44,6 +44,8 @@ class LzComponent : public OpenZLComponent {
         // Repeated bytes (should produce matches)
         inputs.push_back(
                 std::make_unique<SerialOpenZLInput>(std::string(1000, 'x')));
+        inputs.push_back(
+                std::make_unique<SerialOpenZLInput>(std::string(100000, 'x')));
         // Input with repeating pattern (good for LZ matching)
         {
             std::string pattern;

--- a/tests/utils.cpp
+++ b/tests/utils.cpp
@@ -1396,16 +1396,24 @@ size_t testRoundTripImpl(
     cctx.setParameter(CParam::FormatVersion, formatVersion);
     cctx.selectStartingGraph(graph, params);
 
-    auto csize        = cctx.compress(compressed, inputs);
-    auto decompressed = dctx.decompress({ compressed.data(), csize });
+    auto csize = cctx.compress(compressed, inputs);
 
-    if (decompressed.size() != inputs.size()) {
-        throw std::runtime_error("Corruption: Wrong number of outputs");
-    }
-    for (size_t i = 0; i < inputs.size(); ++i) {
-        if (decompressed[i] != inputs[i]) {
-            throw std::runtime_error("Corruption: Output mismatch");
+    try {
+        auto decompressed = dctx.decompress({ compressed.data(), csize });
+
+        // Crash on corruption: This is always a problem and exceptions
+        // shouldn't be caught.
+        ZL_REQUIRE_EQ(
+                decompressed.size(),
+                inputs.size(),
+                "Corruption: Wrong number of outputs");
+        for (size_t i = 0; i < inputs.size(); ++i) {
+            ZL_REQUIRE(
+                    decompressed[i] == inputs[i],
+                    "Corruption: Output mismatch");
         }
+    } catch (const std::exception& e) {
+        ZL_REQUIRE_FAIL("Decompression failed: ", e.what());
     }
 
     return csize;

--- a/tests/utils.h
+++ b/tests/utils.h
@@ -112,7 +112,8 @@ ZL_GraphID buildTrivialGraph(ZL_Compressor* cgraph, ZL_NodeID node);
 /**
  * Tests that round tripping @p inputs works using the given @p graph.
  * NOTE: This function handles format versions older than 15 that don't
- * accept multiple typed inputs.
+ * accept multiple typed inputs. It throws an exception if compression
+ * fails, and crashes if decompression fails or does not round trip.
  *
  * @param compressed The buffer to compress into. It must already be
  *                   sized to be large enough.
@@ -130,7 +131,7 @@ ZL_GraphID buildTrivialGraph(ZL_Compressor* cgraph, ZL_NodeID node);
  *
  * @returns The compressed size.
  *
- * @throws An exception if the inputs do not round trip successfully.
+ * @throws An exception if compression fails.
  */
 size_t testRoundTrip(
         poly::span<char> compressed,


### PR DESCRIPTION
Summary:

The LZ encoder capped `matchLength()` at `UINT16_MAX` because sequence match
lengths are stored as `uint16_t`. If the match had been walked backward at least
`UINT16_MAX` bytes, then the match finding process would resume at a position
which had already been inserted into the hash table. This would result in match
with `distance <= 0` and corruption would ensue.

Differential Revision: D104838040


