### PR TITLE
de-shared ptr internal training structures

### DIFF
--- a/cli/commands/cmd_train.cpp
+++ b/cli/commands/cmd_train.cpp
@@ -86,9 +86,8 @@ int cmdTrain(const TrainArgs& args)
     Logger::log(INFO, "Benchmarking untrained compressor...");
     auto untrainedBenchmark = runCompressionBenchmarks(benchmarkArgs);
 
-    std::vector<std::shared_ptr<const std::string_view>>
-            serializedTrainedCompressors = openzl::training::train(
-                    benchmarkArgs.inputs, *args.compressor(), args.trainParams);
+    auto serializedTrainedCompressors = openzl::training::train(
+            benchmarkArgs.inputs, *args.compressor(), args.trainParams);
 
     poly::optional<tools::io::OutputFile> resultsCsv;
     if (args.trainParams.paretoFrontier) {
@@ -111,7 +110,7 @@ int cmdTrain(const TrainArgs& args)
         // Benchmark the trained compressor
         benchmarkArgs.setCompressor(
                 custom_parsers::createCompressorFromSerialized(
-                        *serializedTrainedCompressor));
+                        serializedTrainedCompressor.serializedCompressor));
         if (!args.trainParams.paretoFrontier) {
             Logger::log(INFO, "Benchmarking trained compressor...");
         }
@@ -142,14 +141,15 @@ int cmdTrain(const TrainArgs& args)
                     + std::to_string(i) + ".zc";
             auto output = tools::io::OutputFile(std::move(outputFilename));
             output.open();
-            output.write(*serializedTrainedCompressor);
+            output.write(serializedTrainedCompressor.serializedCompressor);
             output.close();
         } else {
             if (i != 0) {
                 throw std::logic_error("Must only have one trained compressor");
             }
             // Output file is already open
-            args.output->write(*serializedTrainedCompressor);
+            args.output->write(
+                    serializedTrainedCompressor.serializedCompressor);
             args.output->close();
         }
     }

--- a/contrib/lz-research/Compressor.cpp
+++ b/contrib/lz-research/Compressor.cpp
@@ -814,7 +814,8 @@ nlohmann::json OpenZLCompressor::train(
 
     nlohmann::json out = nlohmann::json::array();
     for (size_t idx = 0; idx < compressors.size(); ++idx) {
-        out.push_back(makeConfig(std::to_string(idx), *compressors[idx]));
+        out.push_back(makeConfig(
+                std::to_string(idx), compressors[idx].serializedCompressor));
     }
 
     return out;

--- a/contrib/openzl-demo/ext/openzl_demo.cpp
+++ b/contrib/openzl-demo/ext/openzl_demo.cpp
@@ -58,8 +58,8 @@ std::vector<nb::bytes> train(
     result.reserve(trainedCompressors.size());
     for (const auto& trainedCompressor : trainedCompressors) {
         result.emplace_back(
-                (const uint8_t*)trainedCompressor->data(),
-                trainedCompressor->size());
+                (const uint8_t*)trainedCompressor.serializedCompressor.data(),
+                trainedCompressor.serializedCompressor.size());
     }
     return result;
 }

--- a/examples/training.cpp
+++ b/examples/training.cpp
@@ -307,7 +307,8 @@ static void train_example(
     // --8<-- [start:compress]
     openzl::CCtx cctx;
     std::string out;
-    auto testCompressor = createCompressorFromSerialized(*serialized);
+    auto testCompressor =
+            createCompressorFromSerialized(serialized.serializedCompressor);
     // Try compressing every file provided
     for (const auto& inputPtr : *inputs) {
         cctx.setParameter(openzl::CParam::FormatVersion, ZL_MAX_FORMAT_VERSION);
@@ -326,7 +327,7 @@ static void train_example(
         std::cerr << "Error opening file for writing: " << outputPath
                   << std::endl;
     }
-    output << *serialized;
+    output << serialized.serializedCompressor;
     output.close();
 }
 

--- a/tools/ml_selector/ml_selector_trainer.cpp
+++ b/tools/ml_selector/ml_selector_trainer.cpp
@@ -14,6 +14,7 @@
 #include "tools/logger/Logger.h"
 #include "tools/training/graph_mutation/graph_mutation_utils.h"
 #include "tools/training/sample_collection/training_sample_collector.h"
+#include "tools/training/utils/serialized_compressor_internal.h"
 
 // Suppress warnings for XGBoost headers
 #pragma GCC diagnostic push
@@ -549,7 +550,7 @@ static void updateCompressor(
     }
 }
 
-std::shared_ptr<const std::string_view> trainMLSelectorGraph(
+SerializedCompressorInternal trainMLSelectorGraph(
         const std::vector<MultiInput>& inputs,
         Compressor& compressor,
         const TrainParams& trainParams)
@@ -647,6 +648,6 @@ std::shared_ptr<const std::string_view> trainMLSelectorGraph(
                 " mlSelector(s) could not be trained - no inputs captured.");
     }
 
-    return graph_mutation::createSharedStringView(compressor.serialize());
+    return SerializedCompressorInternal(compressor.serialize());
 }
 } // namespace openzl::training

--- a/tools/ml_selector/ml_selector_trainer.h
+++ b/tools/ml_selector/ml_selector_trainer.h
@@ -5,6 +5,7 @@
 #include <vector>
 #include "openzl/cpp/Compressor.hpp"
 #include "tools/training/train_params.h"
+#include "tools/training/utils/serialized_compressor_internal.h"
 #include "tools/training/utils/utils.h"
 
 namespace openzl::training {
@@ -25,7 +26,7 @@ extern const std::string ML_SELECTOR_GRAPH_NAME;
  *
  * @returns a trained serialized compressor
  **/
-std::shared_ptr<const std::string_view> trainMLSelectorGraph(
+SerializedCompressorInternal trainMLSelectorGraph(
         const std::vector<MultiInput>& inputs,
         Compressor& compressor,
         const TrainParams& trainParams);

--- a/tools/ml_selector/tests/test_mlSelectorTrainer.cpp
+++ b/tools/ml_selector/tests/test_mlSelectorTrainer.cpp
@@ -11,6 +11,7 @@
 #include "tools/ml_selector/ml_selector_trainer.h"
 #include "tools/training/train.h"
 #include "tools/training/train_params.h"
+#include "tools/training/utils/serialized_compressor_internal.h"
 #include "tools/training/utils/utils.h"
 
 namespace openzl::tests {
@@ -399,11 +400,13 @@ TEST_F(TestMLSelectorTrainer, TrainRoundTrip)
 {
     multiSuccessors_ = setUpCompressor(trainedCompressor_, true);
 
-    auto serializedCompressor = openzl::training::train(
-            multiInputs_, trainedCompressor_, trainParams_);
+    auto serializedCompressor =
+            openzl::training::train(
+                    multiInputs_, trainedCompressor_, trainParams_)
+                    .front();
 
-    Compressor mlCompressor = deserializeCompressor(
-            serializedCompressor.front().serializedCompressor);
+    Compressor mlCompressor =
+            deserializeCompressor(serializedCompressor.serializedCompressor);
 
     testRoundTrip(testData_.front(), mlCompressor);
 }

--- a/tools/ml_selector/tests/test_mlSelectorTrainer.cpp
+++ b/tools/ml_selector/tests/test_mlSelectorTrainer.cpp
@@ -286,12 +286,11 @@ class TestMLSelectorTrainer : public testing::Test {
         EXPECT_EQ(cBuffer, scBuffer);
     }
 
-    Compressor deserializeCompressor(
-            std::shared_ptr<const std::string_view>& serializedCompressor)
+    Compressor deserializeCompressor(std::string_view serializedCompressor)
     {
         Compressor mlCompressor;
         mlCompressor.setParameter(CParam::FormatVersion, ZL_MAX_FORMAT_VERSION);
-        mlCompressor.deserialize(*serializedCompressor.get());
+        mlCompressor.deserialize(serializedCompressor);
 
         return mlCompressor;
     }
@@ -331,7 +330,7 @@ TEST_F(TestMLSelectorTrainer, MultiClassSelection)
             multiInputs_, trainedCompressor_, trainParams_);
 
     // Deserialize the trained compressor
-    Compressor mlCompressor = deserializeCompressor(serializedCompressor);
+    Compressor mlCompressor = deserializeCompressor(*serializedCompressor);
 
     // Check that the ml selector graph selects the correct successor
     for (size_t i = 0; i < multiSuccessors_.size(); i++) {
@@ -351,7 +350,7 @@ TEST_F(TestMLSelectorTrainer, BinaryClassSelection)
             binaryInputs_, trainedCompressor_, trainParams_);
 
     // Deserialize the trained compressor
-    Compressor mlCompressor = deserializeCompressor(serializedCompressor);
+    Compressor mlCompressor = deserializeCompressor(*serializedCompressor);
 
     // Check that the ml selector graph selects the correct successor
     for (size_t i = 0; i < binarySuccessors_.size(); i++) {
@@ -371,7 +370,7 @@ TEST_F(TestMLSelectorTrainer, BinaryClassRoundTrip)
                     binaryInputs_, trainedCompressor_, trainParams_);
 
     Compressor mlCompressor =
-            deserializeCompressor(serializedBinaryClassCompressors);
+            deserializeCompressor(*serializedBinaryClassCompressors);
 
     // Make sure deserialized data is same as original data
     for (size_t i = 0; i < testData_.size(); i++) {
@@ -388,7 +387,7 @@ TEST_F(TestMLSelectorTrainer, MultiClassRoundTrip)
                     multiInputs_, trainedCompressor_, trainParams_);
 
     Compressor mlCompressor =
-            deserializeCompressor(serializedMultiClassCompressors);
+            deserializeCompressor(*serializedMultiClassCompressors);
 
     // Make sure deserialized data is same as original data
     for (size_t i = 0; i < testData_.size(); i++) {
@@ -403,8 +402,8 @@ TEST_F(TestMLSelectorTrainer, TrainRoundTrip)
     auto serializedCompressor = openzl::training::train(
             multiInputs_, trainedCompressor_, trainParams_);
 
-    Compressor mlCompressor =
-            deserializeCompressor(serializedCompressor.front());
+    Compressor mlCompressor = deserializeCompressor(
+            serializedCompressor.front().serializedCompressor);
 
     testRoundTrip(testData_.front(), mlCompressor);
 }
@@ -483,7 +482,7 @@ TEST_F(TestMLSelectorTrainer, TestAmbiguousData)
             trainData, trainedCompressor_, trainParams_);
 
     // Deserialize the trained compressor
-    Compressor mlCompressor = deserializeCompressor(serializedCompressor);
+    Compressor mlCompressor = deserializeCompressor(*serializedCompressor);
 
     // Check that the ml selector graph selects the correct successor
     std::vector<size_t> sizes          = {};

--- a/tools/protobuf/cli.cpp
+++ b/tools/protobuf/cli.cpp
@@ -373,7 +373,7 @@ int handleTrain(TrainArgs args)
     ZL_LOG(ALWAYS,
            "Writing trained compressor to %s",
            std::string(args.output->name()).c_str());
-    args.output->write(*serialized);
+    args.output->write(serialized.serializedCompressor);
 
     return 0;
 }

--- a/tools/training/ace/ace.cpp
+++ b/tools/training/ace/ace.cpp
@@ -14,6 +14,7 @@
 #include "tools/training/ace/automated_compressor_explorer.h"
 #include "tools/training/graph_mutation/graph_mutation_utils.h"
 #include "tools/training/sample_collection/training_sample_collector.h"
+#include "tools/training/utils/serialized_compressor_internal.h"
 #include "tools/training/utils/utils.h"
 
 namespace openzl::training {
@@ -74,7 +75,7 @@ std::string trainBackend(
 
 } // namespace
 
-std::vector<std::shared_ptr<const std::string_view>> ACETrainer::train(
+std::vector<SerializedCompressorInternal> ACETrainer::train(
         const std::vector<MultiInput>& inputs,
         std::string_view serializedCompressorInput,
         const TrainParams& trainParams)
@@ -153,8 +154,7 @@ std::vector<std::shared_ptr<const std::string_view>> ACETrainer::train(
                         compressor.get(), backendGraphID, &gp),
                 "Graph replacement failed");
     }
-    checkPoint_ =
-            graph_mutation::createSharedStringView(compressor.serialize());
-    return getCombinedCompressors(inputs, checkPoint_, trainParams);
+    checkPoint_.emplace(compressor.serialize());
+    return getCombinedCompressors(inputs, *checkPoint_, trainParams);
 }
 } // namespace openzl::training

--- a/tools/training/ace/ace.h
+++ b/tools/training/ace/ace.h
@@ -3,11 +3,13 @@
 #pragma once
 
 #include <memory>
+#include <optional>
 #include <vector>
 
 #include <string_view>
 #include "openzl/cpp/Compressor.hpp"
 #include "tools/training/train_params.h"
+#include "tools/training/utils/serialized_compressor_internal.h"
 #include "tools/training/utils/utils.h"
 
 namespace openzl::training {
@@ -35,7 +37,7 @@ class ACETrainer {
      *         single compressor. Otherwise, it will contain a Pareto frontier
      *         of compressors.
      */
-    std::vector<std::shared_ptr<const std::string_view>> train(
+    std::vector<SerializedCompressorInternal> train(
             const std::vector<MultiInput>& inputs,
             std::string_view serializedCompressorInput,
             const TrainParams& trainParams);
@@ -45,13 +47,13 @@ class ACETrainer {
      * checkpoint is a serialization of the ace states containing the pareto
      * frontier produced during training.
      */
-    std::shared_ptr<const std::string_view> aceCheckpoint()
+    const std::optional<SerializedCompressorInternal>& aceCheckpoint()
     {
         return checkPoint_;
     }
 
    private:
-    std::shared_ptr<const std::string_view> checkPoint_;
+    std::optional<SerializedCompressorInternal> checkPoint_;
 };
 
 } // namespace openzl::training

--- a/tools/training/ace/ace_combination.cpp
+++ b/tools/training/ace/ace_combination.cpp
@@ -10,6 +10,7 @@
 #include "tools/training/graph_mutation/graph_mutation_utils.h"
 #include "tools/training/sample_collection/training_sample_collector.h"
 #include "tools/training/utils/genetic_algorithm.h"
+#include "tools/training/utils/serialized_compressor_internal.h"
 
 namespace openzl::training {
 
@@ -26,7 +27,7 @@ namespace {
  * @returns A serialized compressor of @p compressor where each backend graph is
  * replaced by the given `ACECompressor`.
  */
-std::shared_ptr<const std::string_view> runReplacements(
+SerializedCompressorInternal runReplacements(
         Compressor& compressor,
         const std::unordered_map<std::string, ACECompressor>& replacements,
         bool saveAceState)
@@ -58,7 +59,7 @@ std::shared_ptr<const std::string_view> runReplacements(
     auto json       = Compressor::convertSerializedToJson(serialized);
     Logger::log(VERBOSE3, "Graph with trained ACE successors: ", json);
 
-    return graph_mutation::createSharedStringView(std::move(serialized));
+    return SerializedCompressorInternal(std::move(serialized));
 }
 
 /**
@@ -90,7 +91,7 @@ std::vector<CandidateSelection> mergeParetoFrontier(
  * @returns The compressor for each backend graph that has the best ratio, which
  * is just the first compressor because they are sorted by compressed size.
  */
-std::shared_ptr<const std::string_view> getSmallestCandidate(
+SerializedCompressorInternal getSmallestCandidate(
         const std::function<Compressor()>& makeCompressor,
         const std::unordered_map<
                 std::string,
@@ -132,7 +133,7 @@ std::vector<CandidateSelection> candidatesFromVec(
  * @returns the overall serialized compressor from the choices with ACE
  * graphs replaced of @param candidate.
  */
-std::shared_ptr<const std::string_view> makeCombinedCompressor(
+SerializedCompressorInternal makeCombinedCompressor(
         const CandidateSelection& candidate,
         const std::function<Compressor()>& makeCompressor,
         const std::unordered_map<
@@ -279,9 +280,9 @@ std::vector<CandidateSelection> combineCandidates(
     return currentFrontier;
 }
 
-std::vector<std::shared_ptr<const std::string_view>> getCombinedCompressors(
+std::vector<SerializedCompressorInternal> getCombinedCompressors(
         const std::vector<MultiInput>& inputs,
-        std::shared_ptr<const std::string_view> trainedSerializedCompressor,
+        const SerializedCompressorInternal& trainedSerializedCompressor,
         const TrainParams& trainParams)
 {
     auto makeCompressor = [&trainedSerializedCompressor, &trainParams] {
@@ -346,8 +347,10 @@ std::vector<std::shared_ptr<const std::string_view>> getCombinedCompressors(
     }
 
     if (!trainParams.paretoFrontier) {
-        return { getSmallestCandidate(
-                makeCompressor, allCandidates, trainParams.saveAceState) };
+        std::vector<SerializedCompressorInternal> result;
+        result.push_back(getSmallestCandidate(
+                makeCompressor, allCandidates, trainParams.saveAceState));
+        return result;
     }
     std::vector<std::vector<CandidateSelection>> candidates;
     candidates.reserve(allCandidates.size());
@@ -357,7 +360,7 @@ std::vector<std::shared_ptr<const std::string_view>> getCombinedCompressors(
     auto frontier = combineCandidates(candidates, trainParams);
     frontier = pruneCandidates(std::move(frontier), kNumFinalParetoCandidates);
     std::sort(frontier.begin(), frontier.end());
-    std::vector<std::shared_ptr<const std::string_view>> paretoOptimalResults;
+    std::vector<SerializedCompressorInternal> paretoOptimalResults;
     paretoOptimalResults.reserve(frontier.size());
     for (auto& candidate : frontier) {
         paretoOptimalResults.push_back(makeCombinedCompressor(

--- a/tools/training/ace/ace_combination.h
+++ b/tools/training/ace/ace_combination.h
@@ -12,6 +12,7 @@
 
 #include "tools/training/ace/ace_compressor.h"
 #include "tools/training/train_params.h"
+#include "tools/training/utils/serialized_compressor_internal.h"
 #include "tools/training/utils/thread_pool.h"
 
 namespace openzl::training {
@@ -104,9 +105,9 @@ class CandidateSelection {
  * @param trainedSerializedCompressor The compressor obtained from ace training.
  * @param trainParams The training parameters to use for the algorithm.
  */
-std::vector<std::shared_ptr<const std::string_view>> getCombinedCompressors(
+std::vector<SerializedCompressorInternal> getCombinedCompressors(
         const std::vector<MultiInput>& inputs,
-        std::shared_ptr<const std::string_view> trainedSerializedCompressor,
+        const SerializedCompressorInternal& trainedSerializedCompressor,
         const TrainParams& trainParams);
 
 /**

--- a/tools/training/clustering/clustering_graph_trainer.cpp
+++ b/tools/training/clustering/clustering_graph_trainer.cpp
@@ -15,6 +15,7 @@
 #include "tools/training/clustering/train_api.h"
 #include "tools/training/graph_mutation/graph_mutation_utils.h"
 #include "tools/training/sample_collection/training_sample_collector.h"
+#include "tools/training/utils/serialized_compressor_internal.h"
 #include "tools/training/utils/utils.h"
 
 using namespace openzl::training::graph_mutation;
@@ -160,7 +161,7 @@ void overrideClusteringGraphParams(
 
 } // namespace
 
-std::shared_ptr<const std::string_view> trainClusteringGraph(
+SerializedCompressorInternal trainClusteringGraph(
         const std::vector<MultiInput>& inputs,
         Compressor& compressor,
         const TrainParams& trainParams)
@@ -192,7 +193,7 @@ std::shared_ptr<const std::string_view> trainClusteringGraph(
             clusteringGraphUniqueIDUntrained,
             trainedClusteringGraphID);
 
-    return createSharedStringView(compressor.serialize());
+    return SerializedCompressorInternal(compressor.serialize());
 }
 
 } // namespace openzl::training

--- a/tools/training/clustering/clustering_graph_trainer.h
+++ b/tools/training/clustering/clustering_graph_trainer.h
@@ -4,6 +4,7 @@
 
 #include "openzl/cpp/Compressor.hpp"
 #include "tools/training/train_params.h"
+#include "tools/training/utils/serialized_compressor_internal.h"
 #include "tools/training/utils/utils.h"
 
 namespace openzl::training {
@@ -24,7 +25,7 @@ extern const std::string CLUSTERING_GRAPH_NAME;
  * @return The trained serialized compressor
  */
 
-std::shared_ptr<const std::string_view> trainClusteringGraph(
+SerializedCompressorInternal trainClusteringGraph(
         const std::vector<MultiInput>& inputs,
         Compressor& compressor,
         const TrainParams& trainParams);

--- a/tools/training/clustering/compression_utils.cpp
+++ b/tools/training/clustering/compression_utils.cpp
@@ -196,11 +196,11 @@ std::future<SizeTimePair> CompressionUtils::tryCompress(
                                 fPtr) {
             return compressSample(*ccPtr, *fPtr, samples_.at(i));
         };
-        futures.emplace_back(threadPool_->run(task, configPtr, funcPtr));
+        futures.emplace_back(threadPool_.run(task, configPtr, funcPtr));
     }
     auto futuresPtr = std::make_shared<std::vector<std::future<SizeTimePair>>>(
             std::move(futures));
-    return threadPool_->run([futuresPtr]() {
+    return threadPool_.run([futuresPtr]() {
         SizeTimePair result{};
         for (auto& future : *futuresPtr) {
             result = result + future.get();

--- a/tools/training/clustering/compression_utils.h
+++ b/tools/training/clustering/compression_utils.h
@@ -54,7 +54,7 @@ class CompressionUtils {
             const std::vector<MultiInput>& samples,
             const std::vector<ZL_GraphID>& successors,
             const std::vector<ZL_NodeID>& clusteringCodecs,
-            const std::shared_ptr<ThreadPool>& threadPool)
+            ThreadPool& threadPool)
             : compressor_(compressor),
               samples_(std::move(samples)),
               successors_(successors),
@@ -124,7 +124,7 @@ class CompressionUtils {
     const std::vector<ZL_GraphID> successors_;
     const std::vector<ZL_NodeID> clusteringCodecs_;
     static constexpr int compressBoundFactor_ = 2;
-    const std::shared_ptr<ThreadPool> threadPool_;
+    ThreadPool& threadPool_;
 
     std::map<ZL_Type, std::vector<size_t>> typeToClusteringCodecIdxsMap_;
     const std::vector<ZL_Type> kInputTypes_ = {

--- a/tools/training/clustering/trainers/bottom_up_trainer.cpp
+++ b/tools/training/clustering/trainers/bottom_up_trainer.cpp
@@ -35,7 +35,7 @@ ClusteringConfigBuilder BottomUpTrainer::buildTrainedFullSplitConfig(
                     cUtils.getBestClusterInfo(tags, type, width, metadata);
             return clusterInfo;
         };
-        futures.emplace_back(this->threadPool_->run(task));
+        futures.emplace_back(this->threadPool_.run(task));
     }
     size_t clusterIdx = 0;
     for (auto& future : futures) {
@@ -135,7 +135,7 @@ ClusteringConfigBuilder BottomUpTrainer::getTrainedClusteringConfig(
                                 typeInfo.second,
                                 i);
                     };
-            candidateFutures.emplace_back(this->threadPool_->run(task));
+            candidateFutures.emplace_back(this->threadPool_.run(task));
         }
         std::vector<std::future<SizeTimePair>> costFutures;
         std::vector<ClusteringConfigBuilder> candidates;

--- a/tools/training/clustering/trainers/full_split_trainer.cpp
+++ b/tools/training/clustering/trainers/full_split_trainer.cpp
@@ -37,7 +37,7 @@ ClusteringConfigBuilder FullSplitTrainer::getTrainedClusteringConfig(
                     splitCluster, type, width, metadata);
             return clusterInfo;
         };
-        futures.emplace_back(this->threadPool_->run(task));
+        futures.emplace_back(this->threadPool_.run(task));
     }
     size_t clusterIdx = 0;
     for (auto& future : futures) {

--- a/tools/training/clustering/trainers/greedy_trainer.cpp
+++ b/tools/training/clustering/trainers/greedy_trainer.cpp
@@ -240,7 +240,7 @@ void GreedyTrainer::initSimilarInputs(
                         / (marginalCosts_[column1] + marginalCosts_[column2]);
                 return std::make_pair(contextualSimilarity, column2);
             };
-            futures.emplace_back(threadPool_->run(task));
+            futures.emplace_back(threadPool_.run(task));
         }
         similarityScoreColumns.reserve(futures.size());
         for (auto& future : futures) {

--- a/tools/training/clustering/trainers/trainer.h
+++ b/tools/training/clustering/trainers/trainer.h
@@ -11,8 +11,7 @@ class Trainer {
    public:
     Trainer(int maxThreads = std::thread::hardware_concurrency(),
             poly::optional<size_t> maxTimeSecs = std::nullopt)
-            : threadPool_(std::make_shared<ThreadPool>(maxThreads)),
-              maxTimeSecs_(maxTimeSecs)
+            : threadPool_(maxThreads), maxTimeSecs_(maxTimeSecs)
     {
     }
     virtual ~Trainer() = default;
@@ -26,7 +25,7 @@ class Trainer {
                     typeToDefaultSuccessorIdxMap) = 0;
 
    protected:
-    std::shared_ptr<ThreadPool> threadPool_;
+    ThreadPool threadPool_;
     poly::optional<size_t> maxTimeSecs_;
 };
 } // namespace openzl::training

--- a/tools/training/graph_mutation/BUCK
+++ b/tools/training/graph_mutation/BUCK
@@ -15,5 +15,6 @@ zs_cxxlibrary(
     exported_deps = [
         "../..:logger",
         "../../../cpp:openzl_cpp",
+        "../utils:training_utils",
     ],
 )

--- a/tools/training/graph_mutation/graph_mutation_utils.cpp
+++ b/tools/training/graph_mutation/graph_mutation_utils.cpp
@@ -44,25 +44,6 @@ std::vector<GraphID> findGraphsWhere(const Compressor& compressor, Fn&& fn)
     return state.result;
 }
 
-/**
- * @brief A wrapper class for a CBOR data bundle.
- */
-struct CborDataBundle {
-    std::string buffer;
-    std::string_view view;
-
-    explicit CborDataBundle(std::string buf)
-            : buffer(std::move(buf)), view(buffer)
-    {
-    }
-
-    static std::shared_ptr<const std::string_view> create(std::string buffer)
-    {
-        auto bundle = std::make_shared<CborDataBundle>(std::move(buffer));
-        return std::shared_ptr<const std::string_view>(bundle, &bundle->view);
-    }
-};
-
 } // anonymous namespace
 
 /**
@@ -90,11 +71,6 @@ bool hasTargetGraph(
             (int)targetGraphPrefix.size(),
             targetGraphPrefix.data());
     return !findAllGraphsWithPrefix(compressor, targetGraphPrefix).empty();
-}
-
-std::shared_ptr<const std::string_view> createSharedStringView(std::string str)
-{
-    return CborDataBundle::create(std::move(str));
 }
 
 std::vector<GraphID> findAllGraphsWithPrefix(

--- a/tools/training/graph_mutation/graph_mutation_utils.h
+++ b/tools/training/graph_mutation/graph_mutation_utils.h
@@ -2,7 +2,7 @@
 
 #pragma once
 
-#include <memory>
+#include <optional>
 #include <string>
 #include <string_view>
 #include <vector>
@@ -13,20 +13,6 @@
 #include "openzl/zl_localParams.h"
 
 namespace openzl::training::graph_mutation {
-
-/**
- * @brief Creates a shared_ptr to a string_view from a string.
- *
- * This utility function creates a shared_ptr to a string_view that references
- * the provided string. The string is stored in a bundle object that is managed
- * by the shared_ptr, ensuring that the string_view remains valid as long as
- * the shared_ptr exists.
- *
- * @param str The string to create a string_view from.
- * @return std::shared_ptr<const std::string_view> A shared_ptr to a string_view
- * that references the provided string.
- */
-std::shared_ptr<const std::string_view> createSharedStringView(std::string str);
 
 /**
  * @brief Checks if a compressor contains a graph with a specific prefix.

--- a/tools/training/tests/test_ace_combination.cpp
+++ b/tools/training/tests/test_ace_combination.cpp
@@ -1,12 +1,14 @@
 // Copyright (c) Meta Platforms, Inc. and affiliates.
 
 #include <gtest/gtest.h>
+#include <optional>
 #include <random>
 #include "custom_parsers/dependency_registration.h"
 #include "openzl/cpp/CCtx.hpp"
 #include "openzl/cpp/codecs/ACE.hpp"
 #include "tools/training/ace/ace.h"
 #include "tools/training/ace/ace_combination.h"
+#include "tools/training/utils/serialized_compressor_internal.h"
 
 namespace openzl {
 namespace training {
@@ -172,7 +174,7 @@ TEST_F(ACECombinationTest, NoSaveAceStateProducesSmallerCompressor)
     };
 
     // Train with saveAceState = true
-    std::shared_ptr<const std::string_view> resultWithAceState;
+    std::optional<SerializedCompressorInternal> resultWithAceState;
     {
         Compressor compressor;
         compressor.selectStartingGraph(graphs::ACE()(compressor));
@@ -186,11 +188,11 @@ TEST_F(ACECombinationTest, NoSaveAceStateProducesSmallerCompressor)
         auto results =
                 trainer.train(multiInputs, compressor.serialize(), trainParams);
         ASSERT_FALSE(results.empty());
-        resultWithAceState = results[0];
+        resultWithAceState.emplace(std::move(results[0]));
     }
 
     // Train with saveAceState = false (default)
-    std::shared_ptr<const std::string_view> resultWithoutAceState;
+    std::optional<SerializedCompressorInternal> resultWithoutAceState;
     {
         Compressor compressor;
         compressor.selectStartingGraph(graphs::ACE()(compressor));
@@ -204,11 +206,11 @@ TEST_F(ACECombinationTest, NoSaveAceStateProducesSmallerCompressor)
         auto results =
                 trainer.train(multiInputs, compressor.serialize(), trainParams);
         ASSERT_FALSE(results.empty());
-        resultWithoutAceState = results[0];
+        resultWithoutAceState.emplace(std::move(results[0]));
     }
 
-    auto sizeWithAceState    = resultWithAceState->size();
-    auto sizeWithoutAceState = resultWithoutAceState->size();
+    auto sizeWithAceState    = (**resultWithAceState).size();
+    auto sizeWithoutAceState = (**resultWithoutAceState).size();
 
     // Serialized compressor without ACE state should be significantly smaller
     EXPECT_GT(sizeWithAceState, 0);
@@ -230,8 +232,8 @@ TEST_F(ACECombinationTest, NoSaveAceStateProducesSmallerCompressor)
                         data.data(), data.size() * sizeof(data[0]));
                 return cctx.compressOne(inputForCompress);
             };
-    auto compressedWith    = compressWithResult(*resultWithAceState);
-    auto compressedWithout = compressWithResult(*resultWithoutAceState);
+    auto compressedWith    = compressWithResult(**resultWithAceState);
+    auto compressedWithout = compressWithResult(**resultWithoutAceState);
 
     // Compressed output should be nearly identical — the small difference
     // is due to ACE training being non-deterministic across independent runs.

--- a/tools/training/tests/test_clustering_benchmarks.cpp
+++ b/tools/training/tests/test_clustering_benchmarks.cpp
@@ -31,8 +31,8 @@ class TestClusteringBenchmarks : public testing::Test {
         // Compress the data using the trained compressor
         CCtx cctx;
         cctx.setParameter(CParam::FormatVersion, ZL_MAX_FORMAT_VERSION);
-        auto newCompressor =
-                custom_parsers::createCompressorFromSerialized(*serialized[0]);
+        auto newCompressor = custom_parsers::createCompressorFromSerialized(
+                serialized[0].serializedCompressor);
         cctx.refCompressor(*newCompressor);
         size_t compressedSize   = 0;
         size_t uncompressedSize = 0;

--- a/tools/training/tests/test_clustering_config_builder.cpp
+++ b/tools/training/tests/test_clustering_config_builder.cpp
@@ -34,9 +34,9 @@ class TestClusteringConfigBuilder : public testing::Test {
         typeToClusteringCodecIdxsMap_[ZL_Type_numeric] = { 2 };
         typeToClusteringCodecIdxsMap_[ZL_Type_string]  = { 3, 4 };
         // Set up compressor utils
-        auto samples    = setUpCompressSamples();
-        auto threadPool = std::make_shared<training::ThreadPool>(1);
-        cUtils_         = std::make_unique<training::CompressionUtils>(
+        auto samples = setUpCompressSamples();
+        training::ThreadPool threadPool(1);
+        cUtils_ = std::make_unique<training::CompressionUtils>(
                 compressor_.get(),
                 samples,
                 successors_,

--- a/tools/training/train.cpp
+++ b/tools/training/train.cpp
@@ -15,7 +15,7 @@ using namespace openzl::tools::logger;
 
 namespace openzl::training {
 
-std::vector<std::shared_ptr<const std::string_view>> train(
+std::vector<TrainedCandidate> train(
         const std::vector<MultiInput>& inputs,
         Compressor& compressor,
         const TrainParams& trainParams)
@@ -68,6 +68,14 @@ std::vector<std::shared_ptr<const std::string_view>> train(
                     Compressor::convertSerializedToJson(
                             *serializedTrainedCompressors[0]))
                     .c_str());
-    return serializedTrainedCompressors;
+
+    std::vector<TrainedCandidate> retval;
+    retval.reserve(serializedTrainedCompressors.size());
+    for (auto& trainedCompressor : serializedTrainedCompressors) {
+        retval.emplace_back(
+                TrainedCandidate{ .serializedCompressor =
+                                          std::string(*trainedCompressor) });
+    }
+    return retval;
 }
 } // namespace openzl::training

--- a/tools/training/train.cpp
+++ b/tools/training/train.cpp
@@ -9,6 +9,7 @@
 #include "tools/training/clustering/clustering_graph_trainer.h"
 #include "tools/training/graph_mutation/graph_mutation_utils.h"
 #include "tools/training/train.h"
+#include "tools/training/utils/serialized_compressor_internal.h"
 
 using namespace openzl::training::graph_mutation;
 using namespace openzl::tools::logger;
@@ -21,8 +22,7 @@ std::vector<TrainedCandidate> train(
         const TrainParams& trainParams)
 {
     auto startTime = std::chrono::steady_clock::now();
-    std::vector<std::shared_ptr<const std::string_view>>
-            serializedTrainedCompressors;
+    std::vector<SerializedCompressorInternal> serializedTrainedCompressors;
     if (!trainParams.compressorGenFunc) {
         throw Exception("Compressor generator function is not set.");
     }
@@ -45,8 +45,9 @@ std::vector<TrainedCandidate> train(
     }
 
     if (graph_mutation::hasTargetGraph(compressor, ML_SELECTOR_GRAPH_NAME)) {
-        serializedTrainedCompressors = { trainMLSelectorGraph(
-                inputs, compressor, trainParams) };
+        serializedTrainedCompressors.clear();
+        serializedTrainedCompressors.push_back(
+                trainMLSelectorGraph(inputs, compressor, trainParams));
     }
 
     if (serializedTrainedCompressors.empty()) {

--- a/tools/training/train.h
+++ b/tools/training/train.h
@@ -4,6 +4,7 @@
 
 #include "openzl/cpp/Compressor.hpp"
 #include "tools/training/train_params.h"
+#include "tools/training/utils/serialized_compressor_internal.h"
 #include "tools/training/utils/utils.h"
 
 namespace openzl::training {

--- a/tools/training/train.h
+++ b/tools/training/train.h
@@ -8,6 +8,15 @@
 
 namespace openzl::training {
 
+/// Represents a trained compressor candidate produced by the training
+/// pipeline. Contains the serialized compressor bytes that can be
+/// deserialized into a full Compressor object. The serialized data is
+/// self-contained and safe to outlive the source Compressor.
+struct TrainedCandidate {
+    /// Owned serialized compressor bytes (CBOR-encoded).
+    std::string serializedCompressor;
+};
+
 /**
  * This function trains compressor graphs (clustering and/or ACE graphs).
  * It takes in a vector of buffer data, processes it through the training
@@ -19,12 +28,12 @@ namespace openzl::training {
  * @param maxThreads The maximum number of threads to use for training.
  * @param numSamples The number of samples to use for training (optional).
  *
- * @return A vector shared pointer to the trained serialized compressors.
+ * @return A vector of trained serialized compressors.
  *         If `trainParams.paretoFront` is false, the vector will contain a
  *         single compressor. Otherwise, it will contain a Pareto frontier
  *         of compressors.
  */
-std::vector<std::shared_ptr<const std::string_view>> train(
+std::vector<TrainedCandidate> train(
         const std::vector<MultiInput>& inputs,
         Compressor& compressor,
         const TrainParams& trainParams);

--- a/tools/training/utils/BUCK
+++ b/tools/training/utils/BUCK
@@ -7,10 +7,12 @@ oncall("data_compression")
 zs_cxxlibrary(
     name = "training_utils",
     srcs = [
+        "serialized_compressor_internal.cpp",
         "thread_pool.cpp",
         "utils.cpp",
     ],
     headers = [
+        "serialized_compressor_internal.h",
         "thread_pool.h",
         "utils.h",
     ],

--- a/tools/training/utils/serialized_compressor_internal.cpp
+++ b/tools/training/utils/serialized_compressor_internal.cpp
@@ -1,0 +1,17 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#include "tools/training/utils/serialized_compressor_internal.h"
+
+namespace openzl::training {
+
+SerializedCompressorInternal::SerializedCompressorInternal(std::string&& str)
+        : storage_(std::move(str))
+{
+}
+
+std::string_view SerializedCompressorInternal::operator*() const
+{
+    return storage_;
+}
+
+} // namespace openzl::training

--- a/tools/training/utils/serialized_compressor_internal.h
+++ b/tools/training/utils/serialized_compressor_internal.h
@@ -1,0 +1,34 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#pragma once
+
+#include <cstdlib>
+#include <memory>
+#include <string>
+#include <string_view>
+#include <variant>
+
+namespace openzl::training {
+
+class SerializedCompressorInternal {
+   public:
+    explicit SerializedCompressorInternal(std::string&& str);
+    ~SerializedCompressorInternal() = default;
+
+    SerializedCompressorInternal(const SerializedCompressorInternal& other) =
+            delete;
+    SerializedCompressorInternal& operator=(
+            const SerializedCompressorInternal& other) = delete;
+
+    SerializedCompressorInternal(
+            SerializedCompressorInternal&& other) noexcept = default;
+    SerializedCompressorInternal& operator=(
+            SerializedCompressorInternal&& other) noexcept = default;
+
+    std::string_view operator*() const;
+
+   private:
+    std::string storage_;
+};
+
+} // namespace openzl::training


### PR DESCRIPTION
Summary:
Replace shared_ptr<const string_view> lifetime-management pattern with value types throughout the training infrastructure.

The training code previously used a CborDataBundle helper that created shared_ptr<const string_view> via aliasing constructors to keep serialized compressor data alive. This pattern was unnecessarily complex — it obscured ownership, introduced heap allocations on every serialization, and made the API harder to follow.

This diff makes the following changes:

Introduce SerializedCompressor value type: A simple struct wrapping std::string data, replacing all uses of shared_ptr<const string_view>. The CborDataBundle helper class and createSharedStringView() are deleted in favor of createSerializedCompressor().

Replace shared_ptr<Arena> with unique_ptr<Arena>: decodeSerializedCompressorIntoCbor() now returns a DecodedCbor struct owning the arena via unique_ptr instead of a tuple<shared_ptr<A1C_Item>, shared_ptr<Arena>> with an aliasing shared_ptr to extend the root item's lifetime. The DecodedCbor struct is move-only.

Simplify encodeCborAsSerialized: Returns std::string directly instead of shared_ptr<const string_view>.

De-shared-ptr ThreadPool in training: Trainer and CompressionUtils now own / reference ThreadPool directly rather than through shared_ptr. Trainer owns a ThreadPool member, and CompressionUtils takes it by reference.

Replace aceCheckpoint() return type: Changed from shared_ptr<const string_view> to const optional<SerializedCompressor>&.

Update all call sites: cmd_train.cpp, train.cpp, ace.cpp, ace_combination.cpp, clustering_graph_trainer.cpp, ml_selector_trainer.cpp, and all clustering trainers are updated to use the new value types and access .data instead of dereferencing shared pointers.

Differential Revision: D103693077
