### PR TITLE
Add C-only core target and fix non-x86_64 .S inclusion

### DIFF
--- a/BUCK
+++ b/BUCK
@@ -176,6 +176,17 @@ zs_library(
     ],
 )
 
+# C-only OpenZL core (no C++ wrapper). For consumers that only need the C API
+# and need to build on platforms where the C++ wrapper is not available (e.g. Android).
+cpp_library(
+    # @autodeps-skip
+    name = "openzl_c_core",
+    visibility = ["//openzl:openzl_c_core"],
+    exported_deps = [
+        ":zstronglib",  # @manual
+    ],
+)
+
 # TODO: Fix FSE: Split into compress and decompress pieces.
 zs_library(
     name = "fse",
@@ -183,11 +194,14 @@ zs_library(
         "src/openzl/fse/**/*.c",
         "src/zstrong/fse/**/*.c",
     ]) + select({
-        "DEFAULT": glob([
-            "src/openzl/fse/**/*.S",
-            "src/zstrong/fse/**/*.S",
-        ]),
-        "ovr_config//compiler:msvc": [],
+        "DEFAULT": [],
+        "ovr_config//cpu:x86_64": select({
+            "DEFAULT": glob([
+                "src/openzl/fse/**/*.S",
+                "src/zstrong/fse/**/*.S",
+            ]),
+            "ovr_config//compiler:msvc": [],
+        }),
     }),
     headers = private_headers(glob([
         "src/openzl/fse/**/*.h",


### PR DESCRIPTION
Summary:
Add `openzl_c_core` target to both dev and prod branches. This exposes just the C API (via zstronglib) without the C++ wrapper, enabling consumers like QMF blendshape compression to build on platforms where the C++ wrapper is unavailable (e.g. Android ARM).

Also fix the `fse` target `.S` file inclusion: key on `ovr_config//cpu:x86_64` (positive CPU select) with an MSVC nested exclusion, instead of including `.S` by default and only excluding MSVC. This correctly excludes x86_64 GAS assembly on all non-x86_64 platforms (Android ARM, Apple Silicon, aarch64 Linux) without breaking MSVC x64 builds.

Grafted from dev to prod per directory branching workflow.

Differential Revision: D105238518


