### PR TITLE
Fix serialization fuzzer issues

### DIFF
--- a/tests/registry/components/BitSplit.cpp
+++ b/tests/registry/components/BitSplit.cpp
@@ -101,6 +101,9 @@ class BitSplitComponent : public OpenZLComponent {
     {
         auto nodeID =
                 ZL_Compressor_Graph_getHeadNode(compressor.get(), graphID);
+        if (nodeID == ZL_NODE_ILLEGAL) {
+            throw std::runtime_error("Invalid graph ID");
+        }
         auto params =
                 ZL_Compressor_Node_getLocalParams(compressor.get(), nodeID);
         if (params.copyParams.nbCopyParams != 1) {

--- a/tests/registry/components/MuxLengths.cpp
+++ b/tests/registry/components/MuxLengths.cpp
@@ -164,6 +164,9 @@ class MuxLengthsComponent : public OpenZLComponent {
         // Extract match_length_bias from the graph's parameters.
         auto headNode =
                 ZL_Compressor_Graph_getHeadNode(compressor.get(), graphID);
+        if (headNode == ZL_NODE_ILLEGAL) {
+            throw std::runtime_error("Invalid graph ID");
+        }
         auto localParams =
                 ZL_Compressor_Node_getLocalParams(compressor.get(), headNode);
         unsigned splitPoint      = 4;

--- a/tests/registry/components/Partition.cpp
+++ b/tests/registry/components/Partition.cpp
@@ -224,6 +224,9 @@ class PartitionComponent : public OpenZLComponent {
             GraphID graphID) const
     {
         auto node = ZL_Compressor_Graph_getHeadNode(compressor.get(), graphID);
+        if (node == ZL_NODE_ILLEGAL) {
+            throw std::runtime_error("Invalid graph ID");
+        }
         auto localParams =
                 ZL_Compressor_Node_getLocalParams(compressor.get(), node);
         ZL_PartitionParams params;

--- a/tests/registry/components/Sentinel.cpp
+++ b/tests/registry/components/Sentinel.cpp
@@ -98,6 +98,9 @@ class SentinelNumComponent : public OpenZLComponent {
             uint64_t& sentinel) const
     {
         auto node = ZL_Compressor_Graph_getHeadNode(compressor.get(), graphID);
+        if (node == ZL_NODE_ILLEGAL) {
+            throw std::runtime_error("Invalid graph ID");
+        }
         auto localParams =
                 ZL_Compressor_Node_getLocalParams(compressor.get(), node);
 


### PR DESCRIPTION
Summary:
In the serialization fuzzer the `GraphID` may not be what we expect. So we must check for an invalid node.

Fix in `dev` and graft to `prod`.

Differential Revision: D105578028


