### PR TITLE
Bump dict bundle frame version from v24 to v25

### DIFF
--- a/include/openzl/zl_version.h
+++ b/include/openzl/zl_version.h
@@ -54,7 +54,7 @@ extern "C" {
 /// format changes. But note that once a library with
 /// max format version X is released, we must support X
 /// through our support window.
-#define ZL_MAX_FORMAT_VERSION (24)
+#define ZL_MAX_FORMAT_VERSION (25)
 
 /// Minimum wire format version required to support chunking.
 #define ZL_CHUNK_VERSION_MIN (21)
@@ -63,7 +63,7 @@ extern "C" {
 #define ZL_TYPED_INPUT_VERSION_MIN (14)
 
 /// Minimum wire format version required to expose per-node materialized dicts.
-#define ZL_MATERIALIZED_DICT_VERSION_MIN (24)
+#define ZL_MATERIALIZED_DICT_VERSION_MIN (25)
 
 /**
  * @returns The current encoding version number.

--- a/src/openzl/common/wire_format.h
+++ b/src/openzl/common/wire_format.h
@@ -21,8 +21,8 @@
  *   + bit0: checksum of decoded data
  *   + bit1: checksum of encoded data (also control frame header checksum)
  *   + bit2: presence of a comment field
- *   + bit3: v24+: presence of a dict bundle ID
- * - v24+: if bit3 set: 1-byte ID size + variable-length dict bundle ID (up to
+ *   + bit3: v25+: presence of a dict bundle ID
+ * - v25+: if bit3 set: 1-byte ID size + variable-length dict bundle ID (up to
  * 32 bytes)
  * - Input Type :
  *   + v13-: 0-byte , 1 Input assumed to be Serial
@@ -105,7 +105,7 @@
  * - V16+ : Array of nbRegens
  *   + bit-packed flags separate 1-regen decoders from 2+ ones
  *   + 2+ regens values are shifted (-2) then varint encoded
- * - V24+ : Array of dictIdx (dict bundle offsets)
+ * - V25+ : Array of dictIdx (dict bundle offsets)
  *   + has-dict flags are bit-packed (1 = has dict, 0 = no dict)
  *   + if any has-dict flag is set:
  *     1-byte nbBits = ceil(log2(maxDictIdx + 1))

--- a/src/openzl/compress/encode_frameheader.c
+++ b/src/openzl/compress/encode_frameheader.c
@@ -326,7 +326,7 @@ static void compressNumInputs(
     }
 }
 
-// Compress per-codec dict bundle offsets (v24+)
+// Compress per-codec dict bundle offsets (v25+)
 // - Bitmap encode has-dict flags (1 = has dict, 0 = no dict)
 // - Bitpack encode raw dict indices for has-dict entries
 static void compressDictIdxs(
@@ -496,7 +496,7 @@ static ZL_Report writeFrameHeader_internal(
     ZL_TRY_LET(size_t, hsBound, computeFHBound(fip->numInputs, 0, 0, 0));
     // Add comment bytes relaxing header bound
     hsBound += fip->comment.size ? 4 + fip->comment.size : 0;
-    // Add bundleID bytes (v24+): 1 size byte + up to 32 ID bytes
+    // Add bundleID bytes (v25+): 1 size byte + up to 32 ID bytes
     if (encoder->formatVersion >= ZL_MATERIALIZED_DICT_VERSION_MIN
         && fip->fprop->hasBundleID) {
         hsBound += 1 + ZL_UNIQUE_ID_SIZE;
@@ -530,7 +530,7 @@ static ZL_Report writeFrameHeader_internal(
         ZL_WC_push(&out, flags);
     }
 
-    // Store dict bundle ID (v24+): 1-byte size + variable-length ID
+    // Store dict bundle ID (v25+): 1-byte size + variable-length ID
     if (encoder->formatVersion >= ZL_MATERIALIZED_DICT_VERSION_MIN
         && fip->fprop->hasBundleID) {
         ZL_ASSERT_NN(fip->bundleID);
@@ -881,7 +881,7 @@ static ZL_Report writeChunkHeaderV8_internal(
         }
     }
 
-    /* Encode per-codec dict indices (v24+ only, when bundle is present)
+    /* Encode per-codec dict indices (v25+ only, when bundle is present)
      */
     if (encoder->formatVersion >= ZL_MATERIALIZED_DICT_VERSION_MIN
         && fprop->hasBundleID) {

--- a/src/openzl/decompress/decode_frameheader.c
+++ b/src/openzl/decompress/decode_frameheader.c
@@ -38,7 +38,7 @@ struct ZL_FrameInfo {
     size_t frameHeaderSize;
     void* comment;
     size_t commentSize;
-    ZL_BundleID bundleID; // v24+: dict bundle ID
+    ZL_BundleID bundleID; // v25+: dict bundle ID
 };
 
 static ZL_Type decodeType(uint8_t et)
@@ -299,7 +299,7 @@ static ZL_Report DFH_FrameInfo_decodeFrameHeader(
                 && ((flags & (1 << 3)) != 0);
     }
 
-    // Decode dict bundle ID (v24+): 1-byte size + variable-length ID
+    // Decode dict bundle ID (v25+): 1-byte size + variable-length ID
     if (zfi->properties.hasBundleID) {
         ZL_ERR_IF_LE(cSize, consumed, corruption);
         uint8_t const encLen = ptr[consumed++];
@@ -897,7 +897,7 @@ static ZL_Report decompressNbRegens(
 }
 
 // Decompress per-codec dict bundle offsets
-// (v24+)
+// (v25+)
 // has-dict flags are bitpacked
 // non-zero dict indices are bitpacked
 static ZL_Report decompressDictIdxs(
@@ -1219,7 +1219,7 @@ static ZL_Report decodeChunkHeader_internal(
     }
 
     // Decode per-codec dict indices if a bundle is declared
-    // (v24+ only)
+    // (v25+ only)
     if (decoder->formatVersion >= ZL_MATERIALIZED_DICT_VERSION_MIN
         && dfh->frameinfo->properties.hasBundleID) {
         uint32_t* const dictIdxs = wksp.scratch0;

--- a/tests/integrationtest/DictIntegrationTest.cpp
+++ b/tests/integrationtest/DictIntegrationTest.cpp
@@ -543,7 +543,7 @@ TEST_F(DictIntegrationTest, FullRoundTrip)
     EXPECT_EQ(decompress(compressed, input.size(), dctx.get()), input);
 }
 
-TEST_F(DictIntegrationTest, PreV24FrameOmitsBundleIDEvenWhenBundleIsLoaded)
+TEST_F(DictIntegrationTest, PreV25FrameOmitsBundleIDEvenWhenBundleIsLoaded)
 {
     DictCodecSpec unusedDict = makeDictSpec(11, 0x31);
     ZL_NodeID unusedDictNode = registerDictNode(


### PR DESCRIPTION
Summary:
The latest release puts v24 into prod. This means we need to bump the dict bundle metadata wire format from v24 to v25.

- ZL_MAX_FORMAT_VERSION: 24 → 25
- ZL_MATERIALIZED_DICT_VERSION_MIN: 24 → 25
- Updates all v24 references in comments and docs to v25

Differential Revision: D105707554


