### PR TITLE
Disallow permissive fallback above segmenters

### DIFF
--- a/src/openzl/compress/cctx.c
+++ b/src/openzl/compress/cctx.c
@@ -153,8 +153,7 @@ struct ZL_CCtx_s {
     size_t currentFrameSize; // already written into dstBuffer
     ZL_OperationContext opCtx;
     int inBackupMode; // tracks when graph is in backup mode, to avoid looping
-    int inSegmenter;  // tracks when a segmenter is active, to disallow
-                      // segmenters run after segmenters
+    unsigned segmenterDepth; // 0 until a segmenter starts, then its depth
 };
 
 static ZL_Report CCTX_init(ZL_CCtx* cctx)
@@ -207,9 +206,9 @@ void CCTX_clean(ZL_CCtx* cctx)
 {
     CCTX_cleanChunk(cctx);
     ALLOC_Arena_freeAll(cctx->sessionArena);
-    cctx->comment.size = 0;
-    cctx->comment.data = NULL;
-    cctx->inSegmenter  = 0;
+    cctx->comment.size   = 0;
+    cctx->comment.data   = NULL;
+    cctx->segmenterDepth = 0;
     ZL_ASSERT_EQ(ALLOC_Arena_memUsed(cctx->codecArena), 0);
     ZL_ASSERT_EQ(ALLOC_Arena_memUsed(cctx->graphArena), 0);
     ZL_ASSERT_EQ(ALLOC_Arena_memUsed(cctx->chunkArena), 0);
@@ -298,6 +297,12 @@ int CCTX_getAppliedGParam(const ZL_CCtx* cctx, ZL_CParam gcparam)
 {
     ZL_ASSERT_NN(cctx);
     return GCParams_getParameter(&cctx->appliedGCParams, gcparam);
+}
+
+unsigned CCTX_getSegmenterDepth(const ZL_CCtx* cctx)
+{
+    ZL_ASSERT_NN(cctx);
+    return cctx->segmenterDepth;
 }
 
 int CCTX_isGraphSet(const ZL_CCtx* cctx)
@@ -914,7 +919,8 @@ static ZL_Report CCTX_runSegmenter(
         ZL_GraphID graphid,
         const ZL_RuntimeGraphParameters* rgp,
         const RTStreamID* rtsids,
-        size_t nbInputs)
+        size_t nbInputs,
+        unsigned depth)
 {
     ZL_RESULT_DECLARE_SCOPE_REPORT(cctx);
 
@@ -1002,8 +1008,8 @@ static ZL_Report CCTX_runSegmenter(
             cctx->sessionArena,
             cctx->chunkArena);
     CWAYPOINT(on_segmenterEncode_start, segmenterCtx, /* placeholder */ NULL);
-    cctx->inSegmenter = 1;
-    ZL_Report const r = SEGM_runSegmenter(segmenterCtx);
+    cctx->segmenterDepth = depth;
+    ZL_Report const r    = SEGM_runSegmenter(segmenterCtx);
 
     CWAYPOINT(on_segmenterEncode_end, segmenterCtx, r);
 
@@ -1292,6 +1298,18 @@ static ZL_Report CCTX_runSuccessor_internal(
     if (backupMode != ZL_TernaryParam_enable || cctx->inBackupMode) {
         return outcome;
     }
+    if (cctx->segmenterDepth != 0 && depth <= cctx->segmenterDepth) {
+        /* Permissive fallback above a Segmenter is not currently supported:
+         * fallback graphs currently do not Segment,
+         * and we can't take the risk to attempt compressing a huge Segment.
+         */
+        ZL_ERR_IF_ERR(
+                outcome,
+                "Permissive fallback above a Segmenter is not supported "
+                "(depth=%u, segmenterDepth=%u)",
+                depth,
+                cctx->segmenterDepth);
+    }
 
     ZL_E_log(ZL_RES_error(outcome), ZL_LOG_LVL_V);
     // Report the error as a warning
@@ -1346,13 +1364,14 @@ ZL_Report CCTX_runSuccessor(
     // after nodes are executed.
     int const isSegmentable =
             (rtInputs[0].rtsid == 0 && nbInputs == cctx->nbInputs
-             && cctx->numSegments == 0 && !cctx->inSegmenter
+             && cctx->numSegments == 0 && cctx->segmenterDepth == 0
              && RTGM_getNbNodes(&cctx->rtgraph) == 0);
 
     // Segmenter
     if (CGRAPH_graphType(cctx->cgraph, graphid) == gt_segmenter) {
         if (isSegmentable) {
-            return CCTX_runSegmenter(cctx, graphid, rgp, rtInputs, nbInputs);
+            return CCTX_runSegmenter(
+                    cctx, graphid, rgp, rtInputs, nbInputs, depth);
         }
         ZL_ERR(graph_invalid, "Segmenter can only be used on full input");
     }
@@ -1411,9 +1430,9 @@ CCTX_startCompression(ZL_CCtx* cctx, const ZL_Data* inputs[], size_t nbInputs)
     cctx->inputs = ZL_codemodDatasAsInputs(inputs);
     ZL_ERR_IF_LT(nbInputs, 1, successor_invalidNumInputs);
     ZL_ASSERT_LT(nbInputs, INT_MAX);
-    cctx->nbInputs    = (unsigned)nbInputs;
-    cctx->numSegments = 0;
-    cctx->inSegmenter = 0;
+    cctx->nbInputs       = (unsigned)nbInputs;
+    cctx->numSegments    = 0;
+    cctx->segmenterDepth = 0;
     ALLOC_ARENA_MALLOC_CHECKED(
             RTStreamID, rtsids, nbInputs, cctx->sessionArena);
     for (size_t n = 0; n < nbInputs; n++) {

--- a/src/openzl/compress/cctx.h
+++ b/src/openzl/compress/cctx.h
@@ -203,6 +203,14 @@ ZL_Report CCTX_setAppliedParameters(ZL_CCtx* cctx);
 int CCTX_getAppliedGParam(const ZL_CCtx* cctx, ZL_CParam gcparam);
 
 /**
+ * @brief Get the depth at which the active segmenter started.
+ *
+ * @return 0 if no segmenter has started in the current compression session,
+ * otherwise the graph execution depth of the active segmenter.
+ */
+unsigned CCTX_getSegmenterDepth(const ZL_CCtx* cctx);
+
+/**
  * @brief Add transform header data to the compression context.
  *
  * This function adds header information for a specific transform to the

--- a/src/openzl/compress/segmenter.c
+++ b/src/openzl/compress/segmenter.c
@@ -260,8 +260,8 @@ void* ZL_Segmenter_getScratchSpace(ZL_Segmenter* segCtx, size_t size)
  * RTGraph Reset Strategy: Calls RTGM_reset() before each chunk to ensure
  * clean state, then registers chunk inputs as new runtime streams.
  *
- * Protection Level: Uses depth=1 for graph execution, providing the highest
- * protection level that still allows graphs to make redirection decisions.
+ * Protection Level: Chunk graphs run below the segmenter's depth, while still
+ * allowing graphs to make redirection decisions.
  *
  * Cleanup Pattern: Manual cleanup with proper STREAM_free() calls to handle
  * reference counting, followed by CCTX_cleanChunk() for context cleanup.
@@ -319,8 +319,8 @@ ZL_Report ZL_Segmenter_processChunk(
     }
 
     // Run the starting Graph on the Inputs
-    // This is depth 1, which is the highest level of protection,
-    // allowing the Graph to make redirection decisions if need be.
+    // Run the chunk graph below the segmenter's graph depth, allowing the Graph
+    // to make redirection decisions if need be.
     // Note: depth==0 means "unprotected"
     ZL_ERR_IF_ERR(CCTX_runSuccessor(
             cctx,
@@ -328,7 +328,7 @@ ZL_Report ZL_Segmenter_processChunk(
             rGraphParams,
             rtsids,
             numInputs,
-            /* depth */ 1));
+            CCTX_getSegmenterDepth(cctx) + 1));
 
     ZL_Report r = CCTX_flushChunk(cctx, (void*)chunkInputs, numInputs);
     segCtx->numChunks++;

--- a/tests/round_trip/test_segmenter.cpp
+++ b/tests/round_trip/test_segmenter.cpp
@@ -807,6 +807,64 @@ static ZL_SegmenterDesc const failingIncompleteSegmenter = {
     .numInputs      = 1,
 };
 
+static ZL_Report alwaysFailGraph(
+        ZL_Graph* graph,
+        ZL_Edge* inputs[],
+        size_t nbInputs) ZL_NOEXCEPT_FUNC_PTR
+{
+    ZL_RESULT_DECLARE_SCOPE_REPORT(graph);
+    (void)inputs;
+    (void)nbInputs;
+    ZL_ERR(node_invalid_input, "intentional test failure");
+}
+
+ZL_Report permissiveChunkSegmenterFn(ZL_Segmenter* sctx)
+{
+    ZL_RESULT_DECLARE_SCOPE_REPORT(sctx);
+    ZL_ERR_IF_NE(ZL_Segmenter_numInputs(sctx), 1, node_invalid_input);
+    const ZL_Input* const input = ZL_Segmenter_getInput(sctx, 0);
+    ZL_ERR_IF_NULL(input, node_invalid_input);
+
+    ZL_GraphIDList const customGraphs = ZL_Segmenter_getCustomGraphs(sctx);
+    ZL_ERR_IF_NE(customGraphs.nbGraphIDs, 1, graphParameter_invalid);
+
+    size_t const numElts = ZL_Input_numElts(input);
+    return ZL_Segmenter_processChunk(
+            sctx, &numElts, 1, customGraphs.graphids[0], NULL);
+}
+
+static ZL_GraphID registerSegmenterWithFailingChunkGraph(
+        ZL_Compressor* compressor) noexcept
+{
+    ZL_Report const setr = ZL_Compressor_setParameter(
+            compressor, ZL_CParam_formatVersion, g_testVersion);
+    if (ZL_isError(setr))
+        abort();
+
+    ZL_Type const inType                 = ZL_Type_serial;
+    ZL_FunctionGraphDesc const graphDesc = {
+        .name           = "Always Fail",
+        .graph_f        = alwaysFailGraph,
+        .inputTypeMasks = &inType,
+        .nbInputs       = 1,
+    };
+
+    ZL_GraphID const permissiveChunkSuccessor =
+            ZL_Compressor_registerFunctionGraph(compressor, &graphDesc);
+    ZL_Type const segmenterInputTypeMasks[]         = { ZL_Type_serial };
+    ZL_SegmenterDesc const permissiveChunkSegmenter = {
+        .name            = "Segmenter with failing chunk graph",
+        .segmenterFn     = permissiveChunkSegmenterFn,
+        .inputTypeMasks  = segmenterInputTypeMasks,
+        .numInputs       = 1,
+        .customGraphs    = &permissiveChunkSuccessor,
+        .numCustomGraphs = 1,
+    };
+
+    return ZL_Compressor_registerSegmenter(
+            compressor, &permissiveChunkSegmenter);
+}
+
 TEST(Segmenter, input_incomplete)
 {
     // Custom segmenter without customGraphs: no single-chunk fallback
@@ -814,6 +872,30 @@ TEST(Segmenter, input_incomplete)
         return;
     g_segmenterDescPtr = &failingIncompleteSegmenter;
     (void)cFailTest(registerSegmenter, g_segmenterDescPtr->name);
+}
+
+TEST(Segmenter, permissive_graphThenIncompleteSegmenter)
+{
+    // This reproduces the graph shape where an outer graph redirects full input
+    // to a segmenter, the segmenter resets the runtime graph, and permissive
+    // fallback above the segmenter must fail cleanly instead of dereferencing
+    // the stale runtime stream IDs that existed before the segmenter reset.
+    if (g_testVersion < ZL_CHUNK_VERSION_MIN)
+        return;
+    g_segmenterDescPtr           = &failingIncompleteSegmenter;
+    g_failingGraph_forPermissive = registerGraphAndSegmenter;
+    (void)cFailTest(
+            permissiveGraph_asGraphF,
+            "permissive_graphThenIncompleteSegmenter");
+}
+
+TEST(Segmenter, permissive_insideSegmenterChunk)
+{
+    if (g_testVersion < ZL_CHUNK_VERSION_MIN)
+        return;
+    (void)permissiveTest(
+            registerSegmenterWithFailingChunkGraph,
+            "permissive inside segmenter chunk");
 }
 
 /* =======   Codec precedes segmenter (must fail)  ======== */


### PR DESCRIPTION
Summary:
Tracks the graph depth at which a segmenter starts, runs segmenter chunk graphs below that depth, and refuses permissive fallback for failures that bubble back above the segmenter by forwarding the original failure with extra context. This avoids reusing stale runtime stream IDs after the segmenter resets `RTGraph`, while preserving permissive fallback inside chunk graphs and preserving the actionable segmenter error.

Permissive fallback remains allowed below a Segmenter, where the input has already been chunked. It is intentionally refused above a Segmenter because the current fallback graph does not segment; using it there could collapse the workload back into one large unsegmented compression attempt. A fuller fix would require routing fallback differently depending on whether it is above or below the Segmenter, and may need substantial changes to handle cases where segmentation has already emitted some chunks before failing.

Differential Revision: D105882464


