### PR TITLE
Serialize/deserialize dict bundle IDs and per-node dict IDs in compressor serialization (#772)

### DIFF
--- a/cpp/include/openzl/cpp/Compressor.hpp
+++ b/cpp/include/openzl/cpp/Compressor.hpp
@@ -7,9 +7,11 @@
 #include "openzl/cpp/CParam.hpp"
 #include "openzl/cpp/LocalParams.hpp"
 #include "openzl/cpp/detail/NonNullUniqueCPtr.hpp"
+#include "openzl/cpp/poly/Optional.hpp"
 #include "openzl/zl_ctransform.h"
 #include "openzl/zl_errors.h"
 #include "openzl/zl_opaque_types.h"
+#include "openzl/zl_unique_id.h"
 
 namespace openzl {
 class CustomEncoder;
@@ -146,15 +148,19 @@ class Compressor {
     static std::string convertSerializedToJson(poly::string_view serialized);
 
     /// Ingests @p serialized and materializes the compressor it represents
-    /// into this compressor.
+    /// into this compressor. If the compressor requires a dict bundle, pass it
+    /// as a "fat" bundle via @p fatBundle.
     ///
     /// @note consult zl_compressor_serialization.h for discussion of the
     ///       semantics of this operation.
-    void deserialize(poly::string_view serialized);
+    void deserialize(
+            poly::string_view serialized,
+            poly::string_view fatBundle = {});
 
     struct UnmetDependencies {
         std::vector<std::string> graphNames;
         std::vector<std::string> nodeNames;
+        poly::optional<ZL_BundleID> bundleID{};
     };
 
     /// Compares the serialized compressor in @p serialized against the state

--- a/cpp/src/openzl/cpp/Compressor.cpp
+++ b/cpp/src/openzl/cpp/Compressor.cpp
@@ -215,7 +215,9 @@ std::string Compressor::serializeToJson() const
     return json;
 }
 
-void Compressor::deserialize(poly::string_view serialized)
+void Compressor::deserialize(
+        poly::string_view serialized,
+        poly::string_view fatBundle)
 {
     const auto deserializer = make_deserializer();
 
@@ -224,7 +226,9 @@ void Compressor::deserialize(poly::string_view serialized)
                     deserializer.get(),
                     get(),
                     serialized.data(),
-                    serialized.size()),
+                    serialized.size(),
+                    fatBundle.empty() ? nullptr : fatBundle.data(),
+                    fatBundle.size()),
             "Call to ZL_CompressorDeserializer_deserialize() failed.",
             deserializer.get());
 }
@@ -249,6 +253,9 @@ Compressor::UnmetDependencies Compressor::getUnmetDependencies(
     }
     for (size_t i = 0; i < raw_deps.num_nodes; i++) {
         deps.nodeNames.emplace_back(raw_deps.node_names[i]);
+    }
+    if (ZL_UniqueID_isValid(&raw_deps.bundle_id.id)) {
+        deps.bundleID = raw_deps.bundle_id;
     }
     return deps;
 }

--- a/include/openzl/zl_compressor_serialization.h
+++ b/include/openzl/zl_compressor_serialization.h
@@ -313,14 +313,19 @@ void ZL_CompressorDeserializer_free(ZL_CompressorDeserializer* deserializer);
 
 /**
  * Reads the serialized compressor represented by @p serialized and pushes
- * the graph structure and configuration it describes into @p compressor.
+ * the graph structure and configuration it describes into @p compressor. If the
+ * compressor requires a dict bundle, it should be passed as a "fat" bundle via
+ * @p fatBundle (if no bundle is required, pass NULL). See @ref
+ * ZL_Compressor_loadDictBundle() for more details.
  *
  * In order for materialization to succeed, the @p compressor must already have
  * all of the custom transforms, graph functions, selectors, etc. registered
  * that were available when the compressor was serialized. You can use @ref
  * ZL_CompressorDeserializer_getDependencies() to determine what non-serialized
  * graph components are needed on the destination compressor. You can then set
- * those components up before invoking this operation on that compressor.
+ * those components up before invoking this operation on that compressor. @ref
+ * ZL_CompressorDeserializer_getDependencies() should also be used to determine
+ * if a bundle is required.
  *
  * See the documentation above for a more thorough discussion of these
  * requirements and how best to structure a compressor to meet them.
@@ -333,7 +338,9 @@ ZL_Report ZL_CompressorDeserializer_deserialize(
         ZL_CompressorDeserializer* deserializer,
         ZL_Compressor* compressor,
         const void* serialized,
-        size_t serializedSize);
+        size_t serializedSize,
+        const void* fatBundle,
+        size_t fatBundleSize);
 
 /**
  * Doesn't own any memory.
@@ -344,6 +351,8 @@ typedef struct {
 
     const char* const* node_names;
     size_t num_nodes;
+
+    ZL_BundleID bundle_id; // ZL_BUNDLE_ID_NULL if no bundle is required
 } ZL_CompressorDeserializer_Dependencies;
 
 ZL_RESULT_DECLARE_TYPE(ZL_CompressorDeserializer_Dependencies);

--- a/src/openzl/compress/compressor_serialization.c
+++ b/src/openzl/compress/compressor_serialization.c
@@ -3,6 +3,7 @@
 #include "openzl/zl_compressor_serialization.h"
 
 #include "openzl/zl_compressor.h"
+#include "openzl/zl_dict.h"
 #include "openzl/zl_reflection.h"
 
 #include "openzl/shared/a1cbor.h"
@@ -21,15 +22,17 @@
 
 #include "openzl/zl_materializer.h"
 
+#include "openzl/zl_unique_id.h"
+
 static ZL_RESULT_OF(StringView)
-        cs_hexEncodeMParamID(Arena* const arena, const ZL_MParamID* id)
+        cs_hexEncodeUniqueID(Arena* const arena, const ZL_UniqueID* uid)
 {
     ZL_RESULT_DECLARE_SCOPE(StringView, NULL);
-    const size_t encSize = sizeof(id->id.bytes) * 2;
+    const size_t encSize = sizeof(uid->bytes) * 2;
     char* buf            = ALLOC_Arena_malloc(arena, encSize + 1);
     ZL_ERR_IF_NULL(buf, allocation);
-    for (size_t i = 0; i < sizeof(id->id.bytes); i++) {
-        const uint8_t byte = id->id.bytes[i];
+    for (size_t i = 0; i < sizeof(uid->bytes); i++) {
+        const uint8_t byte = uid->bytes[i];
         buf[i * 2]         = "0123456789abcdef"[byte >> 4];
         buf[i * 2 + 1]     = "0123456789abcdef"[byte & 0x0f];
     }
@@ -37,19 +40,23 @@ static ZL_RESULT_OF(StringView)
     return ZL_WRAP_VALUE(StringView_init(buf, encSize));
 }
 
-ZL_RESULT_DECLARE_TYPE(ZL_MParamID);
+ZL_RESULT_DECLARE_TYPE(ZL_UniqueID);
+ZL_RESULT_DECLARE_TYPE(ZL_BundleID);
 
-static ZL_RESULT_OF(ZL_MParamID) cs_hexDecodeMParamID(const StringView sv)
+static ZL_RESULT_OF(ZL_BundleID)
+        cs_extractDictBundleIDOrNull(const A1C_Item* root);
+
+static ZL_RESULT_OF(ZL_UniqueID) cs_hexDecodeUniqueID(const StringView sv)
 {
-    ZL_RESULT_DECLARE_SCOPE(ZL_MParamID, NULL);
-    ZL_MParamID decoded;
+    ZL_RESULT_DECLARE_SCOPE(ZL_UniqueID, NULL);
+    ZL_UniqueID decoded;
     memset(&decoded, 0, sizeof(decoded));
     ZL_ERR_IF_NE(
             sv.size,
-            sizeof(decoded.id.bytes) * 2,
+            sizeof(decoded.bytes) * 2,
             corruption,
-            "Failed to hex-decode mparam ID: wrong length");
-    for (size_t i = 0; i < sizeof(decoded.id.bytes); i++) {
+            "Failed to hex-decode ZL_UniqueID: wrong length");
+    for (size_t i = 0; i < sizeof(decoded.bytes); i++) {
         const char hi = sv.data[i * 2];
         const char lo = sv.data[i * 2 + 1];
         uint8_t nib_hi, nib_lo;
@@ -60,7 +67,7 @@ static ZL_RESULT_OF(ZL_MParamID) cs_hexDecodeMParamID(const StringView sv)
         } else if (hi >= 'A' && hi <= 'F') {
             nib_hi = (uint8_t)(hi - 'A' + 10);
         } else {
-            ZL_ERR(corruption, "Invalid hex char in mparam ID");
+            ZL_ERR(corruption, "Invalid hex char in unique ID");
         }
         if (lo >= '0' && lo <= '9') {
             nib_lo = (uint8_t)(lo - '0');
@@ -69,9 +76,9 @@ static ZL_RESULT_OF(ZL_MParamID) cs_hexDecodeMParamID(const StringView sv)
         } else if (lo >= 'A' && lo <= 'F') {
             nib_lo = (uint8_t)(lo - 'A' + 10);
         } else {
-            ZL_ERR(corruption, "Invalid hex char in mparam ID");
+            ZL_ERR(corruption, "Invalid hex char in unique ID");
         }
-        decoded.id.bytes[i] = (uint8_t)((nib_hi << 4) | nib_lo);
+        decoded.bytes[i] = (uint8_t)((nib_hi << 4) | nib_lo);
     }
     return ZL_WRAP_VALUE(decoded);
 }
@@ -350,6 +357,7 @@ typedef struct {
     StringView base_node_name;
     StringView param_set_name;
     StringView mparam_id;
+    StringView dict_id;
 } CompressorSerializer_Node;
 
 ////////////////////////////////////////
@@ -929,7 +937,7 @@ static ZL_Report CompressorSerializer_serializeNode_cb(
             ZL_TRY_LET_CONST(
                     StringView,
                     mparam_id_sv,
-                    cs_hexEncodeMParamID(state->arena, &mid));
+                    cs_hexEncodeUniqueID(state->arena, &mid.id));
             ZL_ERR_IF_NULL(
                     CompressorSerializer_MParamMap_find(
                             &state->mparams, &mparam_id_sv),
@@ -941,6 +949,17 @@ static ZL_Report CompressorSerializer_serializeNode_cb(
                     (int)mparam_id_sv.size,
                     mparam_id_sv.data);
             info.mparam_id = mparam_id_sv;
+        }
+    }
+
+    {
+        ZL_DictID did = ZL_Compressor_Node_getDictID(c, nid);
+        if (ZL_UniqueID_isValid(&did.id)) {
+            ZL_TRY_LET_CONST(
+                    StringView,
+                    dict_id_sv,
+                    cs_hexEncodeUniqueID(state->arena, &did.id));
+            info.dict_id = dict_id_sv;
         }
     }
 
@@ -1112,7 +1131,7 @@ static ZL_Report ZL_CompressorSerializer_encodeNode(
 
     A1C_Item_string_refStringView(node_key_item, entry->key);
     const A1C_MapBuilder node_builder =
-            A1C_Item_map_builder(node_val_item, 3, &state->a1c_arena);
+            A1C_Item_map_builder(node_val_item, 4, &state->a1c_arena);
 
     {
         A1C_MAP_TRY_ADD(pair, node_builder);
@@ -1128,8 +1147,14 @@ static ZL_Report ZL_CompressorSerializer_encodeNode(
 
     if (info->mparam_id.size > 0) {
         A1C_MAP_TRY_ADD(pair, node_builder);
-        A1C_Item_string_refCStr(&pair->key, "mparam");
+        A1C_Item_string_refCStr(&pair->key, "mparam_id");
         A1C_Item_string_refStringView(&pair->val, info->mparam_id);
+    }
+
+    if (info->dict_id.size > 0) {
+        A1C_MAP_TRY_ADD(pair, node_builder);
+        A1C_Item_string_refCStr(&pair->key, "dict_id");
+        A1C_Item_string_refStringView(&pair->val, info->dict_id);
     }
 
     return ZL_returnSuccess();
@@ -1313,7 +1338,7 @@ static ZL_Report recordMParam_cb(void* opaque, const ZL_MParam* mparam)
     ZL_TRY_LET_CONST(
             StringView,
             key,
-            cs_hexEncodeMParamID(state->arena, &mparam->mparamID));
+            cs_hexEncodeUniqueID(state->arena, &mparam->mparamID.id));
 
     const CompressorSerializer_MParamMap_Entry entry =
             (CompressorSerializer_MParamMap_Entry){
@@ -1550,7 +1575,7 @@ static ZL_Report ZL_CompressorSerializer_serializeInner(
     A1C_Item* global_params;
     {
         const A1C_MapBuilder root_map_builder =
-                A1C_Item_map_builder(state->root, 7, &state->a1c_arena);
+                A1C_Item_map_builder(state->root, 8, &state->a1c_arena);
         {
             A1C_MAP_TRY_ADD(pair, root_map_builder);
             A1C_Item_string_refCStr(&pair->key, "version");
@@ -1585,6 +1610,16 @@ static ZL_Report ZL_CompressorSerializer_serializeInner(
             A1C_MAP_TRY_ADD(pair, root_map_builder);
             A1C_Item_string_refCStr(&pair->key, "global_params");
             global_params = &pair->val;
+        }
+        const ZL_BundleID* bundleID = ZL_Compressor_getDictBundleID(c);
+        if (bundleID != NULL) {
+            A1C_MAP_TRY_ADD(pair, root_map_builder);
+            A1C_Item_string_refCStr(&pair->key, "dict_bundle_id");
+            ZL_TRY_LET_CONST(
+                    StringView,
+                    bundle_id_sv,
+                    cs_hexEncodeUniqueID(state->arena, &bundleID->id));
+            A1C_Item_string_refStringView(&pair->val, bundle_id_sv);
         }
     }
 
@@ -2365,10 +2400,10 @@ static ZL_Report ZL_CompressorDeserializer_tryBuildNode(
                     &base_local_params,
                     NULL));
 
-    // Read optional "mparam" field (hex string key) and look up the
+    // Read optional "mparam_id" field (hex string key) and look up the
     // corresponding entry from the pre-parsed mparams map.
     ZL_MParam mparam            = { .mparamID = ZL_MPARAM_ID_NULL };
-    const A1C_Item* mparam_item = A1C_Map_get_cstr(&val_map, "mparam");
+    const A1C_Item* mparam_item = A1C_Map_get_cstr(&val_map, "mparam_id");
     if (mparam_item != NULL) {
         A1C_TRY_EXTRACT_STRING(mparam_key_str, mparam_item);
         const StringView mparam_key_sv = StringView_initFromA1C(mparam_key_str);
@@ -2383,11 +2418,25 @@ static ZL_Report ZL_CompressorDeserializer_tryBuildNode(
         mparam = mp_entry->val;
     }
 
+    ZL_DictID dictID          = ZL_DICT_ID_NULL;
+    const A1C_Item* dict_item = A1C_Map_get_cstr(&val_map, "dict_id");
+    if (dict_item != NULL) {
+        A1C_TRY_EXTRACT_STRING(dict_key_str, dict_item);
+        const StringView dict_key_sv = StringView_initFromA1C(dict_key_str);
+        ZL_TRY_LET_CONST(
+                ZL_UniqueID,
+                decoded_dict_uid,
+                cs_hexDecodeUniqueID(dict_key_sv));
+        const ZL_DictID decoded_dict_id = { .id = decoded_dict_uid };
+        dictID                          = decoded_dict_id;
+    }
+
     const ZL_NodeID node_id = ZL_Compressor_registerParameterizedNode(
             compressor,
             &(const ZL_ParameterizedNodeDesc){
                     .node        = base_nid,
                     .localParams = &local_params,
+                    .dictID      = dictID,
                     .mparam      = mparam,
             });
     ZL_ERR_IF_EQ(node_id.nid, ZL_NODE_ILLEGAL.nid, corruption);
@@ -3145,7 +3194,33 @@ static ZL_RESULT_OF(ZL_CompressorDeserializer_Dependencies)
     deps.num_graphs  = num_graphs;
     deps.node_names  = node_names;
     deps.num_nodes   = num_nodes;
+
+    ZL_TRY_SET(
+            ZL_BundleID,
+            deps.bundle_id,
+            cs_extractDictBundleIDOrNull(state->root));
+
     return ZL_WRAP_VALUE(deps);
+}
+
+static ZL_RESULT_OF(ZL_BundleID)
+        cs_extractDictBundleIDOrNull(const A1C_Item* const root)
+{
+    ZL_RESULT_DECLARE_SCOPE(ZL_BundleID, NULL);
+    ZL_BundleID bundle_id = ZL_BUNDLE_ID_NULL;
+
+    A1C_TRY_EXTRACT_MAP(root_map, root);
+    const A1C_Item* const bundle_item =
+            A1C_Map_get_cstr(&root_map, "dict_bundle_id");
+    if (bundle_item == NULL) {
+        return ZL_WRAP_VALUE(bundle_id);
+    }
+
+    A1C_TRY_EXTRACT_STRING(bundle_str, bundle_item);
+    const StringView bundle_sv = StringView_initFromA1C(bundle_str);
+    ZL_TRY_LET_CONST(ZL_UniqueID, decoded_uid, cs_hexDecodeUniqueID(bundle_sv));
+    bundle_id.id = decoded_uid;
+    return ZL_WRAP_VALUE(bundle_id);
 }
 
 static ZL_Report ZL_CompressorDeserializer_decode(
@@ -3259,7 +3334,9 @@ static ZL_Report ZL_CompressorDeserializer_setupMParams(
         A1C_TRY_EXTRACT_STRING(key_str, &pair->key);
         const StringView key_sv = StringView_initFromA1C(key_str);
 
-        ZL_TRY_LET_CONST(ZL_MParamID, decoded_id, cs_hexDecodeMParamID(key_sv));
+        ZL_TRY_LET_CONST(
+                ZL_UniqueID, decoded_uid, cs_hexDecodeUniqueID(key_sv));
+        const ZL_MParamID decoded_id = { .id = decoded_uid };
 
         A1C_TRY_EXTRACT_BYTES(blob, &pair->val);
 
@@ -3359,7 +3436,9 @@ ZL_Report ZL_CompressorDeserializer_deserialize(
         ZL_CompressorDeserializer* const state,
         ZL_Compressor* const compressor,
         const void* const serialized_ptr,
-        const size_t serialized_size)
+        const size_t serialized_size,
+        const void* fatBundle,
+        size_t fatBundleSize)
 {
     ZL_RESULT_DECLARE_SCOPE_REPORT(state);
     ZL_ERR_IF_NULL(state, GENERIC);
@@ -3388,6 +3467,30 @@ ZL_Report ZL_CompressorDeserializer_deserialize(
 
     ZL_ERR_IF_ERR(ZL_CompressorDeserializer_setupGraphs(
             state, ZL_CompressorDeserializer_tryBuildGraph));
+
+    // Load the fat bundle if requested
+    {
+        ZL_TRY_LET_CONST(
+                ZL_BundleID,
+                bundle_id,
+                cs_extractDictBundleIDOrNull(state->root));
+        if (ZL_UniqueID_isValid(&bundle_id.id)) {
+            ZL_ERR_IF_NULL(
+                    fatBundle,
+                    GENERIC,
+                    "Serialized compressor requires a dict bundle, but none was provided");
+            ZL_TRY_LET_CONST(
+                    ZL_BundleInfo,
+                    bundle_info,
+                    ZL_BundleInfo_parse(fatBundle, fatBundleSize));
+            ZL_ERR_IF_NOT(
+                    ZL_UniqueID_eq(&bundle_info.bundleID.id, &bundle_id.id),
+                    corruption,
+                    "Serialized bundle ID does not match the ID of the passed fat bundle");
+            ZL_ERR_IF_ERR(ZL_Compressor_loadDictBundle(
+                    compressor, fatBundle, fatBundleSize));
+        }
+    }
 
     ZL_ERR_IF_ERR(
             ZL_CompressorDeserializer_setStartingGraph(state, compressor));

--- a/tests/compress/test_compressor_serialization.cpp
+++ b/tests/compress/test_compressor_serialization.cpp
@@ -9,7 +9,9 @@
 #include "openzl/common/a1cbor_helpers.h"
 #include "openzl/common/logging.h"
 #include "openzl/compress/private_nodes.h"
+#include "openzl/cpp/Compressor.hpp"
 #include "openzl/cpp/Exception.hpp"
+#include "openzl/dict/dict_constants.h"
 
 #include "tests/datagen/random_producer/PRNGWrapper.h"
 #include "tests/datagen/structures/CompressorProducer.h"
@@ -170,7 +172,8 @@ std::shared_ptr<const std::string_view> convert_to_json(
 
 void deserialize(
         const std::shared_ptr<const std::string_view>& serialized,
-        ZL_Compressor* const materialized)
+        ZL_Compressor* const materialized,
+        const std::vector<uint8_t>& fatBundle = {})
 {
     std::unique_ptr<
             ZL_CompressorDeserializer,
@@ -180,7 +183,9 @@ void deserialize(
             deserializer.get(),
             materialized,
             serialized->data(),
-            serialized->size());
+            serialized->size(),
+            fatBundle.empty() ? nullptr : fatBundle.data(),
+            fatBundle.size());
     if (ZL_RES_isError(des_res)) {
         const auto msg = ZL_CompressorDeserializer_getErrorContextString(
                 deserializer.get(), des_res);
@@ -223,7 +228,8 @@ ZL_CompressorDeserializer_Dependencies get_deps(
 
 std::string roundtrip(
         const ZL_Compressor* const compressor,
-        ZL_Compressor* const materialized)
+        ZL_Compressor* const materialized,
+        const std::vector<uint8_t>& fatBundle = {})
 {
     auto ser      = serialize(compressor);
     auto ser_json = serialize_to_json(compressor);
@@ -232,7 +238,7 @@ std::string roundtrip(
 
     EXPECT_EQ(*ser_json, *json);
 
-    deserialize(ser, materialized);
+    deserialize(ser, materialized, fatBundle);
     return std::string{ *json };
 }
 
@@ -301,19 +307,66 @@ TEST_F(CompressorSerializationTest, Roundtrip)
     roundtrip(compressor, materialized_.get());
 }
 
+TEST_F(CompressorSerializationTest,
+       DependenciesUseNullBundleIDWhenNoBundleRequired)
+{
+    auto compressor = compressor_.get();
+    auto zstd_gid   = ZL_Compressor_registerZstdGraph_withLevel(compressor, 1);
+    ZL_REQUIRE_SUCCESS(
+            ZL_Compressor_selectStartingGraphID(compressor, zstd_gid));
+
+    auto deps = get_deps(serialize(compressor), nullptr);
+
+    EXPECT_FALSE(ZL_UniqueID_isValid(&deps.bundle_id.id));
+}
+
+TEST_F(CompressorSerializationTest, RejectsMismatchedFatBundle)
+{
+    auto compressorProducer = makeCompressorProducer();
+    for (uint32_t i = 0; i < 1000; i++) {
+        auto result = compressorProducer.make_multi(1, 1);
+        if (result.fatBundle.empty()) {
+            continue;
+        }
+
+        auto serialized  = serialize(result.full[0].get());
+        auto wrongBundle = result.fatBundle;
+        wrongBundle[4] ^= 0xff;
+
+        std::unique_ptr<
+                ZL_CompressorDeserializer,
+                ZL_CompressorDeserializer_Deleter>
+                deserializer{ ZL_CompressorDeserializer_create() };
+        ZL_Report report = ZL_CompressorDeserializer_deserialize(
+                deserializer.get(),
+                materialized_.get(),
+                serialized->data(),
+                serialized->size(),
+                wrongBundle.data(),
+                wrongBundle.size());
+
+        EXPECT_TRUE(ZL_isError(report));
+        EXPECT_EQ(ZL_Compressor_getDictBundleID(materialized_.get()), nullptr);
+        return;
+    }
+
+    FAIL() << "CompressorProducer did not generate a dict-backed compressor";
+}
+
 TEST_F(CompressorSerializationTest, RoundtripRandomGraphs)
 {
     auto compressorProducer = makeCompressorProducer();
     for (uint32_t i = 0; i < 1000; i++) {
-        auto compressors   = compressorProducer.make_multi(1, 3);
-        auto original      = std::move(compressors.first[0]);
-        auto intermediate1 = std::move(compressors.second[0]);
-        auto intermediate2 = std::move(compressors.second[1]);
-        auto final         = std::move(compressors.second[2]);
+        auto result        = compressorProducer.make_multi(1, 3);
+        auto original      = std::move(result.full[0]);
+        auto intermediate1 = std::move(result.base[0]);
+        auto intermediate2 = std::move(result.base[1]);
+        auto final         = std::move(result.base[2]);
+        const auto& fb     = result.fatBundle;
 
-        auto json1 = roundtrip(original.get(), intermediate1.get());
-        auto json2 = roundtrip(intermediate1.get(), intermediate2.get());
-        auto json3 = roundtrip(intermediate2.get(), final.get());
+        auto json1 = roundtrip(original.get(), intermediate1.get(), fb);
+        auto json2 = roundtrip(intermediate1.get(), intermediate2.get(), fb);
+        auto json3 = roundtrip(intermediate2.get(), final.get(), fb);
         (void)json1;
         (void)json2;
         (void)json3;
@@ -332,8 +385,6 @@ TEST_F(CompressorSerializationTest, GetDepsWithNULL)
         (void)json;
         auto deps = get_deps(ser, NULL);
         (void)deps;
-        // std::cerr << *json << std::endl;
-        // std::cerr << std::endl;
     }
 }
 
@@ -347,8 +398,6 @@ TEST_F(CompressorSerializationTest, GetDepsWithCompressor)
         (void)json;
         auto deps = get_deps(ser, compressor_.get());
         (void)deps;
-        // std::cerr << *json << std::endl;
-        // std::cerr << std::endl;
     }
 }
 

--- a/tests/datagen/structures/CompressorProducer.cpp
+++ b/tests/datagen/structures/CompressorProducer.cpp
@@ -2,12 +2,20 @@
 
 #include "tests/datagen/structures/CompressorProducer.h"
 
+#include <cstring>
 #include <set>
 
+#include "openzl/zl_ctransform.h"
 #include "openzl/zl_graph_api.h"
 #include "openzl/zl_graphs.h"
+#include "openzl/zl_materializer.h"
 #include "openzl/zl_reflection.h"
 #include "openzl/zl_selector.h"
+#include "openzl/zl_unique_id.h"
+
+#include "openzl/dict/bundle.h"
+#include "openzl/dict/dict.h"
+#include "openzl/dict/dict_constants.h"
 
 #include "tests/utils.h"
 
@@ -22,6 +30,24 @@ struct ZS2_Compressor_Deleter {
         ZL_Compressor_free(compressor);
     }
 };
+
+static ZL_RESULT_OF(ZL_VoidPtr) dictCopyMaterialize(
+        ZL_Materializer* matCtx,
+        const void* src,
+        size_t srcSize) ZL_NOEXCEPT_FUNC_PTR
+{
+    ZL_RESULT_DECLARE_SCOPE(ZL_VoidPtr, nullptr);
+    void* copy = ZL_Materializer_allocate(matCtx, srcSize);
+    ZL_ERR_IF_NULL(copy, allocation);
+    std::memcpy(copy, src, srcSize);
+    return ZL_WRAP_VALUE(copy);
+}
+
+static const ZL_MaterializerDesc2 kDictCopyMaterializer = {
+    .materializeFn   = dictCopyMaterialize,
+    .dematerializeFn = ZL_NOOP_DEMATERIALIZE,
+};
+
 } // anonymous namespace
 
 CompressorProducer::Compressor CompressorProducer::make()
@@ -30,10 +56,7 @@ CompressorProducer::Compressor CompressorProducer::make()
     return std::move(rcmb).make();
 }
 
-std::pair<
-        std::vector<CompressorProducer::Compressor>,
-        std::vector<CompressorProducer::Compressor>>
-CompressorProducer::make_multi(
+CompressorProducer::MultiResult CompressorProducer::make_multi(
         const size_t num_full_compressors,
         const size_t num_base_compressors)
 {
@@ -441,6 +464,73 @@ std::vector<std::string> RandomCompressorMultiBuilder::register_mi_node()
     return names;
 }
 
+std::vector<std::string> RandomCompressorMultiBuilder::register_dict_node()
+{
+    const auto name = make_unique_name("!tests.rand_graph.nodes.dict.");
+
+    ZL_DictID dictID;
+    for (size_t b = 0; b < sizeof(dictID.id.bytes); b++) {
+        dictID.id.bytes[b] =
+                static_cast<uint8_t>(rw_->range("dict_id_byte", 0u, 255u));
+    }
+    if (!ZL_UniqueID_isValid(&dictID.id)) {
+        dictID.id.bytes[0] = 1;
+    }
+
+    if (dict_codec_id_ == 0) {
+        dict_codec_id_ = make_ctid();
+    }
+
+    const auto transform =
+            [](ZL_Encoder* eictx, const ZL_Input*[], size_t) noexcept {
+                ZL_RESULT_DECLARE_SCOPE_REPORT(eictx);
+                ZL_ERR(GENERIC, "Unimplemented! Can't actually run.");
+            };
+    const ZL_Type in_type  = ZL_Type_serial;
+    const ZL_Type out_type = ZL_Type_serial;
+    const auto gd          = (ZL_MIGraphDesc){
+                 .CTid                = dict_codec_id_,
+                 .inputTypes          = &in_type,
+                 .nbInputs            = 1,
+                 .lastInputIsVariable = false,
+                 .soTypes             = &out_type,
+                 .nbSOs               = 1,
+                 .voTypes             = nullptr,
+                 .nbVOs               = 0,
+    };
+    const auto desc = (ZL_MIEncoderDesc){
+        .gd          = gd,
+        .transform_f = transform,
+        .localParams = {},
+        .name        = name.c_str(),
+        .trStateMgr  = {},
+        .dictMat     = kDictCopyMaterializer,
+        .dictID      = dictID,
+    };
+
+    auto names =
+            for_all_compressors([&](ZL_Compressor* const c) -> std::string {
+                const auto nid = ZL_Compressor_registerMIEncoder(c, &desc);
+                ZL_ASSERT(ZL_NodeID_isValid(nid));
+                return ZL_Compressor_Node_getName(c, nid);
+            });
+    record_node(names);
+
+    uint8_t dictContent = static_cast<uint8_t>(dictID.id.bytes[0] ^ 0xAB);
+    std::vector<uint8_t> packed(ZL_DICT_HEADER_SIZE + 1, 0);
+    ZL_REQUIRE_SUCCESS(Dict_pack(
+            packed.data(),
+            packed.size(),
+            dictID,
+            dict_codec_id_,
+            true,
+            &dictContent,
+            1));
+    packed_dicts_.push_back(std::move(packed));
+
+    return names;
+}
+
 std::vector<std::string> RandomCompressorMultiBuilder::register_node(
         const TypeSpec ts)
 {
@@ -462,7 +552,7 @@ std::vector<std::string> RandomCompressorMultiBuilder::register_node(
         }
     }
 
-    switch (rw_->range("kind_of_node_to_register", 0, 4)) {
+    switch (rw_->range("kind_of_node_to_register", 0, 5)) {
         case 0:
             return register_pipe_node();
         case 1:
@@ -473,6 +563,8 @@ std::vector<std::string> RandomCompressorMultiBuilder::register_node(
             return register_vo_node(ts);
         case 4:
             return register_mi_node();
+        case 5:
+            return register_dict_node();
     }
     ZL_REQUIRE_FAIL("Unreachable!");
 }
@@ -529,6 +621,36 @@ std::vector<std::string> RandomCompressorMultiBuilder::clone_node(
         ZL_REQUIRE_FAIL("Unreachable!");
     };
 
+    // If cloning a dict node, generate a fresh dictID for the clone.
+    ZL_DictID newDictID = ZL_DICT_ID_NULL;
+    if (!full_compressors_.empty()) {
+        ZL_Compressor* c0    = full_compressors_[0].get();
+        const auto base_nid0 = ZL_Compressor_getNode(c0, base_names[0].c_str());
+        const ZL_DictID baseDictID =
+                ZL_Compressor_Node_getDictID(c0, base_nid0);
+        if (ZL_UniqueID_isValid(&baseDictID.id)) {
+            for (size_t b = 0; b < sizeof(newDictID.id.bytes); b++) {
+                newDictID.id.bytes[b] = static_cast<uint8_t>(
+                        rw_->range("clone_dict_id_byte", 0u, 255u));
+            }
+            if (!ZL_UniqueID_isValid(&newDictID.id)) {
+                newDictID.id.bytes[0] = 1;
+            }
+            uint8_t dictContent =
+                    static_cast<uint8_t>(newDictID.id.bytes[0] ^ 0xAB);
+            std::vector<uint8_t> packed(ZL_DICT_HEADER_SIZE + 1, 0);
+            ZL_REQUIRE_SUCCESS(Dict_pack(
+                    packed.data(),
+                    packed.size(),
+                    newDictID,
+                    dict_codec_id_,
+                    true,
+                    &dictContent,
+                    1));
+            packed_dicts_.push_back(std::move(packed));
+        }
+    }
+
     std::vector<std::string> names;
     for (size_t i = 0; i < full_compressors_.size(); i++) {
         ZL_Compressor* c      = full_compressors_[i].get();
@@ -538,11 +660,13 @@ std::vector<std::string> RandomCompressorMultiBuilder::clone_node(
                 ZL_Compressor_Node_getLocalParams(c, base_nid);
         const auto new_params =
                 transform_localparams(LocalParams{ base_localparams });
-        auto new_localparams                  = *new_params;
-        new_localparams.refParams             = base_localparams.refParams;
+        auto new_localparams      = *new_params;
+        new_localparams.refParams = base_localparams.refParams;
+
         const ZL_ParameterizedNodeDesc pndesc = {
             .node        = base_nid,
             .localParams = &new_localparams,
+            .dictID      = newDictID,
         };
         const auto new_nid =
                 ZL_Compressor_registerParameterizedNode(c, &pndesc);
@@ -1007,10 +1131,7 @@ std::vector<std::string> RandomCompressorMultiBuilder::build_graph(
     return make_graph(ts, depth);
 }
 
-std::pair<
-        std::vector<RandomCompressorMultiBuilder::Compressor>,
-        std::vector<RandomCompressorMultiBuilder::Compressor>>
-RandomCompressorMultiBuilder::make_multi(
+CompressorProducer::MultiResult RandomCompressorMultiBuilder::make_multi(
         size_t num_full_compressors,
         size_t num_base_compressors) &&
 {
@@ -1048,6 +1169,36 @@ RandomCompressorMultiBuilder::make_multi(
         }
     }
 
+    // Build and load fat bundle before validation so dict indices resolve.
+    std::vector<uint8_t> resultFatBundle;
+    if (!packed_dicts_.empty()) {
+        std::vector<const void*> dictPtrs;
+        std::vector<size_t> dictSizes;
+        size_t totalBytes = 0;
+        for (const auto& d : packed_dicts_) {
+            dictPtrs.push_back(d.data());
+            dictSizes.push_back(d.size());
+            totalBytes += d.size();
+        }
+        const size_t bundleCap = ZL_BUNDLE_HEADER_SIZE
+                + packed_dicts_.size() * ZL_UNIQUE_ID_SIZE + totalBytes;
+        resultFatBundle.resize(bundleCap, 0);
+        ZL_Report fbr = ZL_DictBundle_packFatBundle(
+                resultFatBundle.data(),
+                resultFatBundle.size(),
+                dictPtrs.data(),
+                dictSizes.data(),
+                packed_dicts_.size());
+        ZL_REQUIRE_SUCCESS(fbr);
+        resultFatBundle.resize(ZL_validResult(fbr));
+        for (size_t i = 0; i < full_compressors_.size(); i++) {
+            ZL_REQUIRE_SUCCESS(ZL_Compressor_loadDictBundle(
+                    full_compressors_[i].get(),
+                    resultFatBundle.data(),
+                    resultFatBundle.size()));
+        }
+    }
+
     for (size_t i = 0; i < full_compressors_.size(); i++) {
         auto* const c = full_compressors_[i].get();
         const auto gid =
@@ -1056,13 +1207,15 @@ RandomCompressorMultiBuilder::make_multi(
         ZL_REQUIRE_SUCCESS(ZL_Compressor_selectStartingGraphID(c, gid));
     }
 
-    return { std::move(full_compressors_), std::move(base_compressors_) };
+    return { std::move(full_compressors_),
+             std::move(base_compressors_),
+             std::move(resultFatBundle) };
 }
 
 RandomCompressorMultiBuilder::Compressor RandomCompressorMultiBuilder::make() &&
 {
-    auto compressors = std::move(*this).make_multi(1, 0);
-    return std::move(compressors.first[0]);
+    auto result = std::move(*this).make_multi(1, 0);
+    return std::move(result.full[0]);
 }
 
 } // namespace datagen

--- a/tests/datagen/structures/CompressorProducer.h
+++ b/tests/datagen/structures/CompressorProducer.h
@@ -34,6 +34,12 @@ class CompressorProducer : public DataProducer<std::shared_ptr<ZL_Compressor>> {
    public:
     using Compressor = std::shared_ptr<ZL_Compressor>;
 
+    struct MultiResult {
+        std::vector<Compressor> full;
+        std::vector<Compressor> base;
+        std::vector<uint8_t> fatBundle;
+    };
+
    public:
     explicit CompressorProducer(std::shared_ptr<RandWrapper> generator)
             : DataProducer<Compressor>(), rw_(std::move(generator))
@@ -69,7 +75,7 @@ class CompressorProducer : public DataProducer<std::shared_ptr<ZL_Compressor>> {
      * version of a full compressor. When that's done, the result should be
      * logically identical to the full compressor.
      */
-    std::pair<std::vector<Compressor>, std::vector<Compressor>> make_multi(
+    MultiResult make_multi(
             size_t num_full_compressors,
             size_t num_base_compressors);
 
@@ -84,9 +90,8 @@ class CompressorProducer : public DataProducer<std::shared_ptr<ZL_Compressor>> {
  */
 class RandomCompressorMultiBuilder {
    public:
-    using Compressor = std::shared_ptr<ZL_Compressor>;
-
-   public:
+    using Compressor  = std::shared_ptr<ZL_Compressor>;
+    using MultiResult = CompressorProducer::MultiResult;
     explicit RandomCompressorMultiBuilder(std::shared_ptr<RandWrapper> rw)
             : rw_(std::move(rw)), lpp_(rw_)
     {
@@ -108,7 +113,7 @@ class RandomCompressorMultiBuilder {
      * version of a full compressor. When that's done, the result should be
      * logically identical to the full compressor.
      */
-    std::pair<std::vector<Compressor>, std::vector<Compressor>> make_multi(
+    MultiResult make_multi(
             size_t num_full_compressors,
             size_t num_base_compressors) &&;
 
@@ -215,6 +220,7 @@ class RandomCompressorMultiBuilder {
     NameVec register_typed_node(TypeSpec ts = TypeSpec::all());
     NameVec register_vo_node(TypeSpec ts = TypeSpec::all());
     NameVec register_mi_node();
+    NameVec register_dict_node();
     NameVec register_node(TypeSpec ts = TypeSpec::all());
     std::optional<NameVec> try_pick_node(TypeSpec ts = TypeSpec::all());
     NameVec clone_node(const NameVec& base_nodes);
@@ -317,6 +323,10 @@ class RandomCompressorMultiBuilder {
     std::vector<LocalParams> params_;
 
     ZL_IDType next_ctid_{ 1 };
+
+    // Dict node tracking: packed dicts produced by register_dict_node()
+    std::vector<std::vector<uint8_t>> packed_dicts_;
+    ZL_IDType dict_codec_id_{ 0 };
 };
 
 } // namespace openzl::tests::datagen

--- a/tests/integrationtest/CompressorIntegrationTest.cpp
+++ b/tests/integrationtest/CompressorIntegrationTest.cpp
@@ -1231,7 +1231,9 @@ TEST_F(CompressorIntegrationTest,
                 deserializer,
                 compressor2.get(),
                 serializedCopy.data(),
-                serializedCopy.size());
+                serializedCopy.size(),
+                nullptr,
+                0);
         ASSERT_FALSE(ZL_isError(r));
     }
     ZL_CompressorDeserializer_free(deserializer);

--- a/tests/serialization/fuzz_compressor_serialization.cpp
+++ b/tests/serialization/fuzz_compressor_serialization.cpp
@@ -280,12 +280,16 @@ FUZZ(CompressorSerializationTest, FuzzDeserialization)
 FUZZ(CompressorSerializationTest, FuzzRandomCompressorDeserializesSuccessfully)
 {
     datagen::DataGen dg = fromFDP(f);
-    auto rw             = dg.getRandWrapper();
-    auto producer       = datagen::CompressorProducer(rw);
-    auto zlCompressor   = producer.make();
-    CompressorRef compressor(zlCompressor.get());
+    auto producer       = datagen::CompressorProducer(dg.getRandWrapper());
+    auto result         = producer.make_multi(1, 1);
+    CompressorRef compressor(result.full[0].get());
     auto serialized = compressor.serialize();
-    compressor.deserialize(serialized);
+    CompressorRef deserializedCompressor(result.base[0].get());
+    deserializedCompressor.deserialize(
+            serialized,
+            poly::string_view(
+                    reinterpret_cast<const char*>(result.fatBundle.data()),
+                    result.fatBundle.size()));
 }
 } // namespace
 } // namespace openzl::tests


### PR DESCRIPTION
Summary:

Thread dictionary metadata through compressor serialization and deserialization so that dict-backed compressor graphs survive a serialize → deserialize roundtrip.

Concretely:

Serialization format changes:

Add a top-level dict_bundle_id field (hex-encoded ZL_BundleID) to the serialized compressor when a dict bundle is loaded.
Add a per-node dict_id field (hex-encoded ZL_DictID) for nodes that carry a dictionary.
Rename the per-node mparam key from "mparam" to "mparam_id" for consistency.
Deserialization changes:

ZL_CompressorDeserializer_deserialize now accepts an optional fat bundle (fatBundle/fatBundleSize). When the serialized payload contains a dict_bundle_id, the deserializer loads the fat bundle into the compressor and verifies the bundle ID matches.
Per-node dict_id is decoded and passed through ZL_ParameterizedNodeDesc.dictID when re-registering nodes.
ZL_CompressorDeserializer_Dependencies now reports whether a bundle is required (hasBundleID + bundleID), so callers can fetch the bundle before materializing.
New public API: ZL_Compressor_setDictBundleID — sets the expected bundle ID on a compressor before loading a bundle.

Hex encode/decode refactor: Generalize cs_hexEncodeMParamID / cs_hexDecodeMParamID to cs_hexEncodeUniqueID / cs_hexDecodeUniqueID operating on ZL_UniqueID, since both ZL_MParamID and ZL_DictID wrap the same underlying type.

C++ wrapper: Update Compressor::deserialize() to accept an optional fatBundle parameter, forwarded to the C API.

Test infrastructure: Update CompressorProducer / RandomCompressorMultiBuilder to randomly generate dict-backed nodes, pack fat bundles, and supply them through the roundtrip test. The make_multi return type is changed from std::pair to a MultiResult struct carrying full, base, and fatBundle.

Reviewed By: terrelln

Differential Revision: D103864386


