### PR TITLE
Add standard `sparse_num` codec (#775)

### DIFF
--- a/benchmark/unitBench/benchList.h
+++ b/benchmark/unitBench/benchList.h
@@ -86,6 +86,7 @@ static size_t out_identical(const void* src, size_t srcSize)
 #include "benchmark/unitBench/scenarios/codecs/flatpack.h"
 #include "benchmark/unitBench/scenarios/codecs/huffman.h"
 #include "benchmark/unitBench/scenarios/codecs/rolz.h"
+#include "benchmark/unitBench/scenarios/codecs/sparse_num.h"
 #include "benchmark/unitBench/scenarios/codecs/tokenize.h"
 #include "benchmark/unitBench/scenarios/codecs/transpose.h"
 
@@ -489,6 +490,14 @@ Bench_Entry const scenarioList[] = {
     { "sao_sddl2", .graphF=sao_graph_sddl2 },
     { "saoIngest", saoIngest_wrapper },
     { "saoIngestCompiled", saoIngestCompiled_wrapper },
+    { "sparseNumDecode8_d8", sparseNumDecode8_d8_wrapper, .outSize = sparseNumDecode8_d8_outSize, .display = decoderResult },
+    { "sparseNumDecode16_d8", sparseNumDecode16_d8_wrapper, .outSize = sparseNumDecode16_d8_outSize, .display = decoderResult },
+    { "sparseNumDecode32_d8", sparseNumDecode32_d8_wrapper, .outSize = sparseNumDecode32_d8_outSize, .display = decoderResult },
+    { "sparseNumDecode64_d8", sparseNumDecode64_d8_wrapper, .outSize = sparseNumDecode64_d8_outSize, .display = decoderResult },
+    { "sparseNumEncode8", sparseNumEncode8_wrapper, .outSize = sparseNumEncode8_outSize },
+    { "sparseNumEncode16", sparseNumEncode16_wrapper, .outSize = sparseNumEncode16_outSize },
+    { "sparseNumEncode32", sparseNumEncode32_wrapper, .outSize = sparseNumEncode32_outSize },
+    { "sparseNumEncode64", sparseNumEncode64_wrapper, .outSize = sparseNumEncode64_outSize },
     { "splitBy4", splitBy4_wrapper, .prep = splitBy4_preparation },
     { "splitBy8", splitBy8_wrapper, .prep = splitBy8_preparation },
     { "splitByRange8", .graphF = splitByRange8_graph },

--- a/benchmark/unitBench/scenarios/codecs/sparse_num.c
+++ b/benchmark/unitBench/scenarios/codecs/sparse_num.c
@@ -1,0 +1,177 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#include "benchmark/unitBench/scenarios/codecs/sparse_num.h"
+
+#include <stdint.h>
+#include <stdlib.h>
+
+#include "openzl/codecs/sparse_num/decode_sparse_num_kernel.h"
+#include "openzl/codecs/sparse_num/encode_sparse_num_kernel.h"
+
+static size_t
+sparseNumEncodeOutSize(const void* src, size_t srcSize, size_t valueWidth)
+{
+    (void)src;
+    size_t const numElts = srcSize / valueWidth;
+    if (numElts > (SIZE_MAX - 4) / (valueWidth + 4)) {
+        abort();
+    }
+    return numElts * (valueWidth + 4) + 4;
+}
+
+static size_t sparseNumEncode(
+        const void* src,
+        size_t srcSize,
+        void* dst,
+        size_t dstCapacity,
+        size_t valueWidth)
+{
+    size_t const numElts = srcSize / valueWidth;
+    ZL_SparseNumEncodeInfo const info =
+            ZL_sparseNumComputeEncodeInfo(src, numElts, valueWidth);
+
+    size_t const distanceBytes = info.numDistances * info.distanceWidth;
+    size_t const valueBytes    = info.numValues * valueWidth;
+    if (info.distanceWidth != 1) {
+        abort();
+    }
+    if (valueBytes > dstCapacity || distanceBytes > dstCapacity - valueBytes) {
+        abort();
+    }
+
+    /*
+     * unitBench provides one flat output buffer. Place values first so the
+     * value stream keeps the buffer base alignment required by the kernel.
+     * Distances are D8 in these scenarios, so they do not need extra alignment.
+     */
+    ZL_sparseNumEncode(
+            (uint8_t*)dst + valueBytes,
+            dst,
+            src,
+            numElts,
+            valueWidth,
+            info.distanceWidth);
+
+    return distanceBytes + valueBytes;
+}
+
+#define DEFINE_SPARSE_NUM_ENCODE(bits, width)                               \
+    size_t sparseNumEncode##bits##_outSize(const void* src, size_t srcSize) \
+    {                                                                       \
+        return sparseNumEncodeOutSize(src, srcSize, width);                 \
+    }                                                                       \
+                                                                            \
+    size_t sparseNumEncode##bits##_wrapper(                                 \
+            const void* src,                                                \
+            size_t srcSize,                                                 \
+            void* dst,                                                      \
+            size_t dstCapacity,                                             \
+            void* customPayload)                                            \
+    {                                                                       \
+        (void)customPayload;                                                \
+        return sparseNumEncode(src, srcSize, dst, dstCapacity, width);      \
+    }
+
+DEFINE_SPARSE_NUM_ENCODE(8, 1)
+DEFINE_SPARSE_NUM_ENCODE(16, 2)
+DEFINE_SPARSE_NUM_ENCODE(32, 4)
+DEFINE_SPARSE_NUM_ENCODE(64, 8)
+
+static size_t sparseNumDecodeOutputSize(
+        const void* src,
+        size_t srcSize,
+        size_t valueWidth,
+        size_t distanceWidth)
+{
+    /*
+     * Fixture layout: [values][D8 distances], numDistances == numValues.
+     * Values come first to preserve their numeric alignment.
+     */
+    if (src == NULL) {
+        abort();
+    }
+    if (distanceWidth != 1) {
+        abort();
+    }
+    size_t const recordSize = valueWidth + distanceWidth;
+    if (srcSize % recordSize != 0) {
+        abort();
+    }
+    size_t const numValues    = srcSize / recordSize;
+    size_t const numDistances = numValues;
+    /* D8 distances begin immediately after the aligned values stream. */
+    const uint8_t* const distances =
+            (const uint8_t*)src + numValues * valueWidth;
+    size_t const outputCount = ZL_sparseNumDecodeOutputCount(
+            distances, numDistances, distanceWidth, numValues);
+    if (outputCount == ZL_SPARSE_NUM_DECODE_OUTPUT_COUNT_ERROR) {
+        abort();
+    }
+    if (outputCount > SIZE_MAX / valueWidth) {
+        abort();
+    }
+
+    return outputCount * valueWidth;
+}
+
+static size_t sparseNumDecode(
+        const void* src,
+        size_t srcSize,
+        void* dst,
+        size_t dstCapacity,
+        size_t valueWidth,
+        size_t distanceWidth)
+{
+    if (src == NULL) {
+        abort();
+    }
+    size_t const recordSize = valueWidth + distanceWidth;
+    if (srcSize % recordSize != 0) {
+        abort();
+    }
+    size_t const numValues    = srcSize / recordSize;
+    size_t const numDistances = numValues;
+    /* Mirror sparseNumDecodeOutputSize(): [values][D8 distances]. */
+    const uint8_t* const values    = (const uint8_t*)src;
+    const uint8_t* const distances = values + numValues * valueWidth;
+    size_t const outputSize =
+            sparseNumDecodeOutputSize(src, srcSize, valueWidth, distanceWidth);
+
+    if (dstCapacity < outputSize) {
+        abort();
+    }
+
+    ZL_sparseNumDecode(
+            dst,
+            outputSize,
+            distances,
+            numDistances,
+            distanceWidth,
+            values,
+            numValues,
+            valueWidth);
+
+    return outputSize;
+}
+
+#define DEFINE_SPARSE_NUM_DECODE_D8(bits, width)                               \
+    size_t sparseNumDecode##bits##_d8_outSize(const void* src, size_t srcSize) \
+    {                                                                          \
+        return sparseNumDecodeOutputSize(src, srcSize, width, 1);              \
+    }                                                                          \
+                                                                               \
+    size_t sparseNumDecode##bits##_d8_wrapper(                                 \
+            const void* src,                                                   \
+            size_t srcSize,                                                    \
+            void* dst,                                                         \
+            size_t dstCapacity,                                                \
+            void* customPayload)                                               \
+    {                                                                          \
+        (void)customPayload;                                                   \
+        return sparseNumDecode(src, srcSize, dst, dstCapacity, width, 1);      \
+    }
+
+DEFINE_SPARSE_NUM_DECODE_D8(8, 1)
+DEFINE_SPARSE_NUM_DECODE_D8(16, 2)
+DEFINE_SPARSE_NUM_DECODE_D8(32, 4)
+DEFINE_SPARSE_NUM_DECODE_D8(64, 8)

--- a/benchmark/unitBench/scenarios/codecs/sparse_num.h
+++ b/benchmark/unitBench/scenarios/codecs/sparse_num.h
@@ -1,0 +1,76 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#ifndef ZSTRONG_BENCHMARK_UNITBENCH_SPARSE_NUM_H
+#define ZSTRONG_BENCHMARK_UNITBENCH_SPARSE_NUM_H
+
+#include "benchmark/unitBench/bench_entry.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+size_t sparseNumEncode8_outSize(const void* src, size_t srcSize);
+size_t sparseNumEncode16_outSize(const void* src, size_t srcSize);
+size_t sparseNumEncode32_outSize(const void* src, size_t srcSize);
+size_t sparseNumEncode64_outSize(const void* src, size_t srcSize);
+
+size_t sparseNumEncode8_wrapper(
+        const void* src,
+        size_t srcSize,
+        void* dst,
+        size_t dstCapacity,
+        void* customPayload);
+size_t sparseNumEncode16_wrapper(
+        const void* src,
+        size_t srcSize,
+        void* dst,
+        size_t dstCapacity,
+        void* customPayload);
+size_t sparseNumEncode32_wrapper(
+        const void* src,
+        size_t srcSize,
+        void* dst,
+        size_t dstCapacity,
+        void* customPayload);
+size_t sparseNumEncode64_wrapper(
+        const void* src,
+        size_t srcSize,
+        void* dst,
+        size_t dstCapacity,
+        void* customPayload);
+
+size_t sparseNumDecode8_d8_outSize(const void* src, size_t srcSize);
+size_t sparseNumDecode16_d8_outSize(const void* src, size_t srcSize);
+size_t sparseNumDecode32_d8_outSize(const void* src, size_t srcSize);
+size_t sparseNumDecode64_d8_outSize(const void* src, size_t srcSize);
+
+size_t sparseNumDecode8_d8_wrapper(
+        const void* src,
+        size_t srcSize,
+        void* dst,
+        size_t dstCapacity,
+        void* customPayload);
+size_t sparseNumDecode16_d8_wrapper(
+        const void* src,
+        size_t srcSize,
+        void* dst,
+        size_t dstCapacity,
+        void* customPayload);
+size_t sparseNumDecode32_d8_wrapper(
+        const void* src,
+        size_t srcSize,
+        void* dst,
+        size_t dstCapacity,
+        void* customPayload);
+size_t sparseNumDecode64_d8_wrapper(
+        const void* src,
+        size_t srcSize,
+        void* dst,
+        size_t dstCapacity,
+        void* customPayload);
+
+#ifdef __cplusplus
+} // extern "C"
+#endif
+
+#endif // ZSTRONG_BENCHMARK_UNITBENCH_SPARSE_NUM_H

--- a/benchmark/unitBench/scripts/BUCK
+++ b/benchmark/unitBench/scripts/BUCK
@@ -1,0 +1,14 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+
+load("@fbcode_macros//build_defs:python_binary.bzl", "python_binary")
+
+oncall("data_compression")
+
+python_binary(
+    name = "sparse_num_bench",
+    main_function = ".sparse_num_bench.main",
+    main_src = "sparse_num_bench.py",
+    deps = [
+        "//security/frameworks/python/exec:subprocess",
+    ],
+)

--- a/benchmark/unitBench/scripts/sparse_num_bench.py
+++ b/benchmark/unitBench/scripts/sparse_num_bench.py
@@ -1,0 +1,408 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+
+# pyre-unsafe
+
+from __future__ import annotations
+
+import argparse
+import csv
+import subprocess
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Sequence
+
+
+DEFAULT_WORK_DIR = Path("/tmp/openzl_sparse_num_bench")
+DEFAULT_BUCK_TARGET = "fbcode//openzl/dev/benchmark/unitBench:unitBench"
+DEFAULT_RATIOS = (75, 90, 98)
+DEFAULT_WIDTHS = (8, 16, 32, 64)
+PERIOD = 100
+
+
+@dataclass(frozen=True)
+class UnitBenchResult:
+    source_size: int
+    result_size: int
+    time_us: float
+
+
+@dataclass(frozen=True)
+class SparseNumCase:
+    width_bits: int
+    zero_ratio: int
+    raw_path: Path
+    decode_path: Path
+    raw_size: int
+    encoded_size: int
+    num_elements: int
+
+
+@dataclass(frozen=True)
+class ReportRow:
+    case: SparseNumCase
+    encode: UnitBenchResult
+    decode: UnitBenchResult
+
+
+def parse_csv_ints(value: str, allowed: set[int], name: str) -> list[int]:
+    results: list[int] = []
+    for raw_part in value.split(","):
+        part = raw_part.strip()
+        if not part:
+            continue
+        try:
+            parsed = int(part)
+        except ValueError as error:
+            raise argparse.ArgumentTypeError(f"{name} must be integers") from error
+        if parsed not in allowed:
+            choices = ", ".join(str(choice) for choice in sorted(allowed))
+            raise argparse.ArgumentTypeError(
+                f"unsupported {name} {parsed}; expected one of {choices}"
+            )
+        results.append(parsed)
+    if not results:
+        raise argparse.ArgumentTypeError(f"{name} must not be empty")
+    return results
+
+
+def parse_widths(value: str) -> list[int]:
+    return parse_csv_ints(value, set(DEFAULT_WIDTHS), "width")
+
+
+def parse_ratios(value: str) -> list[int]:
+    return parse_csv_ints(value, set(DEFAULT_RATIOS), "zero ratio")
+
+
+def fbcode_root() -> Path | None:
+    for parent in Path(__file__).resolve().parents:
+        if (parent / "security/frameworks/python/exec/subprocess.py").exists():
+            return parent
+    return None
+
+
+def run_command(
+    executable: str,
+    args: Sequence[str],
+    cwd: Path,
+) -> subprocess.CompletedProcess[str]:
+    root = fbcode_root()
+    if root is not None:
+        root_str = str(root)
+        if root_str not in sys.path:
+            sys.path.insert(0, root_str)
+    try:
+        from security.frameworks.python.exec.subprocess import TrustedSubprocessWithList
+    except ImportError:
+        pass
+    else:
+        return TrustedSubprocessWithList.run(
+            executable=executable,
+            cmd_args=list(args),
+            cwd=cwd,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+        )
+
+    return subprocess.run(
+        [executable, *args],
+        cwd=cwd,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+        check=False,
+    )
+
+
+def check_run(
+    executable: str,
+    args: Sequence[str],
+    cwd: Path,
+) -> subprocess.CompletedProcess[str]:
+    result = run_command(executable, args, cwd)
+    if result.returncode != 0:
+        command = " ".join([executable, *args])
+        raise RuntimeError(
+            f"command failed: {command}\nstdout:\n{result.stdout}\nstderr:\n{result.stderr}"
+        )
+    return result
+
+
+def build_unitbench(cwd: Path, target: str) -> Path:
+    if fbcode_root() is None:
+        raise RuntimeError("--unitbench-bin is required when running outside fbcode")
+    result = check_run(
+        "buck",
+        [
+            "build",
+            "@//mode/opt",
+            target,
+            "--show-full-simple-output",
+        ],
+        cwd,
+    )
+    lines = [line.strip() for line in result.stdout.splitlines() if line.strip()]
+    if not lines:
+        raise RuntimeError("buck build did not print a unitBench binary path")
+    return Path(lines[-1])
+
+
+def resolve_unitbench_bin(path: Path) -> Path:
+    resolved = path.expanduser().resolve()
+    if not resolved.is_file():
+        raise RuntimeError(f"unitBench binary does not exist: {resolved}")
+    return resolved
+
+
+def element_count_for_size(sample_bytes: int, width_bytes: int) -> int:
+    num_elements = sample_bytes // width_bytes
+    num_elements -= num_elements % PERIOD
+    if num_elements <= 0:
+        raise RuntimeError("sample size is too small for the selected widths")
+    return num_elements
+
+
+def nonzero_value(index: int, width_bytes: int) -> bytes:
+    value = (index % 251) + 1
+    return value.to_bytes(width_bytes, "little")
+
+
+def generate_raw_sample(
+    path: Path,
+    width_bits: int,
+    zero_ratio: int,
+    sample_bytes: int,
+) -> tuple[int, int]:
+    width_bytes = width_bits // 8
+    num_elements = element_count_for_size(sample_bytes, width_bytes)
+    data = bytearray(num_elements * width_bytes)
+    for index in range(num_elements):
+        if index % PERIOD < zero_ratio:
+            continue
+        start = index * width_bytes
+        data[start : start + width_bytes] = nonzero_value(index, width_bytes)
+    path.write_bytes(data)
+    return num_elements, len(data)
+
+
+def is_zero_value(data: bytes | bytearray, offset: int, width_bytes: int) -> bool:
+    return all(byte == 0 for byte in data[offset : offset + width_bytes])
+
+
+def generate_decode_fixture(raw_path: Path, fixture_path: Path, width_bits: int) -> int:
+    width_bytes = width_bits // 8
+    raw = raw_path.read_bytes()
+    distances = bytearray()
+    values = bytearray()
+    zero_run = 0
+    for offset in range(0, len(raw), width_bytes):
+        if is_zero_value(raw, offset, width_bytes):
+            zero_run += 1
+            if zero_run > 255:
+                raise RuntimeError(
+                    f"{raw_path} needs distance width > 8 for generated fixture"
+                )
+            continue
+        distances.append(zero_run)
+        values.extend(raw[offset : offset + width_bytes])
+        zero_run = 0
+    if zero_run != 0:
+        raise RuntimeError(f"{raw_path} ends with zeros; d8 fixture would need a tail")
+    # Keep the values stream first so unitBench hands the decode kernel an
+    # aligned numeric values buffer. D8 distances do not need extra alignment.
+    fixture_path.write_bytes(values + distances)
+    return len(distances) + len(values)
+
+
+def prepare_case(
+    work_dir: Path,
+    width_bits: int,
+    zero_ratio: int,
+    sample_bytes: int,
+) -> SparseNumCase:
+    raw_path = work_dir / f"sparse_num_u{width_bits}_zero{zero_ratio}.raw"
+    decode_path = work_dir / f"sparse_num_u{width_bits}_zero{zero_ratio}.d8"
+    num_elements, raw_size = generate_raw_sample(
+        raw_path,
+        width_bits,
+        zero_ratio,
+        sample_bytes,
+    )
+    encoded_size = generate_decode_fixture(raw_path, decode_path, width_bits)
+    return SparseNumCase(
+        width_bits=width_bits,
+        zero_ratio=zero_ratio,
+        raw_path=raw_path,
+        decode_path=decode_path,
+        raw_size=raw_size,
+        encoded_size=encoded_size,
+        num_elements=num_elements,
+    )
+
+
+def parse_unitbench_csv(stdout: str, benchmark_name: str) -> UnitBenchResult:
+    for line in reversed(stdout.splitlines()):
+        if "," not in line:
+            continue
+        row = next(csv.reader([line]))
+        if len(row) < 5 or row[2].strip() != benchmark_name:
+            continue
+        return UnitBenchResult(
+            source_size=int(row[1].strip()),
+            result_size=int(row[3].strip()),
+            time_us=float(row[4].strip()),
+        )
+    raise RuntimeError(f"could not parse unitBench CSV output for {benchmark_name}")
+
+
+def run_unitbench(
+    unitbench_bin: Path,
+    benchmark_name: str,
+    sample_path: Path,
+    duration_s: int,
+    cwd: Path,
+) -> UnitBenchResult:
+    result = check_run(
+        str(unitbench_bin),
+        [
+            f"-i={duration_s}",
+            "--csv",
+            benchmark_name,
+            str(sample_path),
+        ],
+        cwd,
+    )
+    return parse_unitbench_csv(result.stdout, benchmark_name)
+
+
+def mib_per_second(num_bytes: int, time_us: float) -> float:
+    if time_us <= 0:
+        return 0.0
+    return (num_bytes / (1024 * 1024)) / (time_us / 1_000_000)
+
+
+def format_size(num_bytes: int) -> str:
+    if num_bytes >= 1024 * 1024:
+        return f"{num_bytes / (1024 * 1024):.2f} MiB"
+    if num_bytes >= 1024:
+        return f"{num_bytes / 1024:.2f} KiB"
+    return f"{num_bytes} B"
+
+
+def format_table(rows: Sequence[ReportRow]) -> str:
+    lines = [
+        "| width | zeros | elements | raw | encoded | ratio | encode MiB/s | decode MiB/s |",
+        "|---|---:|---:|---:|---:|---:|---:|---:|",
+    ]
+    for row in rows:
+        case = row.case
+        ratio = case.raw_size / case.encoded_size if case.encoded_size else 0.0
+        encode_speed = mib_per_second(case.raw_size, row.encode.time_us)
+        decode_speed = mib_per_second(row.decode.result_size, row.decode.time_us)
+        lines.append(
+            f"| u{case.width_bits} | {case.zero_ratio}% | {case.num_elements} | "
+            f"{format_size(case.raw_size)} | {format_size(case.encoded_size)} | "
+            f"{ratio:.2f} | {encode_speed:.1f} | {decode_speed:.1f} |"
+        )
+    return "\n".join(lines)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Generate sparse_num samples, run unitBench, and print markdown results."
+    )
+    parser.add_argument(
+        "--work-dir",
+        type=Path,
+        default=DEFAULT_WORK_DIR,
+        help=f"Directory for generated samples. Default: {DEFAULT_WORK_DIR}",
+    )
+    parser.add_argument(
+        "--sample-mib",
+        type=int,
+        default=16,
+        help="Raw sample size per width/ratio, in MiB. Default: 16",
+    )
+    parser.add_argument(
+        "--duration-s",
+        type=int,
+        default=1,
+        help="unitBench duration per benchmark, in seconds. Default: 1",
+    )
+    parser.add_argument(
+        "--ratios",
+        type=parse_ratios,
+        default=list(DEFAULT_RATIOS),
+        help="Comma-separated zero ratios. Default: 75,90,98",
+    )
+    parser.add_argument(
+        "--widths",
+        type=parse_widths,
+        default=list(DEFAULT_WIDTHS),
+        help="Comma-separated value widths. Default: 8,16,32,64",
+    )
+    parser.add_argument(
+        "--buck-target",
+        default=DEFAULT_BUCK_TARGET,
+        help=f"unitBench Buck target. Default: {DEFAULT_BUCK_TARGET}",
+    )
+    parser.add_argument(
+        "--unitbench-bin",
+        type=Path,
+        default=None,
+        help=(
+            "Use an already-built unitBench binary instead of building with Buck. "
+            "Required when running outside fbcode."
+        ),
+    )
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    repo_dir = Path.cwd()
+    args.work_dir.mkdir(parents=True, exist_ok=True)
+    sample_bytes = args.sample_mib * 1024 * 1024
+    unitbench_bin = (
+        resolve_unitbench_bin(args.unitbench_bin)
+        if args.unitbench_bin is not None
+        else build_unitbench(repo_dir, args.buck_target)
+    )
+
+    rows: list[ReportRow] = []
+    for width_bits in args.widths:
+        for zero_ratio in args.ratios:
+            case = prepare_case(args.work_dir, width_bits, zero_ratio, sample_bytes)
+            encode = run_unitbench(
+                unitbench_bin,
+                f"sparseNumEncode{width_bits}",
+                case.raw_path,
+                args.duration_s,
+                repo_dir,
+            )
+            decode = run_unitbench(
+                unitbench_bin,
+                f"sparseNumDecode{width_bits}_d8",
+                case.decode_path,
+                args.duration_s,
+                repo_dir,
+            )
+            if encode.result_size != case.encoded_size:
+                raise RuntimeError(
+                    f"encode size mismatch for {case.raw_path}: "
+                    f"unitBench={encode.result_size}, fixture={case.encoded_size}"
+                )
+            if decode.result_size != case.raw_size:
+                raise RuntimeError(
+                    f"decode size mismatch for {case.decode_path}: "
+                    f"unitBench={decode.result_size}, raw={case.raw_size}"
+                )
+            rows.append(ReportRow(case=case, encode=encode, decode=decode))
+
+    print(format_table(rows))
+
+
+if __name__ == "__main__":
+    main()

--- a/cpp/include/openzl/cpp/Codecs.hpp
+++ b/cpp/include/openzl/cpp/Codecs.hpp
@@ -33,6 +33,7 @@
 #include "openzl/cpp/codecs/SDDL2.hpp"            // IWYU pragma: export
 #include "openzl/cpp/codecs/SegmentSerial.hpp"    // IWYU pragma: export
 #include "openzl/cpp/codecs/Sentinel.hpp"         // IWYU pragma: export
+#include "openzl/cpp/codecs/SparseNum.hpp"        // IWYU pragma: export
 #include "openzl/cpp/codecs/Split.hpp"            // IWYU pragma: export
 #include "openzl/cpp/codecs/SplitByStruct.hpp"    // IWYU pragma: export
 #include "openzl/cpp/codecs/Store.hpp"            // IWYU pragma: export

--- a/cpp/include/openzl/cpp/codecs/SparseNum.hpp
+++ b/cpp/include/openzl/cpp/codecs/SparseNum.hpp
@@ -1,0 +1,44 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#pragma once
+
+#include "openzl/codecs/zl_sparse_num.h"
+#include "openzl/cpp/Compressor.hpp"
+#include "openzl/cpp/codecs/Metadata.hpp"
+#include "openzl/cpp/codecs/Node.hpp"
+
+namespace openzl {
+namespace nodes {
+
+class SparseNum : public Node {
+   public:
+    static constexpr NodeID node = ZL_NODE_SPARSE_NUM;
+
+    static constexpr NodeMetadata<1, 2> metadata = {
+        .inputs = { InputMetadata{ .type = Type::Numeric, .name = "values" } },
+        .singletonOutputs = { OutputMetadata{ .type = Type::Numeric,
+                                              .name = "distances" },
+                              OutputMetadata{ .type = Type::Numeric,
+                                              .name = "values" } },
+        .description =
+                "Split a numeric stream into zero-run distances and literal values",
+    };
+
+    NodeID baseNode() const override
+    {
+        return node;
+    }
+
+    GraphID
+    operator()(Compressor& compressor, GraphID distances, GraphID values) const
+    {
+        return buildGraph(
+                compressor,
+                std::initializer_list<GraphID>{ distances, values });
+    }
+
+    ~SparseNum() override = default;
+};
+
+} // namespace nodes
+} // namespace openzl

--- a/include/openzl/codecs/zl_sparse_num.h
+++ b/include/openzl/codecs/zl_sparse_num.h
@@ -1,0 +1,30 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#ifndef OPENZL_CODECS_ZL_SPARSE_NUM_H
+#define OPENZL_CODECS_ZL_SPARSE_NUM_H
+
+#include "openzl/zl_nodes.h"
+
+#if defined(__cplusplus)
+extern "C" {
+#endif
+
+/**
+ * Sparse Num
+ *
+ * Input 0: Numeric stream.
+ * Output 0: Numeric zero-run distances.
+ * Output 1: Numeric literal values.
+ *
+ * `sparse_num` decomposes a numeric stream into runs of zero elements and the
+ * intervening literal values. Literal values may be zero. The distance stream
+ * contains the number of zero elements before each literal, and may contain one
+ * final distance to represent trailing zeros.
+ */
+#define ZL_NODE_SPARSE_NUM ZL_MAKE_NODE_ID(ZL_StandardNodeID_sparse_num)
+
+#if defined(__cplusplus)
+}
+#endif
+
+#endif

--- a/include/openzl/zl_nodes.h
+++ b/include/openzl/zl_nodes.h
@@ -95,6 +95,8 @@ typedef enum {
 
     ZL_StandardNodeID_mux_lengths,
 
+    ZL_StandardNodeID_sparse_num,
+
     ZL_StandardNodeID_public_end // last id, used to detect end of public range
 } ZL_StandardNodeID;
 

--- a/include/openzl/zl_public_nodes.h
+++ b/include/openzl/zl_public_nodes.h
@@ -41,6 +41,7 @@
 #include "openzl/codecs/zl_range_pack.h"           // IWYU pragma: export
 #include "openzl/codecs/zl_sddl.h"                 // IWYU pragma: export
 #include "openzl/codecs/zl_sentinel.h"             // IWYU pragma: export
+#include "openzl/codecs/zl_sparse_num.h"           // IWYU pragma: export
 #include "openzl/codecs/zl_split.h"                // IWYU pragma: export
 #include "openzl/codecs/zl_split_by_struct.h"      // IWYU pragma: export
 #include "openzl/codecs/zl_store.h"                // IWYU pragma: export

--- a/src/openzl/codecs/decoder_registry.c
+++ b/src/openzl/codecs/decoder_registry.c
@@ -32,6 +32,7 @@
 #include "openzl/codecs/range_pack/decode_range_pack_binding.h"
 #include "openzl/codecs/rolz/decode_rolz_binding.h"
 #include "openzl/codecs/sentinel/decode_sentinel_binding.h"
+#include "openzl/codecs/sparse_num/decode_sparse_num_binding.h"
 #include "openzl/codecs/splitByStruct/decode_splitByStruct_binding.h"
 #include "openzl/codecs/splitN/decode_splitN_binding.h"
 #include "openzl/codecs/tokenize/decode_tokenize_binding.h"
@@ -136,6 +137,7 @@ const StandardDTransform SDecoders_array[ZL_StandardTransformID_end] = {
     REGISTER_TTRANSFORM_G(ZL_StandardTransformID_sentinel, 24, DI_SENTINEL, SENTINEL_GRAPH),
     REGISTER_TTRANSFORM_G(ZL_StandardTransformID_lz, 24, DI_LZ, LZ_GRAPH),
     REGISTER_TTRANSFORM_G(ZL_StandardTransformID_mux_lengths, 24, DI_MUX_LENGTHS, MUX_LENGTHS_GRAPH),
+    REGISTER_TTRANSFORM_G(ZL_StandardTransformID_sparse_num, 25, DI_SPARSE_NUM, SPARSE_NUM_GRAPH),
 
     REGISTER_VOTRANSFORM_G(ZL_StandardTransformID_splitn, 9, DI_SPLITN, GRAPH_VO_SERIAL),
     REGISTER_VOTRANSFORM_G(ZL_StandardTransformID_splitn_struct, 14, DI_SPLITN_STRUCT, GRAPH_VO_STRUCT),

--- a/src/openzl/codecs/encoder_registry.c
+++ b/src/openzl/codecs/encoder_registry.c
@@ -31,6 +31,7 @@
 #include "openzl/codecs/range_pack/encode_range_pack_binding.h"
 #include "openzl/codecs/rolz/encode_rolz_binding.h"
 #include "openzl/codecs/sentinel/encode_sentinel_binding.h"
+#include "openzl/codecs/sparse_num/encode_sparse_num_binding.h"
 #include "openzl/codecs/splitByStruct/encode_splitByStruct_binding.h"
 #include "openzl/codecs/splitN/encode_splitN_binding.h"
 #include "openzl/codecs/splitN/encode_split_byrange_binding.h"
@@ -136,6 +137,7 @@ const CNode ER_standardNodes[STANDARD_ENCODERS_NB] = {
     REGISTER_TRANSFORM(ZL_StandardNodeID_sentinel_num, ZL_StandardTransformID_sentinel, 24, 200, EI_SENTINEL),
     REGISTER_TRANSFORM(ZL_StandardNodeID_lz, ZL_StandardTransformID_lz, 24, 200, EI_LZ),
     REGISTER_TRANSFORM(ZL_StandardNodeID_mux_lengths, ZL_StandardTransformID_mux_lengths, 24, 200, EI_MUX_LENGTHS),
+    REGISTER_TRANSFORM(ZL_StandardNodeID_sparse_num, ZL_StandardTransformID_sparse_num, 25, 201, EI_SPARSE_NUM),
 
     // Private Nodes
     REGISTER_TRANSFORM(ZL_PrivateStandardNodeID_set_string_lens,           ZL_StandardTransformID_convert_serial_string, 10, 200, EI_SETSTRINGLENS),

--- a/src/openzl/codecs/sparse_num/common_sparse_num.h
+++ b/src/openzl/codecs/sparse_num/common_sparse_num.h
@@ -1,0 +1,64 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#ifndef OPENZL_CODECS_SPARSE_NUM_COMMON_SPARSE_NUM_H
+#define OPENZL_CODECS_SPARSE_NUM_COMMON_SPARSE_NUM_H
+
+#include <assert.h>
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+
+/** Supported numeric element widths, in bytes: 1, 2, 4, or 8. */
+static inline bool ZL_sparseNumValidValueWidth(size_t width)
+{
+    return width == 1 || width == 2 || width == 4 || width == 8;
+}
+
+/** Supported distance stream widths, in bytes: 1, 2, or 4. */
+static inline bool ZL_sparseNumValidDistanceWidth(size_t width)
+{
+    return width == 1 || width == 2 || width == 4;
+}
+
+/** Returns whether ptr is aligned for width-byte numeric elements. */
+static inline bool ZL_sparseNumIsAlignedForWidth(const void* ptr, size_t width)
+{
+    assert(width > 0);
+    return (((uintptr_t)ptr) & (width - 1)) == 0;
+}
+
+/**
+ * Copies one aligned sparse_num literal value.
+ *
+ * Preconditions:
+ * - dst and src must be non-null.
+ * - dst and src must be aligned for width-byte numeric elements.
+ * - width must be a supported numeric element width.
+ */
+static inline void
+ZL_sparseNumCopyAlignedValue(void* dst, const void* src, size_t width)
+{
+    assert(dst != NULL);
+    assert(src != NULL);
+    assert(ZL_sparseNumIsAlignedForWidth(dst, width));
+    assert(ZL_sparseNumIsAlignedForWidth(src, width));
+    switch (width) {
+        case 1:
+            *(uint8_t*)dst = *(const uint8_t*)src;
+            return;
+        case 2:
+            *(uint16_t*)dst = *(const uint16_t*)src;
+            return;
+        case 4:
+            *(uint32_t*)dst = *(const uint32_t*)src;
+            return;
+        case 8:
+            *(uint64_t*)dst = *(const uint64_t*)src;
+            return;
+        default:
+            assert(false);
+            return;
+    }
+}
+
+#endif

--- a/src/openzl/codecs/sparse_num/decode_sparse_num_binding.c
+++ b/src/openzl/codecs/sparse_num/decode_sparse_num_binding.c
@@ -1,0 +1,84 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#include "openzl/codecs/sparse_num/decode_sparse_num_binding.h"
+
+#include "openzl/codecs/sparse_num/decode_sparse_num_kernel.h"
+#include "openzl/common/assertion.h"
+#include "openzl/common/errors_internal.h"
+#include "openzl/shared/overflow.h"
+
+#include <stdbool.h>
+#include <stdint.h>
+
+ZL_Report DI_sparse_num(ZL_Decoder* dictx, const ZL_Input* ins[])
+{
+    ZL_RESULT_DECLARE_SCOPE_REPORT(dictx);
+    ZL_ASSERT_NN(dictx);
+    ZL_ASSERT_NN(ins);
+
+    const ZL_Input* const distances = ins[0];
+    const ZL_Input* const values    = ins[1];
+    ZL_ASSERT_NN(distances);
+    ZL_ASSERT_NN(values);
+
+    ZL_ASSERT_EQ(ZL_Input_type(distances), ZL_Type_numeric);
+    ZL_ASSERT_EQ(ZL_Input_type(values), ZL_Type_numeric);
+
+    ZL_RBuffer const header = ZL_Decoder_getCodecHeader(dictx);
+    ZL_ERR_IF_NE(
+            header.size,
+            0,
+            corruption,
+            "sparse_num codec header must be empty");
+
+    size_t const distanceWidth = ZL_Input_eltWidth(distances);
+    ZL_ERR_IF_NOT(
+            ZL_sparseNumValidDistanceWidth(distanceWidth),
+            corruption,
+            "sparse_num distance width must be 1, 2 or 4 bytes");
+
+    size_t const valueWidth = ZL_Input_eltWidth(values);
+    ZL_ERR_IF_NOT(
+            ZL_sparseNumValidValueWidth(valueWidth),
+            corruption,
+            "sparse_num value width must be 1, 2, 4 or 8 bytes");
+
+    size_t const numDistances = ZL_Input_numElts(distances);
+    size_t const numValues    = ZL_Input_numElts(values);
+    bool const validCounts    = numDistances == numValues
+            || (numValues < SIZE_MAX && numDistances == numValues + 1);
+    ZL_ERR_IF_NOT(
+            validCounts,
+            corruption,
+            "sparse_num distance count must be value count or value count + 1");
+
+    size_t const outputCount = ZL_sparseNumDecodeOutputCount(
+            ZL_Input_ptr(distances), numDistances, distanceWidth, numValues);
+    ZL_ERR_IF_EQ(
+            outputCount,
+            ZL_SPARSE_NUM_DECODE_OUTPUT_COUNT_ERROR,
+            integerOverflow,
+            "sparse_num output element count overflows size_t");
+    size_t outputSize;
+    ZL_ERR_IF(
+            ZL_overflowMulST(outputCount, valueWidth, &outputSize),
+            integerOverflow,
+            "sparse_num output byte size overflows size_t");
+
+    ZL_Output* const out =
+            ZL_Decoder_create1OutStream(dictx, outputCount, valueWidth);
+    ZL_ERR_IF_NULL(out, allocation);
+
+    ZL_sparseNumDecode(
+            ZL_Output_ptr(out),
+            outputSize,
+            ZL_Input_ptr(distances),
+            numDistances,
+            distanceWidth,
+            ZL_Input_ptr(values),
+            numValues,
+            valueWidth);
+
+    ZL_ERR_IF_ERR(ZL_Output_commit(out, outputCount));
+    return ZL_returnSuccess();
+}

--- a/src/openzl/codecs/sparse_num/decode_sparse_num_binding.h
+++ b/src/openzl/codecs/sparse_num/decode_sparse_num_binding.h
@@ -1,0 +1,19 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#ifndef OPENZL_CODECS_SPARSE_NUM_DECODE_SPARSE_NUM_BINDING_H
+#define OPENZL_CODECS_SPARSE_NUM_DECODE_SPARSE_NUM_BINDING_H
+
+#include "openzl/codecs/sparse_num/graph_sparse_num.h"
+#include "openzl/shared/portability.h"
+#include "openzl/zl_dtransform.h"
+
+ZL_BEGIN_C_DECLS
+
+ZL_Report DI_sparse_num(ZL_Decoder* dictx, const ZL_Input* ins[]);
+
+#define DI_SPARSE_NUM(id) \
+    { .transform_f = DI_sparse_num, .name = "!zl.sparse_num" }
+
+ZL_END_C_DECLS
+
+#endif

--- a/src/openzl/codecs/sparse_num/decode_sparse_num_kernel.c
+++ b/src/openzl/codecs/sparse_num/decode_sparse_num_kernel.c
@@ -1,0 +1,300 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#include "decode_sparse_num_kernel.h"
+
+#include <assert.h>
+#include <stdint.h>
+#include <string.h>
+
+static uint32_t
+ZL_sparseNumReadDistance(const void* src, size_t index, size_t width)
+{
+    const void* const ptr = (const uint8_t*)src + index * width;
+    assert(ZL_sparseNumIsAlignedForWidth(ptr, width));
+    switch (width) {
+        case 1:
+            return *(const uint8_t*)ptr;
+        case 2:
+            return *(const uint16_t*)ptr;
+        case 4:
+            return *(const uint32_t*)ptr;
+        default:
+            assert(false);
+            return 0;
+    }
+}
+
+static inline bool ZL_sparseNumDecodeCanUseUncheckedOutputCountSum(
+        size_t numDistances,
+        size_t numValues)
+{
+    /*
+     * If size_t is at least 64-bit and both stream counts fit in 32 bits, the
+     * output count cannot overflow size_t:
+     * UINT32_MAX values + UINT32_MAX distances each worth UINT32_MAX zeros
+     * is 2^64 - 2^32, which is still below SIZE_MAX.
+     */
+    if (sizeof(size_t) < 8) {
+        return false;
+    }
+    return numDistances <= UINT32_MAX && numValues <= UINT32_MAX;
+}
+
+size_t ZL_sparseNumDecodeOutputCount(
+        const void* distances,
+        size_t numDistances,
+        size_t distanceWidth,
+        size_t numValues)
+{
+    assert(ZL_sparseNumValidDistanceWidth(distanceWidth));
+
+    size_t count = numValues;
+    if (ZL_sparseNumDecodeCanUseUncheckedOutputCountSum(
+                numDistances, numValues)) {
+        for (size_t i = 0; i < numDistances; ++i) {
+            count += ZL_sparseNumReadDistance(distances, i, distanceWidth);
+        }
+
+        return count;
+    }
+
+    if (count == ZL_SPARSE_NUM_DECODE_OUTPUT_COUNT_ERROR) {
+        return ZL_SPARSE_NUM_DECODE_OUTPUT_COUNT_ERROR;
+    }
+
+    for (size_t i = 0; i < numDistances; ++i) {
+        uint32_t const distance =
+                ZL_sparseNumReadDistance(distances, i, distanceWidth);
+        if ((size_t)distance
+            >= ZL_SPARSE_NUM_DECODE_OUTPUT_COUNT_ERROR - count) {
+            return ZL_SPARSE_NUM_DECODE_OUTPUT_COUNT_ERROR;
+        }
+        count += (size_t)distance;
+    }
+
+    return count;
+}
+
+static inline bool ZL_sparseNumDecodeWriteInBounds(
+        size_t expectedDstSize,
+        size_t producedBytes,
+        size_t writeBytes)
+{
+    if (producedBytes > expectedDstSize) {
+        return false;
+    }
+    if (writeBytes > expectedDstSize - producedBytes) {
+        return false;
+    }
+    return true;
+}
+
+static inline void ZL_sparseNumDecodeTrackWrite(
+        size_t expectedDstSize,
+        size_t* producedBytes,
+        size_t writeBytes)
+{
+    bool const ok = ZL_sparseNumDecodeWriteInBounds(
+            expectedDstSize, *producedBytes, writeBytes);
+    assert(ok);
+    (void)ok;
+    *producedBytes += writeBytes;
+}
+
+static inline bool ZL_sparseNumDecodeComplete(
+        size_t expectedDstSize,
+        size_t producedBytes)
+{
+    return producedBytes == expectedDstSize;
+}
+
+static inline void ZL_sparseNumDecodeBody(
+        void* dst,
+        size_t expectedDstSize,
+        const void* distances,
+        size_t numDistances,
+        size_t distanceWidth,
+        const void* values,
+        size_t numValues,
+        size_t valueWidth)
+{
+    uint8_t* out                = (uint8_t*)dst;
+    const uint8_t* const vals   = (const uint8_t*)values;
+    bool const hasFinalDistance = numDistances == numValues + 1;
+    size_t producedBytes        = 0;
+    (void)expectedDstSize;
+
+    for (size_t i = 0; i < numValues; ++i) {
+        uint32_t const distance =
+                ZL_sparseNumReadDistance(distances, i, distanceWidth);
+        assert((size_t)distance <= SIZE_MAX / valueWidth);
+        size_t const zeroBytes = (size_t)distance * valueWidth;
+        ZL_sparseNumDecodeTrackWrite(
+                expectedDstSize, &producedBytes, zeroBytes);
+        memset(out, 0, zeroBytes);
+        out += zeroBytes;
+
+        ZL_sparseNumDecodeTrackWrite(
+                expectedDstSize, &producedBytes, valueWidth);
+        ZL_sparseNumCopyAlignedValue(out, vals + i * valueWidth, valueWidth);
+        out += valueWidth;
+    }
+
+    if (hasFinalDistance) {
+        uint32_t const distance =
+                ZL_sparseNumReadDistance(distances, numValues, distanceWidth);
+        assert((size_t)distance <= SIZE_MAX / valueWidth);
+        size_t const zeroBytes = (size_t)distance * valueWidth;
+        ZL_sparseNumDecodeTrackWrite(
+                expectedDstSize, &producedBytes, zeroBytes);
+        memset(out, 0, zeroBytes);
+    }
+
+    assert(ZL_sparseNumDecodeComplete(expectedDstSize, producedBytes));
+}
+
+static inline void ZL_sparseNumDecodeD8V1(
+        void* dst,
+        size_t expectedDstSize,
+        const void* distances,
+        size_t numDistances,
+        const void* values,
+        size_t numValues)
+{
+    ZL_sparseNumDecodeBody(
+            dst,
+            expectedDstSize,
+            distances,
+            numDistances,
+            1,
+            values,
+            numValues,
+            1);
+}
+
+static inline void ZL_sparseNumDecodeD8V2(
+        void* dst,
+        size_t expectedDstSize,
+        const void* distances,
+        size_t numDistances,
+        const void* values,
+        size_t numValues)
+{
+    ZL_sparseNumDecodeBody(
+            dst,
+            expectedDstSize,
+            distances,
+            numDistances,
+            1,
+            values,
+            numValues,
+            2);
+}
+
+static inline void ZL_sparseNumDecodeD8V4(
+        void* dst,
+        size_t expectedDstSize,
+        const void* distances,
+        size_t numDistances,
+        const void* values,
+        size_t numValues)
+{
+    ZL_sparseNumDecodeBody(
+            dst,
+            expectedDstSize,
+            distances,
+            numDistances,
+            1,
+            values,
+            numValues,
+            4);
+}
+
+static inline void ZL_sparseNumDecodeD8V8(
+        void* dst,
+        size_t expectedDstSize,
+        const void* distances,
+        size_t numDistances,
+        const void* values,
+        size_t numValues)
+{
+    ZL_sparseNumDecodeBody(
+            dst,
+            expectedDstSize,
+            distances,
+            numDistances,
+            1,
+            values,
+            numValues,
+            8);
+}
+
+void ZL_sparseNumDecode(
+        void* dst,
+        size_t expectedDstSize,
+        const void* distances,
+        size_t numDistances,
+        size_t distanceWidth,
+        const void* values,
+        size_t numValues,
+        size_t valueWidth)
+{
+    assert(ZL_sparseNumValidValueWidth(valueWidth));
+    assert(ZL_sparseNumValidDistanceWidth(distanceWidth));
+    assert(numDistances == numValues
+           || (numValues < SIZE_MAX && numDistances == numValues + 1));
+
+    if (distanceWidth == 1) {
+        switch (valueWidth) {
+            case 1:
+                ZL_sparseNumDecodeD8V1(
+                        dst,
+                        expectedDstSize,
+                        distances,
+                        numDistances,
+                        values,
+                        numValues);
+                return;
+            case 2:
+                ZL_sparseNumDecodeD8V2(
+                        dst,
+                        expectedDstSize,
+                        distances,
+                        numDistances,
+                        values,
+                        numValues);
+                return;
+            case 4:
+                ZL_sparseNumDecodeD8V4(
+                        dst,
+                        expectedDstSize,
+                        distances,
+                        numDistances,
+                        values,
+                        numValues);
+                return;
+            case 8:
+                ZL_sparseNumDecodeD8V8(
+                        dst,
+                        expectedDstSize,
+                        distances,
+                        numDistances,
+                        values,
+                        numValues);
+                return;
+            default:
+                assert(false);
+                return;
+        }
+    }
+
+    ZL_sparseNumDecodeBody(
+            dst,
+            expectedDstSize,
+            distances,
+            numDistances,
+            distanceWidth,
+            values,
+            numValues,
+            valueWidth);
+}

--- a/src/openzl/codecs/sparse_num/decode_sparse_num_kernel.h
+++ b/src/openzl/codecs/sparse_num/decode_sparse_num_kernel.h
@@ -1,0 +1,62 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#ifndef OPENZL_CODECS_SPARSE_NUM_DECODE_SPARSE_NUM_KERNEL_H
+#define OPENZL_CODECS_SPARSE_NUM_DECODE_SPARSE_NUM_KERNEL_H
+
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+
+#include "openzl/codecs/sparse_num/common_sparse_num.h"
+#include "openzl/shared/portability.h"
+
+ZL_BEGIN_C_DECLS
+
+#define ZL_SPARSE_NUM_DECODE_OUTPUT_COUNT_ERROR SIZE_MAX
+
+/**
+ * Computes the number of numeric elements produced by sparse_num decode.
+ * Returns ZL_SPARSE_NUM_DECODE_OUTPUT_COUNT_ERROR if the count overflows size_t
+ * or reaches the reserved error value.
+ *
+ * Preconditions:
+ * - distanceWidth must be a supported distance width.
+ * - distances must point to numDistances distanceWidth-byte numeric elements.
+ * - distances must be aligned for distanceWidth-byte numeric elements.
+ */
+size_t ZL_sparseNumDecodeOutputCount(
+        const void* distances,
+        size_t numDistances,
+        size_t distanceWidth,
+        size_t numValues);
+
+/**
+ * Decodes sparse_num into dst.
+ *
+ * Preconditions:
+ * - numDistances must be numValues or numValues + 1.
+ * - distances must point to numDistances distanceWidth-byte numeric elements.
+ * - distances must be aligned for distanceWidth-byte numeric elements.
+ * - values must point to numValues valueWidth-byte numeric elements.
+ * - values must be aligned for valueWidth-byte numeric elements.
+ * - dst must be aligned for valueWidth-byte numeric elements.
+ * - expectedDstSize must be the exact byte size produced by this decode:
+ *   outputCount * valueWidth, where outputCount is returned by
+ *   ZL_sparseNumDecodeOutputCount() for the same distance and value streams.
+ * - expectedDstSize is used as a debug invariant that the kernel writes exactly
+ *   the caller-computed destination size. Release builds still trust the caller
+ *   to provide a correctly sized destination buffer.
+ */
+void ZL_sparseNumDecode(
+        void* dst,
+        size_t expectedDstSize,
+        const void* distances,
+        size_t numDistances,
+        size_t distanceWidth,
+        const void* values,
+        size_t numValues,
+        size_t valueWidth);
+
+ZL_END_C_DECLS
+
+#endif

--- a/src/openzl/codecs/sparse_num/encode_sparse_num_binding.c
+++ b/src/openzl/codecs/sparse_num/encode_sparse_num_binding.c
@@ -1,0 +1,48 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#include "openzl/codecs/sparse_num/encode_sparse_num_binding.h"
+
+#include "openzl/codecs/sparse_num/encode_sparse_num_kernel.h"
+#include "openzl/common/assertion.h"
+#include "openzl/common/errors_internal.h"
+
+ZL_Report EI_sparse_num(ZL_Encoder* eictx, const ZL_Input* ins[], size_t nbIns)
+{
+    ZL_RESULT_DECLARE_SCOPE_REPORT(eictx);
+    ZL_ASSERT_NN(eictx);
+    ZL_ASSERT_EQ(nbIns, 1);
+    ZL_ASSERT_NN(ins);
+
+    const ZL_Input* const in = ins[0];
+    ZL_ASSERT_NN(in);
+    ZL_ASSERT_EQ(ZL_Input_type(in), ZL_Type_numeric);
+
+    size_t const valueWidth = ZL_Input_eltWidth(in);
+    ZL_ERR_IF_NOT(
+            ZL_sparseNumValidValueWidth(valueWidth),
+            node_invalid_input,
+            "sparse_num expects numeric width of 1, 2, 4 or 8 bytes");
+
+    ZL_SparseNumEncodeInfo const info = ZL_sparseNumComputeEncodeInfo(
+            ZL_Input_ptr(in), ZL_Input_numElts(in), valueWidth);
+
+    ZL_Output* const distances = ZL_Encoder_createTypedStream(
+            eictx, 0, info.numDistances, info.distanceWidth);
+    ZL_ERR_IF_NULL(distances, allocation);
+    ZL_Output* const values =
+            ZL_Encoder_createTypedStream(eictx, 1, info.numValues, valueWidth);
+    ZL_ERR_IF_NULL(values, allocation);
+
+    ZL_sparseNumEncode(
+            ZL_Output_ptr(distances),
+            ZL_Output_ptr(values),
+            ZL_Input_ptr(in),
+            ZL_Input_numElts(in),
+            valueWidth,
+            info.distanceWidth);
+
+    ZL_ERR_IF_ERR(ZL_Output_commit(distances, info.numDistances));
+    ZL_ERR_IF_ERR(ZL_Output_commit(values, info.numValues));
+
+    return ZL_returnSuccess();
+}

--- a/src/openzl/codecs/sparse_num/encode_sparse_num_binding.h
+++ b/src/openzl/codecs/sparse_num/encode_sparse_num_binding.h
@@ -1,0 +1,21 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#ifndef OPENZL_CODECS_SPARSE_NUM_ENCODE_SPARSE_NUM_BINDING_H
+#define OPENZL_CODECS_SPARSE_NUM_ENCODE_SPARSE_NUM_BINDING_H
+
+#include "openzl/codecs/sparse_num/graph_sparse_num.h"
+#include "openzl/shared/portability.h"
+#include "openzl/zl_ctransform.h"
+
+ZL_BEGIN_C_DECLS
+
+ZL_Report EI_sparse_num(ZL_Encoder* eictx, const ZL_Input* ins[], size_t nbIns);
+
+#define EI_SPARSE_NUM(id)                  \
+    { .gd          = SPARSE_NUM_GRAPH(id), \
+      .transform_f = EI_sparse_num,        \
+      .name        = "!zl.sparse_num" }
+
+ZL_END_C_DECLS
+
+#endif

--- a/src/openzl/codecs/sparse_num/encode_sparse_num_kernel.c
+++ b/src/openzl/codecs/sparse_num/encode_sparse_num_kernel.c
@@ -1,0 +1,228 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#include "encode_sparse_num_kernel.h"
+
+#include <assert.h>
+
+static inline bool ZL_sparseNumIsZero(const void* ptr, size_t width)
+{
+    const uint8_t* const bytes = (const uint8_t*)ptr;
+    for (size_t i = 0; i < width; ++i) {
+        if (bytes[i] != 0) {
+            return false;
+        }
+    }
+    return true;
+}
+
+static size_t ZL_sparseNumDistanceWidth(uint32_t maxDistance)
+{
+    if (maxDistance <= UINT8_MAX) {
+        return 1;
+    }
+    if (maxDistance <= UINT16_MAX) {
+        return 2;
+    }
+    return 4;
+}
+
+static void ZL_sparseNumWriteDistance(
+        void* dst,
+        size_t index,
+        uint32_t distance,
+        size_t width)
+{
+    void* const ptr = (uint8_t*)dst + index * width;
+    assert(ZL_sparseNumIsAlignedForWidth(ptr, width));
+    switch (width) {
+        case 1:
+            *(uint8_t*)ptr = (uint8_t)distance;
+            return;
+        case 2:
+            *(uint16_t*)ptr = (uint16_t)distance;
+            return;
+        case 4:
+            *(uint32_t*)ptr = distance;
+            return;
+        default:
+            assert(false);
+            return;
+    }
+}
+
+static ZL_SparseNumEncodeInfo ZL_sparseNumComputeEncodeInfo_internal(
+        const void* src,
+        size_t numElts,
+        size_t valueWidth)
+{
+    assert(ZL_sparseNumValidValueWidth(valueWidth));
+
+    const uint8_t* const bytes = (const uint8_t*)src;
+    uint32_t zeroRun           = 0;
+    uint32_t maxDistance       = 0;
+    size_t numValues           = 0;
+    size_t numDistances        = 0;
+
+    for (size_t i = 0; i < numElts; ++i) {
+        const uint8_t* const elt = bytes + i * valueWidth;
+        if (ZL_sparseNumIsZero(elt, valueWidth)) {
+            if (zeroRun == UINT32_MAX) {
+                maxDistance = UINT32_MAX;
+                zeroRun     = 0;
+                ++numValues;
+                ++numDistances;
+                continue;
+            }
+            ++zeroRun;
+            continue;
+        }
+
+        if (zeroRun > maxDistance) {
+            maxDistance = zeroRun;
+        }
+        zeroRun = 0;
+        ++numValues;
+        ++numDistances;
+    }
+
+    if (zeroRun > 0) {
+        if (zeroRun > maxDistance) {
+            maxDistance = zeroRun;
+        }
+        ++numDistances;
+    }
+
+    return (ZL_SparseNumEncodeInfo){
+        .numDistances  = numDistances,
+        .numValues     = numValues,
+        .distanceWidth = ZL_sparseNumDistanceWidth(maxDistance),
+    };
+}
+
+ZL_SparseNumEncodeInfo ZL_sparseNumComputeEncodeInfo(
+        const void* src,
+        size_t numElts,
+        size_t valueWidth)
+{
+    switch (valueWidth) {
+        case 1:
+            return ZL_sparseNumComputeEncodeInfo_internal(src, numElts, 1);
+        case 2:
+            return ZL_sparseNumComputeEncodeInfo_internal(src, numElts, 2);
+        case 4:
+            return ZL_sparseNumComputeEncodeInfo_internal(src, numElts, 4);
+        case 8:
+            return ZL_sparseNumComputeEncodeInfo_internal(src, numElts, 8);
+        default:
+            assert(false);
+            return (ZL_SparseNumEncodeInfo){ 0 };
+    }
+}
+
+static inline void ZL_sparseNumEncode_internal(
+        void* distances,
+        uint8_t* valueDst,
+        const uint8_t* source,
+        size_t numElts,
+        size_t valueWidth,
+        size_t distanceWidth,
+        bool splitFullRun)
+{
+    assert(ZL_sparseNumValidValueWidth(valueWidth));
+    assert(ZL_sparseNumValidDistanceWidth(distanceWidth));
+    assert(!splitFullRun || distanceWidth == 4);
+
+    size_t index   = 0;
+    size_t elts    = 0;
+    size_t zeroRun = 0;
+
+    for (size_t i = 0; i < numElts; ++i) {
+        const uint8_t* const elt = source + i * valueWidth;
+        if (ZL_sparseNumIsZero(elt, valueWidth)) {
+            if (splitFullRun && zeroRun == UINT32_MAX) {
+                ZL_sparseNumWriteDistance(
+                        distances, index, UINT32_MAX, distanceWidth);
+                ZL_sparseNumCopyAlignedValue(
+                        valueDst + index * valueWidth, elt, valueWidth);
+                ++index;
+                elts    = i + 1;
+                zeroRun = 0;
+                continue;
+            }
+            ++zeroRun;
+            continue;
+        }
+
+        assert(zeroRun <= UINT32_MAX);
+        ZL_sparseNumWriteDistance(
+                distances, index, (uint32_t)zeroRun, distanceWidth);
+        ZL_sparseNumCopyAlignedValue(
+                valueDst + index * valueWidth, elt, valueWidth);
+        ++index;
+        elts += zeroRun + 1;
+        zeroRun = 0;
+    }
+
+    /* write the final zero run, if it exists */
+    if (elts < numElts) {
+        assert(elts <= numElts);
+        const size_t lastZeroRun = numElts - elts;
+        assert(lastZeroRun <= UINT32_MAX);
+        ZL_sparseNumWriteDistance(
+                distances, index, (uint32_t)lastZeroRun, distanceWidth);
+    }
+}
+
+void ZL_sparseNumEncode(
+        void* distances,
+        void* values,
+        const void* src,
+        size_t numElts,
+        size_t valueWidth,
+        size_t distanceWidth)
+{
+    assert(ZL_sparseNumValidValueWidth(valueWidth));
+    assert(ZL_sparseNumValidDistanceWidth(distanceWidth));
+
+    const uint8_t* const source = (const uint8_t*)src;
+    uint8_t* const valueDst     = (uint8_t*)values;
+
+    if (distanceWidth == 1) {
+        switch (valueWidth) {
+            case 1:
+                ZL_sparseNumEncode_internal(
+                        distances, valueDst, source, numElts, 1, 1, false);
+                return;
+            case 2:
+                ZL_sparseNumEncode_internal(
+                        distances, valueDst, source, numElts, 2, 1, false);
+                return;
+            case 4:
+                ZL_sparseNumEncode_internal(
+                        distances, valueDst, source, numElts, 4, 1, false);
+                return;
+            case 8:
+                ZL_sparseNumEncode_internal(
+                        distances, valueDst, source, numElts, 8, 1, false);
+                return;
+            default:
+                assert(false);
+                return;
+        }
+    }
+
+    /*
+     * Wider distance streams are uncommon for sparse_num's intended inputs, so
+     * keep them on one generic path for now. This path is expected to be slower
+     * because valueWidth and distanceWidth are not compile-time constants. If a
+     * workload needs faster D16 or D32 encoding, add their specialization.
+     */
+    ZL_sparseNumEncode_internal(
+            distances,
+            valueDst,
+            source,
+            numElts,
+            valueWidth,
+            distanceWidth,
+            distanceWidth == 4);
+}

--- a/src/openzl/codecs/sparse_num/encode_sparse_num_kernel.h
+++ b/src/openzl/codecs/sparse_num/encode_sparse_num_kernel.h
@@ -1,0 +1,76 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#ifndef OPENZL_CODECS_SPARSE_NUM_ENCODE_SPARSE_NUM_KERNEL_H
+#define OPENZL_CODECS_SPARSE_NUM_ENCODE_SPARSE_NUM_KERNEL_H
+
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+
+#include "openzl/codecs/sparse_num/common_sparse_num.h"
+#include "openzl/shared/portability.h"
+
+ZL_BEGIN_C_DECLS
+
+/**
+ * Lean sparse_num encoder kernel API.
+ *
+ * The binding is responsible for validating stream metadata and allocating the
+ * output streams. The kernel only scans numeric elements, reports the required
+ * output layout, and writes the distance and literal-value streams.
+ */
+typedef struct {
+    size_t numDistances;
+    size_t numValues;
+    size_t distanceWidth;
+} ZL_SparseNumEncodeInfo;
+
+/**
+ * Scans src and computes the canonical sparse_num output layout.
+ *
+ * Preconditions:
+ * - src must point to numElts numeric elements, each valueWidth bytes wide.
+ * - src must be aligned for valueWidth-byte numeric elements.
+ * - valueWidth must be a supported numeric element width.
+ *
+ * Returns:
+ * - numDistances: number of zero-run distances to emit.
+ * - numValues: number of literal values to emit.
+ * - distanceWidth: minimal distance width that can encode the largest emitted
+ *   run.
+ */
+ZL_SparseNumEncodeInfo ZL_sparseNumComputeEncodeInfo(
+        const void* src,
+        size_t numElts,
+        size_t valueWidth);
+
+/**
+ * Encodes src into separate sparse_num distance and value streams.
+ *
+ * This function is intended to be called after
+ * ZL_sparseNumComputeEncodeInfo() has succeeded for the same source stream.
+ *
+ * Preconditions:
+ * - src must point to numElts numeric elements, each valueWidth bytes wide.
+ * - src must be aligned for valueWidth-byte numeric elements.
+ * - valueWidth and distanceWidth must be supported widths.
+ * - distanceWidth must be large enough for the largest emitted zero run
+ *   reported by ZL_sparseNumComputeEncodeInfo().
+ * - distances must be aligned for distanceWidth-byte numeric elements.
+ * - distances must have room for info.numDistances * distanceWidth bytes.
+ * - values must be aligned for valueWidth-byte numeric elements.
+ * - values must have room for info.numValues * valueWidth bytes.
+ * - distances and values must not overlap src or each other in a way that
+ *   changes source elements before they are read or corrupts output writes.
+ */
+void ZL_sparseNumEncode(
+        void* distances,
+        void* values,
+        const void* src,
+        size_t numElts,
+        size_t valueWidth,
+        size_t distanceWidth);
+
+ZL_END_C_DECLS
+
+#endif

--- a/src/openzl/codecs/sparse_num/graph_sparse_num.h
+++ b/src/openzl/codecs/sparse_num/graph_sparse_num.h
@@ -1,0 +1,22 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#ifndef OPENZL_CODECS_SPARSE_NUM_GRAPH_SPARSE_NUM_H
+#define OPENZL_CODECS_SPARSE_NUM_GRAPH_SPARSE_NUM_H
+
+#include "openzl/zl_data.h"
+
+/**
+ * Graph definition for the sparse_num transform.
+ *
+ * Input 0: numeric stream to sparsify
+ * Output 0: numeric stream of zero-run distances
+ * Output 1: numeric stream of literal values
+ */
+#define SPARSE_NUM_GRAPH(id)                                               \
+    {                                                                      \
+        .CTid       = id,                                                  \
+        .inputTypes = ZL_STREAMTYPELIST(ZL_Type_numeric),                  \
+        .soTypes    = ZL_STREAMTYPELIST(ZL_Type_numeric, ZL_Type_numeric), \
+    }
+
+#endif

--- a/src/openzl/codecs/sparse_num/spec.md
+++ b/src/openzl/codecs/sparse_num/spec.md
@@ -1,0 +1,93 @@
+## Sparse Num Decoder Specification
+
+### Inputs
+
+The decoder for the `sparse_num` transform takes two numeric streams as input:
+
+1. `distances` -- zero-run lengths.
+2. `values` -- literal values.
+
+The `values` stream element width determines the output element width. It must be
+1, 2, 4, or 8 bytes.
+
+Literal values may be zero. This is valid and unambiguous because each distance
+is interpreted relative to the next literal value, not relative to the next
+nonzero value.
+
+The `distances` stream element width determines the maximum representable zero
+run. It must be 1, 2, or 4 bytes. Distance values are interpreted as unsigned
+integers in the stream's element width. The decoder accepts any supported
+distance width, even when a narrower width would be sufficient to represent all
+distances.
+
+The number of distance elements must be equal to the number of value elements, or
+exactly one greater than the number of value elements. No other count
+relationship is valid.
+
+### Codec Header
+
+The codec header is empty.
+
+### Decoding Algorithm
+
+Each distance is the number of zero elements before a boundary. A boundary is
+either the next literal value or the end of the reconstructed stream.
+
+Let `numValues` be the number of elements in `values`, and `numDistances` be the
+number of elements in `distances`.
+
+- If `numDistances == numValues`, the reconstructed stream ends with the last
+  value.
+- If `numDistances == numValues + 1`, the final distance is the zero run to the
+  end of the reconstructed stream. A final distance of zero is valid and means
+  the stream ends immediately after the last value.
+
+The decoder computes the number of output elements as:
+
+```
+sum(distances) + numValues
+```
+
+The decoder then produces output as follows:
+
+1. For each value index `i` in `[0, numValues)`:
+   1. Emit `distances[i]` zero elements.
+   2. Emit `values[i]`.
+2. If `numDistances == numValues + 1`, emit `distances[numValues]` zero
+   elements.
+
+The output size computation must be checked for integer overflow before
+allocating the output stream. Decoding must fail if the distance/value count
+relationship is invalid, if any stream has an unsupported element width, or if
+the computed output size cannot be represented.
+
+### Encoder Guidance
+
+This specification defines decoder behavior. Encoders are expected to choose an
+efficient, canonical representation, but the decoder must accept less efficient
+representations when they are unambiguous and otherwise valid.
+
+Encoders should use the narrowest distance width that can represent all emitted
+distances. Decoders must still accept any supported distance width.
+
+Encoders should normally omit zero literals and represent zero values through
+distances. Encoders may still emit zero literals when doing so is useful, for
+example to split an otherwise unrepresentable zero run while keeping distances
+limited to 32 bits.
+
+Encoders should use the shorter representation when the input ends with a
+literal value, omitting the final zero-length distance. Decoders must still
+accept `numDistances == numValues + 1` with a final zero distance.
+
+- Empty input is encoded as no distances and no values.
+- An all-zero input of length `N > 0` is encoded as one distance with value `N`
+  and no values, when `N` fits in the selected distance width.
+- Longer zero runs may be split by emitting a zero literal after the largest
+  representable distance.
+- An input ending in a literal value has `numDistances == numValues`.
+- An input ending in one or more zero values has `numDistances == numValues + 1`.
+
+### Output
+
+The decoder produces one numeric stream. Its element width is the element width
+of `values`, and its element count is `sum(distances) + numValues`.

--- a/src/openzl/common/wire_format.h
+++ b/src/openzl/common/wire_format.h
@@ -316,6 +316,8 @@ typedef enum {
 
     ZL_StandardTransformID_mux_lengths = 65,
 
+    ZL_StandardTransformID_sparse_num = 66,
+
     ZL_StandardTransformID_end =
             128 // last id, used to detect end of ID range (impacts
                 // header encoding) give some room to be able to add new

--- a/tests/registry/OpenZLComponents.h
+++ b/tests/registry/OpenZLComponents.h
@@ -89,6 +89,7 @@ enum class OpenZLComponentID {
     CompressSmallLengths,
     Lz,
     MuxLengths,
+    SparseNum,
     // Must be last enum value
     NumComponents,
 };
@@ -164,6 +165,7 @@ std::unique_ptr<OpenZLComponent> makeSentinelNumComponent();
 std::unique_ptr<OpenZLComponent> makeCompressSmallLengthsComponent();
 std::unique_ptr<OpenZLComponent> makeLzComponent();
 std::unique_ptr<OpenZLComponent> makeMuxLengthsComponent();
+std::unique_ptr<OpenZLComponent> makeSparseNumComponent();
 
 } // namespace components
 
@@ -299,6 +301,8 @@ inline std::unique_ptr<OpenZLComponent> makeOpenZLComponent(
             return components::makeLzComponent();
         case OpenZLComponentID::MuxLengths:
             return components::makeMuxLengthsComponent();
+        case OpenZLComponentID::SparseNum:
+            return components::makeSparseNumComponent();
         case OpenZLComponentID::NumComponents:
         default:
             throw std::runtime_error("Invalid component");

--- a/tests/registry/components/SparseNum.cpp
+++ b/tests/registry/components/SparseNum.cpp
@@ -1,0 +1,134 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#include "openzl/cpp/codecs/SparseNum.hpp"
+#include "tests/registry/OpenZLComponents.h"
+#include "tests/registry/OpenZLInput.h"
+
+#include <cstdint>
+
+namespace openzl::tests::components {
+namespace {
+
+template <typename T>
+std::vector<T> sparseVector(datagen::DataGen& gen, size_t maxElts, T min, T max)
+{
+    std::vector<T> values;
+    size_t const numElts = gen.usize_range("numElts", 0, maxElts);
+    values.reserve(numElts);
+    for (size_t i = 0; i < numElts; ++i) {
+        if (gen.coin("isZero", 0.75)) {
+            values.push_back(0);
+            continue;
+        }
+        T value = gen.randVal<T>("value", min, max);
+        if (value == 0) {
+            value = 1;
+        }
+        values.push_back(value);
+    }
+    return values;
+}
+
+class SparseNumComponent : public OpenZLComponent {
+   public:
+    std::string name() const override
+    {
+        return "SparseNum";
+    }
+
+    int minFormatVersion() const override
+    {
+        return 25;
+    }
+
+    size_t compressBound(poly::span<const Input> inputs) const override
+    {
+        return 3 * this->OpenZLComponent::compressBound(inputs);
+    }
+
+    std::vector<NodeID> predefinedNodes(Compressor& compressor) const override
+    {
+        return { nodes::SparseNum{}.parameterize(compressor) };
+    }
+
+    std::vector<std::unique_ptr<OpenZLInput>> predefinedInputs() const override
+    {
+        std::vector<std::unique_ptr<OpenZLInput>> inputs;
+        inputs.push_back(U8OpenZLInput::make(std::vector<uint8_t>{}));
+        inputs.push_back(U8OpenZLInput::make(std::vector<uint8_t>{ 0, 0, 0 }));
+        inputs.push_back(U8OpenZLInput::make(std::vector<uint8_t>{ 1, 2, 3 }));
+        inputs.push_back(U8OpenZLInput::make(std::vector<uint8_t>{ 0, 0, 7 }));
+        inputs.push_back(U8OpenZLInput::make(std::vector<uint8_t>{ 7, 0, 0 }));
+        inputs.push_back(
+                U8OpenZLInput::make(
+                        std::vector<uint8_t>{ 0, 1, 0, 0, 2, 0, 3, 0 }));
+        inputs.push_back(
+                U16OpenZLInput::make(
+                        std::vector<uint16_t>{ 0, 1024, 0, 0, 65535 }));
+        inputs.push_back(
+                U32OpenZLInput::make(
+                        std::vector<uint32_t>{ 0, 0, 1, 0, UINT32_MAX, 0 }));
+        inputs.push_back(
+                U64OpenZLInput::make(
+                        std::vector<uint64_t>{ 0, 1, 0, UINT64_MAX, 0, 0 }));
+        return inputs;
+    }
+
+    std::vector<std::unique_ptr<OpenZLInput>> generateInputs(
+            datagen::DataGen& gen,
+            size_t num,
+            size_t maxInputSize,
+            const Compressor&,
+            GraphID) const override
+    {
+        std::vector<std::unique_ptr<OpenZLInput>> inputs;
+        inputs.reserve(num);
+        for (size_t i = 0; i < num; ++i) {
+            auto widthChoice = gen.usize_range("width", 0, 3);
+            switch (widthChoice) {
+                case 0: {
+                    auto maxElts = maxInputSize / sizeof(uint8_t);
+                    inputs.push_back(
+                            U8OpenZLInput::make(
+                                    sparseVector<uint8_t>(
+                                            gen, maxElts, 0, UINT8_MAX)));
+                    break;
+                }
+                case 1: {
+                    auto maxElts = maxInputSize / sizeof(uint16_t);
+                    inputs.push_back(
+                            U16OpenZLInput::make(
+                                    sparseVector<uint16_t>(
+                                            gen, maxElts, 0, UINT16_MAX)));
+                    break;
+                }
+                case 2: {
+                    auto maxElts = maxInputSize / sizeof(uint32_t);
+                    inputs.push_back(
+                            U32OpenZLInput::make(
+                                    sparseVector<uint32_t>(
+                                            gen, maxElts, 0, UINT32_MAX)));
+                    break;
+                }
+                case 3: {
+                    auto maxElts = maxInputSize / sizeof(uint64_t);
+                    inputs.push_back(
+                            U64OpenZLInput::make(
+                                    sparseVector<uint64_t>(
+                                            gen, maxElts, 0, UINT64_MAX)));
+                    break;
+                }
+            }
+        }
+        return inputs;
+    }
+};
+
+} // namespace
+
+std::unique_ptr<OpenZLComponent> makeSparseNumComponent()
+{
+    return std::make_unique<SparseNumComponent>();
+}
+
+} // namespace openzl::tests::components

--- a/tests/unittest/transforms/test_sparse_num_kernel.cpp
+++ b/tests/unittest/transforms/test_sparse_num_kernel.cpp
@@ -1,0 +1,36 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#include <array>
+#include <cstdint>
+
+#include <gtest/gtest.h>
+
+#include "openzl/codecs/sparse_num/decode_sparse_num_kernel.h"
+
+namespace {
+
+TEST(SparseNumKernelTest, DecodeAcceptsZeroLiteral)
+{
+    std::array<uint8_t, 2> const distances = { 3, 1 };
+    std::array<uint8_t, 1> const values    = { 0 };
+    std::array<uint8_t, 5> expected        = { 0, 0, 0, 0, 0 };
+    std::array<uint8_t, 5> output          = {};
+
+    size_t const outputCount = ZL_sparseNumDecodeOutputCount(
+            distances.data(), distances.size(), sizeof(uint8_t), values.size());
+
+    ASSERT_EQ(outputCount, output.size());
+    ZL_sparseNumDecode(
+            output.data(),
+            output.size() * sizeof(uint8_t),
+            distances.data(),
+            distances.size(),
+            sizeof(uint8_t),
+            values.data(),
+            values.size(),
+            sizeof(uint8_t));
+
+    EXPECT_EQ(output, expected);
+}
+
+} // namespace


### PR DESCRIPTION
Summary:

Adds `sparse_num` as a public standard OpenZL codec.

The current wire format has no codec header. The original element width comes from the input stream width, and the decoded element count is derived from the distance stream and value count during decode.

The diff includes C and C++ public bindings, component-registry correctness coverage, externally driven `unitBench` kernel benchmarks, and a Markdown-reporting `sparse_num` benchmark runner.

Benchmark command: `buck run fbcode//openzl/dev/benchmark/unitBench/scripts:sparse_num_bench -- --sample-mib 2 --duration-s 1`

| width | zeros | elements | raw | encoded | ratio | encode MiB/s | decode MiB/s |
|---|---:|---:|---:|---:|---:|---:|---:|
| u8 | 75% | 2097100 | 2.00 MiB | 1023.97 KiB | 2.00 | 1154.4 | 995.8 |
| u8 | 90% | 2097100 | 2.00 MiB | 409.59 KiB | 5.00 | 1282.6 | 2721.8 |
| u8 | 98% | 2097100 | 2.00 MiB | 81.92 KiB | 25.00 | 1340.6 | 12499.7 |
| u16 | 75% | 1048500 | 2.00 MiB | 767.94 KiB | 2.67 | 1422.9 | 1965.8 |
| u16 | 90% | 1048500 | 2.00 MiB | 307.18 KiB | 6.67 | 1455.9 | 4893.2 |
| u16 | 98% | 1048500 | 2.00 MiB | 61.44 KiB | 33.33 | 1469.8 | 23864.6 |
| u32 | 75% | 524200 | 2.00 MiB | 639.89 KiB | 3.20 | 1943.5 | 3958.9 |
| u32 | 90% | 524200 | 2.00 MiB | 255.96 KiB | 8.00 | 1904.3 | 10727.8 |
| u32 | 98% | 524200 | 2.00 MiB | 51.19 KiB | 40.00 | 1840.8 | 35329.8 |
| u64 | 75% | 262100 | 2.00 MiB | 575.90 KiB | 3.56 | 2516.9 | 7838.7 |
| u64 | 90% | 262100 | 2.00 MiB | 230.36 KiB | 8.89 | 2273.9 | 19264.6 |
| u64 | 98% | 262100 | 2.00 MiB | 46.07 KiB | 44.44 | 2157.1 | 47498.0 |

This is a deliberately generic first implementation. It is not expected to be the final optimized form, but the current speed is sufficient for an initial standard-codec version. The encode kernel dispatches common 8- and 16-bit-distance cases through value-width-specialized calls, keeps the rare 32-bit-distance zero-literal split on a separate constant path, and the decode kernel uses fixed-value-width materialization paths for 8-bit distance streams.

Future optimizations will likely need narrower targets, such as specializing for specific width combinations or using hardware-specific intrinsics.

Follow-up:
- Extend the codec to support non-zero constants.

Differential Revision: D105636186


