### PR TITLE
folly/Conv: remove double-conversion, replace toAppend<float> with fmt

### DIFF
--- a/custom_transforms/parse/decode_parse_float.cpp
+++ b/custom_transforms/parse/decode_parse_float.cpp
@@ -18,6 +18,8 @@ size_t constexpr maxStrLen(double)
 
 class StreamAppender {
    public:
+    using value_type = char;
+
     explicit StreamAppender(ZL_Output* stream)
             : buffer_((char*)ZL_Output_ptr(stream))
     {
@@ -27,6 +29,11 @@ class StreamAppender {
     {
         std::memcpy(buffer_ + idx_, ptr, length);
         idx_ += length;
+    }
+
+    void append(std::string_view sv)
+    {
+        append(sv.data(), sv.size());
     }
 
     void push_back(char c)
@@ -42,7 +49,7 @@ class StreamAppender {
     }
 
    private:
-    char* buffer_;
+    char* buffer_{ nullptr };
     size_t idx_{ 0 };
     size_t prev_{ 0 };
 };


### PR DESCRIPTION
Summary:
Removes the last remaining use of Google's double-conversion library from `folly/Conv.h`:

- Removes `DtoaMode`, `DtoaFlags`, their bitwise operators, and the `detail::` helpers (`convert()`, `kConvMaxFixedDigitsAfterPoint`, `kConvMaxPrecisionDigits`, and the range constants). These were only needed to bridge `toAppend(Src, Tgt*, DtoaMode, ...)` to double-conversion; all callers have migrated away (folly/json in the previous diff, thrift/JsonWriter in the diff before this).
- Removes `toAppend(Src, Tgt*, DtoaMode, unsigned, DtoaFlags)` — the parametric overload is now dead.
- Replaces `toAppend(Src value, Tgt* result)` (the simple double-to-string overload) with fmt's Dragonbox. NaN and Infinity preserve the "NaN"/"Infinity"/"-Infinity" spellings. Other values use `fmt::format("{}", ...)`. The output is the shortest round-trip decimal with fmt's exponent threshold; a small number of `testDoubleToString` golden values change accordingly (e.g., "0.000001" → "1e-06", uppercase "E" → lowercase "e") since fmt and double-conversion use different formatting conventions.
- Simplifies `estimateSpaceNeeded<float>` to a constant 24 + sign, removing dependence on the removed detail constants.
- In `fbcode/folly/BUCK`: swaps `exported_external_deps = ["double_conversion"]` for `"fbsource//third-party/fmt:fmt"` in the `:conv` target.
- Removes the `DtoaMode`/`DtoaFlags` ConvTest tests that tested the removed API.

Reviewed By: skrueger

Differential Revision: D106051019


