### PR TITLE
Add measurements framework (#789)

### DIFF
--- a/tools/ml_selector/BUCK
+++ b/tools/ml_selector/BUCK
@@ -11,6 +11,10 @@ zs_cxxlibrary(
     compiler_flags = [
         "-Wno-unused-exception-parameter",  # For XGBoost warnings
     ],
+    visibility = [
+        "fbcode//common/managed_compression/...",
+        "//openzl/...",
+    ],
     deps = [
         "../..:zstronglib",
         "../../cpp:openzl_cpp",

--- a/tools/training/ace/BUCK
+++ b/tools/training/ace/BUCK
@@ -30,6 +30,10 @@ cpp_library(
         "crowding_distance_selector.h",
     ]),
     header_namespace = "",
+    visibility = [
+        "fbcode//common/managed_compression/...",
+        "//openzl/...",
+    ],
     deps = [
         "../../..:zstronglib",
     ],


### PR DESCRIPTION
Summary:

Add a measurements framework that evaluates different compression methods by running multiple strategies (ML selector, best-successor per cluster, brute-force per sample, generic ML, plain zstd) on captured sample data and printing a side-by-side comparison table.

Added test cases for the measurements and python integration so managed compression trainer can trigger measurements if --capture-data is specified

Differential Revision: D106423347


