### PR TITLE
Extract ZL_DictBundle_genBundleID API and fix CDictMgr cleanup (#790)

### DIFF
--- a/BUCK
+++ b/BUCK
@@ -75,6 +75,7 @@ zs_library(
     ],
     exported_external_deps = [
         ("xxHash", None, "xxhash"),
+        "zstd",
     ],
 )
 

--- a/include/openzl/codecs/zl_zstd.h
+++ b/include/openzl/codecs/zl_zstd.h
@@ -3,6 +3,7 @@
 #ifndef ZSTRONG_CODECS_ZSTD_H
 #define ZSTRONG_CODECS_ZSTD_H
 
+#include "openzl/zl_errors.h"
 #include "openzl/zl_graphs.h"
 #include "openzl/zl_opaque_types.h"
 
@@ -16,6 +17,10 @@ extern "C" {
 ZL_GraphID ZL_Compressor_registerZstdGraph_withLevel(
         ZL_Compressor* cgraph,
         int compressionLevel);
+
+/// @return A trainable zstd graph with the default compression level
+ZL_RESULT_OF(ZL_GraphID)
+ZL_Compressor_buildTrainableZstdGraph(ZL_Compressor* cgraph);
 
 #if defined(__cplusplus)
 }

--- a/include/openzl/zl_dict.h
+++ b/include/openzl/zl_dict.h
@@ -71,6 +71,18 @@ ZL_RESULT_DECLARE_TYPE(ZL_BundleInfo);
 /// the buffer.
 ZL_RESULT_OF(ZL_BundleInfo) ZL_BundleInfo_parse(const void* buf, size_t size);
 
+/**
+ * Generate a canonical bundle ID for a set of dictionary IDs. This is the same
+ * function used by fat bundle packing.
+ *
+ * If @p numDicts is 0, this returns the bundle ID for an empty dictionary set.
+ * In that case, @p dictIDs may be NULL. Otherwise, @p dictIDs must be non-NULL
+ * and point to an array of @p numDicts dictionary IDs.
+ */
+ZL_BundleID ZL_DictBundle_genBundleID(
+        const ZL_DictID* dictIDs,
+        size_t numDicts);
+
 // ============================================================================
 // ZL_DictBundle - A bundle of dictionaries
 // ============================================================================

--- a/src/openzl/codecs/zstd/common_zstd.c
+++ b/src/openzl/codecs/zstd/common_zstd.c
@@ -1,0 +1,109 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#include "openzl/codecs/zstd/common_zstd.h"
+
+#include <string.h>
+
+#include "openzl/shared/mem.h"
+#include "openzl/zl_errors.h"
+#include "openzl/zl_materializer.h"
+
+#ifndef ZSTD_STATIC_LINKING_ONLY
+#    define ZSTD_STATIC_LINKING_ONLY
+#endif
+#include <zstd.h> // ZSTD_customMem, ZSTD_createDDict_advanced
+
+size_t ZL_TrainedZstdContent_packedSize(size_t rawDictSize)
+{
+    return ZL_TRAINED_ZSTD_CONTENT_HEADER_SIZE + rawDictSize;
+}
+
+size_t ZL_TrainedZstdContent_pack(
+        void* dst,
+        size_t dstCapacity,
+        int32_t clevel,
+        const void* rawDict,
+        size_t rawDictSize)
+{
+    size_t const packedSize = ZL_TrainedZstdContent_packedSize(rawDictSize);
+    if (dstCapacity < packedSize)
+        return 0;
+    uint8_t* const p = (uint8_t*)dst;
+    ZL_writeLE32(p + 0, ZL_TRAINED_ZSTD_CONTENT_VERSION);
+    ZL_writeLE32(p + 4, (uint32_t)clevel);
+    if (rawDictSize > 0) {
+        memcpy(p + ZL_TRAINED_ZSTD_CONTENT_HEADER_SIZE, rawDict, rawDictSize);
+    }
+    return packedSize;
+}
+
+bool ZL_TrainedZstdContent_parse(
+        const void* src,
+        size_t srcSize,
+        ZL_TrainedZstdContentParsed* out)
+{
+    if (srcSize < ZL_TRAINED_ZSTD_CONTENT_HEADER_SIZE)
+        return false;
+    const uint8_t* const p = (const uint8_t*)src;
+    uint32_t const version = ZL_readLE32(p + 0);
+    if (version != ZL_TRAINED_ZSTD_CONTENT_VERSION)
+        return false;
+    out->clevel      = (int32_t)ZL_readLE32(p + 4);
+    out->rawDict     = p + ZL_TRAINED_ZSTD_CONTENT_HEADER_SIZE;
+    out->rawDictSize = srcSize - ZL_TRAINED_ZSTD_CONTENT_HEADER_SIZE;
+    return true;
+}
+
+void* ZL_Zstd_materializerAlloc(void* opaque, size_t size)
+{
+    return ZL_Materializer_allocate((ZL_Materializer*)opaque, size);
+}
+
+void ZL_Zstd_materializerFree(void* opaque, void* address)
+{
+    // Arena-managed memory: freed when the owning compressor/dict store is
+    // destroyed. Individual frees are no-ops.
+    (void)opaque;
+    (void)address;
+}
+
+static ZL_RESULT_OF(ZL_VoidPtr) DIZSTD_materializeDDict(
+        ZL_Materializer* matCtx,
+        const void* src,
+        size_t srcSize)
+{
+    ZL_RESULT_DECLARE_SCOPE(ZL_VoidPtr, NULL);
+    ZL_TrainedZstdContentParsed parsed;
+    ZL_ERR_IF_NOT(
+            ZL_TrainedZstdContent_parse(src, srcSize, &parsed),
+            dict_materialization,
+            "Failed to parse trained zstd dict content");
+    ZSTD_customMem const customMem = {
+        .customAlloc = ZL_Zstd_materializerAlloc,
+        .customFree  = ZL_Zstd_materializerFree,
+        .opaque      = matCtx,
+    };
+    ZSTD_DDict* ddict = ZSTD_createDDict_advanced(
+            parsed.rawDict,
+            parsed.rawDictSize,
+            ZSTD_dlm_byCopy,
+            ZSTD_dct_auto,
+            customMem);
+    ZL_ERR_IF_NULL(ddict, dict_materialization, "ZSTD_createDDict failed");
+    return ZL_RESULT_WRAP_VALUE(ZL_VoidPtr, (ZL_VoidPtr)ddict);
+}
+
+static void DIZSTD_dematerializeDDict(
+        ZL_Materializer* matCtx,
+        void* materialized)
+{
+    (void)matCtx;
+    if (materialized != NULL) {
+        ZSTD_freeDDict((ZSTD_DDict*)materialized);
+    }
+}
+
+const ZL_MaterializerDesc2 ZL_Zstd_ddict_materializer = {
+    .materializeFn   = DIZSTD_materializeDDict,
+    .dematerializeFn = DIZSTD_dematerializeDDict,
+};

--- a/src/openzl/codecs/zstd/common_zstd.h
+++ b/src/openzl/codecs/zstd/common_zstd.h
@@ -1,0 +1,78 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#ifndef ZSTRONG_CODECS_ZSTD_COMMON_ZSTD_H
+#define ZSTRONG_CODECS_ZSTD_COMMON_ZSTD_H
+
+#include <stddef.h>
+#include <stdint.h>
+
+#include "openzl/shared/portability.h"
+#include "openzl/zl_materializer.h"
+
+ZL_BEGIN_C_DECLS
+
+/**
+ * Serialized dict content format for zstd dictionaries.
+ *
+ * This format wraps raw zstd dict bytes with compression level metadata.
+ * It is stored as the "dict content" inside the generic ZL_Dict wire format
+ * and is opaque to the generic dict packing layer. Only the zstd CDict/DDict
+ * materializers interpret it.
+ *
+ * Binary layout (little-endian):
+ *   [4 bytes] version = format version (uint32 LE)
+ *   [4 bytes] clevel  = compression level (int32 LE)
+ *   [N bytes] raw zstd dictionary content
+ */
+
+#define ZL_TRAINED_ZSTD_CONTENT_VERSION 1
+#define ZL_TRAINED_ZSTD_CONTENT_HEADER_SIZE 8
+
+typedef struct {
+    int32_t clevel;
+    const void* rawDict;
+    size_t rawDictSize;
+} ZL_TrainedZstdContentParsed;
+
+size_t ZL_TrainedZstdContent_packedSize(size_t rawDictSize);
+
+/**
+ * Pack a trained zstd dict content envelope.
+ * @returns packed size on success, 0 on failure (insufficient capacity).
+ */
+size_t ZL_TrainedZstdContent_pack(
+        void* dst,
+        size_t dstCapacity,
+        int32_t clevel,
+        const void* rawDict,
+        size_t rawDictSize);
+
+/**
+ * Parse a trained zstd dict content envelope.
+ * @returns true on success, false on failure (insufficient size or bad
+ * version).
+ */
+bool ZL_TrainedZstdContent_parse(
+        const void* src,
+        size_t srcSize,
+        ZL_TrainedZstdContentParsed* out);
+
+// TODO(T271643692): This is a convenient way of injecting arena allocation
+// without disturbing the public API. Work needs to be done to allow the MC
+// allocator to be used here.
+/**
+ * Custom allocator hooks for plugging a @ref ZL_Materializer's arena into
+ * zstd's `ZSTD_customMem` callbacks. Pass the `ZL_Materializer*` as the
+ * `opaque` field of `ZSTD_customMem`. The free function is a no-op since
+ * arena memory is reclaimed at compressor teardown.
+ */
+void* ZL_Zstd_materializerAlloc(void* opaque, size_t size);
+void ZL_Zstd_materializerFree(void* opaque, void* address);
+
+/// DDict materializer for decompression-side zstd dict support.
+/// Defined in common_zstd.c, registered in DictLoader.
+extern const ZL_MaterializerDesc2 ZL_Zstd_ddict_materializer;
+
+ZL_END_C_DECLS
+
+#endif // ZSTRONG_CODECS_ZSTD_COMMON_ZSTD_H

--- a/src/openzl/codecs/zstd/decode_zstd_binding.c
+++ b/src/openzl/codecs/zstd/decode_zstd_binding.c
@@ -97,8 +97,10 @@ ZL_Report DI_zstd(ZL_Decoder* dictx, ZL_Input const* ins[])
             ZL_ERR(logicError, "Zstd unable to set parameter!");
         }
     }
-    size_t const dSize = ZSTD_decompressDCtx(
-            dctx, ZL_Output_ptr(out), dstSize, src, srcSize);
+    const ZSTD_DDict* ddict =
+            (const ZSTD_DDict*)ZL_Decoder_getMaterializedDict(dictx);
+    size_t const dSize = ZSTD_decompress_usingDDict(
+            dctx, ZL_Output_ptr(out), dstSize, src, srcSize, ddict);
     ZL_ERR_IF(
             ZSTD_isError(dSize),
             corruption,

--- a/src/openzl/codecs/zstd/decode_zstd_binding.h
+++ b/src/openzl/codecs/zstd/decode_zstd_binding.h
@@ -7,6 +7,8 @@
 #include "openzl/shared/portability.h"
 #include "openzl/zl_dtransform.h"
 
+ZL_BEGIN_C_DECLS
+
 ZL_Report DI_zstd(ZL_Decoder* dictx, const ZL_Input* ins[]);
 
 /* state management */
@@ -28,5 +30,7 @@ void DIZSTD_freeDCtx(void* state);
         .trStateMgr.stateAlloc = DIZSTD_createDCtx,          \
         .trStateMgr.stateFree  = DIZSTD_freeDCtx,            \
     }
+
+ZL_END_C_DECLS
 
 #endif // ZSTRONG_TRANSFORMS_ZSTD_DECODE_ZSTD_BINDING_H

--- a/src/openzl/codecs/zstd/encode_zstd_binding.c
+++ b/src/openzl/codecs/zstd/encode_zstd_binding.c
@@ -1,5 +1,6 @@
 // Copyright (c) Meta Platforms, Inc. and affiliates.
 #include "openzl/codecs/zstd/encode_zstd_binding.h"
+#include "openzl/codecs/zstd/common_zstd.h"
 #include "openzl/common/assertion.h"
 #include "openzl/compress/private_nodes.h" // ZL_PrivateStandardNodeID_zstd
 #include "openzl/shared/varint.h"
@@ -136,6 +137,13 @@ EI_zstdWithCCtx(ZL_Encoder* eictx, ZSTD_CCtx* cctx, const ZL_Input* src)
         ZL_ERR_IF_ZSTD_ERR(ZSTD_CCtx_setParameter(cctx, param, ip.paramValue));
     }
     if (blockSize == srcSize) {
+        // dict only used when not cutting blocks; the subsequent
+        // ZSTD_CCtx_reset in this function's next invocation will unbind it.
+        const ZSTD_CDict* cdict =
+                (const ZSTD_CDict*)ZL_Encoder_getMaterializedDict(eictx);
+        if (cdict != NULL) {
+            ZL_ERR_IF_ZSTD_ERR(ZSTD_CCtx_refCDict(cctx, cdict));
+        }
         size_t const cSize = ZSTD_compress2(
                 cctx,
                 ostart + headerSize,
@@ -203,4 +211,63 @@ ZL_GraphID ZL_Compressor_registerZstdGraph_withLevel(
             });
     return ZL_Compressor_registerStaticGraph_fromNode1o(
             cgraph, node_zstd, ZL_GRAPH_STORE);
+}
+
+ZL_RESULT_OF(ZL_GraphID)
+ZL_Compressor_buildTrainableZstdGraph(ZL_Compressor* cgraph)
+{
+    ZL_RESULT_DECLARE_SCOPE(ZL_GraphID, cgraph);
+    ZL_NodeID node_zstd = ZL_Compressor_registerParameterizedNode(
+            cgraph,
+            &(const ZL_ParameterizedNodeDesc){
+                    .name = "zl.trainable.zstd",
+                    .node = (ZL_NodeID){ ZL_PrivateStandardNodeID_zstd },
+            });
+    ZL_ERR_IF_NOT(
+            ZL_NodeID_isValid(node_zstd),
+            node_invalid,
+            "Failed to build zl.trainable.zstd node");
+    ZL_GraphID const graph = ZL_Compressor_registerStaticGraph_fromNode1o(
+            cgraph, node_zstd, ZL_GRAPH_STORE);
+    ZL_ERR_IF_NOT(
+            ZL_GraphID_isValid(graph),
+            graph_invalid,
+            "Failed to build trainable zstd graph");
+    return ZL_WRAP_VALUE(graph);
+}
+
+ZL_RESULT_OF(ZL_VoidPtr)
+EIZSTD_materializeCDict(
+        ZL_Materializer* matCtx,
+        const void* src,
+        size_t srcSize)
+{
+    ZL_RESULT_DECLARE_SCOPE(ZL_VoidPtr, NULL);
+    ZL_TrainedZstdContentParsed parsed;
+    ZL_ERR_IF_NOT(
+            ZL_TrainedZstdContent_parse(src, srcSize, &parsed),
+            dict_materialization,
+            "Failed to parse trained zstd dict content");
+    ZSTD_customMem const customMem = {
+        .customAlloc = ZL_Zstd_materializerAlloc,
+        .customFree  = ZL_Zstd_materializerFree,
+        .opaque      = matCtx,
+    };
+    ZSTD_CDict* cdict = ZSTD_createCDict_advanced(
+            parsed.rawDict,
+            parsed.rawDictSize,
+            ZSTD_dlm_byCopy,
+            ZSTD_dct_auto,
+            ZSTD_getCParams(parsed.clevel, 0, parsed.rawDictSize),
+            customMem);
+    ZL_ERR_IF_NULL(cdict, dict_materialization, "ZSTD_createCDict failed");
+    return ZL_RESULT_WRAP_VALUE(ZL_VoidPtr, (ZL_VoidPtr)cdict);
+}
+
+void EIZSTD_dematerializeCDict(ZL_Materializer* matCtx, void* materialized)
+{
+    (void)matCtx;
+    if (materialized != NULL) {
+        ZSTD_freeCDict((ZSTD_CDict*)materialized);
+    }
 }

--- a/src/openzl/codecs/zstd/encode_zstd_binding.h
+++ b/src/openzl/codecs/zstd/encode_zstd_binding.h
@@ -6,6 +6,7 @@
 #include "openzl/codecs/entropy/graph_entropy.h"
 #include "openzl/shared/portability.h"
 #include "openzl/zl_ctransform.h"
+#include "openzl/zl_materializer.h"
 
 ZL_BEGIN_C_DECLS
 
@@ -21,13 +22,23 @@ ZL_Report EI_zstd(ZL_Encoder* eictx, const ZL_Input* ins[], size_t nbIns);
 void* EIZSTD_createCCtx(void);
 void EIZSTD_freeCCtx(void* state);
 
-#define EI_ZSTD(id)                                  \
-    {                                                \
-        .gd                    = PIPE_GRAPH(id),     \
-        .transform_f           = EI_zstd,            \
-        .name                  = "!zl.private.zstd", \
-        .trStateMgr.stateAlloc = EIZSTD_createCCtx,  \
-        .trStateMgr.stateFree  = EIZSTD_freeCCtx,    \
+/* CDict materializer for dict-backed zstd compression */
+ZL_RESULT_OF(ZL_VoidPtr)
+EIZSTD_materializeCDict(
+        ZL_Materializer* matCtx,
+        const void* src,
+        size_t srcSize);
+void EIZSTD_dematerializeCDict(ZL_Materializer* matCtx, void* materialized);
+
+#define EI_ZSTD(id)                                           \
+    {                                                         \
+        .gd                      = PIPE_GRAPH(id),            \
+        .transform_f             = EI_zstd,                   \
+        .name                    = "!zl.private.zstd",        \
+        .trStateMgr.stateAlloc   = EIZSTD_createCCtx,         \
+        .trStateMgr.stateFree    = EIZSTD_freeCCtx,           \
+        .dictMat.materializeFn   = EIZSTD_materializeCDict,   \
+        .dictMat.dematerializeFn = EIZSTD_dematerializeCDict, \
     }
 
 #define EI_ZSTD_FIXED(id)                                             \

--- a/src/openzl/common/materializer_ctx.c
+++ b/src/openzl/common/materializer_ctx.c
@@ -1,6 +1,6 @@
 // Copyright (c) Meta Platforms, Inc. and affiliates.
 
-#include "openzl/dict/materializer_ctx.h"
+#include "openzl/common/materializer_ctx.h"
 
 #include "openzl/common/allocation.h"
 #include "openzl/zl_materializer.h"

--- a/src/openzl/common/materializer_ctx.h
+++ b/src/openzl/common/materializer_ctx.h
@@ -1,7 +1,7 @@
 // Copyright (c) Meta Platforms, Inc. and affiliates.
 
-#ifndef OPENZL_DICT_MATERIALIZER_CTX_H
-#define OPENZL_DICT_MATERIALIZER_CTX_H
+#ifndef OPENZL_COMMON_MATERIALIZER_CTX_H
+#define OPENZL_COMMON_MATERIALIZER_CTX_H
 
 #include "openzl/common/allocation.h"       // Arena
 #include "openzl/detail/zl_error_context.h" // ZL_OperationContext
@@ -26,4 +26,4 @@ struct ZL_Materializer_s {
 } // extern "C"
 #endif
 
-#endif // OPENZL_DICT_MATERIALIZER_CTX_H
+#endif // OPENZL_COMMON_MATERIALIZER_CTX_H

--- a/src/openzl/compress/cdictmgr.c
+++ b/src/openzl/compress/cdictmgr.c
@@ -112,6 +112,23 @@ void CDictMgr_destroy(CDictMgr* mgr)
 {
     if (mgr == NULL)
         return;
+    // Dematerialize all cached dicts
+    {
+        CDictMgr_DictMap_Iter iter = CDictMgr_DictMap_iter(&mgr->dictsByID);
+        const CDictMgr_DictMap_Entry* entry;
+        for (; (entry = CDictMgr_DictMap_Iter_next(&iter));) {
+            if (entry->val != NULL && entry->val->dictObj != NULL) {
+                ZL_Materializer dematCtx = {
+                    .persistentArena = NULL,
+                    .scratchArena    = NULL,
+                    .opaquePtr       = entry->key.matDesc.opaque.ptr,
+                    .opCtx           = mgr->opCtx,
+                };
+                entry->key.matDesc.dematerializeFn(
+                        &dematCtx, entry->val->dictObj);
+            }
+        }
+    }
     CDictMgr_DictMap_destroy(&mgr->dictsByID);
     CDictMgr_MParamMap_destroy(&mgr->mparamBlobs);
     if (mgr->scratchArena != NULL) {

--- a/src/openzl/compress/materializer.h
+++ b/src/openzl/compress/materializer.h
@@ -5,7 +5,7 @@
 
 #include "openzl/common/allocation.h" // Arena
 #include "openzl/common/map.h"
-#include "openzl/dict/materializer_ctx.h" // struct ZL_Materializer_s
+#include "openzl/common/materializer_ctx.h" // struct ZL_Materializer_s
 #include "openzl/shared/portability.h"
 #include "openzl/zl_errors.h" // ZL_RESULT_DECLARE_TYPE_IMPL, ZL_RESULT_OF
 

--- a/src/openzl/dict/bundle.c
+++ b/src/openzl/dict/bundle.c
@@ -5,6 +5,7 @@
 #include <stddef.h>
 #include <string.h>
 
+#include "openzl/common/assertion.h"
 #include "openzl/dict/dict.h"
 #include "openzl/dict/dict_constants.h"
 #include "openzl/fse/common/mem.h"
@@ -112,6 +113,15 @@ BundleInfo_pack(void* dst, size_t dstCapacity, const ZL_BundleInfo* info)
     return ZL_returnValue(packedSize);
 }
 
+ZL_BundleID ZL_DictBundle_genBundleID(const ZL_DictID* dictIDs, size_t numDicts)
+{
+    ZL_ASSERT(dictIDs != NULL || numDicts == 0);
+    ZL_BundleID result;
+    result.id =
+            ZL_UniqueID_computeSHA256(dictIDs, numDicts * ZL_UNIQUE_ID_SIZE);
+    return result;
+}
+
 /* ================================================================
  * ZL_DictBundle_packFatBundle
  * ================================================================ */
@@ -165,10 +175,11 @@ ZL_Report ZL_DictBundle_packFatBundle(
     }
 
     /* Generate bundleID as SHA256 of the dictID array */
-    unsigned char* const dictIDArray = bundleIDSlot + ZL_UNIQUE_ID_SIZE + 1 + 4;
-    ZL_UniqueID const bundleHash     = ZL_UniqueID_computeSHA256(
-            dictIDArray, numDicts * ZL_UNIQUE_ID_SIZE);
-    ZL_UniqueID_write(bundleIDSlot, &bundleHash);
+    ZL_DictID* const dictIDArray =
+            (ZL_DictID*)(bundleIDSlot + ZL_UNIQUE_ID_SIZE + 1 + 4);
+    ZL_BundleID const bundleHash =
+            ZL_DictBundle_genBundleID(dictIDArray, numDicts);
+    ZL_UniqueID_write(bundleIDSlot, &bundleHash.id);
 
     /* Append each packed dict blob */
     for (size_t i = 0; i < numDicts; i++) {

--- a/src/openzl/dict/dictloader.c
+++ b/src/openzl/dict/dictloader.c
@@ -4,10 +4,11 @@
 
 #include <stdlib.h>
 
+#include "openzl/codecs/zstd/common_zstd.h"
 #include "openzl/common/allocation.h"
 #include "openzl/common/assertion.h"
+#include "openzl/common/materializer_ctx.h"
 #include "openzl/dict/dict_constants.h"
-#include "openzl/dict/materializer_ctx.h"
 #include "openzl/zl_errors.h"
 
 static void DictLoader_freeOpaquePtr(const ZL_OpaquePtr* opaque)
@@ -167,7 +168,7 @@ const ZL_MaterializerDesc2* DictLoader_getMaterializer(
 static ZL_Report DictLoader_registerStandardMaterializer(
         ZL_DictLoader* loader,
         ZL_NodeID codecID,
-        ZL_MaterializerDesc2* mat)
+        const ZL_MaterializerDesc2* mat)
 {
     ZL_RESULT_DECLARE_SCOPE_REPORT(NULL);
     ZL_ASSERT_NN(loader);
@@ -275,11 +276,10 @@ ZL_Report DictLoader_registerStandardMaterializers(ZL_DictLoader* loader)
     ZL_RESULT_DECLARE_SCOPE_REPORT(NULL);
     ZL_ERR_IF_NULL(loader, GENERIC);
 
-    // TODO: register standard codec materializers (e.g. zstd)
-    // ZL_ERR_IF_ERR(DictLoader_registerStandardMaterializer(
-    //         loader,
-    //         ZL_MAKE_NODE_ID(ZL_PrivateStandardNodeID_zstd),
-    //         ZL_Zstd_materializer));
+    ZL_ERR_IF_ERR(DictLoader_registerStandardMaterializer(
+            loader,
+            (ZL_NodeID){ ZL_StandardTransformID_zstd },
+            &ZL_Zstd_ddict_materializer));
 
     return ZL_returnSuccess();
 }


### PR DESCRIPTION
Summary:

Extract the bundle ID generation logic from ZL_DictBundle_packFatBundle into a standalone public API, and fix a resource leak in the CDictMgr destructor.

ZL_DictBundle_genBundleID (zl_dict.h / bundle.c):
- New public function that computes a canonical bundle ID (SHA256 of the dictID array) for a set of dictionary IDs.
- packFatBundle now delegates to this function instead of computing the hash inline.
- This allows training code to generate bundle IDs without going through the full fat bundle packing path.

CDictMgr cleanup (cdictmgr.c):
- CDictMgr_destroy now iterates all cached dicts and calls their dematerializeFn before freeing the map, preventing leaked ZSTD_CDict / ZSTD_DDict objects.

Reviewed By: terrelln

Differential Revision: D105001081
