### PR TITLE
Adapt custom components in openzl to new component registration pattern [2/n] (#791)

### DIFF
--- a/cpp/include/openzl/cpp/CustomDecoder.hpp
+++ b/cpp/include/openzl/cpp/CustomDecoder.hpp
@@ -23,6 +23,15 @@ class DecoderState {
     DecoderState(const DecoderState&)            = delete;
     DecoderState& operator=(const DecoderState&) = delete;
 
+    ZL_Decoder* get()
+    {
+        return decoder_;
+    }
+    const ZL_Decoder* get() const
+    {
+        return decoder_;
+    }
+
     poly::span<const InputRef> singletonInputs() const
     {
         return singletonInputs_;

--- a/custom_transforms/thrift/thrift_parsers.cpp
+++ b/custom_transforms/thrift/thrift_parsers.cpp
@@ -576,6 +576,8 @@ ZL_Report configurableDecode(
     }
 }
 
+} // namespace
+
 ZL_Report configurableEncodeCompact(
         ZL_Encoder* eictx,
         const ZL_Input* in) noexcept
@@ -619,6 +621,8 @@ ZL_Report configurableDecodeBinary(
             variableSrcs,
             nbVariableSrcs);
 }
+
+namespace {
 
 std::array<
         ZL_Type,

--- a/custom_transforms/thrift/thrift_parsers.h
+++ b/custom_transforms/thrift/thrift_parsers.h
@@ -32,6 +32,28 @@ extern ZL_VODecoderDesc const thriftCompactConfigurableUnSplitter;
 extern ZL_VOEncoderDesc const thriftBinaryConfigurableSplitter;
 extern ZL_VODecoderDesc const thriftBinaryConfigurableUnSplitter;
 
+/**
+ * The configurable Thrift encoder/decoder implementation functions.
+ */
+ZL_Report configurableEncodeCompact(
+        ZL_Encoder* eictx,
+        const ZL_Input* in) noexcept;
+ZL_Report configurableEncodeBinary(
+        ZL_Encoder* eictx,
+        const ZL_Input* in) noexcept;
+ZL_Report configurableDecodeCompact(
+        ZL_Decoder* dictx,
+        const ZL_Input* compulsorySrcs[],
+        size_t nbCompulsorySrcs,
+        const ZL_Input* variableSrcs[],
+        size_t nbVariableSrcs) noexcept;
+ZL_Report configurableDecodeBinary(
+        ZL_Decoder* dictx,
+        const ZL_Input* compulsorySrcs[],
+        size_t nbCompulsorySrcs,
+        const ZL_Input* variableSrcs[],
+        size_t nbVariableSrcs) noexcept;
+
 ZL_Report registerCustomTransforms(ZL_DCtx* dctx);
 
 ZL_NodeID registerCompactTransform(ZL_Compressor* cgraph, ZL_IDType id);


### PR DESCRIPTION
Summary:

Migrating thrift node.

Additionally adds `get()` method to `CustomDecoder` to support decode transform signature used.

Note:
- Builds are failing because this requires D103061033 but that doesn't rebase cleanly.

Reviewed By: Victor-C-Zhang

Differential Revision: D102699582


