### PR TITLE
Add dominant-symbol sparse_num decode support (#800)

### DIFF
--- a/benchmark/unitBench/benchList.h
+++ b/benchmark/unitBench/benchList.h
@@ -86,6 +86,7 @@ static size_t out_identical(const void* src, size_t srcSize)
 #include "benchmark/unitBench/scenarios/codecs/flatpack.h"
 #include "benchmark/unitBench/scenarios/codecs/huffman.h"
 #include "benchmark/unitBench/scenarios/codecs/rolz.h"
+#include "benchmark/unitBench/scenarios/codecs/sparse_num.h"
 #include "benchmark/unitBench/scenarios/codecs/tokenize.h"
 #include "benchmark/unitBench/scenarios/codecs/transpose.h"
 
@@ -489,6 +490,14 @@ Bench_Entry const scenarioList[] = {
     { "sao_sddl2", .graphF=sao_graph_sddl2 },
     { "saoIngest", saoIngest_wrapper },
     { "saoIngestCompiled", saoIngestCompiled_wrapper },
+    { "sparseNumDecode8_d8", sparseNumDecode8_d8_wrapper, .outSize = sparseNumDecode8_d8_outSize, .display = decoderResult },
+    { "sparseNumDecode16_d8", sparseNumDecode16_d8_wrapper, .outSize = sparseNumDecode16_d8_outSize, .display = decoderResult },
+    { "sparseNumDecode32_d8", sparseNumDecode32_d8_wrapper, .outSize = sparseNumDecode32_d8_outSize, .display = decoderResult },
+    { "sparseNumDecode64_d8", sparseNumDecode64_d8_wrapper, .outSize = sparseNumDecode64_d8_outSize, .display = decoderResult },
+    { "sparseNumEncode8", sparseNumEncode8_wrapper, .outSize = sparseNumEncode8_outSize },
+    { "sparseNumEncode16", sparseNumEncode16_wrapper, .outSize = sparseNumEncode16_outSize },
+    { "sparseNumEncode32", sparseNumEncode32_wrapper, .outSize = sparseNumEncode32_outSize },
+    { "sparseNumEncode64", sparseNumEncode64_wrapper, .outSize = sparseNumEncode64_outSize },
     { "splitBy4", splitBy4_wrapper, .prep = splitBy4_preparation },
     { "splitBy8", splitBy8_wrapper, .prep = splitBy8_preparation },
     { "splitByRange8", .graphF = splitByRange8_graph },

--- a/benchmark/unitBench/scenarios/codecs/sparse_num.c
+++ b/benchmark/unitBench/scenarios/codecs/sparse_num.c
@@ -28,7 +28,7 @@ static size_t sparseNumEncode(
 {
     size_t const numElts = srcSize / valueWidth;
     ZL_SparseNumEncodeInfo const info =
-            ZL_sparseNumComputeEncodeInfo(src, numElts, valueWidth);
+            ZL_sparseNumComputeEncodeInfo(src, numElts, valueWidth, 0);
 
     size_t const distanceBytes = info.numDistances * info.distanceWidth;
     size_t const valueBytes    = info.numValues * valueWidth;
@@ -50,7 +50,8 @@ static size_t sparseNumEncode(
             src,
             numElts,
             valueWidth,
-            info.distanceWidth);
+            info.distanceWidth,
+            0);
 
     return distanceBytes + valueBytes;
 }
@@ -147,6 +148,7 @@ static size_t sparseNumDecode(
             distances,
             numDistances,
             distanceWidth,
+            0,
             values,
             numValues,
             valueWidth);

--- a/benchmark/unitBench/scenarios/codecs/sparse_num.c
+++ b/benchmark/unitBench/scenarios/codecs/sparse_num.c
@@ -1,0 +1,177 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#include "benchmark/unitBench/scenarios/codecs/sparse_num.h"
+
+#include <stdint.h>
+#include <stdlib.h>
+
+#include "openzl/codecs/sparse_num/decode_sparse_num_kernel.h"
+#include "openzl/codecs/sparse_num/encode_sparse_num_kernel.h"
+
+static size_t
+sparseNumEncodeOutSize(const void* src, size_t srcSize, size_t valueWidth)
+{
+    (void)src;
+    size_t const numElts = srcSize / valueWidth;
+    if (numElts > (SIZE_MAX - 4) / (valueWidth + 4)) {
+        abort();
+    }
+    return numElts * (valueWidth + 4) + 4;
+}
+
+static size_t sparseNumEncode(
+        const void* src,
+        size_t srcSize,
+        void* dst,
+        size_t dstCapacity,
+        size_t valueWidth)
+{
+    size_t const numElts = srcSize / valueWidth;
+    ZL_SparseNumEncodeInfo const info =
+            ZL_sparseNumComputeEncodeInfo(src, numElts, valueWidth);
+
+    size_t const distanceBytes = info.numDistances * info.distanceWidth;
+    size_t const valueBytes    = info.numValues * valueWidth;
+    if (info.distanceWidth != 1) {
+        abort();
+    }
+    if (valueBytes > dstCapacity || distanceBytes > dstCapacity - valueBytes) {
+        abort();
+    }
+
+    /*
+     * unitBench provides one flat output buffer. Place values first so the
+     * value stream keeps the buffer base alignment required by the kernel.
+     * Distances are D8 in these scenarios, so they do not need extra alignment.
+     */
+    ZL_sparseNumEncode(
+            (uint8_t*)dst + valueBytes,
+            dst,
+            src,
+            numElts,
+            valueWidth,
+            info.distanceWidth);
+
+    return distanceBytes + valueBytes;
+}
+
+#define DEFINE_SPARSE_NUM_ENCODE(bits, width)                               \
+    size_t sparseNumEncode##bits##_outSize(const void* src, size_t srcSize) \
+    {                                                                       \
+        return sparseNumEncodeOutSize(src, srcSize, width);                 \
+    }                                                                       \
+                                                                            \
+    size_t sparseNumEncode##bits##_wrapper(                                 \
+            const void* src,                                                \
+            size_t srcSize,                                                 \
+            void* dst,                                                      \
+            size_t dstCapacity,                                             \
+            void* customPayload)                                            \
+    {                                                                       \
+        (void)customPayload;                                                \
+        return sparseNumEncode(src, srcSize, dst, dstCapacity, width);      \
+    }
+
+DEFINE_SPARSE_NUM_ENCODE(8, 1)
+DEFINE_SPARSE_NUM_ENCODE(16, 2)
+DEFINE_SPARSE_NUM_ENCODE(32, 4)
+DEFINE_SPARSE_NUM_ENCODE(64, 8)
+
+static size_t sparseNumDecodeOutputSize(
+        const void* src,
+        size_t srcSize,
+        size_t valueWidth,
+        size_t distanceWidth)
+{
+    /*
+     * Fixture layout: [values][D8 distances], numDistances == numValues.
+     * Values come first to preserve their numeric alignment.
+     */
+    if (src == NULL) {
+        abort();
+    }
+    if (distanceWidth != 1) {
+        abort();
+    }
+    size_t const recordSize = valueWidth + distanceWidth;
+    if (srcSize % recordSize != 0) {
+        abort();
+    }
+    size_t const numValues    = srcSize / recordSize;
+    size_t const numDistances = numValues;
+    /* D8 distances begin immediately after the aligned values stream. */
+    const uint8_t* const distances =
+            (const uint8_t*)src + numValues * valueWidth;
+    size_t const outputCount = ZL_sparseNumDecodeOutputCount(
+            distances, numDistances, distanceWidth, numValues);
+    if (outputCount == ZL_SPARSE_NUM_DECODE_OUTPUT_COUNT_ERROR) {
+        abort();
+    }
+    if (outputCount > SIZE_MAX / valueWidth) {
+        abort();
+    }
+
+    return outputCount * valueWidth;
+}
+
+static size_t sparseNumDecode(
+        const void* src,
+        size_t srcSize,
+        void* dst,
+        size_t dstCapacity,
+        size_t valueWidth,
+        size_t distanceWidth)
+{
+    if (src == NULL) {
+        abort();
+    }
+    size_t const recordSize = valueWidth + distanceWidth;
+    if (srcSize % recordSize != 0) {
+        abort();
+    }
+    size_t const numValues    = srcSize / recordSize;
+    size_t const numDistances = numValues;
+    /* Mirror sparseNumDecodeOutputSize(): [values][D8 distances]. */
+    const uint8_t* const values    = (const uint8_t*)src;
+    const uint8_t* const distances = values + numValues * valueWidth;
+    size_t const outputSize =
+            sparseNumDecodeOutputSize(src, srcSize, valueWidth, distanceWidth);
+
+    if (dstCapacity < outputSize) {
+        abort();
+    }
+
+    ZL_sparseNumDecode(
+            dst,
+            outputSize,
+            distances,
+            numDistances,
+            distanceWidth,
+            values,
+            numValues,
+            valueWidth);
+
+    return outputSize;
+}
+
+#define DEFINE_SPARSE_NUM_DECODE_D8(bits, width)                               \
+    size_t sparseNumDecode##bits##_d8_outSize(const void* src, size_t srcSize) \
+    {                                                                          \
+        return sparseNumDecodeOutputSize(src, srcSize, width, 1);              \
+    }                                                                          \
+                                                                               \
+    size_t sparseNumDecode##bits##_d8_wrapper(                                 \
+            const void* src,                                                   \
+            size_t srcSize,                                                    \
+            void* dst,                                                         \
+            size_t dstCapacity,                                                \
+            void* customPayload)                                               \
+    {                                                                          \
+        (void)customPayload;                                                   \
+        return sparseNumDecode(src, srcSize, dst, dstCapacity, width, 1);      \
+    }
+
+DEFINE_SPARSE_NUM_DECODE_D8(8, 1)
+DEFINE_SPARSE_NUM_DECODE_D8(16, 2)
+DEFINE_SPARSE_NUM_DECODE_D8(32, 4)
+DEFINE_SPARSE_NUM_DECODE_D8(64, 8)

--- a/benchmark/unitBench/scenarios/codecs/sparse_num.h
+++ b/benchmark/unitBench/scenarios/codecs/sparse_num.h
@@ -1,0 +1,76 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#ifndef ZSTRONG_BENCHMARK_UNITBENCH_SPARSE_NUM_H
+#define ZSTRONG_BENCHMARK_UNITBENCH_SPARSE_NUM_H
+
+#include "benchmark/unitBench/bench_entry.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+size_t sparseNumEncode8_outSize(const void* src, size_t srcSize);
+size_t sparseNumEncode16_outSize(const void* src, size_t srcSize);
+size_t sparseNumEncode32_outSize(const void* src, size_t srcSize);
+size_t sparseNumEncode64_outSize(const void* src, size_t srcSize);
+
+size_t sparseNumEncode8_wrapper(
+        const void* src,
+        size_t srcSize,
+        void* dst,
+        size_t dstCapacity,
+        void* customPayload);
+size_t sparseNumEncode16_wrapper(
+        const void* src,
+        size_t srcSize,
+        void* dst,
+        size_t dstCapacity,
+        void* customPayload);
+size_t sparseNumEncode32_wrapper(
+        const void* src,
+        size_t srcSize,
+        void* dst,
+        size_t dstCapacity,
+        void* customPayload);
+size_t sparseNumEncode64_wrapper(
+        const void* src,
+        size_t srcSize,
+        void* dst,
+        size_t dstCapacity,
+        void* customPayload);
+
+size_t sparseNumDecode8_d8_outSize(const void* src, size_t srcSize);
+size_t sparseNumDecode16_d8_outSize(const void* src, size_t srcSize);
+size_t sparseNumDecode32_d8_outSize(const void* src, size_t srcSize);
+size_t sparseNumDecode64_d8_outSize(const void* src, size_t srcSize);
+
+size_t sparseNumDecode8_d8_wrapper(
+        const void* src,
+        size_t srcSize,
+        void* dst,
+        size_t dstCapacity,
+        void* customPayload);
+size_t sparseNumDecode16_d8_wrapper(
+        const void* src,
+        size_t srcSize,
+        void* dst,
+        size_t dstCapacity,
+        void* customPayload);
+size_t sparseNumDecode32_d8_wrapper(
+        const void* src,
+        size_t srcSize,
+        void* dst,
+        size_t dstCapacity,
+        void* customPayload);
+size_t sparseNumDecode64_d8_wrapper(
+        const void* src,
+        size_t srcSize,
+        void* dst,
+        size_t dstCapacity,
+        void* customPayload);
+
+#ifdef __cplusplus
+} // extern "C"
+#endif
+
+#endif // ZSTRONG_BENCHMARK_UNITBENCH_SPARSE_NUM_H

--- a/benchmark/unitBench/scripts/BUCK
+++ b/benchmark/unitBench/scripts/BUCK
@@ -1,0 +1,14 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+
+load("@fbcode_macros//build_defs:python_binary.bzl", "python_binary")
+
+oncall("data_compression")
+
+python_binary(
+    name = "sparse_num_bench",
+    main_function = ".sparse_num_bench.main",
+    main_src = "sparse_num_bench.py",
+    deps = [
+        "//security/frameworks/python/exec:subprocess",
+    ],
+)

--- a/benchmark/unitBench/scripts/sparse_num_bench.py
+++ b/benchmark/unitBench/scripts/sparse_num_bench.py
@@ -1,0 +1,408 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+
+# pyre-unsafe
+
+from __future__ import annotations
+
+import argparse
+import csv
+import subprocess
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Sequence
+
+
+DEFAULT_WORK_DIR = Path("/tmp/openzl_sparse_num_bench")
+DEFAULT_BUCK_TARGET = "fbcode//openzl/dev/benchmark/unitBench:unitBench"
+DEFAULT_RATIOS = (75, 90, 98)
+DEFAULT_WIDTHS = (8, 16, 32, 64)
+PERIOD = 100
+
+
+@dataclass(frozen=True)
+class UnitBenchResult:
+    source_size: int
+    result_size: int
+    time_us: float
+
+
+@dataclass(frozen=True)
+class SparseNumCase:
+    width_bits: int
+    zero_ratio: int
+    raw_path: Path
+    decode_path: Path
+    raw_size: int
+    encoded_size: int
+    num_elements: int
+
+
+@dataclass(frozen=True)
+class ReportRow:
+    case: SparseNumCase
+    encode: UnitBenchResult
+    decode: UnitBenchResult
+
+
+def parse_csv_ints(value: str, allowed: set[int], name: str) -> list[int]:
+    results: list[int] = []
+    for raw_part in value.split(","):
+        part = raw_part.strip()
+        if not part:
+            continue
+        try:
+            parsed = int(part)
+        except ValueError as error:
+            raise argparse.ArgumentTypeError(f"{name} must be integers") from error
+        if parsed not in allowed:
+            choices = ", ".join(str(choice) for choice in sorted(allowed))
+            raise argparse.ArgumentTypeError(
+                f"unsupported {name} {parsed}; expected one of {choices}"
+            )
+        results.append(parsed)
+    if not results:
+        raise argparse.ArgumentTypeError(f"{name} must not be empty")
+    return results
+
+
+def parse_widths(value: str) -> list[int]:
+    return parse_csv_ints(value, set(DEFAULT_WIDTHS), "width")
+
+
+def parse_ratios(value: str) -> list[int]:
+    return parse_csv_ints(value, set(DEFAULT_RATIOS), "zero ratio")
+
+
+def fbcode_root() -> Path | None:
+    for parent in Path(__file__).resolve().parents:
+        if (parent / "security/frameworks/python/exec/subprocess.py").exists():
+            return parent
+    return None
+
+
+def run_command(
+    executable: str,
+    args: Sequence[str],
+    cwd: Path,
+) -> subprocess.CompletedProcess[str]:
+    root = fbcode_root()
+    if root is not None:
+        root_str = str(root)
+        if root_str not in sys.path:
+            sys.path.insert(0, root_str)
+    try:
+        from security.frameworks.python.exec.subprocess import TrustedSubprocessWithList
+    except ImportError:
+        pass
+    else:
+        return TrustedSubprocessWithList.run(
+            executable=executable,
+            cmd_args=list(args),
+            cwd=cwd,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+        )
+
+    return subprocess.run(
+        [executable, *args],
+        cwd=cwd,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+        check=False,
+    )
+
+
+def check_run(
+    executable: str,
+    args: Sequence[str],
+    cwd: Path,
+) -> subprocess.CompletedProcess[str]:
+    result = run_command(executable, args, cwd)
+    if result.returncode != 0:
+        command = " ".join([executable, *args])
+        raise RuntimeError(
+            f"command failed: {command}\nstdout:\n{result.stdout}\nstderr:\n{result.stderr}"
+        )
+    return result
+
+
+def build_unitbench(cwd: Path, target: str) -> Path:
+    if fbcode_root() is None:
+        raise RuntimeError("--unitbench-bin is required when running outside fbcode")
+    result = check_run(
+        "buck",
+        [
+            "build",
+            "@//mode/opt",
+            target,
+            "--show-full-simple-output",
+        ],
+        cwd,
+    )
+    lines = [line.strip() for line in result.stdout.splitlines() if line.strip()]
+    if not lines:
+        raise RuntimeError("buck build did not print a unitBench binary path")
+    return Path(lines[-1])
+
+
+def resolve_unitbench_bin(path: Path) -> Path:
+    resolved = path.expanduser().resolve()
+    if not resolved.is_file():
+        raise RuntimeError(f"unitBench binary does not exist: {resolved}")
+    return resolved
+
+
+def element_count_for_size(sample_bytes: int, width_bytes: int) -> int:
+    num_elements = sample_bytes // width_bytes
+    num_elements -= num_elements % PERIOD
+    if num_elements <= 0:
+        raise RuntimeError("sample size is too small for the selected widths")
+    return num_elements
+
+
+def nonzero_value(index: int, width_bytes: int) -> bytes:
+    value = (index % 251) + 1
+    return value.to_bytes(width_bytes, "little")
+
+
+def generate_raw_sample(
+    path: Path,
+    width_bits: int,
+    zero_ratio: int,
+    sample_bytes: int,
+) -> tuple[int, int]:
+    width_bytes = width_bits // 8
+    num_elements = element_count_for_size(sample_bytes, width_bytes)
+    data = bytearray(num_elements * width_bytes)
+    for index in range(num_elements):
+        if index % PERIOD < zero_ratio:
+            continue
+        start = index * width_bytes
+        data[start : start + width_bytes] = nonzero_value(index, width_bytes)
+    path.write_bytes(data)
+    return num_elements, len(data)
+
+
+def is_zero_value(data: bytes | bytearray, offset: int, width_bytes: int) -> bool:
+    return all(byte == 0 for byte in data[offset : offset + width_bytes])
+
+
+def generate_decode_fixture(raw_path: Path, fixture_path: Path, width_bits: int) -> int:
+    width_bytes = width_bits // 8
+    raw = raw_path.read_bytes()
+    distances = bytearray()
+    values = bytearray()
+    zero_run = 0
+    for offset in range(0, len(raw), width_bytes):
+        if is_zero_value(raw, offset, width_bytes):
+            zero_run += 1
+            if zero_run > 255:
+                raise RuntimeError(
+                    f"{raw_path} needs distance width > 8 for generated fixture"
+                )
+            continue
+        distances.append(zero_run)
+        values.extend(raw[offset : offset + width_bytes])
+        zero_run = 0
+    if zero_run != 0:
+        raise RuntimeError(f"{raw_path} ends with zeros; d8 fixture would need a tail")
+    # Keep the values stream first so unitBench hands the decode kernel an
+    # aligned numeric values buffer. D8 distances do not need extra alignment.
+    fixture_path.write_bytes(values + distances)
+    return len(distances) + len(values)
+
+
+def prepare_case(
+    work_dir: Path,
+    width_bits: int,
+    zero_ratio: int,
+    sample_bytes: int,
+) -> SparseNumCase:
+    raw_path = work_dir / f"sparse_num_u{width_bits}_zero{zero_ratio}.raw"
+    decode_path = work_dir / f"sparse_num_u{width_bits}_zero{zero_ratio}.d8"
+    num_elements, raw_size = generate_raw_sample(
+        raw_path,
+        width_bits,
+        zero_ratio,
+        sample_bytes,
+    )
+    encoded_size = generate_decode_fixture(raw_path, decode_path, width_bits)
+    return SparseNumCase(
+        width_bits=width_bits,
+        zero_ratio=zero_ratio,
+        raw_path=raw_path,
+        decode_path=decode_path,
+        raw_size=raw_size,
+        encoded_size=encoded_size,
+        num_elements=num_elements,
+    )
+
+
+def parse_unitbench_csv(stdout: str, benchmark_name: str) -> UnitBenchResult:
+    for line in reversed(stdout.splitlines()):
+        if "," not in line:
+            continue
+        row = next(csv.reader([line]))
+        if len(row) < 5 or row[2].strip() != benchmark_name:
+            continue
+        return UnitBenchResult(
+            source_size=int(row[1].strip()),
+            result_size=int(row[3].strip()),
+            time_us=float(row[4].strip()),
+        )
+    raise RuntimeError(f"could not parse unitBench CSV output for {benchmark_name}")
+
+
+def run_unitbench(
+    unitbench_bin: Path,
+    benchmark_name: str,
+    sample_path: Path,
+    duration_s: int,
+    cwd: Path,
+) -> UnitBenchResult:
+    result = check_run(
+        str(unitbench_bin),
+        [
+            f"-i={duration_s}",
+            "--csv",
+            benchmark_name,
+            str(sample_path),
+        ],
+        cwd,
+    )
+    return parse_unitbench_csv(result.stdout, benchmark_name)
+
+
+def mib_per_second(num_bytes: int, time_us: float) -> float:
+    if time_us <= 0:
+        return 0.0
+    return (num_bytes / (1024 * 1024)) / (time_us / 1_000_000)
+
+
+def format_size(num_bytes: int) -> str:
+    if num_bytes >= 1024 * 1024:
+        return f"{num_bytes / (1024 * 1024):.2f} MiB"
+    if num_bytes >= 1024:
+        return f"{num_bytes / 1024:.2f} KiB"
+    return f"{num_bytes} B"
+
+
+def format_table(rows: Sequence[ReportRow]) -> str:
+    lines = [
+        "| width | zeros | elements | raw | encoded | ratio | encode MiB/s | decode MiB/s |",
+        "|---|---:|---:|---:|---:|---:|---:|---:|",
+    ]
+    for row in rows:
+        case = row.case
+        ratio = case.raw_size / case.encoded_size if case.encoded_size else 0.0
+        encode_speed = mib_per_second(case.raw_size, row.encode.time_us)
+        decode_speed = mib_per_second(row.decode.result_size, row.decode.time_us)
+        lines.append(
+            f"| u{case.width_bits} | {case.zero_ratio}% | {case.num_elements} | "
+            f"{format_size(case.raw_size)} | {format_size(case.encoded_size)} | "
+            f"{ratio:.2f} | {encode_speed:.1f} | {decode_speed:.1f} |"
+        )
+    return "\n".join(lines)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Generate sparse_num samples, run unitBench, and print markdown results."
+    )
+    parser.add_argument(
+        "--work-dir",
+        type=Path,
+        default=DEFAULT_WORK_DIR,
+        help=f"Directory for generated samples. Default: {DEFAULT_WORK_DIR}",
+    )
+    parser.add_argument(
+        "--sample-mib",
+        type=int,
+        default=16,
+        help="Raw sample size per width/ratio, in MiB. Default: 16",
+    )
+    parser.add_argument(
+        "--duration-s",
+        type=int,
+        default=1,
+        help="unitBench duration per benchmark, in seconds. Default: 1",
+    )
+    parser.add_argument(
+        "--ratios",
+        type=parse_ratios,
+        default=list(DEFAULT_RATIOS),
+        help="Comma-separated zero ratios. Default: 75,90,98",
+    )
+    parser.add_argument(
+        "--widths",
+        type=parse_widths,
+        default=list(DEFAULT_WIDTHS),
+        help="Comma-separated value widths. Default: 8,16,32,64",
+    )
+    parser.add_argument(
+        "--buck-target",
+        default=DEFAULT_BUCK_TARGET,
+        help=f"unitBench Buck target. Default: {DEFAULT_BUCK_TARGET}",
+    )
+    parser.add_argument(
+        "--unitbench-bin",
+        type=Path,
+        default=None,
+        help=(
+            "Use an already-built unitBench binary instead of building with Buck. "
+            "Required when running outside fbcode."
+        ),
+    )
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    repo_dir = Path.cwd()
+    args.work_dir.mkdir(parents=True, exist_ok=True)
+    sample_bytes = args.sample_mib * 1024 * 1024
+    unitbench_bin = (
+        resolve_unitbench_bin(args.unitbench_bin)
+        if args.unitbench_bin is not None
+        else build_unitbench(repo_dir, args.buck_target)
+    )
+
+    rows: list[ReportRow] = []
+    for width_bits in args.widths:
+        for zero_ratio in args.ratios:
+            case = prepare_case(args.work_dir, width_bits, zero_ratio, sample_bytes)
+            encode = run_unitbench(
+                unitbench_bin,
+                f"sparseNumEncode{width_bits}",
+                case.raw_path,
+                args.duration_s,
+                repo_dir,
+            )
+            decode = run_unitbench(
+                unitbench_bin,
+                f"sparseNumDecode{width_bits}_d8",
+                case.decode_path,
+                args.duration_s,
+                repo_dir,
+            )
+            if encode.result_size != case.encoded_size:
+                raise RuntimeError(
+                    f"encode size mismatch for {case.raw_path}: "
+                    f"unitBench={encode.result_size}, fixture={case.encoded_size}"
+                )
+            if decode.result_size != case.raw_size:
+                raise RuntimeError(
+                    f"decode size mismatch for {case.decode_path}: "
+                    f"unitBench={decode.result_size}, raw={case.raw_size}"
+                )
+            rows.append(ReportRow(case=case, encode=encode, decode=decode))
+
+    print(format_table(rows))
+
+
+if __name__ == "__main__":
+    main()

--- a/cpp/include/openzl/cpp/Codecs.hpp
+++ b/cpp/include/openzl/cpp/Codecs.hpp
@@ -33,6 +33,7 @@
 #include "openzl/cpp/codecs/SDDL2.hpp"            // IWYU pragma: export
 #include "openzl/cpp/codecs/SegmentSerial.hpp"    // IWYU pragma: export
 #include "openzl/cpp/codecs/Sentinel.hpp"         // IWYU pragma: export
+#include "openzl/cpp/codecs/SparseNum.hpp"        // IWYU pragma: export
 #include "openzl/cpp/codecs/Split.hpp"            // IWYU pragma: export
 #include "openzl/cpp/codecs/SplitByStruct.hpp"    // IWYU pragma: export
 #include "openzl/cpp/codecs/Store.hpp"            // IWYU pragma: export

--- a/cpp/include/openzl/cpp/codecs/SparseNum.hpp
+++ b/cpp/include/openzl/cpp/codecs/SparseNum.hpp
@@ -1,0 +1,44 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#pragma once
+
+#include "openzl/codecs/zl_sparse_num.h"
+#include "openzl/cpp/Compressor.hpp"
+#include "openzl/cpp/codecs/Metadata.hpp"
+#include "openzl/cpp/codecs/Node.hpp"
+
+namespace openzl {
+namespace nodes {
+
+class SparseNum : public Node {
+   public:
+    static constexpr NodeID node = ZL_NODE_SPARSE_NUM;
+
+    static constexpr NodeMetadata<1, 2> metadata = {
+        .inputs = { InputMetadata{ .type = Type::Numeric, .name = "values" } },
+        .singletonOutputs = { OutputMetadata{ .type = Type::Numeric,
+                                              .name = "distances" },
+                              OutputMetadata{ .type = Type::Numeric,
+                                              .name = "values" } },
+        .description =
+                "Split a numeric stream into zero-run distances and literal values",
+    };
+
+    NodeID baseNode() const override
+    {
+        return node;
+    }
+
+    GraphID
+    operator()(Compressor& compressor, GraphID distances, GraphID values) const
+    {
+        return buildGraph(
+                compressor,
+                std::initializer_list<GraphID>{ distances, values });
+    }
+
+    ~SparseNum() override = default;
+};
+
+} // namespace nodes
+} // namespace openzl

--- a/cpp/include/openzl/cpp/codecs/SparseNum.hpp
+++ b/cpp/include/openzl/cpp/codecs/SparseNum.hpp
@@ -21,8 +21,10 @@ class SparseNum : public Node {
                               OutputMetadata{ .type = Type::Numeric,
                                               .name = "values" } },
         .description =
-                "Split a numeric stream into zero-run distances and literal values",
+                "Split a numeric stream into zero run distances and literal values",
     };
+
+    SparseNum() {}
 
     NodeID baseNode() const override
     {
@@ -38,6 +40,57 @@ class SparseNum : public Node {
     }
 
     ~SparseNum() override = default;
+};
+
+class SparseNumAuto : public Node {
+   public:
+    static constexpr NodeID node = ZL_NODE_SPARSE_NUM_AUTO;
+
+    static constexpr NodeMetadata<1, 2> metadata = {
+        .inputs = { InputMetadata{ .type = Type::Numeric, .name = "values" } },
+        .singletonOutputs = { OutputMetadata{ .type = Type::Numeric,
+                                              .name = "distances" },
+                              OutputMetadata{ .type = Type::Numeric,
+                                              .name = "values" } },
+        .description =
+                "Split a numeric stream into dominant-symbol run distances and literal values",
+    };
+
+    SparseNumAuto() {}
+    explicit SparseNumAuto(uint64_t dominant) : dominant_(dominant) {}
+    explicit SparseNumAuto(poly::optional<uint64_t> dominant)
+            : dominant_(std::move(dominant))
+    {
+    }
+
+    NodeID baseNode() const override
+    {
+        return node;
+    }
+
+    GraphID
+    operator()(Compressor& compressor, GraphID distances, GraphID values) const
+    {
+        return buildGraph(
+                compressor,
+                std::initializer_list<GraphID>{ distances, values });
+    }
+
+    poly::optional<NodeParameters> parameters() const override
+    {
+        if (dominant_.has_value()) {
+            LocalParams params;
+            params.addCopyParam(
+                    ZL_SPARSE_NUM_DOMINANT_VALUE_PID, dominant_.value());
+            return NodeParameters{ .localParams = std::move(params) };
+        }
+        return poly::nullopt;
+    }
+
+    ~SparseNumAuto() override = default;
+
+   private:
+    poly::optional<uint64_t> dominant_;
 };
 
 } // namespace nodes

--- a/include/openzl/codecs/zl_sparse_num.h
+++ b/include/openzl/codecs/zl_sparse_num.h
@@ -3,6 +3,8 @@
 #ifndef OPENZL_CODECS_ZL_SPARSE_NUM_H
 #define OPENZL_CODECS_ZL_SPARSE_NUM_H
 
+#include <stdint.h>
+
 #include "openzl/zl_nodes.h"
 
 #if defined(__cplusplus)
@@ -13,15 +15,42 @@ extern "C" {
  * Sparse Num
  *
  * Input 0: Numeric stream.
- * Output 0: Numeric zero-run distances.
+ * Output 0: Numeric zero run distances.
  * Output 1: Numeric literal values.
  *
- * `sparse_num` decomposes a numeric stream into runs of zero elements and the
- * intervening literal values. Literal values may be zero. The distance stream
- * contains the number of zero elements before each literal, and may contain one
- * final distance to represent trailing zeros.
+ * `sparse_num` decomposes a numeric stream into runs of zeroes and the
+ * intervening literal values. Literal values may equal zero. The distance
+ * stream contains the number of zero elements before each literal, and may
+ * contain one final distance to represent trailing zeroes.
  */
 #define ZL_NODE_SPARSE_NUM ZL_MAKE_NODE_ID(ZL_StandardNodeID_sparse_num)
+
+/**
+ * Sparse Num Auto
+ *
+ * Input 0: Numeric stream.
+ * Output 0: Numeric dominant-symbol run distances.
+ * Output 1: Numeric literal values.
+ *
+ * `sparse_num_auto` decomposes a numeric stream into runs of a dominant symbol
+ * and the intervening literal values. The encoder auto-detects a dominant
+ * symbol from an input prefix unless one is explicitly provided through
+ * ZL_SPARSE_NUM_DOMINANT_VALUE_PID. Literal values may equal the dominant
+ * symbol. The distance stream contains the number of dominant-symbol elements
+ * before each literal, and may contain one final distance to represent trailing
+ * dominant-symbol values.
+ */
+#define ZL_NODE_SPARSE_NUM_AUTO \
+    ZL_MAKE_NODE_ID(ZL_StandardNodeID_sparse_num_auto)
+
+/**
+ * Optional 8-byte uint64_t local parameter containing the dominant symbol for
+ * ZL_NODE_SPARSE_NUM_AUTO.
+ *
+ * If unset, the encoder auto-detects a dominant symbol. If set to 0, the
+ * encoder uses the canonical zero-dominant representation.
+ */
+#define ZL_SPARSE_NUM_DOMINANT_VALUE_PID 132
 
 #if defined(__cplusplus)
 }

--- a/include/openzl/codecs/zl_sparse_num.h
+++ b/include/openzl/codecs/zl_sparse_num.h
@@ -1,0 +1,30 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#ifndef OPENZL_CODECS_ZL_SPARSE_NUM_H
+#define OPENZL_CODECS_ZL_SPARSE_NUM_H
+
+#include "openzl/zl_nodes.h"
+
+#if defined(__cplusplus)
+extern "C" {
+#endif
+
+/**
+ * Sparse Num
+ *
+ * Input 0: Numeric stream.
+ * Output 0: Numeric zero-run distances.
+ * Output 1: Numeric literal values.
+ *
+ * `sparse_num` decomposes a numeric stream into runs of zero elements and the
+ * intervening literal values. Literal values may be zero. The distance stream
+ * contains the number of zero elements before each literal, and may contain one
+ * final distance to represent trailing zeros.
+ */
+#define ZL_NODE_SPARSE_NUM ZL_MAKE_NODE_ID(ZL_StandardNodeID_sparse_num)
+
+#if defined(__cplusplus)
+}
+#endif
+
+#endif

--- a/include/openzl/zl_nodes.h
+++ b/include/openzl/zl_nodes.h
@@ -95,6 +95,8 @@ typedef enum {
 
     ZL_StandardNodeID_mux_lengths,
 
+    ZL_StandardNodeID_sparse_num,
+
     ZL_StandardNodeID_public_end // last id, used to detect end of public range
 } ZL_StandardNodeID;
 

--- a/include/openzl/zl_nodes.h
+++ b/include/openzl/zl_nodes.h
@@ -96,6 +96,7 @@ typedef enum {
     ZL_StandardNodeID_mux_lengths,
 
     ZL_StandardNodeID_sparse_num,
+    ZL_StandardNodeID_sparse_num_auto,
 
     ZL_StandardNodeID_public_end // last id, used to detect end of public range
 } ZL_StandardNodeID;

--- a/include/openzl/zl_public_nodes.h
+++ b/include/openzl/zl_public_nodes.h
@@ -41,6 +41,7 @@
 #include "openzl/codecs/zl_range_pack.h"           // IWYU pragma: export
 #include "openzl/codecs/zl_sddl.h"                 // IWYU pragma: export
 #include "openzl/codecs/zl_sentinel.h"             // IWYU pragma: export
+#include "openzl/codecs/zl_sparse_num.h"           // IWYU pragma: export
 #include "openzl/codecs/zl_split.h"                // IWYU pragma: export
 #include "openzl/codecs/zl_split_by_struct.h"      // IWYU pragma: export
 #include "openzl/codecs/zl_store.h"                // IWYU pragma: export

--- a/include/openzl/zl_version.h
+++ b/include/openzl/zl_version.h
@@ -13,7 +13,7 @@ extern "C" {
 
 #define ZL_LIBRARY_VERSION_MAJOR 0
 #define ZL_LIBRARY_VERSION_MINOR 2
-#define ZL_LIBRARY_VERSION_PATCH 1
+#define ZL_LIBRARY_VERSION_PATCH 2
 
 #define ZL_LIBRARY_VERSION_NUMBER                                      \
     (ZL_LIBRARY_VERSION_MAJOR * 10000 + ZL_LIBRARY_VERSION_MINOR * 100 \
@@ -54,7 +54,7 @@ extern "C" {
 /// format changes. But note that once a library with
 /// max format version X is released, we must support X
 /// through our support window.
-#define ZL_MAX_FORMAT_VERSION (25)
+#define ZL_MAX_FORMAT_VERSION (26)
 
 /// Minimum wire format version required to support chunking.
 #define ZL_CHUNK_VERSION_MIN (21)

--- a/src/openzl/codecs/decoder_registry.c
+++ b/src/openzl/codecs/decoder_registry.c
@@ -32,6 +32,7 @@
 #include "openzl/codecs/range_pack/decode_range_pack_binding.h"
 #include "openzl/codecs/rolz/decode_rolz_binding.h"
 #include "openzl/codecs/sentinel/decode_sentinel_binding.h"
+#include "openzl/codecs/sparse_num/decode_sparse_num_binding.h"
 #include "openzl/codecs/splitByStruct/decode_splitByStruct_binding.h"
 #include "openzl/codecs/splitN/decode_splitN_binding.h"
 #include "openzl/codecs/tokenize/decode_tokenize_binding.h"
@@ -136,6 +137,7 @@ const StandardDTransform SDecoders_array[ZL_StandardTransformID_end] = {
     REGISTER_TTRANSFORM_G(ZL_StandardTransformID_sentinel, 24, DI_SENTINEL, SENTINEL_GRAPH),
     REGISTER_TTRANSFORM_G(ZL_StandardTransformID_lz, 24, DI_LZ, LZ_GRAPH),
     REGISTER_TTRANSFORM_G(ZL_StandardTransformID_mux_lengths, 24, DI_MUX_LENGTHS, MUX_LENGTHS_GRAPH),
+    REGISTER_TTRANSFORM_G(ZL_StandardTransformID_sparse_num, 25, DI_SPARSE_NUM, SPARSE_NUM_GRAPH),
 
     REGISTER_VOTRANSFORM_G(ZL_StandardTransformID_splitn, 9, DI_SPLITN, GRAPH_VO_SERIAL),
     REGISTER_VOTRANSFORM_G(ZL_StandardTransformID_splitn_struct, 14, DI_SPLITN_STRUCT, GRAPH_VO_STRUCT),

--- a/src/openzl/codecs/decoder_registry.c
+++ b/src/openzl/codecs/decoder_registry.c
@@ -137,7 +137,7 @@ const StandardDTransform SDecoders_array[ZL_StandardTransformID_end] = {
     REGISTER_TTRANSFORM_G(ZL_StandardTransformID_sentinel, 24, DI_SENTINEL, SENTINEL_GRAPH),
     REGISTER_TTRANSFORM_G(ZL_StandardTransformID_lz, 24, DI_LZ, LZ_GRAPH),
     REGISTER_TTRANSFORM_G(ZL_StandardTransformID_mux_lengths, 24, DI_MUX_LENGTHS, MUX_LENGTHS_GRAPH),
-    REGISTER_TTRANSFORM_G(ZL_StandardTransformID_sparse_num, 25, DI_SPARSE_NUM, SPARSE_NUM_GRAPH),
+    REGISTER_TTRANSFORM_G(ZL_StandardTransformID_sparse_num, 26, DI_SPARSE_NUM, SPARSE_NUM_GRAPH),
 
     REGISTER_VOTRANSFORM_G(ZL_StandardTransformID_splitn, 9, DI_SPLITN, GRAPH_VO_SERIAL),
     REGISTER_VOTRANSFORM_G(ZL_StandardTransformID_splitn_struct, 14, DI_SPLITN_STRUCT, GRAPH_VO_STRUCT),

--- a/src/openzl/codecs/encoder_registry.c
+++ b/src/openzl/codecs/encoder_registry.c
@@ -137,7 +137,8 @@ const CNode ER_standardNodes[STANDARD_ENCODERS_NB] = {
     REGISTER_TRANSFORM(ZL_StandardNodeID_sentinel_num, ZL_StandardTransformID_sentinel, 24, 200, EI_SENTINEL),
     REGISTER_TRANSFORM(ZL_StandardNodeID_lz, ZL_StandardTransformID_lz, 24, 200, EI_LZ),
     REGISTER_TRANSFORM(ZL_StandardNodeID_mux_lengths, ZL_StandardTransformID_mux_lengths, 24, 200, EI_MUX_LENGTHS),
-    REGISTER_TRANSFORM(ZL_StandardNodeID_sparse_num, ZL_StandardTransformID_sparse_num, 25, 201, EI_SPARSE_NUM),
+    REGISTER_TRANSFORM(ZL_StandardNodeID_sparse_num, ZL_StandardTransformID_sparse_num, 26, 202, EI_SPARSE_NUM),
+    REGISTER_TRANSFORM(ZL_StandardNodeID_sparse_num_auto, ZL_StandardTransformID_sparse_num, 26, 202, EI_SPARSE_NUM_AUTO),
 
     // Private Nodes
     REGISTER_TRANSFORM(ZL_PrivateStandardNodeID_set_string_lens,           ZL_StandardTransformID_convert_serial_string, 10, 200, EI_SETSTRINGLENS),

--- a/src/openzl/codecs/encoder_registry.c
+++ b/src/openzl/codecs/encoder_registry.c
@@ -31,6 +31,7 @@
 #include "openzl/codecs/range_pack/encode_range_pack_binding.h"
 #include "openzl/codecs/rolz/encode_rolz_binding.h"
 #include "openzl/codecs/sentinel/encode_sentinel_binding.h"
+#include "openzl/codecs/sparse_num/encode_sparse_num_binding.h"
 #include "openzl/codecs/splitByStruct/encode_splitByStruct_binding.h"
 #include "openzl/codecs/splitN/encode_splitN_binding.h"
 #include "openzl/codecs/splitN/encode_split_byrange_binding.h"
@@ -136,6 +137,7 @@ const CNode ER_standardNodes[STANDARD_ENCODERS_NB] = {
     REGISTER_TRANSFORM(ZL_StandardNodeID_sentinel_num, ZL_StandardTransformID_sentinel, 24, 200, EI_SENTINEL),
     REGISTER_TRANSFORM(ZL_StandardNodeID_lz, ZL_StandardTransformID_lz, 24, 200, EI_LZ),
     REGISTER_TRANSFORM(ZL_StandardNodeID_mux_lengths, ZL_StandardTransformID_mux_lengths, 24, 200, EI_MUX_LENGTHS),
+    REGISTER_TRANSFORM(ZL_StandardNodeID_sparse_num, ZL_StandardTransformID_sparse_num, 25, 201, EI_SPARSE_NUM),
 
     // Private Nodes
     REGISTER_TRANSFORM(ZL_PrivateStandardNodeID_set_string_lens,           ZL_StandardTransformID_convert_serial_string, 10, 200, EI_SETSTRINGLENS),

--- a/src/openzl/codecs/sparse_num/common_sparse_num.h
+++ b/src/openzl/codecs/sparse_num/common_sparse_num.h
@@ -1,0 +1,64 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#ifndef OPENZL_CODECS_SPARSE_NUM_COMMON_SPARSE_NUM_H
+#define OPENZL_CODECS_SPARSE_NUM_COMMON_SPARSE_NUM_H
+
+#include <assert.h>
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+
+/** Supported numeric element widths, in bytes: 1, 2, 4, or 8. */
+static inline bool ZL_sparseNumValidValueWidth(size_t width)
+{
+    return width == 1 || width == 2 || width == 4 || width == 8;
+}
+
+/** Supported distance stream widths, in bytes: 1, 2, or 4. */
+static inline bool ZL_sparseNumValidDistanceWidth(size_t width)
+{
+    return width == 1 || width == 2 || width == 4;
+}
+
+/** Returns whether ptr is aligned for width-byte numeric elements. */
+static inline bool ZL_sparseNumIsAlignedForWidth(const void* ptr, size_t width)
+{
+    assert(width > 0);
+    return (((uintptr_t)ptr) & (width - 1)) == 0;
+}
+
+/**
+ * Copies one aligned sparse_num literal value.
+ *
+ * Preconditions:
+ * - dst and src must be non-null.
+ * - dst and src must be aligned for width-byte numeric elements.
+ * - width must be a supported numeric element width.
+ */
+static inline void
+ZL_sparseNumCopyAlignedValue(void* dst, const void* src, size_t width)
+{
+    assert(dst != NULL);
+    assert(src != NULL);
+    assert(ZL_sparseNumIsAlignedForWidth(dst, width));
+    assert(ZL_sparseNumIsAlignedForWidth(src, width));
+    switch (width) {
+        case 1:
+            *(uint8_t*)dst = *(const uint8_t*)src;
+            return;
+        case 2:
+            *(uint16_t*)dst = *(const uint16_t*)src;
+            return;
+        case 4:
+            *(uint32_t*)dst = *(const uint32_t*)src;
+            return;
+        case 8:
+            *(uint64_t*)dst = *(const uint64_t*)src;
+            return;
+        default:
+            assert(false);
+            return;
+    }
+}
+
+#endif

--- a/src/openzl/codecs/sparse_num/decode_sparse_num_binding.c
+++ b/src/openzl/codecs/sparse_num/decode_sparse_num_binding.c
@@ -5,11 +5,19 @@
 #include "openzl/codecs/sparse_num/decode_sparse_num_kernel.h"
 #include "openzl/common/assertion.h"
 #include "openzl/common/errors_internal.h"
+#include "openzl/shared/mem.h"
 #include "openzl/shared/overflow.h"
 
 #include <stdbool.h>
 #include <stdint.h>
 
+/*
+ * Decoder binding responsibilities:
+ * - validate the wire-level header and stream metadata,
+ * - translate the header into a dominant symbol,
+ * - compute and allocate the exact output size,
+ * - then call the small dependency-light kernel.
+ */
 ZL_Report DI_sparse_num(ZL_Decoder* dictx, const ZL_Input* ins[])
 {
     ZL_RESULT_DECLARE_SCOPE_REPORT(dictx);
@@ -24,13 +32,6 @@ ZL_Report DI_sparse_num(ZL_Decoder* dictx, const ZL_Input* ins[])
     ZL_ASSERT_EQ(ZL_Input_type(distances), ZL_Type_numeric);
     ZL_ASSERT_EQ(ZL_Input_type(values), ZL_Type_numeric);
 
-    ZL_RBuffer const header = ZL_Decoder_getCodecHeader(dictx);
-    ZL_ERR_IF_NE(
-            header.size,
-            0,
-            corruption,
-            "sparse_num codec header must be empty");
-
     size_t const distanceWidth = ZL_Input_eltWidth(distances);
     ZL_ERR_IF_NOT(
             ZL_sparseNumValidDistanceWidth(distanceWidth),
@@ -43,14 +44,36 @@ ZL_Report DI_sparse_num(ZL_Decoder* dictx, const ZL_Input* ins[])
             corruption,
             "sparse_num value width must be 1, 2, 4 or 8 bytes");
 
+    ZL_RBuffer const header = ZL_Decoder_getCodecHeader(dictx);
+    ZL_ERR_IF_GT(
+            header.size,
+            valueWidth,
+            corruption,
+            "sparse_num codec header must be no larger than the value width");
+
     size_t const numDistances = ZL_Input_numElts(distances);
     size_t const numValues    = ZL_Input_numElts(values);
-    bool const validCounts    = numDistances == numValues
+
+    /*
+     * Empty header is the canonical zero-dominant mode: all values are
+     * literals, and the kernel can stay on the zero-specialized path.
+     * Non-empty headers encode the dominant symbol directly as little-endian
+     * bytes; missing high bytes are implicit zero.
+     */
+    uint64_t dominant = 0;
+    if (header.size > 0) {
+        if (header.start == NULL) {
+            ZL_ERR(corruption);
+        }
+        dominant = ZL_readLE64_N(header.start, header.size);
+    }
+
+    bool const validCounts = numDistances == numValues
             || (numValues < SIZE_MAX && numDistances == numValues + 1);
     ZL_ERR_IF_NOT(
             validCounts,
             corruption,
-            "sparse_num distance count must be value count or value count + 1");
+            "sparse_num distance count must be literal count or literal count + 1");
 
     size_t const outputCount = ZL_sparseNumDecodeOutputCount(
             ZL_Input_ptr(distances), numDistances, distanceWidth, numValues);
@@ -75,6 +98,7 @@ ZL_Report DI_sparse_num(ZL_Decoder* dictx, const ZL_Input* ins[])
             ZL_Input_ptr(distances),
             numDistances,
             distanceWidth,
+            dominant,
             ZL_Input_ptr(values),
             numValues,
             valueWidth);

--- a/src/openzl/codecs/sparse_num/decode_sparse_num_binding.c
+++ b/src/openzl/codecs/sparse_num/decode_sparse_num_binding.c
@@ -1,0 +1,84 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#include "openzl/codecs/sparse_num/decode_sparse_num_binding.h"
+
+#include "openzl/codecs/sparse_num/decode_sparse_num_kernel.h"
+#include "openzl/common/assertion.h"
+#include "openzl/common/errors_internal.h"
+#include "openzl/shared/overflow.h"
+
+#include <stdbool.h>
+#include <stdint.h>
+
+ZL_Report DI_sparse_num(ZL_Decoder* dictx, const ZL_Input* ins[])
+{
+    ZL_RESULT_DECLARE_SCOPE_REPORT(dictx);
+    ZL_ASSERT_NN(dictx);
+    ZL_ASSERT_NN(ins);
+
+    const ZL_Input* const distances = ins[0];
+    const ZL_Input* const values    = ins[1];
+    ZL_ASSERT_NN(distances);
+    ZL_ASSERT_NN(values);
+
+    ZL_ASSERT_EQ(ZL_Input_type(distances), ZL_Type_numeric);
+    ZL_ASSERT_EQ(ZL_Input_type(values), ZL_Type_numeric);
+
+    ZL_RBuffer const header = ZL_Decoder_getCodecHeader(dictx);
+    ZL_ERR_IF_NE(
+            header.size,
+            0,
+            corruption,
+            "sparse_num codec header must be empty");
+
+    size_t const distanceWidth = ZL_Input_eltWidth(distances);
+    ZL_ERR_IF_NOT(
+            ZL_sparseNumValidDistanceWidth(distanceWidth),
+            corruption,
+            "sparse_num distance width must be 1, 2 or 4 bytes");
+
+    size_t const valueWidth = ZL_Input_eltWidth(values);
+    ZL_ERR_IF_NOT(
+            ZL_sparseNumValidValueWidth(valueWidth),
+            corruption,
+            "sparse_num value width must be 1, 2, 4 or 8 bytes");
+
+    size_t const numDistances = ZL_Input_numElts(distances);
+    size_t const numValues    = ZL_Input_numElts(values);
+    bool const validCounts    = numDistances == numValues
+            || (numValues < SIZE_MAX && numDistances == numValues + 1);
+    ZL_ERR_IF_NOT(
+            validCounts,
+            corruption,
+            "sparse_num distance count must be value count or value count + 1");
+
+    size_t const outputCount = ZL_sparseNumDecodeOutputCount(
+            ZL_Input_ptr(distances), numDistances, distanceWidth, numValues);
+    ZL_ERR_IF_EQ(
+            outputCount,
+            ZL_SPARSE_NUM_DECODE_OUTPUT_COUNT_ERROR,
+            integerOverflow,
+            "sparse_num output element count overflows size_t");
+    size_t outputSize;
+    ZL_ERR_IF(
+            ZL_overflowMulST(outputCount, valueWidth, &outputSize),
+            integerOverflow,
+            "sparse_num output byte size overflows size_t");
+
+    ZL_Output* const out =
+            ZL_Decoder_create1OutStream(dictx, outputCount, valueWidth);
+    ZL_ERR_IF_NULL(out, allocation);
+
+    ZL_sparseNumDecode(
+            ZL_Output_ptr(out),
+            outputSize,
+            ZL_Input_ptr(distances),
+            numDistances,
+            distanceWidth,
+            ZL_Input_ptr(values),
+            numValues,
+            valueWidth);
+
+    ZL_ERR_IF_ERR(ZL_Output_commit(out, outputCount));
+    return ZL_returnSuccess();
+}

--- a/src/openzl/codecs/sparse_num/decode_sparse_num_binding.h
+++ b/src/openzl/codecs/sparse_num/decode_sparse_num_binding.h
@@ -1,0 +1,19 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#ifndef OPENZL_CODECS_SPARSE_NUM_DECODE_SPARSE_NUM_BINDING_H
+#define OPENZL_CODECS_SPARSE_NUM_DECODE_SPARSE_NUM_BINDING_H
+
+#include "openzl/codecs/sparse_num/graph_sparse_num.h"
+#include "openzl/shared/portability.h"
+#include "openzl/zl_dtransform.h"
+
+ZL_BEGIN_C_DECLS
+
+ZL_Report DI_sparse_num(ZL_Decoder* dictx, const ZL_Input* ins[]);
+
+#define DI_SPARSE_NUM(id) \
+    { .transform_f = DI_sparse_num, .name = "!zl.sparse_num" }
+
+ZL_END_C_DECLS
+
+#endif

--- a/src/openzl/codecs/sparse_num/decode_sparse_num_kernel.c
+++ b/src/openzl/codecs/sparse_num/decode_sparse_num_kernel.c
@@ -1,0 +1,300 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#include "decode_sparse_num_kernel.h"
+
+#include <assert.h>
+#include <stdint.h>
+#include <string.h>
+
+static uint32_t
+ZL_sparseNumReadDistance(const void* src, size_t index, size_t width)
+{
+    const void* const ptr = (const uint8_t*)src + index * width;
+    assert(ZL_sparseNumIsAlignedForWidth(ptr, width));
+    switch (width) {
+        case 1:
+            return *(const uint8_t*)ptr;
+        case 2:
+            return *(const uint16_t*)ptr;
+        case 4:
+            return *(const uint32_t*)ptr;
+        default:
+            assert(false);
+            return 0;
+    }
+}
+
+static inline bool ZL_sparseNumDecodeCanUseUncheckedOutputCountSum(
+        size_t numDistances,
+        size_t numValues)
+{
+    /*
+     * If size_t is at least 64-bit and both stream counts fit in 32 bits, the
+     * output count cannot overflow size_t:
+     * UINT32_MAX values + UINT32_MAX distances each worth UINT32_MAX zeros
+     * is 2^64 - 2^32, which is still below SIZE_MAX.
+     */
+    if (sizeof(size_t) < 8) {
+        return false;
+    }
+    return numDistances <= UINT32_MAX && numValues <= UINT32_MAX;
+}
+
+size_t ZL_sparseNumDecodeOutputCount(
+        const void* distances,
+        size_t numDistances,
+        size_t distanceWidth,
+        size_t numValues)
+{
+    assert(ZL_sparseNumValidDistanceWidth(distanceWidth));
+
+    size_t count = numValues;
+    if (ZL_sparseNumDecodeCanUseUncheckedOutputCountSum(
+                numDistances, numValues)) {
+        for (size_t i = 0; i < numDistances; ++i) {
+            count += ZL_sparseNumReadDistance(distances, i, distanceWidth);
+        }
+
+        return count;
+    }
+
+    if (count == ZL_SPARSE_NUM_DECODE_OUTPUT_COUNT_ERROR) {
+        return ZL_SPARSE_NUM_DECODE_OUTPUT_COUNT_ERROR;
+    }
+
+    for (size_t i = 0; i < numDistances; ++i) {
+        uint32_t const distance =
+                ZL_sparseNumReadDistance(distances, i, distanceWidth);
+        if ((size_t)distance
+            >= ZL_SPARSE_NUM_DECODE_OUTPUT_COUNT_ERROR - count) {
+            return ZL_SPARSE_NUM_DECODE_OUTPUT_COUNT_ERROR;
+        }
+        count += (size_t)distance;
+    }
+
+    return count;
+}
+
+static inline bool ZL_sparseNumDecodeWriteInBounds(
+        size_t expectedDstSize,
+        size_t producedBytes,
+        size_t writeBytes)
+{
+    if (producedBytes > expectedDstSize) {
+        return false;
+    }
+    if (writeBytes > expectedDstSize - producedBytes) {
+        return false;
+    }
+    return true;
+}
+
+static inline void ZL_sparseNumDecodeTrackWrite(
+        size_t expectedDstSize,
+        size_t* producedBytes,
+        size_t writeBytes)
+{
+    bool const ok = ZL_sparseNumDecodeWriteInBounds(
+            expectedDstSize, *producedBytes, writeBytes);
+    assert(ok);
+    (void)ok;
+    *producedBytes += writeBytes;
+}
+
+static inline bool ZL_sparseNumDecodeComplete(
+        size_t expectedDstSize,
+        size_t producedBytes)
+{
+    return producedBytes == expectedDstSize;
+}
+
+static inline void ZL_sparseNumDecodeBody(
+        void* dst,
+        size_t expectedDstSize,
+        const void* distances,
+        size_t numDistances,
+        size_t distanceWidth,
+        const void* values,
+        size_t numValues,
+        size_t valueWidth)
+{
+    uint8_t* out                = (uint8_t*)dst;
+    const uint8_t* const vals   = (const uint8_t*)values;
+    bool const hasFinalDistance = numDistances == numValues + 1;
+    size_t producedBytes        = 0;
+    (void)expectedDstSize;
+
+    for (size_t i = 0; i < numValues; ++i) {
+        uint32_t const distance =
+                ZL_sparseNumReadDistance(distances, i, distanceWidth);
+        assert((size_t)distance <= SIZE_MAX / valueWidth);
+        size_t const zeroBytes = (size_t)distance * valueWidth;
+        ZL_sparseNumDecodeTrackWrite(
+                expectedDstSize, &producedBytes, zeroBytes);
+        memset(out, 0, zeroBytes);
+        out += zeroBytes;
+
+        ZL_sparseNumDecodeTrackWrite(
+                expectedDstSize, &producedBytes, valueWidth);
+        ZL_sparseNumCopyAlignedValue(out, vals + i * valueWidth, valueWidth);
+        out += valueWidth;
+    }
+
+    if (hasFinalDistance) {
+        uint32_t const distance =
+                ZL_sparseNumReadDistance(distances, numValues, distanceWidth);
+        assert((size_t)distance <= SIZE_MAX / valueWidth);
+        size_t const zeroBytes = (size_t)distance * valueWidth;
+        ZL_sparseNumDecodeTrackWrite(
+                expectedDstSize, &producedBytes, zeroBytes);
+        memset(out, 0, zeroBytes);
+    }
+
+    assert(ZL_sparseNumDecodeComplete(expectedDstSize, producedBytes));
+}
+
+static inline void ZL_sparseNumDecodeD8V1(
+        void* dst,
+        size_t expectedDstSize,
+        const void* distances,
+        size_t numDistances,
+        const void* values,
+        size_t numValues)
+{
+    ZL_sparseNumDecodeBody(
+            dst,
+            expectedDstSize,
+            distances,
+            numDistances,
+            1,
+            values,
+            numValues,
+            1);
+}
+
+static inline void ZL_sparseNumDecodeD8V2(
+        void* dst,
+        size_t expectedDstSize,
+        const void* distances,
+        size_t numDistances,
+        const void* values,
+        size_t numValues)
+{
+    ZL_sparseNumDecodeBody(
+            dst,
+            expectedDstSize,
+            distances,
+            numDistances,
+            1,
+            values,
+            numValues,
+            2);
+}
+
+static inline void ZL_sparseNumDecodeD8V4(
+        void* dst,
+        size_t expectedDstSize,
+        const void* distances,
+        size_t numDistances,
+        const void* values,
+        size_t numValues)
+{
+    ZL_sparseNumDecodeBody(
+            dst,
+            expectedDstSize,
+            distances,
+            numDistances,
+            1,
+            values,
+            numValues,
+            4);
+}
+
+static inline void ZL_sparseNumDecodeD8V8(
+        void* dst,
+        size_t expectedDstSize,
+        const void* distances,
+        size_t numDistances,
+        const void* values,
+        size_t numValues)
+{
+    ZL_sparseNumDecodeBody(
+            dst,
+            expectedDstSize,
+            distances,
+            numDistances,
+            1,
+            values,
+            numValues,
+            8);
+}
+
+void ZL_sparseNumDecode(
+        void* dst,
+        size_t expectedDstSize,
+        const void* distances,
+        size_t numDistances,
+        size_t distanceWidth,
+        const void* values,
+        size_t numValues,
+        size_t valueWidth)
+{
+    assert(ZL_sparseNumValidValueWidth(valueWidth));
+    assert(ZL_sparseNumValidDistanceWidth(distanceWidth));
+    assert(numDistances == numValues
+           || (numValues < SIZE_MAX && numDistances == numValues + 1));
+
+    if (distanceWidth == 1) {
+        switch (valueWidth) {
+            case 1:
+                ZL_sparseNumDecodeD8V1(
+                        dst,
+                        expectedDstSize,
+                        distances,
+                        numDistances,
+                        values,
+                        numValues);
+                return;
+            case 2:
+                ZL_sparseNumDecodeD8V2(
+                        dst,
+                        expectedDstSize,
+                        distances,
+                        numDistances,
+                        values,
+                        numValues);
+                return;
+            case 4:
+                ZL_sparseNumDecodeD8V4(
+                        dst,
+                        expectedDstSize,
+                        distances,
+                        numDistances,
+                        values,
+                        numValues);
+                return;
+            case 8:
+                ZL_sparseNumDecodeD8V8(
+                        dst,
+                        expectedDstSize,
+                        distances,
+                        numDistances,
+                        values,
+                        numValues);
+                return;
+            default:
+                assert(false);
+                return;
+        }
+    }
+
+    ZL_sparseNumDecodeBody(
+            dst,
+            expectedDstSize,
+            distances,
+            numDistances,
+            distanceWidth,
+            values,
+            numValues,
+            valueWidth);
+}

--- a/src/openzl/codecs/sparse_num/decode_sparse_num_kernel.c
+++ b/src/openzl/codecs/sparse_num/decode_sparse_num_kernel.c
@@ -6,6 +6,11 @@
 #include <stdint.h>
 #include <string.h>
 
+/*
+ * Distances are numeric stream elements, so the binding guarantees alignment
+ * for their element width. Use typed loads instead of byte copies to keep the
+ * kernel dependency-free and to match the numeric-stream host-endian contract.
+ */
 static uint32_t
 ZL_sparseNumReadDistance(const void* src, size_t index, size_t width)
 {
@@ -24,33 +29,38 @@ ZL_sparseNumReadDistance(const void* src, size_t index, size_t width)
     }
 }
 
+/*
+ * Most builds use 64-bit size_t. In that case, when both stream counts fit in
+ * 32 bits, summing all 32-bit distances plus all literals cannot overflow.
+ * This avoids a branch inside the common output-count loop while keeping a
+ * checked fallback for 32-bit platforms and oversized counts.
+ */
 static inline bool ZL_sparseNumDecodeCanUseUncheckedOutputCountSum(
         size_t numDistances,
-        size_t numValues)
+        size_t numLiterals)
 {
-    /*
-     * If size_t is at least 64-bit and both stream counts fit in 32 bits, the
-     * output count cannot overflow size_t:
-     * UINT32_MAX values + UINT32_MAX distances each worth UINT32_MAX zeros
-     * is 2^64 - 2^32, which is still below SIZE_MAX.
-     */
     if (sizeof(size_t) < 8) {
         return false;
     }
-    return numDistances <= UINT32_MAX && numValues <= UINT32_MAX;
+    return numDistances <= UINT32_MAX && numLiterals <= UINT32_MAX;
 }
 
+/*
+ * Compute the reconstructed element count before allocation. The public error
+ * value is SIZE_MAX, so the checked path rejects both real overflow and the
+ * otherwise-valid SIZE_MAX count, keeping the API a single-value return.
+ */
 size_t ZL_sparseNumDecodeOutputCount(
         const void* distances,
         size_t numDistances,
         size_t distanceWidth,
-        size_t numValues)
+        size_t numLiterals)
 {
     assert(ZL_sparseNumValidDistanceWidth(distanceWidth));
 
-    size_t count = numValues;
+    size_t count = numLiterals;
     if (ZL_sparseNumDecodeCanUseUncheckedOutputCountSum(
-                numDistances, numValues)) {
+                numDistances, numLiterals)) {
         for (size_t i = 0; i < numDistances; ++i) {
             count += ZL_sparseNumReadDistance(distances, i, distanceWidth);
         }
@@ -75,6 +85,12 @@ size_t ZL_sparseNumDecodeOutputCount(
     return count;
 }
 
+/*
+ * Debug-only write accounting helper. The binding allocates the destination
+ * from ZL_sparseNumDecodeOutputCount(), so the kernel does not perform runtime
+ * bounds recovery. These predicates exist to assert, in debug builds, that the
+ * write plan still matches the caller-computed destination size.
+ */
 static inline bool ZL_sparseNumDecodeWriteInBounds(
         size_t expectedDstSize,
         size_t producedBytes,
@@ -89,6 +105,12 @@ static inline bool ZL_sparseNumDecodeWriteInBounds(
     return true;
 }
 
+/*
+ * Account for every planned output write. The produced byte counter advances
+ * unconditionally, not inside assert(), so release builds keep the same control
+ * flow and future missing accounting remains visible to the final completeness
+ * assertion in debug builds.
+ */
 static inline void ZL_sparseNumDecodeTrackWrite(
         size_t expectedDstSize,
         size_t* producedBytes,
@@ -101,6 +123,11 @@ static inline void ZL_sparseNumDecodeTrackWrite(
     *producedBytes += writeBytes;
 }
 
+/*
+ * Completeness check paired with ZL_sparseNumDecodeTrackWrite(). It catches
+ * both under-writing and over-writing in debug builds when a future edit
+ * changes the decode loop's write structure.
+ */
 static inline bool ZL_sparseNumDecodeComplete(
         size_t expectedDstSize,
         size_t producedBytes)
@@ -108,12 +135,73 @@ static inline bool ZL_sparseNumDecodeComplete(
     return producedBytes == expectedDstSize;
 }
 
+/*
+ * Emit one run before a literal, or the optional final run. Dominant value 0 is
+ * the sparse-zero mode and maps directly to memset(0), preserving the common
+ * case.
+ */
+static inline void ZL_sparseNumDecodeWriteRun(
+        void* dst,
+        uint64_t dominant,
+        uint32_t distance,
+        size_t runBytes,
+        size_t valueWidth)
+{
+    if (dominant == 0) {
+        memset(dst, 0, runBytes);
+        return;
+    }
+
+    assert(dst != NULL);
+    assert(ZL_sparseNumIsAlignedForWidth(dst, valueWidth));
+
+    switch (valueWidth) {
+        case 1: {
+            memset(dst, (uint8_t)dominant, distance);
+            return;
+        }
+        case 2: {
+            uint16_t* const out  = (uint16_t*)dst;
+            uint16_t const value = (uint16_t)dominant;
+            for (uint32_t i = 0; i < distance; ++i) {
+                out[i] = value;
+            }
+            return;
+        }
+        case 4: {
+            uint32_t* const out  = (uint32_t*)dst;
+            uint32_t const value = (uint32_t)dominant;
+            for (uint32_t i = 0; i < distance; ++i) {
+                out[i] = value;
+            }
+            return;
+        }
+        case 8: {
+            uint64_t* const out = (uint64_t*)dst;
+            for (uint32_t i = 0; i < distance; ++i) {
+                out[i] = dominant;
+            }
+            return;
+        }
+        default:
+            assert(false);
+            return;
+    }
+}
+
+/*
+ * Shared decode loop. Each distance describes how many dominant symbols precede
+ * the next literal; an optional final distance describes the trailing dominant
+ * run. Keeping zero and non-zero dominant modes in one body avoids duplicating
+ * the distance/literal/write-accounting logic.
+ */
 static inline void ZL_sparseNumDecodeBody(
         void* dst,
         size_t expectedDstSize,
         const void* distances,
         size_t numDistances,
         size_t distanceWidth,
+        uint64_t dominant,
         const void* values,
         size_t numValues,
         size_t valueWidth)
@@ -128,11 +216,11 @@ static inline void ZL_sparseNumDecodeBody(
         uint32_t const distance =
                 ZL_sparseNumReadDistance(distances, i, distanceWidth);
         assert((size_t)distance <= SIZE_MAX / valueWidth);
-        size_t const zeroBytes = (size_t)distance * valueWidth;
-        ZL_sparseNumDecodeTrackWrite(
-                expectedDstSize, &producedBytes, zeroBytes);
-        memset(out, 0, zeroBytes);
-        out += zeroBytes;
+        size_t const runBytes = (size_t)distance * valueWidth;
+        ZL_sparseNumDecodeTrackWrite(expectedDstSize, &producedBytes, runBytes);
+        ZL_sparseNumDecodeWriteRun(
+                out, dominant, distance, runBytes, valueWidth);
+        out += runBytes;
 
         ZL_sparseNumDecodeTrackWrite(
                 expectedDstSize, &producedBytes, valueWidth);
@@ -144,15 +232,21 @@ static inline void ZL_sparseNumDecodeBody(
         uint32_t const distance =
                 ZL_sparseNumReadDistance(distances, numValues, distanceWidth);
         assert((size_t)distance <= SIZE_MAX / valueWidth);
-        size_t const zeroBytes = (size_t)distance * valueWidth;
-        ZL_sparseNumDecodeTrackWrite(
-                expectedDstSize, &producedBytes, zeroBytes);
-        memset(out, 0, zeroBytes);
+        size_t const runBytes = (size_t)distance * valueWidth;
+        ZL_sparseNumDecodeTrackWrite(expectedDstSize, &producedBytes, runBytes);
+        ZL_sparseNumDecodeWriteRun(
+                out, dominant, distance, runBytes, valueWidth);
     }
 
     assert(ZL_sparseNumDecodeComplete(expectedDstSize, producedBytes));
 }
 
+/*
+ * D8 is the expected distance width for normal sparse_num data. These shells
+ * force both distance width and value width to compile-time constants in the
+ * zero-dominant hot path, while leaving uncommon wider distances on the generic
+ * body.
+ */
 static inline void ZL_sparseNumDecodeD8V1(
         void* dst,
         size_t expectedDstSize,
@@ -167,6 +261,7 @@ static inline void ZL_sparseNumDecodeD8V1(
             distances,
             numDistances,
             1,
+            0,
             values,
             numValues,
             1);
@@ -186,6 +281,7 @@ static inline void ZL_sparseNumDecodeD8V2(
             distances,
             numDistances,
             1,
+            0,
             values,
             numValues,
             2);
@@ -205,6 +301,7 @@ static inline void ZL_sparseNumDecodeD8V4(
             distances,
             numDistances,
             1,
+            0,
             values,
             numValues,
             4);
@@ -224,17 +321,23 @@ static inline void ZL_sparseNumDecodeD8V8(
             distances,
             numDistances,
             1,
+            0,
             values,
             numValues,
             8);
 }
 
+/*
+ * Public kernel entry point. Dominant value 0 keeps the specialized sparse-zero
+ * dispatch; non-zero dominant values use the generic shared body.
+ */
 void ZL_sparseNumDecode(
         void* dst,
         size_t expectedDstSize,
         const void* distances,
         size_t numDistances,
         size_t distanceWidth,
+        uint64_t dominant,
         const void* values,
         size_t numValues,
         size_t valueWidth)
@@ -244,7 +347,7 @@ void ZL_sparseNumDecode(
     assert(numDistances == numValues
            || (numValues < SIZE_MAX && numDistances == numValues + 1));
 
-    if (distanceWidth == 1) {
+    if (dominant == 0 && distanceWidth == 1) {
         switch (valueWidth) {
             case 1:
                 ZL_sparseNumDecodeD8V1(
@@ -294,6 +397,7 @@ void ZL_sparseNumDecode(
             distances,
             numDistances,
             distanceWidth,
+            dominant,
             values,
             numValues,
             valueWidth);

--- a/src/openzl/codecs/sparse_num/decode_sparse_num_kernel.h
+++ b/src/openzl/codecs/sparse_num/decode_sparse_num_kernel.h
@@ -1,0 +1,62 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#ifndef OPENZL_CODECS_SPARSE_NUM_DECODE_SPARSE_NUM_KERNEL_H
+#define OPENZL_CODECS_SPARSE_NUM_DECODE_SPARSE_NUM_KERNEL_H
+
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+
+#include "openzl/codecs/sparse_num/common_sparse_num.h"
+#include "openzl/shared/portability.h"
+
+ZL_BEGIN_C_DECLS
+
+#define ZL_SPARSE_NUM_DECODE_OUTPUT_COUNT_ERROR SIZE_MAX
+
+/**
+ * Computes the number of numeric elements produced by sparse_num decode.
+ * Returns ZL_SPARSE_NUM_DECODE_OUTPUT_COUNT_ERROR if the count overflows size_t
+ * or reaches the reserved error value.
+ *
+ * Preconditions:
+ * - distanceWidth must be a supported distance width.
+ * - distances must point to numDistances distanceWidth-byte numeric elements.
+ * - distances must be aligned for distanceWidth-byte numeric elements.
+ */
+size_t ZL_sparseNumDecodeOutputCount(
+        const void* distances,
+        size_t numDistances,
+        size_t distanceWidth,
+        size_t numValues);
+
+/**
+ * Decodes sparse_num into dst.
+ *
+ * Preconditions:
+ * - numDistances must be numValues or numValues + 1.
+ * - distances must point to numDistances distanceWidth-byte numeric elements.
+ * - distances must be aligned for distanceWidth-byte numeric elements.
+ * - values must point to numValues valueWidth-byte numeric elements.
+ * - values must be aligned for valueWidth-byte numeric elements.
+ * - dst must be aligned for valueWidth-byte numeric elements.
+ * - expectedDstSize must be the exact byte size produced by this decode:
+ *   outputCount * valueWidth, where outputCount is returned by
+ *   ZL_sparseNumDecodeOutputCount() for the same distance and value streams.
+ * - expectedDstSize is used as a debug invariant that the kernel writes exactly
+ *   the caller-computed destination size. Release builds still trust the caller
+ *   to provide a correctly sized destination buffer.
+ */
+void ZL_sparseNumDecode(
+        void* dst,
+        size_t expectedDstSize,
+        const void* distances,
+        size_t numDistances,
+        size_t distanceWidth,
+        const void* values,
+        size_t numValues,
+        size_t valueWidth);
+
+ZL_END_C_DECLS
+
+#endif

--- a/src/openzl/codecs/sparse_num/decode_sparse_num_kernel.h
+++ b/src/openzl/codecs/sparse_num/decode_sparse_num_kernel.h
@@ -16,36 +16,59 @@ ZL_BEGIN_C_DECLS
 
 /**
  * Computes the number of numeric elements produced by sparse_num decode.
- * Returns ZL_SPARSE_NUM_DECODE_OUTPUT_COUNT_ERROR if the count overflows size_t
- * or reaches the reserved error value.
  *
- * Preconditions:
- * - distanceWidth must be a supported distance width.
- * - distances must point to numDistances distanceWidth-byte numeric elements.
- * - distances must be aligned for distanceWidth-byte numeric elements.
+ * @param distances The distance stream, as numeric elements.
+ * @param numDistances The number of elements in @p distances.
+ * @param distanceWidth The byte width of each distance element.
+ * @param numLiterals The number of literal values in the value stream.
+ * @return The decoded output element count, or
+ *         ZL_SPARSE_NUM_DECODE_OUTPUT_COUNT_ERROR if the count overflows
+ *         size_t or reaches the reserved error value.
+ *
+ * @pre @p distanceWidth must be a supported distance width.
+ * @pre @p distances must point to @p numDistances distanceWidth-byte numeric
+ *      elements.
+ * @pre @p distances must be aligned for distanceWidth-byte numeric elements.
  */
 size_t ZL_sparseNumDecodeOutputCount(
         const void* distances,
         size_t numDistances,
         size_t distanceWidth,
-        size_t numValues);
+        size_t numLiterals);
 
 /**
  * Decodes sparse_num into dst.
  *
- * Preconditions:
- * - numDistances must be numValues or numValues + 1.
- * - distances must point to numDistances distanceWidth-byte numeric elements.
- * - distances must be aligned for distanceWidth-byte numeric elements.
- * - values must point to numValues valueWidth-byte numeric elements.
- * - values must be aligned for valueWidth-byte numeric elements.
- * - dst must be aligned for valueWidth-byte numeric elements.
- * - expectedDstSize must be the exact byte size produced by this decode:
- *   outputCount * valueWidth, where outputCount is returned by
- *   ZL_sparseNumDecodeOutputCount() for the same distance and value streams.
- * - expectedDstSize is used as a debug invariant that the kernel writes exactly
- *   the caller-computed destination size. Release builds still trust the caller
- *   to provide a correctly sized destination buffer.
+ * A dominant value of 0 is the common sparse-zero mode and uses the
+ * zero-specialized internal dispatch.
+ *
+ * @param dst The destination buffer for decoded numeric elements.
+ * @param expectedDstSize The exact byte size produced by this decode.
+ * @param distances The distance stream, as numeric elements.
+ * @param numDistances The number of elements in @p distances.
+ * @param distanceWidth The byte width of each distance element.
+ * @param dominant The dominant symbol value.
+ * @param values The literal value stream, as numeric elements.
+ * @param numValues The number of elements in @p values.
+ * @param valueWidth The byte width of each literal and output element.
+ *
+ * @pre @p numDistances must be @p numValues or @p numValues + 1.
+ * @pre @p distanceWidth must be a supported distance width.
+ * @pre @p distances must point to @p numDistances distanceWidth-byte numeric
+ *      elements.
+ * @pre @p distances must be aligned for distanceWidth-byte numeric elements.
+ * @pre @p dominant must fit in @p valueWidth bytes.
+ * @pre @p valueWidth must be a supported numeric element width.
+ * @pre @p values must point to @p numValues valueWidth-byte numeric elements.
+ * @pre @p values must be aligned for valueWidth-byte numeric elements.
+ * @pre @p dst must be aligned for valueWidth-byte numeric elements.
+ * @pre @p expectedDstSize must be outputCount * valueWidth, where outputCount
+ *      is returned by ZL_sparseNumDecodeOutputCount() for the same distance
+ *      and value streams.
+ *
+ * @note @p expectedDstSize is used as a debug invariant that the kernel writes
+ *       exactly the caller-computed destination size. Release builds still
+ *       trust the caller to provide a correctly sized destination buffer.
  */
 void ZL_sparseNumDecode(
         void* dst,
@@ -53,6 +76,7 @@ void ZL_sparseNumDecode(
         const void* distances,
         size_t numDistances,
         size_t distanceWidth,
+        uint64_t dominant,
         const void* values,
         size_t numValues,
         size_t valueWidth);

--- a/src/openzl/codecs/sparse_num/encode_sparse_num_binding.c
+++ b/src/openzl/codecs/sparse_num/encode_sparse_num_binding.c
@@ -1,0 +1,48 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#include "openzl/codecs/sparse_num/encode_sparse_num_binding.h"
+
+#include "openzl/codecs/sparse_num/encode_sparse_num_kernel.h"
+#include "openzl/common/assertion.h"
+#include "openzl/common/errors_internal.h"
+
+ZL_Report EI_sparse_num(ZL_Encoder* eictx, const ZL_Input* ins[], size_t nbIns)
+{
+    ZL_RESULT_DECLARE_SCOPE_REPORT(eictx);
+    ZL_ASSERT_NN(eictx);
+    ZL_ASSERT_EQ(nbIns, 1);
+    ZL_ASSERT_NN(ins);
+
+    const ZL_Input* const in = ins[0];
+    ZL_ASSERT_NN(in);
+    ZL_ASSERT_EQ(ZL_Input_type(in), ZL_Type_numeric);
+
+    size_t const valueWidth = ZL_Input_eltWidth(in);
+    ZL_ERR_IF_NOT(
+            ZL_sparseNumValidValueWidth(valueWidth),
+            node_invalid_input,
+            "sparse_num expects numeric width of 1, 2, 4 or 8 bytes");
+
+    ZL_SparseNumEncodeInfo const info = ZL_sparseNumComputeEncodeInfo(
+            ZL_Input_ptr(in), ZL_Input_numElts(in), valueWidth);
+
+    ZL_Output* const distances = ZL_Encoder_createTypedStream(
+            eictx, 0, info.numDistances, info.distanceWidth);
+    ZL_ERR_IF_NULL(distances, allocation);
+    ZL_Output* const values =
+            ZL_Encoder_createTypedStream(eictx, 1, info.numValues, valueWidth);
+    ZL_ERR_IF_NULL(values, allocation);
+
+    ZL_sparseNumEncode(
+            ZL_Output_ptr(distances),
+            ZL_Output_ptr(values),
+            ZL_Input_ptr(in),
+            ZL_Input_numElts(in),
+            valueWidth,
+            info.distanceWidth);
+
+    ZL_ERR_IF_ERR(ZL_Output_commit(distances, info.numDistances));
+    ZL_ERR_IF_ERR(ZL_Output_commit(values, info.numValues));
+
+    return ZL_returnSuccess();
+}

--- a/src/openzl/codecs/sparse_num/encode_sparse_num_binding.c
+++ b/src/openzl/codecs/sparse_num/encode_sparse_num_binding.c
@@ -3,10 +3,124 @@
 #include "openzl/codecs/sparse_num/encode_sparse_num_binding.h"
 
 #include "openzl/codecs/sparse_num/encode_sparse_num_kernel.h"
+#include "openzl/codecs/zl_sparse_num.h"
 #include "openzl/common/assertion.h"
 #include "openzl/common/errors_internal.h"
+#include "openzl/shared/bits.h"
+#include "openzl/shared/mem.h"
 
-ZL_Report EI_sparse_num(ZL_Encoder* eictx, const ZL_Input* ins[], size_t nbIns)
+#include <stdbool.h>
+#include <stdint.h>
+
+static bool ZL_sparseNumDominantFitsWidth(uint64_t dominant, size_t width)
+{
+    switch (width) {
+        case 1:
+            return dominant <= UINT8_MAX;
+        case 2:
+            return dominant <= UINT16_MAX;
+        case 4:
+            return dominant <= UINT32_MAX;
+        case 8:
+            return true;
+        default:
+            ZL_ASSERT_FAIL("Unsupported sparse_num value width");
+            return false;
+    }
+}
+
+static size_t ZL_sparseNumWriteDominantHeader(
+        uint8_t header[sizeof(uint64_t)],
+        uint64_t dominant)
+{
+    size_t const size = (size_t)ZL_highbit64(dominant) / 8 + 1;
+    ZL_writeLE64_N(header, dominant, size);
+    return size;
+}
+
+static ZL_Report ZL_sparseNumEncoderDominant(
+        ZL_Encoder* eictx,
+        const ZL_Input* in,
+        size_t valueWidth,
+        uint64_t* dominant)
+{
+    ZL_RESULT_DECLARE_SCOPE_REPORT(eictx);
+    ZL_ASSERT_NN(dominant);
+
+    ZL_RefParam const dominantParam =
+            ZL_Encoder_getLocalParam(eictx, ZL_SPARSE_NUM_DOMINANT_VALUE_PID);
+    if (dominantParam.paramRef != NULL) {
+        ZL_ERR_IF_NE(
+                dominantParam.paramSize,
+                sizeof(uint64_t),
+                graphParameter_invalid,
+                "sparse_num dominant parameter must be uint64_t");
+        uint64_t const explicitDominant =
+                *(const uint64_t*)dominantParam.paramRef;
+        ZL_ERR_IF_NOT(
+                ZL_sparseNumDominantFitsWidth(explicitDominant, valueWidth),
+                node_invalid_input,
+                "sparse_num dominant value does not fit input width");
+        if (ZL_Input_numElts(in) == 0) {
+            *dominant = 0;
+            return ZL_returnSuccess();
+        }
+        *dominant = explicitDominant;
+        return ZL_returnSuccess();
+    }
+
+    *dominant = ZL_sparseNumSelectDominant(
+            ZL_Input_ptr(in), ZL_Input_numElts(in), valueWidth);
+    return ZL_returnSuccess();
+}
+
+static ZL_Report ZL_sparseNumEncodeSelectedDominant(
+        ZL_Encoder* eictx,
+        const ZL_Input* in,
+        size_t valueWidth,
+        uint64_t dominant)
+{
+    ZL_RESULT_DECLARE_SCOPE_REPORT(eictx);
+    bool const nonZeroDominant = dominant != 0;
+
+    if (nonZeroDominant) {
+        uint8_t header[sizeof(uint64_t)];
+        size_t const headerSize =
+                ZL_sparseNumWriteDominantHeader(header, dominant);
+        ZL_ASSERT_LE(headerSize, valueWidth);
+        ZL_Encoder_sendCodecHeader(eictx, header, headerSize);
+    }
+
+    ZL_SparseNumEncodeInfo const info = ZL_sparseNumComputeEncodeInfo(
+            ZL_Input_ptr(in), ZL_Input_numElts(in), valueWidth, dominant);
+
+    ZL_Output* const distances = ZL_Encoder_createTypedStream(
+            eictx, 0, info.numDistances, info.distanceWidth);
+    ZL_ERR_IF_NULL(distances, allocation);
+    ZL_Output* const values =
+            ZL_Encoder_createTypedStream(eictx, 1, info.numValues, valueWidth);
+    ZL_ERR_IF_NULL(values, allocation);
+
+    ZL_sparseNumEncode(
+            ZL_Output_ptr(distances),
+            ZL_Output_ptr(values),
+            ZL_Input_ptr(in),
+            ZL_Input_numElts(in),
+            valueWidth,
+            info.distanceWidth,
+            dominant);
+
+    ZL_ERR_IF_ERR(ZL_Output_commit(distances, info.numDistances));
+    ZL_ERR_IF_ERR(ZL_Output_commit(values, info.numValues));
+
+    return ZL_returnSuccess();
+}
+
+static ZL_Report ZL_sparseNumEncodeNode(
+        ZL_Encoder* eictx,
+        const ZL_Input* ins[],
+        size_t nbIns,
+        bool autoDominant)
 {
     ZL_RESULT_DECLARE_SCOPE_REPORT(eictx);
     ZL_ASSERT_NN(eictx);
@@ -23,26 +137,22 @@ ZL_Report EI_sparse_num(ZL_Encoder* eictx, const ZL_Input* ins[], size_t nbIns)
             node_invalid_input,
             "sparse_num expects numeric width of 1, 2, 4 or 8 bytes");
 
-    ZL_SparseNumEncodeInfo const info = ZL_sparseNumComputeEncodeInfo(
-            ZL_Input_ptr(in), ZL_Input_numElts(in), valueWidth);
+    uint64_t dominant = 0;
+    if (autoDominant) {
+        ZL_ERR_IF_ERR(
+                ZL_sparseNumEncoderDominant(eictx, in, valueWidth, &dominant));
+    }
 
-    ZL_Output* const distances = ZL_Encoder_createTypedStream(
-            eictx, 0, info.numDistances, info.distanceWidth);
-    ZL_ERR_IF_NULL(distances, allocation);
-    ZL_Output* const values =
-            ZL_Encoder_createTypedStream(eictx, 1, info.numValues, valueWidth);
-    ZL_ERR_IF_NULL(values, allocation);
+    return ZL_sparseNumEncodeSelectedDominant(eictx, in, valueWidth, dominant);
+}
 
-    ZL_sparseNumEncode(
-            ZL_Output_ptr(distances),
-            ZL_Output_ptr(values),
-            ZL_Input_ptr(in),
-            ZL_Input_numElts(in),
-            valueWidth,
-            info.distanceWidth);
+ZL_Report EI_sparse_num(ZL_Encoder* eictx, const ZL_Input* ins[], size_t nbIns)
+{
+    return ZL_sparseNumEncodeNode(eictx, ins, nbIns, false);
+}
 
-    ZL_ERR_IF_ERR(ZL_Output_commit(distances, info.numDistances));
-    ZL_ERR_IF_ERR(ZL_Output_commit(values, info.numValues));
-
-    return ZL_returnSuccess();
+ZL_Report
+EI_sparse_num_auto(ZL_Encoder* eictx, const ZL_Input* ins[], size_t nbIns)
+{
+    return ZL_sparseNumEncodeNode(eictx, ins, nbIns, true);
 }

--- a/src/openzl/codecs/sparse_num/encode_sparse_num_binding.h
+++ b/src/openzl/codecs/sparse_num/encode_sparse_num_binding.h
@@ -10,11 +10,18 @@
 ZL_BEGIN_C_DECLS
 
 ZL_Report EI_sparse_num(ZL_Encoder* eictx, const ZL_Input* ins[], size_t nbIns);
+ZL_Report
+EI_sparse_num_auto(ZL_Encoder* eictx, const ZL_Input* ins[], size_t nbIns);
 
 #define EI_SPARSE_NUM(id)                  \
     { .gd          = SPARSE_NUM_GRAPH(id), \
       .transform_f = EI_sparse_num,        \
       .name        = "!zl.sparse_num" }
+
+#define EI_SPARSE_NUM_AUTO(id)             \
+    { .gd          = SPARSE_NUM_GRAPH(id), \
+      .transform_f = EI_sparse_num_auto,   \
+      .name        = "!zl.sparse_num_auto" }
 
 ZL_END_C_DECLS
 

--- a/src/openzl/codecs/sparse_num/encode_sparse_num_binding.h
+++ b/src/openzl/codecs/sparse_num/encode_sparse_num_binding.h
@@ -1,0 +1,21 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#ifndef OPENZL_CODECS_SPARSE_NUM_ENCODE_SPARSE_NUM_BINDING_H
+#define OPENZL_CODECS_SPARSE_NUM_ENCODE_SPARSE_NUM_BINDING_H
+
+#include "openzl/codecs/sparse_num/graph_sparse_num.h"
+#include "openzl/shared/portability.h"
+#include "openzl/zl_ctransform.h"
+
+ZL_BEGIN_C_DECLS
+
+ZL_Report EI_sparse_num(ZL_Encoder* eictx, const ZL_Input* ins[], size_t nbIns);
+
+#define EI_SPARSE_NUM(id)                  \
+    { .gd          = SPARSE_NUM_GRAPH(id), \
+      .transform_f = EI_sparse_num,        \
+      .name        = "!zl.sparse_num" }
+
+ZL_END_C_DECLS
+
+#endif

--- a/src/openzl/codecs/sparse_num/encode_sparse_num_kernel.c
+++ b/src/openzl/codecs/sparse_num/encode_sparse_num_kernel.c
@@ -4,15 +4,101 @@
 
 #include <assert.h>
 
-static inline bool ZL_sparseNumIsZero(const void* ptr, size_t width)
+#define ZL_SPARSE_NUM_DOMINANT_SAMPLE_MAX 4096
+
+static uint64_t ZL_sparseNumReadValue(const void* ptr, size_t width)
 {
-    const uint8_t* const bytes = (const uint8_t*)ptr;
-    for (size_t i = 0; i < width; ++i) {
-        if (bytes[i] != 0) {
-            return false;
+    assert(ZL_sparseNumIsAlignedForWidth(ptr, width));
+    switch (width) {
+        case 1:
+            return *(const uint8_t*)ptr;
+        case 2:
+            return *(const uint16_t*)ptr;
+        case 4:
+            return *(const uint32_t*)ptr;
+        case 8:
+            return *(const uint64_t*)ptr;
+        default:
+            assert(false);
+            return 0;
+    }
+}
+
+uint64_t
+ZL_sparseNumSelectDominant(const void* src, size_t numElts, size_t valueWidth)
+{
+    assert(ZL_sparseNumValidValueWidth(valueWidth));
+
+    const uint8_t* const bytes = (const uint8_t*)src;
+    size_t const sampleElts    = numElts < ZL_SPARSE_NUM_DOMINANT_SAMPLE_MAX
+               ? numElts
+               : ZL_SPARSE_NUM_DOMINANT_SAMPLE_MAX;
+    uint64_t candidate         = 0;
+    size_t votes               = 0;
+
+    for (size_t i = 0; i < sampleElts; ++i) {
+        uint64_t const value =
+                ZL_sparseNumReadValue(bytes + i * valueWidth, valueWidth);
+        if (votes == 0) {
+            candidate = value;
+            votes     = 1;
+            continue;
+        }
+        if (value == candidate) {
+            ++votes;
+        } else {
+            --votes;
         }
     }
-    return true;
+
+    return votes == 0 ? 0 : candidate;
+}
+
+static void ZL_sparseNumWriteValue(void* ptr, size_t width, uint64_t value)
+{
+    assert(ZL_sparseNumIsAlignedForWidth(ptr, width));
+    switch (width) {
+        case 1:
+            *(uint8_t*)ptr = (uint8_t)value;
+            return;
+        case 2:
+            *(uint16_t*)ptr = (uint16_t)value;
+            return;
+        case 4:
+            *(uint32_t*)ptr = (uint32_t)value;
+            return;
+        case 8:
+            *(uint64_t*)ptr = value;
+            return;
+        default:
+            assert(false);
+            return;
+    }
+}
+
+static inline bool ZL_sparseNumIsZero(const void* ptr, size_t width)
+{
+    assert(ZL_sparseNumIsAlignedForWidth(ptr, width));
+    switch (width) {
+        case 1:
+            return *(const uint8_t*)ptr == 0;
+        case 2:
+            return *(const uint16_t*)ptr == 0;
+        case 4:
+            return *(const uint32_t*)ptr == 0;
+        case 8:
+            return *(const uint64_t*)ptr == 0;
+        default:
+            assert(false);
+            return false;
+    }
+}
+
+static inline bool
+ZL_sparseNumMatchesDominant(const void* ptr, size_t width, uint64_t dominant)
+{
+    return dominant == 0 ? ZL_sparseNumIsZero(ptr, width)
+                         : ZL_sparseNumReadValue(ptr, width) == dominant;
 }
 
 static size_t ZL_sparseNumDistanceWidth(uint32_t maxDistance)
@@ -50,44 +136,50 @@ static void ZL_sparseNumWriteDistance(
     }
 }
 
-static ZL_SparseNumEncodeInfo ZL_sparseNumComputeEncodeInfo_internal(
+/*
+ * Shared encode-info scan. The zero-dominant callers still dispatch by
+ * valueWidth before entering this body; the non-zero path is intentionally
+ * generic until benchmark data justifies more specializations.
+ */
+static inline ZL_SparseNumEncodeInfo ZL_sparseNumComputeEncodeInfo_internal(
         const void* src,
         size_t numElts,
-        size_t valueWidth)
+        size_t valueWidth,
+        uint64_t dominant)
 {
     assert(ZL_sparseNumValidValueWidth(valueWidth));
 
     const uint8_t* const bytes = (const uint8_t*)src;
-    uint32_t zeroRun           = 0;
+    uint32_t run               = 0;
     uint32_t maxDistance       = 0;
     size_t numValues           = 0;
     size_t numDistances        = 0;
 
     for (size_t i = 0; i < numElts; ++i) {
         const uint8_t* const elt = bytes + i * valueWidth;
-        if (ZL_sparseNumIsZero(elt, valueWidth)) {
-            if (zeroRun == UINT32_MAX) {
+        if (ZL_sparseNumMatchesDominant(elt, valueWidth, dominant)) {
+            if (run == UINT32_MAX) {
                 maxDistance = UINT32_MAX;
-                zeroRun     = 0;
+                run         = 0;
                 ++numValues;
                 ++numDistances;
                 continue;
             }
-            ++zeroRun;
+            ++run;
             continue;
         }
 
-        if (zeroRun > maxDistance) {
-            maxDistance = zeroRun;
+        if (run > maxDistance) {
+            maxDistance = run;
         }
-        zeroRun = 0;
+        run = 0;
         ++numValues;
         ++numDistances;
     }
 
-    if (zeroRun > 0) {
-        if (zeroRun > maxDistance) {
-            maxDistance = zeroRun;
+    if (run > 0) {
+        if (run > maxDistance) {
+            maxDistance = run;
         }
         ++numDistances;
     }
@@ -102,17 +194,42 @@ static ZL_SparseNumEncodeInfo ZL_sparseNumComputeEncodeInfo_internal(
 ZL_SparseNumEncodeInfo ZL_sparseNumComputeEncodeInfo(
         const void* src,
         size_t numElts,
-        size_t valueWidth)
+        size_t valueWidth,
+        uint64_t dominant)
 {
+    if (dominant == 0) {
+        switch (valueWidth) {
+            case 1:
+                return ZL_sparseNumComputeEncodeInfo_internal(
+                        src, numElts, 1, 0);
+            case 2:
+                return ZL_sparseNumComputeEncodeInfo_internal(
+                        src, numElts, 2, 0);
+            case 4:
+                return ZL_sparseNumComputeEncodeInfo_internal(
+                        src, numElts, 4, 0);
+            case 8:
+                return ZL_sparseNumComputeEncodeInfo_internal(
+                        src, numElts, 8, 0);
+            default:
+                assert(false);
+                return (ZL_SparseNumEncodeInfo){ 0 };
+        }
+    }
+
     switch (valueWidth) {
         case 1:
-            return ZL_sparseNumComputeEncodeInfo_internal(src, numElts, 1);
+            return ZL_sparseNumComputeEncodeInfo_internal(
+                    src, numElts, 1, dominant);
         case 2:
-            return ZL_sparseNumComputeEncodeInfo_internal(src, numElts, 2);
+            return ZL_sparseNumComputeEncodeInfo_internal(
+                    src, numElts, 2, dominant);
         case 4:
-            return ZL_sparseNumComputeEncodeInfo_internal(src, numElts, 4);
+            return ZL_sparseNumComputeEncodeInfo_internal(
+                    src, numElts, 4, dominant);
         case 8:
-            return ZL_sparseNumComputeEncodeInfo_internal(src, numElts, 8);
+            return ZL_sparseNumComputeEncodeInfo_internal(
+                    src, numElts, 8, dominant);
         default:
             assert(false);
             return (ZL_SparseNumEncodeInfo){ 0 };
@@ -126,50 +243,58 @@ static inline void ZL_sparseNumEncode_internal(
         size_t numElts,
         size_t valueWidth,
         size_t distanceWidth,
+        uint64_t dominant,
         bool splitFullRun)
 {
     assert(ZL_sparseNumValidValueWidth(valueWidth));
     assert(ZL_sparseNumValidDistanceWidth(distanceWidth));
     assert(!splitFullRun || distanceWidth == 4);
 
-    size_t index   = 0;
-    size_t elts    = 0;
-    size_t zeroRun = 0;
+    size_t index = 0;
+    size_t elts  = 0;
+    size_t run   = 0;
 
     for (size_t i = 0; i < numElts; ++i) {
         const uint8_t* const elt = source + i * valueWidth;
-        if (ZL_sparseNumIsZero(elt, valueWidth)) {
-            if (splitFullRun && zeroRun == UINT32_MAX) {
+        if (ZL_sparseNumMatchesDominant(elt, valueWidth, dominant)) {
+            if (splitFullRun && run == UINT32_MAX) {
                 ZL_sparseNumWriteDistance(
                         distances, index, UINT32_MAX, distanceWidth);
-                ZL_sparseNumCopyAlignedValue(
-                        valueDst + index * valueWidth, elt, valueWidth);
+                if (dominant == 0) {
+                    ZL_sparseNumCopyAlignedValue(
+                            valueDst + index * valueWidth, elt, valueWidth);
+                } else {
+                    ZL_sparseNumWriteValue(
+                            valueDst + index * valueWidth,
+                            valueWidth,
+                            dominant);
+                }
                 ++index;
-                elts    = i + 1;
-                zeroRun = 0;
+                elts = i + 1;
+                run  = 0;
                 continue;
             }
-            ++zeroRun;
+            ++run;
             continue;
         }
 
-        assert(zeroRun <= UINT32_MAX);
+        assert(run <= UINT32_MAX);
         ZL_sparseNumWriteDistance(
-                distances, index, (uint32_t)zeroRun, distanceWidth);
+                distances, index, (uint32_t)run, distanceWidth);
         ZL_sparseNumCopyAlignedValue(
                 valueDst + index * valueWidth, elt, valueWidth);
         ++index;
-        elts += zeroRun + 1;
-        zeroRun = 0;
+        elts += run + 1;
+        run = 0;
     }
 
-    /* write the final zero run, if it exists */
+    /* write the final dominant-symbol run, if it exists */
     if (elts < numElts) {
         assert(elts <= numElts);
-        const size_t lastZeroRun = numElts - elts;
-        assert(lastZeroRun <= UINT32_MAX);
+        const size_t lastRun = numElts - elts;
+        assert(lastRun <= UINT32_MAX);
         ZL_sparseNumWriteDistance(
-                distances, index, (uint32_t)lastZeroRun, distanceWidth);
+                distances, index, (uint32_t)lastRun, distanceWidth);
     }
 }
 
@@ -179,7 +304,8 @@ void ZL_sparseNumEncode(
         const void* src,
         size_t numElts,
         size_t valueWidth,
-        size_t distanceWidth)
+        size_t distanceWidth,
+        uint64_t dominant)
 {
     assert(ZL_sparseNumValidValueWidth(valueWidth));
     assert(ZL_sparseNumValidDistanceWidth(distanceWidth));
@@ -187,23 +313,23 @@ void ZL_sparseNumEncode(
     const uint8_t* const source = (const uint8_t*)src;
     uint8_t* const valueDst     = (uint8_t*)values;
 
-    if (distanceWidth == 1) {
+    if (dominant == 0 && distanceWidth == 1) {
         switch (valueWidth) {
             case 1:
                 ZL_sparseNumEncode_internal(
-                        distances, valueDst, source, numElts, 1, 1, false);
+                        distances, valueDst, source, numElts, 1, 1, 0, false);
                 return;
             case 2:
                 ZL_sparseNumEncode_internal(
-                        distances, valueDst, source, numElts, 2, 1, false);
+                        distances, valueDst, source, numElts, 2, 1, 0, false);
                 return;
             case 4:
                 ZL_sparseNumEncode_internal(
-                        distances, valueDst, source, numElts, 4, 1, false);
+                        distances, valueDst, source, numElts, 4, 1, 0, false);
                 return;
             case 8:
                 ZL_sparseNumEncode_internal(
-                        distances, valueDst, source, numElts, 8, 1, false);
+                        distances, valueDst, source, numElts, 8, 1, 0, false);
                 return;
             default:
                 assert(false);
@@ -224,5 +350,6 @@ void ZL_sparseNumEncode(
             numElts,
             valueWidth,
             distanceWidth,
+            dominant,
             distanceWidth == 4);
 }

--- a/src/openzl/codecs/sparse_num/encode_sparse_num_kernel.c
+++ b/src/openzl/codecs/sparse_num/encode_sparse_num_kernel.c
@@ -1,0 +1,228 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#include "encode_sparse_num_kernel.h"
+
+#include <assert.h>
+
+static inline bool ZL_sparseNumIsZero(const void* ptr, size_t width)
+{
+    const uint8_t* const bytes = (const uint8_t*)ptr;
+    for (size_t i = 0; i < width; ++i) {
+        if (bytes[i] != 0) {
+            return false;
+        }
+    }
+    return true;
+}
+
+static size_t ZL_sparseNumDistanceWidth(uint32_t maxDistance)
+{
+    if (maxDistance <= UINT8_MAX) {
+        return 1;
+    }
+    if (maxDistance <= UINT16_MAX) {
+        return 2;
+    }
+    return 4;
+}
+
+static void ZL_sparseNumWriteDistance(
+        void* dst,
+        size_t index,
+        uint32_t distance,
+        size_t width)
+{
+    void* const ptr = (uint8_t*)dst + index * width;
+    assert(ZL_sparseNumIsAlignedForWidth(ptr, width));
+    switch (width) {
+        case 1:
+            *(uint8_t*)ptr = (uint8_t)distance;
+            return;
+        case 2:
+            *(uint16_t*)ptr = (uint16_t)distance;
+            return;
+        case 4:
+            *(uint32_t*)ptr = distance;
+            return;
+        default:
+            assert(false);
+            return;
+    }
+}
+
+static ZL_SparseNumEncodeInfo ZL_sparseNumComputeEncodeInfo_internal(
+        const void* src,
+        size_t numElts,
+        size_t valueWidth)
+{
+    assert(ZL_sparseNumValidValueWidth(valueWidth));
+
+    const uint8_t* const bytes = (const uint8_t*)src;
+    uint32_t zeroRun           = 0;
+    uint32_t maxDistance       = 0;
+    size_t numValues           = 0;
+    size_t numDistances        = 0;
+
+    for (size_t i = 0; i < numElts; ++i) {
+        const uint8_t* const elt = bytes + i * valueWidth;
+        if (ZL_sparseNumIsZero(elt, valueWidth)) {
+            if (zeroRun == UINT32_MAX) {
+                maxDistance = UINT32_MAX;
+                zeroRun     = 0;
+                ++numValues;
+                ++numDistances;
+                continue;
+            }
+            ++zeroRun;
+            continue;
+        }
+
+        if (zeroRun > maxDistance) {
+            maxDistance = zeroRun;
+        }
+        zeroRun = 0;
+        ++numValues;
+        ++numDistances;
+    }
+
+    if (zeroRun > 0) {
+        if (zeroRun > maxDistance) {
+            maxDistance = zeroRun;
+        }
+        ++numDistances;
+    }
+
+    return (ZL_SparseNumEncodeInfo){
+        .numDistances  = numDistances,
+        .numValues     = numValues,
+        .distanceWidth = ZL_sparseNumDistanceWidth(maxDistance),
+    };
+}
+
+ZL_SparseNumEncodeInfo ZL_sparseNumComputeEncodeInfo(
+        const void* src,
+        size_t numElts,
+        size_t valueWidth)
+{
+    switch (valueWidth) {
+        case 1:
+            return ZL_sparseNumComputeEncodeInfo_internal(src, numElts, 1);
+        case 2:
+            return ZL_sparseNumComputeEncodeInfo_internal(src, numElts, 2);
+        case 4:
+            return ZL_sparseNumComputeEncodeInfo_internal(src, numElts, 4);
+        case 8:
+            return ZL_sparseNumComputeEncodeInfo_internal(src, numElts, 8);
+        default:
+            assert(false);
+            return (ZL_SparseNumEncodeInfo){ 0 };
+    }
+}
+
+static inline void ZL_sparseNumEncode_internal(
+        void* distances,
+        uint8_t* valueDst,
+        const uint8_t* source,
+        size_t numElts,
+        size_t valueWidth,
+        size_t distanceWidth,
+        bool splitFullRun)
+{
+    assert(ZL_sparseNumValidValueWidth(valueWidth));
+    assert(ZL_sparseNumValidDistanceWidth(distanceWidth));
+    assert(!splitFullRun || distanceWidth == 4);
+
+    size_t index   = 0;
+    size_t elts    = 0;
+    size_t zeroRun = 0;
+
+    for (size_t i = 0; i < numElts; ++i) {
+        const uint8_t* const elt = source + i * valueWidth;
+        if (ZL_sparseNumIsZero(elt, valueWidth)) {
+            if (splitFullRun && zeroRun == UINT32_MAX) {
+                ZL_sparseNumWriteDistance(
+                        distances, index, UINT32_MAX, distanceWidth);
+                ZL_sparseNumCopyAlignedValue(
+                        valueDst + index * valueWidth, elt, valueWidth);
+                ++index;
+                elts    = i + 1;
+                zeroRun = 0;
+                continue;
+            }
+            ++zeroRun;
+            continue;
+        }
+
+        assert(zeroRun <= UINT32_MAX);
+        ZL_sparseNumWriteDistance(
+                distances, index, (uint32_t)zeroRun, distanceWidth);
+        ZL_sparseNumCopyAlignedValue(
+                valueDst + index * valueWidth, elt, valueWidth);
+        ++index;
+        elts += zeroRun + 1;
+        zeroRun = 0;
+    }
+
+    /* write the final zero run, if it exists */
+    if (elts < numElts) {
+        assert(elts <= numElts);
+        const size_t lastZeroRun = numElts - elts;
+        assert(lastZeroRun <= UINT32_MAX);
+        ZL_sparseNumWriteDistance(
+                distances, index, (uint32_t)lastZeroRun, distanceWidth);
+    }
+}
+
+void ZL_sparseNumEncode(
+        void* distances,
+        void* values,
+        const void* src,
+        size_t numElts,
+        size_t valueWidth,
+        size_t distanceWidth)
+{
+    assert(ZL_sparseNumValidValueWidth(valueWidth));
+    assert(ZL_sparseNumValidDistanceWidth(distanceWidth));
+
+    const uint8_t* const source = (const uint8_t*)src;
+    uint8_t* const valueDst     = (uint8_t*)values;
+
+    if (distanceWidth == 1) {
+        switch (valueWidth) {
+            case 1:
+                ZL_sparseNumEncode_internal(
+                        distances, valueDst, source, numElts, 1, 1, false);
+                return;
+            case 2:
+                ZL_sparseNumEncode_internal(
+                        distances, valueDst, source, numElts, 2, 1, false);
+                return;
+            case 4:
+                ZL_sparseNumEncode_internal(
+                        distances, valueDst, source, numElts, 4, 1, false);
+                return;
+            case 8:
+                ZL_sparseNumEncode_internal(
+                        distances, valueDst, source, numElts, 8, 1, false);
+                return;
+            default:
+                assert(false);
+                return;
+        }
+    }
+
+    /*
+     * Wider distance streams are uncommon for sparse_num's intended inputs, so
+     * keep them on one generic path for now. This path is expected to be slower
+     * because valueWidth and distanceWidth are not compile-time constants. If a
+     * workload needs faster D16 or D32 encoding, add their specialization.
+     */
+    ZL_sparseNumEncode_internal(
+            distances,
+            valueDst,
+            source,
+            numElts,
+            valueWidth,
+            distanceWidth,
+            distanceWidth == 4);
+}

--- a/src/openzl/codecs/sparse_num/encode_sparse_num_kernel.h
+++ b/src/openzl/codecs/sparse_num/encode_sparse_num_kernel.h
@@ -3,7 +3,6 @@
 #ifndef OPENZL_CODECS_SPARSE_NUM_ENCODE_SPARSE_NUM_KERNEL_H
 #define OPENZL_CODECS_SPARSE_NUM_ENCODE_SPARSE_NUM_KERNEL_H
 
-#include <stdbool.h>
 #include <stddef.h>
 #include <stdint.h>
 
@@ -26,42 +25,80 @@ typedef struct {
 } ZL_SparseNumEncodeInfo;
 
 /**
- * Scans src and computes the canonical sparse_num output layout.
+ * Selects an automatic dominant symbol from a bounded input prefix.
  *
- * Preconditions:
- * - src must point to numElts numeric elements, each valueWidth bytes wide.
- * - src must be aligned for valueWidth-byte numeric elements.
- * - valueWidth must be a supported numeric element width.
+ * The detector uses Boyer-Moore majority voting over a small prefix. It is a
+ * heuristic for encoder planning, not a decoder-format condition: callers may
+ * encode with the returned non-zero symbol even if it is not dominant over the
+ * full input. Such output remains valid, only potentially inefficient.
  *
- * Returns:
- * - numDistances: number of zero-run distances to emit.
- * - numValues: number of literal values to emit.
- * - distanceWidth: minimal distance width that can encode the largest emitted
- *   run.
+ * @param src The input stream, as numeric elements.
+ * @param numElts The number of elements in @p src.
+ * @param valueWidth The byte width of each input element.
+ * @return The selected dominant symbol candidate.
+ *
+ * @pre @p src must point to @p numElts valueWidth-byte numeric elements.
+ * @pre @p src must be aligned for valueWidth-byte numeric elements.
+ * @pre @p valueWidth must be a supported numeric element width.
+ */
+uint64_t
+ZL_sparseNumSelectDominant(const void* src, size_t numElts, size_t valueWidth);
+
+/**
+ * Scans src and computes the sparse_num output layout.
+ *
+ * A dominant value of 0 is the sparse-zero mode. Non-zero dominant values use
+ * dominant-symbol mode. In both modes, the values stream contains literal
+ * values only.
+ *
+ * @param src The input stream, as numeric elements.
+ * @param numElts The number of elements in @p src.
+ * @param valueWidth The byte width of each input element.
+ * @param dominant The dominant symbol value, or 0 for sparse-zero mode.
+ * @return The number of distance elements, literal value elements, and minimal
+ *         distance width needed to encode the stream.
+ *
+ * @pre @p src must point to @p numElts valueWidth-byte numeric elements.
+ * @pre @p src must be aligned for valueWidth-byte numeric elements.
+ * @pre @p valueWidth must be a supported numeric element width.
+ * @pre @p dominant must fit in @p valueWidth bytes.
  */
 ZL_SparseNumEncodeInfo ZL_sparseNumComputeEncodeInfo(
         const void* src,
         size_t numElts,
-        size_t valueWidth);
+        size_t valueWidth,
+        uint64_t dominant);
 
 /**
  * Encodes src into separate sparse_num distance and value streams.
  *
  * This function is intended to be called after
  * ZL_sparseNumComputeEncodeInfo() has succeeded for the same source stream.
+ * A dominant value of 0 is the sparse-zero mode; non-zero values use
+ * dominant-symbol mode.
  *
- * Preconditions:
- * - src must point to numElts numeric elements, each valueWidth bytes wide.
- * - src must be aligned for valueWidth-byte numeric elements.
- * - valueWidth and distanceWidth must be supported widths.
- * - distanceWidth must be large enough for the largest emitted zero run
- *   reported by ZL_sparseNumComputeEncodeInfo().
- * - distances must be aligned for distanceWidth-byte numeric elements.
- * - distances must have room for info.numDistances * distanceWidth bytes.
- * - values must be aligned for valueWidth-byte numeric elements.
- * - values must have room for info.numValues * valueWidth bytes.
- * - distances and values must not overlap src or each other in a way that
- *   changes source elements before they are read or corrupts output writes.
+ * @param distances The output distance stream.
+ * @param values The output literal value stream.
+ * @param src The input stream, as numeric elements.
+ * @param numElts The number of elements in @p src.
+ * @param valueWidth The byte width of each input and literal value element.
+ * @param distanceWidth The byte width of each output distance element.
+ * @param dominant The dominant symbol value, or 0 for sparse-zero mode.
+ *
+ * @pre @p src must point to @p numElts valueWidth-byte numeric elements.
+ * @pre @p src must be aligned for valueWidth-byte numeric elements.
+ * @pre @p valueWidth must be a supported numeric element width.
+ * @pre @p distanceWidth must be a supported distance width.
+ * @pre @p dominant must fit in @p valueWidth bytes.
+ * @pre @p distanceWidth must be large enough for the largest emitted dominant
+ *      run reported by ZL_sparseNumComputeEncodeInfo().
+ * @pre @p distances must be aligned for distanceWidth-byte numeric elements.
+ * @pre @p distances must have room for info.numDistances * distanceWidth bytes.
+ * @pre @p values must be aligned for valueWidth-byte numeric elements.
+ * @pre @p values must have room for info.numValues * valueWidth bytes.
+ * @pre @p distances and @p values must not overlap @p src or each other in a
+ *      way that changes source elements before they are read or corrupts
+ *      output writes.
  */
 void ZL_sparseNumEncode(
         void* distances,
@@ -69,7 +106,8 @@ void ZL_sparseNumEncode(
         const void* src,
         size_t numElts,
         size_t valueWidth,
-        size_t distanceWidth);
+        size_t distanceWidth,
+        uint64_t dominant);
 
 ZL_END_C_DECLS
 

--- a/src/openzl/codecs/sparse_num/encode_sparse_num_kernel.h
+++ b/src/openzl/codecs/sparse_num/encode_sparse_num_kernel.h
@@ -1,0 +1,76 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#ifndef OPENZL_CODECS_SPARSE_NUM_ENCODE_SPARSE_NUM_KERNEL_H
+#define OPENZL_CODECS_SPARSE_NUM_ENCODE_SPARSE_NUM_KERNEL_H
+
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+
+#include "openzl/codecs/sparse_num/common_sparse_num.h"
+#include "openzl/shared/portability.h"
+
+ZL_BEGIN_C_DECLS
+
+/**
+ * Lean sparse_num encoder kernel API.
+ *
+ * The binding is responsible for validating stream metadata and allocating the
+ * output streams. The kernel only scans numeric elements, reports the required
+ * output layout, and writes the distance and literal-value streams.
+ */
+typedef struct {
+    size_t numDistances;
+    size_t numValues;
+    size_t distanceWidth;
+} ZL_SparseNumEncodeInfo;
+
+/**
+ * Scans src and computes the canonical sparse_num output layout.
+ *
+ * Preconditions:
+ * - src must point to numElts numeric elements, each valueWidth bytes wide.
+ * - src must be aligned for valueWidth-byte numeric elements.
+ * - valueWidth must be a supported numeric element width.
+ *
+ * Returns:
+ * - numDistances: number of zero-run distances to emit.
+ * - numValues: number of literal values to emit.
+ * - distanceWidth: minimal distance width that can encode the largest emitted
+ *   run.
+ */
+ZL_SparseNumEncodeInfo ZL_sparseNumComputeEncodeInfo(
+        const void* src,
+        size_t numElts,
+        size_t valueWidth);
+
+/**
+ * Encodes src into separate sparse_num distance and value streams.
+ *
+ * This function is intended to be called after
+ * ZL_sparseNumComputeEncodeInfo() has succeeded for the same source stream.
+ *
+ * Preconditions:
+ * - src must point to numElts numeric elements, each valueWidth bytes wide.
+ * - src must be aligned for valueWidth-byte numeric elements.
+ * - valueWidth and distanceWidth must be supported widths.
+ * - distanceWidth must be large enough for the largest emitted zero run
+ *   reported by ZL_sparseNumComputeEncodeInfo().
+ * - distances must be aligned for distanceWidth-byte numeric elements.
+ * - distances must have room for info.numDistances * distanceWidth bytes.
+ * - values must be aligned for valueWidth-byte numeric elements.
+ * - values must have room for info.numValues * valueWidth bytes.
+ * - distances and values must not overlap src or each other in a way that
+ *   changes source elements before they are read or corrupts output writes.
+ */
+void ZL_sparseNumEncode(
+        void* distances,
+        void* values,
+        const void* src,
+        size_t numElts,
+        size_t valueWidth,
+        size_t distanceWidth);
+
+ZL_END_C_DECLS
+
+#endif

--- a/src/openzl/codecs/sparse_num/graph_sparse_num.h
+++ b/src/openzl/codecs/sparse_num/graph_sparse_num.h
@@ -1,0 +1,22 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#ifndef OPENZL_CODECS_SPARSE_NUM_GRAPH_SPARSE_NUM_H
+#define OPENZL_CODECS_SPARSE_NUM_GRAPH_SPARSE_NUM_H
+
+#include "openzl/zl_data.h"
+
+/**
+ * Graph definition for the sparse_num transform.
+ *
+ * Input 0: numeric stream to sparsify
+ * Output 0: numeric stream of zero-run distances
+ * Output 1: numeric stream of literal values
+ */
+#define SPARSE_NUM_GRAPH(id)                                               \
+    {                                                                      \
+        .CTid       = id,                                                  \
+        .inputTypes = ZL_STREAMTYPELIST(ZL_Type_numeric),                  \
+        .soTypes    = ZL_STREAMTYPELIST(ZL_Type_numeric, ZL_Type_numeric), \
+    }
+
+#endif

--- a/src/openzl/codecs/sparse_num/spec.md
+++ b/src/openzl/codecs/sparse_num/spec.md
@@ -1,0 +1,93 @@
+## Sparse Num Decoder Specification
+
+### Inputs
+
+The decoder for the `sparse_num` transform takes two numeric streams as input:
+
+1. `distances` -- zero-run lengths.
+2. `values` -- literal values.
+
+The `values` stream element width determines the output element width. It must be
+1, 2, 4, or 8 bytes.
+
+Literal values may be zero. This is valid and unambiguous because each distance
+is interpreted relative to the next literal value, not relative to the next
+nonzero value.
+
+The `distances` stream element width determines the maximum representable zero
+run. It must be 1, 2, or 4 bytes. Distance values are interpreted as unsigned
+integers in the stream's element width. The decoder accepts any supported
+distance width, even when a narrower width would be sufficient to represent all
+distances.
+
+The number of distance elements must be equal to the number of value elements, or
+exactly one greater than the number of value elements. No other count
+relationship is valid.
+
+### Codec Header
+
+The codec header is empty.
+
+### Decoding Algorithm
+
+Each distance is the number of zero elements before a boundary. A boundary is
+either the next literal value or the end of the reconstructed stream.
+
+Let `numValues` be the number of elements in `values`, and `numDistances` be the
+number of elements in `distances`.
+
+- If `numDistances == numValues`, the reconstructed stream ends with the last
+  value.
+- If `numDistances == numValues + 1`, the final distance is the zero run to the
+  end of the reconstructed stream. A final distance of zero is valid and means
+  the stream ends immediately after the last value.
+
+The decoder computes the number of output elements as:
+
+```
+sum(distances) + numValues
+```
+
+The decoder then produces output as follows:
+
+1. For each value index `i` in `[0, numValues)`:
+   1. Emit `distances[i]` zero elements.
+   2. Emit `values[i]`.
+2. If `numDistances == numValues + 1`, emit `distances[numValues]` zero
+   elements.
+
+The output size computation must be checked for integer overflow before
+allocating the output stream. Decoding must fail if the distance/value count
+relationship is invalid, if any stream has an unsupported element width, or if
+the computed output size cannot be represented.
+
+### Encoder Guidance
+
+This specification defines decoder behavior. Encoders are expected to choose an
+efficient, canonical representation, but the decoder must accept less efficient
+representations when they are unambiguous and otherwise valid.
+
+Encoders should use the narrowest distance width that can represent all emitted
+distances. Decoders must still accept any supported distance width.
+
+Encoders should normally omit zero literals and represent zero values through
+distances. Encoders may still emit zero literals when doing so is useful, for
+example to split an otherwise unrepresentable zero run while keeping distances
+limited to 32 bits.
+
+Encoders should use the shorter representation when the input ends with a
+literal value, omitting the final zero-length distance. Decoders must still
+accept `numDistances == numValues + 1` with a final zero distance.
+
+- Empty input is encoded as no distances and no values.
+- An all-zero input of length `N > 0` is encoded as one distance with value `N`
+  and no values, when `N` fits in the selected distance width.
+- Longer zero runs may be split by emitting a zero literal after the largest
+  representable distance.
+- An input ending in a literal value has `numDistances == numValues`.
+- An input ending in one or more zero values has `numDistances == numValues + 1`.
+
+### Output
+
+The decoder produces one numeric stream. Its element width is the element width
+of `values`, and its element count is `sum(distances) + numValues`.

--- a/src/openzl/codecs/sparse_num/spec.md
+++ b/src/openzl/codecs/sparse_num/spec.md
@@ -4,62 +4,76 @@
 
 The decoder for the `sparse_num` transform takes two numeric streams as input:
 
-1. `distances` -- zero-run lengths.
+1. `distances` -- dominant-symbol run lengths.
 2. `values` -- literal values.
 
 The `values` stream element width determines the output element width. It must be
-1, 2, 4, or 8 bytes.
+1, 2, 4, or 8 bytes. The dominant symbol and all literal values use this element
+width.
 
-Literal values may be zero. This is valid and unambiguous because each distance
-is interpreted relative to the next literal value, not relative to the next
-nonzero value.
+Literal values may be equal to the dominant symbol. This is valid and
+unambiguous because each distance is interpreted relative to the next literal
+value, not relative to the next non-dominant value.
 
-The `distances` stream element width determines the maximum representable zero
-run. It must be 1, 2, or 4 bytes. Distance values are interpreted as unsigned
-integers in the stream's element width. The decoder accepts any supported
-distance width, even when a narrower width would be sufficient to represent all
-distances.
+The `distances` stream element width determines the maximum representable
+dominant-symbol run. It must be 1, 2, or 4 bytes. Distance values are interpreted
+as unsigned integers in the stream's element width. The decoder accepts any
+supported distance width, even when a narrower width would be sufficient to
+represent all distances.
 
-The number of distance elements must be equal to the number of value elements, or
-exactly one greater than the number of value elements. No other count
-relationship is valid.
+The number of distance elements must be equal to the number of literal value
+elements, or exactly one greater than the number of literal value elements. No
+other count relationship is valid.
 
 ### Codec Header
 
-The codec header is empty.
+The codec header selects the dominant symbol.
+
+- If the codec header is empty, the dominant symbol is numeric value 0. The
+  `values` stream contains only literal values.
+- If the codec header is non-empty, its bytes are the dominant symbol encoded in
+  little-endian byte order. The header size must be no greater than the `values`
+  stream element width. Any missing high bytes are implicit zero. The `values`
+  stream contains only literal values.
+
+For example, dominant symbol `1` is encoded as `01`, dominant symbol `256` is
+encoded as `00 01`, and dominant symbol `0x123456` is encoded as `56 34 12`.
 
 ### Decoding Algorithm
 
-Each distance is the number of zero elements before a boundary. A boundary is
-either the next literal value or the end of the reconstructed stream.
+Each distance is the number of dominant-symbol elements before a boundary. A
+boundary is either the next literal value or the end of the reconstructed stream.
 
-Let `numValues` be the number of elements in `values`, and `numDistances` be the
-number of elements in `distances`.
+Let `numLiterals` be the number of elements in `values`, and `numDistances` be
+the number of elements in `distances`.
 
-- If `numDistances == numValues`, the reconstructed stream ends with the last
+- If `numDistances == numLiterals`, the reconstructed stream ends with the last
+  literal value.
+- If `numDistances == numLiterals + 1`, the final distance is the
+  dominant-symbol run to the end of the reconstructed stream. A final distance of
+  zero is valid and means the stream ends immediately after the last literal
   value.
-- If `numDistances == numValues + 1`, the final distance is the zero run to the
-  end of the reconstructed stream. A final distance of zero is valid and means
-  the stream ends immediately after the last value.
 
 The decoder computes the number of output elements as:
 
 ```
-sum(distances) + numValues
+sum(distances) + numLiterals
 ```
 
 The decoder then produces output as follows:
 
-1. For each value index `i` in `[0, numValues)`:
-   1. Emit `distances[i]` zero elements.
+1. Decode the dominant symbol from the codec header.
+2. For each literal index `i` in `[0, numLiterals)`:
+   1. Emit `distances[i]` copies of the dominant symbol.
    2. Emit `values[i]`.
-2. If `numDistances == numValues + 1`, emit `distances[numValues]` zero
-   elements.
+3. If `numDistances == numLiterals + 1`, emit `distances[numLiterals]` copies of
+   the dominant symbol.
 
 The output size computation must be checked for integer overflow before
 allocating the output stream. Decoding must fail if the distance/value count
-relationship is invalid, if any stream has an unsupported element width, or if
-the computed output size cannot be represented.
+relationship is invalid, if the codec header is larger than the value element
+width, if any stream has an unsupported element width, or if the computed output
+size cannot be represented.
 
 ### Encoder Guidance
 
@@ -70,24 +84,35 @@ representations when they are unambiguous and otherwise valid.
 Encoders should use the narrowest distance width that can represent all emitted
 distances. Decoders must still accept any supported distance width.
 
-Encoders should normally omit zero literals and represent zero values through
-distances. Encoders may still emit zero literals when doing so is useful, for
-example to split an otherwise unrepresentable zero run while keeping distances
-limited to 32 bits.
+Encoders should normally omit literals equal to the dominant symbol and represent
+dominant-symbol values through distances. Encoders may still emit literals equal
+to the dominant symbol when doing so is useful, for example to split an otherwise
+unrepresentable dominant-symbol run while keeping distances limited to 32 bits.
 
 Encoders should use the shorter representation when the input ends with a
 literal value, omitting the final zero-length distance. Decoders must still
-accept `numDistances == numValues + 1` with a final zero distance.
+accept `numDistances == numLiterals + 1` with a final zero distance.
 
-- Empty input is encoded as no distances and no values.
-- An all-zero input of length `N > 0` is encoded as one distance with value `N`
-  and no values, when `N` fits in the selected distance width.
-- Longer zero runs may be split by emitting a zero literal after the largest
-  representable distance.
-- An input ending in a literal value has `numDistances == numValues`.
-- An input ending in one or more zero values has `numDistances == numValues + 1`.
+Encoders should use the canonical dominant-symbol header:
+
+- If the dominant symbol is 0, use an empty codec header.
+- Otherwise, encode the dominant symbol in little-endian byte order, using the
+  shortest non-empty byte sequence that represents it. The `values` stream
+  contains only literal values.
+
+Decoders must still accept unambiguous non-canonical representations, such as a
+non-empty codec header with trailing zero bytes.
+
+- Empty input is encoded as no distances and no literal values.
+- An all-dominant-symbol input of length `N > 0` is encoded as one distance with
+  value `N` and no literal values, when `N` fits in the selected distance width.
+- Longer dominant-symbol runs may be split by emitting a dominant-symbol literal
+  after the largest representable distance.
+- An input ending in a literal value has `numDistances == numLiterals`.
+- An input ending in one or more dominant-symbol values has
+  `numDistances == numLiterals + 1`.
 
 ### Output
 
 The decoder produces one numeric stream. Its element width is the element width
-of `values`, and its element count is `sum(distances) + numValues`.
+of `values`, and its element count is `sum(distances) + numLiterals`.

--- a/src/openzl/common/wire_format.h
+++ b/src/openzl/common/wire_format.h
@@ -316,6 +316,8 @@ typedef enum {
 
     ZL_StandardTransformID_mux_lengths = 65,
 
+    ZL_StandardTransformID_sparse_num = 66,
+
     ZL_StandardTransformID_end =
             128 // last id, used to detect end of ID range (impacts
                 // header encoding) give some room to be able to add new

--- a/tests/registry/OpenZLComponents.h
+++ b/tests/registry/OpenZLComponents.h
@@ -89,6 +89,7 @@ enum class OpenZLComponentID {
     CompressSmallLengths,
     Lz,
     MuxLengths,
+    SparseNum,
     // Must be last enum value
     NumComponents,
 };
@@ -164,6 +165,7 @@ std::unique_ptr<OpenZLComponent> makeSentinelNumComponent();
 std::unique_ptr<OpenZLComponent> makeCompressSmallLengthsComponent();
 std::unique_ptr<OpenZLComponent> makeLzComponent();
 std::unique_ptr<OpenZLComponent> makeMuxLengthsComponent();
+std::unique_ptr<OpenZLComponent> makeSparseNumComponent();
 
 } // namespace components
 
@@ -299,6 +301,8 @@ inline std::unique_ptr<OpenZLComponent> makeOpenZLComponent(
             return components::makeLzComponent();
         case OpenZLComponentID::MuxLengths:
             return components::makeMuxLengthsComponent();
+        case OpenZLComponentID::SparseNum:
+            return components::makeSparseNumComponent();
         case OpenZLComponentID::NumComponents:
         default:
             throw std::runtime_error("Invalid component");

--- a/tests/registry/components/SparseNum.cpp
+++ b/tests/registry/components/SparseNum.cpp
@@ -1,0 +1,134 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#include "openzl/cpp/codecs/SparseNum.hpp"
+#include "tests/registry/OpenZLComponents.h"
+#include "tests/registry/OpenZLInput.h"
+
+#include <cstdint>
+
+namespace openzl::tests::components {
+namespace {
+
+template <typename T>
+std::vector<T> sparseVector(datagen::DataGen& gen, size_t maxElts, T min, T max)
+{
+    std::vector<T> values;
+    size_t const numElts = gen.usize_range("numElts", 0, maxElts);
+    values.reserve(numElts);
+    for (size_t i = 0; i < numElts; ++i) {
+        if (gen.coin("isZero", 0.75)) {
+            values.push_back(0);
+            continue;
+        }
+        T value = gen.randVal<T>("value", min, max);
+        if (value == 0) {
+            value = 1;
+        }
+        values.push_back(value);
+    }
+    return values;
+}
+
+class SparseNumComponent : public OpenZLComponent {
+   public:
+    std::string name() const override
+    {
+        return "SparseNum";
+    }
+
+    int minFormatVersion() const override
+    {
+        return 25;
+    }
+
+    size_t compressBound(poly::span<const Input> inputs) const override
+    {
+        return 3 * this->OpenZLComponent::compressBound(inputs);
+    }
+
+    std::vector<NodeID> predefinedNodes(Compressor& compressor) const override
+    {
+        return { nodes::SparseNum{}.parameterize(compressor) };
+    }
+
+    std::vector<std::unique_ptr<OpenZLInput>> predefinedInputs() const override
+    {
+        std::vector<std::unique_ptr<OpenZLInput>> inputs;
+        inputs.push_back(U8OpenZLInput::make(std::vector<uint8_t>{}));
+        inputs.push_back(U8OpenZLInput::make(std::vector<uint8_t>{ 0, 0, 0 }));
+        inputs.push_back(U8OpenZLInput::make(std::vector<uint8_t>{ 1, 2, 3 }));
+        inputs.push_back(U8OpenZLInput::make(std::vector<uint8_t>{ 0, 0, 7 }));
+        inputs.push_back(U8OpenZLInput::make(std::vector<uint8_t>{ 7, 0, 0 }));
+        inputs.push_back(
+                U8OpenZLInput::make(
+                        std::vector<uint8_t>{ 0, 1, 0, 0, 2, 0, 3, 0 }));
+        inputs.push_back(
+                U16OpenZLInput::make(
+                        std::vector<uint16_t>{ 0, 1024, 0, 0, 65535 }));
+        inputs.push_back(
+                U32OpenZLInput::make(
+                        std::vector<uint32_t>{ 0, 0, 1, 0, UINT32_MAX, 0 }));
+        inputs.push_back(
+                U64OpenZLInput::make(
+                        std::vector<uint64_t>{ 0, 1, 0, UINT64_MAX, 0, 0 }));
+        return inputs;
+    }
+
+    std::vector<std::unique_ptr<OpenZLInput>> generateInputs(
+            datagen::DataGen& gen,
+            size_t num,
+            size_t maxInputSize,
+            const Compressor&,
+            GraphID) const override
+    {
+        std::vector<std::unique_ptr<OpenZLInput>> inputs;
+        inputs.reserve(num);
+        for (size_t i = 0; i < num; ++i) {
+            auto widthChoice = gen.usize_range("width", 0, 3);
+            switch (widthChoice) {
+                case 0: {
+                    auto maxElts = maxInputSize / sizeof(uint8_t);
+                    inputs.push_back(
+                            U8OpenZLInput::make(
+                                    sparseVector<uint8_t>(
+                                            gen, maxElts, 0, UINT8_MAX)));
+                    break;
+                }
+                case 1: {
+                    auto maxElts = maxInputSize / sizeof(uint16_t);
+                    inputs.push_back(
+                            U16OpenZLInput::make(
+                                    sparseVector<uint16_t>(
+                                            gen, maxElts, 0, UINT16_MAX)));
+                    break;
+                }
+                case 2: {
+                    auto maxElts = maxInputSize / sizeof(uint32_t);
+                    inputs.push_back(
+                            U32OpenZLInput::make(
+                                    sparseVector<uint32_t>(
+                                            gen, maxElts, 0, UINT32_MAX)));
+                    break;
+                }
+                case 3: {
+                    auto maxElts = maxInputSize / sizeof(uint64_t);
+                    inputs.push_back(
+                            U64OpenZLInput::make(
+                                    sparseVector<uint64_t>(
+                                            gen, maxElts, 0, UINT64_MAX)));
+                    break;
+                }
+            }
+        }
+        return inputs;
+    }
+};
+
+} // namespace
+
+std::unique_ptr<OpenZLComponent> makeSparseNumComponent()
+{
+    return std::make_unique<SparseNumComponent>();
+}
+
+} // namespace openzl::tests::components

--- a/tests/registry/components/SparseNum.cpp
+++ b/tests/registry/components/SparseNum.cpp
@@ -38,7 +38,7 @@ class SparseNumComponent : public OpenZLComponent {
 
     int minFormatVersion() const override
     {
-        return 25;
+        return 26;
     }
 
     size_t compressBound(poly::span<const Input> inputs) const override
@@ -48,7 +48,9 @@ class SparseNumComponent : public OpenZLComponent {
 
     std::vector<NodeID> predefinedNodes(Compressor& compressor) const override
     {
-        return { nodes::SparseNum{}.parameterize(compressor) };
+        return { nodes::SparseNum{}.parameterize(compressor),
+                 nodes::SparseNumAuto{}.parameterize(compressor),
+                 nodes::SparseNumAuto{ 7 }.parameterize(compressor) };
     }
 
     std::vector<std::unique_ptr<OpenZLInput>> predefinedInputs() const override
@@ -63,8 +65,14 @@ class SparseNumComponent : public OpenZLComponent {
                 U8OpenZLInput::make(
                         std::vector<uint8_t>{ 0, 1, 0, 0, 2, 0, 3, 0 }));
         inputs.push_back(
+                U8OpenZLInput::make(
+                        std::vector<uint8_t>{ 7, 7, 1, 7, 2, 7, 7 }));
+        inputs.push_back(
                 U16OpenZLInput::make(
                         std::vector<uint16_t>{ 0, 1024, 0, 0, 65535 }));
+        inputs.push_back(
+                U16OpenZLInput::make(
+                        std::vector<uint16_t>{ 1024, 5, 1024, 1024, 6 }));
         inputs.push_back(
                 U32OpenZLInput::make(
                         std::vector<uint32_t>{ 0, 0, 1, 0, UINT32_MAX, 0 }));

--- a/tests/unittest/transforms/test_sparse_num_kernel.cpp
+++ b/tests/unittest/transforms/test_sparse_num_kernel.cpp
@@ -1,0 +1,36 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#include <array>
+#include <cstdint>
+
+#include <gtest/gtest.h>
+
+#include "openzl/codecs/sparse_num/decode_sparse_num_kernel.h"
+
+namespace {
+
+TEST(SparseNumKernelTest, DecodeAcceptsZeroLiteral)
+{
+    std::array<uint8_t, 2> const distances = { 3, 1 };
+    std::array<uint8_t, 1> const values    = { 0 };
+    std::array<uint8_t, 5> expected        = { 0, 0, 0, 0, 0 };
+    std::array<uint8_t, 5> output          = {};
+
+    size_t const outputCount = ZL_sparseNumDecodeOutputCount(
+            distances.data(), distances.size(), sizeof(uint8_t), values.size());
+
+    ASSERT_EQ(outputCount, output.size());
+    ZL_sparseNumDecode(
+            output.data(),
+            output.size() * sizeof(uint8_t),
+            distances.data(),
+            distances.size(),
+            sizeof(uint8_t),
+            values.data(),
+            values.size(),
+            sizeof(uint8_t));
+
+    EXPECT_EQ(output, expected);
+}
+
+} // namespace

--- a/tests/unittest/transforms/test_sparse_num_kernel.cpp
+++ b/tests/unittest/transforms/test_sparse_num_kernel.cpp
@@ -6,6 +6,7 @@
 #include <gtest/gtest.h>
 
 #include "openzl/codecs/sparse_num/decode_sparse_num_kernel.h"
+#include "openzl/codecs/sparse_num/encode_sparse_num_kernel.h"
 
 namespace {
 
@@ -26,11 +27,122 @@ TEST(SparseNumKernelTest, DecodeAcceptsZeroLiteral)
             distances.data(),
             distances.size(),
             sizeof(uint8_t),
+            0,
             values.data(),
             values.size(),
             sizeof(uint8_t));
 
     EXPECT_EQ(output, expected);
+}
+
+TEST(SparseNumKernelTest, DecodeWithExplicitDominant)
+{
+    uint64_t const dominant                = 7;
+    std::array<uint8_t, 3> const distances = { 2, 0, 1 };
+    std::array<uint8_t, 2> const literals  = { 1, 2 };
+    std::array<uint8_t, 5> const expected  = { 7, 7, 1, 2, 7 };
+    std::array<uint8_t, 5> output          = {};
+
+    size_t const outputCount = ZL_sparseNumDecodeOutputCount(
+            distances.data(),
+            distances.size(),
+            sizeof(uint8_t),
+            literals.size());
+
+    ASSERT_EQ(outputCount, output.size());
+    ZL_sparseNumDecode(
+            output.data(),
+            output.size() * sizeof(uint8_t),
+            distances.data(),
+            distances.size(),
+            sizeof(uint8_t),
+            dominant,
+            literals.data(),
+            literals.size(),
+            sizeof(uint8_t));
+
+    EXPECT_EQ(output, expected);
+}
+
+TEST(SparseNumKernelTest, DecodeWithWideExplicitDominant)
+{
+    uint64_t const dominant                = 1024;
+    std::array<uint8_t, 2> const distances = { 1, 2 };
+    std::array<uint16_t, 2> const values   = { 5, 6 };
+    std::array<uint16_t, 5> const expected = { 1024, 5, 1024, 1024, 6 };
+    std::array<uint16_t, 5> output         = {};
+
+    size_t const outputCount = ZL_sparseNumDecodeOutputCount(
+            distances.data(), distances.size(), sizeof(uint8_t), values.size());
+
+    ASSERT_EQ(outputCount, output.size());
+    ZL_sparseNumDecode(
+            output.data(),
+            output.size() * sizeof(uint16_t),
+            distances.data(),
+            distances.size(),
+            sizeof(uint8_t),
+            dominant,
+            values.data(),
+            values.size(),
+            sizeof(uint16_t));
+
+    EXPECT_EQ(output, expected);
+}
+
+TEST(SparseNumKernelTest, EncodeWithSmallDominant)
+{
+    std::array<uint8_t, 7> const input = { 7, 7, 1, 7, 2, 7, 7 };
+    uint64_t const dominant            = ZL_sparseNumSelectDominant(
+            input.data(), input.size(), sizeof(uint8_t));
+
+    ASSERT_EQ(dominant, 7);
+
+    ZL_SparseNumEncodeInfo const info = ZL_sparseNumComputeEncodeInfo(
+            input.data(), input.size(), sizeof(uint8_t), dominant);
+    ASSERT_EQ(info.numDistances, 3);
+    ASSERT_EQ(info.numValues, 2);
+    ASSERT_EQ(info.distanceWidth, sizeof(uint8_t));
+
+    std::array<uint8_t, 3> distances = {};
+    std::array<uint8_t, 2> values    = {};
+    ZL_sparseNumEncode(
+            distances.data(),
+            values.data(),
+            input.data(),
+            input.size(),
+            sizeof(uint8_t),
+            info.distanceWidth,
+            dominant);
+
+    EXPECT_EQ(distances, (std::array<uint8_t, 3>{ 2, 1, 2 }));
+    EXPECT_EQ(values, (std::array<uint8_t, 2>{ 1, 2 }));
+}
+
+TEST(SparseNumKernelTest, EncodeWithWideDominant)
+{
+    std::array<uint16_t, 5> const input = { 1024, 5, 1024, 1024, 6 };
+    uint64_t const dominant             = 1024;
+
+    ZL_SparseNumEncodeInfo const info = ZL_sparseNumComputeEncodeInfo(
+            input.data(), input.size(), sizeof(uint16_t), dominant);
+    ASSERT_EQ(info.numDistances, 2);
+    ASSERT_EQ(info.numValues, 2);
+    ASSERT_EQ(info.distanceWidth, sizeof(uint8_t));
+
+    std::array<uint8_t, 2> distances = {};
+    std::array<uint16_t, 2> values   = {};
+    ZL_sparseNumEncode(
+            distances.data(),
+            values.data(),
+            input.data(),
+            input.size(),
+            sizeof(uint16_t),
+            info.distanceWidth,
+            dominant);
+
+    EXPECT_EQ(distances, (std::array<uint8_t, 2>{ 1, 2 }));
+    EXPECT_EQ(values, (std::array<uint16_t, 2>{ 5, 6 }));
 }
 
 } // namespace


### PR DESCRIPTION
Summary:

Add support for dominant-symbol `sparse_num` encoding and decoding while preserving the existing `sparse_num` encoder node as the zero-dominant entry point.

The wire format remains empty-header zero-dominant for the common case. A non-empty codec header directly stores the dominant symbol as the shortest little-endian byte sequence that represents it, with missing high bytes interpreted as zero and header size limited to the value stream width. The `values` stream always contains literal values only; it is never prefixed by the dominant symbol.

The public encoder surface now has two nodes. `ZL_NODE_SPARSE_NUM` / `!zl.sparse_num` / `nodes::SparseNum` keeps the previous sparse-zero meaning and forces dominant symbol `0`, so it skips auto-detection. `ZL_NODE_SPARSE_NUM_AUTO` / `!zl.sparse_num_auto` / `nodes::SparseNumAuto` auto-detects a dominant symbol from an input prefix unless one is explicitly provided via `ZL_SPARSE_NUM_DOMINANT_VALUE_PID` (`132`). Both nodes emit the same `ZL_StandardTransformID_sparse_num` transform and share the same decoder/wire format.

The decoder validates the compact header, passes a `uint64_t` dominant value into the single decode kernel entry point, and preserves the zero-dominant D8V* fast path internally. UnitBench direct-kernel scenarios were updated for the unified decode signature.

Zero-dominant encode performance was rechecked after keeping the common path specialized. Latest full `unitBench` run: `buck run fbcode//openzl/dev/benchmark/unitBench/scripts:sparse_num_bench -- --sample-mib 2 --duration-s 3`.

| width | zeros | elements | raw | encoded | ratio | encode MiB/s | decode MiB/s |
|---|---:|---:|---:|---:|---:|---:|---:|
| u8 | 75% | 2097100 | 2.00 MiB | 1023.97 KiB | 2.00 | 1118.3 | 1091.9 |
| u8 | 90% | 2097100 | 2.00 MiB | 409.59 KiB | 5.00 | 1247.2 | 2499.6 |
| u8 | 98% | 2097100 | 2.00 MiB | 81.92 KiB | 25.00 | 1320.2 | 12429.8 |
| u16 | 75% | 1048500 | 2.00 MiB | 767.94 KiB | 2.67 | 2222.1 | 2008.1 |
| u16 | 90% | 1048500 | 2.00 MiB | 307.18 KiB | 6.67 | 2397.0 | 5070.6 |
| u16 | 98% | 1048500 | 2.00 MiB | 61.44 KiB | 33.33 | 2564.9 | 23583.2 |
| u32 | 75% | 524200 | 2.00 MiB | 639.89 KiB | 3.20 | 4362.3 | 4284.7 |
| u32 | 90% | 524200 | 2.00 MiB | 255.96 KiB | 8.00 | 4970.6 | 9754.5 |
| u32 | 98% | 524200 | 2.00 MiB | 51.19 KiB | 40.00 | 5304.1 | 35965.2 |
| u64 | 75% | 262100 | 2.00 MiB | 575.90 KiB | 3.56 | 8462.4 | 7768.7 |
| u64 | 90% | 262100 | 2.00 MiB | 230.36 KiB | 8.89 | 9486.1 | 20851.6 |
| u64 | 98% | 262100 | 2.00 MiB | 46.07 KiB | 44.44 | 9840.9 | 48068.9 |

Reviewed By: terrelln

Differential Revision: D106528533
