### PR TITLE
use bdep for SVE2_BITPERM-enabled ZL_bitDeposit64

### DIFF
--- a/src/openzl/shared/bits.h
+++ b/src/openzl/shared/bits.h
@@ -16,6 +16,10 @@
 #    include <immintrin.h>
 #endif
 
+#if ZL_HAS_SVE2_BITPERM
+#    include <arm_sve.h>
+#endif
+
 ZL_BEGIN_C_DECLS
 
 ZL_INLINE bool ZL_32bits(void)
@@ -510,6 +514,11 @@ ZL_INLINE uint64_t ZL_bitDeposit64(uint64_t src, uint64_t mask)
 {
 #if ZL_HAS_BMI2
     return _pdep_u64(src, mask);
+#elif ZL_HAS_SVE2_BITPERM
+    // This is not as terse as the BMI2 instruction because SVE2 BDEP is a
+    // vector instruction
+    return svlastb_u64(
+            svptrue_b64(), svbdep_u64(svdup_n_u64(src), svdup_n_u64(mask)));
 #else
     return ZL_bitDeposit64_fallback(src, mask);
 #endif
@@ -524,6 +533,9 @@ ZL_INLINE uint32_t ZL_bitDeposit32(uint32_t src, uint32_t mask)
 {
 #if ZL_HAS_BMI2
     return _pdep_u32(src, mask);
+#elif ZL_HAS_SVE2_BITPERM
+    return (uint32_t)svlastb_u32(
+            svptrue_b32(), svbdep_u32(svdup_n_u32(src), svdup_n_u32(mask)));
 #else
     return ZL_bitDeposit32_fallback(src, mask);
 #endif

--- a/src/openzl/shared/portability.h
+++ b/src/openzl/shared/portability.h
@@ -110,6 +110,12 @@ ZL_BEGIN_C_DECLS
 #    define ZL_HAS_FEATURE(x) 0
 #endif
 
+#ifdef __has_include
+#    define ZL_HAS_INCLUDE(x) __has_include(x)
+#else
+#    define ZL_HAS_INCLUDE(x) 0
+#endif
+
 #ifndef ZL_ADDRESS_SANITIZER
 #    if ZL_HAS_FEATURE(address_sanitizer)
 #        define ZL_ADDRESS_SANITIZER 1
@@ -275,6 +281,13 @@ ZL_INLINE bool ZL_addressIsPoisoned(const void* ptr)
 #    define ZL_HAS_BMI2 1
 #else
 #    define ZL_HAS_BMI2 0
+#endif
+
+#if defined(__aarch64__) && defined(__ARM_FEATURE_SVE) \
+        && defined(__ARM_FEATURE_SVE2_BITPERM) && ZL_HAS_INCLUDE(<arm_sve.h>)
+#    define ZL_HAS_SVE2_BITPERM 1
+#else
+#    define ZL_HAS_SVE2_BITPERM 0
 #endif
 
 #if defined(__AVX2__)


### PR DESCRIPTION
Summary: x64 BMI has a really nice `pdep` instruction that allows us to not need to do the serial loop implementation. SVE2 finally adds this as well... but only in the BitPerm extension (AVX512 deja-vu??). Fortunately, Neoverse-V2 Grace has it, as does our V3/V4 future.

Differential Revision: D106435321


