### PR TITLE
Extend introspection hooks and sample collection for per-node capture (#805)

### DIFF
--- a/tools/training/sample_collection/introspection_hooks.cpp
+++ b/tools/training/sample_collection/introspection_hooks.cpp
@@ -14,27 +14,31 @@ namespace openzl::training {
 
 using namespace tools::logger;
 
-void UntrainedGraphHook::on_migraphEncode_start(
+void SampleCollectionHook::on_migraphEncode_start(
         ZL_Graph* /* gctx */,
         const ZL_Compressor* compressor,
         ZL_GraphID gid,
         ZL_Edge* inputs[],
         size_t nbInputs)
 {
+    if (targetGraphNames_.empty()) {
+        return;
+    }
+
     std::string graphName = ZL_Compressor_Graph_getName(compressor, gid);
     if (graphName.empty()) {
         throw Exception("Graph name is null!");
     }
 
-    bool isTargetGraph = false;
-    for (const auto& targetGraphName : targetGraphNames_) {
-        if (graphName == targetGraphName) {
-            isTargetGraph = true;
+    bool isTarget = false;
+    for (const auto& target : targetGraphNames_) {
+        if (graphName == target) {
+            isTarget = true;
             break;
         }
     }
 
-    if (!isTargetGraph) {
+    if (!isTarget) {
         return;
     }
 
@@ -44,8 +48,6 @@ void UntrainedGraphHook::on_migraphEncode_start(
             nbInputs,
             graphName.c_str());
 
-    // Each time a graph is called, we should record a separate set of inputs
-    // for that graph.
     auto encodeInputs = MultiInput();
     for (size_t i = 0; i < nbInputs; ++i) {
         if (!inputs[i]) {
@@ -65,8 +67,54 @@ void UntrainedGraphHook::on_migraphEncode_start(
     inputs_[graphName].push_back(std::move(encodeInputs));
 }
 
+void SampleCollectionHook::on_codecEncode_start(
+        ZL_Encoder* /* eictx */,
+        const ZL_Compressor* compressor,
+        ZL_NodeID nid,
+        const ZL_Input* inStreams[],
+        size_t nbInStreams)
+{
+    if (targetNodeNames_.empty()) {
+        return;
+    }
+
+    const char* name = ZL_Compressor_Node_getName(compressor, nid);
+    if (name == nullptr || name[0] == '\0') {
+        return;
+    }
+
+    std::string nodeName(name);
+    bool isTarget = false;
+    for (const auto& target : targetNodeNames_) {
+        if (nodeName == target) {
+            isTarget = true;
+            break;
+        }
+    }
+
+    if (!isTarget) {
+        return;
+    }
+
+    Logger::log_c(
+            VERBOSE1,
+            "Capturing %zu inputs for target node: %s",
+            nbInStreams,
+            nodeName.c_str());
+
+    auto encodeInputs = MultiInput();
+    for (size_t i = 0; i < nbInStreams; ++i) {
+        if (!inStreams[i]) {
+            errorMessage_ = "Node input is null at index " + std::to_string(i);
+            return;
+        }
+        encodeInputs.add(InputCopy(inStreams[i]));
+    }
+    inputs_[nodeName].push_back(std::move(encodeInputs));
+}
+
 const std::map<std::string, std::vector<MultiInput>>&
-UntrainedGraphHook::getInputs() const
+SampleCollectionHook::getInputs() const
 {
     if (!errorMessage_.empty()) {
         Logger::log(ERRORS, "Error message present: ", errorMessage_);

--- a/tools/training/sample_collection/introspection_hooks.h
+++ b/tools/training/sample_collection/introspection_hooks.h
@@ -1,6 +1,7 @@
 // Copyright (c) Meta Platforms, Inc. and affiliates.
 
 #pragma once
+#include <map>
 #include <memory>
 #include <string>
 #include <vector>
@@ -11,28 +12,6 @@
 #include "tools/training/utils/utils.h"
 
 namespace openzl::training {
-class UntrainedGraphHook : public openzl::CompressIntrospectionHooks {
-   public:
-    explicit UntrainedGraphHook(std::vector<std::string> targetGraphNames)
-            : CompressIntrospectionHooks(),
-              targetGraphNames_(std::move(targetGraphNames))
-    {
-    }
-
-    void on_migraphEncode_start(
-            ZL_Graph* gctx,
-            const ZL_Compressor* compressor,
-            ZL_GraphID gid,
-            ZL_Edge* inputs[],
-            size_t nbInputs) override;
-
-    const std::map<std::string, std::vector<MultiInput>>& getInputs() const;
-
-   private:
-    std::vector<std::string> targetGraphNames_;
-    std::map<std::string, std::vector<MultiInput>> inputs_{};
-    std::string errorMessage_{};
-};
 
 class InputCopy : public Input {
    public:
@@ -47,6 +26,43 @@ class InputCopy : public Input {
                         ZL_codemodInputAsData(input)),
                 "Failed to copy input data");
     }
+};
+
+/// Introspection hook that captures inputs flowing into targeted graphs
+/// (via on_migraphEncode_start) and/or targeted codec nodes
+/// (via on_codecEncode_start) in a single compression pass.
+class SampleCollectionHook : public openzl::CompressIntrospectionHooks {
+   public:
+    SampleCollectionHook(
+            std::vector<std::string> targetGraphNames,
+            std::vector<std::string> targetNodeNames)
+            : CompressIntrospectionHooks(),
+              targetGraphNames_(std::move(targetGraphNames)),
+              targetNodeNames_(std::move(targetNodeNames))
+    {
+    }
+
+    void on_migraphEncode_start(
+            ZL_Graph* gctx,
+            const ZL_Compressor* compressor,
+            ZL_GraphID gid,
+            ZL_Edge* inputs[],
+            size_t nbInputs) override;
+
+    void on_codecEncode_start(
+            ZL_Encoder* eictx,
+            const ZL_Compressor* compressor,
+            ZL_NodeID nid,
+            const ZL_Input* inStreams[],
+            size_t nbInStreams) override;
+
+    const std::map<std::string, std::vector<MultiInput>>& getInputs() const;
+
+   private:
+    std::vector<std::string> targetGraphNames_;
+    std::vector<std::string> targetNodeNames_;
+    std::map<std::string, std::vector<MultiInput>> inputs_{};
+    std::string errorMessage_{};
 };
 
 } // namespace openzl::training

--- a/tools/training/sample_collection/training_sample_collector.cpp
+++ b/tools/training/sample_collection/training_sample_collector.cpp
@@ -14,99 +14,90 @@ namespace openzl::training {
 
 using namespace tools::logger;
 
-namespace {
-
-/**
- * Sets up introspection hooks for capturing inputs to an untrained graph node.
- *
- * @param cctx Compression context to attach hooks to
- * @param untrainedGraphName Name of the untrained graph node
- * @return A hook object that can be used to retrieve captured inputs
- */
-UntrainedGraphHook setupIntrospectionHooks(
-        CCtx& cctx,
-        const std::vector<std::string>& untrainedGraphNames)
+std::map<std::string, std::vector<MultiInput>> collectInputStreams(
+        const std::vector<MultiInput>& inputs,
+        const std::vector<std::string>& graphNames,
+        const std::vector<std::string>& nodeNames,
+        CCtx& cctx)
 {
-    UntrainedGraphHook hooks(untrainedGraphNames);
-    ZL_CompressIntrospectionHooks* rawHooks = hooks.getRawHooks();
-    openzl::unwrap(
-            ZL_CCtx_attachIntrospectionHooks(cctx.get(), rawHooks),
-            "Failed to attach introspection hooks",
-            cctx.get());
-    return hooks;
-}
+    if (graphNames.empty() && nodeNames.empty()) {
+        return {};
+    }
 
-/**
- * Processes a single multi-input sample and updates the input streams map.
- *
- * @param input Multi-input sample to process
- * @param cctx Compression context to use
- * @param hooks Hook object to capture inputs from
- * @param inputStreamsPerSampleFilePerGraph Map to update with captured inputs
- */
-void captureInputs(
-        const MultiInput& input,
-        CCtx& cctx,
-        UntrainedGraphHook& hooks,
-        std::map<std::string, std::vector<MultiInput>>& samplesPerGraph)
-{
-    cctx.compress(*input);
-    const auto& captured = hooks.getInputs();
-
-    for (const auto& [graphName, samples] : captured) {
-        auto [it, _] =
-                samplesPerGraph.emplace(graphName, std::vector<MultiInput>());
-        for (auto& sample : samples) {
-            it->second.push_back(sample);
+    // double-check for duplicates
+    {
+        std::unordered_set<std::string> names;
+        for (const auto& graphName : graphNames) {
+            if (names.find(graphName) != names.end()) {
+                throw Exception("Duplicate graph name: " + graphName);
+            }
+            names.insert(graphName);
+        }
+        for (const auto& nodeName : nodeNames) {
+            if (names.find(nodeName) != names.end()) {
+                throw Exception("Duplicate node name: " + nodeName);
+            }
+            names.insert(nodeName);
         }
     }
-}
 
-} // anonymous namespace
+    Logger::log_c(
+            VERBOSE1,
+            "Collecting input streams for %zu graphs and %zu nodes",
+            graphNames.size(),
+            nodeNames.size());
+
+    std::map<std::string, std::vector<MultiInput>> result;
+
+    for (const auto& mi : inputs) {
+        SampleCollectionHook hooks(graphNames, nodeNames);
+        openzl::unwrap(
+                ZL_CCtx_attachIntrospectionHooks(
+                        cctx.get(), hooks.getRawHooks()),
+                "Failed to attach introspection hooks",
+                cctx.get());
+
+        cctx.compress(*mi);
+
+        for (const auto& [name, samples] : hooks.getInputs()) {
+            for (auto& sample : samples) {
+                result[name].push_back(sample);
+            }
+        }
+
+        openzl::unwrap(
+                ZL_CCtx_detachAllIntrospectionHooks(cctx.get()),
+                "Failed to detach introspection hooks",
+                cctx.get());
+    }
+
+    return result;
+}
 
 std::vector<MultiInput> collectInputStreamsForGraph(
         const std::vector<MultiInput>& inputs,
         const std::string& untrainedGraphName,
         CCtx& cctx)
 {
-    auto map =
-            collectInputStreamsForGraphs(inputs, { untrainedGraphName }, cctx);
+    auto map = collectInputStreams(inputs, { untrainedGraphName }, {}, cctx);
     return std::move(map[untrainedGraphName]);
 }
-
-/**
- * Collects input streams from multi-input samples for training multiple
- * unconfigured nodes.
- *
- * @param inputs Set of multi-input samples to process
- * @param untrainedGraphNames Names of the unconfigured graph nodes to train
- * @param cctx Compression context to use for processing samples
- * @return Map from graph name to vector of streams per sample
- */
 
 std::map<std::string, std::vector<MultiInput>> collectInputStreamsForGraphs(
         const std::vector<MultiInput>& inputs,
         const std::vector<std::string>& untrainedGraphNames,
         CCtx& cctx)
 {
-    Logger::log_c(
-            VERBOSE1,
-            "Collecting input streams for %zu graphs",
-            untrainedGraphNames.size());
+    return collectInputStreams(inputs, untrainedGraphNames, {}, cctx);
+}
 
-    std::map<std::string, std::vector<MultiInput>> samplesPerGraph;
-
-    for (const auto& mi : inputs) {
-        auto hooks = setupIntrospectionHooks(cctx, untrainedGraphNames);
-        captureInputs(mi, cctx, hooks, samplesPerGraph);
-    }
-
-    openzl::unwrap(
-            ZL_CCtx_detachAllIntrospectionHooks(cctx.get()),
-            "Failed to detach introspection hooks",
-            cctx.get());
-
-    return samplesPerGraph;
+std::vector<MultiInput> collectInputStreamsForNode(
+        const std::vector<MultiInput>& inputs,
+        const std::string& nodeName,
+        CCtx& cctx)
+{
+    auto map = collectInputStreams(inputs, {}, { nodeName }, cctx);
+    return std::move(map[nodeName]);
 }
 
 } // namespace openzl::training

--- a/tools/training/sample_collection/training_sample_collector.h
+++ b/tools/training/sample_collection/training_sample_collector.h
@@ -10,28 +10,47 @@
 namespace openzl::training {
 
 /**
- * Collects input streams from a set of multi-input samples for training an
- * unconfigured node.
+ * Collects input streams from a set of multi-input samples for training.
  *
- * This function compresses the samples providedusing the provided compression
- * context, and captures the input streams that would be processed by the
- * unconfigured node. These input streams can then be used for training.
+ * This function compresses the samples using the provided compression
+ * context, and captures the input streams that would be processed by
+ * the targeted graphs and codec nodes. These input streams can then
+ * be used for training.
  *
- * @param inputs Multi input samples to process
- * @param untrainedGraphName Name of the unconfigured graph node to train
- * @param cctx Compression context to use for processing samples
- * @return Vector of samples, where each sample is a vector of shared pointers
- * to input streams
+ * Graph targets intercept at graph entry (on_migraphEncode_start).
+ * Node targets intercept at codec entry (on_codecEncode_start).
+ * Both may be specified simultaneously; the results are merged into a
+ * single map keyed by graph name or node name.
+ *
+ * @param inputs        Multi-input samples to compress.
+ * @param graphNames    Names of graphs to capture inputs for (may be empty).
+ * @param nodeNames     Names of codec nodes to capture inputs for (may be
+ *                      empty).
+ * @param cctx          Compression context to use for processing samples.
+ * @return Map from target name (graph or node) to captured samples.
  */
+std::map<std::string, std::vector<MultiInput>> collectInputStreams(
+        const std::vector<MultiInput>& inputs,
+        const std::vector<std::string>& graphNames,
+        const std::vector<std::string>& nodeNames,
+        CCtx& cctx);
 
+/// Convenience: collect input streams for a single graph.
 std::vector<MultiInput> collectInputStreamsForGraph(
         const std::vector<MultiInput>& inputs,
         const std::string& untrainedGraphName,
         CCtx& cctx);
 
+/// Convenience: collect input streams for multiple graphs.
 std::map<std::string, std::vector<MultiInput>> collectInputStreamsForGraphs(
         const std::vector<MultiInput>& inputs,
         const std::vector<std::string>& untrainedGraphNames,
+        CCtx& cctx);
+
+/// Convenience: collect input streams for a single codec node.
+std::vector<MultiInput> collectInputStreamsForNode(
+        const std::vector<MultiInput>& inputs,
+        const std::string& nodeName,
         CCtx& cctx);
 
 } // namespace openzl::training

--- a/tools/training/train.cpp
+++ b/tools/training/train.cpp
@@ -1,7 +1,7 @@
 // Copyright (c) Meta Platforms, Inc. and affiliates.
 
 #include <chrono>
-#include <stdexcept>
+#include <vector>
 
 #include "tools/logger/Logger.h"
 #include "tools/ml_selector/ml_selector_trainer.h"
@@ -73,7 +73,7 @@ std::vector<TrainedCandidate> train(
     std::vector<TrainedCandidate> retval;
     retval.reserve(serializedTrainedCompressors.size());
     for (auto& trainedCompressor : serializedTrainedCompressors) {
-        retval.emplace_back(
+        retval.push_back(
                 TrainedCandidate{ .serializedCompressor =
                                           std::string(*trainedCompressor) });
     }


### PR DESCRIPTION
Summary:

Refactor the introspection hook and sample collection layer to support capturing input streams for individual codec nodes in addition to graphs. This enables dict training, which needs the raw data flowing into specific codec nodes (e.g. zstd) rather than graph-level inputs.

introspection_hooks.h/cpp:
- Rename UntrainedGraphHook to SampleCollectionHook to reflect broader scope.
- Add targetNodeNames_ member and on_codecEncode_start() hook that captures per-node input streams by node name.
- Move InputCopy class above SampleCollectionHook (was below, now used by both hooks).
- Constructor now accepts both targetGraphNames and targetNodeNames.
- Add early-return when the respective target list is empty.

training_sample_collector.h/cpp:
- Add collectInputStreams() as the unified API accepting both graphNames and nodeNames. Hooks are attached per-sample and detached after each compress call for clean isolation.
- Add collectInputStreamsForNode() convenience wrapper.
- Rewrite collectInputStreamsForGraph/ForGraphs as thin wrappers around collectInputStreams.
- Add duplicate name validation (throws on collisions between graph and node names).

train.cpp:
- Replace <stdexcept> with <vector> include.
- Change emplace_back to push_back for TrainedCandidate construction (aggregate init).

Reviewed By: terrelln

Differential Revision: D105006089


