### PR TITLE
Add Arm64 ZL_Vec128 implementation

### DIFF
--- a/src/openzl/codecs/mux_lengths/encode_mux_lengths_kernel.c
+++ b/src/openzl/codecs/mux_lengths/encode_mux_lengths_kernel.c
@@ -7,6 +7,119 @@
 #include "openzl/shared/bits.h"
 #include "openzl/shared/mem.h"
 
+#if ZL_HAS_SVE2_BITPERM
+#    include <arm_sve.h>
+
+static size_t ZL_muxLengthsEncode_2_sve(
+        uint8_t* muxedOut,
+        uint16_t* longOut,
+        const uint16_t* literalLengths,
+        const uint16_t* matchLengths,
+        size_t numElements,
+        unsigned splitPoint,
+        unsigned matchLengthBias)
+{
+    const uint16_t llMask = (uint16_t)((1u << splitPoint) - 1);
+    const uint16_t mlMask = (uint16_t)((1u << (8 - splitPoint)) - 1);
+
+    // Process a full vector worth of u16 lengths per iteration. SVE compact
+    // only supports u32+ element widths, so the mux byte path stays u16 and
+    // each half is widened to u32 for compacting the variable-length longOut
+    // stream.
+    const svuint16_t llMaskV = svdup_n_u16(llMask);
+    const svuint16_t mlMaskV = svdup_n_u16(mlMask);
+    const svuint16_t biasV   = svdup_n_u16((uint16_t)matchLengthBias);
+    const svuint16_t shiftV  = svdup_n_u16((uint16_t)splitPoint);
+
+    // Keep the vector loop to fixed 16-bit lane blocks. That avoids a
+    // per-iteration tail predicate in the hot loop; the final partial block
+    // uses scalar code.
+    const size_t lanes  = svcnth();
+    const size_t end    = numElements - (numElements % lanes);
+    const svbool_t pg   = svptrue_b16();
+    const svbool_t pg32 = svptrue_b32();
+    size_t count        = 0;
+    size_t i            = 0;
+
+    for (; i < end; i += lanes) {
+        // Load ll/ml pairs as u16 lanes:
+        //   ll = [ll0, ll1, ...]
+        //   ml = [ml0, ml1, ...] - matchLengthBias
+        const svuint16_t ll = svld1_u16(pg, literalLengths + i);
+        const svuint16_t ml =
+                svsub_u16_x(pg, svld1_u16(pg, matchLengths + i), biasV);
+
+        // Token lanes are the saturated field values stored in the mux byte:
+        //   llTok = min(ll, llMask)
+        //   mlTok = min(ml, mlMask)
+        // The final byte is llTok | (mlTok << splitPoint). svst1b_u16 writes
+        // only the low byte of each active u16 lane.
+        const svuint16_t llTok = svmin_u16_x(pg, ll, llMaskV);
+        const svuint16_t mlTok = svmin_u16_x(pg, ml, mlMaskV);
+        const svuint16_t mux =
+                svorr_u16_x(pg, llTok, svlsl_u16_x(pg, mlTok, shiftV));
+        svst1b_u16(pg, muxedOut + i, mux);
+
+        // Overflow semantics match the scalar path: a value overflows when it
+        // is >= the mask, and the long stream stores value - mask. Keep mux
+        // generation in u16 lanes, but compute overflow compaction directly in
+        // u32 halves to avoid b16 predicate unpack/flag conversion.
+        // TODO: this whole widening loop can be avoided if svcompact_u16
+        // existed. It's coming to GCC, so any day now...
+#    define ZL_MUX_LENGTHS_COMPACT_HALF(ll32, ml32)                         \
+        do {                                                                \
+            const svbool_t llOverflow = svcmpge_n_u32(pg32, ll32, llMask);  \
+            const svbool_t mlOverflow = svcmpge_n_u32(pg32, ml32, mlMask);  \
+            const svuint32_t llExtra  = svsub_n_u32_x(pg32, ll32, llMask);  \
+            const svuint32_t mlExtra  = svsub_n_u32_x(pg32, ml32, mlMask);  \
+            const svuint32_t extra01  = svzip1_u32(llExtra, mlExtra);       \
+            const svuint32_t extra23  = svzip2_u32(llExtra, mlExtra);       \
+            const svbool_t overflow01 = svzip1_b32(llOverflow, mlOverflow); \
+            const svbool_t overflow23 = svzip2_b32(llOverflow, mlOverflow); \
+            svst1h_u32(                                                     \
+                    pg32,                                                   \
+                    longOut + count,                                        \
+                    svcompact_u32(overflow01, extra01));                    \
+            count += svcntp_b32(pg32, overflow01);                          \
+            svst1h_u32(                                                     \
+                    pg32,                                                   \
+                    longOut + count,                                        \
+                    svcompact_u32(overflow23, extra23));                    \
+            count += svcntp_b32(pg32, overflow23);                          \
+        } while (0)
+
+        ZL_MUX_LENGTHS_COMPACT_HALF(svunpklo_u32(ll), svunpklo_u32(ml));
+        ZL_MUX_LENGTHS_COMPACT_HALF(svunpkhi_u32(ll), svunpkhi_u32(ml));
+#    undef ZL_MUX_LENGTHS_COMPACT_HALF
+    }
+
+    // Scalar tail for elements that do not fit in a full SVE block.
+    for (; i < numElements; ++i) {
+        const uint16_t ll = literalLengths[i];
+        const uint16_t ml = matchLengths[i] - (uint16_t)matchLengthBias;
+        uint8_t mux       = 0;
+
+        if (ll >= llMask) {
+            mux              = (uint8_t)llMask;
+            longOut[count++] = (uint16_t)(ll - llMask);
+        } else {
+            mux = (uint8_t)ll;
+        }
+
+        if (ml >= mlMask) {
+            mux |= (uint8_t)(mlMask << splitPoint);
+            longOut[count++] = (uint16_t)(ml - mlMask);
+        } else {
+            mux |= (uint8_t)(ml << splitPoint);
+        }
+
+        muxedOut[i] = mux;
+    }
+
+    return count;
+}
+#endif /* ZL_HAS_SVE2_BITPERM */
+
 #if ZL_HAS_AVX2
 
 static size_t ZL_muxLengthsEncode_2(
@@ -274,7 +387,18 @@ size_t ZL_muxLengthsEncode(
     ZL_ASSERT_LE(splitPoint, 8);
     ZL_ASSERT_LE(matchLengthBias, 15);
 
-#if ZL_HAS_AVX2
+#if ZL_HAS_SVE2_BITPERM
+    if (eltWidth == 2) {
+        return ZL_muxLengthsEncode_2_sve(
+                muxedOut,
+                (uint16_t*)longOut,
+                (const uint16_t*)literalLengths,
+                (const uint16_t*)matchLengths,
+                numElements,
+                splitPoint,
+                matchLengthBias);
+    }
+#elif ZL_HAS_AVX2
     if (eltWidth == 2) {
         return ZL_muxLengthsEncode_2(
                 muxedOut,

--- a/src/openzl/codecs/mux_lengths/encode_mux_lengths_kernel.h
+++ b/src/openzl/codecs/mux_lengths/encode_mux_lengths_kernel.h
@@ -10,7 +10,7 @@
 ZL_BEGIN_C_DECLS
 
 /// Need at least this many elements
-#define ZL_MUX_LONG_SLOP_ELTS 16
+#define ZL_MUX_LONG_SLOP_ELTS 128
 
 /// Encode literal lengths and match lengths into muxed bytes with overflow.
 ///

--- a/src/openzl/shared/simd_wrapper.h
+++ b/src/openzl/shared/simd_wrapper.h
@@ -12,6 +12,12 @@
 
 #if ZL_ARCH_X86_64
 #    include <emmintrin.h>
+#elif ZL_ARCH_ARM64
+#    include <arm_neon.h>
+#    if ZL_HAS_SVE2_BITPERM
+#        include <arm_neon_sve_bridge.h>
+#        include <arm_sve.h>
+#    endif
 #endif
 #ifdef __AVX2__
 #    include <immintrin.h>
@@ -106,6 +112,56 @@ ZL_INLINE ZL_Vec128 ZL_Vec128_and(ZL_Vec128 x, ZL_Vec128 y)
 ZL_INLINE ZL_VecMask ZL_Vec128_mask8(ZL_Vec128 v)
 {
     return (ZL_VecMask)_mm_movemask_epi8(v);
+}
+
+#elif ZL_ARCH_ARM64
+
+typedef uint8x16_t ZL_Vec128;
+
+ZL_INLINE ZL_Vec128 ZL_Vec128_read(void const* ptr)
+{
+    return vld1q_u8((uint8_t const*)ptr);
+}
+
+ZL_INLINE void ZL_Vec128_write(void* ptr, ZL_Vec128 v)
+{
+    vst1q_u8((uint8_t*)ptr, v);
+}
+
+ZL_INLINE ZL_Vec128 ZL_Vec128_set8(uint8_t val)
+{
+    return vdupq_n_u8(val);
+}
+
+ZL_INLINE ZL_Vec128 ZL_Vec128_cmp8(ZL_Vec128 x, ZL_Vec128 y)
+{
+    return vceqq_u8(x, y);
+}
+
+ZL_INLINE ZL_Vec128 ZL_Vec128_and(ZL_Vec128 x, ZL_Vec128 y)
+{
+    return vandq_u8(x, y);
+}
+
+ZL_INLINE ZL_VecMask ZL_Vec128_mask8(ZL_Vec128 v)
+{
+#    if ZL_HAS_SVE2_BITPERM
+    uint64x2_t const neon64 = vreinterpretq_u64_u8(v);
+    svuint64_t const sve64  = svset_neonq_u64(svundef_u64(), neon64);
+    svuint64_t const mask64 =
+            svbext_u64(sve64, svdup_n_u64(0x8080808080808080ULL));
+    uint64x2_t const out64 = svget_neonq_u64(mask64);
+    return (ZL_VecMask)vgetq_lane_u64(out64, 0)
+            | ((ZL_VecMask)vgetq_lane_u64(out64, 1) << 8);
+#    else
+    static uint8_t const weights[16] = { 1, 2, 4, 8, 16, 32, 64, 128,
+                                         1, 2, 4, 8, 16, 32, 64, 128 };
+    uint8x16_t const highBits        = vshrq_n_u8(v, 7);
+    uint8x16_t const weighted        = vmulq_u8(highBits, vld1q_u8(weights));
+    uint8_t const loAcc              = vaddv_u8(vget_low_u8(weighted));
+    uint8_t const hiAcc              = vaddv_u8(vget_high_u8(weighted));
+    return (ZL_VecMask)loAcc | ((ZL_VecMask)hiAcc << 8);
+#    endif
 }
 
 #else


### PR DESCRIPTION
Summary:
Add an Arm64 implementation of the 128-bit SIMD wrapper using NEON for the common vector operations: unaligned reads/writes, byte splats, byte equality compares, bitwise AND, and byte-mask extraction.

For `ZL_HAS_SVE2_BITPERM` builds, implement `ZL_Vec128_mask8()` with the NEON/SVE bridge and `svbext` to extract the byte high bits efficiently. For non-SVE2 Arm64 builds, use a NEON fallback that weights and horizontally sums the high bits into the same `ZL_VecMask` layout used by the x86 path.

*ASIDE:* The whole Vec128 utility is not very ARM-friendly. It pre-supposes the AVX primitives, meaning code that may otherwise have a simple SVE spelling needs to contort itself around the AVX way of doing things. It might be worth considering doing away with it entirely and/or rewriting it in terms of what actually needs to be computed (match lengths, vectorized boolean logic, etc).

Reviewed By: terrelln

Differential Revision: D107441580


