### PR TITLE
Enable Pyrefly in fbcode/openzl

### DIFF
--- a/benchmark/runner/zstrong_gbenchmarks.py
+++ b/benchmark/runner/zstrong_gbenchmarks.py
@@ -228,6 +228,7 @@ class ZstrongGoogleBenchmarkResults:
         return cls.from_scuba("zstrong_benchmarks", "raw", filters={"run_id": run_id})
 
     def to_markdown(self) -> str:
+        # pyrefly: ignore [missing-attribute]
         md = self.results.to_markdown(showindex=False).replace("|:--", "|---")
         if md is None:
             raise RuntimeError("Unable to create markdown, tabulate might be missing")
@@ -462,5 +463,7 @@ class ZstrongGoogleBenchmarkRunner:
                 result = result.append(curr_result)
             else:
                 result = curr_result
+        # pyrefly: ignore [missing-attribute]
         result.set_timestamp()
+        # pyrefly: ignore [bad-return]
         return result


### PR DESCRIPTION
Summary:
Automated migration to enable Pyrefly type checking for `fbcode/openzl`.

- Added `python.set_pyrefly(True)` to PACKAGE file
- Suppressed pre-existing type errors

Pyrefly is Meta's next-generation Python type checker, replacing Pyre.

If you encounter issues, you can revert the PACKAGE change by removing
the `python.set_pyrefly(True)` line.
#pyreupgrade

Differential Revision: D108312605


