### PR TITLE
Add ZL_UniqueID to/from U16/U32/U64 helpers

### DIFF
--- a/include/openzl/zl_errors.h
+++ b/include/openzl/zl_errors.h
@@ -12,6 +12,7 @@
 
 #include <assert.h>
 #include <stddef.h> // size_t
+#include <stdint.h>
 
 #include "openzl/zl_common_types.h"  // ZL_VoidPtr, ZL_ConstVoidPtr
 #include "openzl/zl_errors_types.h"  // ZL_ErrorCode
@@ -198,6 +199,10 @@ ZL_RESULT_DECLARE_TYPE(ZL_GraphID);
 ZL_RESULT_DECLARE_TYPE(ZL_NodeID);
 ZL_RESULT_DECLARE_TYPE(ZL_VoidPtr);
 ZL_RESULT_DECLARE_TYPE(ZL_ConstVoidPtr);
+
+ZL_RESULT_DECLARE_TYPE(uint16_t);
+ZL_RESULT_DECLARE_TYPE(uint32_t);
+ZL_RESULT_DECLARE_TYPE(uint64_t);
 
 /*-*********************************************
  *  ZL_Report type

--- a/include/openzl/zl_unique_id.h
+++ b/include/openzl/zl_unique_id.h
@@ -5,7 +5,9 @@
 
 #include <stdbool.h>
 #include <stddef.h>
+#include <stdint.h>
 
+#include "openzl/zl_errors.h"
 #include "openzl/zl_opaque_types.h"
 
 #if defined(__cplusplus)
@@ -57,6 +59,31 @@ ZL_UniqueID ZL_UniqueID_computeSHA256(const void* data, size_t size);
  * trailing zero bytes can be omitted.
  */
 size_t ZL_UniqueID_significantBytes(const ZL_UniqueID* id);
+
+/**
+ * Create a ZL_UniqueID from a 16-bit integer, stored in little-endian byte
+ * order. Bytes 2-31 are zeroed.
+ */
+ZL_UniqueID ZL_UniqueID_fromU16(uint16_t value);
+
+/**
+ * Create a ZL_UniqueID from a 32-bit integer, stored in little-endian byte
+ * order. Bytes 4-31 are zeroed.
+ */
+ZL_UniqueID ZL_UniqueID_fromU32(uint32_t value);
+
+/**
+ * Create a ZL_UniqueID from a 64-bit integer, stored in little-endian byte
+ * order. Bytes 8-31 are zeroed.
+ */
+ZL_UniqueID ZL_UniqueID_fromU64(uint64_t value);
+
+/**
+ * Inverse of the fromXYZ functions. Returns error if parsing fails.
+ */
+ZL_RESULT_OF(uint16_t) ZL_UniqueID_toU16(const ZL_UniqueID* id);
+ZL_RESULT_OF(uint32_t) ZL_UniqueID_toU32(const ZL_UniqueID* id);
+ZL_RESULT_OF(uint64_t) ZL_UniqueID_toU64(const ZL_UniqueID* id);
 
 #if defined(__cplusplus)
 } // extern "C"

--- a/src/openzl/common/unique_id.c
+++ b/src/openzl/common/unique_id.c
@@ -5,6 +5,7 @@
 #include <string.h>
 
 #include "openzl/common/sha256.h"
+#include "openzl/shared/mem.h" // ZL_writeLE16, ZL_writeLE32, ZL_writeLE64
 #include "openzl/shared/xxhash.h"
 
 void ZL_UniqueID_write(void* dst, const ZL_UniqueID* id)
@@ -69,4 +70,61 @@ size_t ZL_UniqueID_significantBytes(const ZL_UniqueID* id)
         }
     }
     return 0;
+}
+
+ZL_UniqueID ZL_UniqueID_fromU16(uint16_t value)
+{
+    ZL_UniqueID id;
+    memset(id.bytes, 0, sizeof(id.bytes));
+    ZL_writeLE16(id.bytes, value);
+    return id;
+}
+
+ZL_UniqueID ZL_UniqueID_fromU32(uint32_t value)
+{
+    ZL_UniqueID id;
+    memset(id.bytes, 0, sizeof(id.bytes));
+    ZL_writeLE32(id.bytes, value);
+    return id;
+}
+
+ZL_UniqueID ZL_UniqueID_fromU64(uint64_t value)
+{
+    ZL_UniqueID id;
+    memset(id.bytes, 0, sizeof(id.bytes));
+    ZL_writeLE64(id.bytes, value);
+    return id;
+}
+
+ZL_RESULT_OF(uint16_t) ZL_UniqueID_toU16(const ZL_UniqueID* id)
+{
+    ZL_RESULT_DECLARE_SCOPE(uint16_t, NULL);
+    ZL_ERR_IF_GT(
+            ZL_UniqueID_significantBytes(id),
+            sizeof(uint16_t),
+            GENERIC,
+            "ZL_UniqueID_toU16: id is not a 16-bit value");
+    return ZL_WRAP_VALUE(ZL_readLE16(id->bytes));
+}
+
+ZL_RESULT_OF(uint32_t) ZL_UniqueID_toU32(const ZL_UniqueID* id)
+{
+    ZL_RESULT_DECLARE_SCOPE(uint32_t, NULL);
+    ZL_ERR_IF_GT(
+            ZL_UniqueID_significantBytes(id),
+            sizeof(uint32_t),
+            GENERIC,
+            "ZL_UniqueID_toU32: id is not a 32-bit value");
+    return ZL_WRAP_VALUE(ZL_readLE32(id->bytes));
+}
+
+ZL_RESULT_OF(uint64_t) ZL_UniqueID_toU64(const ZL_UniqueID* id)
+{
+    ZL_RESULT_DECLARE_SCOPE(uint64_t, NULL);
+    ZL_ERR_IF_GT(
+            ZL_UniqueID_significantBytes(id),
+            sizeof(uint64_t),
+            GENERIC,
+            "ZL_UniqueID_toU64: id is not a 64-bit value");
+    return ZL_WRAP_VALUE(ZL_readLE64(id->bytes));
 }

--- a/src/openzl/shared/varint.h
+++ b/src/openzl/shared/varint.h
@@ -120,8 +120,6 @@ ZL_FORCE_INLINE size_t ZL_varintEncode64Fast(uint64_t value, uint8_t* const dst)
 #endif
 }
 
-ZL_RESULT_DECLARE_TYPE(uint64_t);
-
 ZL_INLINE ZL_RESULT_OF(uint64_t)
         ZL_varintDecode(const uint8_t** src, const uint8_t* end)
 {

--- a/tests/unittest/common/UniqueIDTest.cpp
+++ b/tests/unittest/common/UniqueIDTest.cpp
@@ -5,6 +5,7 @@
 #include <string>
 
 #include "openzl/zl_unique_id.h"
+#include "tests/datagen/DataGen.h"
 
 #include "sha_vec.h"
 
@@ -12,7 +13,7 @@ using namespace ::testing;
 
 namespace openzl::tests {
 
-TEST(Sha256Test, Validity)
+TEST(UniqueIDTest, Validity)
 {
     ZL_UniqueID zero1;
     for (size_t i = 0; i < 32; ++i) {
@@ -36,7 +37,7 @@ TEST(Sha256Test, Validity)
     ASSERT_FALSE(ZL_UniqueID_isValid(nullptr));
 }
 
-TEST(Sha256Test, SanityCheck)
+TEST(UniqueIDTest, SanityCheck)
 {
     std::vector<std::string_view> inputs = {
         "",
@@ -66,7 +67,7 @@ TEST(Sha256Test, SanityCheck)
     }
 }
 
-TEST(Sha256Test, NISTVectors)
+TEST(UniqueIDTest, NISTVectors)
 {
     for (size_t i = 0; i < NIST_testVectorSet.nbVectors; ++i) {
         ZL_UniqueID expected;
@@ -75,6 +76,64 @@ TEST(Sha256Test, NISTVectors)
                 NIST_testVectorSet.vectors[i].input,
                 NIST_testVectorSet.vectors[i].inputLen);
         ASSERT_TRUE(ZL_UniqueID_eq(&actual, &expected));
+    }
+}
+
+TEST(UniqueIDTest, SignificantBytes)
+{
+    ZL_UniqueID zero = ZL_UniqueID_zero();
+    EXPECT_EQ(ZL_UniqueID_significantBytes(&zero), 0u);
+
+    // Single byte at position 0
+    ZL_UniqueID one = ZL_UniqueID_fromU32(0x00000042);
+    EXPECT_EQ(ZL_UniqueID_significantBytes(&one), 1u);
+
+    // Non-zero bytes 0-1
+    ZL_UniqueID two = ZL_UniqueID_fromU16(UINT16_MAX);
+    EXPECT_EQ(ZL_UniqueID_significantBytes(&two), 2u);
+
+    // Non-zero at position 4 (bytes 0-4 significant, 5-31 zero)
+    ZL_UniqueID five = ZL_UniqueID_fromU64(0x0100000000);
+    EXPECT_EQ(ZL_UniqueID_significantBytes(&five), 5u);
+
+    // Non-zero byte at the very end
+    ZL_UniqueID full = ZL_UniqueID_zero();
+    full.bytes[31]   = 0xFF;
+    EXPECT_EQ(ZL_UniqueID_significantBytes(&full), 32u);
+
+    // Sparse: bytes 0 and 3 non-zero, rest zero
+    ZL_UniqueID sparse = ZL_UniqueID_fromU32(0x02000001);
+    EXPECT_EQ(ZL_UniqueID_significantBytes(&sparse), 4u);
+}
+
+TEST(UniqueIDTest, IntRoundtrip)
+{
+    datagen::DataGen dg;
+    std::vector<uint16_t> input16 =
+            dg.randVector<uint16_t>("uint16s", 0, UINT16_MAX, 1000);
+    for (auto i : input16) {
+        ZL_UniqueID id = ZL_UniqueID_fromU16(i);
+        auto r16       = ZL_UniqueID_toU16(&id);
+        ASSERT_FALSE(ZL_RES_isError(r16));
+        ASSERT_EQ(ZL_RES_value(r16), i);
+    }
+
+    std::vector<uint32_t> input32 =
+            dg.randVector<uint32_t>("uint32s", 0, UINT32_MAX, 1000);
+    for (auto i : input32) {
+        ZL_UniqueID id = ZL_UniqueID_fromU32(i);
+        auto r32       = ZL_UniqueID_toU32(&id);
+        ASSERT_FALSE(ZL_RES_isError(r32));
+        ASSERT_EQ(ZL_RES_value(r32), i);
+    }
+
+    std::vector<uint64_t> input64 =
+            dg.randVector<uint64_t>("uint64s", 0, UINT64_MAX, 1000);
+    for (auto i : input64) {
+        ZL_UniqueID id = ZL_UniqueID_fromU64(i);
+        auto r64       = ZL_UniqueID_toU64(&id);
+        ASSERT_FALSE(ZL_RES_isError(r64));
+        ASSERT_EQ(ZL_RES_value(r64), i);
     }
 }
 


### PR DESCRIPTION
Summary:
Add utility functions to ZL_UniqueID for constructing IDs from integer
values and computing their minimal wire representation:

- ZL_UniqueID_significantBytes: returns the 1-based position of the last
  non-zero byte, useful for variable-length serialization where trailing
  zero bytes can be omitted.
- ZL_UniqueID_fromU16/fromU32/fromU64: construct a ZL_UniqueID from an
  integer stored in little-endian byte order, with remaining bytes zeroed.
  Uses existing ZL_writeLE16/32/64 helpers from mem.h.

Also adds unit tests covering all new functions (zero, boundary values,
little-endian byte ordering, significantBytes for sparse IDs).

Note: we expect to use this to generate properly-formed IDs for managed compression

Reviewed By: terrelln

Differential Revision: D102890012


