### PR TITLE
Model A Eval: Resolve fuzzer timeouts

### DIFF
--- a/tests/version/VersionTestInterface.cpp
+++ b/tests/version/VersionTestInterface.cpp
@@ -69,8 +69,24 @@ VersionTestInterface::VersionTestInterface(
 
     nodeCustomDataCache_  = {};
     graphCustomDataCache_ = {};
-    nodes_                = getAllNodes();
-    graphs_               = getAllGraphs();
+}
+
+std::vector<Node> const& VersionTestInterface::nodes()
+{
+    if (!nodesInitialized_) {
+        nodes_            = getAllNodes();
+        nodesInitialized_ = true;
+    }
+    return nodes_;
+}
+
+std::vector<Graph> const& VersionTestInterface::graphs()
+{
+    if (!graphsInitialized_) {
+        graphs_            = getAllGraphs();
+        graphsInitialized_ = true;
+    }
+    return graphs_;
 }
 
 unsigned VersionTestInterface::majorVersion() const

--- a/tests/version/VersionTestInterface.h
+++ b/tests/version/VersionTestInterface.h
@@ -158,14 +158,8 @@ class VersionTestInterface {
     unsigned minFormatVersion() const;
     unsigned maxFormatVersion() const;
 
-    std::vector<Node> const& nodes() const
-    {
-        return nodes_;
-    }
-    std::vector<Graph> const& graphs() const
-    {
-        return graphs_;
-    }
+    std::vector<Node> const& nodes();
+    std::vector<Graph> const& graphs();
 
     /// @returns custom data for the given node, if any exists
     const std::vector<CustomData>& customData(NodeID node);
@@ -263,6 +257,8 @@ class VersionTestInterface {
     };
     std::unique_ptr<void, DlcloseDeleter> handle_;
     VTable vtable_;
+    bool nodesInitialized_{ false };
+    bool graphsInitialized_{ false };
     std::vector<Node> nodes_;
     std::vector<Graph> graphs_;
     std::map<NodeID, std::vector<CustomData>> nodeCustomDataCache_;


### PR DESCRIPTION
Summary:
Addresses failure: https://www.internalfb.com/intern/test/844425255859808

The `VersionTestInterface` calls `getAllNodes()` and `getAllGraphs()`, which is expensive, possibly causing test to fail due to timeouts. Instead, initialize nodes and graphs lazily when actually used.

Note: I am not 100% confident about the change because I don't know exactly how to reproduce sandcastle failures, but it looks right to me.

Reviewed By: terrelln

Differential Revision: D108913020


