### PR TITLE
Expose protobuf CLI training and compression tuning flags

### DIFF
--- a/tools/protobuf/ProtoSerializer.h
+++ b/tools/protobuf/ProtoSerializer.h
@@ -30,6 +30,11 @@ class ProtoSerializer {
         cctx_.refCompressor(compressor_);
     }
 
+    void setCompressionLevel(int level)
+    {
+        cctx_.setParameter(CParam::CompressionLevel, level);
+    }
+
     Compressor* getCompressor()
     {
         return &compressor_;

--- a/tools/protobuf/cli.cpp
+++ b/tools/protobuf/cli.cpp
@@ -49,6 +49,10 @@ std::string kProto       = "proto";
 std::string kDescriptor  = "descriptor";
 std::string kProtoPath   = "proto-path";
 std::string kMessageType = "message-type";
+std::string kCompressionLevel = "compression-level";
+std::string kTrainer          = "trainer";
+std::string kThreads          = "threads";
+std::string kMaxTimeSecs      = "max-time-secs";
 
 enum Cmd : int {
     UNSPECIFIED = 0,
@@ -94,6 +98,18 @@ std::string ext(Protocol protocol)
             return "json";
     }
     throw std::runtime_error("Invalid protocol!");
+}
+
+training::ClusteringTrainer parseTrainer(const std::string& trainer)
+{
+    if (trainer == "greedy") {
+        return training::ClusteringTrainer::Greedy;
+    } else if (trainer == "bottom-up") {
+        return training::ClusteringTrainer::BottomUp;
+    } else if (trainer == "full-split") {
+        return training::ClusteringTrainer::FullSplit;
+    }
+    throw std::runtime_error("Unrecognized trainer: " + trainer);
 }
 
 /**
@@ -190,6 +206,10 @@ class BenchmarkArgs : public Args {
             numIters =
                     std::stoi(args.cmdFlag(Cmd::BENCHMARK, kNumIters).value());
         }
+        if (args.cmdHasFlag(Cmd::BENCHMARK, kCompressionLevel)) {
+            serializer.setCompressionLevel(std::stoi(
+                    args.cmdFlag(Cmd::BENCHMARK, kCompressionLevel).value()));
+        }
     }
 
     size_t numIters = 10;
@@ -204,6 +224,10 @@ class SerializeArgs : public Args {
 
         check  = args.cmdHasFlag(Cmd::SERIALIZE, kCheck);
         output = args.cmdFlag(Cmd::SERIALIZE, kOutput);
+        if (args.cmdHasFlag(Cmd::SERIALIZE, kCompressionLevel)) {
+            serializer.setCompressionLevel(std::stoi(
+                    args.cmdFlag(Cmd::SERIALIZE, kCompressionLevel).value()));
+        }
     }
 
     Protocol outputType;
@@ -217,8 +241,21 @@ class TrainArgs : public Args {
     {
         output = std::make_unique<tools::io::OutputFile>(
                 args.cmdRequiredFlag(Cmd::TRAIN, kOutput));
+        if (args.cmdHasFlag(Cmd::TRAIN, kTrainer)) {
+            trainParams.clusteringTrainer =
+                    parseTrainer(args.cmdFlag(Cmd::TRAIN, kTrainer).value());
+        }
+        if (args.cmdHasFlag(Cmd::TRAIN, kThreads)) {
+            trainParams.threads =
+                    std::stoul(args.cmdFlag(Cmd::TRAIN, kThreads).value());
+        }
+        if (args.cmdHasFlag(Cmd::TRAIN, kMaxTimeSecs)) {
+            trainParams.maxTimeSecs =
+                    std::stoul(args.cmdFlag(Cmd::TRAIN, kMaxTimeSecs).value());
+        }
     }
     std::unique_ptr<tools::io::OutputFile> output;
+    training::TrainParams trainParams;
 };
 
 void updateResults(
@@ -364,7 +401,7 @@ int handleTrain(TrainArgs args)
 
     auto compressor = args.serializer.getCompressor();
 
-    auto params = training::TrainParams();
+    auto params = args.trainParams;
     params.compressorGenFunc =
             openzl::custom_parsers::createCompressorFromSerialized;
 
@@ -443,6 +480,12 @@ int main(int argc, char** argv)
             'c',
             false,
             "Check if serialization round trip is correct.");
+    parser.addCommandFlag(
+            Cmd::SERIALIZE,
+            kCompressionLevel,
+            'l',
+            true,
+            "OpenZL compression level to use for ZL serialization.");
 
     // benchmark
     parser.addCommand(Cmd::BENCHMARK, "benchmark", 'b');
@@ -452,6 +495,12 @@ int main(int argc, char** argv)
             'n',
             true,
             "The number of iterations to run for each file.");
+    parser.addCommandFlag(
+            Cmd::BENCHMARK,
+            kCompressionLevel,
+            'l',
+            true,
+            "OpenZL compression level to use for ZL serialization.");
 
     // train
     parser.addCommand(Cmd::TRAIN, "train", 't');
@@ -461,6 +510,24 @@ int main(int argc, char** argv)
             'o',
             true,
             "The output trained compressor file");
+    parser.addCommandFlag(
+            Cmd::TRAIN,
+            kTrainer,
+            0,
+            true,
+            "The trainer to use for training (greedy|bottom-up|full-split).");
+    parser.addCommandFlag(
+            Cmd::TRAIN,
+            kThreads,
+            0,
+            true,
+            "Number of training worker threads.");
+    parser.addCommandFlag(
+            Cmd::TRAIN,
+            kMaxTimeSecs,
+            0,
+            true,
+            "Maximum training time in seconds.");
 
     auto args = parser.parse(argc, argv);
 


### PR DESCRIPTION
# Expose protobuf CLI training and compression tuning flags

## Summary

This PR exposes a few existing protobuf CLI tuning knobs so `protobuf_cli` can be used for reproducible benchmarking and compression tuning:

- `serialize --compression-level <level>`
- `benchmark --compression-level <level>`
- `train --trainer greedy|bottom-up|full-split`
- `train --threads <n>`
- `train --max-time-secs <seconds>`

The default behavior is unchanged when these flags are not provided.

## Motivation

The protobuf CLI already supports training and serializing protobuf payloads, but several important tuning parameters were only reachable from code defaults. That makes it hard to compare OpenZL behavior across compression levels, trainer choices, thread counts, or bounded training budgets.

These flags are useful for:

- benchmarking OpenZL against other compressors with controlled compression levels;
- comparing OpenZL trainers on the same dataset;
- making training faster or more predictable with `--threads`;
- preventing long-running training jobs with `--max-time-secs`;
- improving reproducibility of CLI-based experiments.

## Changes

### Compression level

Adds `ProtoSerializer::setCompressionLevel(int level)`, which forwards to:

```cpp
cctx_.setParameter(CParam::CompressionLevel, level);
```

The protobuf CLI now applies this setting for:

```bash
protobuf_cli serialize ... --compression-level 9
protobuf_cli benchmark ... --compression-level 9
```

### Trainer selection

Adds CLI parsing for the existing `training::ClusteringTrainer` variants:

```bash
protobuf_cli train ... --trainer greedy
protobuf_cli train ... --trainer bottom-up
protobuf_cli train ... --trainer full-split
```

### Training controls

Adds CLI flags that map to existing `training::TrainParams` fields:

```bash
protobuf_cli train ... --threads 8
protobuf_cli train ... --max-time-secs 120
```

## Backward Compatibility

All new flags are optional.

Existing invocations continue to use the same defaults as before:

- default serializer compression behavior is unchanged;
- default trainer selection remains unchanged;
- default training thread/time behavior remains unchanged.

No serialization format changes are introduced.

## Example

```bash
protobuf_cli train \
  --descriptor schema.desc \
  --message-type my.package.Message \
  --input train \
  --output trained.zlc \
  --trainer greedy \
  --threads 8 \
  --max-time-secs 300

protobuf_cli serialize \
  --descriptor schema.desc \
  --message-type my.package.Message \
  --input message.binpb \
  --output message.zl \
  --compressor trained.zlc \
  --compression-level 9
```

## Testing

Built `protobuf_cli` successfully with:

```bash
cmake \
  -S . \
  -B build \
  -DCMAKE_BUILD_TYPE=Release \
  -DOPENZL_BUILD_PROTOBUF_TOOLS=ON

cmake --build build --target protobuf_cli -j 8
```
