### PR TITLE
dict training deduplication and bundle info

### DIFF
--- a/src/openzl/compress/compressor_serialization.c
+++ b/src/openzl/compress/compressor_serialization.c
@@ -2431,9 +2431,21 @@ static ZL_Report ZL_CompressorDeserializer_tryBuildNode(
         dictID                          = decoded_dict_id;
     }
 
+    // Preserve the node's registered name prefix (e.g. "zl.trainable.zstd")
+    // across the round-trip. Without an explicit name the framework would
+    // derive the name from the base node's prefix, dropping any custom name
+    // the node carried (which downstream consumers, such as dict training,
+    // rely on to identify nodes). The serialized key is the node's unique
+    // name ("prefix#id"); strip the "#id" fragment to recover the prefix.
+    ZL_TRY_LET_CONST(
+            StringView,
+            node_name_prefix,
+            mk_sv_strip_name_fragment(state->arena, ser_name_unterm));
+
     const ZL_NodeID node_id = ZL_Compressor_registerParameterizedNode(
             compressor,
             &(const ZL_ParameterizedNodeDesc){
+                    .name        = node_name_prefix.data,
                     .node        = base_nid,
                     .localParams = &local_params,
                     .dictID      = dictID,

--- a/tools/training/dict/base_dict_trainer.cpp
+++ b/tools/training/dict/base_dict_trainer.cpp
@@ -2,6 +2,8 @@
 
 #include "tools/training/dict/base_dict_trainer.h"
 
+#include <cstring>
+#include <set>
 #include <vector>
 
 #include "openzl/compress/cgraph.h"
@@ -28,6 +30,16 @@ std::vector<std::unique_ptr<DictTrainer>> createAllTrainers()
     return trainers;
 }
 
+/// ZL_DictID is a plain C struct with no operator<, so std::set needs an
+/// explicit comparator. The ID is a fixed 32-byte value; compare it bytewise.
+struct DictIDCmp {
+    bool operator()(const ZL_DictID& lhs, const ZL_DictID& rhs) const noexcept
+    {
+        return std::memcmp(lhs.id.bytes, rhs.id.bytes, sizeof(lhs.id.bytes))
+                < 0;
+    }
+};
+
 } // anonymous namespace
 
 TrainedCandidate trainDictsForCandidate(
@@ -35,14 +47,22 @@ TrainedCandidate trainDictsForCandidate(
         Compressor& compressor,
         const TrainParams& trainParams)
 {
+    auto trainers = createAllTrainers();
+    return trainDictsForCandidate(inputs, compressor, trainParams, trainers);
+}
+
+TrainedCandidate trainDictsForCandidate(
+        const std::vector<MultiInput>& inputs,
+        Compressor& compressor,
+        const TrainParams& trainParams,
+        const std::vector<std::unique_ptr<DictTrainer>>& trainers)
+{
     (void)trainParams;
 
     TrainedCandidate candidate;
     candidate.serializedCompressor = compressor.serialize();
 
     // Ask each registered trainer to find its dict-requiring nodes.
-    auto trainers = createAllTrainers();
-
     struct TrainerWork {
         DictTrainer* trainer;
         DictNodeInfo node;
@@ -76,6 +96,7 @@ TrainedCandidate trainDictsForCandidate(
     auto cctx           = refCCtxForTraining(compressor);
     auto samplesPerNode = collectInputStreams(inputs, {}, nodeNames, cctx);
 
+    std::set<ZL_DictID, DictIDCmp> uniqueDictIDs;
     for (auto& [trainer, node] : work) {
         auto it = samplesPerNode.find(node.nodeName);
         if (it == samplesPerNode.end() || it->second.empty()) {
@@ -109,7 +130,7 @@ TrainedCandidate trainDictsForCandidate(
             continue;
         }
 
-        // Pack into the generic ZL_Dict wire format.
+        // Pack into the generic ZL_Dict wire format, with an auto-generated ID.
         std::string packedDict(ZL_DICT_HEADER_SIZE + dictContent->size(), '\0');
         ZL_Report report = Dict_pack(
                 packedDict.data(),
@@ -133,6 +154,14 @@ TrainedCandidate trainDictsForCandidate(
         compressor.unwrap(ZL_Compressor_overrideNodeParams(
                 compressor.get(), node.nodeID, &nodeParams));
 
+        if (uniqueDictIDs.find(generatedDictID) != uniqueDictIDs.end()) {
+            // This dict is a duplicate of a previously trained dict. No need to
+            // add it to the candidate. OpenZL dict loading will materialize
+            // properly.
+            continue;
+        }
+
+        uniqueDictIDs.insert(generatedDictID);
         candidate.dicts.push_back(
                 TrainedCandidate::DictEntry{
                         .dictID     = generatedDictID,

--- a/tools/training/dict/base_dict_trainer.h
+++ b/tools/training/dict/base_dict_trainer.h
@@ -69,4 +69,12 @@ TrainedCandidate trainDictsForCandidate(
         Compressor& compressor,
         const TrainParams& trainParams);
 
+/// For testing. Inject a custom set of dict trainers instead of using the
+/// default
+TrainedCandidate trainDictsForCandidate(
+        const std::vector<MultiInput>& inputs,
+        Compressor& compressor,
+        const TrainParams& trainParams,
+        const std::vector<std::unique_ptr<DictTrainer>>& trainers);
+
 } // namespace openzl::training

--- a/tools/training/tests/test_dict_training.cpp
+++ b/tools/training/tests/test_dict_training.cpp
@@ -3,7 +3,10 @@
 #include <gtest/gtest.h>
 
 #include <cstring>
+#include <exception>
+#include <memory>
 #include <string>
+#include <utility>
 #include <vector>
 
 #include "openzl/codecs/zl_zstd.h"
@@ -64,6 +67,89 @@ static std::vector<MultiInput> toMultiInputs(
         inputs.push_back(std::move(mi));
     }
     return inputs;
+}
+
+// A custom trainer that overrides the Zstd trainer by returning (incrementally)
+// from a fixed set of return strings
+class FakeZstdTrainer : public ZstdDictTrainer {
+   public:
+    explicit FakeZstdTrainer(std::vector<std::string> rets)
+            : rets_(std::move(rets))
+    {
+    }
+
+    poly::optional<std::string> trainDict(
+            const std::vector<MultiInput>& /* inputs */,
+            const Compressor& /* compressor */,
+            ZL_LocalParams /* localParams */) override
+    {
+        if (idx_ >= rets_.size()) {
+            std::string exc = "too many dicts! too many dicts!";
+            throw std::runtime_error(exc);
+        }
+        return rets_[idx_++];
+    }
+
+   private:
+    std::vector<std::string> rets_;
+    size_t idx_{ 0 };
+};
+
+// -------------------------------------------------------
+// Unit tests for BaseDictTrainer class
+// -------------------------------------------------------
+TEST(BaseDictTrainer, DuplicateDictsAreDeduped)
+{
+    auto sampleData = generateSampleData(
+            2, 4096); // not really used, we inject a custom trainer
+    auto inputs = toMultiInputs(sampleData);
+
+    // Generate a compressor that splits an input into 3, and sends each to a
+    // trainable zstd node
+    Compressor compressor;
+    {
+        constexpr size_t kNumSegments                = 3;
+        constexpr size_t kSegmentSizes[kNumSegments] = { 1024, 1024, 0 };
+        // Build one trainable zstd graph per segment so training produces a
+        // separate dictionary for each.
+        std::vector<ZL_GraphID> successors;
+        successors.reserve(kNumSegments);
+        for (size_t i = 0; i < kNumSegments; ++i) {
+            successors.push_back(compressor.unwrap(
+                    ZL_Compressor_buildTrainableZstdGraph(compressor.get()),
+                    "Failed to build trainable zstd graph"));
+        }
+
+        auto gid = ZL_Compressor_registerSplitGraph(
+                compressor.get(),
+                ZL_Type_serial,
+                kSegmentSizes,
+                successors.data(),
+                kNumSegments);
+        compressor.selectStartingGraph(gid);
+    }
+
+    // Train with a FakeZstdTrainer that returns identical dict content for the
+    // first two nodes and different content for the third. The two identical
+    // dicts hash to the same ID and must be deduplicated, leaving two dicts.
+    std::vector<std::unique_ptr<DictTrainer>> trainers;
+    trainers.push_back(
+            std::make_unique<FakeZstdTrainer>(std::vector<std::string>{
+                    "duplicate_dict_content_AAAAAAAAAAAAAAAA",
+                    "duplicate_dict_content_AAAAAAAAAAAAAAAA",
+                    "unique_dict_content_BBBBBBBBBBBBBBBB",
+            }));
+
+    TrainParams params{};
+    auto candidate =
+            trainDictsForCandidate(inputs, compressor, params, trainers);
+
+    // Three nodes were trained, but two produced identical dicts, so only two
+    // unique dicts should remain in the candidate.
+    ASSERT_EQ(candidate.dicts.size(), 2u);
+    EXPECT_FALSE(ZL_UniqueID_eq(
+            &candidate.dicts[0].dictID.id, &candidate.dicts[1].dictID.id));
+    EXPECT_NE(candidate.dicts[0].packedDict, candidate.dicts[1].packedDict);
 }
 
 // -------------------------------------------------------

--- a/tools/training/trained_candidate.cpp
+++ b/tools/training/trained_candidate.cpp
@@ -198,6 +198,36 @@ void TrainedCandidate::replaceDictID(
     ALLOC_Arena_freeArena(arena);
 }
 
+std::string TrainedCandidate::packBundleInfo() const
+{
+    if (dicts.empty()) {
+        throw Exception("packBundleInfo: no dicts in candidate");
+    }
+
+    std::vector<ZL_DictID> dictIDs;
+    dictIDs.reserve(dicts.size());
+    for (const auto& entry : dicts) {
+        dictIDs.push_back(entry.dictID);
+    }
+
+    ZL_BundleInfo info;
+    std::memset(&info, 0, sizeof(info));
+    info.bundleID    = bundleID;
+    info.isFatBundle = false;
+    info.numDicts    = dictIDs.size();
+    info.dictIDs     = dictIDs.data();
+
+    std::string result(
+            ZL_BUNDLE_HEADER_SIZE + dicts.size() * ZL_UNIQUE_ID_SIZE, '\0');
+    ZL_Report report = BundleInfo_pack(result.data(), result.size(), &info);
+    if (ZL_isError(report)) {
+        throw Exception("packBundleInfo: BundleInfo_pack failed");
+    }
+
+    result.resize(ZL_validResult(report));
+    return result;
+}
+
 std::string TrainedCandidate::packFatBundle() const
 {
     if (dicts.empty()) {

--- a/tools/training/trained_candidate.h
+++ b/tools/training/trained_candidate.h
@@ -50,6 +50,10 @@ struct TrainedCandidate {
     /// ZL_DictBundle_packFatBundle().
     /// @returns The packed fat bundle bytes.
     std::string packFatBundle() const;
+
+    /// Pack the current bundle metadata without appending dict contents.
+    /// @returns The packed standalone BundleInfo bytes.
+    std::string packBundleInfo() const;
 };
 
 } // namespace openzl::training


### PR DESCRIPTION
Summary:
Add deduplication for trained dictionaries and bundle info packing support to the OpenZL training infrastructure.

base_dict_trainer.cpp:
- Add DictIDCmp comparator for ZL_DictID to enable std::set usage with bytewise comparison.
- Track unique dict IDs during training to skip duplicate dictionaries. When a generated dict ID already exists in the set, the duplicate is skipped since OpenZL dict loading will materialize it properly from the existing entry.

trained_candidate.cpp/h:
- Add packBundleInfo() method to pack standalone bundle metadata without appending dict contents. Creates a ZL_BundleInfo structure with bundle ID, dict IDs, and packs it using BundleInfo_pack().

Reviewed By: daniellerozenblit

Differential Revision: D108207923


