### PR TITLE
Use cross-platform zstd/xxhash deps for Android build support

### DIFF
--- a/BUCK
+++ b/BUCK
@@ -75,13 +75,11 @@ zs_library(
     ),
     header_namespace = "",
     exported_deps = [
+        "fbsource//third-party/xxHash:xxhash",
+        "fbsource//third-party/zstd:zstd",
         ":config",
         ":fse",
         ":public_headers",
-    ],
-    exported_external_deps = [
-        ("xxHash", None, "xxhash"),
-        "zstd",
     ],
 )
 
@@ -114,12 +112,10 @@ zs_library(
         "fbsource//third-party/lz4:lz4",
     ],
     exported_deps = [
+        "fbsource//third-party/zstd:zstd",
         ":common",
         ":dict",
         ":fse",
-    ],
-    exported_external_deps = [
-        "zstd",
     ],
 )
 
@@ -148,12 +144,10 @@ zs_library(
         "fbsource//third-party/lz4:lz4",
     ],
     exported_deps = [
+        "fbsource//third-party/zstd:zstd",
         ":common",
         ":dict",
         ":fse",
-    ],
-    exported_external_deps = [
-        "zstd",
     ],
 )
 
@@ -179,13 +173,11 @@ zs_library(
 zs_library(
     name = "zstronglib",
     exported_deps = [
+        "fbsource//third-party/zstd:zstd",
         ":common",
         ":compress",
         ":decompress",
         ":dict",
-    ],
-    exported_external_deps = [
-        "zstd",
     ],
 )
 


### PR DESCRIPTION
Summary:
Replace `exported_external_deps` with direct `fbsource//third-party/` target references for zstd and xxhash. The `external_deps` macro resolution does not resolve correctly for Android cross-compilation configs, causing `zstd.h` not found errors when building `openzl_c_core` for android-arm64.

The existing `lz4` dep in the same file already uses this pattern (`fbsource//third-party/lz4:lz4`), so this is consistent with the codebase.

Reviewed By: terrelln, zchuck-meta

Differential Revision: D109060720


