### PR TITLE
Simplify `ZL_OC_getLastError()` (#835)

### DIFF
--- a/cpp/include/openzl/cpp/Exception.hpp
+++ b/cpp/include/openzl/cpp/Exception.hpp
@@ -28,7 +28,7 @@ class Exception : public std::runtime_error {
     /// @see ExceptionBuilder
     Exception(
             poly::string_view msg,
-            poly::optional<ZL_ErrorCode> code,
+            poly::optional<ZL_Error> error,
             poly::string_view errorContext,
             poly::source_location location);
 
@@ -37,9 +37,13 @@ class Exception : public std::runtime_error {
         return msg_;
     }
 
-    const poly::optional<ZL_ErrorCode>& code() const noexcept
+    poly::optional<ZL_ErrorCode> code() const noexcept
     {
-        return code_;
+        if (error_) {
+            return ZL_E_code(error_.value());
+        } else {
+            return {};
+        }
     }
 
     poly::string_view errorContext() const noexcept
@@ -54,7 +58,7 @@ class Exception : public std::runtime_error {
 
    private:
     std::string msg_;
-    poly::optional<ZL_ErrorCode> code_;
+    poly::optional<ZL_Error> error_;
     std::string errorContext_;
     poly::source_location location_;
 };

--- a/cpp/src/openzl/cpp/Exception.cpp
+++ b/cpp/src/openzl/cpp/Exception.cpp
@@ -10,7 +10,7 @@ namespace openzl {
 namespace {
 std::string formatMsg(
         std::string_view msg,
-        const poly::optional<ZL_ErrorCode>& code,
+        const poly::optional<ZL_Error>& error,
         poly::string_view errorContext,
         const poly::source_location& location)
 {
@@ -21,11 +21,11 @@ std::string formatMsg(
         out += msg;
         out += '\n';
     }
-    if (code.has_value()) {
+    if (error.has_value()) {
         out += "OpenZL error code: ";
-        out += std::to_string(code.value());
+        out += std::to_string(ZL_E_code(error.value()));
         out += "\nOpenZL error string: ";
-        out += ZL_ErrorCode_toString(code.value());
+        out += ZL_ErrorCode_toString(ZL_E_code(error.value()));
         out += "\n";
     }
     if (!errorContext.empty()) {
@@ -60,12 +60,12 @@ Exception::Exception(poly::string_view msg, poly::source_location location)
 
 Exception::Exception(
         poly::string_view msg,
-        poly::optional<ZL_ErrorCode> code,
+        poly::optional<ZL_Error> error,
         poly::string_view errorContext,
         poly::source_location location)
-        : std::runtime_error(formatMsg(msg, code, errorContext, location)),
+        : std::runtime_error(formatMsg(msg, error, errorContext, location)),
           msg_(msg),
-          code_(std::move(code)),
+          error_(std::move(error)),
           errorContext_(errorContext),
           location_(std::move(location))
 {
@@ -148,11 +148,7 @@ ExceptionBuilder&& ExceptionBuilder::addErrorContext<ZL_Graph>(
 
 Exception ExceptionBuilder::build() && noexcept
 {
-    poly::optional<ZL_ErrorCode> code;
-    if (error_.has_value()) {
-        code.emplace(ZL_E_code(error_.value()));
-    }
-    return Exception(msg_, code, errorContext_, std::move(location_));
+    return Exception(msg_, error_, errorContext_, std::move(location_));
 }
 
 ZL_Error_Array get_warnings(const ZL_CCtx* const& cctx)

--- a/src/openzl/common/operation_context.c
+++ b/src/openzl/common/operation_context.c
@@ -118,13 +118,9 @@ size_t ZL_OC_numWarnings(const ZL_OperationContext* opCtx)
     return VECTOR_SIZE(opCtx->warnings);
 }
 
-ZL_DynamicErrorInfo const* ZL_OC_getError(
-        ZL_OperationContext const* opCtx,
-        ZL_ErrorCode opCode)
+ZL_DynamicErrorInfo const* ZL_OC_getLastError(ZL_OperationContext const* opCtx)
 {
     if (opCtx == NULL)
-        return NULL;
-    if (opCode == ZL_ErrorCode_no_error)
         return NULL;
     if (VECTOR_SIZE(opCtx->errorInfos) == 0)
         return NULL;

--- a/src/openzl/common/operation_context.h
+++ b/src/openzl/common/operation_context.h
@@ -90,9 +90,8 @@ size_t ZL_OC_numErrors(const ZL_OperationContext* opCtx);
 size_t ZL_OC_numWarnings(const ZL_OperationContext* opCtx);
 
 /// @returns The current error info or NULL if there is no error.
-ZL_DynamicErrorInfo const* ZL_OC_getError(
-        ZL_OperationContext const* opCtx,
-        ZL_ErrorCode opCode);
+/// Mostly for tests...
+ZL_DynamicErrorInfo const* ZL_OC_getLastError(ZL_OperationContext const* opCtx);
 
 /// @returns The idx'th warning stored in the context.
 ZL_Error ZL_OC_getWarning(ZL_OperationContext const* opCtx, size_t idx);

--- a/tests/unittest/common/test_errors.cpp
+++ b/tests/unittest/common/test_errors.cpp
@@ -592,9 +592,7 @@ TEST(ErrorsTest, ErrorInfoWorks)
 
         // Check that the fields are set as expected
         EXPECT_NE(ZL_E_dy(error), nullptr);
-        EXPECT_EQ(
-                ZL_E_dy(error),
-                ZL_OC_getError(&opCtx, ZL_ErrorCode_corruption));
+        EXPECT_EQ(ZL_E_dy(error), ZL_OC_getLastError(&opCtx));
         EXPECT_EQ(ZL_EE_code(error._info), ZL_ErrorCode_corruption);
         EXPECT_EQ(ZL_EE_message(error._info), std::string("MyFmtString 350"));
         EXPECT_EQ(ZL_EE_nbStackFrames(error._info), size_t(1));
@@ -672,9 +670,7 @@ TEST(ErrorsTest, ErrorInfoWorks)
                 350);
 
         EXPECT_NE(ZL_E_dy(error), nullptr);
-        EXPECT_EQ(
-                ZL_E_dy(error),
-                ZL_OC_getError(&opCtx, ZL_ErrorCode_allocation));
+        EXPECT_EQ(ZL_E_dy(error), ZL_OC_getLastError(&opCtx));
         EXPECT_EQ(ZL_EE_code(error._info), ZL_ErrorCode_allocation);
         EXPECT_EQ(ZL_EE_message(error._info), std::string("MyFmtString 350"));
         EXPECT_EQ(ZL_EE_nbStackFrames(error._info), size_t(1));

--- a/tests/unittest/common/test_operation_context.cpp
+++ b/tests/unittest/common/test_operation_context.cpp
@@ -70,45 +70,37 @@ TEST(OperationContextTest, BasicUsage)
     ZL_ErrorContext scopeCtx = { &opCtx };
 
     EXPECT_EQ(ZL_OC_numErrors(&opCtx), 0u);
-    EXPECT_EQ(ZL_OC_getError(&opCtx, ZL_ErrorCode_no_error), nullptr);
-    EXPECT_EQ(ZL_OC_getError(&opCtx, ZL_ErrorCode_corruption), nullptr);
+    EXPECT_EQ(ZL_OC_getLastError(&opCtx), nullptr);
 
     ZL_OC_startOperation(&opCtx, ZL_Operation_compress);
 
     EXPECT_EQ(ZL_OC_numErrors(&opCtx), 0u);
-    EXPECT_EQ(ZL_OC_getError(&opCtx, ZL_ErrorCode_no_error), nullptr);
-    EXPECT_EQ(ZL_OC_getError(&opCtx, ZL_ErrorCode_corruption), nullptr);
+    EXPECT_EQ(ZL_OC_getLastError(&opCtx), nullptr);
 
     ZL_E_create(nullptr, &scopeCtx, "", "", 0, ZL_ErrorCode_corruption, "");
 
     EXPECT_EQ(ZL_OC_numErrors(&opCtx), 1u);
-    EXPECT_EQ(ZL_OC_getError(&opCtx, ZL_ErrorCode_no_error), nullptr);
-    EXPECT_NE(ZL_OC_getError(&opCtx, ZL_ErrorCode_corruption), nullptr);
-    EXPECT_NE(ZL_OC_getError(&opCtx, ZL_ErrorCode_GENERIC), nullptr);
-    EXPECT_EQ(
-            ZL_OC_getError(&opCtx, ZL_ErrorCode_corruption),
-            ZL_OC_getError(&opCtx, ZL_ErrorCode_corruption));
+    EXPECT_NE(ZL_OC_getLastError(&opCtx), nullptr);
 
     ZL_OC_clearErrors(&opCtx);
 
     EXPECT_EQ(ZL_OC_numErrors(&opCtx), 0u);
-    EXPECT_EQ(ZL_OC_getError(&opCtx, ZL_ErrorCode_no_error), nullptr);
-    EXPECT_EQ(ZL_OC_getError(&opCtx, ZL_ErrorCode_corruption), nullptr);
+    EXPECT_EQ(ZL_OC_getLastError(&opCtx), nullptr);
 
     ZL_E_create(nullptr, &scopeCtx, "", "", 0, ZL_ErrorCode_corruption, "");
 
     EXPECT_EQ(ZL_OC_numErrors(&opCtx), 1u);
-    EXPECT_NE(ZL_OC_getError(&opCtx, ZL_ErrorCode_corruption), nullptr);
+    EXPECT_NE(ZL_OC_getLastError(&opCtx), nullptr);
 
     ZL_E_create(nullptr, &scopeCtx, "", "", 0, ZL_ErrorCode_allocation, "");
 
     EXPECT_EQ(ZL_OC_numErrors(&opCtx), 2u);
-    EXPECT_NE(ZL_OC_getError(&opCtx, ZL_ErrorCode_allocation), nullptr);
+    EXPECT_NE(ZL_OC_getLastError(&opCtx), nullptr);
 
     ZL_OC_startOperation(&opCtx, ZL_Operation_compress);
 
     EXPECT_EQ(ZL_OC_numErrors(&opCtx), 0u);
-    EXPECT_EQ(ZL_OC_getError(&opCtx, ZL_ErrorCode_corruption), nullptr);
+    EXPECT_EQ(ZL_OC_getLastError(&opCtx), nullptr);
 
     ZL_OC_destroy(&opCtx);
 }
@@ -141,7 +133,7 @@ TEST(OperationContextTest, Warnings)
 
         auto dy1 = ZL_E_dy(e1);
         EXPECT_NE(dy1, nullptr);
-        EXPECT_EQ(dy1, ZL_OC_getError(&opCtx, ZL_ErrorCode_corruption));
+        EXPECT_EQ(dy1, ZL_OC_getLastError(&opCtx));
 
         ZL_OC_markAsWarning(&opCtx, e1);
 
@@ -167,7 +159,7 @@ TEST(OperationContextTest, Warnings)
 
         auto dy2 = ZL_E_dy(e2);
         EXPECT_NE(dy2, nullptr);
-        EXPECT_EQ(dy2, ZL_OC_getError(&opCtx, ZL_ErrorCode_corruption));
+        EXPECT_EQ(dy2, ZL_OC_getLastError(&opCtx));
 
         ZL_OC_markAsWarning(&opCtx, e2);
 


### PR DESCRIPTION
Summary:


This function maybe shouldn't exist. But we do use it in tests. At least
simplify it by getting rid of this weird arg.

Reviewed By: daniellerozenblit

Differential Revision: D101645608
