### PR TITLE
Fix build warnings introduced by D101645708

### DIFF
--- a/include/openzl/detail/zl_error_context.h
+++ b/include/openzl/detail/zl_error_context.h
@@ -7,6 +7,8 @@
 #    include <cstddef> // nullptr_t
 #endif
 
+#include <stdbool.h>
+
 #include "openzl/zl_errors_types.h"
 #include "openzl/zl_opaque_types.h"
 #include "openzl/zl_portability.h"


### PR DESCRIPTION
Summary:
* Fix unused variable warning in `Exception.hpp`
  * Only `prod` needs the fix, as the variable is used in `dev`
* Add missing `stdbool.h` include

Reviewed By: georgehong

Differential Revision: D109582885


