### PR TITLE
Add aligned-bit helpers to ff_bitstream (#847)

### DIFF
--- a/src/openzl/codecs/common/bitstream/ff_bitstream.h
+++ b/src/openzl/codecs/common/bitstream/ff_bitstream.h
@@ -31,6 +31,10 @@ ZL_INLINE ZL_Report ZS_BitCStreamFF_finish(ZS_BitCStreamFF* bits);
 ZL_INLINE void
 ZS_BitCStreamFF_write(ZS_BitCStreamFF* bits, size_t value, size_t nbBits);
 ZL_INLINE void ZS_BitCStreamFF_flush(ZS_BitCStreamFF* bits);
+ZL_INLINE uint8_t* ZS_BitCStreamFF_reserveAlignedBits(
+        ZS_BitCStreamFF* bits,
+        size_t nbBits);
+ZL_INLINE void ZS_BitCStreamFF_commitReservedBits(ZS_BitCStreamFF* bits);
 
 ZL_INLINE void ZS_BitCStreamFF_writeExpGolomb(
         ZS_BitCStreamFF* bits,
@@ -52,6 +56,7 @@ typedef struct {
     uint8_t const* ptr;
     uint8_t const* limit;
     uint8_t const* end;
+    uint8_t const* begin;
 } ZS_BitDStreamFF;
 
 ZL_INLINE ZS_BitDStreamFF
@@ -62,6 +67,9 @@ ZL_INLINE size_t
 ZS_BitDStreamFF_peek(ZS_BitDStreamFF const* bits, size_t nbBits);
 ZL_INLINE void ZS_BitDStreamFF_skip(ZS_BitDStreamFF* bits, size_t nbBits);
 ZL_INLINE void ZS_BitDStreamFF_reload(ZS_BitDStreamFF* bits);
+ZL_INLINE uint8_t const* ZS_BitDStreamFF_popAlignedBits(
+        ZS_BitDStreamFF* bits,
+        size_t nbBits);
 
 ZL_INLINE uint32_t
 ZS_BitDStreamFF_readExpGolomb(ZS_BitDStreamFF* bits, size_t order)
@@ -80,11 +88,13 @@ ZS_BitDStreamFF_readExpGolomb(ZS_BitDStreamFF* bits, size_t order)
 
 ZL_INLINE ZS_BitCStreamFF ZS_BitCStreamFF_init(uint8_t* dst, size_t dstCapacity)
 {
+    const size_t limit =
+            dstCapacity < sizeof(size_t) ? 0 : dstCapacity - sizeof(size_t) + 1;
     return (ZS_BitCStreamFF){
         .container = 0,
         .nbBits    = 0,
         .ptr       = dst,
-        .limit     = dst + dstCapacity - sizeof(size_t),
+        .limit     = dst + limit,
         .end       = dst + dstCapacity,
         .begin     = dst,
     };
@@ -94,7 +104,7 @@ ZL_INLINE ZL_Report ZS_BitCStreamFF_finish(ZS_BitCStreamFF* bits)
 {
     ZL_RESULT_DECLARE_SCOPE_REPORT((ZL_OperationContext*)NULL);
     size_t bytesToWrite = (bits->nbBits + 7) / 8;
-    if (bits->end < bits->ptr + bytesToWrite)
+    if ((size_t)(bits->end - bits->ptr) < bytesToWrite)
         ZL_ERR(internalBuffer_tooSmall);
     if (bytesToWrite) {
         ZL_ASSERT_EQ(
@@ -116,7 +126,7 @@ ZS_BitCStreamFF_write(ZS_BitCStreamFF* bits, size_t value, size_t nbBits)
 
 ZL_INLINE void ZS_BitCStreamFF_flush(ZS_BitCStreamFF* bits)
 {
-    if (bits->ptr > bits->limit) {
+    if (bits->ptr >= bits->limit) {
         return;
     }
     size_t const nbBytes = bits->nbBits >> 3;
@@ -124,6 +134,62 @@ ZL_INLINE void ZS_BitCStreamFF_flush(ZS_BitCStreamFF* bits)
     bits->ptr += nbBytes;
     bits->nbBits &= 7;
     bits->container >>= (nbBytes << 3);
+}
+
+ZL_INLINE uint8_t* ZS_BitCStreamFF_reserveAlignedBits(
+        ZS_BitCStreamFF* bits,
+        size_t nbBits)
+{
+    if (nbBits > SIZE_MAX - 7) {
+        return NULL;
+    }
+
+    size_t const bufferedBytes = (bits->nbBits + 7) / 8;
+    if (bufferedBytes > (size_t)(bits->end - bits->ptr)) {
+        return NULL;
+    }
+
+    size_t const nbBytes   = (nbBits + 7) / 8;
+    size_t const available = (size_t)(bits->end - bits->ptr) - bufferedBytes;
+    if (nbBytes > available) {
+        return NULL;
+    }
+
+    ZL_ASSERT_LE(bufferedBytes, sizeof(size_t));
+    if (bufferedBytes != 0) {
+        ZL_writeLE64_N(bits->ptr, bits->container, bufferedBytes);
+        bits->ptr += bufferedBytes;
+        bits->container = 0;
+        bits->nbBits    = 0;
+    }
+    ZL_ASSERT_EQ(bits->nbBits, 0);
+
+    uint8_t* const out = bits->ptr;
+    bits->ptr          = out + (nbBits / 8);
+    bits->nbBits       = nbBits & 7;
+    bits->container    = 0;
+    return out;
+}
+
+ZL_INLINE void ZS_BitCStreamFF_commitReservedBits(ZS_BitCStreamFF* bits)
+{
+    if (bits->nbBits == 0) {
+        bits->container = 0;
+        return;
+    }
+    bits->container = bits->ptr[0] & (((size_t)1 << bits->nbBits) - 1);
+}
+
+// Little-endian load of the first @p nbBytes (< sizeof(size_t)) bytes at @p src
+// into a container word. Used for streams shorter than a full word, where every
+// byte lives in the container.
+ZL_INLINE size_t ZS_BitDStreamFF_loadPartial(uint8_t const* src, size_t nbBytes)
+{
+    size_t container = 0;
+    for (size_t i = 0; i < nbBytes; ++i) {
+        container |= (size_t)src[i] << (i << 3);
+    }
+    return container;
 }
 
 ZL_INLINE ZS_BitDStreamFF
@@ -136,19 +202,19 @@ ZS_BitDStreamFF_init(uint8_t const* src, size_t srcSize)
             .ptr        = src,
             .limit      = src + srcSize - sizeof(size_t) + 1,
             .end        = src + srcSize,
+            .begin      = src,
         };
         return bits;
     } else {
-        ZS_BitDStreamFF bits = {
-            .container  = 0,
-            .nbBitsRead = (sizeof(size_t) - srcSize) * 8,
-            .ptr        = src + srcSize,
-            .limit      = src,
-            .end        = src + srcSize,
+        uint8_t const* const end = srcSize > 0 ? src + srcSize : src;
+        ZS_BitDStreamFF bits     = {
+                .container  = ZS_BitDStreamFF_loadPartial(src, srcSize),
+                .nbBitsRead = (sizeof(size_t) - srcSize) * 8,
+                .ptr        = end,
+                .limit      = src,
+                .end        = end,
+                .begin      = src,
         };
-        for (size_t i = 0; i < srcSize; ++i) {
-            bits.container |= (size_t)src[i] << (i << 3);
-        }
         return bits;
     }
 }
@@ -159,7 +225,13 @@ ZL_INLINE ZL_Report ZS_BitDStreamFF_finish(ZS_BitDStreamFF const* bits)
     if (bits->nbBitsRead > ZS_BITSTREAM_READ_MAX_BITS) {
         ZL_ERR(GENERIC);
     }
-    return ZL_returnSuccess();
+    size_t bytesRead = (size_t)(bits->ptr - bits->begin);
+    bytesRead += bits->nbBitsRead >> 3;
+    bytesRead += (bits->nbBitsRead & 7) != 0;
+    if ((size_t)(bits->end - bits->begin) < sizeof(size_t)) {
+        bytesRead -= sizeof(size_t);
+    }
+    return ZL_returnValue(bytesRead);
 }
 
 ZL_INLINE size_t ZS_BitDStreamFF_read(ZS_BitDStreamFF* bits, size_t nbBits)
@@ -189,22 +261,93 @@ ZL_INLINE void ZS_BitDStreamFF_skip(ZS_BitDStreamFF* bits, size_t nbBits)
 
 ZL_INLINE void ZS_BitDStreamFF_reload(ZS_BitDStreamFF* bits)
 {
-    bits->ptr += bits->nbBitsRead >> 3;
-    if (ZL_LIKELY(bits->ptr < bits->limit)) {
-        size_t const next = ZL_readLEST(bits->ptr);
+    uint8_t const* const ptr = bits->ptr + (bits->nbBitsRead >> 3);
+    if (ZL_LIKELY(ptr < bits->limit)) {
+        bits->ptr = ptr;
         bits->nbBitsRead &= 7;
-        bits->container = next >> bits->nbBitsRead;
+        bits->container = ZL_readLEST(ptr) >> bits->nbBitsRead;
         return;
     }
 
-    if (bits->ptr >= bits->end)
+    // Past the end: leave ptr and nbBitsRead untouched. This keeps the consumed
+    // bit count -- (ptr - begin) * 8 + nbBitsRead -- exact for finish() and
+    // popAlignedBits(), while an over-read still leaves nbBitsRead too large
+    // for finish() to accept.
+    if (ptr >= bits->end)
         return;
 
-    uint8_t const* const limit = bits->limit - 1;
-    size_t const skippedBits   = (size_t)((bits->ptr - limit) << 3);
-    size_t const next          = ZL_readLEST(limit);
+    uint8_t const* const tail = bits->limit - 1;
+    size_t const skippedBits  = (size_t)((ptr - tail) << 3);
+    bits->ptr                 = ptr;
     bits->nbBitsRead &= 7;
-    bits->container = next >> (bits->nbBitsRead + skippedBits);
+    bits->container = ZL_readLEST(tail) >> (bits->nbBitsRead + skippedBits);
+}
+
+ZL_INLINE uint8_t const* ZS_BitDStreamFF_popAlignedBits(
+        ZS_BitDStreamFF* bits,
+        size_t nbBits)
+{
+    if (nbBits > SIZE_MAX - 7) {
+        return NULL;
+    }
+
+    // check if the stream is already in an invalid state
+    if (bits->nbBitsRead > ZS_BITSTREAM_READ_MAX_BITS) {
+        return NULL;
+    }
+
+    size_t const streamSize = (size_t)(bits->end - bits->begin);
+    if (streamSize > SIZE_MAX / 8) {
+        return NULL;
+    }
+
+    size_t consumedBits =
+            (size_t)(bits->ptr - bits->begin) * 8 + bits->nbBitsRead;
+    if (streamSize < sizeof(size_t)) {
+        consumedBits -= sizeof(size_t) * 8;
+    }
+
+    size_t const bitSize = streamSize * 8;
+    if (consumedBits > bitSize || consumedBits > SIZE_MAX - 7) {
+        return NULL;
+    }
+
+    size_t const alignedBits = ((consumedBits + 7) / 8) * 8;
+    if (nbBits > bitSize - alignedBits) {
+        return NULL;
+    }
+
+    uint8_t const* const out = bits->begin + alignedBits / 8;
+
+    // Reposition the stream just past the aligned region we handed out.
+    size_t const bitPos      = alignedBits + nbBits;
+    uint8_t const* const pos = bits->begin + bitPos / 8;
+    size_t const bitShift    = bitPos & 7;
+
+    if (streamSize >= sizeof(size_t)) {
+        // Refill the 64-bit window at `pos`, clamping the load back from the
+        // end when fewer than 8 bytes remain; the matching shift exposes the
+        // same bit either way. A shift of the full word width (the whole
+        // stream consumed) leaves an empty window.
+        uint8_t const* const tail = bits->end - sizeof(size_t);
+        uint8_t const* const load = pos <= tail ? pos : tail;
+        size_t const shift        = bitPos - (size_t)(load - bits->begin) * 8;
+        bits->container =
+                shift < sizeof(size_t) * 8 ? ZL_readLEST(load) >> shift : 0;
+        bits->nbBitsRead = bitShift;
+        bits->ptr        = pos;
+    } else {
+        // Short stream: every byte already lives in the container.
+        size_t const remaining = (size_t)(bits->end - pos);
+        bits->container        = 0;
+        for (size_t i = 0; i < remaining; ++i) {
+            bits->container |= (size_t)pos[i] << (i << 3);
+        }
+        bits->container >>= bitShift;
+        bits->nbBitsRead = (sizeof(size_t) - remaining) * 8 + bitShift;
+        bits->ptr        = bits->end;
+    }
+    return out;
 }
 
 ZL_END_C_DECLS

--- a/src/openzl/codecs/huffman_pivoted/README.md
+++ b/src/openzl/codecs/huffman_pivoted/README.md
@@ -1,0 +1,14 @@
+# Huffman Pivoted
+
+This is an implementation of PivCo-Huffman coding from Marcin Zukowski.
+The code is based on ideas from:
+
+- [The paper](https://arxiv.org/abs/2606.05765)
+- [The repo](https://github.com/MarcinZukowski/pivco-huffman)
+- [Ryg's blog](https://fgiesen.wordpress.com/2026/06/21/pivco-huffman-merge-operations/)
+
+OpenZL re-implements PivCo-Huffman instead of using the upstream repo for several reasons:
+
+1. OpenZL needs full control over the wire-format.
+2. Upstream is currently not hardened against decoding corrupted data.
+3. The upstream repo isn't currently set-up to be imported into OpenZL, and includes code that is only needed for benchmarking.

--- a/src/openzl/shared/cpu.h
+++ b/src/openzl/shared/cpu.h
@@ -201,6 +201,13 @@ B(avx512vl, 31)
 #define C(name, bit) X(name, f7c, bit)
 C(prefetchwt1, 0)
 C(avx512vbmi, 1)
+C(avx512vbmi2, 6)
+C(vaes, 9)
+C(vpclmulqdq, 10)
+C(avx512vnni, 11)
+C(avx512bitalg, 12)
+C(avx512vpopcntdq, 14)
+C(rdpid, 22)
 #undef C
 
 #undef X

--- a/tests/unittest/common/test_bitstream.cpp
+++ b/tests/unittest/common/test_bitstream.cpp
@@ -1,9 +1,13 @@
 // Copyright (c) Meta Platforms, Inc. and affiliates.
 
 #include <chrono>
+#include <cstdint>
+#include <cstring>
 #include <functional>
 #include <random>
 #include <stdexcept>
+#include <utility>
+#include <vector>
 
 #include <gtest/gtest.h>
 
@@ -257,7 +261,13 @@ class RoundTripTest {
             ZS_BitDStreamFF_reload(&bits);
         }
 
-        return !ZL_isError(ZS_BitDStreamFF_finish(&bits));
+        ZL_Report const report = ZS_BitDStreamFF_finish(&bits);
+        if (ZL_isError(report)) {
+            return false;
+        }
+        // finish() reports the exact number of bytes consumed, which must equal
+        // the encoded size regardless of any extra trailing capacity.
+        return ZL_validResult(report) == bitSize;
     }
 
     template <size_t kNbUnrolls>
@@ -439,6 +449,165 @@ INSTANTIATE_TEST_SUITE_P(
                 BitstreamImpl::FSE,
                 BitstreamImpl::ZS,
                 BitstreamImpl::ZS_BF));
+
+// Mask of the low @p nbBits bits.
+size_t lowMask(size_t nbBits)
+{
+    if (nbBits == 0)
+        return 0;
+    if (nbBits >= sizeof(size_t) * 8)
+        return ~(size_t)0;
+    return ((size_t)1 << nbBits) - 1;
+}
+
+// Round-trips `leading` bits, a byte-aligned raw region holding `region` bits,
+// then `trailing` bits. The region is written with the reserve/commit aligned
+// API and read back with ZS_BitDStreamFF_popAlignedBits, mirroring how the
+// Huffman Pivoted kernels embed raw bitmaps in the stream. Verifies every bit
+// and the raw region survive. When `extra` is set the decoder gets slack
+// capacity past the encoded size (the large-stream path); otherwise it sees the
+// exact end, exercising the near-end and short-stream paths in popAlignedBits.
+//
+// `reload` reloads the window after every field read. The kernels do not do
+// this (popAlignedBits refills the window itself), but it must still be a valid
+// thing to do: popAlignedBits has to recover the exact bit position from any
+// reloaded stream state, including a short stream whose reload ran past the
+// end.
+void roundTripAlignedField(
+        const std::vector<std::pair<size_t, size_t>>& leading,
+        const std::vector<bool>& region,
+        const std::vector<std::pair<size_t, size_t>>& trailing,
+        bool extra,
+        bool reload)
+{
+    size_t const regionBytes = (region.size() + 7) / 8;
+    size_t totalBits         = 0;
+    for (auto const& w : leading)
+        totalBits += w.second;
+    for (auto const& w : trailing)
+        totalBits += w.second;
+    std::vector<uint8_t> buf(totalBits / 8 + regionBytes + 64, 0);
+
+    ZS_BitCStreamFF writer = ZS_BitCStreamFF_init(buf.data(), buf.size());
+    for (auto const& [value, nbBits] : leading) {
+        ZS_BitCStreamFF_write(&writer, value, nbBits);
+        ZS_BitCStreamFF_flush(&writer);
+    }
+    uint8_t* const slot =
+            ZS_BitCStreamFF_reserveAlignedBits(&writer, region.size());
+    ASSERT_NE(slot, nullptr);
+    std::memset(slot, 0, regionBytes);
+    for (size_t i = 0; i < region.size(); ++i) {
+        if (region[i])
+            slot[i / 8] |= (uint8_t)(1u << (i & 7));
+    }
+    ZS_BitCStreamFF_commitReservedBits(&writer);
+    for (auto const& [value, nbBits] : trailing) {
+        ZS_BitCStreamFF_write(&writer, value, nbBits);
+        ZS_BitCStreamFF_flush(&writer);
+    }
+    ZL_Report const report = ZS_BitCStreamFF_finish(&writer);
+    ASSERT_ZS_VALID(report);
+    size_t const encodedSize = ZL_validResult(report);
+
+    ZS_BitDStreamFF reader =
+            ZS_BitDStreamFF_init(buf.data(), extra ? buf.size() : encodedSize);
+    for (auto const& [value, nbBits] : leading) {
+        EXPECT_EQ(
+                ZS_BitDStreamFF_read(&reader, nbBits), value & lowMask(nbBits));
+        if (reload)
+            ZS_BitDStreamFF_reload(&reader);
+    }
+    uint8_t const* const popped =
+            ZS_BitDStreamFF_popAlignedBits(&reader, region.size());
+    ASSERT_NE(popped, nullptr);
+    for (size_t i = 0; i < region.size(); ++i) {
+        EXPECT_EQ((popped[i / 8] >> (i & 7)) & 1u, region[i] ? 1u : 0u)
+                << "region bit " << i;
+    }
+    for (auto const& [value, nbBits] : trailing) {
+        EXPECT_EQ(
+                ZS_BitDStreamFF_read(&reader, nbBits), value & lowMask(nbBits));
+        if (reload)
+            ZS_BitDStreamFF_reload(&reader);
+    }
+    ASSERT_ZS_VALID(ZS_BitDStreamFF_finish(&reader));
+}
+
+std::vector<bool> makeRegionBits(size_t nbBits)
+{
+    std::vector<bool> bits(nbBits);
+    for (size_t i = 0; i < nbBits; ++i)
+        bits[i] = (((i * 7) + 3) % 5) < 2;
+    return bits;
+}
+
+TEST(BitstreamAlignedBitsTest, ReserveCommitPopRoundTrip)
+{
+    using BitWrites          = std::vector<std::pair<size_t, size_t>>;
+    BitWrites const someBits = {
+        { 0x1, 1 }, { 0x2, 3 }, { 0xABCD, 13 }, { 0x7F, 7 }
+    };
+
+    struct Scenario {
+        const char* name;
+        BitWrites leading;
+        size_t regionBits;
+        BitWrites trailing;
+    };
+    std::vector<Scenario> const scenarios = {
+        // Region alone, with nothing around it.
+        { "empty_region", {}, 0, {} },
+        { "byte_region_only", {}, 8, {} },
+        { "aligned_region_only", {}, 64, {} },
+        // Region followed by bits (window stays mid-stream).
+        { "region_then_bits", {}, 24, someBits },
+        // Bits then a region that ends the stream (window lands at the end).
+        { "bits_then_region", someBits, 40, {} },
+        // Region surrounded on both sides.
+        { "bits_region_bits", someBits, 32, someBits },
+        // Unaligned leading bits force the region past padding.
+        { "unaligned_leading", { { 0x5, 3 } }, 16, { { 0x9, 5 } } },
+        // Region whose bit count is not a multiple of 8 (partial trailing
+        // byte).
+        { "partial_region", someBits, 19, someBits },
+        { "partial_region_at_end", someBits, 13, {} },
+        // Tiny total so the exact-capacity decode hits the short-stream path.
+        { "tiny_small_stream", { { 0x1, 2 } }, 8, {} },
+        // Large region exercises the steady-state window refill.
+        { "large_region", someBits, 1000, someBits },
+    };
+
+    for (auto const& s : scenarios) {
+        for (bool extra : { true, false }) {
+            for (bool reload : { false, true }) {
+                SCOPED_TRACE(
+                        std::string(s.name) + (extra ? " extra" : " exact")
+                        + (reload ? " reload" : " noreload"));
+                roundTripAlignedField(
+                        s.leading,
+                        makeRegionBits(s.regionBits),
+                        s.trailing,
+                        extra,
+                        reload);
+            }
+        }
+    }
+}
+
+TEST(BitstreamAlignedBitsTest, ReserveReturnsNullWhenBufferTooSmall)
+{
+    std::vector<uint8_t> buf(4, 0);
+    ZS_BitCStreamFF writer = ZS_BitCStreamFF_init(buf.data(), buf.size());
+    EXPECT_EQ(ZS_BitCStreamFF_reserveAlignedBits(&writer, 8 * 64), nullptr);
+}
+
+TEST(BitstreamAlignedBitsTest, PopReturnsNullPastEndOfStream)
+{
+    std::vector<uint8_t> buf(8, 0xAB);
+    ZS_BitDStreamFF reader = ZS_BitDStreamFF_init(buf.data(), buf.size());
+    EXPECT_EQ(ZS_BitDStreamFF_popAlignedBits(&reader, 8 * 64), nullptr);
+}
 
 struct BenchmarkResult {
     int64_t encodeNs{ 0 };


### PR DESCRIPTION
Summary:

Adds byte-aligned bit reservation and pop primitives to the FF bitstream, needed by the upcoming PivCo-Huffman kernels:

- `ZS_BitCStreamFF_reserveAlignedBits` / `ZS_BitCStreamFF_commitReservedBits` on the write side.
- `ZS_BitDStreamFF_popAlignedBits` on the read side, plus a `begin` cursor in `ZS_BitDStreamFF` so the reader can compute byte offsets.
- `ZS_BitDStreamFF_finish` now returns the number of bytes consumed.
- Hardens `ZS_BitCStreamFF_init`/`_finish`/`_flush` against small buffers by avoiding pointer arithmetic that could underflow.

Reviewed By: kevinjzhang

Differential Revision: D109878843


