### PR TITLE
Classify records as instant-parse vs requires-scan

### DIFF
--- a/tools/sddl2/compiler/codegen/CodeGenerator.cpp
+++ b/tools/sddl2/compiler/codegen/CodeGenerator.cpp
@@ -288,6 +288,10 @@ class CodeGeneratorImpl {
             }
             case ConvertedNodeType::RECORD: {
                 auto record = type->as_record();
+                if (record->annotations().requires_scan) {
+                    throw CodegenError(
+                            type->loc(), "Scan records are not yet supported.");
+                }
                 // Save the current stack depth
                 auto reg = registers_.allocate();
                 output += "push.stack_depth";

--- a/tools/sddl2/compiler/parser/AST.h
+++ b/tools/sddl2/compiler/parser/AST.h
@@ -199,9 +199,28 @@ class ASTVar : public ASTConverted {
     bool is_last_reference_ = false;
 };
 
+/**
+ * Annotations populated by post-parse passes (semantic analyzer, etc.) and
+ * read by later passes (codegen). Attached to every ASTConverted node via
+ * `annotations()`. Add new fields here rather than to individual node
+ * subclasses so passes can share annotation state without changing AST
+ * shape.
+ */
+struct Annotations {
+    bool requires_scan = false;
+};
+
 class ASTField : public ASTConverted {
    public:
     using ASTConverted::ASTConverted;
+
+    Annotations& annotations() const
+    {
+        return annotations_;
+    }
+
+   private:
+    mutable Annotations annotations_;
 };
 
 class ASTBuiltinField : public ASTField {

--- a/tools/sddl2/compiler/semantic_analyzer/SemanticAnalyzer.cpp
+++ b/tools/sddl2/compiler/semantic_analyzer/SemanticAnalyzer.cpp
@@ -22,8 +22,8 @@ enum class TypeKind {
 };
 
 struct Type {
-    TypeKind kind           = TypeKind::NONE;
-    const ASTNode* type_def = nullptr;
+    TypeKind kind            = TypeKind::NONE;
+    const ASTField* type_def = nullptr;
 };
 
 void expectNumeric(const SourceLocation& loc, const Type& t)
@@ -85,6 +85,17 @@ Type assumedType(const Type& field_type)
 struct ScopeContext {
     // Symbol table: every name currently in scope mapped to its type.
     std::unordered_map<std::string, Type> var_types;
+
+    // Set of names of fields in the current record. Used to detect scan
+    // records.
+    std::unordered_set<std::string> current_record_fields;
+    bool requires_scan = false;
+
+    void clear()
+    {
+        current_record_fields.clear();
+        requires_scan = false;
+    }
 };
 
 class SemanticAnalyzerImpl {
@@ -148,6 +159,9 @@ class SemanticAnalyzerImpl {
             throw SemanticError(
                     var.loc(), "Undefined variable: '" + var.name() + "'");
         }
+        if (scope_.current_record_fields.count(var.name()) > 0) {
+            scope_.requires_scan = true;
+        };
         return it->second;
     }
 
@@ -159,7 +173,11 @@ class SemanticAnalyzerImpl {
 
     Type analyze(const ASTArray& array)
     {
-        expectFieldType(array.field()->loc(), analyzeNode(array.field()));
+        auto element_type = analyzeNode(array.field());
+        expectFieldType(array.field()->loc(), element_type);
+        if (element_type.type_def->annotations().requires_scan) {
+            scope_.requires_scan = true;
+        }
         if (array.len()) {
             expectNumeric(array.len()->loc(), analyzeNode(array.len()));
         } else {
@@ -174,14 +192,25 @@ class SemanticAnalyzerImpl {
         if (!var) {
             throw SemanticError(field.loc(), "Field name must be a variable.");
         }
-        expectFieldType(field.type()->loc(), analyzeNode(field.type()));
+        auto t = analyzeNode(field.type());
+        expectFieldType(field.type()->loc(), t);
+        scope_.current_record_fields.insert(var->name());
+        scope_.var_types[var->name()] = assumedType(t);
+
+        // Transitivity: a field whose type is itself a requires-scan
+        // record or array makes the enclosing record requires-scan too.
+        if (t.type_def->annotations().requires_scan) {
+            scope_.requires_scan = true;
+        }
         return Type{ TypeKind::NONE };
     }
 
     Type analyze(const ASTRecord& record)
     {
-        // Validate params are variable names and introduce them as NUMERIC
         auto saved = scope_;
+        scope_.clear();
+
+        // Validate params are variable names and introduce them as NUMERIC
         for (const auto& param : record.params()) {
             const auto* var = param->as_var();
             if (!var) {
@@ -197,7 +226,8 @@ class SemanticAnalyzerImpl {
             analyzeNode(field);
         }
 
-        scope_ = std::move(saved);
+        record.annotations().requires_scan = scope_.requires_scan;
+        scope_                             = std::move(saved);
 
         return Type{ TypeKind::RECORD, &record };
     }

--- a/tools/sddl2/compiler/tests/SemanticAnalyzerTest.cpp
+++ b/tools/sddl2/compiler/tests/SemanticAnalyzerTest.cpp
@@ -5,6 +5,24 @@
 namespace openzl::sddl2::tests {
 namespace {
 class SemanticAnalyzerTest : public CompilerTest {};
+
+const ASTRecord* find_record(const ASTVec& ast, const std::string& name)
+{
+    for (const auto& node : ast) {
+        auto op = node->as_op();
+        if (!op || (op->op() != Op::ASSIGN && op->op() != Op::ASSUME)) {
+            continue;
+        }
+        auto var = op->args()[0]->as_var();
+        if (!var || var->name() != name) {
+            continue;
+        }
+        if (auto rec = op->args()[1]->as_record()) {
+            return rec;
+        }
+    }
+    return nullptr;
+}
 } // namespace
 
 TEST_F(SemanticAnalyzerTest, UndefinedVar)
@@ -330,7 +348,8 @@ TEST_F(SemanticAnalyzerTest, WhenBlockInRecordWithFieldReference)
         : Data
     )";
 
-    expect_error(prog, "Undefined variable");
+    // TODO: code generation should succeed
+    expect_error(prog, "Scan records are not yet supported.");
 }
 
 TEST_F(SemanticAnalyzerTest, AbsFieldType)
@@ -440,5 +459,127 @@ TEST_F(SemanticAnalyzerTest, ConsumeAfterWhenBlockWithAutoSizedArray)
         : Int32LE
     )";
     expect_error(prog, "Auto-sized array must be last statement");
+}
+
+// ---------------------------------------------------------------------------
+// requires_scan classification
+// ---------------------------------------------------------------------------
+
+TEST_F(SemanticAnalyzerTest, InstantParseSimple)
+{
+    const auto prog = R"(
+        record Foo() {
+            x: Int32LE,
+            y: Int16LE
+        }
+    )";
+    auto ast        = compiler_->compile_ast(prog, "[local_input]");
+    EXPECT_FALSE(find_record(ast, "Foo")->annotations().requires_scan);
+}
+
+TEST_F(SemanticAnalyzerTest, InstantParseWithParam)
+{
+    const auto prog = R"(
+        record Foo(N) {
+            data: Bytes(N)
+        }
+    )";
+    auto ast        = compiler_->compile_ast(prog, "[local_input]");
+    EXPECT_FALSE(find_record(ast, "Foo")->annotations().requires_scan);
+}
+
+TEST_F(SemanticAnalyzerTest, ScanSimple)
+{
+    const auto prog = R"(
+        record Foo() {
+            n: Int32LE,
+            data: Bytes(n + 1)
+        }
+    )";
+    auto ast        = compiler_->compile_ast(prog, "[local_input]");
+    EXPECT_TRUE(find_record(ast, "Foo")->annotations().requires_scan);
+}
+
+TEST_F(SemanticAnalyzerTest, RequiresScanConditional)
+{
+    const auto prog = R"(
+        record Foo() {
+            flags: UInt8,
+            when flags == 1 {
+                optional: UInt16LE
+            }
+        }
+    )";
+    auto ast        = compiler_->compile_ast(prog, "[local_input]");
+    EXPECT_TRUE(find_record(ast, "Foo")->annotations().requires_scan);
+}
+
+TEST_F(SemanticAnalyzerTest, RequiresScanNested)
+{
+    const auto prog = R"(
+        record Inner() {
+            n: Int32LE,
+            data: Bytes(n)
+        }
+        record Outer() {
+            inner: Inner[5]
+        }
+    )";
+    auto ast        = compiler_->compile_ast(prog, "[local_input]");
+    EXPECT_TRUE(find_record(ast, "Inner")->annotations().requires_scan);
+    EXPECT_TRUE(find_record(ast, "Outer")->annotations().requires_scan);
+}
+
+TEST_F(SemanticAnalyzerTest, RequiresScanNestedConditional)
+{
+    const auto prog = R"(
+        record Inner() {
+            n: Int32LE,
+            data: Bytes(n)
+        }
+        record Outer(flags) {
+            when flags == 1 {
+                inner: Inner[5]
+            }
+        }
+        flags: UInt8
+    )";
+    auto ast        = compiler_->compile_ast(prog, "[local_input]");
+    EXPECT_TRUE(find_record(ast, "Inner")->annotations().requires_scan);
+    EXPECT_TRUE(find_record(ast, "Outer")->annotations().requires_scan);
+}
+
+TEST_F(SemanticAnalyzerTest, RequiresScanOuter)
+{
+    const auto prog = R"(
+        record Inner(N) {
+            head: Int32LE,
+            data: Bytes(N)
+        }
+        record Outer() {
+            n: Int32LE,
+            inner: Inner(n)
+        }
+    )";
+    auto ast        = compiler_->compile_ast(prog, "[local_input]");
+    EXPECT_TRUE(find_record(ast, "Outer")->annotations().requires_scan);
+    EXPECT_FALSE(find_record(ast, "Inner")->annotations().requires_scan);
+}
+
+TEST_F(SemanticAnalyzerTest, TypeCheckReferencedFields)
+{
+    const auto prog = R"(
+        record Inner(N) {
+            head: Int32LE,
+            data: Bytes(N)
+        }
+        record Outer() {
+            inner: Inner(5),
+            when inner == 1 {
+                n: Int32LE
+            }
+        }
+    )";
+    expect_error(prog, "numeric");
 }
 } // namespace openzl::sddl2::tests


### PR DESCRIPTION
Summary:
## Stack
The goal of this stack is to support scan records in SDDL2.

## Diff
This diff introduces classification of records as either "instant-parse" or "requires-scan" based on whether their layout depends on their own field values.

Reviewed By: terrelln

Differential Revision: D105572482


