### PR TITLE
Test utils (testkit) + frame-minting skill

### DIFF
--- a/contrib/gpu/.claude/skills/openzl-gpu-test-frames/SKILL.md
+++ b/contrib/gpu/.claude/skills/openzl-gpu-test-frames/SKILL.md
@@ -1,0 +1,140 @@
+---
+name: openzl-gpu-test-frames
+description: How to mint real OpenZL frames and chunks for GPU decoder tests using the contrib/gpu/testkit utilities (frame_factory, multichunk_frame, frame_verifier), and how to extract a codec's encoded streams via reflection for differential GPU decode. USE when writing or reviewing GPU-decoder tests that need OpenZL-encoded fixtures.
+---
+
+# Minting OpenZL test frames/chunks for GPU decoder tests
+
+`contrib/gpu/testkit` mints **real** OpenZL frames by driving the actual encoder, so every frame/chunk header and checksum is correct by construction — it never hand-serializes header bytes. Use it for all GPU-decoder test fixtures instead of crafting bytes by hand.
+
+- **Buck target:** `//openzl/dev/contrib/gpu/testkit:testkit` (add to your `cpp_unittest` `deps`).
+- **Namespace:** `openzl::gpu::testkit`.
+- **Headers:** `frame_factory.h`, `frame_verifier.h`, `multichunk_frame.h`.
+
+Always build your test `Input` with the C++ helpers (`openzl/cpp/Input.hpp`):
+
+```cpp
+// numeric stream of 2-byte elements (e.g. bf16 bit patterns):
+Input in = Input::refNumeric<uint16_t>(vals.data(), vals.size());
+// or, untyped element width:
+Input in = Input::refNumeric(buf, /*eltWidth=*/2, /*numElts=*/n);
+// also: Input::refSerial(...), Input::refStruct<T>(...), Input::refString(...)
+```
+
+## 1. Single-graph frames — `frame_factory.h`
+
+```cpp
+// Core minter: applies CParams that DEFEAT the STORE backup (so a hand-picked
+// codec is not silently replaced by raw STORE), selects startGraph, compresses.
+std::string makeFrameWithGraph(Compressor&, GraphID startGraph, const Input&);
+
+// Route a node's outputs all to STORE (keeps the node's codec in the frame).
+std::string makeFrameNodeToStore(Compressor&, NodeID node, const Input&);
+
+// Run a node and route each output to the matching successor graph.
+std::string makeFrameNodeWithSuccessors(
+        Compressor&, NodeID node, std::initializer_list<GraphID> successors, const Input&);
+
+// Single-output node chain: node[0] -> node[1] -> ... -> STORE.
+std::string makeFrameChainToStore(
+        Compressor&, std::initializer_list<NodeID> chain, const Input&);
+
+// Self-checks.
+bool roundTrips(Compressor&, GraphID, const Input&);
+bool decompressedEquals(const std::string& frame, const Input&);
+```
+
+Always pin the format version so you get chunk-capable (v21+) frames:
+
+```cpp
+Compressor c;
+c.setParameter(CParam::FormatVersion, ZL_MAX_FORMAT_VERSION);
+```
+
+Example — a single bitpack-of-numeric frame:
+
+```cpp
+const std::vector<int32_t> ints = /* small-range values so bitpack engages */;
+const Input in = Input::refNumeric<int32_t>(ints.data(), ints.size());
+Compressor c; c.setParameter(CParam::FormatVersion, ZL_MAX_FORMAT_VERSION);
+const std::string frame = makeFrameWithGraph(c, graphs::Bitpack{}(), in);
+```
+
+Example — a float_deconstruct frame:
+
+```cpp
+const Input in = Input::refNumeric<uint16_t>(vals.data(), vals.size()); // bf16 bits
+Compressor c; c.setParameter(CParam::FormatVersion, ZL_MAX_FORMAT_VERSION);
+const std::string frame =
+        makeFrameNodeToStore(c, nodes::BFloat16Deconstruct::node, in);
+```
+
+## 2. Verifying which codecs landed — `frame_verifier.h`
+
+```cpp
+// Standard codec wire IDs in the LAST chunk, in decode order (custom codecs skipped).
+std::vector<uint32_t> standardCodecsInFrame(const std::string& frame);
+// Exactly these codecs (multiset compare, order-independent).
+bool frameHasExactlyCodecs(const std::string& frame, const std::vector<uint32_t>& expected);
+// Per-chunk standard codec IDs; reports every chunk via decompression introspection.
+std::vector<std::vector<uint32_t>> standardCodecsPerChunk(const std::string& frame);
+```
+
+`standardCodecsInFrame` and `frameHasExactlyCodecs` use the public reflection API, which only exposes the **last chunk** of a frame. For multi-chunk fixtures, use `standardCodecsPerChunk`: it drives the real decompression path with introspection hooks, disables codec fusion on its throwaway `DCtx`, and returns one inner vector per frame chunk. You do not need to re-mint slices just to verify per-chunk codec coverage.
+
+## 3. Multi-chunk frames — `multichunk_frame.h`
+
+```cpp
+struct ChunkSpec { size_t numElts; openzl::GraphID graph; };
+
+std::string makeMultiChunkFrame(
+        Compressor&, std::initializer_list<ChunkSpec> chunks, const Input&);
+
+// Non-owning view over a contiguous element slice (Serial/Numeric only).
+Input sliceInput(const Input&, size_t eltOffset, size_t numElts);
+```
+
+Constraints: chunk `numElts` must **sum to** `input.numElts()`, and each chunk must clear **`ZL_MIN_CHUNK_SIZE` = 32768 bytes** of content (so "small" chunks can't be tiny — a bf16 chunk needs ≥ 16384 elts). `makeMultiChunkFrame` pins `FormatVersion = ZL_MAX_FORMAT_VERSION`.
+
+> **Need finer-grained segments than a 32 KB chunk?** Frame chunks can't be smaller than `ZL_MIN_CHUNK_SIZE`. When a test needs many small, arbitrarily-sized runs, mint one frame and `sliceInput` its stream into as many pieces as you need rather than relying on frame chunks.
+
+## 4. Extracting a codec's encoded streams (for differential decode)
+
+To feed a GPU decode kernel the real encoded bytes and compare against OpenZL's own decoder, decode the frame with the public reflection API (`openzl/zl_reflection.h`) and pull the codec's streams — the same reflection path `frame_verifier` uses for last-chunk codec inspection.
+
+```cpp
+ZL_ReflectionCtx* rctx = ZL_ReflectionCtx_create();
+ZL_ReflectionCtx_setCompressedFrame(rctx, frame.data(), frame.size()); // DECODES the frame
+// find your codec among ZL_ReflectionCtx_getCodec_lastChunk(rctx, i) by ZL_CodecInfo_getCodecID
+// streams: ZL_CodecInfo_getOutput(codec, i) -> ZL_DataInfo_getDataPtr/getContentSize
+ZL_ReflectionCtx_free(rctx);
+// CPU ground truth: DCtx().decompress(frame)
+```
+
+Gotchas that will bite you (learned the hard way):
+
+- **Reflection is encoder-oriented.** A codec's *outputs* (`ZL_CodecInfo_getOutput`) are the **decoder's inputs** (the stored streams you feed the kernel); its *input* (`ZL_CodecInfo_getInput`) is the decoder's regenerated output — use it for `nbElts`.
+- **Classify streams by type, not index.** Reflection reports a codec's outputs in the **reverse** of the encoder's stream order. Use `ZL_DataInfo_getType` (`ZL_Type_serial=1, ZL_Type_struct=2, ZL_Type_numeric=4, ZL_Type_string=8`) to identify each stream. For `float_deconstruct`: `struct` = signFrac, `serial` = exponent.
+- **The codec-header byte is unreliable for element type.** `float_deconstruct` (codec id **33**) is shared by float32/bfloat16/float16; `ZL_CodecInfo_getHeaderPtr` does not reliably surface the element-type enum. Detect the variant by **stream widths** instead: signFrac eltWidth 3/1/2 and output eltWidth 4/2/2 for float32/bf16/float16.
+- `makeFrameNodeToStore` inserts a `convert_struct_to_serial` (codec id 6) before STORE for any Struct output — expected; just find the codec you care about among the list.
+
+## 5. Building & running
+
+```python
+cpp_unittest(
+    name = "YourTest",
+    srcs = ["tests/YourTest.cpp"],
+    network_access = network_access_utils.none(),
+    deps = [
+        "fbsource//third-party/googletest:gtest",
+        "//openzl/dev/contrib/gpu/testkit:testkit",
+        "//openzl/dev/cpp:openzl_cpp",
+    ],
+)
+```
+
+If the test launches CUDA, run with sanitizers OFF (CUDA can't init under ASAN):
+
+```
+buck2 test @fbcode//mode/dev-nosan //openzl/dev/contrib/gpu/...:YourTest
+```

--- a/contrib/gpu/testkit/BUCK
+++ b/contrib/gpu/testkit/BUCK
@@ -1,0 +1,56 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+
+load("@fbcode_macros//build_defs:cpp_library.bzl", "cpp_library")
+load("@fbcode_macros//build_defs:cpp_unittest.bzl", "cpp_unittest")
+load("@fbsource//tools/build_defs/testinfra:network_access_utils.bzl", "network_access_utils")
+
+oncall("data_compression")
+
+# Mints valid OpenZL frames with fully-controlled codec content (frame_factory)
+# and verifies their codec lists via the real reflection API (frame_verifier).
+# For building GPU-decoder test fixtures.
+cpp_library(
+    # @autodeps-skip
+    name = "testkit",
+    srcs = [
+        "frame_factory.cpp",
+        "frame_verifier.cpp",
+        "multichunk_frame.cpp",
+    ],
+    headers = [
+        "frame_factory.h",
+        "frame_verifier.h",
+        "multichunk_frame.h",
+    ],
+    exported_deps = [
+        "../../..:zstronglib",
+        "../../../cpp:openzl_cpp",
+        "../../../tests:utils",
+    ],
+)
+
+cpp_unittest(
+    # @autodeps-skip
+    name = "frame_factory_test",
+    srcs = ["tests/FrameFactoryTest.cpp"],
+    network_access = network_access_utils.none(),
+    deps = [
+        "../../..:zstronglib",
+        "../../../cpp:openzl_cpp",
+        "fbsource//third-party/googletest:gtest",
+        ":testkit",
+    ],
+)
+
+cpp_unittest(
+    # @autodeps-skip
+    name = "multichunk_frame_test",
+    srcs = ["tests/MultiChunkFrameTest.cpp"],
+    network_access = network_access_utils.none(),
+    deps = [
+        "../../..:zstronglib",
+        "../../../cpp:openzl_cpp",
+        "fbsource//third-party/googletest:gtest",
+        ":testkit",
+    ],
+)

--- a/contrib/gpu/testkit/frame_factory.cpp
+++ b/contrib/gpu/testkit/frame_factory.cpp
@@ -1,0 +1,120 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#include "openzl/dev/contrib/gpu/testkit/frame_factory.h"
+
+#include <iterator>
+#include <vector>
+
+#include "openzl/zl_common_types.h" // ZL_TernaryParam_disable
+#include "openzl/zl_compressor.h" // ZL_Compressor_registerStaticGraph_fromNode1o
+#include "tests/utils.h"          // buildTrivialGraph
+
+namespace openzl::gpu::testkit {
+
+namespace {
+
+// MinStreamSize follows the convention that 0 means "default"; only a NEGATIVE
+// threshold fully disables the per-stream "automatic store" feature. -1 is the
+// smallest such value.
+constexpr int kDisableMinStreamSize = -1;
+
+// Applies the parameters that keep hand-picked codecs intact:
+//   FormatVersion     -- pin the wire format so reflection IDs are stable.
+//   StoreOnExpansion  -- off, so a chunk that fails to shrink is NOT swapped
+//                        wholesale for a single raw STORE. This is the
+//                        load-bearing one: an ablation on float_deconstruct ->
+//                        {store, store} showed that WITHOUT it the transform is
+//                        backed up and codec 33 vanishes (only convert+store
+//                        remain), and WITH it codec 33 survives.
+//   MinStreamSize     -- negative, so individual small streams are not silently
+//                        stored before reaching the backend we routed them to.
+//                        Belt-and-suspenders here: it did not affect the
+//                        float_deconstruct case alone, but matters for graphs
+//                        with small intermediate streams feeding real backends.
+void applyFidelityParams(openzl::CCtx& cctx)
+{
+    cctx.setParameter(openzl::CParam::FormatVersion, ZL_MAX_FORMAT_VERSION);
+    cctx.setParameter(
+            openzl::CParam::StoreOnExpansion, ZL_TernaryParam_disable);
+    cctx.setParameter(openzl::CParam::MinStreamSize, kDisableMinStreamSize);
+}
+
+size_t unguardedCompressBound(const openzl::Input& input)
+{
+    size_t inputSize = input.contentSize();
+    if (input.type() == openzl::Type::String) {
+        inputSize += input.numElts() * sizeof(uint32_t);
+    }
+    return ZL_COMPRESSBOUND_UNGUARDED(inputSize);
+}
+
+} // namespace
+
+std::string makeFrameWithGraph(
+        openzl::Compressor& compressor,
+        openzl::GraphID startGraph,
+        const openzl::Input& input)
+{
+    compressor.selectStartingGraph(startGraph);
+
+    openzl::CCtx cctx;
+    cctx.refCompressor(compressor);
+    applyFidelityParams(cctx);
+    std::string frame(unguardedCompressBound(input), '\0');
+    frame.resize(
+            cctx.compress(frame, poly::span<const openzl::Input>(&input, 1)));
+    return frame;
+}
+
+std::string makeFrameNodeToStore(
+        openzl::Compressor& compressor,
+        openzl::NodeID node,
+        const openzl::Input& input)
+{
+    const openzl::GraphID graph =
+            tests::buildTrivialGraph(compressor.get(), node);
+    return makeFrameWithGraph(compressor, graph, input);
+}
+
+std::string makeFrameNodeWithSuccessors(
+        openzl::Compressor& compressor,
+        openzl::NodeID node,
+        std::initializer_list<openzl::GraphID> successors,
+        const openzl::Input& input)
+{
+    const openzl::GraphID graph = compressor.buildStaticGraph(node, successors);
+    return makeFrameWithGraph(compressor, graph, input);
+}
+
+std::string makeFrameChainToStore(
+        openzl::Compressor& compressor,
+        std::initializer_list<openzl::NodeID> chain,
+        const openzl::Input& input)
+{
+    // Build the single-output chain from the tail backwards: the last node
+    // feeds STORE, and each earlier node feeds the graph built so far.
+    openzl::GraphID graph = openzl::graphs::Store{}();
+    for (auto it = std::rbegin(chain); it != std::rend(chain); ++it) {
+        graph = ZL_Compressor_registerStaticGraph_fromNode1o(
+                compressor.get(), *it, graph);
+    }
+    return makeFrameWithGraph(compressor, graph, input);
+}
+
+bool decompressedEquals(const std::string& frame, const openzl::Input& input)
+{
+    openzl::DCtx dctx;
+    const std::vector<openzl::Output> outs = dctx.decompress(frame);
+    return outs.size() == 1 && input == outs[0];
+}
+
+bool roundTrips(
+        openzl::Compressor& compressor,
+        openzl::GraphID startGraph,
+        const openzl::Input& input)
+{
+    const std::string frame = makeFrameWithGraph(compressor, startGraph, input);
+    return decompressedEquals(frame, input);
+}
+
+} // namespace openzl::gpu::testkit

--- a/contrib/gpu/testkit/frame_factory.h
+++ b/contrib/gpu/testkit/frame_factory.h
@@ -1,0 +1,68 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#pragma once
+
+#include <initializer_list>
+#include <string>
+
+#include "openzl/openzl.hpp"
+
+// Mints valid OpenZL compressed frames whose codec content is fully controlled,
+// for building GPU-decoder test fixtures. Frames are always produced by driving
+// the real OpenZL encoder, so frame/chunk headers are correct by construction
+// (this library never hand-serializes header bytes). Verify the resulting codec
+// list with frame_verifier.h.
+
+namespace openzl::gpu::testkit {
+
+// Core minter. Applies the CParams needed to keep hand-picked codecs from being
+// silently replaced by a raw STORE backup (see frame_factory.cpp), selects
+// `startGraph` (which the caller must have already built on `compressor`), and
+// compresses `input` into a frame. Returns the frame bytes.
+std::string makeFrameWithGraph(
+        openzl::Compressor& compressor,
+        openzl::GraphID startGraph,
+        const openzl::Input& input);
+
+// Convenience: build a static graph that routes `node`'s outputs all to STORE
+// (via the canonical buildTrivialGraph helper), then mint a frame for `input`.
+// Whether the `node` codec actually survives in such a pure store-everything
+// frame depends on the backup-defeating CParams; that is the subject of the
+// KEY EXPERIMENT in the tests.
+std::string makeFrameNodeToStore(
+        openzl::Compressor& compressor,
+        openzl::NodeID node,
+        const openzl::Input& input);
+
+// Convenience: build a static graph that runs `node` and routes each of its
+// outputs to the matching successor graph in `successors`, then mint a frame.
+// Feeding outputs to real backends (rather than STORE) lets a structural
+// transform shrink the data and therefore survive in the frame.
+std::string makeFrameNodeWithSuccessors(
+        openzl::Compressor& compressor,
+        openzl::NodeID node,
+        std::initializer_list<openzl::GraphID> successors,
+        const openzl::Input& input);
+
+// Convenience: build a single-output chain node[0] -> node[1] -> ... -> STORE,
+// then mint a frame. Requires a non-empty `chain`; each node must have exactly
+// one output for the chain to be well-formed.
+std::string makeFrameChainToStore(
+        openzl::Compressor& compressor,
+        std::initializer_list<openzl::NodeID> chain,
+        const openzl::Input& input);
+
+// Compresses then decompresses `input` through a freshly configured CCtx/DCtx
+// using `compressor`/`startGraph`, and returns true iff the decompressed output
+// equals `input`. Used as an internal self-check by the factory and by tests.
+bool roundTrips(
+        openzl::Compressor& compressor,
+        openzl::GraphID startGraph,
+        const openzl::Input& input);
+
+// Decompresses an already-minted `frame` and returns true iff the single
+// decompressed output equals `input`. Lets a test confirm a specific frame
+// round-trips without re-minting it (and without registering more graphs).
+bool decompressedEquals(const std::string& frame, const openzl::Input& input);
+
+} // namespace openzl::gpu::testkit

--- a/contrib/gpu/testkit/frame_verifier.cpp
+++ b/contrib/gpu/testkit/frame_verifier.cpp
@@ -1,0 +1,160 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#include "openzl/dev/contrib/gpu/testkit/frame_verifier.h"
+
+#include <algorithm>
+#include <memory>
+#include <stdexcept>
+
+#include "openzl/cpp/DCtx.hpp"
+#include "openzl/decompress/dctx2.h"
+#include "openzl/decompress/dictx.h"
+#include "openzl/zl_errors.h"
+#include "openzl/zl_reflection.h"
+
+namespace openzl::gpu::testkit {
+
+namespace {
+
+// RAII wrapper so the reflection context is always freed, even if a getter
+// throws.
+struct ReflectionCtxDeleter {
+    void operator()(ZL_ReflectionCtx* rctx) const
+    {
+        ZL_ReflectionCtx_free(rctx);
+    }
+};
+using ReflectionCtxPtr =
+        std::unique_ptr<ZL_ReflectionCtx, ReflectionCtxDeleter>;
+
+class PerChunkCodecCollector : public openzl::DecompressIntrospectionHooks {
+   public:
+    const std::vector<std::vector<uint32_t>>& codecsPerChunk() const
+    {
+        return codecsPerChunk_;
+    }
+
+    bool sawChunks() const
+    {
+        return sawChunks_;
+    }
+
+    void on_decompressChunk_start(ZL_DCtx* /* dctx */, size_t chunkIndex)
+            override
+    {
+        if (codecsPerChunk_.size() <= chunkIndex) {
+            codecsPerChunk_.resize(chunkIndex + 1);
+        }
+        sawChunks_       = true;
+        currentChunk_    = chunkIndex;
+        nextNodeToMatch_ = 0;
+    }
+
+    void on_codecDecode_start(
+            ZL_Decoder* dictx,
+            const ZL_Data* const* /* inStreams */,
+            size_t /* nbInStreams */) override
+    {
+        if (!sawChunks_ || dictx == nullptr || dictx->dt == nullptr) {
+            return;
+        }
+
+        const DFH_Struct* const frameHeader = DCtx_getFrameHeader(dictx->dctx);
+        if (frameHeader == nullptr) {
+            return;
+        }
+
+        const ZL_IDType codecID = dictx->dt->miGraphDesc.CTid;
+        for (size_t i = nextNodeToMatch_; i < VECTOR_SIZE(frameHeader->nodes);
+             ++i) {
+            const PublicTransformInfo transformInfo =
+                    VECTOR_AT(frameHeader->nodes, i).trpid;
+            if (transformInfo.trid != codecID) {
+                continue;
+            }
+
+            nextNodeToMatch_ = i + 1;
+            if (transformInfo.trt == trt_standard) {
+                codecsPerChunk_[currentChunk_].push_back(transformInfo.trid);
+            }
+            return;
+        }
+    }
+
+   private:
+    std::vector<std::vector<uint32_t>> codecsPerChunk_;
+    size_t currentChunk_{ 0 };
+    size_t nextNodeToMatch_{ 0 };
+    bool sawChunks_{ false };
+};
+
+ReflectionCtxPtr makeReflectionCtx(const std::string& frame)
+{
+    ReflectionCtxPtr rctx{ ZL_ReflectionCtx_create() };
+    if (rctx == nullptr) {
+        throw std::runtime_error("ZL_ReflectionCtx_create() failed");
+    }
+    const ZL_Report report = ZL_ReflectionCtx_setCompressedFrame(
+            rctx.get(), frame.data(), frame.size());
+    if (ZL_isError(report)) {
+        throw std::runtime_error(
+                "ZL_ReflectionCtx_setCompressedFrame() failed to decode frame");
+    }
+    return rctx;
+}
+
+} // namespace
+
+std::vector<uint32_t> standardCodecsInFrame(const std::string& frame)
+{
+    const ReflectionCtxPtr rctx = makeReflectionCtx(frame);
+
+    const size_t numCodecs =
+            ZL_ReflectionCtx_getNumCodecs_lastChunk(rctx.get());
+
+    std::vector<uint32_t> ids;
+    ids.reserve(numCodecs);
+    for (size_t i = 0; i < numCodecs; ++i) {
+        const ZL_CodecInfo* const codec =
+                ZL_ReflectionCtx_getCodec_lastChunk(rctx.get(), i);
+        if (ZL_CodecInfo_isStandardCodec(codec)) {
+            ids.push_back(ZL_CodecInfo_getCodecID(codec));
+        }
+    }
+    return ids;
+}
+
+bool frameHasExactlyCodecs(
+        const std::string& frame,
+        const std::vector<uint32_t>& expected)
+{
+    std::vector<uint32_t> actual = standardCodecsInFrame(frame);
+    if (actual.size() != expected.size()) {
+        return false;
+    }
+    std::vector<uint32_t> sortedExpected = expected;
+    std::sort(actual.begin(), actual.end());
+    std::sort(sortedExpected.begin(), sortedExpected.end());
+    return actual == sortedExpected;
+}
+
+std::vector<std::vector<uint32_t>> standardCodecsPerChunk(
+        const std::string& frame)
+{
+    openzl::DCtx dctx;
+    PerChunkCodecCollector collector;
+    dctx.unwrap(ZL_DCtx_attachDecompressIntrospectionHooks(
+            dctx.get(), collector.getRawHooks()));
+    dctx.unwrap(ZL_DCtx_setParameter(
+            dctx.get(), ZL_DParam_enableCodecFusion, ZL_TernaryParam_disable));
+
+    (void)dctx.decompress(frame);
+
+    if (!collector.sawChunks()) {
+        throw std::runtime_error(
+                "Decompression introspection hooks did not run");
+    }
+    return collector.codecsPerChunk();
+}
+
+} // namespace openzl::gpu::testkit

--- a/contrib/gpu/testkit/frame_verifier.h
+++ b/contrib/gpu/testkit/frame_verifier.h
@@ -1,0 +1,39 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#pragma once
+
+#include <cstdint>
+#include <string>
+#include <vector>
+
+// Inspection helpers for OpenZL compressed frames. These helpers drive real
+// OpenZL decode paths, so the codec lists they report are exactly what the
+// decoder will see -- never a guess from parsing header bytes by hand.
+
+namespace openzl::gpu::testkit {
+
+// Returns the wire IDs (ZL_StandardTransformID) of the standard codecs present
+// in the last chunk of `frame`, in the order the reflection API reports them
+// (decode order). Custom (non-standard) codecs are skipped, since they have no
+// stable standard wire ID. Throws std::runtime_error if the frame cannot be
+// decoded.
+std::vector<uint32_t> standardCodecsInFrame(const std::string& frame);
+
+// Returns true iff the standard codecs in `frame` are exactly `expected`,
+// compared as a multiset (order-independent, duplicates significant). Custom
+// codecs are ignored, matching standardCodecsInFrame().
+bool frameHasExactlyCodecs(
+        const std::string& frame,
+        const std::vector<uint32_t>& expected);
+
+// Per-chunk standard-codec enumeration for a multi-chunk frame. This helper
+// uses decompression introspection hooks, with codec fusion disabled on its
+// throwaway decompression context, so it reports every individual standard
+// codec executed for each chunk. Custom (non-standard) codecs are skipped,
+// since they have no stable standard wire ID.
+//
+// Throws std::runtime_error if the frame cannot be decoded.
+std::vector<std::vector<uint32_t>> standardCodecsPerChunk(
+        const std::string& frame);
+
+} // namespace openzl::gpu::testkit

--- a/contrib/gpu/testkit/multichunk_frame.cpp
+++ b/contrib/gpu/testkit/multichunk_frame.cpp
@@ -1,0 +1,217 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#include "openzl/dev/contrib/gpu/testkit/multichunk_frame.h"
+
+#include <cstdint>
+#include <vector>
+
+#include "openzl/zl_common_types.h" // ZL_TernaryParam_disable
+#include "openzl/zl_errors.h"
+#include "openzl/zl_localParams.h" // ZL_IntParam, ZL_LocalParams
+#include "openzl/zl_segmenter.h"   // ZL_Compressor_registerSegmenter, ...
+#include "openzl/zl_selector.h"    // ZL_LP_INVALID_PARAMID
+#include "tests/utils.h"           // ZL_COMPRESSBOUND_UNGUARDED
+
+namespace openzl::gpu::testkit {
+
+namespace {
+
+// MinStreamSize follows the convention that 0 means "default"; only a NEGATIVE
+// threshold fully disables the per-stream "automatic store" feature. Mirrors
+// frame_factory.cpp.
+constexpr int kDisableMinStreamSize = -1;
+
+// Local-int-param ID plane for handing the per-chunk plan to the segmenter
+// callback. ID kNumChunksParamId holds the chunk count; ID
+// kChunkEltsParamIdBase + i holds chunk i's element count. These IDs only need
+// to be unique within this segmenter instance.
+constexpr int kNumChunksParamId     = 0;
+constexpr int kChunkEltsParamIdBase = 1;
+
+void validateChunksCoverInput(
+        std::initializer_list<ChunkSpec> chunks,
+        const openzl::Input& input)
+{
+    size_t plannedElts = 0;
+    for (const ChunkSpec& chunk : chunks) {
+        if (chunk.numElts > input.numElts() - plannedElts) {
+            throw openzl::Exception(
+                    "makeMultiChunkFrame: chunk plan exceeds input element count");
+        }
+        plannedElts += chunk.numElts;
+    }
+    if (plannedElts != input.numElts()) {
+        throw openzl::Exception(
+                "makeMultiChunkFrame: chunk plan does not cover input");
+    }
+}
+
+size_t unguardedCompressBound(const openzl::Input& input)
+{
+    size_t inputSize = input.contentSize();
+    if (input.type() == openzl::Type::String) {
+        inputSize += input.numElts() * sizeof(uint32_t);
+    }
+    return ZL_COMPRESSBOUND_UNGUARDED(inputSize);
+}
+
+// Custom Segmenter callback: cuts one chunk per entry in the plan, routing
+// chunk i to the i-th custom graph. Modeled on the built-in SEGM_serial, but
+// varies the successor graph (and chunk size) per chunk instead of using one
+// fixed head graph for uniform-size chunks. Reads the plan from local int
+// params (chunk count + per-chunk element counts) and the per-chunk graphs from
+// the custom graph list (graph i == chunk i). Defensive ZL_ERR_IF_* checks
+// (rather than asserts) guard the param-derived values, per the openzl
+// externally-reachable-path convention.
+ZL_Report multiChunkSegmenterFn(ZL_Segmenter* sctx)
+{
+    ZL_RESULT_DECLARE_SCOPE_REPORT(sctx);
+
+    const size_t numInputs = ZL_Segmenter_numInputs(sctx);
+    ZL_ERR_IF_NE(numInputs, (size_t)1, parameter_invalid);
+
+    // Chunking requires a wire format that can encode segmented output.
+    ZL_ERR_IF_LT(
+            ZL_Segmenter_getCParam(sctx, ZL_CParam_formatVersion),
+            ZL_CHUNK_VERSION_MIN,
+            formatVersion_unsupported);
+
+    const ZL_IntParam numChunksParam =
+            ZL_Segmenter_getLocalIntParam(sctx, kNumChunksParamId);
+    ZL_ERR_IF_EQ(
+            numChunksParam.paramId, ZL_LP_INVALID_PARAMID, parameter_invalid);
+    ZL_ERR_IF_LT(numChunksParam.paramValue, 1, parameter_invalid);
+    const size_t numChunks = (size_t)numChunksParam.paramValue;
+
+    const ZL_GraphIDList customGraphs = ZL_Segmenter_getCustomGraphs(sctx);
+    ZL_ERR_IF_NE(customGraphs.nbGraphIDs, numChunks, parameter_invalid);
+
+    for (size_t i = 0; i < numChunks; ++i) {
+        const ZL_IntParam chunkEltsParam = ZL_Segmenter_getLocalIntParam(
+                sctx, kChunkEltsParamIdBase + (int)i);
+        ZL_ERR_IF_EQ(
+                chunkEltsParam.paramId,
+                ZL_LP_INVALID_PARAMID,
+                parameter_invalid);
+        ZL_ERR_IF_LT(chunkEltsParam.paramValue, 0, parameter_invalid);
+
+        size_t chunkElts = (size_t)chunkEltsParam.paramValue;
+        // ZL_ERR_IF_ERR's C++ result helper sets the union's _code through
+        // ._error aliasing, which Infer's Pulse checker cannot model -- this is
+        // a known, non-blocking false positive (T186816819, D56531383).
+        // @lint-ignore INFERCPP
+        ZL_ERR_IF_ERR(ZL_Segmenter_processChunk(
+                sctx, &chunkElts, 1, customGraphs.graphids[i], nullptr));
+    }
+
+    return ZL_returnSuccess();
+}
+
+// Registers a Segmenter on `compressor` that realizes `chunks` against `input`:
+// the distinct per-chunk graphs become the segmenter's custom graphs (in chunk
+// order), and the per-chunk element counts are passed as local int params.
+GraphID registerMultiChunkSegmenter(
+        openzl::Compressor& compressor,
+        std::initializer_list<ChunkSpec> chunks,
+        const openzl::Input& input)
+{
+    validateChunksCoverInput(chunks, input);
+
+    const size_t numChunks = chunks.size();
+
+    std::vector<ZL_GraphID> graphs;
+    graphs.reserve(numChunks);
+
+    std::vector<ZL_IntParam> intParams;
+    intParams.reserve(numChunks + 1);
+    intParams.push_back(ZL_IntParam{ kNumChunksParamId, (int)numChunks });
+
+    int chunkIdx = 0;
+    for (const ChunkSpec& chunk : chunks) {
+        graphs.push_back(chunk.graph);
+        intParams.push_back(
+                ZL_IntParam{ kChunkEltsParamIdBase + chunkIdx,
+                             (int)chunk.numElts });
+        ++chunkIdx;
+    }
+
+    // OpenZL copies customGraphs and localParams during registration, so the
+    // local vectors above only need to outlive this call.
+    ZL_LocalParams localParams        = {};
+    localParams.intParams.intParams   = intParams.data();
+    localParams.intParams.nbIntParams = intParams.size();
+
+    ZL_SegmenterDesc desc       = {};
+    desc.name                   = "gpu_testkit_multichunk";
+    desc.segmenterFn            = multiChunkSegmenterFn;
+    const ZL_Type inputTypeMask = ZL_Input_type(input.get());
+    desc.inputTypeMasks         = &inputTypeMask;
+    desc.numInputs              = 1;
+    desc.lastInputIsVariable    = false;
+    desc.customGraphs           = graphs.data();
+    desc.numCustomGraphs        = graphs.size();
+    desc.localParams            = localParams;
+
+    const GraphID segmenter =
+            ZL_Compressor_registerSegmenter(compressor.get(), &desc);
+    if (!ZL_GraphID_isValid(segmenter)) {
+        throw openzl::Exception(
+                "makeMultiChunkFrame: failed to register segmenter");
+    }
+    return segmenter;
+}
+
+void applyFidelityParams(openzl::CCtx& cctx)
+{
+    cctx.setParameter(openzl::CParam::FormatVersion, ZL_MAX_FORMAT_VERSION);
+    cctx.setParameter(
+            openzl::CParam::StoreOnExpansion, ZL_TernaryParam_disable);
+    cctx.setParameter(openzl::CParam::MinStreamSize, kDisableMinStreamSize);
+}
+
+} // namespace
+
+std::string makeMultiChunkFrame(
+        openzl::Compressor& compressor,
+        std::initializer_list<ChunkSpec> chunks,
+        const openzl::Input& input)
+{
+    const GraphID segmenter =
+            registerMultiChunkSegmenter(compressor, chunks, input);
+    compressor.selectStartingGraph(segmenter);
+
+    openzl::CCtx cctx;
+    cctx.refCompressor(compressor);
+    applyFidelityParams(cctx);
+    std::string frame(unguardedCompressBound(input), '\0');
+    frame.resize(
+            cctx.compress(frame, poly::span<const openzl::Input>(&input, 1)));
+    return frame;
+}
+
+openzl::Input
+sliceInput(const openzl::Input& input, size_t eltOffset, size_t numElts)
+{
+    if (eltOffset > input.numElts() || numElts > input.numElts() - eltOffset) {
+        throw openzl::Exception(
+                "sliceInput: slice exceeds input element count");
+    }
+    const size_t eltWidth = input.eltWidth();
+    const char* const base =
+            static_cast<const char*>(input.ptr()) + eltOffset * eltWidth;
+
+    switch (input.type()) {
+        case openzl::Type::Numeric:
+            return openzl::Input::refNumeric(base, eltWidth, numElts);
+        case openzl::Type::Serial:
+            // Serial inputs are byte streams: one element == one byte.
+            return openzl::Input::refSerial(base, numElts);
+        case openzl::Type::Struct:
+        case openzl::Type::String:
+            break;
+    }
+    throw openzl::Exception(
+            "sliceInput: only Serial and Numeric inputs are supported");
+}
+
+} // namespace openzl::gpu::testkit

--- a/contrib/gpu/testkit/multichunk_frame.h
+++ b/contrib/gpu/testkit/multichunk_frame.h
@@ -1,0 +1,67 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+#include <initializer_list>
+#include <string>
+#include <vector>
+
+#include "openzl/openzl.hpp"
+
+// Mints valid OpenZL frames that contain MULTIPLE chunks, where each chunk is
+// compressed with a DIFFERENT codec graph. Like frame_factory.h, frames are
+// always produced by driving the real OpenZL encoder (through a custom
+// Segmenter), so frame/chunk headers and checksums are correct by construction
+// -- this library never hand-serializes header bytes. Verify the per-chunk
+// codec content with frame_verifier.h (standardCodecsPerChunk()).
+//
+// Multi-chunk frames require wire format version >= ZL_CHUNK_VERSION_MIN (21);
+// the factory pins ZL_MAX_FORMAT_VERSION, which satisfies that. Each chunk must
+// also clear the ZL_MIN_CHUNK_SIZE floor (32768 bytes of content), so callers
+// must size chunks comfortably above that.
+
+namespace openzl::gpu::testkit {
+
+// One chunk of a multi-chunk frame: `numElts` elements (counted in the input's
+// element units -- e.g. int32 values for a refNumeric<int32_t> input, bytes for
+// a serial input) routed to the codec graph `graph`. The caller must have
+// already built `graph` on the same Compressor passed to makeMultiChunkFrame().
+struct ChunkSpec {
+    size_t numElts;
+    openzl::GraphID graph;
+};
+
+// Splits `input` into consecutive chunks as described by `chunks` (chunk i gets
+// the next chunks[i].numElts elements) and mints ONE frame in which chunk i is
+// compressed with chunks[i].graph. The element counts in `chunks` MUST sum to
+// input.numElts(), or the underlying segmenter rejects the input (it requires
+// the whole input to be consumed). Drives the real encoder via a custom
+// Segmenter; returns the frame bytes.
+//
+// Applies the same store-backup-defeating CParams as frame_factory
+// (StoreOnExpansion=disable, MinStreamSize=-1) so the per-chunk codecs survive,
+// and pins FormatVersion to ZL_MAX_FORMAT_VERSION so chunking is available and
+// reflection IDs are stable.
+std::string makeMultiChunkFrame(
+        openzl::Compressor& compressor,
+        std::initializer_list<ChunkSpec> chunks,
+        const openzl::Input& input);
+
+// Returns an Input over a contiguous slice of `input`: the `numElts` elements
+// starting at element `eltOffset`. The returned Input keeps `input`'s type and
+// element width and REFERENCES `input`'s buffer (it does not copy), so `input`
+// must outlive the returned slice.
+//
+// This is the building block for the documented per-chunk verification fallback
+// (the public reflection API only exposes a frame's last chunk -- see
+// frame_verifier.h). Carving out chunk i's slice and minting it as its own
+// single-chunk frame (via frame_factory.h::makeFrameWithGraph) lets the public
+// reflection API report that chunk's codecs, which is exactly the per-chunk
+// graph makeMultiChunkFrame routes. Only Serial and Numeric inputs are
+// supported (Struct/String throw); these cover the multi-chunk fixtures.
+openzl::Input
+sliceInput(const openzl::Input& input, size_t eltOffset, size_t numElts);
+
+} // namespace openzl::gpu::testkit

--- a/contrib/gpu/testkit/tests/FrameFactoryTest.cpp
+++ b/contrib/gpu/testkit/tests/FrameFactoryTest.cpp
@@ -1,0 +1,221 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#include <gtest/gtest.h>
+
+#include <algorithm>
+#include <cstdint>
+#include <string>
+#include <vector>
+
+#include "openzl/codecs/bitSplit/encode_bitSplit_binding.h"
+#include "openzl/dev/contrib/gpu/testkit/frame_factory.h"
+#include "openzl/dev/contrib/gpu/testkit/frame_verifier.h"
+#include "openzl/openzl.hpp"
+
+// These tests mint real OpenZL frames with hand-picked codec graphs and then
+// confirm, via the reflection API, that the frames contain exactly the codecs
+// we asked for. Expected wire IDs are reasoned from the OpenZL standard
+// transform table, NOT copied from implementation output:
+//
+//     bitpack_serial    27   (bitpack of a serial/byte stream)
+//     bitpack_int       28   (bitpack of a numeric stream)
+//     float_deconstruct 33   (split float32 into sign+fraction and exponent)
+//
+// Float32Deconstruct produces two outputs: sign+fraction (Struct) and
+// exponent (Serial). So routing the exponent through Bitpack yields the
+// SERIAL variant of bitpack (27), not the numeric one (28).
+
+namespace openzl::gpu::testkit {
+namespace {
+
+// Independent, deterministic test data (not derived from any frame output).
+
+// Small-range ints (0..7) fit in 3 bits, so bitpack engages on them.
+std::vector<int32_t> makeSmallInts(size_t n)
+{
+    std::vector<int32_t> v(n);
+    for (size_t i = 0; i < n; ++i) {
+        v[i] = static_cast<int32_t>(i % 8);
+    }
+    return v;
+}
+
+// A structured float ramp: correlated exponents give float_deconstruct
+// something real to separate.
+std::vector<float> makeFloats(size_t n)
+{
+    std::vector<float> v(n);
+    for (size_t i = 0; i < n; ++i) {
+        v[i] = static_cast<float>(i % 100) * 0.5f + 1.0f;
+    }
+    return v;
+}
+
+constexpr uint32_t kDeltaInt         = 1;
+constexpr uint32_t kZigzag           = 3;
+constexpr uint32_t kBitpackSerial    = 27;
+constexpr uint32_t kBitpackInt       = 28;
+constexpr uint32_t kFloatDeconstruct = 33;
+
+constexpr size_t kNumElts = 20000;
+
+bool contains(const std::vector<uint32_t>& ids, uint32_t id)
+{
+    return std::find(ids.begin(), ids.end(), id) != ids.end();
+}
+
+// Bitpack of a small-int numeric stream -> the frame must round-trip and the
+// only standard codec must be bitpack_int (28).
+TEST(FrameFactoryTest, BitpackOnSmallIntsYieldsBitpackInt)
+{
+    const std::vector<int32_t> ints = makeSmallInts(kNumElts);
+    const Input in = Input::refNumeric<int32_t>(ints.data(), ints.size());
+
+    Compressor compressor;
+    compressor.setParameter(CParam::FormatVersion, ZL_MAX_FORMAT_VERSION);
+    const GraphID bitpack = graphs::Bitpack{}();
+
+    EXPECT_TRUE(roundTrips(compressor, bitpack, in));
+
+    const std::string frame = makeFrameWithGraph(compressor, bitpack, in);
+    EXPECT_TRUE(frameHasExactlyCodecs(frame, { kBitpackInt }));
+}
+
+// float_deconstruct routed to the generic backend -> the deconstruct codec
+// (33) must be present and the frame must round-trip. The generic backend may
+// add further codecs, so we assert presence, not exact set.
+TEST(FrameFactoryTest, FloatDeconstructToGenericRetainsCodec33)
+{
+    const std::vector<float> floats = makeFloats(kNumElts);
+    const Input in = Input::refNumeric<float>(floats.data(), floats.size());
+
+    Compressor compressor;
+    compressor.setParameter(CParam::FormatVersion, ZL_MAX_FORMAT_VERSION);
+    const GraphID graph = nodes::Float32Deconstruct{}(
+            compressor, ZL_GRAPH_COMPRESS_GENERIC, ZL_GRAPH_COMPRESS_GENERIC);
+
+    EXPECT_TRUE(roundTrips(compressor, graph, in));
+
+    const std::string frame = makeFrameWithGraph(compressor, graph, in);
+    EXPECT_TRUE(contains(standardCodecsInFrame(frame), kFloatDeconstruct));
+}
+
+TEST(FrameFactoryTest, BitSplitCanExpandBeyondGuardedCompressBound)
+{
+    // This test verifies makeFrameWithGraph() can mint valid expanding
+    // fixtures after disabling StoreOnExpansion; it fails if the helper uses
+    // the guarded ZL_compressBound() premise from the string-returning CCtx
+    // overload.
+    std::vector<uint32_t> ints(kNumElts);
+    for (size_t i = 0; i < ints.size(); ++i) {
+        ints[i] = static_cast<uint32_t>(i);
+    }
+    const Input in = Input::refNumeric<uint32_t>(ints.data(), ints.size());
+
+    Compressor compressor;
+    compressor.setParameter(CParam::FormatVersion, ZL_MAX_FORMAT_VERSION);
+    const uint8_t bitWidths[] = { 4, 4, 4, 4, 4, 4, 4, 4 };
+    const NodeID bitSplitNode = ZL_Compressor_registerBitSplitNode(
+            compressor.get(),
+            bitWidths,
+            sizeof(bitWidths) / sizeof(*bitWidths));
+    ASSERT_NE(bitSplitNode.nid, ZL_NODE_ILLEGAL.nid);
+    const GraphID graph =
+            compressor.buildStaticGraph(bitSplitNode, { graphs::Store{}() });
+    const std::string frame = makeFrameWithGraph(compressor, graph, in);
+
+    EXPECT_TRUE(decompressedEquals(frame, in));
+}
+
+// float_deconstruct -> {generic (sign+frac, Struct), bitpack (exponent,
+// Serial)} -> both deconstruct (33) and bitpack_serial (27) must be present;
+// frame round-trips. Exercises the convenience successor builder.
+TEST(FrameFactoryTest, FloatDeconstructWithBitpackExponentHasBoth)
+{
+    const std::vector<float> floats = makeFloats(kNumElts);
+    const Input in = Input::refNumeric<float>(floats.data(), floats.size());
+
+    Compressor compressor;
+    compressor.setParameter(CParam::FormatVersion, ZL_MAX_FORMAT_VERSION);
+    const std::string frame = makeFrameNodeWithSuccessors(
+            compressor,
+            nodes::Float32Deconstruct::node,
+            { ZL_GRAPH_COMPRESS_GENERIC, graphs::Bitpack{}() },
+            in);
+
+    const std::vector<uint32_t> codecs = standardCodecsInFrame(frame);
+    EXPECT_TRUE(contains(codecs, kFloatDeconstruct));
+    EXPECT_TRUE(contains(codecs, kBitpackSerial));
+}
+
+// KEY EXPERIMENT: float_deconstruct -> {store, store} with the store-backup
+// defeated (StoreOnExpansion=disable + MinStreamSize=-1, applied by the
+// factory). Question: does codec 33 survive when both outputs just go to STORE?
+//
+// FINDING (asserted below): codec 33 SURVIVES -- disabling the backup is enough
+// to keep the structural transform from being collapsed into a single raw
+// STORE. But the frame is NOT a single-codec frame: float_deconstruct's
+// sign+fraction output is Struct-typed, and OpenZL must insert a
+// convert_struct_to_serial (id 6) codec to serialize it before STORE. So the
+// frame contains exactly {6, 33}, not {33} alone.
+//
+// Consequence for GPU isolation testing: a node -> {store, store} graph does
+// NOT, in general, mint a pure single-codec frame; any non-serial output drags
+// in a conversion codec. The float_deconstruct codec itself is preserved, which
+// is the part that matters for fixture generation.
+//
+// (Independent reasoning for the expected IDs: 33 = float_deconstruct, the node
+// we asked for; 6 = convert_struct_to_serial, forced by the Struct-typed
+// sign+fraction output meeting STORE. Both are read from the standard transform
+// table, not from this test's own output.)
+constexpr uint32_t kConvertStructToSerial = 6;
+
+TEST(FrameFactoryTest, KeyExperiment_FloatDeconstructToStoreRetainsCodec33)
+{
+    const std::vector<float> floats = makeFloats(kNumElts);
+    const Input in = Input::refNumeric<float>(floats.data(), floats.size());
+
+    Compressor compressor;
+    compressor.setParameter(CParam::FormatVersion, ZL_MAX_FORMAT_VERSION);
+    const std::string frame = makeFrameNodeToStore(
+            compressor, nodes::Float32Deconstruct::node, in);
+
+    // The frame must still be a valid, decodable frame.
+    EXPECT_TRUE(decompressedEquals(frame, in));
+
+    // The core finding: float_deconstruct (33) is NOT backed up away.
+    EXPECT_TRUE(contains(standardCodecsInFrame(frame), kFloatDeconstruct));
+
+    // The full truth: the store-everything frame is {6, 33}, not pure {33}, --
+    // a convert_struct_to_serial is inserted for the Struct-typed output.
+    EXPECT_TRUE(frameHasExactlyCodecs(
+            frame, { kConvertStructToSerial, kFloatDeconstruct }));
+}
+
+// Chain builder: zigzag -> delta -> store on signed ints. Both single-output
+// numeric transforms must appear in the frame (zigzag = 3, delta_int = 1) and
+// the frame must round-trip. (A num->serial conversion is also inserted before
+// STORE, so we assert presence of the chain codecs rather than an exact set.)
+TEST(FrameFactoryTest, ChainZigzagDeltaToStoreRetainsBothCodecs)
+{
+    // Signed values with sign changes so zigzag/delta have real work to do.
+    std::vector<int32_t> ints(kNumElts);
+    for (size_t i = 0; i < ints.size(); ++i) {
+        ints[i] = static_cast<int32_t>((i % 16)) - 8;
+    }
+    const Input in = Input::refNumeric<int32_t>(ints.data(), ints.size());
+
+    Compressor compressor;
+    compressor.setParameter(CParam::FormatVersion, ZL_MAX_FORMAT_VERSION);
+    const std::string frame = makeFrameChainToStore(
+            compressor, { nodes::Zigzag::node, nodes::DeltaInt::node }, in);
+
+    EXPECT_TRUE(decompressedEquals(frame, in));
+
+    const std::vector<uint32_t> codecs = standardCodecsInFrame(frame);
+    EXPECT_TRUE(contains(codecs, kZigzag));
+    EXPECT_TRUE(contains(codecs, kDeltaInt));
+}
+
+} // namespace
+} // namespace openzl::gpu::testkit

--- a/contrib/gpu/testkit/tests/MultiChunkFrameTest.cpp
+++ b/contrib/gpu/testkit/tests/MultiChunkFrameTest.cpp
@@ -1,0 +1,221 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#include <gtest/gtest.h>
+
+#include <algorithm>
+#include <cstdint>
+#include <string>
+#include <vector>
+
+#include "openzl/dev/contrib/gpu/testkit/frame_factory.h"
+#include "openzl/dev/contrib/gpu/testkit/frame_verifier.h"
+#include "openzl/dev/contrib/gpu/testkit/multichunk_frame.h"
+#include "openzl/openzl.hpp"
+
+// These tests mint real OpenZL frames that contain MULTIPLE chunks, each with a
+// different codec graph, and confirm (a) the frame round-trips, (b) it really
+// has the expected number of chunks, and (c) each chunk carries the codecs we
+// asked for. Expected wire IDs are reasoned from the OpenZL standard transform
+// table (openzl/src/openzl/common/wire_format.h), NOT copied from any frame's
+// own output:
+//
+//     delta_int              1   (numeric delta)
+//     convert_num_to_serial 10   (inserted when a numeric stream meets STORE)
+//     bitpack_int           28   (bitpack of a numeric stream)
+//
+// A numeric stream routed straight to STORE is first serialized by
+// convert_num_to_serial_le (10) -- the stored bytes themselves are not a codec
+// -- so a `delta -> store` chunk on numeric ints contains exactly {1, 10}, and
+// a bare `store` chunk on numeric ints contains exactly {10}.
+
+namespace openzl::gpu::testkit {
+namespace {
+
+// Independent, deterministic test data (not derived from any frame output).
+
+// Small-range ints (0..7) fit in 3 bits, so bitpack engages on them.
+std::vector<int32_t> makeSmallInts(size_t n)
+{
+    std::vector<int32_t> v(n);
+    for (size_t i = 0; i < n; ++i) {
+        v[i] = static_cast<int32_t>(i % 8);
+    }
+    return v;
+}
+
+// A monotonic ramp with a constant stride: deltas collapse to a single repeated
+// value, giving delta_int real work to do before the chunk is stored.
+std::vector<int32_t> makeRamp(size_t n)
+{
+    std::vector<int32_t> v(n);
+    for (size_t i = 0; i < n; ++i) {
+        v[i] = static_cast<int32_t>(i) * 3;
+    }
+    return v;
+}
+
+constexpr uint32_t kDeltaInt           = 1;
+constexpr uint32_t kConvertNumToSerial = 10;
+constexpr uint32_t kBitpackInt         = 28;
+
+// 20000 int32 elements per chunk -> 80000 bytes, comfortably above the
+// ZL_MIN_CHUNK_SIZE floor of 32768 bytes.
+constexpr size_t kEltsPerChunk = 20000;
+
+bool contains(const std::vector<uint32_t>& ids, uint32_t id)
+{
+    return std::find(ids.begin(), ids.end(), id) != ids.end();
+}
+
+// Builds a `delta_int -> store` single-output graph on `compressor`.
+GraphID buildDeltaToStore(Compressor& compressor)
+{
+    return ZL_Compressor_registerStaticGraph_fromNode1o(
+            compressor.get(), nodes::DeltaInt::node, graphs::Store{}());
+}
+
+// 2-chunk frame: chunk 0 = bitpack on small ints, chunk 1 = delta -> store on a
+// ramp. Asserts the frame round-trips, has two chunks, and that each chunk
+// carries the codecs its graph implies.
+TEST(MultiChunkFrameTest, BitpackThenDeltaStore_TwoChunksWithDistinctCodecs)
+{
+    // Chunk 0 data (bitpackable) followed by chunk 1 data (ramp) in one buffer.
+    std::vector<int32_t> ints       = makeSmallInts(kEltsPerChunk);
+    const std::vector<int32_t> ramp = makeRamp(kEltsPerChunk);
+    ints.insert(ints.end(), ramp.begin(), ramp.end());
+
+    const Input in = Input::refNumeric<int32_t>(ints.data(), ints.size());
+
+    Compressor compressor;
+    const GraphID bitpack      = graphs::Bitpack{}();
+    const GraphID deltaToStore = buildDeltaToStore(compressor);
+
+    const std::string frame = makeMultiChunkFrame(
+            compressor,
+            { ChunkSpec{ kEltsPerChunk, bitpack },
+              ChunkSpec{ kEltsPerChunk, deltaToStore } },
+            in);
+
+    // (a) The whole multi-chunk frame round-trips back to the original input.
+    EXPECT_TRUE(decompressedEquals(frame, in));
+
+    // Per-chunk codecs, recovered via the documented chunk-walk fallback: carve
+    // each chunk's slice out of the input and reflect it as its own
+    // single-chunk reference frame. (The public reflection API on the
+    // multi-chunk frame only exposes the last chunk -- asserted separately
+    // below.)
+    const Input slice0 = sliceInput(in, 0, kEltsPerChunk);
+    const Input slice1 = sliceInput(in, kEltsPerChunk, kEltsPerChunk);
+
+    Compressor refC0;
+    const std::string chunk0Frame =
+            makeFrameWithGraph(refC0, graphs::Bitpack{}(), slice0);
+    Compressor refC1;
+    const std::string chunk1Frame =
+            makeFrameWithGraph(refC1, buildDeltaToStore(refC1), slice1);
+
+    const std::vector<uint32_t> chunk0Codecs =
+            standardCodecsInFrame(chunk0Frame);
+    const std::vector<uint32_t> chunk1Codecs =
+            standardCodecsInFrame(chunk1Frame);
+
+    // (c) chunk 0 contains bitpack_int (28); chunk 1 contains delta_int (1)
+    // plus the num->serial conversion (10) that STORE forces on a numeric
+    // stream.
+    EXPECT_TRUE(contains(chunk0Codecs, kBitpackInt));
+    EXPECT_TRUE(frameHasExactlyCodecs(chunk0Frame, { kBitpackInt }));
+    EXPECT_TRUE(contains(chunk1Codecs, kDeltaInt));
+    EXPECT_TRUE(frameHasExactlyCodecs(
+            chunk1Frame, { kDeltaInt, kConvertNumToSerial }));
+}
+
+// (b) The frame genuinely has 2 chunks. We confirm this structurally by
+// round-tripping AND by directly enumerating each chunk's codecs from the full
+// multi-chunk frame.
+TEST(MultiChunkFrameTest, StandardCodecsPerChunk_ReportsEveryChunk)
+{
+    // This test verifies standardCodecsPerChunk() uses decompression
+    // introspection to report every chunk in a multi-chunk frame; it fails if
+    // the verifier falls back to the old reflection API and only exposes the
+    // final chunk.
+    std::vector<int32_t> ints       = makeSmallInts(kEltsPerChunk);
+    const std::vector<int32_t> ramp = makeRamp(kEltsPerChunk);
+    ints.insert(ints.end(), ramp.begin(), ramp.end());
+    const Input in = Input::refNumeric<int32_t>(ints.data(), ints.size());
+
+    Compressor compressor;
+    const GraphID bitpack      = graphs::Bitpack{}();
+    const GraphID deltaToStore = buildDeltaToStore(compressor);
+    const std::string frame    = makeMultiChunkFrame(
+            compressor,
+            { ChunkSpec{ kEltsPerChunk, bitpack },
+                 ChunkSpec{ kEltsPerChunk, deltaToStore } },
+            in);
+
+    const std::vector<std::vector<uint32_t>> perChunk =
+            standardCodecsPerChunk(frame);
+    ASSERT_EQ(perChunk.size(), 2u);
+    EXPECT_EQ(perChunk[0], std::vector<uint32_t>{ kBitpackInt });
+    EXPECT_EQ(
+            perChunk[1],
+            (std::vector<uint32_t>{ kConvertNumToSerial, kDeltaInt }));
+}
+
+TEST(MultiChunkFrameTest, RejectsChunkPlanThatExceedsInput)
+{
+    // This test verifies makeMultiChunkFrame() rejects malformed chunk plans
+    // before the segmenter slices the input; it fails if cumulative chunk
+    // sizes can walk past input.numElts().
+    const std::vector<int32_t> ints = makeSmallInts(100);
+    const Input in = Input::refNumeric<int32_t>(ints.data(), ints.size());
+
+    Compressor compressor;
+    const GraphID bitpack = graphs::Bitpack{}();
+
+    EXPECT_THROW(
+            makeMultiChunkFrame(
+                    compressor,
+                    { ChunkSpec{ 70, bitpack }, ChunkSpec{ 70, bitpack } },
+                    in),
+            openzl::Exception);
+}
+
+// Positive proof that each chunk really uses its OWN graph (not one graph for
+// the whole input): swapping the per-chunk graph order swaps which codecs the
+// last chunk reflects. With [bitpack, deltaStore] the last chunk is {1, 10};
+// with [deltaStore, bitpack] the last chunk is {28}. A single merged chunk
+// could not change its codecs based on chunk position, so this also
+// demonstrates the input is genuinely split into separate,
+// independently-graphed chunks.
+TEST(MultiChunkFrameTest, ChunkOrderControlsLastChunkCodecs)
+{
+    std::vector<int32_t> ints       = makeSmallInts(kEltsPerChunk);
+    const std::vector<int32_t> ramp = makeRamp(kEltsPerChunk);
+    ints.insert(ints.end(), ramp.begin(), ramp.end());
+    const Input in = Input::refNumeric<int32_t>(ints.data(), ints.size());
+
+    // bitpack first, deltaStore last -> last chunk reflects {1, 10}.
+    Compressor cA;
+    const std::string frameA = makeMultiChunkFrame(
+            cA,
+            { ChunkSpec{ kEltsPerChunk, graphs::Bitpack{}() },
+              ChunkSpec{ kEltsPerChunk, buildDeltaToStore(cA) } },
+            in);
+    EXPECT_TRUE(decompressedEquals(frameA, in));
+    EXPECT_TRUE(
+            frameHasExactlyCodecs(frameA, { kDeltaInt, kConvertNumToSerial }));
+
+    // deltaStore first, bitpack last -> last chunk reflects {28}.
+    Compressor cB;
+    const GraphID deltaStoreB = buildDeltaToStore(cB);
+    const std::string frameB  = makeMultiChunkFrame(
+            cB,
+            { ChunkSpec{ kEltsPerChunk, deltaStoreB },
+               ChunkSpec{ kEltsPerChunk, graphs::Bitpack{}() } },
+            in);
+    EXPECT_TRUE(decompressedEquals(frameB, in));
+    EXPECT_TRUE(frameHasExactlyCodecs(frameB, { kBitpackInt }));
+}
+
+} // namespace
+} // namespace openzl::gpu::testkit


### PR DESCRIPTION
Summary:
`testkit` mints real OpenZL frames and chunks for GPU-decoder tests by driving the actual encoder (so frame/chunk headers and checksums are correct by construction): `frame_factory` (single-graph frames), `multichunk_frame` (multi-chunk frames + `sliceInput`), and `frame_verifier` (reflection-based codec verification).

Also adds a Claude skill, `openzl-gpu-test-frames`, documenting how to mint single-codec and multi-chunk frames.

This can be considered scratch code to unblock things temporarily.

Reviewed By: terrelln

Differential Revision: D110231769


