### PR TITLE
Stub single-frame GPU decode entrypoint (#860)

### DIFF
--- a/contrib/gpu/src/decompress/BUCK
+++ b/contrib/gpu/src/decompress/BUCK
@@ -1,0 +1,12 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+
+load("@fbcode_macros//build_defs:cpp_library.bzl", "cpp_library")
+
+oncall("data_compression")
+
+cpp_library(
+    name = "decompress",
+    srcs = ["gpu_decompress.cpp"],
+    headers = ["gpu_decompress.h"],
+    exported_deps = ["../../../..:zstronglib"],
+)

--- a/contrib/gpu/src/decompress/gpu_decompress.cpp
+++ b/contrib/gpu/src/decompress/gpu_decompress.cpp
@@ -1,0 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#include "openzl/dev/contrib/gpu/src/decompress/gpu_decompress.h"
+
+extern "C" ZL_Report
+ZL_GPU_decompress(void*, size_t, const void*, size_t, ZL_GPU_Stream)
+{
+    return ZL_returnError(ZL_ErrorCode_GENERIC); // not implemented yet
+}

--- a/contrib/gpu/src/decompress/gpu_decompress.h
+++ b/contrib/gpu/src/decompress/gpu_decompress.h
@@ -1,0 +1,43 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#pragma once
+
+#include <stddef.h>
+
+#include "openzl/zl_errors.h" // ZL_Report
+
+// Device stream handle. Structurally identical to cudaStream_t; opaque here so
+// this header stays CUDA-free.
+typedef struct CUstream_st* ZL_GPU_Stream;
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * Decompress a single OpenZL frame that already resides in GPU memory.
+ *
+ * GPU analogue of core `ZL_decompress`: decodes exactly ONE frame -- which may
+ * itself contain multiple chunks -- from @p src_d into @p dst_d. Both buffers
+ * are device pointers; the decode is enqueued on @p stream and may run
+ * asynchronously with respect to the host.
+ *
+ * @param dst_d Device buffer that receives the decompressed output.
+ * @param dstCapacity Capacity of @p dst_d in bytes; at least the frame's
+ * decompressed size.
+ * @param src_d Device buffer holding the compressed frame.
+ * @param srcSize Size of the compressed frame, in bytes.
+ * @param stream CUDA stream the decode is enqueued on (opaque `ZL_GPU_Stream`
+ * so this header stays CUDA-free).
+ * @returns A `ZL_Report`: the decompressed size on success, or an error.
+ */
+ZL_Report ZL_GPU_decompress(
+        void* dst_d,
+        size_t dstCapacity,
+        const void* src_d,
+        size_t srcSize,
+        ZL_GPU_Stream stream);
+
+#ifdef __cplusplus
+}
+#endif


### PR DESCRIPTION
Summary:

Scaffolds the GPU decoder module with a stubbed single-frame decode entrypoint `ZL_GPU_decompress(dst, dstCapacity, src, srcSize, stream)` mirroring core `ZL_decompress` over GPU-resident memory.

The stub returns `ZL_ErrorCode_GENERIC`; real frame-header parsing and decode follow.

Reviewed By: terrelln

Differential Revision: D110231817


