### PR TITLE
Linter fixes

### DIFF
--- a/custom_parsers/zip_lexer.c
+++ b/custom_parsers/zip_lexer.c
@@ -4,7 +4,6 @@
 
 #include "openzl/shared/mem.h"
 #include "openzl/shared/utils.h"
-#include "openzl/shared/varint.h"
 
 static const uint16_t kZip64InfoID                           = 0x0001;
 static const uint16_t kDataDescriptorMask                    = (1 << 3);

--- a/src/openzl/shared/data_stats.c
+++ b/src/openzl/shared/data_stats.c
@@ -5,7 +5,6 @@
 #include "openzl/shared/bits.h"
 #include "openzl/shared/data_stats.h"
 #include "openzl/shared/histogram.h"
-#include "openzl/shared/portability.h" // ZL_UNUSED_ATTR
 #include "openzl/shared/utils.h"
 #include "openzl/shared/varint.h"
 

--- a/tests/unittest/common/test_errors_in_c.c
+++ b/tests/unittest/common/test_errors_in_c.c
@@ -6,7 +6,6 @@
 
 #include "openzl/common/assertion.h"
 #include "openzl/common/errors_internal.h"
-#include "openzl/common/operation_context.h"
 #include "openzl/zl_errors.h"
 
 #include "tests/unittest/common/test_errors_in_c.h"

--- a/tests/unittest/dict/FatBundleDictLoaderTest.cpp
+++ b/tests/unittest/dict/FatBundleDictLoaderTest.cpp
@@ -5,7 +5,6 @@
 #include "openzl/zl_dictloader.h"
 #include "openzl/zl_materializer.h"
 
-#include "openzl/dict/dictloader.h" // ZL_RES_value(ZL_DictLoader_fetchDictBundl)e
 #include "tests/unittest/dict/DictTestHelpers.h"
 
 namespace {

--- a/tests/unittest/dict/FatBundleTest.cpp
+++ b/tests/unittest/dict/FatBundleTest.cpp
@@ -5,7 +5,6 @@
 #include <vector>
 
 #include "openzl/dict/bundle.h"
-#include "openzl/dict/dict.h"
 
 #include "DictTestHelpers.h"
 


### PR DESCRIPTION
Summary:
Remove unused #include directives flagged by facebook-unused-include-check (clang-tidy). Each removed include was verified to have no referenced symbols, macros, or templates in its translation unit, with the flagged symbols resolving from other already-included headers.

Files:
- openzl/dev/custom_parsers/zip_lexer.c: openzl/shared/varint.h (T279453826)
- openzl/prod/src/openzl/codecs/bitSplit/encode_bitSplit_binding.c: openzl/zl_graph_api.h (T278406280)
- openzl/prod/src/openzl/shared/data_stats.c: openzl/shared/portability.h (T275751985)
- openzl/prod/tests/datagen/structures/CompressorProducer.cpp: openzl/zl_selector.h (T275751981)
- openzl/prod/tests/unittest/dict/FatBundleTest.cpp: openzl/dict/dict.h (T275751988)
- openzl/prod/tests/unittest/dict/FatBundleDictLoaderTest.cpp: openzl/dict/dictloader.h (T278406293)
- common/managed_compression/zstrong/tests/ManagedCompressionSerializedGraphTest.cpp: openzl/codecs/zl_store.h (T278406300)
- tests/unittest/common/test_errors_in_c.c: openzl/common/operation_context.h (T275751978)

Note: T279453837 (SegmentNumeric.cpp) and T278406283 (ManagedCompressionZstrongGraphRegistry.cpp) are stale — the flagged include was already removed / the file no longer exists.

Reviewed By: daniellerozenblit

Differential Revision: D112003197


