### PR TITLE
bf16 float_deconstruct decode kernel + host API (#868)

### DIFF
--- a/contrib/gpu/source/codecs/float_deconstruct/BUCK
+++ b/contrib/gpu/source/codecs/float_deconstruct/BUCK
@@ -1,0 +1,15 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+
+load("@fbcode_macros//build_defs:cpp_library.bzl", "cpp_library")
+load("//tools/build/buck:nvcc_flags.bzl", "get_nvcc_arch_args")
+
+oncall("data_compression")
+
+# GPU decode kernel for the bfloat16 float_deconstruct codec.
+cpp_library(
+    name = "decode_float_deconstruct_bf16",
+    srcs = ["decode_float_deconstruct_bf16.cu"],
+    headers = ["decode_float_deconstruct_bf16.cuh"],
+    nvcc_flags = get_nvcc_arch_args() + ["-lineinfo"],
+    exported_external_deps = [("cuda", None, "cuda-lazy")],
+)

--- a/contrib/gpu/source/codecs/float_deconstruct/decode_float_deconstruct_bf16.cu
+++ b/contrib/gpu/source/codecs/float_deconstruct/decode_float_deconstruct_bf16.cu
@@ -1,0 +1,82 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#include "decode_float_deconstruct_bf16.cuh"
+
+#include <stdexcept>
+#include <string>
+
+namespace openzl::gpu {
+
+namespace {
+
+constexpr int kThreads = 256;
+
+// chunk = blockIdx.y; each block's threads grid-stride over that chunk along x.
+// One chunk is just numInBatch == 1, so this handles single and multi chunk.
+// gridDim.y caps numInBatch at 65535.
+__global__ void decodeChunksKernel(
+        const FloatDeconChunk* __restrict__ chunks,
+        uint32_t numInBatch)
+{
+    const uint32_t b = blockIdx.y;
+    if (b >= numInBatch) {
+        return;
+    }
+    const FloatDeconChunk c = chunks[b];
+    const size_t stride     = (size_t)gridDim.x * blockDim.x;
+    for (size_t i = (size_t)blockIdx.x * blockDim.x + threadIdx.x; i < c.nbElts;
+         i += stride) {
+        c.dst[i] = decodeBf16Elt(c.exponent[i], c.signFrac[i]);
+    }
+}
+
+// 1D grid size that fills the GPU for a given kernel at kThreads.
+uint32_t fillGpuGrid(const void* kernel)
+{
+    int maxBlocksPerSM = 0;
+    cudaOccupancyMaxActiveBlocksPerMultiprocessor(
+            &maxBlocksPerSM, kernel, kThreads, 0);
+    int dev    = 0;
+    int numSMs = 0;
+    cudaGetDevice(&dev);
+    cudaDeviceGetAttribute(&numSMs, cudaDevAttrMultiProcessorCount, dev);
+    const uint32_t grid = (uint32_t)maxBlocksPerSM * (uint32_t)numSMs;
+    return grid == 0 ? 1 : grid;
+}
+
+} // namespace
+
+void bf16DeconDecode(
+        uint32_t numInBatch,
+        const FloatDeconChunk* chunks_d,
+        cudaStream_t stream)
+{
+    if (numInBatch == 0) {
+        return;
+    }
+    if (numInBatch > kMaxNumInBatch) {
+        throw std::runtime_error(
+                "bf16DeconDecode: numInBatch " + std::to_string(numInBatch)
+                + " exceeds kMaxNumInBatch " + std::to_string(kMaxNumInBatch)
+                + " (gridDim.y limit); split the batch across calls");
+    }
+    // Oversubscribe x so blocksPerChunk * numInBatch roughly fills the GPU;
+    // grid-stride in x then covers any per-chunk size.
+    const uint32_t target = fillGpuGrid((const void*)decodeChunksKernel);
+    const uint32_t blocksPerChunk = (target + numInBatch - 1) / numInBatch;
+    const dim3 grid(blocksPerChunk, numInBatch);
+    decodeChunksKernel<<<grid, kThreads, 0, stream>>>(chunks_d, numInBatch);
+}
+
+KernelLaunchInfo bf16DeconDecodeLaunchInfo()
+{
+    int maxActiveBlocksPerSM = 0;
+    cudaOccupancyMaxActiveBlocksPerMultiprocessor(
+            &maxActiveBlocksPerSM,
+            (const void*)decodeChunksKernel,
+            kThreads,
+            0);
+    return { kThreads, maxActiveBlocksPerSM };
+}
+
+} // namespace openzl::gpu

--- a/contrib/gpu/source/codecs/float_deconstruct/decode_float_deconstruct_bf16.cuh
+++ b/contrib/gpu/source/codecs/float_deconstruct/decode_float_deconstruct_bf16.cuh
@@ -1,0 +1,51 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+
+#include <cuda_runtime.h>
+
+namespace openzl::gpu {
+
+// Describes one bf16 float-deconstruct chunk. All pointers are device pointers
+struct FloatDeconChunk {
+    const uint8_t* exponent;
+    const uint8_t* signFrac;
+    uint16_t* dst;
+    size_t nbElts;
+};
+
+// Canonical single element decode
+__host__ __device__ __forceinline__ uint16_t
+decodeBf16Elt(uint8_t exponent, uint8_t signFrac)
+{
+    const uint16_t sign  = (uint16_t)(signFrac << 15);
+    const uint16_t expnt = (uint16_t)(exponent << 7);
+    const uint16_t frac  = (uint16_t)(signFrac >> 1);
+    return sign | expnt | frac;
+}
+
+// Maximum chunks per bf16DeconDecode call. numInBatch maps to gridDim.y, which
+// CUDA caps at 65535; a caller (or binding) with more chunks must split the
+// batch across multiple calls.
+constexpr uint32_t kMaxNumInBatch = 65535;
+
+// Decodes `numInBatch` bf16 float-deconstruct chunks, writing each chunk's
+// result into its own `dst`. Throws std::runtime_error if numInBatch exceeds
+// kMaxNumInBatch (the gridDim.y limit).
+void bf16DeconDecode(
+        uint32_t numInBatch,
+        const FloatDeconChunk* chunks_d,
+        cudaStream_t stream);
+
+// Occupancy/launch metadata for the main decode kernel, so a benchmark harness
+// can report theoretical occupancy without seeing the kernel internals
+struct KernelLaunchInfo {
+    int blockSize;
+    int maxActiveBlocksPerSM;
+};
+KernelLaunchInfo bf16DeconDecodeLaunchInfo();
+
+} // namespace openzl::gpu


### PR DESCRIPTION
Summary:

## What

**Problem:** There is no GPU decoder for the bf16 `float_deconstruct` codec; reassembling bf16 from the `exponent`/`signFrac` byte streams is CPU-only.

**Changes made:** First GPU decode kernel and host API. `decodeChunksKernel` maps `blockIdx.y` to the chunk and grid-strides over its elements, so one kernel handles single- and multi-chunk (`numInBatch == 1` is just one row). `bf16DeconDecode(numInBatch, chunks_d, stream)` sizes an x-oversubscribed grid to fill the GPU and launches it. `decodeBf16Elt` is the shared per-element reassembly, `FloatDeconChunk` is the per-chunk descriptor, and `bf16DeconDecodeLaunchInfo` reports block size + max active blocks/SM for occupancy. Naive first version (no tiling/search); data assumed already on device.

## Why

Establishes the baseline GPU decode path that the rest of the stack builds on (error checking, harness, benchmark, faster kernels).

## Stack Context

- **Previous diff:** none (base of the stack).
- **Where we are in the stack:** the naive baseline kernel + host API.
- **Next diff:** shared ZL_CUDA_CHECK error macro.

## Clarifications & Assumptions

N/A - all important items clarified in comments.

Reviewed By: terrelln

Differential Revision: D110368647


