### PR TITLE
Shared ZL_CUDA_CHECK error macro (#869)

### DIFF
--- a/contrib/gpu/source/common/BUCK
+++ b/contrib/gpu/source/common/BUCK
@@ -1,0 +1,12 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+
+load("@fbcode_macros//build_defs:cpp_library.bzl", "cpp_library")
+
+oncall("data_compression")
+
+# Shared CUDA error-check macros for GPU host code.
+cpp_library(
+    name = "cuda_error",
+    headers = ["cuda_error.cuh"],
+    exported_external_deps = [("cuda", None, "cuda-lazy")],
+)

--- a/contrib/gpu/source/common/cuda_error.cuh
+++ b/contrib/gpu/source/common/cuda_error.cuh
@@ -1,0 +1,30 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#pragma once
+
+#include <stdexcept>
+#include <string>
+
+#include <cuda_runtime.h>
+
+// Shared CUDA error checks for GPU host code, following the OpenZL error-macro
+// conventions (ZL_ prefix, uppercase). Throw-based so it works in the
+// benchmark's main and reports a failure under gtest. ZL_CUDA_CHECK wraps a
+// CUDA call; ZL_CUDA_CHECK_LAST checks cudaGetLastError after a kernel launch.
+
+namespace openzl::gpu {
+
+inline void cudaCheck(cudaError_t err, const char* file, int line)
+{
+    if (err != cudaSuccess) {
+        throw std::runtime_error(
+                std::string("CUDA error ") + file + ":" + std::to_string(line)
+                + ": " + cudaGetErrorString(err));
+    }
+}
+
+} // namespace openzl::gpu
+
+#define ZL_CUDA_CHECK(expr) ::openzl::gpu::cudaCheck((expr), __FILE__, __LINE__)
+#define ZL_CUDA_CHECK_LAST() \
+    ::openzl::gpu::cudaCheck(cudaGetLastError(), __FILE__, __LINE__)


### PR DESCRIPTION
Summary:

## What

**Problem:** GPU host code (kernel, harness, benchmark, test) needs consistent CUDA error checking; without a shared helper each consumer hand-rolls its own.

**Changes made:** New `source/common/cuda_error.cuh` (its own `cuda_error` cpp_library) providing `ZL_CUDA_CHECK(expr)` and `ZL_CUDA_CHECK_LAST()`, following OpenZL's `ZL_`-prefixed error-macro convention. Throw-based so it works in the benchmark `main` and surfaces as a gtest failure; behavior follows `ZL_REQUIRE` (always on). Keeps the C++ throw rather than the `ZL_Report` return path since the GPU host code does not use the core error machinery.

## Why

Lands the shared macro before its first consumer so the harness, benchmark, and test use one error path from the start instead of each carrying an ad-hoc check.

## Stack Context

- **Previous diff:** bf16 float_deconstruct decode kernel + host API.
- **Where we are in the stack:** the shared CUDA error-check header.
- **Next diff:** shared GPU decode + benchmark harness (first consumer).

## Clarifications & Assumptions

N/A - all important items clarified in comments.

Reviewed By: terrelln

Differential Revision: D111255017


