### PR TITLE
Rename Annotations to InferredAnnotations

### DIFF
--- a/tools/sddl2/compiler/codegen/CodeGenerator.cpp
+++ b/tools/sddl2/compiler/codegen/CodeGenerator.cpp
@@ -288,7 +288,7 @@ class CodeGeneratorImpl {
             }
             case ConvertedNodeType::RECORD: {
                 auto record = type->as_record();
-                if (record->annotations().requires_scan) {
+                if (record->inferred_annotations().requires_scan) {
                     throw CodegenError(
                             type->loc(), "Scan records are not yet supported.");
                 }

--- a/tools/sddl2/compiler/optimizer/ConstFoldPass.cpp
+++ b/tools/sddl2/compiler/optimizer/ConstFoldPass.cpp
@@ -73,19 +73,20 @@ class ConstFoldImpl {
     ASTPtr optimizeBytes(const ASTBytes& bytes)
     {
         return Codegen(bytes.loc())
-                .bytes(optimizeNode(bytes.len()), bytes.annotations());
+                .bytes(optimizeNode(bytes.len()), bytes.inferred_annotations());
     }
 
     ASTPtr optimizeArray(const ASTArray& array)
     {
         if (!array.len()) {
             return Codegen(array.loc())
-                    .array(optimizeNode(array.field()), array.annotations());
+                    .array(optimizeNode(array.field()),
+                           array.inferred_annotations());
         }
         return Codegen(array.loc())
                 .array(optimizeNode(array.field()),
                        optimizeNode(array.len()),
-                       array.annotations());
+                       array.inferred_annotations());
     }
 
     ASTPtr optimizeCall(const ASTCall& call)
@@ -93,7 +94,7 @@ class ConstFoldImpl {
         return Codegen(call.loc())
                 .call(optimizeNode(call.target()),
                       optimizeVec(call.args()),
-                      call.annotations());
+                      call.inferred_annotations());
     }
 
     ASTPtr optimizeRecord(const ASTRecord& record)
@@ -104,7 +105,7 @@ class ConstFoldImpl {
         return Codegen(record.loc())
                 .record(record.params(),
                         std::move(new_fields),
-                        record.annotations());
+                        record.inferred_annotations());
     }
 
     ASTVec optimizeWhen(const ASTWhen& when)

--- a/tools/sddl2/compiler/optimizer/DeadVarPass.cpp
+++ b/tools/sddl2/compiler/optimizer/DeadVarPass.cpp
@@ -140,19 +140,21 @@ class DeadVarImpl {
     ASTPtr optimizeBytes(const ASTBytes* bytes)
     {
         return Codegen(bytes->loc())
-                .bytes(optimizeNode(bytes->len()), bytes->annotations());
+                .bytes(optimizeNode(bytes->len()),
+                       bytes->inferred_annotations());
     }
 
     ASTPtr optimizeArray(const ASTArray* arr)
     {
         if (!arr->len()) {
             return Codegen(arr->loc())
-                    .array(optimizeNode(arr->field()), arr->annotations());
+                    .array(optimizeNode(arr->field()),
+                           arr->inferred_annotations());
         }
         return Codegen(arr->loc())
                 .array(optimizeNode(arr->field()),
                        optimizeNode(arr->len()),
-                       arr->annotations());
+                       arr->inferred_annotations());
     }
 
     ASTPtr optimizeCall(const ASTCall* call)
@@ -160,7 +162,7 @@ class DeadVarImpl {
         return Codegen(call->loc())
                 .call(optimizeNode(call->target()),
                       optimizeVec(call->args()),
-                      call->annotations());
+                      call->inferred_annotations());
     }
 
     ASTPtr optimizeOp(const ASTOp* op)

--- a/tools/sddl2/compiler/parser/AST.h
+++ b/tools/sddl2/compiler/parser/AST.h
@@ -200,13 +200,12 @@ class ASTVar : public ASTConverted {
 };
 
 /**
- * Annotations populated by post-parse passes (semantic analyzer, etc.) and
- * read by later passes (codegen). Attached to every ASTConverted node via
- * `annotations()`. Add new fields here rather than to individual node
- * subclasses so passes can share annotation state without changing AST
- * shape.
+ * Facts inferred by post-parse passes (semantic analyzer, etc.) and read by
+ * later passes (codegen). Attached to every ASTField via
+ * `inferred_annotations()`. Add new fields here rather than to individual node
+ * subclasses so passes can share state without changing AST shape.
  */
-struct Annotations {
+struct InferredAnnotations {
     bool requires_scan = false;
 };
 
@@ -214,13 +213,13 @@ class ASTField : public ASTConverted {
    public:
     using ASTConverted::ASTConverted;
 
-    Annotations& annotations() const
+    InferredAnnotations& inferred_annotations() const
     {
-        return annotations_;
+        return inferred_annotations_;
     }
 
    private:
-    mutable Annotations annotations_;
+    mutable InferredAnnotations inferred_annotations_;
 };
 
 class ASTBuiltinField : public ASTField {
@@ -520,43 +519,47 @@ class Codegen {
         return std::make_shared<ASTBuiltinField>(loc_, sym);
     }
 
-    ASTPtr array(ASTPtr field, ASTPtr len, Annotations annotations = {}) const
+    ASTPtr array(ASTPtr field, ASTPtr len, InferredAnnotations inferred = {})
+            const
     {
         auto node =
                 std::make_shared<ASTArray>(std::move(field), std::move(len));
-        node->annotations() = annotations;
+        node->inferred_annotations() = inferred;
         return node;
     }
 
-    ASTPtr array(ASTPtr field, Annotations annotations = {}) const
+    ASTPtr array(ASTPtr field, InferredAnnotations inferred = {}) const
     {
-        auto node           = std::make_shared<ASTArray>(std::move(field));
-        node->annotations() = annotations;
+        auto node = std::make_shared<ASTArray>(std::move(field));
+        node->inferred_annotations() = inferred;
         return node;
     }
 
-    ASTPtr bytes(ASTPtr len, Annotations annotations = {}) const
+    ASTPtr bytes(ASTPtr len, InferredAnnotations inferred = {}) const
     {
         auto node = std::make_shared<ASTBytes>(
                 loc_, paren_list({ std::move(len) }));
-        node->annotations() = annotations;
+        node->inferred_annotations() = inferred;
         return node;
     }
 
-    ASTPtr record(ASTVec params, ASTVec fields, Annotations annotations = {})
-            const
+    ASTPtr record(
+            ASTVec params,
+            ASTVec fields,
+            InferredAnnotations inferred = {}) const
     {
         auto node = std::make_shared<ASTRecord>(
                 paren_list(std::move(params)), curly_list(std::move(fields)));
-        node->annotations() = annotations;
+        node->inferred_annotations() = inferred;
         return node;
     }
 
-    ASTPtr call(ASTPtr target, ASTVec args, Annotations annotations = {}) const
+    ASTPtr call(ASTPtr target, ASTVec args, InferredAnnotations inferred = {})
+            const
     {
         auto node =
                 std::make_shared<ASTCall>(std::move(target), std::move(args));
-        node->annotations() = annotations;
+        node->inferred_annotations() = inferred;
         return node;
     }
 

--- a/tools/sddl2/compiler/semantic_analyzer/SemanticAnalyzer.cpp
+++ b/tools/sddl2/compiler/semantic_analyzer/SemanticAnalyzer.cpp
@@ -175,7 +175,7 @@ class SemanticAnalyzerImpl {
     {
         auto element_type = analyzeNode(array.field());
         expectFieldType(array.field()->loc(), element_type);
-        if (element_type.type_def->annotations().requires_scan) {
+        if (element_type.type_def->inferred_annotations().requires_scan) {
             scope_.requires_scan = true;
         }
         if (array.len()) {
@@ -199,7 +199,7 @@ class SemanticAnalyzerImpl {
 
         // Transitivity: a field whose type is itself a requires-scan
         // record or array makes the enclosing record requires-scan too.
-        if (t.type_def->annotations().requires_scan) {
+        if (t.type_def->inferred_annotations().requires_scan) {
             scope_.requires_scan = true;
         }
         return Type{ TypeKind::NONE };
@@ -226,8 +226,8 @@ class SemanticAnalyzerImpl {
             analyzeNode(field);
         }
 
-        record.annotations().requires_scan = scope_.requires_scan;
-        scope_                             = std::move(saved);
+        record.inferred_annotations().requires_scan = scope_.requires_scan;
+        scope_                                      = std::move(saved);
 
         return Type{ TypeKind::RECORD, &record };
     }
@@ -376,7 +376,7 @@ class SemanticAnalyzerImpl {
         }
 
         auto* record = lhs_type.type_def->as_record();
-        if (record->annotations().requires_scan) {
+        if (record->inferred_annotations().requires_scan) {
             throw SemanticError(
                     op.args()[0]->loc(),
                     "Member access not supported on scan records.");

--- a/tools/sddl2/compiler/tests/SemanticAnalyzerTest.cpp
+++ b/tools/sddl2/compiler/tests/SemanticAnalyzerTest.cpp
@@ -519,7 +519,7 @@ TEST_F(SemanticAnalyzerTest, InstantParseSimple)
         }
     )";
     auto ast        = compiler_->compile_ast(prog, "[local_input]");
-    EXPECT_FALSE(find_record(ast, "Foo")->annotations().requires_scan);
+    EXPECT_FALSE(find_record(ast, "Foo")->inferred_annotations().requires_scan);
 }
 
 TEST_F(SemanticAnalyzerTest, InstantParseWithParam)
@@ -530,7 +530,7 @@ TEST_F(SemanticAnalyzerTest, InstantParseWithParam)
         }
     )";
     auto ast        = compiler_->compile_ast(prog, "[local_input]");
-    EXPECT_FALSE(find_record(ast, "Foo")->annotations().requires_scan);
+    EXPECT_FALSE(find_record(ast, "Foo")->inferred_annotations().requires_scan);
 }
 
 TEST_F(SemanticAnalyzerTest, ScanSimple)
@@ -542,7 +542,7 @@ TEST_F(SemanticAnalyzerTest, ScanSimple)
         }
     )";
     auto ast        = compiler_->compile_ast(prog, "[local_input]");
-    EXPECT_TRUE(find_record(ast, "Foo")->annotations().requires_scan);
+    EXPECT_TRUE(find_record(ast, "Foo")->inferred_annotations().requires_scan);
 }
 
 TEST_F(SemanticAnalyzerTest, RequiresScanConditional)
@@ -556,7 +556,7 @@ TEST_F(SemanticAnalyzerTest, RequiresScanConditional)
         }
     )";
     auto ast        = compiler_->compile_ast(prog, "[local_input]");
-    EXPECT_TRUE(find_record(ast, "Foo")->annotations().requires_scan);
+    EXPECT_TRUE(find_record(ast, "Foo")->inferred_annotations().requires_scan);
 }
 
 TEST_F(SemanticAnalyzerTest, RequiresScanNested)
@@ -571,8 +571,10 @@ TEST_F(SemanticAnalyzerTest, RequiresScanNested)
         }
     )";
     auto ast        = compiler_->compile_ast(prog, "[local_input]");
-    EXPECT_TRUE(find_record(ast, "Inner")->annotations().requires_scan);
-    EXPECT_TRUE(find_record(ast, "Outer")->annotations().requires_scan);
+    EXPECT_TRUE(
+            find_record(ast, "Inner")->inferred_annotations().requires_scan);
+    EXPECT_TRUE(
+            find_record(ast, "Outer")->inferred_annotations().requires_scan);
 }
 
 TEST_F(SemanticAnalyzerTest, RequiresScanNestedConditional)
@@ -590,8 +592,10 @@ TEST_F(SemanticAnalyzerTest, RequiresScanNestedConditional)
         flags: UInt8
     )";
     auto ast        = compiler_->compile_ast(prog, "[local_input]");
-    EXPECT_TRUE(find_record(ast, "Inner")->annotations().requires_scan);
-    EXPECT_TRUE(find_record(ast, "Outer")->annotations().requires_scan);
+    EXPECT_TRUE(
+            find_record(ast, "Inner")->inferred_annotations().requires_scan);
+    EXPECT_TRUE(
+            find_record(ast, "Outer")->inferred_annotations().requires_scan);
 }
 
 TEST_F(SemanticAnalyzerTest, RequiresScanOuter)
@@ -607,8 +611,10 @@ TEST_F(SemanticAnalyzerTest, RequiresScanOuter)
         }
     )";
     auto ast        = compiler_->compile_ast(prog, "[local_input]");
-    EXPECT_TRUE(find_record(ast, "Outer")->annotations().requires_scan);
-    EXPECT_FALSE(find_record(ast, "Inner")->annotations().requires_scan);
+    EXPECT_TRUE(
+            find_record(ast, "Outer")->inferred_annotations().requires_scan);
+    EXPECT_FALSE(
+            find_record(ast, "Inner")->inferred_annotations().requires_scan);
 }
 
 TEST_F(SemanticAnalyzerTest, TypeCheckReferencedFields)


### PR DESCRIPTION
Summary:
## Stack
The goal of this stack is to add author-facing `@` annotations to SDDL2 records, starting with `instant_parse`.

## Diff
Pure rename of the compiler-inferred `Annotations` to `InferredAnnotations`, to make room for a separate author-written annotation type in the next diff. No behavior change.

Differential Revision: D112335339


