### PR TITLE
Add grammar annotation (@name) syntax to records

### DIFF
--- a/tools/sddl2/compiler/Syntax.cpp
+++ b/tools/sddl2/compiler/Syntax.cpp
@@ -119,6 +119,8 @@ static const std::map<Symbol, poly::string_view> syms_to_debug_strs{
     { Symbol::RECORD, "RECORD" },
 
     { Symbol::WHEN, "WHEN" },
+
+    { Symbol::AT, "AT" },
 };
 
 poly::string_view sym_to_debug_str(Symbol sym)
@@ -193,6 +195,8 @@ const std::vector<std::pair<poly::string_view, Symbol>> strs_to_syms{
 
     { "record", Symbol::RECORD },
     { "when", Symbol::WHEN },
+
+    { "@", Symbol::AT },
 };
 
 /* These symbols can't actually be accessed via these names. */

--- a/tools/sddl2/compiler/Syntax.h
+++ b/tools/sddl2/compiler/Syntax.h
@@ -94,7 +94,10 @@ enum class Symbol {
     RECORD,
 
     // Control Flow
-    WHEN
+    WHEN,
+
+    // Annotations
+    AT // '@', introduces a record annotation (e.g., @instant_parse)
 };
 
 /// @returns a name string for a symbol.

--- a/tools/sddl2/compiler/codegen/CodeGenerator.cpp
+++ b/tools/sddl2/compiler/codegen/CodeGenerator.cpp
@@ -288,7 +288,7 @@ class CodeGeneratorImpl {
             }
             case ConvertedNodeType::RECORD: {
                 auto record = type->as_record();
-                if (record->annotations().requires_scan) {
+                if (record->inferred_annotations().requires_scan) {
                     throw CodegenError(
                             type->loc(), "Scan records are not yet supported.");
                 }

--- a/tools/sddl2/compiler/optimizer/ConstFoldPass.cpp
+++ b/tools/sddl2/compiler/optimizer/ConstFoldPass.cpp
@@ -73,19 +73,20 @@ class ConstFoldImpl {
     ASTPtr optimizeBytes(const ASTBytes& bytes)
     {
         return Codegen(bytes.loc())
-                .bytes(optimizeNode(bytes.len()), bytes.annotations());
+                .bytes(optimizeNode(bytes.len()), bytes.inferred_annotations());
     }
 
     ASTPtr optimizeArray(const ASTArray& array)
     {
         if (!array.len()) {
             return Codegen(array.loc())
-                    .array(optimizeNode(array.field()), array.annotations());
+                    .array(optimizeNode(array.field()),
+                           array.inferred_annotations());
         }
         return Codegen(array.loc())
                 .array(optimizeNode(array.field()),
                        optimizeNode(array.len()),
-                       array.annotations());
+                       array.inferred_annotations());
     }
 
     ASTPtr optimizeCall(const ASTCall& call)
@@ -93,7 +94,7 @@ class ConstFoldImpl {
         return Codegen(call.loc())
                 .call(optimizeNode(call.target()),
                       optimizeVec(call.args()),
-                      call.annotations());
+                      call.inferred_annotations());
     }
 
     ASTPtr optimizeRecord(const ASTRecord& record)
@@ -104,7 +105,7 @@ class ConstFoldImpl {
         return Codegen(record.loc())
                 .record(record.params(),
                         std::move(new_fields),
-                        record.annotations());
+                        record.inferred_annotations());
     }
 
     ASTVec optimizeWhen(const ASTWhen& when)

--- a/tools/sddl2/compiler/optimizer/ConstFoldPass.cpp
+++ b/tools/sddl2/compiler/optimizer/ConstFoldPass.cpp
@@ -105,6 +105,7 @@ class ConstFoldImpl {
         return Codegen(record.loc())
                 .record(record.params(),
                         std::move(new_fields),
+                        record.annotations(),
                         record.inferred_annotations());
     }
 

--- a/tools/sddl2/compiler/optimizer/DeadVarPass.cpp
+++ b/tools/sddl2/compiler/optimizer/DeadVarPass.cpp
@@ -140,19 +140,21 @@ class DeadVarImpl {
     ASTPtr optimizeBytes(const ASTBytes* bytes)
     {
         return Codegen(bytes->loc())
-                .bytes(optimizeNode(bytes->len()), bytes->annotations());
+                .bytes(optimizeNode(bytes->len()),
+                       bytes->inferred_annotations());
     }
 
     ASTPtr optimizeArray(const ASTArray* arr)
     {
         if (!arr->len()) {
             return Codegen(arr->loc())
-                    .array(optimizeNode(arr->field()), arr->annotations());
+                    .array(optimizeNode(arr->field()),
+                           arr->inferred_annotations());
         }
         return Codegen(arr->loc())
                 .array(optimizeNode(arr->field()),
                        optimizeNode(arr->len()),
-                       arr->annotations());
+                       arr->inferred_annotations());
     }
 
     ASTPtr optimizeCall(const ASTCall* call)
@@ -160,7 +162,7 @@ class DeadVarImpl {
         return Codegen(call->loc())
                 .call(optimizeNode(call->target()),
                       optimizeVec(call->args()),
-                      call->annotations());
+                      call->inferred_annotations());
     }
 
     ASTPtr optimizeOp(const ASTOp* op)

--- a/tools/sddl2/compiler/parser/AST.cpp
+++ b/tools/sddl2/compiler/parser/AST.cpp
@@ -317,10 +317,14 @@ ASTPtr ASTBytes::extract_len(const ASTPtr& paren_ptr)
     return list->nodes()[0];
 }
 
-ASTRecord::ASTRecord(const ASTPtr& params, const ASTPtr& fields)
+ASTRecord::ASTRecord(
+        const ASTPtr& params,
+        const ASTPtr& fields,
+        GrammarAnnotations annotations)
         : ASTField(params->loc() + fields->loc()),
           params_(extract_params(loc(), params)),
-          fields_(extract_fields(loc(), fields))
+          fields_(extract_fields(loc(), fields)),
+          annotations_(std::move(annotations))
 
 {
 }

--- a/tools/sddl2/compiler/parser/AST.h
+++ b/tools/sddl2/compiler/parser/AST.h
@@ -3,6 +3,8 @@
 #pragma once
 
 #include <memory>
+#include <set>
+#include <string>
 #include <vector>
 
 #include "openzl/shared/a1cbor.h"
@@ -200,6 +202,21 @@ class ASTVar : public ASTConverted {
 };
 
 /**
+ * Annotations written by the author in source via `@`-syntax (e.g.
+ * `@instant_parse`) and attached to the node by the parser. An open set: any
+ * identifier may be applied, and multiple annotations may be attached to a
+ * single node. Consumers act on the specific names they recognize.
+ */
+struct GrammarAnnotations {
+    std::set<std::string> names;
+
+    bool has(const std::string& name) const
+    {
+        return names.count(name) > 0;
+    }
+};
+
+/**
  * Facts inferred by post-parse passes (semantic analyzer, etc.) and read by
  * later passes (codegen). Attached to every ASTField via
  * `inferred_annotations()`. Add new fields here rather than to individual node
@@ -264,7 +281,10 @@ class ASTBytes : public ASTField {
 
 class ASTRecord : public ASTField {
    public:
-    explicit ASTRecord(const ASTPtr& params, const ASTPtr& fields);
+    explicit ASTRecord(
+            const ASTPtr& params,
+            const ASTPtr& fields,
+            GrammarAnnotations annotations = {});
 
     const ASTRecord* as_record() const override;
 
@@ -278,6 +298,11 @@ class ASTRecord : public ASTField {
     const ASTVec& params() const;
     const ASTVec& fields() const;
 
+    const GrammarAnnotations& annotations() const
+    {
+        return annotations_;
+    }
+
    private:
     static ASTVec extract_fields(
             const SourceLocation& loc,
@@ -289,6 +314,7 @@ class ASTRecord : public ASTField {
 
     const ASTVec params_;
     const ASTVec fields_;
+    const GrammarAnnotations annotations_;
 };
 
 class ASTCall : public ASTField {
@@ -546,10 +572,13 @@ class Codegen {
     ASTPtr record(
             ASTVec params,
             ASTVec fields,
-            InferredAnnotations inferred = {}) const
+            GrammarAnnotations annotations = {},
+            InferredAnnotations inferred   = {}) const
     {
         auto node = std::make_shared<ASTRecord>(
-                paren_list(std::move(params)), curly_list(std::move(fields)));
+                paren_list(std::move(params)),
+                curly_list(std::move(fields)),
+                std::move(annotations));
         node->inferred_annotations() = inferred;
         return node;
     }

--- a/tools/sddl2/compiler/parser/AST.h
+++ b/tools/sddl2/compiler/parser/AST.h
@@ -200,13 +200,12 @@ class ASTVar : public ASTConverted {
 };
 
 /**
- * Annotations populated by post-parse passes (semantic analyzer, etc.) and
- * read by later passes (codegen). Attached to every ASTConverted node via
- * `annotations()`. Add new fields here rather than to individual node
- * subclasses so passes can share annotation state without changing AST
- * shape.
+ * Facts inferred by post-parse passes (semantic analyzer, etc.) and read by
+ * later passes (codegen). Attached to every ASTField via
+ * `inferred_annotations()`. Add new fields here rather than to individual node
+ * subclasses so passes can share state without changing AST shape.
  */
-struct Annotations {
+struct InferredAnnotations {
     bool requires_scan = false;
 };
 
@@ -214,13 +213,13 @@ class ASTField : public ASTConverted {
    public:
     using ASTConverted::ASTConverted;
 
-    Annotations& annotations() const
+    InferredAnnotations& inferred_annotations() const
     {
-        return annotations_;
+        return inferred_annotations_;
     }
 
    private:
-    mutable Annotations annotations_;
+    mutable InferredAnnotations inferred_annotations_;
 };
 
 class ASTBuiltinField : public ASTField {
@@ -520,43 +519,47 @@ class Codegen {
         return std::make_shared<ASTBuiltinField>(loc_, sym);
     }
 
-    ASTPtr array(ASTPtr field, ASTPtr len, Annotations annotations = {}) const
+    ASTPtr array(ASTPtr field, ASTPtr len, InferredAnnotations inferred = {})
+            const
     {
         auto node =
                 std::make_shared<ASTArray>(std::move(field), std::move(len));
-        node->annotations() = annotations;
+        node->inferred_annotations() = inferred;
         return node;
     }
 
-    ASTPtr array(ASTPtr field, Annotations annotations = {}) const
+    ASTPtr array(ASTPtr field, InferredAnnotations inferred = {}) const
     {
-        auto node           = std::make_shared<ASTArray>(std::move(field));
-        node->annotations() = annotations;
+        auto node = std::make_shared<ASTArray>(std::move(field));
+        node->inferred_annotations() = inferred;
         return node;
     }
 
-    ASTPtr bytes(ASTPtr len, Annotations annotations = {}) const
+    ASTPtr bytes(ASTPtr len, InferredAnnotations inferred = {}) const
     {
         auto node = std::make_shared<ASTBytes>(
                 loc_, paren_list({ std::move(len) }));
-        node->annotations() = annotations;
+        node->inferred_annotations() = inferred;
         return node;
     }
 
-    ASTPtr record(ASTVec params, ASTVec fields, Annotations annotations = {})
-            const
+    ASTPtr record(
+            ASTVec params,
+            ASTVec fields,
+            InferredAnnotations inferred = {}) const
     {
         auto node = std::make_shared<ASTRecord>(
                 paren_list(std::move(params)), curly_list(std::move(fields)));
-        node->annotations() = annotations;
+        node->inferred_annotations() = inferred;
         return node;
     }
 
-    ASTPtr call(ASTPtr target, ASTVec args, Annotations annotations = {}) const
+    ASTPtr call(ASTPtr target, ASTVec args, InferredAnnotations inferred = {})
+            const
     {
         auto node =
                 std::make_shared<ASTCall>(std::move(target), std::move(args));
-        node->annotations() = annotations;
+        node->inferred_annotations() = inferred;
         return node;
     }
 

--- a/tools/sddl2/compiler/parser/Grammar.cpp
+++ b/tools/sddl2/compiler/parser/Grammar.cpp
@@ -489,6 +489,64 @@ class AnonymousRecordRule : public GrammarRule {
     }
 };
 
+/**
+ * Parses a general `<expr> @ <name>` annotation postfix, attaching the named
+ * annotation to the annotated node. Multiple annotations may be chained onto a
+ * single record. Currently annotations may only be applied to records.
+ */
+class AnnotationRule : public GrammarRule {
+   public:
+    explicit AnnotationRule()
+            : GrammarRule(
+                      Symbol::AT,
+                      Precedence::ACCESS,
+                      std::vector<ArgType>({ ArgType::EXPR, ArgType::EXPR }),
+                      /* has_lhs_arg */ true)
+    {
+    }
+
+   private:
+    ASTPtr do_gen(ASTPtr op, ArgsVec args) const override
+    {
+        auto& annotated = args.at(0);
+        auto& name_node = args.at(1);
+
+        const auto* name_var = name_node->as_var();
+        if (name_var == nullptr) {
+            throw ParseError(
+                    some(op).loc(), "Annotation name must be an identifier.");
+        }
+        const auto& name = name_var->name();
+
+        // The annotated expression is either a bare record (anonymous record)
+        // or an ASSIGN(name, record) produced by RecordRule (named record).
+        const auto* assign  = annotated->as_op();
+        const bool is_named = assign != nullptr && assign->op() == Op::ASSIGN;
+        const ASTRecord* record = is_named ? assign->args().at(1)->as_record()
+                                           : annotated->as_record();
+        if (record == nullptr) {
+            throw ParseError(
+                    some(op).loc(),
+                    "Annotation '@" + name
+                            + "' can only be applied to a record.");
+        }
+
+        // Rebuild the record with the annotation added, keeping the AST
+        // immutable (grammar annotations are known at parse time). Chained
+        // annotations accumulate: copy the existing set and add this name.
+        GrammarAnnotations annotations = record->annotations();
+        annotations.names.insert(name);
+        auto new_record = Codegen{ record->loc() }.record(
+                record->params(), record->fields(), std::move(annotations));
+
+        if (is_named) {
+            return Codegen{ annotated->loc() }.assign(
+                    assign->args().at(0), std::move(new_record));
+        }
+        return new_record;
+    }
+};
+
 class CallRule : public GrammarRule {
    public:
     explicit CallRule()
@@ -650,6 +708,9 @@ const std::vector<std::unique_ptr<const GrammarRule>> grammar_rules{ []() {
     add_rule<RecordRule>(r);
     add_rule<AnonymousRecordRule>(r);
     add_rule<BytesRule>(r);
+
+    // Annotations
+    add_rule<AnnotationRule>(r);
 
     // Ops
     add_rule<UnaryOpRule>(r, Symbol::EXPECT, Precedence::ASSIGNMENT);

--- a/tools/sddl2/compiler/semantic_analyzer/SemanticAnalyzer.cpp
+++ b/tools/sddl2/compiler/semantic_analyzer/SemanticAnalyzer.cpp
@@ -175,7 +175,7 @@ class SemanticAnalyzerImpl {
     {
         auto element_type = analyzeNode(array.field());
         expectFieldType(array.field()->loc(), element_type);
-        if (element_type.type_def->annotations().requires_scan) {
+        if (element_type.type_def->inferred_annotations().requires_scan) {
             scope_.requires_scan = true;
         }
         if (array.len()) {
@@ -199,7 +199,7 @@ class SemanticAnalyzerImpl {
 
         // Transitivity: a field whose type is itself a requires-scan
         // record or array makes the enclosing record requires-scan too.
-        if (t.type_def->annotations().requires_scan) {
+        if (t.type_def->inferred_annotations().requires_scan) {
             scope_.requires_scan = true;
         }
         return Type{ TypeKind::NONE };
@@ -226,8 +226,8 @@ class SemanticAnalyzerImpl {
             analyzeNode(field);
         }
 
-        record.annotations().requires_scan = scope_.requires_scan;
-        scope_                             = std::move(saved);
+        record.inferred_annotations().requires_scan = scope_.requires_scan;
+        scope_                                      = std::move(saved);
 
         return Type{ TypeKind::RECORD, &record };
     }
@@ -376,7 +376,7 @@ class SemanticAnalyzerImpl {
         }
 
         auto* record = lhs_type.type_def->as_record();
-        if (record->annotations().requires_scan) {
+        if (record->inferred_annotations().requires_scan) {
             throw SemanticError(
                     op.args()[0]->loc(),
                     "Member access not supported on scan records.");

--- a/tools/sddl2/compiler/tests/ParserTest.cpp
+++ b/tools/sddl2/compiler/tests/ParserTest.cpp
@@ -423,4 +423,35 @@ TEST_F(ParserTest, WhenBlockInRecordAST)
     expect_ast(prog, expected);
 }
 
+TEST_F(ParserTest, AnnotationOnNonRecord)
+{
+    const auto prog = R"(
+        x = 5 @some_annotation
+    )";
+    expect_error(prog, "can only be applied to a record");
+}
+
+TEST_F(ParserTest, AnnotationNameRequiresIdentifier)
+{
+    const auto prog = R"(
+        record Foo() {
+            x: Int32LE
+        } @ 5
+    )";
+    expect_error(prog, "Annotation name must be an identifier");
+}
+
+TEST_F(ParserTest, AnnotationAllowsSpaceAfterSigil)
+{
+    // `@ name` (with a space) must tokenize and parse the same as `@name`.
+    const auto prog = R"(
+        record Foo() {
+            x: Int32LE
+        } @ some_annotation
+    )";
+    EXPECT_NO_THROW(compiler_->compile_ast(prog, "[local_input]"))
+            << "Compiler debug logs:\n"
+            << logs_.str();
+}
+
 } // namespace openzl::sddl2::tests

--- a/tools/sddl2/compiler/tests/SemanticAnalyzerTest.cpp
+++ b/tools/sddl2/compiler/tests/SemanticAnalyzerTest.cpp
@@ -633,4 +633,42 @@ TEST_F(SemanticAnalyzerTest, TypeCheckReferencedFields)
     )";
     expect_error(prog, "numeric");
 }
+
+// ---------------------------------------------------------------------------
+// Grammar annotations (@name)
+// ---------------------------------------------------------------------------
+
+TEST_F(SemanticAnalyzerTest, GrammarAnnotationAttached)
+{
+    const auto prog = R"(
+        record Foo() {
+            x: Int32LE
+        } @some_annotation
+    )";
+    auto ast        = compiler_->compile_ast(prog, "[local_input]");
+    const auto* foo = find_record(ast, "Foo");
+    EXPECT_TRUE(foo->annotations().has("some_annotation"));
+}
+
+TEST_F(SemanticAnalyzerTest, MultipleGrammarAnnotationsOnOneRecord)
+{
+    const auto prog = R"(
+        record Foo() {
+            x: Int32LE
+        } @first @second
+    )";
+    auto ast        = compiler_->compile_ast(prog, "[local_input]");
+    const auto* foo = find_record(ast, "Foo");
+    EXPECT_TRUE(foo->annotations().has("first"));
+    EXPECT_TRUE(foo->annotations().has("second"));
+}
+
+TEST_F(SemanticAnalyzerTest, GrammarAnnotationOnAnonymousRecord)
+{
+    const auto prog = R"(
+        entry: record() { id: Int32LE } @some_annotation
+        expect entry.id == 0
+    )";
+    expect_success(prog);
+}
 } // namespace openzl::sddl2::tests

--- a/tools/sddl2/compiler/tests/SemanticAnalyzerTest.cpp
+++ b/tools/sddl2/compiler/tests/SemanticAnalyzerTest.cpp
@@ -519,7 +519,7 @@ TEST_F(SemanticAnalyzerTest, InstantParseSimple)
         }
     )";
     auto ast        = compiler_->compile_ast(prog, "[local_input]");
-    EXPECT_FALSE(find_record(ast, "Foo")->annotations().requires_scan);
+    EXPECT_FALSE(find_record(ast, "Foo")->inferred_annotations().requires_scan);
 }
 
 TEST_F(SemanticAnalyzerTest, InstantParseWithParam)
@@ -530,7 +530,7 @@ TEST_F(SemanticAnalyzerTest, InstantParseWithParam)
         }
     )";
     auto ast        = compiler_->compile_ast(prog, "[local_input]");
-    EXPECT_FALSE(find_record(ast, "Foo")->annotations().requires_scan);
+    EXPECT_FALSE(find_record(ast, "Foo")->inferred_annotations().requires_scan);
 }
 
 TEST_F(SemanticAnalyzerTest, ScanSimple)
@@ -542,7 +542,7 @@ TEST_F(SemanticAnalyzerTest, ScanSimple)
         }
     )";
     auto ast        = compiler_->compile_ast(prog, "[local_input]");
-    EXPECT_TRUE(find_record(ast, "Foo")->annotations().requires_scan);
+    EXPECT_TRUE(find_record(ast, "Foo")->inferred_annotations().requires_scan);
 }
 
 TEST_F(SemanticAnalyzerTest, RequiresScanConditional)
@@ -556,7 +556,7 @@ TEST_F(SemanticAnalyzerTest, RequiresScanConditional)
         }
     )";
     auto ast        = compiler_->compile_ast(prog, "[local_input]");
-    EXPECT_TRUE(find_record(ast, "Foo")->annotations().requires_scan);
+    EXPECT_TRUE(find_record(ast, "Foo")->inferred_annotations().requires_scan);
 }
 
 TEST_F(SemanticAnalyzerTest, RequiresScanNested)
@@ -571,8 +571,10 @@ TEST_F(SemanticAnalyzerTest, RequiresScanNested)
         }
     )";
     auto ast        = compiler_->compile_ast(prog, "[local_input]");
-    EXPECT_TRUE(find_record(ast, "Inner")->annotations().requires_scan);
-    EXPECT_TRUE(find_record(ast, "Outer")->annotations().requires_scan);
+    EXPECT_TRUE(
+            find_record(ast, "Inner")->inferred_annotations().requires_scan);
+    EXPECT_TRUE(
+            find_record(ast, "Outer")->inferred_annotations().requires_scan);
 }
 
 TEST_F(SemanticAnalyzerTest, RequiresScanNestedConditional)
@@ -590,8 +592,10 @@ TEST_F(SemanticAnalyzerTest, RequiresScanNestedConditional)
         flags: UInt8
     )";
     auto ast        = compiler_->compile_ast(prog, "[local_input]");
-    EXPECT_TRUE(find_record(ast, "Inner")->annotations().requires_scan);
-    EXPECT_TRUE(find_record(ast, "Outer")->annotations().requires_scan);
+    EXPECT_TRUE(
+            find_record(ast, "Inner")->inferred_annotations().requires_scan);
+    EXPECT_TRUE(
+            find_record(ast, "Outer")->inferred_annotations().requires_scan);
 }
 
 TEST_F(SemanticAnalyzerTest, RequiresScanOuter)
@@ -607,8 +611,10 @@ TEST_F(SemanticAnalyzerTest, RequiresScanOuter)
         }
     )";
     auto ast        = compiler_->compile_ast(prog, "[local_input]");
-    EXPECT_TRUE(find_record(ast, "Outer")->annotations().requires_scan);
-    EXPECT_FALSE(find_record(ast, "Inner")->annotations().requires_scan);
+    EXPECT_TRUE(
+            find_record(ast, "Outer")->inferred_annotations().requires_scan);
+    EXPECT_FALSE(
+            find_record(ast, "Inner")->inferred_annotations().requires_scan);
 }
 
 TEST_F(SemanticAnalyzerTest, TypeCheckReferencedFields)


### PR DESCRIPTION
Summary:
## Stack
The goal of this stack is to add author-facing `@` annotations to SDDL2 records, starting with `instant_parse`.

## Diff
Adds the general `name` annotation syntax: lexes `@`, and a postfix `AnnotationRule` attaches an open set of names (`GrammarAnnotations`) to a record. Multiple annotations can be chained (`record ... {} a b`). No annotation carries meaning yet.

Differential Revision: D112335336


