### PR TITLE
Enforce the @instant_parse record annotation (#873)

### DIFF
--- a/tools/sddl2/compiler/Syntax.h
+++ b/tools/sddl2/compiler/Syntax.h
@@ -3,6 +3,7 @@
 #pragma once
 
 #include <map>
+#include <string>
 #include <vector>
 
 #include "openzl/cpp/poly/StringView.hpp"
@@ -99,6 +100,11 @@ enum class Symbol {
     // Annotations
     AT // '@', introduces a record annotation (e.g., @instant_parse)
 };
+
+/**
+ * Recognized Annotations
+ */
+constexpr std::string_view kInstantParse = "instant_parse";
 
 /// @returns a name string for a symbol.
 /// (E.g., Symbol::ADD -> "ADD")

--- a/tools/sddl2/compiler/parser/AST.h
+++ b/tools/sddl2/compiler/parser/AST.h
@@ -210,9 +210,9 @@ class ASTVar : public ASTConverted {
 struct GrammarAnnotations {
     std::set<std::string> names;
 
-    bool has(const std::string& name) const
+    bool has(const std::string_view& name) const
     {
-        return names.count(name) > 0;
+        return names.count(std::string(name)) > 0;
     }
 };
 

--- a/tools/sddl2/compiler/semantic_analyzer/SemanticAnalyzer.cpp
+++ b/tools/sddl2/compiler/semantic_analyzer/SemanticAnalyzer.cpp
@@ -229,6 +229,14 @@ class SemanticAnalyzerImpl {
         record.inferred_annotations().requires_scan = scope_.requires_scan;
         scope_                                      = std::move(saved);
 
+        if (record.annotations().has(kInstantParse)
+            && record.inferred_annotations().requires_scan) {
+            throw SemanticError(
+                    record.loc(),
+                    "Record is annotated @instant_parse but is not instant-parse "
+                    "(its layout depends on parsed data).");
+        }
+
         return Type{ TypeKind::RECORD, &record };
     }
 

--- a/tools/sddl2/compiler/tests/SemanticAnalyzerTest.cpp
+++ b/tools/sddl2/compiler/tests/SemanticAnalyzerTest.cpp
@@ -671,4 +671,81 @@ TEST_F(SemanticAnalyzerTest, GrammarAnnotationOnAnonymousRecord)
     )";
     expect_success(prog);
 }
+
+// ---------------------------------------------------------------------------
+// @instant_parse annotation
+// ---------------------------------------------------------------------------
+
+TEST_F(SemanticAnalyzerTest, InstantParseAnnotationAccepted)
+{
+    const auto prog = R"(
+        record Foo() {
+            x: Int32LE,
+            y: Int16LE
+        } @instant_parse
+    )";
+    expect_success(prog);
+}
+
+TEST_F(SemanticAnalyzerTest, InstantParseAnnotationConditionalOnParamAccepted)
+{
+    const auto prog = R"(
+        record Foo(flag) {
+            x: Int32LE,
+            when flag == 1 {
+                y: UInt16LE
+            }
+        } @instant_parse
+    )";
+    expect_success(prog);
+}
+
+TEST_F(SemanticAnalyzerTest, InstantParseAnnotationRejectsScanRecord)
+{
+    const auto prog = R"(
+        record Foo() {
+            n: Int32LE,
+            data: Bytes(n)
+        } @instant_parse
+    )";
+    expect_error(prog, "not instant-parse");
+}
+
+TEST_F(SemanticAnalyzerTest, InstantParseAnnotationRejectsConditionalScan)
+{
+    const auto prog = R"(
+        record Foo() {
+            flags: UInt8,
+            when flags == 1 {
+                optional: UInt16LE
+            }
+        } @instant_parse
+    )";
+    expect_error(prog, "not instant-parse");
+}
+
+TEST_F(SemanticAnalyzerTest, InstantParseAnnotationRejectsTransitiveScan)
+{
+    const auto prog = R"(
+        record Inner() {
+            n: Int32LE,
+            data: Bytes(n)
+        }
+        record Outer() {
+            inner: Inner[5]
+        } @instant_parse
+    )";
+    expect_error(prog, "not instant-parse");
+}
+
+TEST_F(SemanticAnalyzerTest, InstantParseAnnotationOnAnonymousScanRecord)
+{
+    const auto prog = R"(
+        : record() {
+            n: Int32LE,
+            data: Bytes(n)
+        } @instant_parse
+    )";
+    expect_error(prog, "not instant-parse");
+}
 } // namespace openzl::sddl2::tests


### PR DESCRIPTION
Summary:

## Stack
The goal of this stack is to add author-facing `@` annotations to SDDL2 records, starting with `instant_parse`.

## Diff
Adds enforcement for `instant_parse`: the SemanticAnalyzer rejects any record annotated `instant_parse` whose layout requires scanning (`requires_scan == true`).

Reviewed By: terrelln

Differential Revision: D112335343


