### PR TITLE
Document annotations and instant-parse (#874)

### DIFF
--- a/doc/mkdocs/doc/sddl/core-concepts.md
+++ b/doc/mkdocs/doc/sddl/core-concepts.md
@@ -109,6 +109,29 @@ When you need a one-off record structure without defining a named type, use an a
 
 This is useful for simple groupings where a named record would add unnecessary boilerplate.
 
+### Annotations
+
+A record can be annotated with `@name` after its closing brace; multiple annotations may be chained.
+
+```sddl
+record Header(payload_size) {
+  magic: Bytes(4),
+  payload: Bytes(payload_size)
+} @first @second
+```
+
+
+The `@instant_parse` annotation makes the compiler verify that the record's layout is computable from parameters and constants alone:
+
+```sddl
+record Header(payload_size) {
+  magic: Bytes(4),
+  payload: Bytes(payload_size)
+} @instant_parse
+```
+
+See [Instant-Parse](instant-parse.md) for details.
+
 ## Arrays
 
 ### Fixed-Size Arrays

--- a/doc/mkdocs/doc/sddl/instant-parse.md
+++ b/doc/mkdocs/doc/sddl/instant-parse.md
@@ -1,0 +1,71 @@
+# Instant-Parse
+
+An **instant-parse** record is one whose layout — every field's offset and size — can be computed from its parameters and constants alone, without examining the data being parsed. A record that is not instant-parse is said to **require scanning**: its layout depends on values that are only known once the data has been read.
+
+## Instant-Parse vs. Requires-Scan
+
+The distinction comes down to whether a field's size or presence depends on a **parameter** (known upfront) or on a **previously parsed field** (only known after reading data).
+
+**Instant-parse** — sizes depend only on parameters:
+
+```sddl
+record Header(payload_size) {
+  magic: Bytes(4),
+  version: UInt16LE,
+  payload: Bytes(payload_size)  # size is a parameter, known upfront
+}
+```
+
+Given `payload_size`, every offset is known before reading a byte: `magic` at 0, `version` at 4, `payload` at 6.
+
+**Requires-scan** — a size depends on a parsed field:
+
+```sddl
+record Message() {
+  magic: Bytes(4),
+  size: UInt16LE,
+  payload: Bytes(size)  # size depends on a parsed field, must scan
+}
+```
+
+Here `payload`'s offset and the total record size cannot be known until `size` has been read.
+
+## The `@instant_parse` Annotation
+
+Records may carry **annotations**, written as `@name` immediately after the record's closing brace. Multiple annotations may be chained (`record ... {} @a @b`). `instant_parse` is the first annotation the compiler acts on. It asserts that the record is instant-parse — **the compiler errors if the record actually requires scanning:**
+
+```sddl
+record Header(has_checksum) {
+  magic: Bytes(4),
+  version: UInt16LE,
+  when has_checksum { checksum: UInt32LE }
+} @instant_parse
+```
+
+If the record's layout depends on parsed data, compilation fails:
+
+```sddl
+record Message() {
+  magic: Bytes(4),
+  size: UInt16LE,
+  payload: Bytes(size)  # depends on a parsed field
+} @instant_parse
+```
+
+```
+semantic error: Record is annotated @instant_parse but is not instant-parse (its layout depends on parsed data).
+```
+
+The annotation works on both named and anonymous records:
+
+```sddl
+: record() {
+  x: Int32LE,
+  y: Int32LE
+} @instant_parse
+```
+
+### Why Use It?
+
+- **Documentation:** makes the instant-parse requirement explicit at the definition site.
+- **Enforcement:** prevents a later edit from silently introducing a scan dependency. Scan dependencies are significantly less efficient than instant-parse.

--- a/doc/mkdocs/doc/sddl/reference.md
+++ b/doc/mkdocs/doc/sddl/reference.md
@@ -83,6 +83,15 @@ record Name(COND) {
 expect condition
 ```
 
+### Annotations
+
+```sddl
+record Name() { ... } @instant_parse   # error if the record is not instant-parse
+record Name() { ... } @a @b            # multiple annotations may be chained
+```
+
+See [Instant-Parse](instant-parse.md) for details.
+
 ## Operators
 
 ### Arithmetic

--- a/doc/mkdocs/mkdocs.yml
+++ b/doc/mkdocs/mkdocs.yml
@@ -40,6 +40,7 @@ nav:
         - Core Concepts: sddl/core-concepts.md
         - Conditional Fields: sddl/conditional-fields.md
         - Validation: sddl/validation.md
+        - Instant-Parse: sddl/instant-parse.md
         - Examples: sddl/examples.md
         - Quick Reference: sddl/reference.md
       - North Star (v0.6):

--- a/tools/sddl2/compiler/Syntax.h
+++ b/tools/sddl2/compiler/Syntax.h
@@ -3,6 +3,7 @@
 #pragma once
 
 #include <map>
+#include <string>
 #include <vector>
 
 #include "openzl/cpp/poly/StringView.hpp"
@@ -99,6 +100,11 @@ enum class Symbol {
     // Annotations
     AT // '@', introduces a record annotation (e.g., @instant_parse)
 };
+
+/**
+ * Recognized Annotations
+ */
+constexpr std::string_view kInstantParse = "instant_parse";
 
 /// @returns a name string for a symbol.
 /// (E.g., Symbol::ADD -> "ADD")

--- a/tools/sddl2/compiler/parser/AST.h
+++ b/tools/sddl2/compiler/parser/AST.h
@@ -210,9 +210,9 @@ class ASTVar : public ASTConverted {
 struct GrammarAnnotations {
     std::set<std::string> names;
 
-    bool has(const std::string& name) const
+    bool has(const std::string_view& name) const
     {
-        return names.count(name) > 0;
+        return names.count(std::string(name)) > 0;
     }
 };
 

--- a/tools/sddl2/compiler/semantic_analyzer/SemanticAnalyzer.cpp
+++ b/tools/sddl2/compiler/semantic_analyzer/SemanticAnalyzer.cpp
@@ -229,6 +229,14 @@ class SemanticAnalyzerImpl {
         record.inferred_annotations().requires_scan = scope_.requires_scan;
         scope_                                      = std::move(saved);
 
+        if (record.annotations().has(kInstantParse)
+            && record.inferred_annotations().requires_scan) {
+            throw SemanticError(
+                    record.loc(),
+                    "Record is annotated @instant_parse but is not instant-parse "
+                    "(its layout depends on parsed data).");
+        }
+
         return Type{ TypeKind::RECORD, &record };
     }
 

--- a/tools/sddl2/compiler/tests/SemanticAnalyzerTest.cpp
+++ b/tools/sddl2/compiler/tests/SemanticAnalyzerTest.cpp
@@ -671,4 +671,81 @@ TEST_F(SemanticAnalyzerTest, GrammarAnnotationOnAnonymousRecord)
     )";
     expect_success(prog);
 }
+
+// ---------------------------------------------------------------------------
+// @instant_parse annotation
+// ---------------------------------------------------------------------------
+
+TEST_F(SemanticAnalyzerTest, InstantParseAnnotationAccepted)
+{
+    const auto prog = R"(
+        record Foo() {
+            x: Int32LE,
+            y: Int16LE
+        } @instant_parse
+    )";
+    expect_success(prog);
+}
+
+TEST_F(SemanticAnalyzerTest, InstantParseAnnotationConditionalOnParamAccepted)
+{
+    const auto prog = R"(
+        record Foo(flag) {
+            x: Int32LE,
+            when flag == 1 {
+                y: UInt16LE
+            }
+        } @instant_parse
+    )";
+    expect_success(prog);
+}
+
+TEST_F(SemanticAnalyzerTest, InstantParseAnnotationRejectsScanRecord)
+{
+    const auto prog = R"(
+        record Foo() {
+            n: Int32LE,
+            data: Bytes(n)
+        } @instant_parse
+    )";
+    expect_error(prog, "not instant-parse");
+}
+
+TEST_F(SemanticAnalyzerTest, InstantParseAnnotationRejectsConditionalScan)
+{
+    const auto prog = R"(
+        record Foo() {
+            flags: UInt8,
+            when flags == 1 {
+                optional: UInt16LE
+            }
+        } @instant_parse
+    )";
+    expect_error(prog, "not instant-parse");
+}
+
+TEST_F(SemanticAnalyzerTest, InstantParseAnnotationRejectsTransitiveScan)
+{
+    const auto prog = R"(
+        record Inner() {
+            n: Int32LE,
+            data: Bytes(n)
+        }
+        record Outer() {
+            inner: Inner[5]
+        } @instant_parse
+    )";
+    expect_error(prog, "not instant-parse");
+}
+
+TEST_F(SemanticAnalyzerTest, InstantParseAnnotationOnAnonymousScanRecord)
+{
+    const auto prog = R"(
+        : record() {
+            n: Int32LE,
+            data: Bytes(n)
+        } @instant_parse
+    )";
+    expect_error(prog, "not instant-parse");
+}
 } // namespace openzl::sddl2::tests


### PR DESCRIPTION
Summary:

## Stack
The goal of this stack is to add author-facing `@` annotations to SDDL2 records, starting with `instant_parse`.

## Diff
Documents `instant_parse` and the instant-parse concept in the Current Language docs.

Reviewed By: terrelln

Differential Revision: D112335338


