### PR TITLE
Migrate openzl visitation users to AOR

### DIFF
--- a/custom_transforms/thrift/kernels/tests/BUCK
+++ b/custom_transforms/thrift/kernels/tests/BUCK
@@ -5,6 +5,7 @@
 load("@fbcode_macros//build_defs:cpp_library.bzl", "cpp_library")
 load("@fbcode_macros//build_defs:cpp_unittest.bzl", "cpp_unittest")
 load("@fbcode_macros//build_defs:thrift_library.bzl", "thrift_library")
+load("@fbsource//tools/build_defs/testinfra:network_access_utils.bzl", "network_access_utils")
 load("../../../../defs.bzl", "relative_headers", "zs_fuzzers")
 
 oncall("data_compression")
@@ -14,7 +15,6 @@ thrift_library(
     languages = [
         "cpp2",
     ],
-    thrift_cpp2_options = "reflection",
     thrift_srcs = {"fuzz_data.thrift": []},
 )
 
@@ -26,10 +26,10 @@ cpp_library(
         "../../../..:zstronglib",
         "../../../../tests/datagen:datagen",
         ":fuzz_data-cpp2-types",
-        ":fuzz_data-cpp2-visitation",
         "//folly:overload",
         "//folly:range",
         "//folly/io:iobuf",
+        "//thrift/lib/cpp2/op:get",
         "//thrift/lib/cpp2/protocol:protocol",
     ],
 )
@@ -37,6 +37,7 @@ cpp_library(
 cpp_unittest(
     name = "test_thrift_kernel",
     srcs = ["test_thrift_kernel.cpp"],
+    network_access = network_access_utils.none(),
     deps = [
         "..:decode_thrift_kernel",
         "..:encode_thrift_kernel",
@@ -65,6 +66,7 @@ zs_fuzzers(
         ":thrift_kernel_test_utils",
         "//folly:range",
         "//folly/io:iobuf",
+        "//thrift/lib/cpp2/op:get",
         "//thrift/lib/cpp2/protocol:protocol",
     ],
 )

--- a/custom_transforms/thrift/kernels/tests/fuzz_thrift_kernel.cpp
+++ b/custom_transforms/thrift/kernels/tests/fuzz_thrift_kernel.cpp
@@ -4,6 +4,7 @@
 
 #include <folly/Range.h>
 #include <folly/io/IOBuf.h>
+#include <thrift/lib/cpp2/op/Get.h>
 #include <thrift/lib/cpp2/protocol/Serializer.h>
 
 #include "security/lionhead/utils/lib_ftest/enable_sfdp_thrift.h"
@@ -137,10 +138,10 @@ class ThriftKernelTest : public ZStrongTest {
 
     void testRoundTrip(ThriftKernelData const& data)
     {
-        apache::thrift::visit_union(
-                data, [this](const auto&, const auto& value) {
-                    testRoundTrip(value);
-                });
+        apache::thrift::op::visit_union_with_tag(
+                data,
+                [this](auto, const auto& value) { testRoundTrip(value); },
+                [] {});
     }
 
     using ZStrongTest::testRoundTrip;

--- a/custom_transforms/thrift/kernels/tests/thrift_kernel_test_utils.h
+++ b/custom_transforms/thrift/kernels/tests/thrift_kernel_test_utils.h
@@ -11,6 +11,7 @@
 
 #include <folly/Overload.h>
 #include <folly/io/IOBuf.h>
+#include <thrift/lib/cpp2/op/Get.h>
 #include <thrift/lib/cpp2/protocol/Serializer.h>
 
 #include "openzl/zl_version.h"
@@ -21,10 +22,8 @@
 // TODO: Not sure if there is a better way to do this
 #if ZL_FBCODE_IS_RELEASE
 #    include "openzl/prod/custom_transforms/thrift/kernels/tests/gen-cpp2/fuzz_data_types.h"
-#    include "openzl/prod/custom_transforms/thrift/kernels/tests/gen-cpp2/fuzz_data_visitation.h"
 #else
 #    include "openzl/dev/custom_transforms/thrift/kernels/tests/gen-cpp2/fuzz_data_types.h"
-#    include "openzl/dev/custom_transforms/thrift/kernels/tests/gen-cpp2/fuzz_data_visitation.h"
 #endif
 
 namespace openzl::thrift::tests {
@@ -167,7 +166,8 @@ template <typename T, typename RNG>
 void fillThrift(T& thrift, RNG&& gen)
 {
     std::bernoulli_distribution shouldFill(0.5);
-    apache::thrift::for_each_field(thrift, [&](const auto&, auto&& field_ref) {
+    apache::thrift::op::for_each_field_id<T>([&]<class Id>(Id) {
+        auto&& field_ref = apache::thrift::op::get<Id>(thrift);
         if (!shouldFill(gen)) {
             return;
         }


### PR DESCRIPTION
Summary: Replace generated thrift visitation helpers in OpenZL thrift kernel tests with AOR `apache::thrift::op` helpers and remove generated visitation deps.

Differential Revision: D111823412


