### PR TITLE
Add more AVX512 support to ZL_cpuid (#845)

### DIFF
--- a/src/openzl/shared/cpu.h
+++ b/src/openzl/shared/cpu.h
@@ -201,6 +201,13 @@ B(avx512vl, 31)
 #define C(name, bit) X(name, f7c, bit)
 C(prefetchwt1, 0)
 C(avx512vbmi, 1)
+C(avx512vbmi2, 6)
+C(vaes, 9)
+C(vpclmulqdq, 10)
+C(avx512vnni, 11)
+C(avx512bitalg, 12)
+C(avx512vpopcntdq, 14)
+C(rdpid, 22)
 #undef C
 
 #undef X


### PR DESCRIPTION
Summary:

See https://www.internalfb.com/code/fbsource/[0b9e4a2588b4f716d3259505ea591a25cea158a1]/fbcode/folly/CpuId.h?lines=155-164

Reviewed By: daniellerozenblit

Differential Revision: D109877948


