### PR TITLE
Add doxygen docblocks

### DIFF
--- a/src/openzl/codecs/common/bitstream/bf_bitstream.h
+++ b/src/openzl/codecs/common/bitstream/bf_bitstream.h
@@ -23,11 +23,55 @@ typedef struct {
     uint8_t* begin;
 } ZS_BitCStreamBF;
 
+/**
+ * Initializes a backward-forward (BF) bit-writer over @p dst.
+ *
+ * Unlike the FF writer, a BF stream packs bits MSB-first and flushes whole
+ * bytes *backward*, starting at the end of @p dst and moving toward its start.
+ * This lays values out so a forward reader (see @ref ZS_BitDStreamBF_init)
+ * recovers them in reverse of the write order -- the layout used by FSE/tANS
+ * coders, which encode symbols in reverse so they decode in the original order.
+ *
+ * @param dst Destination buffer to write into.
+ * @param dstCapacity Capacity of @p dst, in bytes.
+ * @return An initialized writer positioned at the end of @p dst.
+ */
 ZL_INLINE ZS_BitCStreamBF
 ZS_BitCStreamBF_init(uint8_t* dst, size_t dstCapacity);
+
+/**
+ * Flushes remaining bits, appends a padding marker, and finalizes the stream.
+ *
+ * A single set bit followed by zero-padding is written so the forward decoder
+ * can locate the true start of the data (see ZS_BitDStreamBF_init()). Since the
+ * stream grows backward, the finalized data occupies the tail of @p dst.
+ *
+ * @param bits The writer to finalize.
+ * @return The number of bytes written (measured back from the end of @p dst),
+ *         or an error if @p dst was too small.
+ */
 ZL_INLINE ZL_Report ZS_BitCStreamBF_finish(ZS_BitCStreamBF* bits);
+
+/**
+ * Appends the low @p nbBits bits of @p value to the stream (MSB-first).
+ *
+ * Bits are accumulated in the container until ZS_BitCStreamBF_flush() (or
+ * ZS_BitCStreamBF_finish()) is called. The buffered bit count must not exceed
+ * #ZS_BITSTREAM_WRITE_MAX_BITS between flushes.
+ *
+ * @param bits The writer.
+ * @param value Source value; only its low @p nbBits bits are used.
+ * @param nbBits Number of bits to write.
+ */
 ZL_INLINE void
 ZS_BitCStreamBF_write(ZS_BitCStreamBF* bits, size_t value, size_t nbBits);
+
+/**
+ * Writes the whole bytes currently buffered in the container out to @p dst,
+ * moving the write pointer backward.
+ *
+ * @param bits The writer.
+ */
 ZL_INLINE void ZS_BitCStreamBF_flush(ZS_BitCStreamBF* bits);
 
 ZL_INLINE ZS_BitCStreamBF ZS_BitCStreamBF_init(uint8_t* dst, size_t dstCapacity)
@@ -95,10 +139,45 @@ typedef struct {
     ZS_BitDStreamFF bits;
 } ZS_BitDStreamBF;
 
+/**
+ * Initializes a bit-reader for a backward-forward (BF) stream.
+ *
+ * A BF stream is decoded forward -- the reader wraps the FF decoder -- but the
+ * data begins with a padding marker written by ZS_BitCStreamBF_finish(). This
+ * constructor skips that leading padding (the zero bits up to and including the
+ * first set bit) so reads begin at the first real value.
+ *
+ * @param src Source buffer; must point at the start of the BF data.
+ * @param capacity Size of @p src, in bytes.
+ * @return An initialized reader positioned past the padding marker.
+ */
 ZL_INLINE ZS_BitDStreamBF
 ZS_BitDStreamBF_init(const uint8_t* src, size_t capacity);
+
+/**
+ * Reads @p nbBits bits and advances the stream past them.
+ *
+ * @param bits The reader.
+ * @param nbBits Number of bits to read (at most #ZS_BITSTREAM_READ_MAX_BITS).
+ * @return The decoded value in its low @p nbBits bits.
+ */
 ZL_INLINE size_t ZS_BitDStreamBF_read(ZS_BitDStreamBF* bits, size_t nbBits);
+
+/**
+ * Refills the container from the source to keep enough bits available between
+ * reads.
+ *
+ * @param bits The reader.
+ */
 ZL_INLINE void ZS_BitDStreamBF_reload(ZS_BitDStreamBF* bits);
+
+/**
+ * Validates that the stream was consumed without over-reading and reports how
+ * many bytes were consumed.
+ *
+ * @param bits The reader.
+ * @return The number of bytes consumed, or an error on over-read.
+ */
 ZL_INLINE ZL_Report ZS_BitDStreamBF_finish(ZS_BitDStreamBF* bits);
 
 ZL_INLINE ZS_BitDStreamBF

--- a/src/openzl/codecs/common/bitstream/ff_bitstream.h
+++ b/src/openzl/codecs/common/bitstream/ff_bitstream.h
@@ -25,17 +25,95 @@ typedef struct {
     uint8_t* begin;
 } ZS_BitCStreamFF;
 
+/**
+ * Initializes a forward-forward (FF) bit-writer over @p dst.
+ *
+ * An FF stream packs bits LSB-first into a word-sized container and flushes
+ * whole bytes forward, from @p dst toward higher addresses. Values are read
+ * back in the same order they were written (see @ref ZS_BitDStreamFF_init).
+ *
+ * @param dst Destination buffer to write into.
+ * @param dstCapacity Capacity of @p dst, in bytes.
+ * @return An initialized writer positioned at the start of @p dst.
+ */
 ZL_INLINE ZS_BitCStreamFF
 ZS_BitCStreamFF_init(uint8_t* dst, size_t dstCapacity);
+
+/**
+ * Flushes any remaining buffered bits and finalizes the stream.
+ *
+ * @param bits The writer to finalize.
+ * @return The total number of bytes written, or an error if @p dst was too
+ *         small to hold the trailing bits.
+ */
 ZL_INLINE ZL_Report ZS_BitCStreamFF_finish(ZS_BitCStreamFF* bits);
+
+/**
+ * Appends the low @p nbBits bits of @p value to the stream.
+ *
+ * Bits are accumulated in the container and are not committed to @p dst until
+ * ZS_BitCStreamFF_flush() (or ZS_BitCStreamFF_finish()) is called. The caller
+ * must flush often enough that the buffered bit count never exceeds
+ * #ZS_BITSTREAM_WRITE_MAX_BITS between flushes.
+ *
+ * @param bits The writer.
+ * @param value Source value; only its low @p nbBits bits are used.
+ * @param nbBits Number of bits to write.
+ */
 ZL_INLINE void
 ZS_BitCStreamFF_write(ZS_BitCStreamFF* bits, size_t value, size_t nbBits);
+
+/**
+ * Writes the whole bytes currently buffered in the container out to @p dst,
+ * retaining the leftover (< 8) bits for subsequent writes.
+ *
+ * Becomes a no-op once the write pointer reaches the buffer's safety limit, so
+ * ZS_BitCStreamFF_finish() must still be called to emit the final partial word.
+ *
+ * @param bits The writer.
+ */
 ZL_INLINE void ZS_BitCStreamFF_flush(ZS_BitCStreamFF* bits);
+
+/**
+ * Reserves a byte-aligned region of @p nbBits bits for raw, direct writes.
+ *
+ * Flushes buffered bits up to the next byte boundary, then returns a pointer to
+ * a contiguous region of ceil(@p nbBits / 8) bytes that the caller may fill
+ * directly (e.g. to embed a raw bitmap). After filling it, call
+ * ZS_BitCStreamFF_commitReservedBits() before resuming bit-level writes.
+ *
+ * @param bits The writer.
+ * @param nbBits Size of the region to reserve, in bits.
+ * @return A pointer to the reserved region, or NULL if @p dst cannot hold it.
+ */
 ZL_INLINE uint8_t* ZS_BitCStreamFF_reserveAlignedBits(
         ZS_BitCStreamFF* bits,
         size_t nbBits);
+
+/**
+ * Resumes bit-level writing after a ZS_BitCStreamFF_reserveAlignedBits()
+ * region.
+ *
+ * Reloads the partial trailing byte of the reserved region back into the
+ * container so the residual (nbBits & 7) bits are carried by subsequent writes.
+ *
+ * @param bits The writer.
+ */
 ZL_INLINE void ZS_BitCStreamFF_commitReservedBits(ZS_BitCStreamFF* bits);
 
+/**
+ * Writes @p value as an order-@p order exponential-Golomb code.
+ *
+ * The low @p order bits of @p value are emitted verbatim, then the remaining
+ * high bits are coded with an Elias gamma code (a unary length prefix followed
+ * by the mantissa). Smaller values cost fewer bits, so this is suited to
+ * distributions skewed toward zero. Decode with ZS_BitDStreamFF_readExpGolomb()
+ * using the same @p order.
+ *
+ * @param bits The writer.
+ * @param value Value to encode.
+ * @param order Number of low bits stored verbatim (0 for plain exp-Golomb).
+ */
 ZL_INLINE void ZS_BitCStreamFF_writeExpGolomb(
         ZS_BitCStreamFF* bits,
         uint32_t value,
@@ -59,18 +137,96 @@ typedef struct {
     uint8_t const* begin;
 } ZS_BitDStreamFF;
 
+/**
+ * Initializes a forward-forward (FF) bit-reader over @p src.
+ *
+ * Reads back bits in the order they were written by an FF bit-writer. Streams
+ * shorter than a machine word are handled specially so that reads stay in
+ * bounds.
+ *
+ * @param src Source buffer to read from.
+ * @param srcSize Size of @p src, in bytes.
+ * @return An initialized reader positioned at the start of @p src.
+ */
 ZL_INLINE ZS_BitDStreamFF
 ZS_BitDStreamFF_init(uint8_t const* src, size_t srcSize);
+
+/**
+ * Validates that the stream was consumed without over-reading and reports how
+ * many bytes were consumed.
+ *
+ * @param bits The reader.
+ * @return The number of bytes consumed, or an error if more bits were read than
+ *         the stream contained.
+ */
 ZL_INLINE ZL_Report ZS_BitDStreamFF_finish(ZS_BitDStreamFF const* bits);
+
+/**
+ * Reads @p nbBits bits and advances the stream past them.
+ *
+ * Equivalent to ZS_BitDStreamFF_peek() followed by ZS_BitDStreamFF_skip(). The
+ * container must hold at least @p nbBits unconsumed bits; call
+ * ZS_BitDStreamFF_reload() periodically to refill it.
+ *
+ * @param bits The reader.
+ * @param nbBits Number of bits to read (at most #ZS_BITSTREAM_READ_MAX_BITS).
+ * @return The decoded value in its low @p nbBits bits.
+ */
 ZL_INLINE size_t ZS_BitDStreamFF_read(ZS_BitDStreamFF* bits, size_t nbBits);
+
+/**
+ * Returns the next @p nbBits bits without consuming them.
+ *
+ * @param bits The reader.
+ * @param nbBits Number of bits to inspect.
+ * @return The peeked value in its low @p nbBits bits.
+ */
 ZL_INLINE size_t
 ZS_BitDStreamFF_peek(ZS_BitDStreamFF const* bits, size_t nbBits);
+
+/**
+ * Advances the stream by @p nbBits bits without returning them.
+ *
+ * @param bits The reader.
+ * @param nbBits Number of bits to skip.
+ */
 ZL_INLINE void ZS_BitDStreamFF_skip(ZS_BitDStreamFF* bits, size_t nbBits);
+
+/**
+ * Refills the container from @p src, discarding whole bytes already consumed.
+ *
+ * Should be called periodically between reads to keep enough bits available.
+ * Once the stream is exhausted it leaves the consumed-bit count intact so that
+ * ZS_BitDStreamFF_finish() can still detect an over-read.
+ *
+ * @param bits The reader.
+ */
 ZL_INLINE void ZS_BitDStreamFF_reload(ZS_BitDStreamFF* bits);
+
+/**
+ * Consumes a byte-aligned region of @p nbBits bits and returns a raw pointer to
+ * it.
+ *
+ * Byte-aligns the current read position (regardless of any prior reloads or
+ * over-reads), returns a pointer to the ceil(@p nbBits / 8)-byte region, and
+ * repositions the reader just past it. This is the decode-side counterpart to
+ * ZS_BitCStreamFF_reserveAlignedBits().
+ *
+ * @param bits The reader.
+ * @param nbBits Size of the region to pop, in bits.
+ * @return A pointer to the aligned region, or NULL if it lies out of bounds.
+ */
 ZL_INLINE uint8_t const* ZS_BitDStreamFF_popAlignedBits(
         ZS_BitDStreamFF* bits,
         size_t nbBits);
 
+/**
+ * Reads a value encoded by ZS_BitCStreamFF_writeExpGolomb().
+ *
+ * @param bits The reader.
+ * @param order Order used at encode time; must match the encoder's @p order.
+ * @return The decoded value.
+ */
 ZL_INLINE uint32_t
 ZS_BitDStreamFF_readExpGolomb(ZS_BitDStreamFF* bits, size_t order)
 {
@@ -180,9 +336,17 @@ ZL_INLINE void ZS_BitCStreamFF_commitReservedBits(ZS_BitCStreamFF* bits)
     bits->container = bits->ptr[0] & (((size_t)1 << bits->nbBits) - 1);
 }
 
-// Little-endian load of the first @p nbBytes (< sizeof(size_t)) bytes at @p src
-// into a container word. Used for streams shorter than a full word, where every
-// byte lives in the container.
+/**
+ * Little-endian load of the first @p nbBytes bytes at @p src into a container
+ * word.
+ *
+ * Used for streams shorter than a full word, where every byte lives in the
+ * container and a full-width load would read out of bounds.
+ *
+ * @param src Source bytes.
+ * @param nbBytes Number of bytes to load; must be < sizeof(size_t).
+ * @return The loaded bytes packed little-endian into the low bits of the word.
+ */
 ZL_INLINE size_t ZS_BitDStreamFF_loadPartial(uint8_t const* src, size_t nbBytes)
 {
     size_t container = 0;


### PR DESCRIPTION
Summary: Add docblocks to the bitstream headers

Reviewed By: kevinjzhang

Differential Revision: D112347254


