### PR TITLE
Add pkgconfig generation to cmake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,6 +7,7 @@ cmake_minimum_required(VERSION 3.20.2 FATAL_ERROR)
 cmake_policy(SET CMP0077 NEW)
 
 set(PACKAGE_NAME "openzl")
+set(PACKAGE_DESCRIPTION "A novel data compression framework")
 project(${PACKAGE_NAME} CXX C ASM)
 
 # ---- Build Options ----
@@ -310,7 +311,23 @@ if (OPENZL_INSTALL)
         COMPONENT dev
     )
 
-    # TODO: Generate a pkg-config file
+    configure_file(
+        "${CMAKE_CURRENT_SOURCE_DIR}/scripts/openzl.pc.in"
+        "${CMAKE_CURRENT_BINARY_DIR}/openzl.pc"
+        @ONLY
+    )
+    
+    configure_file(
+        "${CMAKE_CURRENT_SOURCE_DIR}/scripts/openzl-cpp.pc.in"
+        "${CMAKE_CURRENT_BINARY_DIR}/openzl-cpp.pc"
+        @ONLY
+    )
+
+    install(
+        FILES "${CMAKE_CURRENT_BINARY_DIR}/openzl.pc" "${CMAKE_CURRENT_BINARY_DIR}/openzl-cpp.pc"
+        DESTINATION ${CMAKE_INSTALL_LIBDIR}/pkgconfig
+    )
+
 endif()
 
 # ---- Trailing User Messages ----

--- a/scripts/openzl-cpp.pc.in
+++ b/scripts/openzl-cpp.pc.in
@@ -1,0 +1,14 @@
+prefix=@CMAKE_INSTALL_PREFIX@
+exec_prefix=${prefix}
+libdir=${prefix}/@CMAKE_INSTALL_LIBDIR@
+includedir=${prefix}/@CMAKE_INSTALL_INCLUDEDIR@
+
+name: @PACKAGE_NAME@-cpp
+description: @PACKAGE_DESCRIPTION@
+version: @PACKAGE_VERSION@
+license: BSD-3-Clause
+url: https://openzl.org
+source: http://github.com/facebook/openzl/archive/v@PACKAGE_VERSION@/openzl-@PACKAGE_VERSION@.tar.gz
+requires: libzstd openzl
+libs: -L${libdir} -lopenzl_cpp
+cflags: -I${includedir}

--- a/scripts/openzl.pc.in
+++ b/scripts/openzl.pc.in
@@ -1,0 +1,14 @@
+prefix=@CMAKE_INSTALL_PREFIX@
+exec_prefix=${prefix}
+libdir=${prefix}/@CMAKE_INSTALL_LIBDIR@
+includedir=${prefix}/@CMAKE_INSTALL_INCLUDEDIR@
+
+name: @PACKAGE_NAME@
+description: @PACKAGE_DESCRIPTION@
+version: @PACKAGE_VERSION@
+license: BSD-3-Clause
+url: https://openzl.org
+source: http://github.com/facebook/openzl/archive/v@PACKAGE_VERSION@/openzl-@PACKAGE_VERSION@.tar.gz
+requires: libzstd
+libs: -L${libdir} -lopenzl
+cflags: -I${includedir}


### PR DESCRIPTION
## Summary
This PR provides two pkg-config file templates, for `openzl` and `openzl_cpp`,
along with `configure_file` calls for them in the corresponding section of the cmake build.

## Type of Change
Build/CI changes

## Test Plan
I built the project using a few different `CMAKE_INSTALL_PREFIX`'s to ensure the installation path was being handled correctly, as well as using `pccritic` from `pkgconf` to validate the installed `.pc` files, and ensure they weren't missing any major fields.

### Test Configuration
- Compiler: GCC 16.1.0
- Build type: CMake v4.2.1
- Platform(s): amd64 Linux

I noticed there was a comment in the  `CMakeLists.txt` noting intent to add support for pkgconfig files in the installation, and I happen to be very familiar with the format, so I decided I'd lend a hand.

The `.pc.in` files in the commit reside in `scripts/`, though this may not be the correct place for them. I initially tried to put them in `build-scripts/cmake/` which felt like a much more sensible location, however that led me to notice this line in the `.gitignore`:
```
build-*/
```
Which... I imagine must be a mistake, as this matches the `build-scripts/` directory, which prevented me from adding them to that location.