### PR TITLE
Migrate OpenZL visitation deps to reflection

### DIFF
--- a/custom_transforms/thrift/tests/BUCK
+++ b/custom_transforms/thrift/tests/BUCK
@@ -37,7 +37,6 @@ cpp_library(
         "../../../tools:zstrong_cpp",
         "../kernels/tests:thrift_kernel_test_utils",
         ":thrift_test_schema-cpp2-types",
-        ":thrift_test_schema-cpp2-visitation",
         "//common/gtest:gtest",
         "//thrift/lib/cpp2/protocol:protocol",
     ],

--- a/custom_transforms/thrift/tests/util.h
+++ b/custom_transforms/thrift/tests/util.h
@@ -18,10 +18,8 @@
 
 #if ZL_FBCODE_IS_RELEASE
 #    include "openzl/prod/custom_transforms/thrift/tests/gen-cpp2/test_schema_types.h"
-#    include "openzl/prod/custom_transforms/thrift/tests/gen-cpp2/test_schema_visitation.h"
 #else
 #    include "openzl/dev/custom_transforms/thrift/tests/gen-cpp2/test_schema_types.h"
-#    include "openzl/dev/custom_transforms/thrift/tests/gen-cpp2/test_schema_visitation.h"
 #endif
 
 #include <folly/Range.h>

--- a/custom_transforms/tulip_v2/tests/BUCK
+++ b/custom_transforms/tulip_v2/tests/BUCK
@@ -34,7 +34,6 @@ cpp_library(
         "../../../tools:zstrong_cpp",
         "../../thrift/kernels/tests:thrift_kernel_test_utils",
         ":tulip_v2_data-cpp2-types",
-        ":tulip_v2_data-cpp2-visitation",
         "//folly:range",
         "//folly:subprocess",
         "//folly/io:iobuf",

--- a/custom_transforms/tulip_v2/tests/tulip_v2_data_utils.h
+++ b/custom_transforms/tulip_v2/tests/tulip_v2_data_utils.h
@@ -23,10 +23,8 @@
 // TODO: Not sure if there is a better way to do this
 #if ZL_FBCODE_IS_RELEASE
 #    include "openzl/prod/custom_transforms/tulip_v2/tests/gen-cpp2/tulip_v2_data_types.h"
-#    include "openzl/prod/custom_transforms/tulip_v2/tests/gen-cpp2/tulip_v2_data_visitation.h"
 #else
 #    include "openzl/dev/custom_transforms/tulip_v2/tests/gen-cpp2/tulip_v2_data_types.h"
-#    include "openzl/dev/custom_transforms/tulip_v2/tests/gen-cpp2/tulip_v2_data_visitation.h"
 #endif
 
 namespace openzl::tulip_v2::tests {


### PR DESCRIPTION
Summary: Remove OpenZL test visitation dependencies and redundant visitation headers now that reflection is emitted by `cpp2-types`.

Differential Revision: D112639374


