### PR TITLE
Add new mparam API for graphs and segmenters

### DIFF
--- a/include/openzl/zl_compressor.h
+++ b/include/openzl/zl_compressor.h
@@ -20,6 +20,7 @@
 #include "openzl/zl_compress.h"     // ZL_CCtx
 #include "openzl/zl_errors.h"       // ZL_Report, ZL_ErrorCode
 #include "openzl/zl_localParams.h"  // ZL_LocalParams
+#include "openzl/zl_materializer.h" // ZL_MParam
 #include "openzl/zl_opaque_types.h" // ZL_GraphID, ZL_Compressor
 #include "openzl/zl_portability.h"  // ZL_NOEXCEPT_FUNC_PTR
 #include "openzl/zl_public_nodes.h"
@@ -412,6 +413,9 @@ typedef struct ZL_GraphParameters_s {
     size_t nbCustomNodes;
     /// NULL means don't override
     const ZL_LocalParams* localParams;
+    /// Optional MParam blob to (re)materialize on the target graph. Empty
+    /// content means don't override the graph's MParam.
+    ZL_MParam mparam;
 } ZL_GraphParameters;
 
 /**
@@ -446,6 +450,10 @@ typedef struct {
     size_t nbCustomNodes;
     /// NULL means don't override
     const ZL_LocalParams* localParams;
+    /// Optional per-instance MParam blob. It is materialized at registration
+    /// using the base graph's materializer (mparamMat). Empty content means no
+    /// MParam.
+    ZL_MParam mparam;
 } ZL_ParameterizedGraphDesc;
 
 /**

--- a/include/openzl/zl_graph_api.h
+++ b/include/openzl/zl_graph_api.h
@@ -99,6 +99,21 @@ struct ZL_FunctionGraphDesc {
      * registration fails, and it lives for the lifetime of the compressor.
      */
     ZL_OpaquePtr opaque;
+    /**
+     * Optional materializer for compression-only materialized parameters
+     * (MParams). If materializeFn is non-null, it will be called during
+     * compressor deserialization to create the materialized object from
+     * the serialized MParam blob. Unlike dicts, MParams are NOT required
+     * at decompression time.
+     */
+    ZL_MaterializerDesc2 mparamMat;
+    /**
+     * Optional MParam associated with this graph. The provided content blob
+     * will be materialized as dictated by @p mparamMat . OpenZL will not take
+     * ownership of the content provided. The caller is free to free the buffer
+     * anytime after registering the graph.
+     */
+    ZL_MParam mparam;
 };
 
 /**
@@ -152,6 +167,13 @@ ZL_RefParam ZL_Graph_getLocalRefParam(const ZL_Graph* gctx, int refParamId);
  * the encoder.
  */
 const ZL_LocalParams* ZL_Graph_getLocalParams(const ZL_Graph* gctx);
+
+/**
+ * @returns The materialized MParam object associated with this graph, if
+ * there is one. Otherwise NULL. MParams are compression-only resources
+ * that are not required at decompression time.
+ */
+const void* ZL_Graph_getMParam(const ZL_Graph* gctx);
 
 /**
  * Determines whether @nodeid is supported given the applied global parameters

--- a/include/openzl/zl_reflection.h
+++ b/include/openzl/zl_reflection.h
@@ -369,6 +369,22 @@ const void* ZL_Compressor_Node_getMParamObj(
         ZL_NodeID node);
 
 /**
+ * @returns A pointer to the *unmaterialized* MParam associated with the @p
+ * graph, or NULL if no MParam is associated.
+ */
+const ZL_MParam* ZL_Compressor_Graph_getMParam(
+        ZL_Compressor const* cgraph,
+        ZL_GraphID graph);
+
+/**
+ * @returns The *materialized* Mparam object associated with the @p graph or
+ * NULL if no MParam is associated.
+ */
+const void* ZL_Compressor_Graph_getMParamObj(
+        ZL_Compressor const* cgraph,
+        ZL_GraphID graph);
+
+/**
  * @returns The number of unique MParam blobs stored in the @p compressor.
  */
 size_t ZL_Compressor_numMParams(const ZL_Compressor* compressor);

--- a/include/openzl/zl_segmenter.h
+++ b/include/openzl/zl_segmenter.h
@@ -103,6 +103,21 @@ typedef struct {
      * registration fails, and it lives for the lifetime of the compressor.
      */
     ZL_OpaquePtr opaque;
+    /**
+     * Optional materializer for compression-only materialized parameters
+     * (MParams). If materializeFn is non-null, it will be called during
+     * compressor deserialization to create the materialized object from
+     * the serialized MParam blob. Unlike dicts, MParams are NOT required
+     * at decompression time.
+     */
+    ZL_MaterializerDesc2 mparamMat;
+    /**
+     * Optional MParam associated with this segmenter. The provided content
+     * blob will be materialized as dictated by @p mparamMat . OpenZL will not
+     * take ownership of the content provided. The caller is free to free the
+     * buffer anytime after registering the segmenter.
+     */
+    ZL_MParam mparam;
 } ZL_SegmenterDesc;
 
 /**
@@ -192,6 +207,13 @@ ZL_IntParam ZL_Segmenter_getLocalIntParam(
 ZL_RefParam ZL_Segmenter_getLocalRefParam(
         const ZL_Segmenter* segCtx,
         int refParamId);
+
+/**
+ * @returns The materialized MParam object associated with this segmenter, if
+ * there is one. Otherwise NULL. MParams are compression-only resources
+ * that are not required at decompression time.
+ */
+const void* ZL_Segmenter_getMParam(const ZL_Segmenter* segCtx);
 
 /**
  * @brief Retrieve the list of custom successor graphs available to this

--- a/src/openzl/compress/cctx.c
+++ b/src/openzl/compress/cctx.c
@@ -890,6 +890,7 @@ static ZL_Graph GCTX_init(ZL_CCtx* cctx, const ZL_FunctionGraphDesc* dgd)
         .rtsids        = VECTOR_EMPTY(ZL_ENCODER_GRAPH_LIMIT),
         .status        = ZL_returnSuccess(),
         .dgd           = dgd,
+        .graphid       = ZL_GRAPH_ILLEGAL,
         .graphArena    = cctx->graphArena,
         .chunkArena    = cctx->chunkArena,
     };
@@ -1006,7 +1007,8 @@ static ZL_Report CCTX_runSegmenter(
             cctx,
             &cctx->rtgraph,
             cctx->sessionArena,
-            cctx->chunkArena);
+            cctx->chunkArena,
+            graphid);
     CWAYPOINT(on_segmenterEncode_start, segmenterCtx, /* placeholder */ NULL);
     cctx->segmenterDepth = depth;
     ZL_Report const r    = SEGM_runSegmenter(segmenterCtx);
@@ -1050,6 +1052,7 @@ static ZL_Report CCTX_runGraphDesc(
     ZL_Graph graphCtx     = GCTX_init(cctx, migd);
     graphCtx.privateParam = privateParam;
     graphCtx.depth        = depth;
+    graphCtx.graphid      = graphid;
 
     for (unsigned n = 0; n < nbInputs; n++) {
         const ZL_Report ret =

--- a/src/openzl/compress/cgraph.c
+++ b/src/openzl/compress/cgraph.c
@@ -69,6 +69,7 @@ ZL_Compressor* ZL_Compressor_create(void)
     }
     // Back-populate CDictMgr pointers
     cgraph->nmgr.ctm.cdictMgr = &cgraph->cdictMgr;
+    GM_setCDictMgr(cgraph->gm, &cgraph->cdictMgr);
 
 #if ZL_ENABLE_ASSERT
     // In debug mode, runtime check on the configuration of the Standard Graphs
@@ -840,6 +841,7 @@ ZL_Compressor_parameterizeGraph(
         .customNodes    = params->customNodes,
         .nbCustomNodes  = params->nbCustomNodes,
         .localParams    = params->localParams,
+        .mparam         = params->mparam,
     };
     return GM_registerParameterizedGraph(compressor->gm, &desc);
 }
@@ -895,6 +897,7 @@ ZL_GraphID ZL_Compressor_registerParameterizedGraph(
         .customNodes    = desc->customNodes,
         .nbCustomNodes  = desc->nbCustomNodes,
         .localParams    = desc->localParams,
+        .mparam         = desc->mparam,
     };
     ZL_RESULT_OF(ZL_GraphID)
     graphidResult =
@@ -1012,6 +1015,14 @@ const ZL_SegmenterDesc* CGRAPH_getSegmenterDesc(
 {
     ZL_ASSERT_NN(compressor);
     return GM_getSegmenterDesc(compressor->gm, graphid);
+}
+
+const void* CGRAPH_getGraphMParamObj(
+        const ZL_Compressor* compressor,
+        ZL_GraphID graphid)
+{
+    ZL_ASSERT_NN(compressor);
+    return GM_getGraphMParamObj(compressor->gm, graphid);
 }
 
 const void* CGRAPH_graphPrivateParam(
@@ -1169,6 +1180,40 @@ ZL_LocalParams ZL_Compressor_Graph_getLocalParams(
         ZL_GraphID graphid)
 {
     return GM_getGraphMetadata(compressor->gm, graphid).localParams;
+}
+
+// Returns a pointer to the graph's MParam descriptor (blob + id), handling both
+// function graphs and segmenters, or NULL when the graph is invalid. Mirrors
+// reading cnode->transformDesc.publicDesc.mparam on the node side.
+static const ZL_MParam* getGraphMParamPtr(
+        const ZL_Compressor* cgraph,
+        ZL_GraphID graph)
+{
+    const ZL_FunctionGraphDesc* migd =
+            CGRAPH_getMultiInputGraphDesc(cgraph, graph);
+    if (migd != NULL)
+        return &migd->mparam;
+    const ZL_SegmenterDesc* segDesc = CGRAPH_getSegmenterDesc(cgraph, graph);
+    if (segDesc != NULL)
+        return &segDesc->mparam;
+    return NULL;
+}
+
+const ZL_MParam* ZL_Compressor_Graph_getMParam(
+        ZL_Compressor const* cgraph,
+        ZL_GraphID graph)
+{
+    const ZL_MParam* mp = getGraphMParamPtr(cgraph, graph);
+    if (mp == NULL || !ZL_UniqueID_isValid(&mp->mparamID.id))
+        return NULL;
+    return mp;
+}
+
+const void* ZL_Compressor_Graph_getMParamObj(
+        ZL_Compressor const* cgraph,
+        ZL_GraphID graph)
+{
+    return CGRAPH_getGraphMParamObj(cgraph, graph);
 }
 
 size_t ZL_Compressor_Node_getNumInputs(

--- a/src/openzl/compress/cgraph.h
+++ b/src/openzl/compress/cgraph.h
@@ -45,6 +45,10 @@ const ZL_SegmenterDesc* CGRAPH_getSegmenterDesc(
         const ZL_Compressor* compressor,
         ZL_GraphID graphid);
 
+const void* CGRAPH_getGraphMParamObj(
+        const ZL_Compressor* compressor,
+        ZL_GraphID graphid);
+
 const void* CGRAPH_graphPrivateParam(
         const ZL_Compressor* cgraph,
         ZL_GraphID graphid);

--- a/src/openzl/compress/compressor_serialization.c
+++ b/src/openzl/compress/compressor_serialization.c
@@ -380,6 +380,7 @@ typedef struct {
     VECTOR(StringView) successor_graphs;
 
     StringView param_set_name;
+    StringView mparam_id;
 } CompressorSerializer_Graph;
 
 static void CompressorSerializer_Graph_destroy(CompressorSerializer_Graph* g)
@@ -859,6 +860,27 @@ static ZL_Report CompressorSerializer_serializeGraph_cb(
         info->param_set_name = StringView_init(NULL, 0);
     }
 
+    {
+        const ZL_MParam* const mparam = ZL_Compressor_Graph_getMParam(c, gid);
+        if (mparam != NULL && ZL_MParamID_hasValue(&mparam->mparamID)) {
+            ZL_TRY_LET_CONST(
+                    StringView,
+                    mparam_id_sv,
+                    cs_hexEncodeUniqueID(state->arena, &mparam->mparamID.id));
+            ZL_ERR_IF_NULL(
+                    CompressorSerializer_MParamMap_find(
+                            &state->mparams, &mparam_id_sv),
+                    logicError,
+                    "Graph '%.*s' references mparam ID '%.*s' which was not "
+                    "recorded in the mparams map",
+                    (int)info->graph_name.size,
+                    info->graph_name.data,
+                    (int)mparam_id_sv.size,
+                    mparam_id_sv.data);
+            info->mparam_id = mparam_id_sv;
+        }
+    }
+
     return ZL_returnSuccess();
 }
 
@@ -1209,6 +1231,9 @@ static ZL_Report ZL_CompressorSerializer_encodeGraph(
                    "Invalid graph type for graph \"%s\"!",
                    info->graph_name);
     }
+    if (info->mparam_id.size > 0) {
+        num_pairs += 1; // mparam_id
+    }
 
     A1C_Item_string_refStringView(key, entry->key);
     const A1C_MapBuilder builder =
@@ -1303,6 +1328,12 @@ static ZL_Report ZL_CompressorSerializer_encodeGraph(
         } else {
             A1C_Item_null(&pair->val);
         }
+    }
+
+    if (info->mparam_id.size > 0) {
+        A1C_MAP_TRY_ADD(pair, builder);
+        A1C_Item_string_refCStr(&pair->key, "mparam_id");
+        A1C_Item_string_refStringView(&pair->val, info->mparam_id);
     }
 
     ZL_ERR_IF_NE(val->map.size, num_pairs, logicError);
@@ -2748,6 +2779,26 @@ static ZL_Report ZL_CompressorDeserializer_tryBuildGraph(
                 graphs[i] = gid;
             }
 
+            // Read optional "mparam_id" field (hex string key) and look up the
+            // corresponding entry from the pre-parsed mparams map.
+            ZL_MParam mparam = { .mparamID = ZL_MPARAM_ID_NULL };
+            const A1C_Item* mparam_item =
+                    A1C_Map_get_cstr(&val_map, "mparam_id");
+            if (mparam_item != NULL) {
+                A1C_TRY_EXTRACT_STRING(mparam_key_str, mparam_item);
+                const StringView mparam_key_sv =
+                        StringView_initFromA1C(mparam_key_str);
+
+                const CompressorDeserializer_MParamMap_Entry* const mp_entry =
+                        CompressorDeserializer_MParamMap_find(
+                                &state->mparams_map, &mparam_key_sv);
+                ZL_ERR_IF_NULL(
+                        mp_entry,
+                        corruption,
+                        "Graph references mparam ID not found in mparams section");
+                mparam = mp_entry->val;
+            }
+
             const ZL_ParameterizedGraphDesc graph_desc =
                     (ZL_ParameterizedGraphDesc){
                         .name           = new_graph_name_base.data,
@@ -2757,6 +2808,7 @@ static ZL_Report ZL_CompressorDeserializer_tryBuildGraph(
                         .customNodes    = nodes,
                         .nbCustomNodes  = num_nodes,
                         .localParams    = &local_params,
+                        .mparam         = mparam,
                     };
             const ZL_GraphID gid = ZL_Compressor_registerParameterizedGraph(
                     compressor, &graph_desc);

--- a/src/openzl/compress/dyngraph_interface.c
+++ b/src/openzl/compress/dyngraph_interface.c
@@ -110,6 +110,12 @@ const ZL_LocalParams* ZL_Graph_getLocalParams(const ZL_Graph* gctx)
     return &gctx->dgd->localParams;
 }
 
+const void* ZL_Graph_getMParam(const ZL_Graph* gctx)
+{
+    ZL_ASSERT_NN(gctx);
+    return CGRAPH_getGraphMParamObj(CCTX_getCGraph(gctx->cctx), gctx->graphid);
+}
+
 const ZL_LocalParams* GCTX_getAllLocalParams(const ZL_Graph* gctx)
 {
     ZL_ASSERT_NN(gctx);

--- a/src/openzl/compress/dyngraph_interface.h
+++ b/src/openzl/compress/dyngraph_interface.h
@@ -88,6 +88,7 @@ struct ZL_Graph_s {
     RTGraph* rtgraph; /**< Runtime graph for querying stream IDs */
     const ZL_FunctionGraphDesc* dgd; /**< Graph descriptor */
     const void* privateParam;        /**< Private parameters for the graph */
+    ZL_GraphID graphid;              /**< Graph id of the graph */
     VECTOR(DG_StreamCtx)
     streamCtxs; /**< Stream contexts created by this graph */
     VECTOR(DestGraphDesc) dstGraphDescs; /**< Destination graph descriptors */

--- a/src/openzl/compress/graph_registry.h
+++ b/src/openzl/compress/graph_registry.h
@@ -56,6 +56,11 @@ typedef struct {
     /// recognize this graph and use this component for compression in the
     /// expected manner.
     unsigned minLibraryVersion;
+    /// The materialized MParam object associated with this graph or segmenter,
+    /// or NULL when none. Produced at registration from the descriptor's
+    /// mparam blob via the compressor's CDictMgr, and exposed at runtime
+    /// through ZL_Graph_getMParam() / ZL_Segmenter_getMParam().
+    const void* mparamObj;
 } Graph_Desc_internal;
 
 typedef struct {

--- a/src/openzl/compress/graphmgr.c
+++ b/src/openzl/compress/graphmgr.c
@@ -7,6 +7,7 @@
 #include "openzl/common/logging.h" // ZL_DLOG, STR_REPLACE_NULL for logging and debugging
 #include "openzl/common/map.h" // ZL_DECLARE_PREDEF_MAP_TYPE, GraphMap for name-to-GraphID mapping
 #include "openzl/common/opaque.h" // ZL_OpaquePtrRegistry for managing opaque pointers
+#include "openzl/compress/cdictmgr.h" // CDictMgr, CDictMgr_materializeMParam, CDictMgr_getMParam
 #include "openzl/compress/cgraph.h" // CNODE_getName, CNode definitions, graph context functions
 #include "openzl/compress/graph_registry.h" // ZL_PrivateStandardGraphID_end, GR_standardGraphs, InternalGraphDesc
 #include "openzl/compress/implicit_conversion.h" // ICONV_isCompatible for type checking
@@ -18,6 +19,7 @@
 #include "openzl/zl_ctransform.h" // ZL_MaterializerDesc, ZL_Materializer for materialization
 #include "openzl/zl_opaque_types.h" // Opaque type definitions used by the API
 #include "openzl/zl_reflection.h" // ZL_MIGraphDesc and type reflection utilities
+#include "openzl/zl_unique_id.h" // ZL_UniqueID_isValid, ZL_UniqueID_computeSHA256
 
 /* ===   State Management   === */
 
@@ -35,6 +37,9 @@ struct GraphsMgr_s {
     ZL_OpaquePtrRegistry opaquePtrs;
     MaterializedParamMap materializedParams;
     ZL_OperationContext* opCtx;
+    /// Non-owning pointer to the compressor's CDictMgr, used to materialize and
+    /// cache MParam objects at registration. Set via GM_setCDictMgr().
+    CDictMgr* cdictMgr;
 }; // note: typedef'd to GraphsMgr
 
 static ZL_Report GM_fillStandardGraphsCallback(
@@ -102,6 +107,65 @@ void GM_free(GraphsMgr* gm)
     ALLOC_Arena_freeArena(gm->scratchAllocator);
     ALLOC_Arena_freeArena(gm->allocator);
     ZL_free(gm);
+}
+
+void GM_setCDictMgr(GraphsMgr* gm, CDictMgr* cdictMgr)
+{
+    ZL_ASSERT_NN(gm);
+    gm->cdictMgr = cdictMgr;
+}
+
+/**
+ * Materializes the @p mparam blob (if provided) using @p mparamMat via the
+ * compressor's CDictMgr, storing the resulting object into @p mparamObj and
+ * replacing @p mparam with the CDictMgr-owned copy (guaranteed lifetime).
+ * No-op when no MParam content is supplied. Mirrors the node path in
+ * CTM_registerCNode (cnodes.c).
+ */
+static ZL_Report GM_materializeMParam(
+        GraphsMgr* gm,
+        ZL_MParam* mparam,
+        const ZL_MaterializerDesc2* mparamMat,
+        const void** mparamObj)
+{
+    ZL_RESULT_DECLARE_SCOPE_REPORT(gm->opCtx);
+    *mparamObj = NULL;
+    if (mparam->content == NULL && mparam->size == 0) {
+        return ZL_returnSuccess();
+    }
+    ZL_ERR_IF_NULL(
+            gm->cdictMgr,
+            logicError,
+            "Gm must have a non-null pointer to CDictMgr");
+    ZL_ERR_IF_NULL(
+            mparam->content,
+            graph_invalid,
+            "MParam must have non-null content");
+    ZL_ERR_IF_EQ(
+            mparam->size,
+            0,
+            graph_invalid,
+            "Non-null MParam must have non-zero size");
+    ZL_ERR_IF(
+            mparamMat->materializeFn == NULL
+                    || mparamMat->dematerializeFn == NULL,
+            graph_invalid,
+            "MParam materializer must declare both a materialize and dematerialize function");
+
+    // Assign a content-derived ID when none was provided.
+    if (!ZL_UniqueID_isValid(&mparam->mparamID.id)) {
+        mparam->mparamID.id =
+                ZL_UniqueID_computeSHA256(mparam->content, mparam->size);
+    }
+
+    ZL_TRY_LET_CONST(
+            ZL_ConstVoidPtr,
+            obj,
+            CDictMgr_materializeMParam(gm->cdictMgr, *mparam, mparamMat));
+    *mparamObj = obj;
+    // Replace with the cached copy that has a guaranteed lifetime.
+    *mparam = *CDictMgr_getMParam(gm->cdictMgr, mparam->mparamID);
+    return ZL_returnSuccess();
 }
 
 /* ===   Indexing scheme   === */
@@ -304,6 +368,7 @@ static ZL_RESULT_OF(ZL_GraphID) GM_registerInternalGraph(
     gdi.baseGraphID       = originalGraphID;
     gdi.originalGraphType = originalGraphType;
     gdi.migd              = *migd;
+    gdi.mparamObj         = NULL;
     ZL_ERR_IF_ERR(GM_transferTypes(
             gm,
             migd->inputTypeMasks,
@@ -334,6 +399,9 @@ static ZL_RESULT_OF(ZL_GraphID) GM_registerInternalGraph(
                 &gdi.migd.localParams,
                 &migd->materializer));
     }
+    // Materialize the compression-only MParam blob (if any) via CDictMgr.
+    ZL_ERR_IF_ERR(GM_materializeMParam(
+            gm, &gdi.migd.mparam, &gdi.migd.mparamMat, &gdi.mparamObj));
 
     if (ppSize == 0) {
         // No need to transfer, just copy the pointer
@@ -577,6 +645,16 @@ ZL_Report GM_overrideGraphParams(
         migd->localParams = *gp->localParams;
         ZL_ERR_IF_ERR(GM_transferLocalParameters(gm, &migd->localParams));
     }
+    if (gp->mparam.content != NULL || gp->mparam.size != 0) {
+        // Re-materialize the MParam blob using the materializer that was
+        // inherited from the base graph at parameterization time.
+        migd->mparam = gp->mparam;
+        ZL_ERR_IF_ERR(GM_materializeMParam(
+                gm,
+                &migd->mparam,
+                &migd->mparamMat,
+                &VECTOR_AT(gm->gdv, lid).mparamObj));
+    }
     if (gp->name) {
         ZL_ERR(parameter_invalid, "Cannot replace the name of a graph");
     }
@@ -740,6 +818,9 @@ GM_registerParameterizedGraph(
         } else {
             segDesc.name = ZL_Name_prefix(&baseMeta.name);
         }
+        if (desc->mparam.content != NULL || desc->mparam.size != 0) {
+            segDesc.mparam = desc->mparam;
+        }
 
         // Keep originalGraphType as segmenter, use baseGraphID to indicate
         // parameterization
@@ -776,6 +857,9 @@ GM_registerParameterizedGraph(
         // graph needs a new non-anchor name.
         ZL_Name name = GM_getGraphMetadata(gm, desc->graph).name;
         miDesc.name  = ZL_Name_prefix(&name);
+    }
+    if (desc->mparam.content != NULL || desc->mparam.size != 0) {
+        miDesc.mparam = desc->mparam;
     }
 
     return GM_registerInternalGraph(
@@ -830,6 +914,7 @@ static ZL_RESULT_OF(ZL_GraphID) GM_registerSegmenter_internal(
     gdi.baseGraphID       = originalGraphID;
     gdi.originalGraphType = originalGraphType;
     gdi.segDesc           = *segDesc;
+    gdi.mparamObj         = NULL;
     ZL_ERR_IF_ERR(GM_transferTypes(
             gm,
             segDesc->inputTypeMasks,
@@ -857,6 +942,9 @@ static ZL_RESULT_OF(ZL_GraphID) GM_registerSegmenter_internal(
                 &gdi.segDesc.localParams,
                 &segDesc->materializer));
     }
+    // Materialize the compression-only MParam blob (if any) via CDictMgr.
+    ZL_ERR_IF_ERR(GM_materializeMParam(
+            gm, &gdi.segDesc.mparam, &gdi.segDesc.mparamMat, &gdi.mparamObj));
 
     if (ppSize == 0) {
         // No need to transfer, just copy the pointer
@@ -1103,6 +1191,19 @@ const ZL_SegmenterDesc* GM_getSegmenterDesc(
     if (VECTOR_AT(gm->gdv, lgid).originalGraphType != ZL_GraphType_segmenter)
         return NULL;
     return &VECTOR_AT(gm->gdv, lgid).segDesc;
+}
+
+const void* GM_getGraphMParamObj(const GraphsMgr* gm, ZL_GraphID graphid)
+{
+    if (GR_isStandardGraph(graphid)) {
+        // Standard graphs never carry an MParam.
+        return NULL;
+    }
+    ZL_IDType const lgid = GM_GraphID_to_lgid(graphid);
+    ZL_ASSERT_NN(gm);
+    if (lgid >= VECTOR_SIZE(gm->gdv))
+        return NULL;
+    return VECTOR_AT(gm->gdv, lgid).mparamObj;
 }
 
 GraphType_e GM_graphType(const GraphsMgr* gm, ZL_GraphID graphid)

--- a/src/openzl/compress/graphmgr.h
+++ b/src/openzl/compress/graphmgr.h
@@ -14,9 +14,16 @@
 ZL_BEGIN_C_DECLS
 
 typedef struct GraphsMgr_s GraphsMgr;
+typedef struct CDictMgr_s CDictMgr; // forward declaration
 // note: may need an update to support custom allocator
 GraphsMgr* GM_create(const Nodes_manager* nmgr);
 void GM_free(GraphsMgr* gm);
+
+/**
+ * Populate the graph manager with a pointer to the compressor's CDictMgr,
+ * for management of MParam objects.
+ */
+void GM_setCDictMgr(GraphsMgr* gm, CDictMgr* cdictMgr);
 
 /*   registration actions   */
 
@@ -119,6 +126,13 @@ const ZL_FunctionGraphDesc* GM_getMultiInputGraphDesc(
 const ZL_SegmenterDesc* GM_getSegmenterDesc(
         const GraphsMgr* compressor,
         ZL_GraphID graphid);
+
+/**
+ * @returns The materialized MParam object associated with @graphid (a function
+ * graph or segmenter), or NULL when there is none. Standard graphs always
+ * return NULL.
+ */
+const void* GM_getGraphMParamObj(const GraphsMgr* gm, ZL_GraphID graphid);
 
 const void* GM_getPrivateParam(const GraphsMgr* gmgr, ZL_GraphID graphid);
 

--- a/src/openzl/compress/segmenter.c
+++ b/src/openzl/compress/segmenter.c
@@ -6,6 +6,7 @@
 #include "openzl/common/stream.h" // STREAM_*
 #include "openzl/common/vector.h"
 #include "openzl/compress/cctx.h"        // CCTX_*
+#include "openzl/compress/cgraph.h"      // CGRAPH_getGraphMParamObj
 #include "openzl/compress/localparams.h" // LP_*
 #include "openzl/compress/rtgraphs.h"
 #include "openzl/zl_data.h"   // ZL_Data, ZL_Type
@@ -25,6 +26,7 @@ struct ZL_Segmenter_s {
     size_t numChunks;
     Arena* sessionArena;
     Arena* chunkArena;
+    ZL_GraphID graphid;
 };
 
 /**
@@ -51,7 +53,8 @@ ZL_Segmenter* SEGM_init(
         ZL_CCtx* cctx,
         RTGraph* rtgm,
         Arena* sessionArena,
-        Arena* chunkArena)
+        Arena* chunkArena,
+        ZL_GraphID graphid)
 {
     ZL_DLOG(BLOCK, "SEGM_init");
     ZL_Segmenter* seg = ALLOC_Arena_malloc(sessionArena, sizeof(ZL_Segmenter));
@@ -63,6 +66,7 @@ ZL_Segmenter* SEGM_init(
     seg->rtgm         = rtgm;
     seg->sessionArena = sessionArena;
     seg->chunkArena   = chunkArena;
+    seg->graphid      = graphid;
     ZL_ASSERT_EQ(nbInputs, VECTOR_SIZE(rtgm->streams));
     seg->nbInputs = nbInputs;
     seg->inputs = ALLOC_Arena_malloc(sessionArena, nbInputs * sizeof(ZL_Data*));
@@ -158,6 +162,13 @@ const ZL_LocalParams* ZL_Segmenter_getLocalParams(const ZL_Segmenter* segCtx)
 {
     ZL_ASSERT_NN(segCtx);
     return &segCtx->segDesc->localParams;
+}
+
+const void* ZL_Segmenter_getMParam(const ZL_Segmenter* segCtx)
+{
+    ZL_ASSERT_NN(segCtx);
+    return CGRAPH_getGraphMParamObj(
+            CCTX_getCGraph(segCtx->cctx), segCtx->graphid);
 }
 
 /* Consultation request for Custom Successor Graphs */

--- a/src/openzl/compress/segmenter.h
+++ b/src/openzl/compress/segmenter.h
@@ -53,7 +53,8 @@ ZL_Segmenter* SEGM_init(
         ZL_CCtx* cctx,
         RTGraph* rtgm,
         Arena* sessionArena,
-        Arena* chunkArena);
+        Arena* chunkArena,
+        ZL_GraphID graphid);
 
 /**
  * @brief Execute the segmenter function to process all input data.

--- a/tests/integrationtest/CompressorIntegrationTest.cpp
+++ b/tests/integrationtest/CompressorIntegrationTest.cpp
@@ -3,6 +3,7 @@
 #include <gtest/gtest.h>
 
 #include <cstring>
+#include <map>
 #include <vector>
 
 #include "openzl/dict/bundle.h"
@@ -22,6 +23,8 @@
 #include "openzl/zl_reflection.h"
 #include "openzl/zl_segmenter.h"
 #include "openzl/zl_selector.h"
+
+#include "openzl/compress/cgraph.h" // ZL_Compressor_overrideGraphParams (internal)
 
 using namespace ::testing;
 
@@ -1250,6 +1253,612 @@ TEST_F(CompressorIntegrationTest,
     ASSERT_EQ(
             std::string(dst.data(), compressedSize),
             std::string(dst2.data(), compressedSize));
+}
+
+// ============================================================================
+// MParam (compression-only materialized param) tests for graphs & segmenters.
+// These exercise ZL_Graph_getMParam / ZL_Segmenter_getMParam, mirroring the
+// codec-side ZL_Encoder_getMParam. The materializer (copyDictMaterialize)
+// produces a copy of the raw blob, so the runtime object equals the content.
+// ============================================================================
+
+// Graph function that reads its MParam and copies it into a ref-param output
+// buffer, so the test can verify the materialized content.
+static ZL_Report graphVerifyMParamFn(
+        ZL_Graph* graph,
+        ZL_Edge* inputs[],
+        size_t nbInputs) ZL_NOEXCEPT_FUNC_PTR
+{
+    ZL_RESULT_DECLARE_SCOPE_REPORT(graph);
+    ZL_ERR_IF_NE(nbInputs, 1, GENERIC);
+
+    const void* mparam = ZL_Graph_getMParam(graph);
+    ZL_ERR_IF_NULL(mparam, GENERIC, "Expected getMParam non-null");
+
+    const int size = ZL_Graph_getLocalIntParam(graph, 1).paramValue;
+    void* out = const_cast<void*>(ZL_Graph_getLocalRefParam(graph, 3).paramRef);
+    ZL_ERR_IF_NULL(out, GENERIC, "Expected output ref param non-null");
+    memcpy(out, mparam, (size_t)size);
+
+    return ZL_Edge_setDestination(inputs[0], ZL_GRAPH_STORE);
+}
+
+// Graph function asserting that getMParam is NULL when no MParam is registered.
+static ZL_Report graphExpectNoMParamFn(
+        ZL_Graph* graph,
+        ZL_Edge* inputs[],
+        size_t nbInputs) ZL_NOEXCEPT_FUNC_PTR
+{
+    ZL_RESULT_DECLARE_SCOPE_REPORT(graph);
+    ZL_ERR_IF_NE(nbInputs, 1, GENERIC);
+    ZL_ERR_IF_NN(
+            ZL_Graph_getMParam(graph),
+            GENERIC,
+            "Expected getMParam NULL for graph without an MParam");
+    return ZL_Edge_setDestination(inputs[0], ZL_GRAPH_STORE);
+}
+
+TEST_F(CompressorIntegrationTest,
+       GIVENaFunctionGraphWithMParamWHENinvokedTHENitIsAccessible)
+{
+    std::string mparamContent = "function-graph-mparam-blob";
+    std::string out(mparamContent.size(), 0);
+
+    ZL_IntParam ip = { .paramId = 1, .paramValue = (int)mparamContent.size() };
+    ZL_RefParam rp = { .paramId = 3, .paramRef = out.data() };
+    ZL_LocalParams lp = {
+        .intParams = { .intParams = &ip, .nbIntParams = 1 },
+        .refParams = { .refParams = &rp, .nbRefParams = 1 },
+    };
+
+    ZL_MaterializerDesc2 mparamMat{};
+    mparamMat.materializeFn   = copyDictMaterialize;
+    mparamMat.dematerializeFn = ZL_NOOP_DEMATERIALIZE;
+
+    static ZL_Type inputType = ZL_Type_serial;
+    ZL_FunctionGraphDesc graphDesc = {
+        .name           = "test_graph_getmparam",
+        .graph_f        = graphVerifyMParamFn,
+        .inputTypeMasks = &inputType,
+        .nbInputs       = 1,
+        .localParams    = lp,
+        .mparamMat      = mparamMat,
+        .mparam         = {
+            .content = mparamContent.data(),
+            .size    = mparamContent.size(),
+        },
+    };
+
+    auto graphId = compressor_.registerFunctionGraph(graphDesc);
+    ASSERT_NE(graphId.gid, ZL_GRAPH_ILLEGAL.gid);
+    compressor_.selectStartingGraph(graphId);
+
+    compressData();
+    EXPECT_EQ(mparamContent, out);
+    EXPECT_EQ(ZL_Compressor_numMParams(compressor_.get()), 1u);
+
+    // Reflection getters expose the same MParam blob + materialized object.
+    const ZL_MParam* reflected =
+            ZL_Compressor_Graph_getMParam(compressor_.get(), graphId);
+    ASSERT_NE(reflected, nullptr);
+    EXPECT_EQ(
+            std::string(
+                    static_cast<const char*>(reflected->content),
+                    reflected->size),
+            mparamContent);
+    const void* reflectedObj =
+            ZL_Compressor_Graph_getMParamObj(compressor_.get(), graphId);
+    ASSERT_NE(reflectedObj, nullptr);
+    EXPECT_EQ(
+            std::string(
+                    static_cast<const char*>(reflectedObj),
+                    mparamContent.size()),
+            mparamContent);
+}
+
+TEST_F(CompressorIntegrationTest,
+       GIVENaFunctionGraphWithoutMParamWHENinvokedTHENgetMParamReturnsNull)
+{
+    static ZL_Type inputType       = ZL_Type_serial;
+    ZL_FunctionGraphDesc graphDesc = {
+        .name           = "test_graph_no_mparam",
+        .graph_f        = graphExpectNoMParamFn,
+        .inputTypeMasks = &inputType,
+        .nbInputs       = 1,
+    };
+
+    auto graphId = compressor_.registerFunctionGraph(graphDesc);
+    ASSERT_NE(graphId.gid, ZL_GRAPH_ILLEGAL.gid);
+    compressor_.selectStartingGraph(graphId);
+
+    compressData();
+    EXPECT_EQ(ZL_Compressor_numMParams(compressor_.get()), 0u);
+
+    // Reflection getters report no MParam for a graph without one.
+    EXPECT_EQ(
+            ZL_Compressor_Graph_getMParam(compressor_.get(), graphId), nullptr);
+    EXPECT_EQ(
+            ZL_Compressor_Graph_getMParamObj(compressor_.get(), graphId),
+            nullptr);
+}
+
+// Segmenter function that reads its MParam and copies it into a ref-param
+// output buffer.
+static ZL_Report segmenterVerifyMParamFn(ZL_Segmenter* segmenter)
+        ZL_NOEXCEPT_FUNC_PTR
+{
+    ZL_RESULT_DECLARE_SCOPE_REPORT(segmenter);
+
+    const void* mparam = ZL_Segmenter_getMParam(segmenter);
+    ZL_ERR_IF_NULL(mparam, GENERIC, "Expected getMParam non-null");
+
+    const int size = ZL_Segmenter_getLocalIntParam(segmenter, 1).paramValue;
+    void* out      = const_cast<void*>(
+            ZL_Segmenter_getLocalRefParam(segmenter, 3).paramRef);
+    ZL_ERR_IF_NULL(out, GENERIC, "Expected output ref param non-null");
+    memcpy(out, mparam, (size_t)size);
+
+    // Forward the whole input as a single chunk to STORE.
+    size_t numInputs = ZL_Segmenter_numInputs(segmenter);
+    size_t* numElts  = (size_t*)ZL_Segmenter_getScratchSpace(
+            segmenter, numInputs * sizeof(size_t));
+    ZL_ERR_IF_NULL(numElts, allocation);
+    ZL_ERR_IF_ERR(ZL_Segmenter_getNumElts(segmenter, numElts, numInputs));
+    ZL_ERR_IF_ERR(ZL_Segmenter_processChunk(
+            segmenter, numElts, numInputs, ZL_GRAPH_STORE, nullptr));
+    return ZL_returnSuccess();
+}
+
+TEST_F(CompressorIntegrationTest,
+       GIVENaSegmenterWithMParamWHENinvokedTHENitIsAccessible)
+{
+    std::string mparamContent = "segmenter-mparam-blob";
+    std::string out(mparamContent.size(), 0);
+
+    ZL_IntParam ip = { .paramId = 1, .paramValue = (int)mparamContent.size() };
+    ZL_RefParam rp = { .paramId = 3, .paramRef = out.data() };
+    ZL_LocalParams lp = {
+        .intParams = { .intParams = &ip, .nbIntParams = 1 },
+        .refParams = { .refParams = &rp, .nbRefParams = 1 },
+    };
+
+    ZL_MaterializerDesc2 mparamMat{};
+    mparamMat.materializeFn   = copyDictMaterialize;
+    mparamMat.dematerializeFn = ZL_NOOP_DEMATERIALIZE;
+
+    static ZL_Type inputType = ZL_Type_serial;
+    ZL_SegmenterDesc segDesc = {
+        .name                = "test_segmenter_getmparam",
+        .segmenterFn         = segmenterVerifyMParamFn,
+        .inputTypeMasks      = &inputType,
+        .numInputs           = 1,
+        .lastInputIsVariable = false,
+        .localParams         = lp,
+        .mparamMat           = mparamMat,
+        .mparam              = {
+            .content = mparamContent.data(),
+            .size    = mparamContent.size(),
+        },
+    };
+
+    auto graphId = ZL_Compressor_registerSegmenter(compressor_.get(), &segDesc);
+    ASSERT_NE(graphId.gid, ZL_GRAPH_ILLEGAL.gid);
+    compressor_.selectStartingGraph(graphId);
+
+    compressData();
+    EXPECT_EQ(mparamContent, out);
+    EXPECT_EQ(ZL_Compressor_numMParams(compressor_.get()), 1u);
+
+    // Reflection getters resolve the MParam through the segmenter union member.
+    const ZL_MParam* reflected =
+            ZL_Compressor_Graph_getMParam(compressor_.get(), graphId);
+    ASSERT_NE(reflected, nullptr);
+    EXPECT_EQ(
+            std::string(
+                    static_cast<const char*>(reflected->content),
+                    reflected->size),
+            mparamContent);
+    const void* reflectedObj =
+            ZL_Compressor_Graph_getMParamObj(compressor_.get(), graphId);
+    ASSERT_NE(reflectedObj, nullptr);
+    EXPECT_EQ(
+            std::string(
+                    static_cast<const char*>(reflectedObj),
+                    mparamContent.size()),
+            mparamContent);
+}
+
+// Collects a compressor's MParams (id -> content) so two compressors' MParam
+// sets can be compared for equality.
+static ZL_Report collectMParamsCb(void* opaque, const ZL_MParam* mparam)
+        ZL_NOEXCEPT_FUNC_PTR
+{
+    auto* out = static_cast<std::map<std::string, std::string>*>(opaque);
+    std::string id(
+            reinterpret_cast<const char*>(mparam->mparamID.id.bytes),
+            sizeof(mparam->mparamID.id.bytes));
+    std::string content(
+            static_cast<const char*>(mparam->content), mparam->size);
+    (*out)[id] = content;
+    return ZL_returnSuccess();
+}
+
+TEST_F(CompressorIntegrationTest,
+       GIVENaFunctionGraphWithMParamWHENserializedTHENitRoundTrips)
+{
+    std::string mparamContent = "function-graph-mparam-serialize";
+    std::string out(mparamContent.size(), 0);
+
+    ZL_IntParam ip = { .paramId = 1, .paramValue = (int)mparamContent.size() };
+    ZL_RefParam rp = { .paramId = 3, .paramRef = out.data() };
+    ZL_LocalParams lp = {
+        .intParams = { .intParams = &ip, .nbIntParams = 1 },
+        .refParams = { .refParams = &rp, .nbRefParams = 1 },
+    };
+
+    ZL_MaterializerDesc2 mparamMat{};
+    mparamMat.materializeFn   = copyDictMaterialize;
+    mparamMat.dematerializeFn = ZL_NOOP_DEMATERIALIZE;
+
+    static ZL_Type inputType = ZL_Type_serial;
+    auto makeGraphDesc       = [&]() -> ZL_FunctionGraphDesc {
+        return ZL_FunctionGraphDesc{
+            .name           = "test_graph_mparam_serialize",
+            .graph_f        = graphVerifyMParamFn,
+            .inputTypeMasks = &inputType,
+            .nbInputs       = 1,
+            .localParams    = lp,
+            .mparamMat      = mparamMat,
+            .mparam         = {
+                    .content = mparamContent.data(),
+                    .size    = mparamContent.size(),
+            },
+        };
+    };
+
+    ZL_FunctionGraphDesc graphDesc = makeGraphDesc();
+    auto graphId = compressor_.registerFunctionGraph(graphDesc);
+    ASSERT_NE(graphId.gid, ZL_GRAPH_ILLEGAL.gid);
+    compressor_.selectStartingGraph(graphId);
+    ASSERT_EQ(ZL_Compressor_numMParams(compressor_.get()), 1u);
+
+    // First compress.
+    cctx_.refCompressor(compressor_);
+    cctx_.setParameter(CParam::FormatVersion, ZL_MAX_FORMAT_VERSION);
+    std::string src =
+            "Let me think. That's just inherently very difficult. What are we doing?";
+    std::vector<char> dst(1000);
+    size_t compressedSize =
+            cctx_.compressSerial(poly::span<char>(dst.data(), dst.size()), src);
+    ASSERT_GT(compressedSize, 0u);
+
+    // Serialize the compressor.
+    ZL_CompressorSerializer* serializer = ZL_CompressorSerializer_create();
+    ASSERT_NE(serializer, nullptr);
+    void* serialized      = nullptr;
+    size_t serializedSize = 0;
+    {
+        ZL_Report r = ZL_CompressorSerializer_serialize(
+                serializer, compressor_.get(), &serialized, &serializedSize);
+        ASSERT_FALSE(ZL_isError(r));
+    }
+    std::vector<uint8_t> serializedCopy(
+            (const uint8_t*)serialized,
+            (const uint8_t*)serialized + serializedSize);
+    ZL_CompressorSerializer_free(serializer);
+
+    // The MParam blob must actually be embedded in the serialized form, not
+    // merely present via pre-registration on the destination compressor.
+    EXPECT_NE(
+            std::string(serializedCopy.begin(), serializedCopy.end())
+                    .find(mparamContent),
+            std::string::npos);
+
+    // Deserialize into a new compressor. The function graph (which carries the
+    // materializer) must be pre-registered under the same name, exactly as for
+    // custom nodes; the MParam blob is round-tripped in the serialized form.
+    openzl::Compressor compressor2;
+    std::string out2(mparamContent.size(), 0);
+    // Re-point the output ref param at compressor2's own buffer.
+    rp.paramRef                     = out2.data();
+    ZL_FunctionGraphDesc graphDesc2 = makeGraphDesc();
+    compressor2.registerFunctionGraph(graphDesc2);
+    ASSERT_EQ(ZL_Compressor_numMParams(compressor2.get()), 1u);
+
+    ZL_CompressorDeserializer* deserializer =
+            ZL_CompressorDeserializer_create();
+    ASSERT_NE(deserializer, nullptr);
+    {
+        ZL_Report r = ZL_CompressorDeserializer_deserialize(
+                deserializer,
+                compressor2.get(),
+                serializedCopy.data(),
+                serializedCopy.size(),
+                nullptr,
+                0);
+        ASSERT_FALSE(ZL_isError(r));
+    }
+    ZL_CompressorDeserializer_free(deserializer);
+
+    // The deserialized compressor must expose an MParam set identical to the
+    // original compressor's (same ids and blob contents).
+    std::map<std::string, std::string> originalMParams;
+    std::map<std::string, std::string> deserializedMParams;
+    ASSERT_FALSE(ZL_isError(ZL_Compressor_forEachMParam(
+            compressor_.get(), collectMParamsCb, &originalMParams)));
+    ASSERT_FALSE(ZL_isError(ZL_Compressor_forEachMParam(
+            compressor2.get(), collectMParamsCb, &deserializedMParams)));
+    EXPECT_EQ(
+            ZL_Compressor_numMParams(compressor2.get()),
+            ZL_Compressor_numMParams(compressor_.get()));
+    EXPECT_FALSE(originalMParams.empty());
+    EXPECT_EQ(deserializedMParams, originalMParams);
+
+    // Second compress with the deserialized compressor must match, and the
+    // graph must observe its MParam again.
+    openzl::CCtx cctx2;
+    cctx2.refCompressor(compressor2);
+    cctx2.setParameter(CParam::FormatVersion, ZL_MAX_FORMAT_VERSION);
+    std::vector<char> dst2(1000);
+    size_t compressedSize2 = cctx2.compressSerial(
+            poly::span<char>(dst2.data(), dst2.size()), src);
+    ASSERT_EQ(compressedSize, compressedSize2);
+    ASSERT_EQ(
+            std::string(dst.data(), compressedSize),
+            std::string(dst2.data(), compressedSize2));
+    EXPECT_EQ(mparamContent, out2);
+}
+
+// ============================================================================
+// Parameterized-graph MParam tests. A parameterized graph inherits its base
+// graph's materializer (mparamMat) and carries its own per-instance MParam blob
+// via ZL_ParameterizedGraphDesc.mparam / ZL_GraphParameters.mparam. These
+// exercise the register, override (re-materialize), and serialize round-trip
+// paths that complete the graph MParam API to parity with nodes.
+// ============================================================================
+
+// Graph function that only asserts its MParam is present and routes to STORE.
+// It uses no ref params, so a graph parameterized from it stays serializable.
+static ZL_Report graphRequireMParamFn(
+        ZL_Graph* graph,
+        ZL_Edge* inputs[],
+        size_t nbInputs) ZL_NOEXCEPT_FUNC_PTR
+{
+    ZL_RESULT_DECLARE_SCOPE_REPORT(graph);
+    ZL_ERR_IF_NE(nbInputs, 1, GENERIC);
+    ZL_ERR_IF_NULL(
+            ZL_Graph_getMParam(graph),
+            GENERIC,
+            "Expected getMParam non-null on parameterized graph");
+    return ZL_Edge_setDestination(inputs[0], ZL_GRAPH_STORE);
+}
+
+TEST_F(CompressorIntegrationTest,
+       GIVENaParameterizedGraphWithMParamWHENinvokedTHENitIsAccessible)
+{
+    const std::string mparamContent = "parameterized-graph-mparam-blob";
+    std::string out(mparamContent.size(), 0);
+
+    ZL_IntParam ip = { .paramId = 1, .paramValue = (int)mparamContent.size() };
+    ZL_RefParam rp = { .paramId = 3, .paramRef = out.data() };
+    ZL_LocalParams lp = {
+        .intParams = { .intParams = &ip, .nbIntParams = 1 },
+        .refParams = { .refParams = &rp, .nbRefParams = 1 },
+    };
+
+    ZL_MaterializerDesc2 mparamMat{};
+    mparamMat.materializeFn   = copyDictMaterialize;
+    mparamMat.dematerializeFn = ZL_NOOP_DEMATERIALIZE;
+
+    static ZL_Type inputType = ZL_Type_serial;
+    // Base function graph carries the materializer but no MParam of its own.
+    ZL_FunctionGraphDesc baseDesc = {
+        .name           = "test_param_base",
+        .graph_f        = graphVerifyMParamFn,
+        .inputTypeMasks = &inputType,
+        .nbInputs       = 1,
+        .localParams    = lp,
+        .mparamMat      = mparamMat,
+    };
+    auto baseId = compressor_.registerFunctionGraph(baseDesc);
+    ASSERT_NE(baseId.gid, ZL_GRAPH_ILLEGAL.gid);
+    EXPECT_EQ(ZL_Compressor_numMParams(compressor_.get()), 0u);
+
+    // Parameterize the base, attaching the per-instance MParam blob.
+    const ZL_ParameterizedGraphDesc paramDesc = {
+        .graph  = baseId,
+        .mparam = { .content = mparamContent.data(),
+                    .size    = mparamContent.size() },
+    };
+    const ZL_GraphID paramId = ZL_Compressor_registerParameterizedGraph(
+            compressor_.get(), &paramDesc);
+    ASSERT_NE(paramId.gid, ZL_GRAPH_ILLEGAL.gid);
+    EXPECT_EQ(ZL_Compressor_numMParams(compressor_.get()), 1u);
+
+    ASSERT_FALSE(ZL_isError(
+            ZL_Compressor_selectStartingGraphID(compressor_.get(), paramId)));
+    compressData();
+    EXPECT_EQ(mparamContent, out);
+
+    // Reflection getters expose the per-instance blob + materialized object.
+    const ZL_MParam* reflected =
+            ZL_Compressor_Graph_getMParam(compressor_.get(), paramId);
+    ASSERT_NE(reflected, nullptr);
+    EXPECT_EQ(
+            std::string(
+                    static_cast<const char*>(reflected->content),
+                    reflected->size),
+            mparamContent);
+    const void* reflectedObj =
+            ZL_Compressor_Graph_getMParamObj(compressor_.get(), paramId);
+    ASSERT_NE(reflectedObj, nullptr);
+    EXPECT_EQ(
+            std::string(
+                    static_cast<const char*>(reflectedObj),
+                    mparamContent.size()),
+            mparamContent);
+}
+
+TEST_F(CompressorIntegrationTest,
+       GIVENaParameterizedGraphMParamWHENoverriddenTHENitIsReMaterialized)
+{
+    // Two equal-length blobs so the graph's size int-param stays valid.
+    const std::string mparamContent1 = "parameterized-graph-mparam-AAAAA";
+    const std::string mparamContent2 = "parameterized-graph-mparam-BBBBB";
+    ASSERT_EQ(mparamContent1.size(), mparamContent2.size());
+    std::string out(mparamContent1.size(), 0);
+
+    ZL_IntParam ip = { .paramId = 1, .paramValue = (int)mparamContent1.size() };
+    ZL_RefParam rp = { .paramId = 3, .paramRef = out.data() };
+    ZL_LocalParams lp = {
+        .intParams = { .intParams = &ip, .nbIntParams = 1 },
+        .refParams = { .refParams = &rp, .nbRefParams = 1 },
+    };
+
+    ZL_MaterializerDesc2 mparamMat{};
+    mparamMat.materializeFn   = copyDictMaterialize;
+    mparamMat.dematerializeFn = ZL_NOOP_DEMATERIALIZE;
+
+    static ZL_Type inputType      = ZL_Type_serial;
+    ZL_FunctionGraphDesc baseDesc = {
+        .name           = "test_param_override_base",
+        .graph_f        = graphVerifyMParamFn,
+        .inputTypeMasks = &inputType,
+        .nbInputs       = 1,
+        .localParams    = lp,
+        .mparamMat      = mparamMat,
+    };
+    auto baseId = compressor_.registerFunctionGraph(baseDesc);
+    ASSERT_NE(baseId.gid, ZL_GRAPH_ILLEGAL.gid);
+
+    const ZL_ParameterizedGraphDesc paramDesc = {
+        .graph  = baseId,
+        .mparam = { .content = mparamContent1.data(),
+                    .size    = mparamContent1.size() },
+    };
+    const ZL_GraphID paramId = ZL_Compressor_registerParameterizedGraph(
+            compressor_.get(), &paramDesc);
+    ASSERT_NE(paramId.gid, ZL_GRAPH_ILLEGAL.gid);
+    ASSERT_FALSE(ZL_isError(
+            ZL_Compressor_selectStartingGraphID(compressor_.get(), paramId)));
+
+    compressData();
+    EXPECT_EQ(mparamContent1, out);
+
+    // Override with a new MParam blob; it must be re-materialized in place.
+    const ZL_GraphParameters overrideParams = {
+        .mparam = { .content = mparamContent2.data(),
+                    .size    = mparamContent2.size() },
+    };
+    ASSERT_FALSE(ZL_isError(ZL_Compressor_overrideGraphParams(
+            compressor_.get(), paramId, &overrideParams)));
+
+    out.assign(out.size(), 0);
+    compressData();
+    EXPECT_EQ(mparamContent2, out);
+
+    const ZL_MParam* reflected =
+            ZL_Compressor_Graph_getMParam(compressor_.get(), paramId);
+    ASSERT_NE(reflected, nullptr);
+    EXPECT_EQ(
+            std::string(
+                    static_cast<const char*>(reflected->content),
+                    reflected->size),
+            mparamContent2);
+}
+
+TEST_F(CompressorIntegrationTest,
+       GIVENaParameterizedGraphWithMParamWHENserializedTHENitRoundTrips)
+{
+    const std::string mparamContent = "parameterized-graph-mparam-serialize";
+
+    ZL_MaterializerDesc2 mparamMat{};
+    mparamMat.materializeFn   = copyDictMaterialize;
+    mparamMat.dematerializeFn = ZL_NOOP_DEMATERIALIZE;
+
+    static ZL_Type inputType = ZL_Type_serial;
+    // Base function graph provides the materializer. Like a custom node backing
+    // a serialized parameterized node, it is non-serializable and must be
+    // pre-registered on the deserialization target under the same name.
+    auto makeBaseDesc = [&]() -> ZL_FunctionGraphDesc {
+        return ZL_FunctionGraphDesc{
+            .name           = "test_param_serialize_base",
+            .graph_f        = graphRequireMParamFn,
+            .inputTypeMasks = &inputType,
+            .nbInputs       = 1,
+            .mparamMat      = mparamMat,
+        };
+    };
+
+    ZL_FunctionGraphDesc baseDesc = makeBaseDesc();
+    auto baseId                   = compressor_.registerFunctionGraph(baseDesc);
+    ASSERT_NE(baseId.gid, ZL_GRAPH_ILLEGAL.gid);
+
+    const ZL_ParameterizedGraphDesc paramDesc = {
+        .name   = "test_param_serialize_instance",
+        .graph  = baseId,
+        .mparam = { .content = mparamContent.data(),
+                    .size    = mparamContent.size() },
+    };
+    const ZL_GraphID paramId = ZL_Compressor_registerParameterizedGraph(
+            compressor_.get(), &paramDesc);
+    ASSERT_NE(paramId.gid, ZL_GRAPH_ILLEGAL.gid);
+    ASSERT_FALSE(ZL_isError(
+            ZL_Compressor_selectStartingGraphID(compressor_.get(), paramId)));
+    ASSERT_EQ(ZL_Compressor_numMParams(compressor_.get()), 1u);
+
+    // First compress.
+    cctx_.refCompressor(compressor_);
+    cctx_.setParameter(CParam::FormatVersion, ZL_MAX_FORMAT_VERSION);
+    const std::string src =
+            "Let me think. That's just inherently very difficult. What are we doing?";
+    std::vector<char> dst(1000);
+    const size_t compressedSize =
+            cctx_.compressSerial(poly::span<char>(dst.data(), dst.size()), src);
+    ASSERT_GT(compressedSize, 0u);
+
+    // Serialize; the blob must be embedded, not merely referenced.
+    const std::string serialized = compressor_.serialize();
+    EXPECT_NE(serialized.find(mparamContent), std::string::npos);
+
+    // Deserialize into a fresh compressor with only the base pre-registered.
+    openzl::Compressor compressor2;
+    ZL_FunctionGraphDesc baseDesc2 = makeBaseDesc();
+    compressor2.registerFunctionGraph(baseDesc2);
+    compressor2.deserialize(serialized);
+
+    // MParam sets must match (same ids and blob contents).
+    std::map<std::string, std::string> originalMParams;
+    std::map<std::string, std::string> deserializedMParams;
+    ASSERT_FALSE(ZL_isError(ZL_Compressor_forEachMParam(
+            compressor_.get(), collectMParamsCb, &originalMParams)));
+    ASSERT_FALSE(ZL_isError(ZL_Compressor_forEachMParam(
+            compressor2.get(), collectMParamsCb, &deserializedMParams)));
+    EXPECT_FALSE(originalMParams.empty());
+    EXPECT_EQ(deserializedMParams, originalMParams);
+
+    // The deserialized parameterized graph must expose the same blob.
+    const ZL_GraphID startGid = compressor2.getStartingGraph();
+    const ZL_MParam* reflected =
+            ZL_Compressor_Graph_getMParam(compressor2.get(), startGid);
+    ASSERT_NE(reflected, nullptr);
+    EXPECT_EQ(
+            std::string(
+                    static_cast<const char*>(reflected->content),
+                    reflected->size),
+            mparamContent);
+
+    // Second compress with the deserialized compressor must match.
+    openzl::CCtx cctx2;
+    cctx2.refCompressor(compressor2);
+    cctx2.setParameter(CParam::FormatVersion, ZL_MAX_FORMAT_VERSION);
+    std::vector<char> dst2(1000);
+    const size_t compressedSize2 = cctx2.compressSerial(
+            poly::span<char>(dst2.data(), dst2.size()), src);
+    ASSERT_EQ(compressedSize, compressedSize2);
+    ASSERT_EQ(
+            std::string(dst.data(), compressedSize),
+            std::string(dst2.data(), compressedSize2));
 }
 
 } // namespace openzl


### PR DESCRIPTION
Summary:
Adds dedicated mparam API.

Public API added:
```
const void* ZL_Graph_getMParam(const ZL_Graph* gctx);
const void* ZL_Segmenter_getMParam(const ZL_Segmenter* segCtx);
const void* ZL_Compressor_Graph_getMParamObj(
        ZL_Compressor const* cgraph,
        ZL_GraphID graph);
const ZL_MParam* ZL_Compressor_Graph_getMParam(
        ZL_Compressor const* cgraph,
        ZL_GraphID graph);
```

Mostly mirrors D99579815 with one exception: `ZL_Encoder` has a direct pointer to `CNode` where the materialized object is stored. `ZL_Graph` does not have an accessor to `Graph_Desc_internal` where the materialized object is stored so an additional `ZL_GraphId` field was added here to allow lookup. There are some differences with node manager and graph manager which also lead to minor differences in internal APIs.

The next stacked diff will remove the old API and do a renaming.

Reviewed By: terrelln

Differential Revision: D112240467


