### PR TITLE
Add PivCo GPU implementation to contrib (#889)

### DIFF
--- a/.github/workflows/dev-ci.yml
+++ b/.github/workflows/dev-ci.yml
@@ -245,6 +245,7 @@ jobs:
         with:
           clang-format-version: '21'
           check-path: '.'
+          exclude-regex: '.*/datasets/.*'
 
   # Python formatting check
   test-python-format:

--- a/contrib/pivco-huffman/gpu/BENCHMARKS.md
+++ b/contrib/pivco-huffman/gpu/BENCHMARKS.md
@@ -1,0 +1,265 @@
+# PivCo-Huffman GPU Decode Benchmarks
+
+Device: **NVIDIA A100 (SM 8.0)**. Benchmark: 256 MiB expanded
+(`--size=268435456`), 8192 blocks of 32 KiB, decode timed with CUDA events
+(H2D/D2H excluded). Run-to-run GPU-clock variance is ~±15%; treat
+`decode_min_time_GiBps` as the more stable figure and always re-measure A/B
+back-to-back. Path is the production bottom-up scheduled merge decoder.
+
+Command (the real datasets come from the upstream pivco-huffman repo's
+`extras/datasets`, https://github.com/MarcinZukowski/pivco-huffman — clone it and
+point `--dataset-dir` at that directory):
+
+```bash
+git clone https://github.com/MarcinZukowski/pivco-huffman
+buck2 build @fbcode//mode/opt fbcode//openzl/dev/contrib/pivco-huffman/gpu:pivco_gpu_bench
+<BIN> --size=268435456 --iterations=15 --dataset-dir=pivco-huffman/extras/datasets
+```
+
+## 2026-07-20 — vectorized flat-root fast path (256 MiB, 15 iters)
+
+`fastDecodeFlatRootKernel` (used whenever the whole tree is a single flat leaf:
+uniform / incompressible / small-alphabet data) was left decoding one symbol per
+thread — a dependent 1-2 byte load, a bank-conflicted 256-entry shared gather,
+and a byte store per output. `ncu` on `uniform` measured it at DRAM 23% / compute
+21% / memory 24% SOL with 4.5M shared bank conflicts, i.e. ~4x below its roofline
+and purely latency-bound. Rewrote it to the same shape the scheduled flat kernel
+already used: 8 outputs per thread, one packed load, unpack the eight indices from
+a register, one coalesced 8-byte store, with depth-2 MLP. Byte-identical output;
+all 11 GPU unit tests pass; partial-final-block over-store verified against a
+non-block-aligned size.
+
+`decode_median_GiBps`, delta vs the round-1 baseline that the table below uses.
+
+| dataset | before | after | delta |
+|---|---|---|---|
+| sparse_4 | 280.3 | 884.6 | +216% |
+| flat_M3 | 233.0 | 827.6 | +255% |
+| sparse_16 | 272.8 | 790.1 | +190% |
+| flat_M5 | 268.9 | 718.1 | +167% |
+| flat_M6 | 263.4 | 682.0 | +159% |
+| gzip_random.gz | 244.6 | 654.5 | +168% |
+| flat_M7 | 262.8 | 654.5 | +149% |
+| uniform | 246.6 | 622.8 | +153% |
+
+Every other dataset is within ±0.5% (a different code path). Aggregate over all
+30 datasets: geomean 189.2 -> 248.9 GiB/s (+31.5%), arithmetic mean 232.5 -> 357.7
+GiB/s (+53.9%), no regressions.
+
+The deep-tree scheduled cascade (the ~100-115 GiB/s slow tier: json, log, pride,
+source_c, cat-wiki, proba02, zipfian, bell_s30) is unchanged and remains at its
+architectural floor: independent `ncu` profiling confirms the vector/vector merge
+that dominates it (~68% of json decode) is latency-bound at max occupancy (256
+threads x 8 blocks/SM = 64 warps/SM, the A100 ceiling), with both the compute and
+DRAM pipes below their roofs and per-thread MLP register-capped. Its levers
+(radix-4 fusion, megakernel, cp.async staging) were all measured net-negative in
+prior rounds; small inner-loop tweaks land inside the ~±12% per-build code-layout
+noise.
+
+## Current — 2026-07-18 after 7 wins, default block size now 64 KiB (256 MiB, 15 iters)
+
+`decode_median_GiBps`, delta vs the round-1 baseline (which was at 32 KiB blocks).
+Committed wins: per-thread 8-symbol flat unpack, aligned read-only (`__ldg`) merge
+child loads, directory `__launch_bounds__`, fusing the rank-directory build into
+the merge kernels (shared memory), byte-wise `readBits` in the parse, vectorizing
+the constant/constant merge, and reselecting the default block size to 64 KiB
+(scheduled fast path now supports it; ~+15% everywhere, slightly better ratio).
+
+### Real datasets
+
+| dataset | ratio | decode GiB/s | vs base |
+|---|---|---|---|
+| gzip_random.gz | 1.000 | 285.9 | ~flat |
+| calgary_pic | 0.209 | 191.6 | +61% |
+| dna_fasta.fa | 0.283 | 190.6 | +86% |
+| csv_numeric.csv | 0.418 | 144.3 | +104% |
+| chinese_text.txt | 0.731 | 112.5 | +74% |
+| source_c.c | 0.623 | 111.1 | +99% |
+| log_apache.log | 0.692 | 104.5 | +102% |
+| pride.txt | 0.573 | 104.3 | +99% |
+| json_api.json | 0.655 | 101.1 | +97% |
+
+### Synthetic datasets
+
+| dataset | ratio | decode GiB/s | vs base |
+|---|---|---|---|
+| two_sym_90/10 | 0.125 | 928.3 | +226% |
+| two_sym_eq | 0.125 | 884.6 | +164% |
+| proba80 | 0.156 | 401.5 | +56% |
+| uniform | 1.000 | 286.9 | +15% |
+| sparse_4/16 | - | 273-280 | ~flat |
+| flat_M3..M7 | - | 263-276 | ~flat (fast path) |
+| proba50 | 0.250 | 223.0 | +65% |
+| bell_s80 | 0.995 | 190.6 | +95% |
+| geometric | 0.265 | 181.8 | +75% |
+| english | 0.531 | 154.8 | +109% |
+| bell_s10 | 0.685 | 123.7 | +111% |
+| proba14 | 0.527 | 118.6 | +94% |
+| zipfian | 0.783 | 111.1 | +94% |
+| bell_s30 | 0.877 | 105.6 | +106% |
+| proba02 | 0.891 | 99.8 | +101% |
+
+**Roughly 2x on the previously-slow tier vs the round-1 baseline** (json 51->101,
+log 52->105, pride 52->104, csv 71->144, dna 102->191, source_c 56->111), 2.6-3.2x
+on two-symbol data, and every real file improved with no regression. Fast/flat
+tier ~flat (flat_M* -3% is clock noise). The remaining slow tier (proba02/bell_s30
+~100-106) is bounded by the vector/vector merge, which profiles balanced (58%
+compute, 60% memory, 91% occupancy) -- near its per-kernel floor.
+
+## Round-1 baseline — 2026-07-18 (256 MiB, 15 iters), `decode_median_GiBps`
+
+### Real datasets
+
+| dataset | ratio | decode GiB/s |
+|---|---|---|
+| gzip_random.gz | 1.000 | 289.3 |
+| calgary_pic | 0.209 | 118.8 |
+| dna_fasta.fa | 0.283 | 102.3 |
+| cat-image.jpg | 0.990 | 76.2 |
+| csv_numeric.csv | 0.418 | 70.6 |
+| chinese_text.txt | 0.732 | 64.7 |
+| source_c.c | 0.624 | 55.9 |
+| pride.txt | 0.573 | 52.4 |
+| log_apache.log | 0.692 | 51.8 |
+| cat-wiki.html | 0.692 | 51.7 |
+| json_api.json | 0.655 | 51.2 (min-time 59.5; noisy) |
+
+### Synthetic datasets
+
+| dataset | ratio | decode GiB/s |
+|---|---|---|
+| two_sym_eq | 0.125 | 335.4 |
+| sparse_4 | 0.250 | 286.9 |
+| two_sym_90/10 | 0.125 | 285.2 |
+| flat_M3 | 0.375 | 282.2 |
+| sparse_16 | 0.500 | 280.9 |
+| flat_M5 | 0.625 | 274.3 |
+| flat_M6 | 0.750 | 271.0 |
+| flat_M7 | 0.875 | 269.5 |
+| proba80 | 0.157 | 257.8 |
+| uniform | 1.000 | 248.4 |
+| proba50 | 0.250 | 134.7 |
+| geometric | 0.266 | 103.6 |
+| bell_s80 | 0.995 | 97.7 |
+| english | 0.531 | 73.9 |
+| proba14 | 0.527 | 61.1 |
+| bell_s10 | 0.686 | 58.6 |
+| zipfian | 0.783 | 57.3 (min-time 63.1; noisy) |
+| bell_s30 | 0.878 | 51.2 |
+| proba02 | 0.891 | 49.6 |
+
+### Observations
+
+- **Fast tier (~250-335 GiB/s):** flat-root / shallow / highly-skewed
+  distributions — decode is dominated by one coalesced output write.
+- **Slow tier (~50-75 GiB/s):** deep Huffman trees (most real text/binary:
+  json, log, pride, cat-wiki, source_c, chinese; synthetics proba02/14,
+  bell_s10/30). Dominated by the per-level vector/vector merge cascade.
+- Working hypothesis (verify by profiling): the slow tier is limited by the
+  O(tree-depth) global-memory round-trips of the ping-pong intermediate streams.
+  The AVX512 CPU path keeps that ping-pong in cache; the GPU path stages it in
+  global memory.
+
+## Size-adaptive dispatch: chunk-TD decoder for small inputs (round 9)
+
+The chunk-in-shared top-down decoder (PIVCO_CHUNK_TD) runs 3 kernel launches vs the
+bottom-up cascade's ~30. For small inputs the cascade's fixed per-launch overhead
+dominates, so decode is now size-adaptive: dstSize <= 8 MiB uses the chunk decoder,
+larger uses the cascade (unchanged). Measured @ 4 MiB, baseline vs chunk-TD (GiB/s):
+
+| dataset | baseline | chunk-TD | speedup |
+| calgary_pic | 18.4 | 27.6 | 1.50x |
+| cat-image.jpg | 27.1 | 35.3 | 1.31x |
+| cat-wiki.html | 15.9 | 24.1 | 1.52x |
+| chinese_text.txt | 19.2 | 27.4 | 1.43x |
+| csv_numeric.csv | 20.6 | 29.8 | 1.45x |
+| dna_fasta.fa | 25.6 | 36.7 | 1.43x |
+| json_api.json | 16.9 | 24.5 | 1.45x |
+| log_apache.log | 15.6 | 23.1 | 1.48x |
+| pride.txt | 17.0 | 25.4 | 1.50x |
+| source_c.c | 17.7 | 25.3 | 1.43x |
+
+At 1 MiB the win is larger (json 3.6->8.4 = 2.3x, calgary 5.0->9.1 = 1.8x). Above
+~8-12 MiB the cascade's steady-state throughput wins (chunk-TD is wavelet-tree
+ALU-bound once its DRAM traffic is ~0). Large-input numbers unchanged.
+
+## Round 11: size-adaptive chunk width extends the win to ~12 MiB
+
+The chunk decoder's chunk width is now chosen at dispatch (runtime kernel arg):
+1024 outputs for tiny inputs (more chunks -> more grid parallelism), 2048 above
+6 MiB (each per-chunk tree descent is fixed overhead, so a wider chunk amortizes
+it). The wider chunk raises the decoder's steady-state ~15-20%, pushing the
+crossover with the cascade from ~8 MiB out to ~12 MiB. The auto threshold is
+gated on tree depth (deep trees tableLog>=10: chunk-TD to 12 MiB; shallow trees
+like an incompressible .gz: 4 MiB, since their baseline is already fast).
+
+Measured (A100, min-time GiB/s, decode only), baseline vs auto, no regression:
+
+| dataset | 4 MiB base | 4 MiB auto | 10 MiB base | 10 MiB auto |
+| calgary_pic | 15.9 | 28.5 (+79%) | 45.2 | 52.1 (+15%) |
+| cat-image.jpg | 27.4 | 38.9 (+41%) | 50.2 | 60.7 (+21%) |
+| cat-wiki.html | 16.0 | 24.8 (+54%) | 30.8 | 41.8 (+35%) |
+| chinese_text.txt | 19.3 | 27.6 (+43%) | 35.9 | 46.3 (+29%) |
+| csv_numeric.csv | 21.1 | 29.8 (+41%) | 40.9 | 51.6 (+25%) |
+| dna_fasta.fa | 26.5 | 39.3 (+48%) | 54.2 | 70.1 (+29%) |
+| gzip_random.gz | 57.8 | 59.6 (+3%) | 151.4 | 151.4 (+0%) |
+| json_api.json | 16.9 | 25.3 (+49%) | 32.7 | 43.0 (+31%) |
+| log_apache.log | 15.9 | 24.0 (+50%) | 32.9 | 43.7 (+33%) |
+| pride.txt | 16.7 | 26.1 (+56%) | 32.5 | 45.2 (+38%) |
+| source_c.c | 17.6 | 25.8 (+46%) | 34.1 | 45.0 (+32%) |
+
+The 8-12 MiB regime was baseline-only before round 11; it is now chunk-TD. Above
+~12 MiB the cascade still wins (chunk-TD is wavelet-tree ALU-bound; see the round
+10 floor). Forced chunk-TD @64 MiB improved too (json 37->44, calgary 63->76, dna
+90->102, log 47->54 GiB/s) but the cascade remains faster at that size.
+
+## Bottom-up vs top-down decoder, head-to-head (forced)
+
+Direct comparison of the two decode kernels on every real dataset, forcing each
+path (`PIVCO_CHUNK_TD=0` = bottom-up cascade, `PIVCO_CHUNK_TD=1` = top-down
+chunk-in-shared) regardless of the auto-dispatch. Decode-only median GiB/s,
+A100, 64 KiB blocks, DCGM profiling muted (`sudo dyno dcgm_profiling
+--mute=true`) for stable clocks, 25 iterations. The shipped decoder auto-selects
+the winner per input size and tree depth (top-down for deep trees to ~12 MiB,
+bottom-up above); these forced numbers show why.
+
+**8 MiB** (top-down uses the 2048-output chunk):
+
+| dataset | bottom-up | top-down | top-down / bottom-up |
+|---|---|---|---|
+| calgary_pic | 34.2 | 44.9 | 1.31x |
+| cat-image.jpg | 42.6 | 51.9 | 1.22x |
+| cat-wiki.html | 27.5 | 37.2 | 1.35x |
+| chinese_text.txt | 31.1 | 38.5 | 1.24x |
+| csv_numeric.csv | 35.2 | 42.2 | 1.20x |
+| dna_fasta.fa | 46.8 | 58.2 | 1.24x |
+| gzip_random.gz | 119.2 | 117.4 | 0.98x |
+| json_api.json | 27.4 | 36.5 | 1.33x |
+| log_apache.log | 28.8 | 37.0 | 1.29x |
+| pride.txt | 27.4 | 36.7 | 1.34x |
+| source_c.c | 29.1 | 38.3 | 1.32x |
+
+**64 MiB** (steady state; the cascade's O(depth) ALU hides behind DRAM latency):
+
+| dataset | bottom-up | top-down | top-down / bottom-up |
+|---|---|---|---|
+| calgary_pic | 146.0 | 74.3 | 0.51x |
+| cat-image.jpg | 122.1 | 74.6 | 0.61x |
+| cat-wiki.html | 85.6 | 53.2 | 0.62x |
+| chinese_text.txt | 92.5 | 55.4 | 0.60x |
+| csv_numeric.csv | 113.4 | 67.3 | 0.59x |
+| dna_fasta.fa | 147.1 | 99.7 | 0.68x |
+| gzip_random.gz | 189.6 | 190.1 | 1.00x |
+| json_api.json | 84.3 | 51.8 | 0.61x |
+| log_apache.log | 86.7 | 52.8 | 0.61x |
+| pride.txt | 85.8 | 54.3 | 0.63x |
+| source_c.c | 78.0 | 54.4 | 0.70x |
+
+At 8 MiB the top-down wins 1.20-1.35x on every compressible dataset (it pays 3
+kernel launches vs the cascade's ~30, and its intermediates never leave shared);
+`gzip_random.gz` (incompressible, shallow tree, fast baseline) is a 0.98x tie.
+At 64 MiB the cascade wins ~1.5-2x: the per-chunk top-down exposes the
+wavelet-tree O(depth) ALU serially, while the cascade hides that same ALU behind
+DRAM latency at full occupancy (see DEVELOPMENT_LOG rounds 9-11). The crossover
+is ~12 MiB for deep trees; `gzip_random.gz` ties everywhere (both ~190 GiB/s at
+64 MiB -- its shallow tree makes the cascade cheap).

--- a/contrib/pivco-huffman/gpu/BUCK
+++ b/contrib/pivco-huffman/gpu/BUCK
@@ -1,0 +1,99 @@
+load("@fbcode//tools/build/buck:nvcc_flags.bzl", "get_nvcc_arch_args")
+load("@fbcode_macros//build_defs:cpp_binary.bzl", "cpp_binary")
+load("@fbcode_macros//build_defs:cpp_library.bzl", "cpp_library")
+load("@fbcode_macros//build_defs:cpp_unittest.bzl", "cpp_unittest")
+load("@fbcode_macros//build_defs:gpu_cpp_unittest.bzl", "gpu_cpp_unittest")
+load("@fbcode_macros//build_defs/lib:re_test_utils.bzl", "re_test_utils")
+load("@fbsource//tools/build_defs/testinfra:network_access_utils.bzl", "network_access_utils")
+
+oncall("data_compression")
+
+nvcc_flags = get_nvcc_arch_args() + [
+    "--expt-relaxed-constexpr",
+]
+
+cpp_library(
+    name = "pivco_gpu_cpu_index",
+    srcs = ["pivco_block_index.cpp"],
+    headers = ["pivco_block_index.h"],
+    deps = [
+        "../../..:common",
+    ],
+)
+
+cpp_library(
+    name = "pivco_gpu",
+    srcs = [
+        "pivco_gpu.cu",
+        "pivco_gpu_context.cpp",
+    ],
+    headers = [
+        "pivco_gpu.cuh",
+        "pivco_gpu.h",
+        "pivco_gpu_tree.h",
+    ],
+    keep_gpu_sections = True,
+    nvcc_flags = nvcc_flags,
+    deps = [
+        "../../..:common",
+    ],
+    external_deps = [
+        ("cuda", None, "cuda-lazy"),
+    ],
+    exported_external_deps = [
+        ("cuda", None, "cuda-lazy"),
+    ],
+)
+
+cpp_unittest(
+    name = "pivco_block_index_test",
+    srcs = ["PivCoBlockIndexTest.cpp"],
+    network_access = network_access_utils.none(),
+    deps = [
+        "../../..:zstronglib",
+        "fbsource//third-party/googletest:gtest",
+        ":pivco_gpu_cpu_index",
+    ],
+)
+
+gpu_cpp_unittest(
+    name = "pivco_gpu_test",
+    srcs = ["PivCoGpuTest.cpp"],
+    # The hipified host translation unit includes <hip/hip_runtime.h>, which only
+    # declares the host runtime APIs (hipMalloc/hipFree/hipMemcpy/...) once a HIP
+    # platform macro is defined. gpu_cpp_unittest already injects the amdhip64
+    # runtime dep for the AMD leg; this defines the macro so the host compile of
+    # the hipified test resolves those symbols.
+    hip_preprocessor_flags = ["-D__HIP_PLATFORM_AMD__=1"],
+    keep_gpu_sections = True,
+    network_access = network_access_utils.none(),
+    nvcc_flags = nvcc_flags,
+    remote_execution = re_test_utils.remote_execution(
+        platform = "gpu-remote-execution",
+        subplatform = "A100",
+    ),
+    deps = [
+        "../../..:zstronglib",
+        "fbsource//third-party/googletest:gtest",
+        ":pivco_gpu",
+        ":pivco_gpu_cpu_index",
+    ],
+    external_deps = [
+        ("cuda", None, "cuda-lazy"),
+    ],
+)
+
+cpp_binary(
+    name = "pivco_gpu_bench",
+    srcs = ["PivCoGpuBench.cpp"],
+    keep_gpu_sections = True,
+    nvcc_flags = nvcc_flags,
+    deps = [
+        "../../..:zstronglib",
+        ":pivco_gpu",
+        ":pivco_gpu_cpu_index",
+    ],
+    external_deps = [
+        ("cuda", None, "cuda-lazy"),
+    ],
+)

--- a/contrib/pivco-huffman/gpu/DEVELOPMENT_LOG.md
+++ b/contrib/pivco-huffman/gpu/DEVELOPMENT_LOG.md
@@ -1,0 +1,1635 @@
+# PivCo-Huffman GPU Development Log
+
+This log tracks decode and encode optimization ideas for the dataset benchmark.
+Worked optimizations are committed separately. Failed ideas are rolled back and
+kept here with the measured reason.
+
+Benchmark protocol unless otherwise noted:
+
+- Build mode: `@fbcode//mode/opt`
+- Benchmark target: `fbcode//openzl/dev/contrib/pivco-huffman/gpu:pivco_gpu_bench`
+- Dataset size: 268,435,456 bytes
+- Block size: 32,768 bytes
+- Throughput: GiB/s over decompressed bytes, measured with CUDA events; bulk
+  H2D/D2H transfer is excluded.
+
+## Plan
+
+1. Establish real-dataset baselines from `BENCHMARKS.md` and targeted reruns.
+2. Add narrow generic-shape decode fast paths when the tree shape is common in
+   the real benchmark set.
+3. Move from shape-specific paths to a general per-symbol parallel decoder:
+   parse block metadata once, build rank/select metadata for internal-node
+   bitmaps, and let CUDA threads decode output bytes independently.
+4. Keep successful decode optimizations as separate commits. Roll back failed
+   code and record why it did not survive.
+5. Defer encode optimization until decode ideas are exhausted.
+
+## Ideas And Results
+
+### Flat-root decode fast path
+
+- Status: worked, committed separately
+- Idea: when the whole Huffman tree is one flat leaf, decode each output symbol
+  independently in a CTA instead of using the serial generic tree-walk decoder.
+- Expected impact: improves `gzip_random.gz` and the `uniform`/`flat_M*`
+  synthetic cases; it should not affect broad non-flat real datasets.
+- Baseline for `gzip_random.gz`, 256 MiB, 5 iterations:
+  - Decode median: 2.2128 GiB/s
+  - Decode best: 2.2129 GiB/s
+- Result for `gzip_random.gz`, 256 MiB, 5 iterations:
+  - Decode median: 261.0257 GiB/s
+  - Decode best: 261.1479 GiB/s
+- Notes: this only handles whole-tree flat leaves. It does not improve deep or
+  mixed real datasets such as `cat-wiki.html`, `json_api.json`, or
+  `chinese_text.txt`.
+
+### Root-constant subtree merge fast path
+
+- Status: failed, rolled back
+- Idea: when the root has exactly one constant child, keep the existing serial
+  decode for the non-constant child but parallelize the root bitmap merge across
+  a CTA. This targets skewed datasets where the root bitmap covers every output
+  byte and dominates the generic serial merge.
+- Expected impact: possible gains for `calgary_pic`, `dna_fasta.fa`,
+  `csv_numeric.csv`, and other skewed real files if their root split isolates a
+  constant symbol.
+- Result: regressed the likely target datasets, so the code was removed.
+  - `calgary_pic`: 6.6559 GiB/s baseline to 3.7762 GiB/s
+  - `dna_fasta.fa`: 5.4315 GiB/s baseline to 2.4459 GiB/s
+  - `csv_numeric.csv`: 3.9410 GiB/s baseline to 2.1666 GiB/s
+- Reason: the child subtree still decodes serially, and the extra CTA-wide
+  prefix scan plus synchronization costs more than it saves for these trees.
+- Caveat: the three measurements above were collected during concurrent GPU
+  benchmark runs, so they are not used as final benchmark data. The
+  implementation stayed rolled back because the generic rank/select decoder
+  superseded it and produced broader sequential-run wins.
+
+### Generic rank/select decoder
+
+- Status: worked, committed separately
+- Idea: parse each block into per-node bitmap/leaf metadata, build per-node
+  64-bit popcount directories, then let CTA threads decode output bytes
+  independently by traversing the fixed Huffman tree with rank/select.
+- Expected impact: broad non-flat datasets should improve because output merge
+  work moves from one serial thread per block to many threads per block.
+- Results from sequential 256 MiB, 5-iteration real-dataset runs:
+  - `cat-image.jpg`: 1.9884 to 7.4654 GiB/s
+  - `cat-wiki.html`: 2.3813 to 6.1704 GiB/s
+  - `calgary_pic`: 6.6559 to 11.8104 GiB/s
+  - `dna_fasta.fa`: 5.4315 to 11.5975 GiB/s
+  - `json_api.json`: 2.5705 to 6.5415 GiB/s
+  - `pride.txt`: 2.8095 to 6.3873 GiB/s
+  - `chinese_text.txt`: 2.4370 to 6.4994 GiB/s
+  - `csv_numeric.csv`: 3.9410 to 7.6437 GiB/s
+  - `source_c.c`: 2.8235 to 6.4926 GiB/s
+  - `log_apache.log`: 2.3944 to 6.7020 GiB/s
+  - `gzip_random.gz`: flat-root path still selected, 265.1901 GiB/s
+- Notes: the parser and directory builder are still serial within each block,
+  and every output byte performs a full tree traversal. This is a useful generic
+  baseline but not close to the 100 GiB/s target for mixed trees.
+
+### Rank/select 32-bit directory
+
+- Status: worked, committed separately
+- Idea: replace the rank/select directory stride from 64 bitmap bits with
+  32 bitmap bits and store prefix counts as `uint16_t`. For the 32 KiB benchmark
+  block size, counts fit in 16 bits, directory byte size stays about the same,
+  and each output traversal step popcounts at most four bitmap bytes instead of
+  eight.
+- Expected impact: improve mixed-tree datasets where per-symbol rank/select
+  traversal dominates over serial block parsing.
+- Results from sequential 256 MiB, 5-iteration real-dataset runs:
+  - `cat-image.jpg`: 7.4654 to 8.0096 GiB/s
+  - `calgary_pic`: 11.8104 to 12.6213 GiB/s
+  - `json_api.json`: 6.5415 to 7.2178 GiB/s
+
+### Rank/select binary-constant node shortcut
+
+- Status: failed, rolled back
+- Idea: when an internal node has two constant children, decode its output
+  symbol directly from the node bitmap. The rank/select decoder does not need a
+  popcount directory or child-node traversal for that node.
+- Expected impact: reduce parse metadata and per-symbol traversal work near the
+  bottom of mixed trees.
+- Result: regressed sampled real datasets, so the code was removed.
+  - `cat-image.jpg`: 8.0096 to 7.1788 GiB/s
+  - `calgary_pic`: 12.6213 to 12.3421 GiB/s
+- Reason: the extra branch and node kind did not pay for itself in the hot
+  traversal loop. Keeping one uniform internal-node path is faster.
+
+### Rank/select shared node metadata
+
+- Status: worked, committed separately
+- Idea: store parsed per-node metadata in CTA shared memory instead of per-block
+  global workspace. Directory data stays in global workspace, but every output
+  thread repeatedly reads node records during traversal, so shared metadata may
+  reduce traversal latency.
+- Expected impact: improve mixed-tree datasets if node metadata load latency is
+  significant compared with rank directory and bitmap loads.
+- Results from sequential 256 MiB, 5-iteration real-dataset runs:
+  - `cat-image.jpg`: 8.0096 to 7.8950 GiB/s
+  - `calgary_pic`: 12.6213 to 12.9308 GiB/s
+  - `json_api.json`: 7.2178 to 7.4054 GiB/s
+  - `dna_fasta.fa`: 11.5975 to 13.1476 GiB/s
+  - `cat-wiki.html`: 6.1704 to 7.6401 GiB/s
+- Notes: `cat-image.jpg` regressed slightly, but the sampled real mix improved
+  overall. Keeping this while continuing to look for a high-entropy-specific
+  improvement.
+
+### Top-down bulk position-list decoder
+
+- Status: worked, committed separately
+- Idea: parse the block once, then process node streams level-by-level with
+  `uint16_t` position lists. Internal nodes partition positions into child
+  streams; leaves write symbols directly to output. This avoids an independent
+  root-to-leaf rank/select traversal for every output byte.
+- Expected impact: a larger algorithmic step toward 100 GiB/s if bulk
+  partitioning has better memory behavior than per-symbol rank/select traversal.
+- Results from sequential 256 MiB, 5-iteration real-dataset runs:
+  - `cat-image.jpg`: 7.8950 to 10.5538 GiB/s
+  - `calgary_pic`: 12.9308 to 18.0469 GiB/s
+  - `json_api.json`: 7.4054 to 8.4420 GiB/s
+  - `cat-wiki.html`: 7.6401 to 9.0523 GiB/s
+  - `dna_fasta.fa`: 13.1476 to 13.2929 GiB/s
+  - `csv_numeric.csv`: 7.6437 to 11.7893 GiB/s
+  - `log_apache.log`: 6.7020 to 7.4752 GiB/s
+  - `source_c.c`: 6.4926 to 7.7788 GiB/s
+  - `pride.txt`: 6.3873 to 8.6228 GiB/s
+  - `chinese_text.txt`: 6.4994 to 9.3560 GiB/s
+- Notes: this is a better algorithmic direction than independent per-symbol
+  rank/select, but it is still position-list heavy and remains far below the
+  100 GiB/s target for mixed real datasets.
+
+### Bottom-up compact-stream decoder
+
+- Status: worked, pending commit
+- Idea: follow the CPU generic decoder and AVX512 merge shape more closely.
+  Decode leaves into compact byte streams, then merge child streams upward using
+  the parent bitmap and per-node popcount directories. The root merge writes
+  directly to the final output buffer.
+- Expected impact: reduce intermediate traffic versus top-down position lists
+  because compact symbol streams use one byte per element instead of two-byte
+  output positions, and make internal-node work resemble the CPU masked-expand
+  merge.
+- Initial result before chunked merges:
+  - `cat-image.jpg`: 10.5538 to 10.6510 GiB/s
+  - `calgary_pic`: 18.0469 to 15.3086 GiB/s
+  - `json_api.json`: 8.4420 to 7.0627 GiB/s
+  - `cat-wiki.html`: 9.0523 to 9.1351 GiB/s
+  - `dna_fasta.fa`: 13.2929 to 16.3082 GiB/s
+- Notes: the plain bottom-up path was mixed, but the user explicitly asked to
+  keep exploring bottom-up rather than rolling it back.
+
+### Bottom-up constant-child direct merge
+
+- Status: failed, rolled back
+- Idea: do not materialize constant leaves into scratch streams. Instead, have
+  parent internal-node merges substitute the constant symbol directly for a
+  constant child, similar to the CPU `mergeConstantVector` and
+  `mergeVectorConstant` variants.
+- Expected impact: reduce scratch writes and reads for trees with constant
+  leaves near the bottom.
+- Result:
+  - `dna_fasta.fa`: 16.3082 to 13.7212 GiB/s
+- Reason: the extra child-kind branches in the internal merge loop outweighed
+  the avoided scratch traffic on the sampled skewed dataset.
+
+### Bottom-up chunked bitmap-byte merge
+
+- Status: worked, pending commit
+- Idea: for large internal-node streams, have one CUDA thread handle an 8-symbol
+  bitmap byte. The thread computes the child cursors once with the rank
+  directory, then emits the eight parent symbols from compact child streams.
+  Keep per-symbol merging for node streams smaller than 1024 symbols to preserve
+  parallelism in small/deep subtrees.
+- Expected impact: reduce rank-directory lookups and per-symbol branch overhead
+  for large internal nodes while avoiding under-parallelizing small nodes.
+- Results from sequential 256 MiB, 5-iteration real-dataset runs compared with
+  the top-down bulk decoder snapshot:
+  - `cat-image.jpg`: 10.5538 to 12.7302 GiB/s
+  - `calgary_pic`: 18.0469 to 17.8374 GiB/s
+  - `cat-wiki.html`: 9.0523 to 10.8595 GiB/s
+  - `chinese_text.txt`: 9.3560 to 9.1616 GiB/s
+  - `csv_numeric.csv`: 11.7893 to 13.4258 GiB/s
+  - `dna_fasta.fa`: 13.2929 to 19.3354 GiB/s
+  - `json_api.json`: 8.4420 to 10.2090 GiB/s
+  - `log_apache.log`: 7.4752 to 8.9345 GiB/s
+  - `pride.txt`: 8.6228 to 8.5871 GiB/s
+  - `source_c.c`: 7.7788 to 9.2200 GiB/s
+- Notes: this is not uniformly better on every real file, but it improves most
+  of the broad-tree dataset set and strongly improves `dna_fasta.fa`,
+  `cat-image.jpg`, and structured text. It remains far below 100 GiB/s.
+
+### Bottom-up chunk threshold sweep
+
+- Status: stopped, reverted to 1024
+- Idea: tune the node-count threshold that selects per-symbol versus bitmap-byte
+  chunked internal-node merges. A 2048-symbol threshold was prepared for a
+  quick sweep.
+- Result: the sweep was intentionally stopped by the user before collecting
+  valid measurements. The code was restored to the last measured threshold of
+  1024.
+
+### Node-scheduled bottom-up decoder
+
+- Status: worked, selected for eligible generic decode
+- Idea: build a static preorder tree schedule once in `PivCoGpuContext`, parse
+  every block against that schedule into per-block/per-node state, then execute
+  bottom-up kernels across all blocks with grid work units of `(logical node,
+  PivCo block)`. Constant leaves are not materialized; parent merge kernels
+  inject constants directly. Flat leaves use specialized depth 1..8 kernels,
+  with depth 8 as direct byte lookup.
+- Expected impact: reduce per-block serial work and expose parallelism across
+  the tree's node streams, especially when small/deep node streams limited the
+  old one-CTA-per-block bottom-up decoder.
+- Correctness:
+  - `buck test --local-only @fbcode//mode/dev-nosan fbcode//openzl/dev/contrib/pivco-huffman/gpu:pivco_gpu_test`
+
+### Windowed flat bit extraction
+
+- Status: failed, rolled back
+- Idea: use the useful low-level bit-reader idea from commit `2bc254781d`.
+  Replace the hot `dGetBits` bit-by-bit loop for fields up to 8 bits with a
+  bounded one-or-two-byte load, shift, and mask. This keeps the existing
+  one-thread-per-output flat kernels and avoids the store under-parallelism that
+  made the earlier depth-3 chunked flat kernel regress.
+- Build and lint:
+  - `arc f contrib/pivco-huffman/gpu/pivco_gpu.cu contrib/pivco-huffman/gpu/DEVELOPMENT_LOG.md`
+  - `arc lint contrib/pivco-huffman/gpu/pivco_gpu.cu contrib/pivco-huffman/gpu/DEVELOPMENT_LOG.md`
+  - `buck build --show-output @fbcode//mode/opt fbcode//openzl/dev/contrib/pivco-huffman/gpu:pivco_gpu_bench`
+- A/B setup: NVIDIA A100, 256 MiB expanded input, 32 KiB blocks,
+  20 iterations. Baseline is the existing bit-by-bit `dGetBits`; candidate is
+  the bounded one-or-two-byte reader.
+- Representative real files:
+  - `cat-image.jpg`: 33.5220 to 44.4539 GiB/s
+  - `dna_fasta.fa`: 46.6630 to 46.6719 GiB/s
+  - `json_api.json`: 32.3665 to 32.6391 GiB/s
+  - `cat-wiki.html`: 34.2750 to 41.7549 GiB/s
+  - `calgary_pic`: 51.8455 to 51.8786 GiB/s
+  - `log_apache.log`: 33.7164 to 34.1982 GiB/s
+  - Geometric mean: 38.0471 to 41.3746 GiB/s (+8.7%).
+- All real files:
+  - `cat-image.jpg`: 33.5220 to 44.4539 GiB/s
+  - `calgary_pic`: 51.8455 to 51.8786 GiB/s
+  - `cat-wiki.html`: 34.2750 to 41.7549 GiB/s
+  - `chinese_text.txt`: 36.3088 to 37.3933 GiB/s
+  - `csv_numeric.csv`: 36.8625 to 37.0078 GiB/s
+  - `dna_fasta.fa`: 46.6630 to 46.6719 GiB/s
+  - `gzip_random.gz`: 246.3579 to 246.8561 GiB/s
+  - `json_api.json`: 32.3665 to 32.6391 GiB/s
+  - `log_apache.log`: 33.7164 to 34.1982 GiB/s
+  - `pride.txt`: 40.4541 to 35.1484 GiB/s
+  - `source_c.c`: 27.4840 to 27.1932 GiB/s
+  - Geometric mean: 43.7077 to 45.2736 GiB/s (+3.6%).
+- Conclusion: despite large wins on `cat-image.jpg` and `cat-wiki.html`, this
+  misses the representative +10% gate, only improves all-real geomean by 3.6%,
+  and regresses `pride.txt` by 13.1%. Because the current direction must keep a
+  single generic strategy rather than a selector, the change is rolled back.
+
+### Regular vector/vector packed stores
+
+- Status: failed, rolled back
+- Idea: after packed final stores made the fused root kernel much faster, try to
+  get the same win in `scheduledMergeVectorVectorKernel`. Two variants were
+  tested:
+  - Keep the warp-per-32-bit mapping and have each 8-lane subgroup cooperatively
+    pack eight produced symbols into one 64-bit store.
+  - Align scheduled intermediate stream buffers and node stream bases, then
+    replace the large-node warp mapping with a one-thread-per-bitmap-byte loop
+    that writes one packed 64-bit store per eight symbols.
+- Results on `json_api.json`, 256 MiB:
+  - Cooperative packed stores without aligned stream bases: decode stayed flat
+    at 38.9 GiB/s, and Nsight Compute still reported about 16.6 useful global
+    store bytes per 32-byte sector for the profiled
+    `scheduledMergeVectorVectorKernel` launch.
+  - Cooperative packed stores with aligned scheduled streams: the same NCU
+    launch was 1.15 ms, still about 16.2 useful global store bytes per sector,
+    versus the committed warp-mapped launch's 1.13 ms and 16.6 useful store
+    bytes per sector.
+  - Byte-loop packed stores with aligned scheduled streams regressed the
+    20-iteration `json_api.json` benchmark to 34.5173 GiB/s, versus the recent
+    committed range of about 37.4-39.0 GiB/s.
+- Reason: sparse-lane cooperative 64-bit stores did not improve the profiler's
+  store transaction shape, and the byte-loop variant gave up the warp mapping
+  that was responsible for the earlier vector/vector speedup. Regular
+  vector/vector remains a gather/rank dependency problem more than a simple
+  output-store packing problem.
+
+### Scheduled producer kernel rewrites
+
+- Status: failed, rolled back
+- Profiling setup: Nsight Systems and Nsight Compute on `json_api.json`,
+  256 MiB, 32 KiB blocks. The hot producer kernels before changes were
+  `scheduledMergeConstantVectorKernel` at 3.746 ms total over four decodes and
+  `scheduledFlatKernel<3>` at 2.533 ms total over four decodes.
+- Constant/vector idea: remap large `scheduledMergeConstantVectorKernel` and
+  `scheduledMergeVectorConstantKernel` nodes to the same one-warp-per-32-bits
+  layout used by regular vector/vector merges.
+  - Local NCU result on the largest constant/vector launch looked promising:
+    duration fell from 500.38 us to 457.18 us, executed instructions fell from
+    174.2M to 156.5M, and branch efficiency improved from 40.0% to 85.7%.
+  - Whole-decode result did not hold. Representative 20-iteration results
+    included `json_api.json` falling to 32.5912 GiB/s and `log_apache.log`
+    falling to 33.5128 GiB/s. Isolated reruns confirmed `json_api.json` around
+    32.61 GiB/s and `log_apache.log` around 33.7 GiB/s, both below the current
+    packed-root baseline.
+  - Nsight Systems after the change showed constant/vector total time dropping
+    from 3.746 ms to 3.477 ms over four decodes, but regular
+    vector/vector time rose from 7.038 ms to 9.374 ms. A single-store variant
+    for the warp-mapped constant/vector kernel still measured only
+    32.6478 GiB/s on `json_api.json` and 34.2990 GiB/s on `log_apache.log`.
+- Flat-depth idea: specialize `scheduledFlatKernel<3>` so one thread decodes
+  eight 3-bit symbols from three input bytes and optionally emits one 64-bit
+  packed store.
+  - NCU on the large `scheduledFlatKernel<3>` launch regressed from 327.84 us
+    to 451.49 us. Executed instructions dropped from 96.8M to 40.4M, but the
+    kernel became memory/LG-throttle limited, with useful global store bytes per
+    32-byte sector falling from 16.0 to 3.7.
+- Reason: producer kernels are not simple output-store problems. The
+  constant/vector warp mapping improved the isolated producer but worsened the
+  following vector/vector stages, and the flat-depth chunking under-parallelized
+  stores badly enough to erase the bit-unpack instruction savings.
+
+### Root three-level top-subtree fusion
+
+- Status: failed, rolled back
+- Profiling setup: Nsight Systems on `json_api.json`, 256 MiB, 32 KiB blocks.
+  The committed root-two fusion leaves one final level-2 wave before the fused
+  root kernel. In the pre-change trace, that wave cost about 1.676 ms per decode
+  (`scheduledFlatKernel<3>` about 0.331 ms, `scheduledMergeVectorVectorKernel`
+  about 0.843 ms, and `scheduledMergeConstantVectorKernel` about 0.500 ms),
+  followed by the packed root-two kernel at about 1.913 ms.
+- Idea: add a shape-driven root-three fusion for the existing root plus two
+  level-1 vector/vector shape. The new kernel skipped level 2 and resolved the
+  four level-2 grandchildren directly inside the packed root loop, reading
+  level-3 streams where needed.
+- Result:
+  - `json_api.json`, 256 MiB, 20 iterations regressed to 25.2316 GiB/s.
+  - Nsight Systems showed `scheduledMergeRoot3VectorVectorKernel` taking
+    32.853 ms over four decodes, about 8.213 ms per decode.
+- Reason: inlining the grandchildren moved too much rank/select and child
+  dispatch work into the byte-serial packed root loop. The removed level-2
+  kernels plus the old root-two kernel cost about 3.6 ms per decode, while the
+  root-three kernel alone cost more than 8 ms. A viable deeper fusion would need
+  to preserve per-node/warp parallelism or precompute child positions, not just
+  inline another tree level into the root byte loop.
+
+### Directory and stage pruning audit
+
+- Status: no code change
+- Idea: after the producer and top-subtree experiments, look for directory or
+  stage work made dead by the selected fused decode path.
+- Result: with the failed root-three fusion rolled back, the selected generic
+  path is still the packed root-two fusion. That path already skips GPU stage
+  launches for levels 0 and 1. The remaining directory work is still live:
+  the fused root-two kernel needs the root and both level-1 rank directories,
+  and every lower internal node directory feeds a surviving merge kernel.
+- Profiling context: the current `json_api.json` trace shows
+  `scheduledDirectoryKernel` at about 1.06 ms per decode with `gridY = 22`.
+  Removing root and level-1 directories would break the fused root kernel, and
+  no level-2 stages can be skipped without the root-three fusion that regressed.
+- Conclusion: there is no deterministic pruning opportunity in the current
+  selected design. Directory/stage pruning should be revisited only after a
+  deeper fusion strategy preserves per-node parallelism and actually removes
+  downstream consumers.
+- Baseline commit: `71a3d5ab9031` (`Add bottom-up GPU decode path`).
+- Representative real-file gate, 256 MiB, 5 iterations, compared with the
+  bottom-up chunked bitmap-byte snapshot above:
+  - `cat-image.jpg`: 12.7302 to 22.5084 GiB/s
+  - `dna_fasta.fa`: 19.3354 to 31.6990 GiB/s
+  - `json_api.json`: 10.2090 to 19.2664 GiB/s
+  - `cat-wiki.html`: 10.8595 to 16.4623 GiB/s
+  - `calgary_pic`: 17.8374 to 37.6325 GiB/s
+  - `log_apache.log`: 8.9345 to 18.7960 GiB/s
+  - Geometric mean: 12.7761 to 23.3016 GiB/s (+82.4%)
+- All real files, 256 MiB, 5 iterations:
+  - `cat-image.jpg`: 12.7302 to 22.5084 GiB/s
+  - `calgary_pic`: 17.8374 to 37.6325 GiB/s
+  - `cat-wiki.html`: 10.8595 to 16.4623 GiB/s
+  - `chinese_text.txt`: 9.1616 to 16.9250 GiB/s
+  - `csv_numeric.csv`: 13.4258 to 23.5501 GiB/s
+  - `dna_fasta.fa`: 19.3354 to 31.6990 GiB/s
+  - `gzip_random.gz`: 265.1901 to 286.7709 GiB/s
+  - `json_api.json`: 10.2090 to 19.2664 GiB/s
+  - `log_apache.log`: 8.9345 to 18.7960 GiB/s
+  - `pride.txt`: 8.5871 to 16.2005 GiB/s
+  - `source_c.c`: 9.2200 to 17.6455 GiB/s
+  - Geometric mean: 15.3604 to 26.8508 GiB/s (+74.8%)
+- Notes: no real-file decode regressions were observed in this 5-iteration
+  run. The flat-root fast path remains selected for `gzip_random.gz`.
+
+### Parallel scheduled directory build
+
+- Status: worked, pending commit
+- Profiling setup: Nsight Systems CUDA trace on `json_api.json`, 256 MiB,
+  32 KiB blocks, 1 measured iteration. The benchmark's three warmup decodes
+  make decode kernels appear four times in the kernel summary.
+- Bottleneck before change:
+  - `scheduledMergeVectorVectorKernel`: 33.699 ms total over four decodes,
+    about 8.425 ms per decode.
+  - `scheduledParseKernel`: 21.690 ms total over four decodes, about
+    5.423 ms per decode.
+  - Parse was one thread per block and serially built every non-constant
+    internal node's rank/select directory, which alone capped
+    `json_api.json` below 50 GiB/s.
+- Idea: split parsing from directory construction. The parse kernel now reads
+  stored `numOnes`, assigns child counts and directory ranges, and only serially
+  popcounts both-constant nodes where the bitstream does not store a count. A
+  new node-scheduled directory kernel builds and validates popcount directories
+  in parallel across `(internal node, block)` CTAs before bottom-up execution.
+- Profiling after change on the same setup:
+  - `scheduledParseKernel`: 1.687 ms total over four decodes, about
+    0.422 ms per decode.
+  - `scheduledDirectoryKernel`: 4.247 ms total over four decodes, about
+    1.062 ms per decode.
+  - `scheduledMergeVectorVectorKernel`: still about 8.425 ms per decode and is
+    now the clear next bottleneck.
+- Correctness:
+  - `buck test --local-only @fbcode//mode/dev-nosan fbcode//openzl/dev/contrib/pivco-huffman/gpu:pivco_gpu_test`
+- Representative real files, 256 MiB, 5 iterations, compared with the
+  node-scheduled baseline above:
+  - `cat-image.jpg`: 22.5084 to 29.5978 GiB/s
+  - `dna_fasta.fa`: 31.6990 to 52.8783 GiB/s
+  - `json_api.json`: 19.2664 to 20.9403 GiB/s
+  - `cat-wiki.html`: 16.4623 to 23.3491 GiB/s
+  - `calgary_pic`: 37.6325 to 50.8752 GiB/s
+  - `log_apache.log`: 18.7960 to 21.1174 GiB/s
+  - Geometric mean: 23.3016 to 30.6071 GiB/s (+31.4%)
+- Notes: an accidental pair of concurrent benchmark runs was discarded and the
+  table above uses sequential reruns only. This is still far from 100 GiB/s;
+  the next large target is vector/vector merge throughput.
+
+### Skip both-constant scheduled popcount
+
+- Status: kept, no measurable benchmark win
+- Idea: in the scheduled parser, do not popcount both-constant merge bitmaps.
+  The wire format stores no `numOnes` for those nodes, and the scheduled
+  decoder's both-constant kernel emits directly from the bitmap plus the two
+  constant symbols. The child counts are therefore unused because constant
+  children are never materialized.
+- Correctness:
+  - `buck test --local-only @fbcode//mode/dev-nosan fbcode//openzl/dev/contrib/pivco-huffman/gpu:pivco_gpu_test`
+- Representative real files, 256 MiB, 20 iterations, compared with the
+  parallel scheduled directory build run above:
+  - `cat-image.jpg`: 29.5978 to 36.2814 GiB/s
+  - `dna_fasta.fa`: 52.8783 to 43.1172 GiB/s
+  - `json_api.json`: 20.9403 to 21.0114 GiB/s
+  - `cat-wiki.html`: 23.3491 to 21.8185 GiB/s
+  - `calgary_pic`: 50.8752 to 51.2406 GiB/s
+  - `log_apache.log`: 21.1174 to 21.1502 GiB/s
+  - Geometric mean: 30.6071 to 30.3220 GiB/s (-0.9%)
+- Notes: this removes provably unused parse work, but the benchmark movement is
+  within normal run noise and is not a meaningful throughput improvement. The
+  vector/vector merge remains the dominant measured bottleneck.
+
+### 16-symbol vector/vector merge chunks
+
+- Status: failed, reverted
+- Idea: for large scheduled vector/vector merge streams, have each thread
+  process 16 output symbols from two bitmap bytes instead of 8 output symbols
+  from one bitmap byte. This halves rank-directory lookups on root and
+  near-root nodes, which dominated the `json_api.json` profile.
+- Result:
+  - `json_api.json`, 256 MiB, 20 iterations: 21.0114 to 15.9736 GiB/s.
+  - Nsight Systems CUDA trace, 256 MiB, 1 measured iteration:
+    `scheduledMergeVectorVectorKernel` rose from 33.699 ms to 49.799 ms total
+    over the four decode passes.
+- Reason: the saved rank-directory lookups did not pay for the extra serial
+  work per thread and reduced effective parallelism in the large merge levels.
+  The current 8-symbol bitmap-byte chunk is a better point on this GPU.
+
+### Constant/vector bitmap-byte chunks
+
+- Status: failed, reverted
+- Idea: apply the 8-symbol bitmap-byte merge used by large vector/vector nodes
+  to constant/vector and vector/constant merge nodes.
+- Result: the measurements were inconsistent. A full representative run with
+  the simple 1024-symbol threshold had a better geometric mean, but reruns and
+  an isolation pass showed dataset-dependent regressions, especially on
+  `dna_fasta.fa`. A tableLog-based selector avoided some regressions but did
+  not preserve the apparent `json_api.json` and `cat-wiki.html` wins.
+- Profiling note: Nsight Systems did not show the intended
+  `scheduledMergeConstantVectorKernel` improvement on `json_api.json`; it was
+  still about 3.8 ms total over the four decode passes. Since this did not move
+  the profiled bottleneck and required a heuristic selector, the code was
+  reverted.
+
+### Root two-level vector/vector fusion
+
+- Status: worked, pending commit
+- Profiling setup: Nsight Systems CUDA trace on `json_api.json`, 256 MiB,
+  32 KiB blocks, 1 measured iteration. The benchmark's three warmup decodes
+  make decode kernels appear four times in the kernel summary.
+- Bottleneck before change: after the parallel directory build,
+  `scheduledMergeVectorVectorKernel` was the dominant cost at 33.699 ms total
+  over four decodes. The last two vector/vector launches in each decode were
+  about 2.97 ms and 2.67 ms, more than half of decode kernel time.
+- Idea: when the root and both level-1 children are vector/vector merge nodes,
+  skip the level-1 and root materialization stages and replace them with one
+  fused root kernel. The fused kernel reads the root and level-1 bitmaps plus
+  level-2 streams and writes final output directly, avoiding a full-block
+  intermediate stream.
+- Profiling after change:
+  - `scheduledMergeVectorVectorKernel`: 11.084 ms total over 28 launches.
+  - `scheduledMergeRoot2VectorVectorKernel`: 16.794 ms total over four
+    launches, about 4.199 ms per decode.
+  - Combined vector/vector merge time fell from 33.699 ms to 27.878 ms over the
+    four profiled decodes, saving about 1.46 ms per decode on `json_api.json`.
+- Correctness:
+  - `buck test --local-only @fbcode//mode/dev-nosan fbcode//openzl/dev/contrib/pivco-huffman/gpu:pivco_gpu_test`
+- Representative real files, 256 MiB, 20 iterations, compared with the
+  preceding committed run:
+  - `cat-image.jpg`: 36.2814 to 36.1988 GiB/s
+  - `dna_fasta.fa`: 43.1172 to 42.9693 GiB/s
+  - `json_api.json`: 21.0114 to 23.9586 GiB/s
+  - `cat-wiki.html`: 21.8185 to 25.7336 GiB/s
+  - `calgary_pic`: 51.2406 to 51.2503 GiB/s
+  - `log_apache.log`: 21.1502 to 29.8154 GiB/s
+  - Geometric mean: 30.3220 to 33.7022 GiB/s (+11.1%)
+- All real files, 256 MiB, 20 iterations:
+  - `cat-image.jpg`: 29.4268 GiB/s
+  - `calgary_pic`: 51.3926 GiB/s
+  - `cat-wiki.html`: 24.9855 GiB/s
+  - `chinese_text.txt`: 25.5399 GiB/s
+  - `csv_numeric.csv`: 41.5466 GiB/s
+  - `dna_fasta.fa`: 43.1272 GiB/s
+  - `gzip_random.gz`: 246.9965 GiB/s
+  - `json_api.json`: 23.9453 GiB/s
+  - `log_apache.log`: 24.1756 GiB/s
+  - `pride.txt`: 24.9968 GiB/s
+  - `source_c.c`: 23.7771 GiB/s
+  - Geometric mean versus the last all-real table in this log: 26.8508 to
+    36.3623 GiB/s (+35.4%).
+- Notes: `gzip_random.gz` uses the separate flat-root fast path and is not
+  affected by the fusion selector; its lower number versus the older all-real
+  table appears to be run-to-run variance in that unchanged path. The fusion is
+  deliberately selected only for the exact root plus two level-1 vector/vector
+  shape.
+
+### Fused root child-bit preloading
+
+- Status: failed, reverted
+- Idea: inside the fused root two-level vector/vector kernel, load the next
+  level-1 child bitmap bits into registers once per root bitmap byte instead of
+  calling `dGetBit` for each emitted symbol.
+- Result: `json_api.json`, 256 MiB, 20 iterations regressed from the root
+  fusion run to 23.5752 GiB/s. Nsight Systems showed
+  `scheduledMergeRoot2VectorVectorKernel` rising from about 4.199 ms to
+  4.353 ms per decode.
+- Reason: the extra unaligned child-bit load and register pressure outweighed
+  the removed per-symbol byte/bit extraction in the fused kernel.
+
+### Nsight Compute `mergeVectorVector` bottleneck profile
+
+- Status: profiling evidence, no code change
+- Setup: muted DCGM profiling with
+  `sudo dyno dcgm_profiling --mute=true --duration=1200_s`, then profiled the
+  direct Buck-built `pivco_gpu_bench` binary with `/usr/local/cuda/bin/ncu`
+  because profiling through `buck run` did not attach to the benchmark child
+  process reliably.
+- Large remaining `scheduledMergeVectorVectorKernel` launch on `json_api.json`,
+  256 MiB, 32 KiB blocks:
+  - Duration: 1.47 ms for grid `(8192, 2, 1)`.
+  - DRAM throughput: 10.5% of peak, 203.5 GB/s.
+  - L2 throughput: 69.1% of peak.
+  - Compute throughput: 19.9% of peak.
+  - Achieved occupancy: 92.0%, but only 0.36 eligible warps per scheduler and
+    82.7% cycles with no eligible warp.
+  - Dominant stalls: long scoreboard 50.75 cycles per issued instruction and
+    LG throttle 27.60.
+  - Memory transaction shape: global loads average 2.17 useful bytes per
+    32-byte sector, global stores average 4.01 bytes per sector. L2 load hit
+    rate is only 10.8%, while store hit rate is 99.3%.
+  - Device memory moved by the kernel: 169.9 MB read and 128.2 MB written.
+- Fused `scheduledMergeRoot2VectorVectorKernel` launch on the same data:
+  - Duration: 4.20 ms for grid `(8192, 1, 1)`.
+  - DRAM throughput: 8.15% of peak, 157.8 GB/s.
+  - L2 throughput: 68.7% of peak.
+  - Compute throughput: 38.8% of peak.
+  - Achieved occupancy: 96.1%, but only 0.76 eligible warps per scheduler and
+    67.0% cycles with no eligible warp.
+  - Dominant stalls: long scoreboard 30.55 cycles per issued instruction and
+    LG throttle 9.10.
+  - Memory transaction shape: global loads average 2.42 useful bytes per
+    32-byte sector, global stores average 2.83 bytes per sector.
+- Conclusion: current `mergeVectorVector` is not limited by raw HBM bandwidth.
+  The limiting behavior is byte-granular, poorly coalesced load/store traffic
+  combined with dependent rank/select addressing. Large next steps should focus
+  on changing the merge layout or work mapping to produce coalesced vectorized
+  writes and reduce rank-dependent stream gathers, not on small arithmetic or
+  popcount tweaks.
+
+### Warp-mapped vector/vector merge
+
+- Status: kept
+- Idea: remap large `scheduledMergeVectorVectorKernel` nodes from one thread
+  per bitmap byte with an eight-symbol serial loop to one warp per 32-bit
+  bitmap word, with one lane producing one output symbol. This keeps a single
+  generic vector/vector implementation for large nodes while improving output
+  coalescing and removing the per-thread serial byte loop.
+- Nsight Compute on the same large `scheduledMergeVectorVectorKernel` launch as
+  the prior profile, `json_api.json`, 256 MiB, 32 KiB blocks:
+  - Duration: 1.47 ms to 1.13 ms.
+  - DRAM throughput: 10.5% to 13.0% of peak.
+  - L2 throughput: 69.1% to 30.0% of peak.
+  - Compute throughput: 19.9% to 63.2% of peak.
+  - Achieved occupancy: 92.0% to 96.9%.
+  - Eligible warps per scheduler: 0.36 to 1.74; cycles with no eligible warp:
+    82.7% to 40.4%.
+  - Dominant stalls improved from long scoreboard 50.75 and LG throttle 27.60
+    to long scoreboard 18.41 and LG throttle 0.04 cycles per issued
+    instruction.
+  - Average active threads per warp: 28.37 to 31.99; average predicated-on
+    threads per warp: 21.38 to 28.24.
+  - Global load bytes per sector: 2.17 to 4.64. Global store bytes per sector:
+    4.01 to 16.56.
+  - Instruction count increased from 123.7M to 328.1M for this launch, but the
+    lower memory dependency stalls and much better store coalescing made the
+    kernel faster.
+- Representative real files, 256 MiB, 20 iterations, compared with the prior
+  representative table in this log:
+  - `cat-image.jpg`: 36.1988 to 33.4852 GiB/s
+  - `dna_fasta.fa`: 42.9693 to 46.6897 GiB/s
+  - `json_api.json`: 23.9586 to 24.9174 GiB/s
+  - `cat-wiki.html`: 25.7336 to 26.0806 GiB/s
+  - `calgary_pic`: 51.2503 to 51.9559 GiB/s
+  - `log_apache.log`: 29.8154 to 25.7125 GiB/s
+  - Geometric mean: 33.7022 to 33.2746 GiB/s (-1.3%). This run showed large
+    run-to-run variance on `cat-image.jpg` and `log_apache.log`; the full-real
+    run below was used with the profiler evidence to decide whether to keep the
+    direction.
+- All real files, 256 MiB, 20 iterations, compared with the prior all-real
+  table in this log:
+  - `cat-image.jpg`: 29.4268 to 35.2753 GiB/s
+  - `calgary_pic`: 51.3926 to 51.8565 GiB/s
+  - `cat-wiki.html`: 24.9855 to 31.6901 GiB/s
+  - `chinese_text.txt`: 25.5399 to 26.7551 GiB/s
+  - `csv_numeric.csv`: 41.5466 to 36.8960 GiB/s
+  - `dna_fasta.fa`: 43.1272 to 46.5917 GiB/s
+  - `gzip_random.gz`: 246.9965 to 246.1095 GiB/s
+  - `json_api.json`: 23.9453 to 24.9072 GiB/s
+  - `log_apache.log`: 24.1756 to 25.8596 GiB/s
+  - `pride.txt`: 24.9968 to 26.2573 GiB/s
+  - `source_c.c`: 23.7771 to 27.5026 GiB/s
+  - Geometric mean: 36.3623 to 38.8605 GiB/s (+6.9%).
+- Notes: `csv_numeric.csv` regressed by 11.2% in this run. Per user direction,
+  this change intentionally does not add a selector between the byte-loop and
+  warp-mapped implementations; keep one implementation and continue improving
+  the vector/vector path.
+- Correctness:
+  - `buck test --local-only @fbcode//mode/dev-nosan fbcode//openzl/dev/contrib/pivco-huffman/gpu:pivco_gpu_test`
+
+### Warp load broadcast inside vector/vector merge
+
+- Status: failed, reverted
+- Idea: after the warp-mapped vector/vector merge, have lane 0 load the
+  directory entry and bitmap word once and broadcast them with `__shfl_sync`,
+  instead of letting every lane load the same cached values.
+- Result: representative real-file timing regressed versus the plain warp
+  mapping:
+  - `cat-image.jpg`: 32.6749 GiB/s
+  - `dna_fasta.fa`: 45.8768 GiB/s
+  - `json_api.json`: 24.7287 GiB/s
+  - `cat-wiki.html`: 31.3384 GiB/s
+  - `calgary_pic`: 51.6505 GiB/s
+  - `log_apache.log`: 25.5240 GiB/s
+- Reason: the extra shuffle and lane-0 dependency cost more than the redundant
+  cached directory/bitmap loads in this kernel.
+
+### Warp-mapped fused root vector/vector merge
+
+- Status: failed, reverted
+- Idea: apply the same one-warp-per-32-root-bits mapping to
+  `scheduledMergeRoot2VectorVectorKernel`. Each warp would load a 32-bit root
+  word, derive contiguous left/right child windows, and use child rank bases
+  plus per-lane popcounts to write final output positions directly.
+- Result: Nsight Compute on `json_api.json`, 256 MiB, 32 KiB blocks showed a
+  clear regression:
+  - `scheduledMergeRoot2VectorVectorKernel` duration rose from 4.20 ms to
+    8.64 ms.
+  - DRAM throughput fell from 8.15% to 3.79% of peak.
+  - L2 throughput fell from 68.7% to 11.1% of peak.
+  - Compute throughput rose from 38.8% to 80.8% of peak.
+  - Eligible warps per scheduler improved from 0.76 to 6.04, but average
+    active threads per warp collapsed from 21.49 to 7.64.
+- Reason: the rewrite traded the original memory-pressure problem for a much
+  worse compute/control problem. The child-window rank setup and warp shuffles
+  left most lanes inactive for large parts of the instruction stream, so the
+  kernel became compute dominated and about 2x slower.
+
+### Current decode timeline breakdown after warp-mapped vector/vector merge
+
+- Status: profiling evidence, no code change
+- Setup: Nsight Systems CUDA trace on `json_api.json`, 256 MiB, 32 KiB blocks,
+  1 measured iteration. The benchmark emits three warmup decodes plus the
+  measured decode; steady-state numbers below exclude the first decode's
+  inflated CPU launch API time.
+- Steady-state decode timeline:
+  - GPU decode span: 10.098 ms.
+  - Decode kernel sum: 10.059 ms.
+  - GPU gaps between decode kernels: 0.038 ms.
+  - Decode kernel launches: 30 per decode.
+  - CPU-side `cudaLaunchKernel` API time for those launches: 0.257 ms per
+    decode. This is not the dominant device-timeline cost today; most launch
+    API time is hidden because GPU gaps are only about 0.04 ms.
+- Kernel breakdown per decode:
+  - `scheduledMergeRoot2VectorVectorKernel`: 4.202 ms, 41.8%.
+  - `scheduledMergeVectorVectorKernel`: 2.344 ms, 23.3%.
+  - `scheduledDirectoryKernel`: 1.062 ms, 10.6%.
+  - `scheduledFlatKernel<*>`: 1.051 ms, 10.4%.
+  - `scheduledMergeConstantVectorKernel`: 0.929 ms, 9.2%.
+  - `scheduledParseKernel`: 0.410 ms, 4.1%.
+  - `scheduledMergeConstantConstantKernel`: 0.062 ms, 0.6%.
+- One steady-state decode launch sequence ends with the largest kernels:
+  - `scheduledMergeVectorVectorKernel`, grid `(8192, 2, 1)`: 0.593 ms.
+  - `scheduledMergeVectorVectorKernel`, grid `(8192, 2, 1)`: 1.146 ms.
+  - `scheduledMergeConstantVectorKernel`: 0.498 ms.
+  - `scheduledMergeRoot2VectorVectorKernel`: 4.192 ms.
+- Host/device transfer components in the profiled benchmark are outside the
+  decode kernel span:
+  - Host-to-device copies: 83.782 ms total over 12 copies for the full
+    encode/decode benchmark process.
+  - Device-to-host copies: 29.090 ms total over four copies.
+  - CUDA memsets: 0.009 ms total.
+- Conclusion: the next large optimization target is still the top of the tree,
+  especially `scheduledMergeRoot2VectorVectorKernel`. However, the failed
+  warp-mapped root rewrite shows that simply making root output stores
+  coalesced is not enough if it adds child-window rank setup and lane
+  under-utilization. A better next root strategy needs to keep high lane
+  utilization while reducing the root kernel's byte-granular stream gathers.
+
+### Disable root vector/vector fusion after warp-mapped regular merges
+
+- Status: failed, reverted
+- Idea: after the regular vector/vector merge became faster, disable
+  `fuseRootVectorVector` entirely and let the same warp-mapped
+  `scheduledMergeVectorVectorKernel` handle the two level-1 nodes and root as
+  ordinary stages.
+- Result: `json_api.json`, 256 MiB, 20 iterations regressed to 24.1723 GiB/s
+  versus the current root-fused path's recent 24.5-24.9 GiB/s range.
+- Reason: despite being the biggest remaining kernel, the fused root path still
+  beats re-materializing the level-1 streams and root as separate regular
+  vector/vector stages.
+
+### Packed final stores in fused root vector/vector merge
+
+- Status: kept
+- Idea: keep the existing `scheduledMergeRoot2VectorVectorKernel` byte-loop and
+  child rank logic, but pack each full eight-symbol output group into one
+  64-bit final-output store. This targets the same store-sector inefficiency
+  fixed in the regular vector/vector merge without remapping the root kernel to
+  one lane per output. The implementation falls back to byte stores for the
+  tail and for unaligned destination addresses.
+- Nsight Compute on `scheduledMergeRoot2VectorVectorKernel`, `json_api.json`,
+  256 MiB, 32 KiB blocks:
+  - Duration: 4.20 ms to 1.91 ms.
+  - DRAM throughput: 8.15% to 17.2% of peak.
+  - L2 throughput: 68.7% to 19.0% of peak.
+  - Compute throughput: 38.8% to 86.9% of peak.
+  - Eligible warps per scheduler: 0.76 to 5.46.
+  - Cycles with no eligible warp: 67.0% to 27.5%.
+  - Average active threads per warp: 21.49 to 23.31.
+  - Global store bytes per sector: 2.83 to 32.00.
+- Representative real files, 256 MiB, 20 iterations, compared with the prior
+  representative table in this log:
+  - `cat-image.jpg`: 33.4852 to 33.4990 GiB/s
+  - `dna_fasta.fa`: 46.6897 to 46.3969 GiB/s
+  - `json_api.json`: 24.9174 to 38.9503 GiB/s
+  - `cat-wiki.html`: 26.0806 to 38.6788 GiB/s
+  - `calgary_pic`: 51.9559 to 51.6919 GiB/s
+  - `log_apache.log`: 25.7125 to 33.7211 GiB/s
+  - Geometric mean: 33.2746 to 39.9765 GiB/s (+20.1%).
+- All real files, 256 MiB, 20 iterations, compared with the prior all-real
+  table in this log:
+  - `cat-image.jpg`: 35.2753 to 33.4898 GiB/s
+  - `calgary_pic`: 51.8565 to 51.8455 GiB/s
+  - `cat-wiki.html`: 31.6901 to 34.3183 GiB/s
+  - `chinese_text.txt`: 26.7551 to 36.3683 GiB/s
+  - `csv_numeric.csv`: 36.8960 to 36.8681 GiB/s
+  - `dna_fasta.fa`: 46.5917 to 46.6184 GiB/s
+  - `gzip_random.gz`: 246.1095 to 285.8790 GiB/s
+  - `json_api.json`: 24.9072 to 37.6122 GiB/s
+  - `log_apache.log`: 25.8596 to 36.4172 GiB/s
+  - `pride.txt`: 26.2573 to 40.0954 GiB/s
+  - `source_c.c`: 27.5026 to 31.9263 GiB/s
+  - Geometric mean: 38.8605 to 45.8155 GiB/s (+17.9%).
+- Post-change Nsight Systems steady-state breakdown on `json_api.json`:
+  - GPU decode span: 7.804 ms.
+  - Decode kernel sum: 7.764 ms.
+  - GPU gaps between decode kernels: 0.040 ms.
+  - `scheduledMergeVectorVectorKernel`: 2.343 ms, 30.2%.
+  - `scheduledMergeRoot2VectorVectorKernel`: 1.907 ms, 24.6%.
+  - `scheduledDirectoryKernel`: 1.062 ms, 13.7%.
+  - `scheduledFlatKernel<*>`: 1.050 ms, 13.5%.
+  - `scheduledMergeConstantVectorKernel`: 0.929 ms, 12.0%.
+  - `scheduledParseKernel`: 0.411 ms, 5.3%.
+  - `scheduledMergeConstantConstantKernel`: 0.062 ms, 0.8%.
+- Follow-up check: after adding the unaligned-destination byte-store fallback,
+  `json_api.json`, 256 MiB, 20 iterations measured 37.3761 GiB/s, consistent
+  with the packed-store improvement.
+- Next target: regular vector/vector is now the largest decode bucket again,
+  followed by the packed root kernel and then directory/flat/constant-vector
+  work. Further large gains likely need another reduction in regular
+  vector/vector gather/rank work or a broader top-of-tree fusion that preserves
+  the packed root store behavior.
+- Correctness:
+  - `buck test --local-only @fbcode//mode/dev-nosan fbcode//openzl/dev/contrib/pivco-huffman/gpu:pivco_gpu_test`
+
+### Block-resident single-CTA decode (shared-memory pivot)
+
+- Status: failed, reverted (kept as a documented negative result)
+- Hypothesis: the scheduled path is not HBM-bound (DRAM 10-17% of peak) but
+  pays ~2x-tree-depth global round-trips of the block through `bufferA/bufferB`
+  plus byte-granular, rank-dependent child gathers. A 32 KiB block's working set
+  fits in A100 shared memory, so decoding each block in ONE CTA with all
+  bitmaps/rank-directories/intermediate streams on-chip should cut global
+  traffic to the theoretical minimum (read slice once, write output once) and
+  turn the scattered global gathers into cheap shared accesses.
+- Baselines re-measured on this box (median GiB/s, 256 MiB, 20 iters):
+  `json_api.json` 33.1, `cat-image.jpg` 33.5, `cat-wiki.html` 34.2,
+  `calgary_pic` 52.0, `dna_fasta.fa` 46.6, `log_apache.log` 33.7.
+- Variant A -- top-down per-symbol rank/select walk, everything in shared. Each
+  thread walks root->leaf for its own output positions (coalesced stores, no
+  barriers). Result on `json_api.json`, 256 MiB: 12.0 GiB/s.
+  - Nsight Compute: the hypothesis held on memory -- DRAM 0.87% of peak, memory
+    throughput 29% -- but the kernel became compute/issue bound: Compute (SM)
+    74.6%, IPC 2.71, 8.5 G issued instructions for the launch (~33 instr per
+    output byte) from the deep per-symbol dependent rank chain
+    (`dLoadLe32Masked` byte loop + `dGetBits` bit loop x tableLog levels). At
+    ~67% of peak issue rate, this is fundamentally issue-limited; a tree walk
+    cannot reach ~4 instr/byte.
+- Variant B -- bottom-up warp-cooperative merge in shared ping-pong buffers (the
+  GPU analog of the CPU AVX512 `vpexpandb` path). Single-pass cooperative merge
+  per node. Result on `json_api.json`, 256 MiB: 18.5 GiB/s.
+  - Nsight Compute: DRAM 1.34% (memory again free), Compute 44%, but achieved
+    occupancy only 24.8% (Block Limit Shared Mem = 2 CTAs/SM from the 2xblockSize
+    = 64 KiB buffers) and 56.8% of cycles had no eligible warp. Bound by the
+    per-node cooperative rank-scan barrier storm (log-depth `__syncthreads` x
+    ~190 internal nodes/block) starving the few resident warps.
+  - Smaller blocks made it worse (16 KiB 16.8, 8 KiB 14.8 GiB/s): the tree node
+    count is fixed by the weights, so smaller blocks give the same ~190 nodes
+    fewer symbols each, so the per-node barrier overhead dominates even more.
+- Variant B2 -- split each level into a cooperative pass for the few large
+  near-root nodes and a warp-parallel pass (warp-scan rank, no block barriers)
+  for the many small deep-tree nodes. Result on 256 MiB: `json_api.json` 15.9,
+  `calgary_pic` 21.2, `dna_fasta.fa` 23.7 GiB/s -- warp-serial small-node
+  processing regressed json vs the single-pass merge and stayed far below
+  baseline. (A full-mask `__shfl_sync` executed under `if (lane == 0)`
+  dead-locked the first build; noted as a gotcha.)
+- Conclusion: keeping a block resident in shared memory does remove the memory
+  bottleneck (verified: DRAM < 2% of peak in every variant), but a single CTA
+  per 32 KiB deep-tree block cannot match the scheduled path's throughput. The
+  scheduled path's strength is massive `(block x node)` grid parallelism that
+  hides latency at 92-96% occupancy; folding a block into one CTA trades that
+  away for an intra-block serial/barrier/occupancy bottleneck. The decode is
+  latency/issue bound per symbol, not bandwidth bound, so the well-tuned
+  scheduled path is at or near the practical ceiling for mixed deep trees on this
+  GPU. Reverted to the scheduled decoder.
+
+### Kernel-by-kernel latency/instruction optimization pass
+
+Note on measurement: this box shows large run-to-run variance (GPU clock;
+`log_apache.log` was seen bouncing 37-45 GiB/s across identical runs, `calgary_pic`
+57-70). Each result below is a back-to-back A/B against the immediately prior
+build; absolute cross-session numbers are not comparable.
+
+- Vector/vector merge, 2-way MLP -- kept. `ncu` on the large
+  `scheduledMergeVectorVectorKernel` launches: DRAM 13% of peak, L1 hit 88%,
+  L2 hit 82%, long-scoreboard 71% of stall cycles at ~97% occupancy -- i.e. not
+  bandwidth bound but latency bound on the `directory` load -> data-dependent
+  child gather. Processing two independent bitmap words per thread (both gathers
+  issued before either store) doubles memory-level parallelism. Back-to-back
+  (256 MiB, 10 iters): `cat-image.jpg` 33.5->38.2, `dna_fasta.fa` 46.6->50.8,
+  `log_apache.log` 33.7->36.0, `cat-wiki.html` 34.2->36.2, ~+7% geomean, no
+  regressions.
+  - A prior attempt to coalesce the same gather by staging child streams into
+    shared memory REGRESSED ~15%: the child streams are L1/L2-resident, so the
+    "uncoalesced" 4.6 bytes/sector load is not the cost -- the staging copy plus
+    the 32 KiB shared occupancy hit is. Latency, not bandwidth, is the limiter.
+- Flat-leaf windowed bit extraction -- kept. `scheduledFlatKernel<Depth>`
+  replaced `dGetBits`' bit-by-bit loop (which re-reads the same 1-2 bytes Depth
+  times) with a single windowed 1-2 byte read + shift + mask. Back-to-back:
+  `cat-image.jpg` 38.2->43.8, `chinese_text.txt` 38.4->39.8, others +1-3%, no
+  regressions. Unlike the earlier reverted windowed attempt this changes only the
+  read path (not the store mapping), so `pride.txt`/`source_c.c` do not regress.
+- Constant/vector and vector/constant merges, warp-mapped -- kept. These used a
+  scalar thread-per-output loop with a `directory` load per output; converted the
+  large-node path to the warp-per-32-bit-word mapping (one dir load per 32
+  outputs) plus 2-way MLP. Back-to-back: `calgary_pic` 53.8->69.6 (+29%),
+  `log_apache.log` 36.6->44.7 (+22%), `dna_fasta.fa` 50.8->52.9, no regressions.
+  The earlier-logged constant/vector warp-map regression of downstream
+  vector/vector did NOT recur (the vector/vector merge is now itself warp-mapped).
+- Fused root-two, 2-way MLP -- reverted. `ncu` shows
+  `scheduledMergeRoot2VectorVectorKernel` is COMPUTE bound (SM 87%, DRAM 17%),
+  not latency bound, so unrolling by two bytes gave only ~+1%; not worth the added
+  register pressure. Root2's cost is the serial 8-bit routing loop; reducing its
+  instruction count (not hiding latency) is the only lever, and it is already
+  packed-store optimized.
+- Disable root-two fusion (let the now-faster warp-mapped vector/vector handle
+  root + level 1) -- reverted. Regressed the fusion-eligible datasets ~21%
+  (`json_api.json` 35->28, `cat-wiki.html` 37->29, `chinese_text.txt`,
+  `pride.txt`), because it re-materializes two full-block level-1 streams. Even
+  compute-bound, the fused kernel beats three separate merge passes. Only
+  `source_c.c` improved (+9%).
+- Net: the three kept changes give roughly +10-20% geomean over the prior
+  scheduled baseline (dataset-dependent; skewed/flat-heavy files gain most). The
+  merges are latency- or compute-bound on cache-resident data at high occupancy,
+  so the effective levers are memory-level parallelism (VV, CV/VC) and
+  instruction reduction (flat), not coalescing.
+
+### Thread-per-byte contiguous-stream merge (breakthrough)
+
+- Status: kept -- largest single win.
+- Idea (contiguous stream reads + register-shift selection, the GPU analog of
+  the CPU merge): give each thread one bitmap byte (8 outputs) instead of the
+  warp-per-word mapping. Read the rank once, then pull up to 8 CONTIGUOUS bytes
+  from each child stream into a u64 register (the most either child can supply
+  for 8 outputs) and select per bit by shifting the bottom byte out of the chosen
+  child. Result per 8 outputs: two contiguous child loads + register shifts + one
+  coalesced 8-byte store, versus eight scattered, dependent child gathers. All
+  routing stays in registers. `dLoad8Bounded` keeps the reads inside the child
+  stream. Applied to vector/vector, constant/vector, vector/constant.
+- This is why it beats the warp-per-word gather: the scattered gather's cost was
+  the per-output dependent load latency (long-scoreboard), not bandwidth;
+  replacing 8 dependent scattered loads with 2 independent contiguous loads
+  collapses the stall.
+- Decode throughput, 256 MiB, 10 iters, vs the warp-mapped merges:
+  `dna_fasta.fa` 52.9->77.9 (+47%), `cat-image.jpg` 44.0->60.9 (+38%),
+  `calgary_pic` 57->76.3 (+34%), `csv_numeric.csv` 41.9->56.6 (+35%),
+  `source_c.c` 31.4->42.5 (+35%), `json_api.json` 35.1->39.3,
+  `cat-wiki.html` 37.1->40.6 GiB/s.
+
+### Fused root-two: window child partition bits
+
+- Status: kept. Root2 is compute bound (SM 87%); its inner loop called `dGetBit`
+  8x per root byte. Load each child's <=8 partition bits into a register once
+  (LSB-first, second byte read only when the bits span it) and consume by
+  shifting; grandchild streams still gathered per output. +3-4% on Root2-using
+  datasets (`json_api.json`, `cat-wiki.html`, `pride.txt`, `chinese_text.txt`),
+  `source_c.c` more.
+- A full-window variant that also cached the four grandchild streams in u64
+  registers REGRESSED ~5% -- the extra wide-register pressure dropped occupancy
+  on this already register-heavy, compute-bound kernel. Grandchild gathers hit L1
+  and are cheap to leave per-output.
+
+### `__byte_perm` merge (four outputs per instruction)
+
+- Status: kept. Replace the eight-iteration register selection loop in the byte
+  merge with two `__byte_perm` (PRMT) instructions, each merging four outputs.
+  A 16-entry selector table (`kMergeSel`, indexed by the 4-bit partition mask)
+  permutes the four output bytes from {left bytes : right bytes} in one hardware
+  op; a constant child is supplied as a replicated byte, and the child windows
+  advance by the mask popcount between the two groups.
+- Decode throughput, 256 MiB, 10 iters, vs the prior commit (no regressions):
+  `calgary_pic` 76.4->83.0 (+8.6%), `cat-image.jpg` 60.9->64.8 (+6.4%),
+  `dna_fasta.fa` 77.8->82.6 (+6.2%), `csv_numeric.csv` 56.5->59.2,
+  `json_api.json` 40.4->41.5, `cat-wiki.html` 41.9->42.7 GiB/s.
+
+### Cumulative result
+
+- All real datasets, 256 MiB, 20 iters, versus the original scheduled baseline
+  (`BENCHMARKS.md` / start-of-session reruns), noting ~+-15% run-to-run GPU-clock
+  variance on this box:
+  `cat-image.jpg` 33.5->64.8 (+93%), `dna_fasta.fa` 46.6->83.1 (+78%),
+  `calgary_pic` 52.0->83.4 (+60%), `source_c.c` ->52.9, `csv_numeric.csv`
+  ->59.8, `log_apache.log` 33.7->49.4 (+47%), `chinese_text.txt` ->45.8,
+  `pride.txt` ->43.2, `cat-wiki.html` 34.2->42.9 (+25%), `json_api.json`
+  33.1->41.4 (+25%); `gzip_random.gz` 287 (flat-root, unchanged). Roughly +50%
+  geomean on the representative set, up to ~1.9x (`cat-image.jpg`,
+  `dna_fasta.fa`).
+- Takeaways: the merges were latency/compute bound on cache-resident data, not
+  bandwidth bound. The winning levers were (1) turning the scattered per-output
+  child gather into two contiguous per-byte loads + register-shift / `__byte_perm`
+  selection, (2) amortizing the rank-directory load, (3) instruction reduction
+  via windowed bit extraction. Coalescing mattered as *fewer independent
+  contiguous loads* (killing the dependency chain), not as sector utilization.
+
+### Kernel anti-pattern sweep
+
+Systematic per-kernel audit (heaviest first), each fix profiled and gated.
+
+- Rank-directory scan: replaced the O(entries log entries) Hillis-Steele block
+  scan with a single-warp shuffle scan for small nodes (<=32 entries, no
+  barriers) and a work-efficient two-level scan for large ones, plus 2-way MLP on
+  the popcount loads. `scheduledDirectoryKernel` Compute (SM) 76%->54%; the
+  kernel is now latency bound on its many small per-node CTAs.
+- Scheduled parse: dropped the up-front zeroing of all node states (only `count`
+  is read before write, and corrupt input is gated by `status`) and folded the
+  per-level stream-offset assignment into the single pre-order pass, removing an
+  O(levels*nodes) second pass. `scheduledParseKernel` 245->139 us; `calgary_pic`
+  94->101, `dna_fasta.fa` 97->102 GiB/s.
+- Flat merge (`scheduledFlatKernel`): cache the leaf's 2^Depth symbols in shared
+  so the per-output table lookup hits shared. `csv_numeric.csv` 67->71,
+  `chinese_text.txt` 53->56.
+- Flat-root fast path (`fastDecodeFlatRootKernel`): the depth<8 path used
+  per-symbol `dGetBits`; replaced with windowed extraction + shared symbols.
+  `flat_M7` 61->227 (+3.7x), `flat_M6` 75->230, `sparse_16` 94->238, `flat_M3`
+  120->240 GiB/s.
+- Removed dead `rankSelectDecodeKernel` and `topDownDecodeKernel` (defined but
+  never launched; superseded by the scheduled decoder).
+- Audited but left as-is: the vector/vector merge (now bandwidth bound on the
+  bottom-up child-read/output-write traffic, ~44% DRAM on large nodes -- at its
+  floor) and the `decodeKernel`/`bottomUpDecodeKernel` correctness fallbacks
+  (not reachable at the 32 KiB benchmark block size).
+
+## Top-down scatter decoder (exploration, `PIVCO_TOPDOWN=1`)
+
+An env-gated alternative decode path that inverts the dataflow: start every block
+with the identity index list `0,1,2,...`; each internal node partitions its index
+list into a left and a right child list by the node bitmap (rank/select), a
+constant child scatters its symbol to `dst[idx]` instead of materializing a list,
+a both-constant node scatters one of two symbols, and a flat leaf scatters one of
+its `2^Depth` symbols. It reuses the scheduled parse + rank directory, then runs
+one partition/flat kernel per (level, op).
+
+Kept the bottom-up learnings and profiled each step:
+
+- **Word reconstruction via `__ballot`.** The first version had all 32 lanes of a
+  warp redundantly assemble the same masked 32-bit bitmap word
+  (`dLoadLe32Masked` x32). A lane-0 load + `__shfl` broadcast was *slower*
+  (serializes on lane 0's latency). The win was to have each lane read only its
+  own bit and reconstruct the word with `__ballot_sync` -- less compute, no
+  serialization, coalesced byte loads. `json_api.json` 19.7->23.1,
+  `calgary_pic` 43.6->48.3, `dna_fasta.fa` 42.9->47.8 GiB/s.
+- **2-way MLP in the partition.** The partition is latency bound (52%
+  no-eligible-warp). Processing two words per warp iteration -- both ballots and
+  both directory/index-list loads issued before the dependent stores -- overlaps
+  the memory latency. `dna_fasta.fa` 47.8->54.7, `calgary_pic` 48.3->53.1,
+  `cat-wiki.html` 22.0->26.0, `json_api.json` 23.1->24.4 GiB/s.
+
+### Result: top-down is structurally ~2x slower for real Huffman data
+
+After tuning, decode ratio (top-down / bottom-up), 128-256 MiB:
+
+- **Flat / uniform distributions -- parity (~1.0x):** `flat_M3` 1.08, `flat_M5`
+  0.98, `flat_M7` 1.00, `uniform` 1.00, `sparse_16` 1.00, `two_sym_eq` 0.82.
+  These have no multi-level index-list traffic and their terminal writes are
+  dense, so top-down matches (and `flat_M3` slightly beats) bottom-up.
+- **Real Huffman trees -- ~0.5x:** `calgary_pic` 0.53, `dna_fasta.fa` 0.54,
+  `cat-image.jpg` 0.51, `csv_numeric.csv` 0.51, `chinese_text.txt` 0.48,
+  `json_api.json` 0.48, `log_apache.log` 0.48, `pride.txt` 0.47, `source_c.c`
+  0.48, `cat-wiki.html` 0.54.
+- **Skewed distributions -- 0.38-0.49x:** `zipfian` 0.45, `geometric` 0.46,
+  `bell_s30` 0.49, `proba14` 0.46, `proba50` 0.41, `proba80` 0.38 (bottom-up is
+  fastest exactly where top-down is relatively worst).
+
+The ratio is remarkably consistent, which is the tell that it is structural, not a
+tuning gap. Two fundamental costs, confirmed by ncu:
+
+1. **~2x intermediate traffic.** Top-down moves `uint16` index lists across every
+   tree level (2 bytes/position/level); bottom-up moves `uint8` symbol streams
+   (1 byte/position/level).
+2. **Scattered terminal writes.** Every constant/flat/both-constant leaf writes
+   `dst[idx]` at rank-permuted addresses. ncu on the flat scatter: DRAM 62%
+   (1.2 TB/s) but 42% excess sectors, stores 10.9/32 effective. Bottom-up writes
+   output in position order (coalesced). This is irreducible in a scatter design
+   -- the whole point is that leaf positions are spread across the block.
+
+The one untried structural lever, partition-two-levels-per-kernel (level fusion),
+only attacks cost (1) and is bounded (best case ~0.63x on the partition-heavy
+`json`); it cannot touch the fundamental scatter of cost (2), and near-root
+multi-child windowing already regressed from register pressure in the bottom-up
+`Root2` work. Per the "no small refinements unless they unlock multiples"
+guidance it was not pursued.
+
+**Conclusion:** the bottom-up scheduled merge remains the production decode path.
+Top-down reaches parity only for flat/uniform data; for actual entropy-coded data
+it is ~2x slower for structural (not tunable) reasons. The path is retained behind
+`PIVCO_TOPDOWN=1` for reference/experimentation.
+
+## Bottom-up round 2 (profile-driven, AVX512-inspired)
+
+Re-profiled the production path fresh. json decode breakdown (per decode):
+vector/vector merge ~47%, rank directory ~20%, flat3 ~11%, constant/vector ~6%,
+parse ~6%. `ncu` on the largest VV-merge launch: **not** DRAM bound (DRAM 43%,
+compute 39%) -- it is latency bound (59% no-eligible-warp, 1.06 eligible warps at
+89% occupancy) with **66% excess load sectors** (7.8/32 thread efficiency on the
+child-stream loads).
+
+### Negative result: warp-level expand merge (1 byte/lane)
+
+Tried the direct `vpexpandb` analog: a warp owns one 32-output word, each lane
+loads one coalesced child byte, `__ballot` builds the mask and `__shfl`
+distributes the k-th dense byte by intra-word rank (`__popc(mask & lanemask_lt)`).
+Fully coalesced loads and stores.
+
+- Gotcha (fixed): the two `__shfl_sync(0xFFFFFFFF, ...)` for the left/right pick
+  must run on the full converged warp; putting them in the data-dependent
+  `if (bit)`/`else` deadlocks on Volta+ (each half waits for the other). Call both
+  unconditionally, then select.
+- Result: **json 27.8 vs ~51 GiB/s baseline -- ~2x slower.** The GPU has no
+  single-instruction warp expand; 1 output/lane costs 2 `__shfl` + `__ballot` +
+  `__popc` per output with no ILP, which dwarfs the coalescing win. The existing
+  thread-per-byte merge already uses `__byte_perm` as a 4-output mini-expand per
+  instruction at 8 bytes/lane -- far higher compute density. Reverted.
+
+This matches the `extras/gpu` Metal microbench notes
+(https://github.com/MarcinZukowski/pivco-huffman/tree/main/extras/gpu): their
+`tree_merge_step` is the same 1-byte/lane `simd_prefix_sum`
+gather, and their recorded verdict is "1 byte per GPU lane is too thin -- the
+cross-lane prefix sum can't amortize; 4-bytes-per-lane vectorization is the
+obvious next step." Our 8-byte/lane `byteMergeThread` is already that design; the
+excess load sectors are L2 hits (intermediates stay L2-resident), so the true
+limiter is per-group latency, not coalescing. Next levers to try: more MLP on the
+merge (deeper unroll), cheaper rank, and cutting the O(depth) merge cascade.
+
+### Wins (round 2)
+
+Three committed wins after a fresh profile + a 5-thread literature search
+(summarized in `IDEAS.md`):
+
+1. **Directory `__launch_bounds__(256, 8)`.** The rank-directory kernel was
+   register-limited (40 regs -> 6 blocks/SM, 63% occupancy) and compute+latency
+   bound. Capping at 32 regs lifts it to 8 blocks/SM (85% occupancy). Directory
+   kernel 522 -> 449 us (~14%).
+
+2. **Multi-symbol per-thread flat unpack.** `scheduledFlatKernel<Depth>` decoded
+   one symbol per thread (small depths re-read the same bitmap byte across
+   threads). Now each thread loads the 8-symbol group's `Depth` bytes once,
+   unpacks all eight `Depth`-bit indices from the register, and writes one
+   coalesced 8-byte group (GPU analog of AVX512 `vpmultishiftqb`). flat1 on dna
+   2.7x (943 -> 350 us).
+
+3. **Aligned read-only child loads in the merge (the big one).** The merge read
+   each child window with an unaligned 8-byte load; across a warp the rank-based
+   cursors overlap/misalign, wasting ~66% of load sectors and leaving it latency
+   bound (Long Scoreboard 66%). `dLoad8Aligned` issues two *aligned* 8-byte
+   `__ldg` (read-only) loads of the enclosing 16-byte window + a funnel shift:
+   aligned windows let neighbouring threads share L2/read-only sectors and the
+   read-only path spares the L1 the rank loads use. VV merge -26%; it flips from
+   latency bound (43% DRAM) to bandwidth-leaning (64% DRAM, 1.25 TB/s).
+
+Combined decode gains (256 MiB, min-time vs round-1 baseline): deep-tree real
+files +30-40% (json 51->68, log 52->73, cat-wiki 52->72, cat-image 76->116,
+source_c 56->73, pride 52->68), skewed synthetics +30-68% (bell_s80 98->164,
+proba02 50->78, english 74->104, proba14 61->84). dna 102->135 (flat+merge). Fast
+tier unchanged. One regression: `calgary_pic` 119->111 (-7%) -- its small
+cache-resident child streams make the merge compute bound, where the aligned
+load's funnelshift costs more than the sector sharing saves (no clean per-node
+gate: same node counts as json, only the global L2 working set differs).
+
+**Negative results this round:** explicit K-way MLP in the merge (batch all ranks,
+then all gathers, then all merges) -- K=2 ~1.5% (noise), K=4 regressed from
+register-pressure occupancy loss; the dependent rank->gather chain caps it. New
+profile (json): VV merge 42%, directory 21%, flat 14%, parse 7%, CV 6%. The merge
+is now DRAM-bound with ~4x child-load over-read (byte_perm loads up to 8 from each
+child = 2x, aligned doubles to 4x); intermediates exceed the 40 MB L2 so the
+level-synchronous schedule thrashes to DRAM. Remaining levers in `IDEAS.md`.
+
+### Wins (round 3): fuse the rank directory into the merge
+
+4. **Directory-into-merge fusion (big win).** The standalone `scheduledDirectoryKernel`
+   (~21% of decode) built every node's rank directory in *global* memory; each
+   merge read it back, and -- because the two kernels are separate launches with
+   all 8192 blocks processed between them -- the node bitmap was evicted from L2
+   and re-read from DRAM by the merge. Each merge kernel now builds its own node's
+   directory in *shared* memory (`buildSharedDirectory`) before merging, and the
+   bottom-up dispatch drops the directory kernel. This removes the global directory
+   write+read, serves the merge's rank from shared, and reuses the just-built
+   bitmap (no redundant DRAM re-read). +40-92% across merge-heavy datasets, no
+   regressions, and it recovered the `calgary_pic` aligned-load regression (now
+   above its original baseline). The negative-result-earlier "fuse dir into merge
+   is break-even" estimate was wrong: it missed the redundant-bitmap-DRAM-reread
+   cost of the separate launch.
+
+   Cumulative decode vs the round-1 baseline (256 MiB, median): json 51->84,
+   log 52->88, pride 52->82, cat-wiki 52->87, chinese 65->94, csv 71->102,
+   source_c 56->88, dna 102->167, calgary 119->138, cat-image 76->120, and skewed
+   synthetics bell_s80 98->188, proba02 50->83, english 74->122, proba14 61->101
+   -- roughly 1.4-1.9x on the previously-slow tier, fast tier unchanged. The
+   top-down path keeps its standalone directory kernel (it reads the global
+   directory in `topDownPartitionKernel`).
+
+### Megakernel rejected by a size sweep
+
+Before attempting the research's #1 idea (block-per-codec-block megakernel /
+top-M shared fusion to keep intermediates on-chip), a working-set size sweep
+settled whether the level-synchronous schedule is L2-thrash bound. json decode:
+256blk 24, 512 46, 1024 61, 2048 78, 4096 77, 8192 84 GiB/s -- throughput
+*rises* with block count and plateaus ~2048 blocks. If L2 thrash were the cost, a
+smaller (L2-resident) working set would be faster per byte; instead it is slower
+(under-occupied). The decode is parallelism/latency bound and parallelism-saturated
+at full size. A megakernel trades away the block parallelism the workload needs --
+exactly why both prior single-CTA attempts lost. Rejected. (This is the payoff of
+the user's kernel-microbenchmark instinct: a cheap measurement killed a doomed
+multi-hour rewrite.)
+
+### Wins (round 4): parse readBits + constant/constant merge
+
+5. **Byte-wise `readBits`.** The serial 1-thread parse read each node's numOnes
+   field bit-by-bit; replaced with a byte-span load + shift/mask. Parse kernel
+   580->452 us (~22%), decode +~2% across merge-heavy sets; also speeds the
+   top-down path (shared parse kernel).
+
+6. **Vectorized constant/constant merge.** `scheduledMergeConstantConstantKernel`
+   decoded one output per thread with a per-bit read; now each thread loads one
+   bitmap byte, selects left/right per bit from a 2-entry register table, and
+   writes one coalesced 8-byte group (same shape as the flat unpack). CC kernel on
+   csv 1.15M->459k ns (2.5x); decode csv 102->120 (+18%), and two-symbol
+   distributions (root CC) 339->875/921 GiB/s (2.6-3.2x, now write-bound).
+
+The vector/vector merge (60% of the deep-tree cost) now profiles as balanced --
+58% compute, 60% memory, 62% L2 hit, 91% occupancy, latency bound on the child
+loads -- i.e. near its floor: reducing compute or memory just exposes the other,
+and directory coarsening was shown to *add* net popcount compute (the merge's
+extra sub-word popcounts outweigh the halved build), so it is not pursued. Flat is
+bandwidth bound on its coalesced output write; parse is at its serial floor.
+
+### Win (round 5): default block size 64 KiB
+
+7. **Reselect the default block size to 64 KiB.** A block-size sweep showed 16 KiB
+   is slower than 32 KiB (2x the per-block overhead) and >32 KiB fell back to the
+   generic decoder (~2 GiB/s) because the scheduled path capped at 32 KiB. Raising
+   `kRankSelectMaxBlockSize` to 64 KiB (the merge's shared directory grows to
+   ~8 KiB/CTA but occupancy stays 8 blocks/SM, register-limited) lets 64 KiB use
+   the fast path, and 64 KiB halves the per-block overhead (parse, per-node
+   directory builds, launches) at no merge cost -- the tree structure is fixed by
+   the symbol distribution, not the block size, so a 64 KiB block has the same
+   node count as a 32 KiB block but there are half as many blocks. Block count
+   stays past the parallelism-saturation knee (~2048). 128 KiB was worse (shared
+   bloat, launch issues, and 2048 blocks at the saturation edge).
+
+   Default changed to 64 KiB in the bench. Decode +~15% *everywhere* with slightly
+   better ratio, no real-file regression: json 85->101, log 89->105, pride 88->104,
+   calgary 143->192, csv 120->144, dna 168->191, uniform 250->287, geometric
+   150->182, bell_s10 101->124, proba02 84->100.
+
+### Round 6: instruction / redundant-code reduction
+
+Directive: reduce the number of instructions -- remove redundant/inefficient
+code, move edge cases out of the hot loop. Findings (the decode is memory-latency
+bound: the VV merge issues only 0.45 warps/scheduler/cycle -- ~55% idle issue
+slots -- with 74% memory-scoreboard stalls, so total-instruction cuts on the
+parallel kernels are perf-neutral; they help only where issue/serial bound):
+
+- **Directory-build zeroing removal (win, +1-2%).** `buildRankSelectDirectoryCooperative`
+  zeroed all of prefixA[0..words] before the popcount loop overwrote [1..words];
+  only prefixA[0] needs it. Removed the O(words) redundant-write pass and its
+  barrier. json 101->103, dna 191->194, calgary 191->195.
+- **Skip dead numOnes in the fused build (neutral, dead-code).** `*ones` (a
+  corruption check) is never read by the merge; templated the builder on
+  `ComputeOnes` and pass false from the merge, dropping the read + 2 barriers.
+  Correct, perf-neutral (those barriers were cheap).
+- **Drop merge tail masking (neutral, cleaner).** The final partial group's high
+  bits only route over-stored outputs (into padding/slop); removed the per-group
+  `n=min(8,...)` + mask from the hot loop. Perf-neutral.
+- **Negative: `dLoadLe32Masked` single-load fast path.** Replacing the
+  byte-by-byte bounds loop with one unaligned `memcpy` + a branch *regressed* VV
+  -13% (json 103->93). The compiler already vectorizes the L1-hot byte loop; the
+  unaligned load + branch is worse. Reverted.
+
+Takeaway: instruction reduction helps the *serial/issue-bound* stages (parse
+`readBits` +22%, directory-build zeroing +1-2%) but not the memory-latency-bound
+parallel merges (idle issue slots), and hand "optimizing" the compiler's hot
+loops can regress. The decode remains at its memory-latency floor.
+
+### Round 7: breaking the child-load latency (research + radix-4)
+
+Directive: break the ~200-cycle dependent child-load. Two more research passes
+(3 agents) + implementation:
+- **Concurrency floor confirmed (Little's Law).** At the 64-warp/SM ceiling with
+  MLP=2 (register-capped) and fixed L2 latency, `bytes_in_flight` is pinned; the
+  merge issues only 0.45 warps/scheduler/cycle (~55% idle issue slots), 74%
+  memory-scoreboard stalls. The `byte_perm` LUT expand is already the SotA GPU
+  expand (no `vpexpandb`/`PDEP` on NVIDIA); the merge is wavelet-tree
+  reconstruction. Neutral/negative: `prefetch.global.L2` ahead (elided / already
+  L2-warm), explicit depth-2 software pipeline (unroll=2 already = MLP=2),
+  `__ldcg` (loses read-only-cache dedup), cp.async streaming (occupancy),
+  warp-specialization (parallelism-saturated).
+- **Win: flat kernel depth-2 MLP.** The flat kernels had no unroll (MLP=1) and are
+  latency bound on the packed-index load; fetching 2 groups before unpacking gives
+  MLP=2. +1-2% on flat-heavy sets (csv, proba14, chinese, english). (MLP=4 was
+  neutral -- reverted.)
+- **Directory build zeroing removal** (round 6, +1-2%) and dead-numOnes / tail-mask
+  removals (neutral cleanups).
+- **REJECTED (measured): radix-4 level fusion.** Fuse a node + 2 internal children,
+  gather from the 4 grandchildren, skip child materialization. Root-scoped
+  (buffer-safe) measured json 65 vs 103 GiB/s: the fused child level is at an
+  UNALIGNED position (childPos = node rank), forcing slow bit-level rank
+  (`dRankSelectOnesBefore`) + `dGetBits`, plus extra directory builds, which
+  overwhelm the ~1/3 intermediate-traffic savings. The general version also breaks
+  the 2-buffer ping-pong (L reads L+2, same parity). This was the one structural
+  lever to cut the O(depth) load-levels; it does not pay off. The decode is at its
+  A100 concurrency floor.
+
+### Session cumulative
+
+vs the round-1 baseline (32 KiB), ~2x on the previously-slow tier: json 51->101,
+log 52->105, pride 52->104, cat-wiki 52->~104, source_c 56->111, csv 71->144, dna
+102->191, chinese 65->112; skewed synthetics ~2x (proba02 50->100, bell_s30
+51->106, english 74->155); two-symbol 2.6-3.2x (335->928). Fast/flat tier
+unchanged. Seven committed wins (flat unpack, aligned merge loads, directory
+launch_bounds, directory-into-merge fusion, byte-wise readBits, CC vectorization,
+64 KiB blocks); megakernel/level-fusion rejected by a size sweep (the workload is
+parallelism-saturated, not L2-thrash bound). The vector/vector merge is now
+balanced/near-floor; further multiples would need a different algorithm (top-down
+was ~2x slower).
+
+## Round 8 -- shared-memory staging of the merge inputs (cp.async) -- REJECTED
+
+Directive: stage the vec/vec & cst/vec merge child inputs in shared memory to fix
+the "each thread loads from a different region" (scattered DRAM gather) pattern.
+Pursued exhaustively (two research sub-agents, profile-driven), then reverted as a
+net regression. Full A/B (real datasets, GiB/s), staged vs committed baseline:
+
+| dataset | baseline | staged (final) | ratio |
+|---|---|---|---|
+| dna | 190.6 | 174.0 | 0.91 |
+| calgary | 191.6 | 171.3 | 0.89 |
+| json | 101.1 | 88.4 | 0.87 |
+| log | 104.5 | 90.9 | 0.87 |
+| csv | 144.3 | ~150 | 1.04 (only win) |
+
+Design (all correct, verified): rank is monotonic, so a contiguous output chunk
+reads a contiguous slice of each child. Chunk the node (2048 outputs); cp.async
+double-buffer each child's slice global->shared (coalesced) overlapped with the
+prior chunk's merge; merge with the compute-light `byteMerge8` from shared, folding
+the chunk's child base into the shared pointer so the per-output cursor math equals
+the non-staged path. Iterated: naive stage (dna 109) -> warp-shuffle expand (55-71,
+too ALU-heavy) -> transpose STG.64 stores -> cp.async double-buffer + byteMerge8
+(147) -> buffer-pointer consolidation 40->32 regs => 6->8 blocks/SM, 92% occ (170)
+-> geom carry (174). `__launch_bounds__` spills (hurts); chunk 2048 optimal.
+
+**Why it loses (profiled, definitive):**
+- Baseline big VV: DRAM 63% / ALU 52% / 481us -- **DRAM-latency-bound** on the
+  scattered gather (23.8-cyc memory-scoreboard stall), ALU has slack. `dLoad8Aligned`
+  (aligned `__ldg` + funnelshift) already dedups sectors, so it moves ~min DRAM.
+- Staged big VV: coalescing worked (moves the load off the critical path) but the
+  kernel becomes **ALU-bound at 69% / DRAM 54% / 569us**. It executes ~1.5x the
+  baseline's ALU (96M vs ~61M). Attacked that ALU three ways -- fold child base into
+  the pointer (no change; compiler already CSE'd it), byte-aligned chunk-rank (worse),
+  carry geometry to halve rank lookups (+1-2%) -- the ~1.5x gap resists reduction.
+- Net: coalescing the load cannot speed up a merge whose real limit, once coalesced,
+  is per-output integer work; the extra staging ALU exceeds the DRAM saving.
+
+Lesson: the scattered child gather is NOT wasting DRAM (the aligned read-only load
+already coalesces it); the merges are latency-bound at the A100 concurrency floor,
+and the true ceiling is per-output ALU (rank + byteMerge8 + window extraction),
+which staging adds to rather than removes. Reverted to the baseline merges. The
+cp.async staged implementation is preserved in IDEAS.md as the best-known staged
+design (a foundation if the per-output ALU is ever cut, e.g. a cheaper rank/expand).
+
+## Round 9 -- chunked top-down decode entirely in shared memory (IN PROGRESS, behind PIVCO_CHUNK_TD)
+
+New single-kernel decoder: a warp owns one contiguous CHUNK (S=1024 outputs) of a
+block and decodes the WHOLE tree for that chunk with all intermediate node streams
+resident in shared -- only bitmaps/flat-indices read from L2, output written once.
+Enabled with PIVCO_CHUNK_TD=1 (default path unchanged). Dispatch: parse ->
+directory (per-node rank dirs for the descent) -> pivcoChunkTopDownKernel.
+
+Structure (3 research rounds informed it): Phase 0 builds per-level node lists in
+shared (CTA-wide). Phase 1 = warp-parallel top-down descent (levels serial, nodes
+within a level 32-wide; two boundary ranks/node from the L2 directory give each
+child's contiguous chunk sub-range; streamOff via warp scan). Phase 2 = bottom-up
+merge (deepest level first) in the 2*S ping-pong shared buffers, byteMerge8 with a
+warp-scan group rank (no per-group directory read). Phase 3 = coalesced flush.
+
+Correctness: verified on all 11 real datasets (compute-sanitizer caught & fixed a
+CC-children uninitialized-subLen OOB). Progress (dna / json / calgary / log GiB/s):
+lane-0 serial descent + 1-out/lane merge 42/18/24/19 -> warp-parallel descent +
+per-level lists + flat 2-byte window 56/28/43/29 -> byteMerge8 + warp-scan rank
+64/30/42/31.
+
+Profiling (json): **DRAM 4.2%** -- the design goal (near-zero global traffic,
+intermediates in shared) is ACHIEVED (baseline merge is 63% DRAM). Now
+COMPUTE-bound (SM 71%, ALU highest) and occupancy-limited (48%, register+shared cap
+at 4 blocks/SM). The dna(64)/json(30) split is the small-node pathology: many-symbol
+trees give each node a tiny per-chunk sub-range, so per-node warp overhead dominates.
+
+Still ~3-4x below baseline (193/103/194/106). Next levers (identified, not yet done):
+(1) load-balancing search per level (process a level's concatenated outputs 32-wide
+with node lookup, moderngpu MergePath) to kill the small-node overhead -- the top
+remaining win for json/calgary/log; (2) occupancy (cut registers/shared to reach 8
+blocks); (3) aligned uint64 store via 8-byte-padded streamOff. The design has
+cleared its highest-risk gate (collapsing the cascade to shared DOES drop DRAM to
+~4%); the remaining gap is compute/occupancy, not memory.
+
+### Round 9 continued -- chunk-TD optimizations + fundamental ceiling analysis
+
+Optimizations landed (all behind PIVCO_CHUNK_TD, correct on all 11 datasets;
+GiB/s at 268 MiB, dna / json / calgary / log):
+- warp-parallel descent + per-level node lists + flat 2-byte window: 56 / 28 / 43 / 29
+- byteMerge8 + warp-scan group rank: 64 / 30 / 42 / 31
+- __launch_bounds__(256,6) (occupancy 48%->72%): +occupancy
+- node-per-lane merge for >=8-node levels (32 small nodes in parallel): dna big win
+- loop-free descent rank (dRankOnesBeforeFast): json 32->35, calgary 46->49
+- aligned uint64 stores on 8-byte-padded few-node levels: json 35->38, calgary 49->52, dna ->75
+
+Current chunk-TD: dna 75, json 38, calgary 52, log 38 vs baseline 193/103/194/106.
+Profile (json): DRAM 5.5% (design goal met), compute-bound SM 78% / ALU 61%,
+occupancy 72%.
+
+**Fundamental ceiling (research round 3, confirmed):** PivCo's partition tree IS a
+(truncated) wavelet tree; reconstructing the root sequence from the per-node bitmaps
+is inherently Theta(n * avg-leaf-depth) = Theta(n log sigma) ALU -- every output is
+touched once per tree level on its root->leaf path. The BASELINE cascade does the
+SAME total ALU but is DRAM-latency-bound at 64 warps/SM, so that ALU runs for free
+in the shadow of memory stalls. The chunk-in-shared decoder deleted the DRAM
+traffic (63%->~5%) and thereby deleted the thing that was hiding the ALU, so the
+same work is now fully exposed and it is ~2-3x slower on deep (many-symbol) trees.
+To beat the baseline the chunk decoder must cut ALU ~3.2x (json) / ~2.2x (dna).
+
+Ruled out (research): table-driven multi-symbol decode is INFEASIBLE for this format
+-- symbol i's codeword bits are scattered one-per-level across the bitmaps at
+rank-dependent positions; there is no contiguous codeword stream to index, and
+assembling one IS the O(depth) walk. cp.async double-buffer / megakernel / plain
+shared-staging are all measured losses (the baseline's latency-hidden cascade is
+already the "overlap ALU behind idle memory" design). The one remaining decode-only
+lever is radix-K level fusion (cut the depth factor); the biggest lever overall
+(shallower trees / wider FLAT leaves) is an ENCODER change, out of scope here.
+
+Net: the chunk-TD is a correct, well-optimized realization of "decode entirely in
+shared" that achieves its stated goal (near-zero intermediate global traffic), but
+the workload is compute-bound once memory is removed, so it does not beat the
+DRAM-latency-hidden baseline on this GPU. It would win only where the baseline is
+DRAM-BANDWIDTH bound (not the case at 58% DRAM-SOL / latency-bound today).
+
+### Round 9 result -- chunk-TD wins for SMALL inputs; now auto-dispatched
+
+Key measured finding: although the chunk-in-shared decoder is ~2.5x slower than the
+bottom-up cascade at large sizes (compute/wavelet-tree-ALU bound), it is FASTER for
+small inputs because it runs only 3 kernel launches (parse, directory, chunk) vs the
+cascade's ~30 per-level launches, whose fixed ~5us/launch overhead dominates small
+decodes. Measured baseline vs chunk-TD (GiB/s):
+- 1 MiB:  json 3.6->8.4 (2.3x), calgary 5.0->9.1 (1.8x)
+- 4 MiB:  json 17->24 (1.4x), calgary 19->28, dna 45->54, log 28->33
+- 8 MiB:  all datasets still favor chunk-TD (~1.2x)
+- >=12 MiB: cascade pulls ahead (steady-state throughput wins)
+
+So decode is now **size-adaptive**: dstSize <= 8 MiB uses the chunk-TD kernel,
+larger uses the bottom-up cascade (unchanged). `PIVCO_CHUNK_TD=1` forces chunk-TD at
+any size; `PIVCO_CHUNK_TD=0` forces the cascade. This makes small-payload decode
+1.2-2.3x faster with zero large-input regression -- a real payoff from the top-down
+direction, distinct from (and orthogonal to) the large-input cascade work. Correct
+on all 11 datasets at small and large sizes.
+
+### Round 10 -- large-input chunk-TD is at the occupancy/issue floor (levers exhausted)
+
+Attacked the large-input chunk-TD again, driven by the ncu profile (compute/issue
+bound: SM 78%, ALU 61%, IPC 3.11/4, issue-slots ~78%, DRAM ~5%, 40 regs, 72%
+occupancy). Since the bottleneck is instruction ISSUE, the only real lever is fewer
+dynamic instructions per output byte. Went through them:
+
+- **Skip constant-child materialization** (CV/VC): landed (b83ce5421dd0). A CV/VC
+  merge emits its constant side from leftSym/rightSym and never reads that child's
+  stream, so zeroing the const child's subLen skips the fill. calgary 52->54, log
+  38->39 GiB/s @256MB, neutral elsewhere. Small clean win.
+
+- **Aligned uint64 stores on many-node (node-per-lane) levels: MEASURED -24%,
+  reverted.** `mergeNodeSingleLane`'s internal branch byte-stores (up to 8 STS.U8
+  per group) because node-per-lane buffers are byte-packed, not 8-aligned. The
+  few-node levels already 8-byte-pad for aligned stores (that was the +8.5% json
+  35->38 win). Extending padding+aligned-stores to levels with 8..31 nodes
+  (`kChunkTdPadThreshold=32`, templated `mergeNodeSingleLane<Aligned>`) cut the
+  store instruction count but grew the per-warp buffer by ~224 B, which crossed an
+  occupancy cliff (6->5 blocks). Same-size A/B @64MB forced chunk-TD:
+  json 37.1->28.3, calgary 63.2->48.1, dna 89.9->70.8, log 46.6->35.1 -- a uniform
+  ~-24%. The occupancy loss dwarfs the instruction savings. KEY INSIGHT: the kernel
+  is NOT purely issue-bound; its ~22% stall cycles are hidden by occupancy, so ANY
+  instruction cut that costs shared memory is net-negative. Padding ALL levels (for
+  full alignment) would ~2x the buffer (leaf level has up to ~256 nodes) and halve
+  occupancy -- strictly worse.
+
+- **byteMerge8 / dLoad8Shared: at the instruction floor.** byteMerge8 = 2
+  __byte_perm (minimal: each emits 4 of the 8 bytes) + 2 LUT loads; dLoad8Shared
+  already skips the 2nd shared load on the aligned path. No cheaper form.
+
+- **kMergeSel -> __constant__: rejected on analysis.** The LUT index (mask nibble)
+  is data-divergent per lane; constant memory only broadcasts on uniform access and
+  serializes divergent access, so it would be SLOWER than the current __device__
+  const (L1/L2-cached, parallel).
+
+Net for Round 10: the two shared-neutral instruction cuts are both measured losses
+(radix-4 -37% in ROOFLINE.md; aligned-store -24% here), and the kernel sits on an
+occupancy cliff so shared-costing cuts backfire. **The large-input chunk-TD is at
+its floor.** The bottom-up cascade remains the better large-input decoder (it hides
+the same wavelet-tree ALU behind DRAM latency; see Round 9), and chunk-TD stays the
+size-adaptive winner for small inputs (<=8 MiB). No decode-only lever beats the
+baseline on large inputs on this GPU; the only structural win left is an ENCODER
+change (shallower trees / wider FLAT leaves / quad-vector format), which is out of
+scope.
+
+**Latent issue discovered (pre-existing, not from this round):** compute-sanitizer
+on the forced chunk-TD path flags a 1-byte `__global__` over-read on the LAST block
+(`dRankOnesBeforeFast`/`bm[bi+1]`/`slice[bi+1]` read up to a few bytes past the
+bitstream, by design "into the trailing slop, all masked off"). For interior blocks
+the slop is the next block's bytes; the last block relies on `src` having trailing
+slop. Verified pre-existing (reproduces with the change reverted). Harmless in
+deployment (cudaMalloc rounds allocations up, and the bytes are masked off) but
+technically OOB when `src` is exactly sized. The bottom-up rank helpers share the
+pattern. Left as-is (fixing it means defining/padding a src-slop contract, orthogonal
+to decode perf); recorded here so a future robustness pass can add trailing src slop.
+
+### Round 11 -- WIN: size-adaptive chunk width (the chunk size was under-tuned)
+
+The occupancy-cliff insight from Round 10 (the kernel's stall cycles are hidden
+by occupancy, so shared-costing instruction cuts backfire) pointed at a lever I
+had NOT tried: change the CHUNK SIZE. Each per-chunk tree descent (Phase 0/1) is
+fixed overhead paid once per chunk; a wider chunk amortizes it over more outputs.
+Swept kChunkTdOutputs @64 MiB forced chunk-TD:
+
+- 512:  json 27, calgary 39, dna 59, log 30  (per-chunk overhead dominates)
+- 1024: json 37, calgary 63, dna 90, log 47  (the shipped value -- UNDER-TUNED)
+- 2048: json 44, calgary 76, dna 102, log 54 (+13-21%, dna breaks 100 GiB/s)
+- 4096: json 38, calgary 71, dna 88, log 47  (overshoots; buffer/occupancy loss)
+
+2048 is the optimum for large inputs. But the optima are OPPOSITE by size: tiny
+inputs want the small chunk (its extra chunks give the grid enough parallelism to
+fill the GPU -- at 4 MiB dna 1024=54 vs 2048=40), large inputs want the wide chunk
+(amortization). So the chunk size is now chosen at dispatch by input size and
+passed to the kernel at RUNTIME (S and the per-warp buffer are runtime; the shared
+budget is set per launch). No templating needed -- S only appears in arithmetic.
+
+The wider chunk lifts the chunk decoder's steady-state enough to push the
+crossover with the bottom-up cascade from ~8 MiB out to ~12 MiB. Measured
+crossover (same-run A/B): auto wins at 12 MiB for every dataset (+4..+27%); at
+16 MiB it is mixed (dna +14% but calgary -7% -- deep 256-symbol trees cross
+earliest). So the flat auto threshold is 12 MiB.
+
+Shape gate for the one exception: gzip_random.gz (incompressible, shallow tree,
+tableLog 8) has a fast baseline (few merge levels -> few launches) and crosses at
+~5-6 MiB, so a flat 12 MiB threshold regressed it -5%. Gating the wide auto window
+on tree depth fixes it cleanly: deep trees (tableLog >= 10) use chunk-TD to
+12 MiB, shallow trees cap at 4 MiB (where gzip still ties). tableLog cleanly
+separates the datasets (gzip=8; everything else 10-12).
+
+Final shipped result (A100, min-time GiB/s, decode only; no regression anywhere):
+- 4 MiB:  +41..+79% across all 11 real datasets (gzip +3%).
+- 10 MiB: +15..+38% across all 11 real datasets (gzip +0%, uses baseline).
+- >12 MiB: unchanged (baseline; chunk-TD still loses there per Rounds 9-10).
+
+Tests 11/11; compute-sanitizer clean on the 2048 path. Committed b2bb5b0278cb.
+This is the payoff from the top-down direction on medium inputs: the 8-12 MiB
+regime was baseline-only before and is now chunk-TD, and the whole <=12 MiB range
+is faster. Note the large-input (>12 MiB) decode is still the cascade -- the
+Round 10 floor stands there; the win is that the chunk decoder's own ceiling rose
+enough to extend its regime.
+
+## Round 12 (2026-07-20) -- WIN: vectorized the flat-root fast path
+
+Every prior round optimized the scheduled-cascade slow tier and treated the two
+`fastMode` paths as done. Re-profiling from scratch (taking the docs "with a grain
+of salt") showed one of them was ~4x below its own roofline.
+
+`fastDecodeFlatRootKernel` handles the case where the whole tree is a single flat
+leaf: uniform / incompressible / small-alphabet data (uniform, gzip_random,
+sparse_4/16, flat_M3/5/6/7). It was decoding ONE symbol per thread -- a dependent
+1-2 byte load, a bank-conflicted 256-entry shared gather, and a byte store per
+output. This is exactly the shape `scheduledFlatKernel` had already been optimized
+away from (Round 2's "multi-symbol per-thread flat unpack"), but the fast-root twin
+never got the same treatment.
+
+`ncu` on `uniform` (depth-8 flat root, 128 MiB): DRAM 23.2% / compute 21.1% / mem
+24.5% SOL, 4.48M shared bank conflicts, 574 us. Neither pipe near its roof --
+purely latency-bound on the per-symbol dependent load + conflicted gather. At
+246 GiB/s it *looked* fast next to the 100 GiB/s deep-tree tier, but its own DRAM
+roofline (2 B/out) is ~930 GiB/s.
+
+Fix: rewrote the kernel to the scheduled-flat shape -- 8 outputs per thread, one
+packed load of the group's `depth` bytes via `dLoad8Bounded`, unpack the eight
+`depth`-bit indices from the register, one shared-table lookup each, one coalesced
+8-byte store, with depth-2 MLP (two groups' loads issued before either unpack). A
+single unified path covers depths 1-8 (depth 8 -> mask 0xFF, each packed byte is
+one index). `out = dst + blockOff` is 8-byte aligned (blockOff is a multiple of the
+block size) with `PIVCO_GPU_DECODE_DST_SLOP` trailing slop, so the final group's
+over-store is harmless -- same store contract as the merge kernels.
+
+Result (256 MiB, 15 iters, decode_median_GiBps), vs the round-1 baseline:
+
+| dataset | before | after | delta |
+|---|---|---|---|
+| sparse_4 | 280.3 | 884.6 | +216% |
+| flat_M3 | 233.0 | 827.6 | +255% |
+| sparse_16 | 272.8 | 790.1 | +190% |
+| flat_M5 | 268.9 | 718.1 | +167% |
+| flat_M6 | 263.4 | 682.0 | +159% |
+| gzip_random.gz | 244.6 | 654.5 | +168% |
+| flat_M7 | 262.8 | 654.5 | +149% |
+| uniform | 246.6 | 622.8 | +153% |
+
+Every other dataset (which takes the cascade / three-symbol paths) is within
++-0.5%. Aggregate over all 30 datasets: geomean 189.2 -> 248.9 GiB/s (+31.5%),
+arithmetic mean 232.5 -> 357.7 GiB/s (+53.9%). No regressions. Byte-identical
+output; GPU tests 11/11; partial-final-block over-store verified against a
+non-block-aligned size (`--size=33554321`).
+
+TRIED-NO-WIN this round (reverted, both in the ~+-12% per-build code-layout noise
+with real regressions on some datasets):
+- Lowering `kBottomUpChunkedMergeThreshold` (vectorize small merge nodes): helped
+  calgary/csv/zipfian but regressed chinese_text -10% (mid-size nodes prefer the
+  scalar path's full-CTA occupancy over byteMerge's thread underutilization); the
+  scalar/vector crossover is data-dependent, so no single threshold wins.
+- `dLoadLe32Masked` single-load fast path for the common interior word: mixed
+  bidirectional swings (source_c/dna +11-13%, chinese/csv -12%) that tracked the
+  build, not the change.
+
+Independent `ncu` re-confirmed the deep-tree slow tier is unmoved and at its floor:
+the VV merge (~68% of json decode) is latency-bound, not throughput-bound -- across
+its per-level launches compute peaks ~71%, DRAM peaks ~64%, neither saturates,
+CPI ~19-30 at ~78% occupancy with warps maxed (64/SM). Consistent with the prior
+rounds' concurrency-floor conclusion; a further multiple there needs an algorithm
+or wire-format change, not a kernel tweak.
+
+Lesson: audit the "already fast" fast paths against their OWN roofline, not against
+the slow tier -- 250 GiB/s was 4x under ceiling.

--- a/contrib/pivco-huffman/gpu/IDEAS.md
+++ b/contrib/pivco-huffman/gpu/IDEAS.md
@@ -1,0 +1,369 @@
+# PivCo-Huffman GPU Decode — Optimization Idea Queue
+
+Working queue for the bottom-up decode optimization effort. High-level context in
+`DEVELOPMENT_LOG.md`; per-dataset numbers in `BENCHMARKS.md`. Status legend:
+**QUEUED** / **IN PROGRESS** / **DONE** / **TRIED-NO-WIN** / **REJECTED**.
+
+Profiling summary (json, the hardest deep-tree real file): decode ~51 GiB/s,
+split VV-merge ~47%, rank directory ~20%, flat ~15%, constant/vector ~6%, parse
+~6%. The VV merge is latency bound (Long Scoreboard 66% of cycles) on L2-resident
+child gathers, NOT DRAM bound (43% DRAM). Deep trees pay O(N x depth) merge work
+across a cascade of dependent per-level kernels. **The convergent conclusion from
+a 5-thread literature search: the bottleneck is the on-device dependent
+round-trip per tree level, not launch overhead or bandwidth. Highest-value moves
+either collapse the O(depth) cascade so intermediates stay on-chip, or run many
+independent dependency chains concurrently to hide the ~200-cycle L2 latency.**
+
+## Active queue (priority order)
+
+0. **REJECTED (measured -37%) — Radix-4 level fusion.** Implemented root-scoped
+   (buffer-safe: root writes dst): decode the root + its 2 internal children in one
+   kernel, gathering from the 4 grandchildren via 3 byteMerge8, skipping the
+   level-1 child materialization. Correct, but json 65 vs 103 GiB/s. The fused
+   child level operates at the data-dependent `childPos = node_rank0(j)` -- an
+   UNALIGNED bit position -- so its rank falls onto the slow general
+   `dRankSelectOnesBefore` (byte-by-byte `dLoadLe32Masked` + popcount) and its
+   bitmap bits onto `dGetBits`' bit-by-bit loop, plus a 3rd/2nd directory build;
+   this compute overwhelms the ~1/3 intermediate-traffic savings. The general
+   version would be worse (also breaks the 2-buffer ping-pong: a node at level L
+   reads L+2 which shares its buffer parity -> needs a 3rd buffer). Definitively
+   killed. (Below: the earlier analysis that predicted this.)
+
+   Earlier analysis (confirmed by the measurement): The child load is a
+   concurrency floor (round-7 research: Little's Law -- warps maxed, MLP=2
+   register-capped, latency fixed; `byte_perm` LUT expand already SotA;
+   scatter/running-cursor/wide-load/prefetch/cp.async all neutral-or-worse). The
+   structural lever would be fusing a node + its two INTERNAL children into one
+   kernel that gathers from the 4 grandchildren (3 byteMerge8: gc0,gc1->child0;
+   gc2,gc3->child1; child0,child1->parent), skipping child materialization.
+   Detailed analysis says it is likely net-negative on this workload, for the same
+   reasons the megakernel/cp.async lost:
+   - **Unaligned child level.** The fused child cursor `childPos = node_rank0(j)`
+     is data-dependent, so the child-level rank + bitmap-byte extraction fall off
+     the byte-aligned fast path onto bit-level ops -- extra compute on an already
+     58%-compute-SOL kernel.
+   - **Register pressure -> occupancy.** The 2-level byte_perm needs 4 grandchild
+     windows + 2 child windows live; ~48-64 regs drops from 8 to ~5 blocks/SM, and
+     the size sweep proved the workload is parallelism-saturated (losing blocks
+     hurts).
+   - **Upside only ~1/3.** It reads 4 grandchildren vs 6 stream-reads for two
+     normal levels (saves the 2 intermediate child reads + 2 writes), not a 2x load
+     cut. Root-only radix-4 == the old `Root2` fusion (+3-6%, previously removed as
+     not worth the complexity); the general version adds irregular-tree scheduling
+     on top. Verdict: high complexity + occupancy risk for ~1/3 traffic savings;
+     parked below the measured floor unless a future idea removes the unaligned
+     child-level cost.
+
+1. **QUEUED — Recover the `calgary_pic` -7% regression.** After the aligned-load
+   win, calgary's VV merge is compute bound (68% SM, 6.8% DRAM): its small
+   cache-resident child streams make the funnelshift cost more than the
+   sector-sharing saves. Options: cheaper byte funnel via PRMT (`__byte_perm` on
+   the two words instead of shift/or), or gate aligned vs unaligned load by a
+   compressibility/stream-size proxy. Payoff: recover one real-file regression;
+   risk: low.
+
+1b. **TRIED-NO-WIN — Explicit MLP in the merge (batch K chains).** [Strategy 5]
+   Restructured `byteMergeThread` into phases (all K ranks, then all K gathers,
+   then all K merges). K=2 gave ~1.5% (noise); K=4 regressed (occupancy 89->68%
+   from register pressure). The dependent rank->gather chain and register budget
+   cap the benefit. Reverted.
+
+2. **TRIED-NO-WIN — Warp-tile merge (coalesced load + `__shfl` distribute).**
+   Each warp loads a 256-output tile's child streams coalesced & non-overlapping
+   (2x vs the aligned load's 4x), warp-scans the rank, distributes 8-byte windows
+   via `__shfl`+funnelshift. Correct but json 51 vs 68 -- the shfl/scan compute
+   (4 shfl + 5-step scan per group) exceeds the halved memory traffic (same lesson
+   as the 1-byte warp-expand). `byte_perm` density + simple aligned loads win; the
+   merge inner loop is near-optimal. The 256-entry PRMT-LUT variant would pay the
+   same cross-lane distribution cost -- deprioritized.
+
+3. **REJECTED — Megakernel / hybrid level fusion in shared memory.** A
+   working-set size sweep (json, 20 iters) settles it: decode throughput *rises*
+   with more blocks -- 256blk 24, 512 46, 1024 61, 2048 78, 8192 84 GiB/s --
+   and plateaus at ~2048 blocks. If the level-synchronous schedule were L2-thrash
+   bound, a smaller (L2-resident) working set would be *faster* per byte; instead
+   it is *slower* (fewer blocks = under-occupied). The decode is parallelism /
+   latency bound and already parallelism-saturated at full size. Any block-sync
+   megakernel (or top-M shared fusion) trades away that block parallelism for L2
+   residency the workload does not need -- which is exactly why both prior
+   single-CTA attempts lost. Do not pursue. The 62% L2 hit / 38% DRAM on the
+   merge is not hurting because 8192-block parallelism hides the latency. Refocus:
+   per-kernel compute/latency and total work, not memory-residency restructuring.
+
+4. **QUEUED — Wide-lane rank/select (uint32/uint64 lane).** [Strategy 3] Replace
+   the 8-bit lane with a 32- or 64-output lane: one `__popc`/`__popcll` for the
+   lane's ones, a 5-step `__shfl_up_sync` warp scan for the cross-lane base, and
+   **derive rank0 = i - rank1** (drops a whole scan). Optional two-level sampled
+   popcount directory (superblock 512b + block 64b) per the GPU wavelet-tree
+   thesis (arxiv 2505.03372, A100 rank >=10x CPU). Payoff: medium-high; risk:
+   register pressure at uint64.
+
+5. **QUEUED (tooling) — Kernel-level microbenchmarks (ideal-case per-kernel
+   ceilings).** Build a standalone harness that runs each decode kernel (VV/CV/VC
+   merge, flat<depth>, directory build, parse) in isolation on synthetic inputs
+   sized to fit L2, repeated many times so inputs stay warm -- measuring each
+   kernel's *ideal* throughput (no level-cascade L2 thrash, no cross-kernel
+   interference). Compare against the in-pipeline nsys time to quantify how much
+   each kernel loses to the level-synchronous schedule (the suspected merge L2
+   thrash) vs its own inefficiency. This tells us, per kernel, whether it is at
+   its floor or has headroom, and directly sizes the megakernel/L2-residency
+   payoff before we build it. Payoff: high (de-risks and targets all further
+   per-kernel work); risk: low (pure measurement tooling). Do this early.
+
+6. **QUEUED — Directory kernel: pack small nodes, cut wasted CTAs.** Grid is
+   ~90k CTAs of 256 threads; most internal nodes are tiny and use ~1 warp.
+   Process several small nodes per CTA or use a smaller blockDim for the small
+   stage. (Now folded into the merge via dir-fusion on the bottom-up path; still
+   relevant for the top-down path's standalone directory kernel.) Payoff: low-med.
+
+6. **QUEUED — Rank-directory software prefetch.** [Strategy 6] Directory
+   addresses are index-derived and known ahead, so prefetch `rank[i+PDIST]` while
+   working on `i` (the child gather is NOT prefetchable -- depends on the rank).
+   Route child stream through `__ldg`/read-only path to spare the L1 the rank
+   loads use. Payoff: partial (first hop only); risk: low. Composes with idea 1.
+
+7. **QUEUED — cp.async double-buffer child gathers to shared.** [Strategy 7]
+   `cuda::memcpy_async`/`__pipeline_*`, 16-byte `.cg` copies, S=2/3 stages, to
+   overlap the L2 latency non-blockingly and off the register path. Only pays off
+   with real pipelining; largely subsumed by idea 3 if that lands. Payoff:
+   conditional; risk: medium.
+
+8. **QUEUED — L2 residency / eviction hints.** [Strategy 8] Cheap: tag ping-pong
+   reads `__ldcg`, raw input / final output `__ldcs`/`__stcs` (streaming), and
+   `discard` fully-consumed child streams. Bigger hammer: persist the small hot
+   metadata (rank directories) via `cudaAccessPolicyWindow` hitRatio=1.0 (footgun:
+   thrash if window > set-aside). Payoff: medium; risk: low (hints) / medium
+   (persist).
+
+9. **QUEUED — Parallelize `scheduledParseKernel` (1 thread/block today).** ~6%.
+   Cooperative parse across the CTA. Payoff: small; risk: low.
+
+10. **DONE (big win) — Block-size reselected to 64 KiB.** Sweep showed 16 KiB
+    slower (2x per-block overhead) and >32 KiB fell back to the generic decoder.
+    Raised `kRankSelectMaxBlockSize` to 64 KiB (merge shared dir ~8 KiB/CTA,
+    occupancy unchanged at 8 blocks/SM) and set the default to 64 KiB. LARGER
+    blocks (not smaller) win: the tree/node count is fixed by the symbol
+    distribution, so 64 KiB halves the block count and thus the per-block overhead
+    (parse, per-node directory builds, launches) at no merge cost. ~+15%
+    everywhere, slightly better ratio, no real-file regression. Committed. (Note:
+    CUDA Graphs would only remove host launch bubbles -- not the on-device
+    bottleneck -- so not pursued.)
+
+## Update (2026-07-20): DONE (big win) — vectorized the flat-root fast path
+
+The prior effort concentrated entirely on the scheduled-cascade slow tier and
+treated the "fast paths" as done. But `fastDecodeFlatRootKernel` was never given
+the multi-symbol treatment its scheduled sibling (`scheduledFlatKernel`) got:
+it decoded one symbol per thread (dependent 1-2 byte load + bank-conflicted
+256-entry shared gather + byte store). `ncu` on `uniform`: DRAM 23% / compute
+21% / mem 24% SOL, 4.5M shared bank conflicts -- ~4x below roofline, latency
+bound. Rewrote it as 8 outputs/thread + one packed load + register unpack + one
+coalesced 8-byte store + depth-2 MLP. Result: sparse/flat/uniform/gzip
+(flat-root data) +149..+255%; overall geomean 189->249 (+31.5%), arithmetic mean
+233->358 (+54%), no regressions, byte-identical, all tests pass. Lesson: audit the
+"already fast" fast paths against their own roofline -- 250 GiB/s looked fast next
+to the 100 GiB/s slow tier but was 4x under its own ceiling.
+
+Also re-confirmed (independent `ncu`, contradicting the earlier "at DRAM roofline"
+framing but agreeing with the concurrency-floor conclusion): the VV merge is
+*latency* bound, not throughput bound -- across its per-level launches compute
+peaks ~71%, DRAM peaks ~64%, neither saturates, CPI ~19-30 at ~78% occupancy with
+warps maxed. So the slow tier's remaining gap is dependent-load latency at a
+genuine concurrency floor, unmovable without an algorithm/format change.
+
+## Status (2026-07-18): queue largely exhausted
+
+Seven wins landed (flat unpack, aligned merge loads, directory launch_bounds,
+directory-into-merge fusion, byte-wise readBits, CC vectorization, 64 KiB blocks)
+-> ~2x on the slow tier this session. The vector/vector merge (now ~63% of the
+deep-tree cost) profiles balanced (58% compute, 60% memory, 91% occupancy) and is
+at its per-kernel floor; the workload is parallelism-saturated (megakernel
+REJECTED). Remaining queue items 4/6/7/8 all target the merge's memory/latency,
+which is no longer the sole limiter (it's balanced), so their expected payoff is
+now small; item 9 (parse) dropped to ~4% after 64 KiB. The kernel microbench
+(item 5) is built and confirms the floors.
+
+### Conclusion (2026-07-18): bottom-up decode is at its architectural floor
+
+A second research pass and trying its top idea (cp.async streaming) confirms it:
+the vector/vector merge is at its A100 floor -- balanced compute+memory, max
+occupancy (64 warps/SM), latency-bound on the monotone child stream, and every
+latency-hiding restructure (megakernel, warp-tile shuffle, cp.async shared
+streaming) loses to the plain `__ldg` + read-only-cache merge because the workload
+is parallelism-saturated and those schemes trade away occupancy / add overhead.
+MLP is register-capped; directory coarsening adds net compute; `__ldcg`/unaligned
+loads lose the sector dedup. Flat is output-bandwidth-bound; parse is at its
+serial floor; CC/directory are vectorized/fused. **Another multiple would require
+a different algorithm or hardware** (top-down ~2x slower; per-symbol walk
+diverges; Hopper TMA/DPX absent on A100 and don't map to byte routing). Session:
+~2x on the slow tier, multiple-x over the original baseline, no regressions.
+
+## Tried
+
+- **TRIED-NO-WIN — Break the child-load latency (round 7, research-driven).** The
+  merge is latency-bound on the dependent child load (rank->load->byte_perm).
+  Little's-Law framing (research agent): at the 64-warp/SM ceiling with MLP~2 and
+  fixed L2 latency, `bytes_in_flight` is pinned, so only MLP or latency are free.
+  Tried: (a) `prefetch.global.L2` a fixed distance (512 B) ahead of the monotone
+  child cursor -- neutral (ptxas often elides it; the monotone window is already
+  L2-warm from read-only-cache sector reuse); (b) explicit depth-2 software
+  pipeline (issue next group's rank+loads before consuming current) -- neutral,
+  because `unroll=2` already gives MLP=2 and deeper is register-capped (the K=4
+  cliff). Warp-specialization and L2 persisting-window were assessed as
+  net-negative/bounded for this parallelism-saturated profile. Confirms the merge
+  is at a genuine concurrency floor; a structural (algorithmic) change is required.
+- **TRIED-NO-WIN — cp.async double-buffered shared streaming of child slices
+  (research Idea 1).** The strongest novel idea: since rank is monotone, each
+  warp's contiguous output tile consumes two contiguous child slices, so
+  double-buffer them into a per-warp shared ring with `cp.async` (hiding the
+  L2/DRAM child-load latency off the critical path) and read child bytes from
+  shared. Implemented and correct, but json 75 vs 101 GiB/s -- the shared-staging
+  + funnel-shift-from-shared + `__syncwarp`/pipeline overhead exceeds the latency
+  hiding. Same root cause as the megakernel: the workload is parallelism-saturated
+  at max occupancy, so the plain `__ldg` merge (HW unaligned load + read-only
+  cache sector dedup) already hides the latency with its 64 warps/SM, and any
+  shared-buffer scheme just adds overhead. This also moots research Ideas 2 (only
+  helps paired with Idea 1) and 3 (streaming fusion built on Idea 1). Reverted.
+- **TRIED-NO-WIN — `__ldcg` (cache-global, bypass read-only) child loads.** Net
+  -2-3% vs `__ldg`; the read-only cache's cross-thread sector dedup on the
+  overlapping monotone child windows is worth more than L1 bypass. Reverted.
+- **DONE (tooling) — `PIVCO_KERNEL_TIMING` per-kernel microbench.** Env-gated
+  per-stage CUDA-event timing in the bottom-up dispatch; prints the isolated
+  per-kernel GPU time (parse + each merge/flat op). Off by default (perf path
+  unchanged). Confirmed the vector/vector merge is ~60% (json mergeVV=0.93ms) and
+  the constant/vector merge dominates skewed real files (calgary CV>VV).
+- **TRIED-NO-WIN — Unaligned load for the constant/vector merge.** CV/VC profile
+  as compute bound (58% SM, memory headroom), so I tried the plain unaligned load
+  (no funnel-shift) for the single vector child, keeping aligned for VV. Regressed
+  (calgary 192->178): even "compute-bound" CV is really latency-bound (43%
+  no-eligible), and the aligned read-only load's sector sharing beats the saved
+  funnel-shift compute. The aligned load is universally best. Reverted.
+- **DONE — Aligned read-only child loads in the merge (`dLoad8Aligned`).** Two
+  aligned `__ldg` 8-byte loads + funnelshift instead of one unaligned load;
+  overlapping thread windows share sectors via the read-only cache. VV merge -26%.
+  Decode +30-68% on merge-heavy datasets. Committed. (Realizes the coalescing goal
+  of queue idea 2 more simply than the PRMT-LUT expand, which remains available to
+  stack on top.)
+- **DONE — Multi-symbol per-thread flat unpack.** 8 outputs/thread, one load of
+  the group's `Depth` bytes, unpack 8 indices, coalesced 8-byte store. flat1 on
+  dna 2.7x (943->350 us). Decode: dna 102->120, json 51->58, csv 71->77. Committed.
+- **DONE — Directory `__launch_bounds__(256, 8)`.** 40->32 regs, 63->85%
+  occupancy. Directory kernel 522->449 us (~14%). Committed.
+- **REJECTED — Warp expand merge at 1 byte/lane.** json 27.8 vs ~51 (2x slower);
+  no single-instruction GPU warp expand, 2 shfl+ballot+popc per output with no
+  ILP. Matches extras/gpu Metal notes ("1 byte per lane too thin").
+- **TRIED-NO-WIN — Merge `#pragma unroll` 4 and/or `__launch_bounds__`.** VV merge
+  time unchanged (already 8 blocks/SM; compiler didn't reorder to batch loads --
+  hence explicit-MLP idea 1).
+- **TRIED-NO-WIN (earlier) — Plain shared-staging of child streams.** Regressed
+  ~15%: moves efficient HW-unaligned 8-byte global loads to byte-wise shared
+  reads; intermediates already L2-resident.
+
+## Parked / structural (revisit if queue exhausted)
+
+- **Full single-CTA-per-block tree walk** (all levels in shared). Lost before;
+  idea 3 is the salvageable hybrid.
+- **Per-symbol top-down rank/select walk** (no intermediate streams). Killer is
+  warp divergence + scattered bitmap reads.
+- **DONE (big win, not break-even) — Fuse directory build into the merge.** Each
+  merge kernel now builds its node's rank directory in shared memory
+  (`buildSharedDirectory`) and the standalone directory kernel is dropped on the
+  bottom-up path. The earlier "break-even" estimate missed that the standalone
+  kernel forced a redundant bitmap DRAM re-read (evicted from L2 between the two
+  launches) plus the directory global write+read. +40-92% across merge-heavy
+  datasets; also recovered the calgary aligned-load regression. Committed.
+- Wire-format tricks that do NOT apply (fixed bitstream): GDeflate/Brotli-G 32-way
+  substream swizzle, DietGPU interleaved rANS, Yamamoto gap arrays, Weissenberger
+  self-sync. Relevant only if a format revision is ever on the table.
+
+## Investigated & rejected: cp.async shared-staging of merge inputs (round 8)
+
+Staging the vec/vec & cst/vec child inputs into shared (cp.async double-buffered,
+coalesced) was built end-to-end and REJECTED as a net ~10% regression (see
+DEVELOPMENT_LOG round 8 for the A/B and profiling). Keep as the best-known staged
+design if per-output merge ALU is ever reduced:
+- Rank is monotonic => a contiguous output chunk maps to a contiguous slice of each
+  child (numL+numR == chunk outputs). Chunk = 2048 outputs.
+- cp.async (`__pipeline_memcpy_async`, 8B, from the 8-aligned floor + head offset)
+  double-buffers each child slice global->shared, overlapped with the prior chunk's
+  merge (`__pipeline_commit` / `__pipeline_wait_prior(1)`).
+- Merge with `byteMerge8` from shared (`dLoad8Shared`), folding the chunk's child
+  base into the shared pointer so per-output cursor math == the global path.
+- Consolidate the 2 parity buffers into one array/child (base+parity*stride) to keep
+  registers at 32 => 8 blocks/SM (92% occupancy). `__launch_bounds__` spills.
+- Blocker: becomes ALU-bound (~1.5x baseline ALU); the coalescing doesn't help
+  because the baseline is already DRAM-min (aligned read-only gather dedups sectors).
+
+Follow-on ideas that WOULD make staging (or the baseline) win -- all target
+per-output merge ALU, the true ceiling:
+- Cheaper rank: avoid `dRankSelectOnesBeforeAligned` per 8-output group; derive
+  intra-group rank from the bitmap word via `__popc` (warp-cooperative) so only one
+  directory read per 32 outputs.
+- Lighter window extraction: the `dLoad8*` funnelshift is 2 loads + shifts/child;
+  find a merge that needs fewer per-output integer ops.
+- Per-node dispatch: staging wins on csv (+4%); a shape/size heuristic could pick
+  staged vs baseline per node.
+
+## Chunk-TD (round 9) -- shipped for small inputs; next levers to raise the crossover
+
+Status: the chunk-in-shared top-down decoder is auto-dispatched for dstSize <= 8 MiB
+(1.3-2.3x faster there via 3 launches vs the cascade's ~30). Large inputs use the
+cascade (chunk-TD is wavelet-tree ALU-bound once DRAM is removed; ~2.5x slower).
+Raising the chunk-TD's throughput raises the crossover, expanding the win regime.
+
+Remaining decode-only levers (not yet done), ranked:
+1. **Radix-4 (2-level) fusion in shared** -- compute a node's output directly from
+   its 4 grandchildren, skipping the child level's materialization. Now viable
+   (shared kills the unaligned-rank penalty that made it -37% in L2). ~1.4-1.8x on
+   the merge, ~2x crossover. Complex: reconstruct both child windows in registers
+   via 2 extra byteMerge8 + 2 unaligned shared ranks per parent group; only when
+   both children are internal (fall back at leaf boundaries); partial-fusion per
+   node makes the ping-pong bookkeeping tricky. Highest value, highest risk.
+2. **Cursor-carry variant for small inputs** -- warp-per-block processing its
+   chunks sequentially carries per-node rank cursors, eliminating the directory
+   kernel (3 launches -> 2) and its build/read. Occupancy-irrelevant at small
+   scale (the only regime chunk-TD runs). Cuts fixed overhead where it matters.
+3. **Parse parallelism** -- scheduledParseKernel is <<<numBlocks,1>>> (serial tree
+   parse per block); at small sizes with few blocks it underutilizes. Inherently
+   serial per block (sequential bitstream), but helps both paths if parallelized.
+4. **Per-tree-depth crossover threshold** -- shallow trees (dna) win to ~12+ MiB,
+   deep (json) to ~10 MiB; a depth-aware threshold beats the fixed 8 MiB.
+
+Rejected (measured/analysed): table-driven multi-symbol decode (transposed bitmap
+layout has no codeword stream; assembling one IS the O(depth) walk); s_nodes shared
+cache (marginal -- kernel is ALU- not memory-bound).
+
+Aligned uint64 stores on many-node levels: **MEASURED -24% (Round 10), rejected.**
+Padding levels with 8..31 nodes (to 8-byte-align their stores, replacing ~8 STS.U8
+with 1 STS.U64) grew the per-warp buffer ~224 B and crossed a 6->5 block occupancy
+cliff; same-size @64MB A/B lost ~24% uniformly. **Occupancy-cliff insight:** the
+kernel's ~22% stall cycles are hidden by occupancy, so it is NOT purely issue-bound
+-- any instruction cut that costs shared memory backfires. This raises the risk on
+lever #1 (radix-4): even though it is shared-neutral, its 2 extra byteMerge8 +
+child-window regs per group add register pressure that could cross the register
+occupancy cliff (already at 40 regs / 6 blocks); combined with the -37% L2 result,
+its realistic ceiling is parity with the baseline, not a clear win.
+
+Latent (pre-existing): forced chunk-TD trips a 1-byte __global__ over-read on the
+last block under compute-sanitizer (rank/bitmap helpers read a few bytes past the
+bitstream by design, "into trailing slop, all masked off"; the last block has no
+next-block slop). Harmless in deployment (allocator rounding + masked off); a future
+robustness pass should give `src` a few bytes of trailing slop.
+
+## Round 11 outcome: chunk width was the lever (LANDED, b2bb5b0278cb)
+
+The occupancy-cliff insight (Round 10) pointed here: the per-chunk tree descent is
+fixed overhead, so a wider chunk amortizes it. Chunk width is now runtime-selected
+by input size (1024 tiny / 2048 >6 MiB) and the auto crossover is shape-gated on
+tree depth (deep tableLog>=10: 12 MiB; shallow: 4 MiB). Result: +41..79% @4 MiB and
++15..38% @10 MiB across all real datasets, no regression; the 8-12 MiB regime moved
+from cascade to chunk-TD. Note this raised the chunk decoder's CEILING (extending
+its regime), not the large-input floor -- >12 MiB is still the cascade (Round 10).
+
+Next levers if pushing further: (1) sweep the 1024/2048 boundary and the 12 MiB
+cap per tree shape (currently a coarse tableLog gate -- a smarter depth/skew model
+could reclaim the 16 MiB dna win without the calgary regression); (2) the descent
+(Phase 0/1) is now a larger fraction at 2048 -- parallelizing scheduledParseKernel
+(still <<<numBlocks,1>>>) or fusing the directory build would cut the fixed cost
+further and could push the crossover past 12 MiB. Radix-4 remains parity-ceilinged
+(-37% measured) and is not worth it.

--- a/contrib/pivco-huffman/gpu/PivCoBlockIndexTest.cpp
+++ b/contrib/pivco-huffman/gpu/PivCoBlockIndexTest.cpp
@@ -1,0 +1,249 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#include "openzl/dev/contrib/pivco-huffman/gpu/pivco_block_index.h"
+
+#include <algorithm>
+#include <cstddef>
+#include <cstdint>
+#include <vector>
+
+#include <gtest/gtest.h>
+
+#include "openzl/codecs/pivco_huffman/common_pivco_kernel.h"
+#include "openzl/codecs/pivco_huffman/decode_pivco_kernel.h"
+#include "openzl/codecs/pivco_huffman/encode_pivco_kernel.h"
+#include "openzl/zl_errors.h"
+
+namespace {
+
+struct Encoded {
+    std::vector<uint8_t> bytes;
+    size_t size;
+};
+
+Encoded encode(
+        const std::vector<uint8_t>& weights,
+        const std::vector<uint8_t>& data,
+        size_t blockSize)
+{
+    const int tableLog =
+            ZL_PivCoHuffman_computeTableLog(weights.data(), weights.size());
+    EXPECT_GE(tableLog, 0);
+    const size_t bound = ZL_PivCoHuffmanEncode_bound(data.size(), blockSize);
+    EXPECT_NE(bound, SIZE_MAX);
+    std::vector<uint8_t> encoded(bound);
+    std::vector<uint8_t> scratch(
+            ZL_PivCoHuffmanEncode_scratchElements(data.size(), blockSize));
+    const size_t encodedSize = ZL_PivCoHuffman_encode(
+            encoded.data(),
+            encoded.size(),
+            scratch.data(),
+            scratch.size(),
+            weights.data(),
+            weights.size(),
+            tableLog,
+            data.data(),
+            data.size(),
+            blockSize,
+            &ZL_PivCoHuffmanEncode_generic);
+    EXPECT_NE(encodedSize, SIZE_MAX);
+    encoded.resize(encodedSize);
+    return Encoded{ std::move(encoded), encodedSize };
+}
+
+std::vector<uint8_t> decodeSlice(
+        const std::vector<uint8_t>& weights,
+        const uint8_t* bitstream,
+        size_t bitstreamSize,
+        size_t decodedSize)
+{
+    std::vector<uint8_t> decoded(decodedSize);
+    std::vector<uint8_t> scratch(
+            ZL_PivCoHuffmanDecode_scratchBytes(decodedSize, decodedSize));
+    EXPECT_TRUE(ZL_PivCoHuffman_decode(
+            decoded.data(),
+            decoded.size(),
+            scratch.data(),
+            scratch.size(),
+            weights.data(),
+            weights.size(),
+            bitstream,
+            bitstreamSize,
+            decodedSize,
+            &ZL_PivCoHuffmanDecode_generic));
+    return decoded;
+}
+
+TEST(PivCoBlockIndexTest, EmptyInputReturnsSingleZeroOffset)
+{
+    uint64_t offset = 123;
+    const ZL_Report report =
+            pivcoFindBlockOffsets(&offset, 1, nullptr, 0, nullptr, 0, 0, 7);
+
+    ASSERT_FALSE(ZL_isError(report));
+    EXPECT_EQ(ZL_validResult(report), 1);
+    EXPECT_EQ(offset, 0);
+}
+
+TEST(PivCoBlockIndexTest, ConstantInputAllowsRepeatedZeroOffsets)
+{
+    std::vector<uint8_t> weights(8);
+    weights[7] = 1;
+    const std::vector<uint8_t> data(20, 7);
+    constexpr size_t kBlockSize = 7;
+
+    const Encoded encoded = encode(weights, data, kBlockSize);
+    ASSERT_EQ(encoded.size, 0);
+
+    std::vector<uint64_t> offsets(4, 99);
+    const ZL_Report report = pivcoFindBlockOffsets(
+            offsets.data(),
+            offsets.size(),
+            weights.data(),
+            weights.size(),
+            encoded.bytes.data(),
+            encoded.size,
+            data.size(),
+            kBlockSize);
+
+    ASSERT_FALSE(ZL_isError(report));
+    EXPECT_EQ(ZL_validResult(report), offsets.size());
+    EXPECT_EQ(offsets, (std::vector<uint64_t>{ 0, 0, 0, 0 }));
+}
+
+TEST(PivCoBlockIndexTest, OffsetsBoundIndependentlyDecodableSlices)
+{
+    const std::vector<uint8_t> weights{ 1, 1 };
+    const std::vector<uint8_t> data{ 0, 1, 1, 0, 1, 0, 0, 1, 1, 1,
+                                     0, 0, 1, 0, 1, 0, 1, 1, 0 };
+    constexpr size_t kBlockSize = 7;
+
+    const Encoded encoded = encode(weights, data, kBlockSize);
+    std::vector<uint64_t> offsets(4);
+    const ZL_Report report = pivcoFindBlockOffsets(
+            offsets.data(),
+            offsets.size(),
+            weights.data(),
+            weights.size(),
+            encoded.bytes.data(),
+            encoded.size,
+            data.size(),
+            kBlockSize);
+
+    ASSERT_FALSE(ZL_isError(report));
+    EXPECT_EQ(offsets.front(), 0);
+    EXPECT_EQ(offsets.back(), encoded.size);
+    EXPECT_TRUE(std::is_sorted(offsets.begin(), offsets.end()));
+
+    for (size_t block = 0; block + 1 < offsets.size(); ++block) {
+        const size_t decodedOffset = block * kBlockSize;
+        const size_t decodedSize =
+                std::min(kBlockSize, data.size() - decodedOffset);
+        const auto decoded = decodeSlice(
+                weights,
+                encoded.bytes.data() + offsets[block],
+                offsets[block + 1] - offsets[block],
+                decodedSize);
+        EXPECT_EQ(
+                decoded,
+                std::vector<uint8_t>(
+                        data.begin() + decodedOffset,
+                        data.begin() + decodedOffset + decodedSize));
+    }
+}
+
+TEST(PivCoBlockIndexTest, RejectsInvalidWeights)
+{
+    const std::vector<uint8_t> weights{ 13 };
+    uint64_t offsets[2]    = {};
+    const ZL_Report report = pivcoFindBlockOffsets(
+            offsets, 2, weights.data(), weights.size(), nullptr, 0, 1, 1);
+
+    EXPECT_TRUE(ZL_isError(report));
+}
+
+TEST(PivCoBlockIndexTest, RejectsTruncatedBitstream)
+{
+    const std::vector<uint8_t> weights{ 1, 1 };
+    const std::vector<uint8_t> data{ 0, 1, 1, 0, 1, 0, 0 };
+    const Encoded encoded = encode(weights, data, data.size());
+    ASSERT_GT(encoded.size, 0);
+
+    uint64_t offsets[2]    = {};
+    const ZL_Report report = pivcoFindBlockOffsets(
+            offsets,
+            2,
+            weights.data(),
+            weights.size(),
+            encoded.bytes.data(),
+            encoded.size - 1,
+            data.size(),
+            data.size());
+
+    EXPECT_TRUE(ZL_isError(report));
+}
+
+TEST(PivCoBlockIndexTest, RejectsUnconsumedTrailingBytes)
+{
+    const std::vector<uint8_t> weights{ 1, 1 };
+    const std::vector<uint8_t> data{ 0, 1, 1, 0, 1, 0, 0 };
+    Encoded encoded = encode(weights, data, data.size());
+    encoded.bytes.push_back(0);
+
+    uint64_t offsets[2]    = {};
+    const ZL_Report report = pivcoFindBlockOffsets(
+            offsets,
+            2,
+            weights.data(),
+            weights.size(),
+            encoded.bytes.data(),
+            encoded.bytes.size(),
+            data.size(),
+            data.size());
+
+    EXPECT_TRUE(ZL_isError(report));
+}
+
+TEST(PivCoBlockIndexTest, RejectsBitmapCountMismatch)
+{
+    const std::vector<uint8_t> weights{ 2, 1, 1 };
+    const std::vector<uint8_t> data{ 0, 1, 2, 0, 2, 1, 0 };
+    Encoded encoded = encode(weights, data, data.size());
+    ASSERT_GT(encoded.size, 0);
+
+    encoded.bytes[0] ^= 1;
+
+    uint64_t offsets[2]    = {};
+    const ZL_Report report = pivcoFindBlockOffsets(
+            offsets,
+            2,
+            weights.data(),
+            weights.size(),
+            encoded.bytes.data(),
+            encoded.size,
+            data.size(),
+            data.size());
+
+    EXPECT_TRUE(ZL_isError(report));
+}
+
+TEST(PivCoBlockIndexTest, RejectsTooSmallOffsetBuffer)
+{
+    const std::vector<uint8_t> weights{ 1, 1 };
+    const std::vector<uint8_t> data{ 0, 1, 0, 1, 0, 1, 0, 1 };
+    const Encoded encoded  = encode(weights, data, 3);
+    uint64_t offsets[2]    = {};
+    const ZL_Report report = pivcoFindBlockOffsets(
+            offsets,
+            2,
+            weights.data(),
+            weights.size(),
+            encoded.bytes.data(),
+            encoded.size,
+            data.size(),
+            3);
+
+    EXPECT_TRUE(ZL_isError(report));
+}
+
+} // namespace

--- a/contrib/pivco-huffman/gpu/PivCoGpuBench.cpp
+++ b/contrib/pivco-huffman/gpu/PivCoGpuBench.cpp
@@ -1,0 +1,944 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#define HUF_STATIC_LINKING_ONLY
+
+#include "openzl/dev/contrib/pivco-huffman/gpu/pivco_gpu.cuh"
+
+#include <dirent.h>
+#include <sys/stat.h>
+#include <algorithm>
+#include <array>
+#include <chrono>
+#include <cmath>
+#include <cstddef>
+#include <cstdint>
+#include <cstdlib>
+#include <fstream>
+#include <iomanip>
+#include <iostream>
+#include <stdexcept>
+#include <string>
+#include <string_view>
+#include <vector>
+
+#include <cuda_runtime.h>
+
+#include "openzl/codecs/pivco_huffman/common_pivco_kernel.h"
+#include "openzl/codecs/pivco_huffman/decode_pivco_kernel.h"
+#include "openzl/codecs/pivco_huffman/encode_pivco_kernel.h"
+#include "openzl/dev/contrib/pivco-huffman/gpu/pivco_block_index.h"
+#include "openzl/fse/huf.h"
+#include "openzl/shared/histogram.h"
+#include "openzl/zl_errors.h"
+
+namespace {
+
+constexpr size_t kSyntheticBaseBytes = 8 * 1024 * 1024;
+
+struct Args {
+    size_t size = size_t{ 1 } << 30;
+    // 64 KiB is the reselected default: it decodes ~14-20% faster than 32 KiB
+    // (halves per-block overhead at no merge cost) with slightly better ratio,
+    // and is the max the scheduled fast path supports
+    // (kRankSelectMaxBlockSize).
+    size_t blockSize = 64 * 1024;
+    int iterations   = 20;
+    // Real benchmark inputs live in the upstream pivco-huffman repo under
+    // extras/datasets (https://github.com/MarcinZukowski/pivco-huffman). Clone
+    // it and pass --dataset-dir=<checkout>/extras/datasets; the default assumes
+    // the benchmark is run from an upstream checkout root.
+    std::string datasetDir = "extras/datasets";
+    std::string dataset;
+};
+
+struct Weights {
+    std::vector<uint8_t> bytes;
+    int tableLog;
+};
+
+struct Encoded {
+    std::vector<uint8_t> bytes;
+    std::vector<uint64_t> offsets;
+};
+
+struct DatasetInput {
+    std::string name;
+    std::string kind;
+    size_t sourceBytes;
+    std::vector<uint8_t> data;
+};
+
+struct Result {
+    std::string name;
+    std::string kind;
+    size_t sourceBytes;
+    size_t expandedBytes;
+    size_t compressedBytes;
+    size_t blocks;
+    size_t weightsSize;
+    int tableLog;
+    double ratio;
+    double decodeMedianMs;
+    double decodeMinMs;
+    double decodeMedianGiBps;
+    double decodeMinTimeGiBps;
+    double encodeMedianMs;
+    double encodeMinMs;
+    double encodeMedianGiBps;
+    double encodeMinTimeGiBps;
+    double h2dMs;
+    double d2hMs;
+};
+
+Args parseArgs(int argc, char** argv)
+{
+    Args args;
+    for (int i = 1; i < argc; ++i) {
+        const std::string_view arg(argv[i]);
+        const size_t eq = arg.find('=');
+        const std::string_view key =
+                eq == std::string_view::npos ? arg : arg.substr(0, eq);
+        const std::string value = eq == std::string_view::npos
+                ? ""
+                : std::string(arg.substr(eq + 1));
+        if (key == "--size") {
+            args.size = std::strtoull(value.c_str(), nullptr, 0);
+        } else if (key == "--block-size") {
+            args.blockSize = std::strtoull(value.c_str(), nullptr, 0);
+        } else if (key == "--iterations") {
+            args.iterations = std::atoi(value.c_str());
+        } else if (key == "--dataset-dir") {
+            args.datasetDir = value;
+        } else if (key == "--dataset") {
+            args.dataset = value;
+        } else {
+            throw std::runtime_error("unknown argument: " + std::string(arg));
+        }
+    }
+    return args;
+}
+
+std::string pathJoin(const std::string& dir, const std::string& name)
+{
+    if (!dir.empty() && dir.back() == '/') {
+        return dir + name;
+    }
+    return dir + "/" + name;
+}
+
+bool isDirectory(const std::string& path)
+{
+    struct stat st;
+    return stat(path.c_str(), &st) == 0 && S_ISDIR(st.st_mode);
+}
+
+bool isRegularFile(const std::string& path)
+{
+    struct stat st;
+    return stat(path.c_str(), &st) == 0 && S_ISREG(st.st_mode);
+}
+
+std::string resolveDatasetDir(const std::string& requested)
+{
+    if (isDirectory(requested)) {
+        return requested;
+    }
+
+    throw std::runtime_error(
+            "dataset directory does not exist: " + requested
+            + " -- clone https://github.com/MarcinZukowski/pivco-huffman and pass "
+              "--dataset-dir=<checkout>/extras/datasets");
+}
+
+std::vector<std::string> listDatasetFiles(const std::string& dir)
+{
+    DIR* const handle = opendir(dir.c_str());
+    if (handle == nullptr) {
+        throw std::runtime_error("cannot open dataset directory: " + dir);
+    }
+
+    std::vector<std::string> names;
+    while (dirent* const entry = readdir(handle)) {
+        const std::string name = entry->d_name;
+        if (name == "." || name == ".." || name == "README.md") {
+            continue;
+        }
+        if (isRegularFile(pathJoin(dir, name))) {
+            names.push_back(name);
+        }
+    }
+    closedir(handle);
+    std::sort(names.begin(), names.end());
+    return names;
+}
+
+std::vector<uint8_t> readFile(const std::string& path)
+{
+    std::ifstream file(path, std::ios::binary | std::ios::ate);
+    if (!file) {
+        throw std::runtime_error("cannot open dataset file: " + path);
+    }
+    const std::streamsize size = file.tellg();
+    file.seekg(0);
+    std::vector<uint8_t> data(size > 0 ? static_cast<size_t>(size) : 0);
+    if (size > 0 && !file.read(reinterpret_cast<char*>(data.data()), size)) {
+        throw std::runtime_error("failed to read dataset file: " + path);
+    }
+    return data;
+}
+
+uint64_t nextRandom(uint64_t& state)
+{
+    state ^= state << 13;
+    state ^= state >> 7;
+    state ^= state << 17;
+    return state;
+}
+
+uint64_t seedFromName(const std::string& name)
+{
+    uint64_t seed = 1469598103934665603ull;
+    for (const char c : name) {
+        seed ^= static_cast<uint8_t>(c);
+        seed *= 1099511628211ull;
+    }
+    return seed == 0 ? 0x9E3779B97F4A7C15ull : seed;
+}
+
+std::array<uint32_t, 256> probaCounts(int percent)
+{
+    std::array<uint32_t, 256> counts{};
+    uint32_t remaining = 2048;
+    for (size_t symbol = 0; symbol < counts.size() && remaining != 0;
+         ++symbol) {
+        uint32_t count = (remaining * static_cast<uint32_t>(percent)) / 100u;
+        if (count == 0) {
+            count = 1;
+        }
+        if (symbol + 1 == counts.size() || count > remaining) {
+            count = remaining;
+        }
+        counts[symbol] = count;
+        remaining -= count;
+    }
+    return counts;
+}
+
+std::array<uint32_t, 256> equalCounts(size_t distinct)
+{
+    std::array<uint32_t, 256> counts{};
+    for (size_t i = 0; i < distinct; ++i) {
+        counts[i] = 1;
+    }
+    return counts;
+}
+
+std::array<uint32_t, 256> bellCounts(double sigma)
+{
+    std::array<double, 256> weights{};
+    double sum = 0.0;
+    for (size_t i = 0; i < weights.size(); ++i) {
+        const double x = (static_cast<double>(i) - 127.5) / sigma;
+        weights[i]     = std::exp(-0.5 * x * x);
+        sum += weights[i];
+    }
+
+    std::array<uint32_t, 256> counts{};
+    const double scale = 65536.0 / sum;
+    for (size_t i = 0; i < counts.size(); ++i) {
+        counts[i] = std::max<uint32_t>(
+                1, static_cast<uint32_t>(std::llround(weights[i] * scale)));
+    }
+    return counts;
+}
+
+std::array<uint32_t, 256> englishCounts()
+{
+    std::array<uint32_t, 256> counts{};
+    counts[' ']  = 18288;
+    counts['e']  = 10266;
+    counts['t']  = 7517;
+    counts['a']  = 6532;
+    counts['o']  = 6160;
+    counts['n']  = 5701;
+    counts['i']  = 5668;
+    counts['s']  = 5317;
+    counts['r']  = 4988;
+    counts['h']  = 4979;
+    counts['l']  = 3318;
+    counts['d']  = 3283;
+    counts['u']  = 2276;
+    counts['c']  = 2234;
+    counts['m']  = 2027;
+    counts['f']  = 1983;
+    counts['w']  = 1703;
+    counts['g']  = 1624;
+    counts['p']  = 1504;
+    counts['y']  = 1428;
+    counts['b']  = 1260;
+    counts['v']  = 796;
+    counts['k']  = 560;
+    counts['x']  = 140;
+    counts['j']  = 98;
+    counts['q']  = 84;
+    counts['z']  = 51;
+    counts['.']  = 1200;
+    counts[',']  = 1000;
+    counts['\n'] = 800;
+    return counts;
+}
+
+std::array<uint32_t, 256> zipfianCounts()
+{
+    std::array<uint32_t, 256> counts{};
+    for (size_t i = 0; i < counts.size(); ++i) {
+        counts[i] = std::max<uint32_t>(
+                1,
+                static_cast<uint32_t>(
+                        std::llround(65536.0 / static_cast<double>(i + 1))));
+    }
+    return counts;
+}
+
+std::array<uint32_t, 256> geometricCounts()
+{
+    std::array<uint32_t, 256> counts{};
+    for (size_t i = 0; i < counts.size(); ++i) {
+        counts[i] = i < 31 ? (uint32_t{ 1 } << (30 - i)) : 1;
+    }
+    return counts;
+}
+
+std::vector<uint8_t> sampleCounts(
+        const std::string& name,
+        const std::array<uint32_t, 256>& counts,
+        size_t size)
+{
+    std::array<uint64_t, 256> cumulative{};
+    uint64_t total  = 0;
+    size_t distinct = 0;
+    for (size_t i = 0; i < counts.size(); ++i) {
+        if (counts[i] != 0) {
+            ++distinct;
+        }
+        total += counts[i];
+        cumulative[i] = total;
+    }
+    if (total == 0 || size < distinct) {
+        throw std::runtime_error("invalid synthetic distribution: " + name);
+    }
+
+    std::vector<uint8_t> data;
+    data.reserve(size);
+    for (size_t i = 0; i < counts.size(); ++i) {
+        if (counts[i] != 0) {
+            data.push_back(static_cast<uint8_t>(i));
+        }
+    }
+
+    uint64_t state = seedFromName(name);
+    while (data.size() < size) {
+        const uint64_t sample = nextRandom(state) % total;
+        const auto it =
+                std::upper_bound(cumulative.begin(), cumulative.end(), sample);
+        data.push_back(static_cast<uint8_t>(it - cumulative.begin()));
+    }
+
+    for (size_t i = data.size(); i > 1; --i) {
+        const size_t j = static_cast<size_t>(nextRandom(state) % i);
+        std::swap(data[i - 1], data[j]);
+    }
+    return data;
+}
+
+std::array<uint32_t, 256> syntheticCounts(const std::string& name)
+{
+    if (name == "proba80") {
+        return probaCounts(80);
+    }
+    if (name == "proba50") {
+        return probaCounts(50);
+    }
+    if (name == "proba14") {
+        return probaCounts(14);
+    }
+    if (name == "proba02") {
+        return probaCounts(2);
+    }
+    if (name == "bell_s10") {
+        return bellCounts(10.0);
+    }
+    if (name == "bell_s30") {
+        return bellCounts(30.0);
+    }
+    if (name == "bell_s80") {
+        return bellCounts(80.0);
+    }
+    if (name == "uniform") {
+        return equalCounts(256);
+    }
+    if (name == "english") {
+        return englishCounts();
+    }
+    if (name == "zipfian") {
+        return zipfianCounts();
+    }
+    if (name == "sparse_4") {
+        return equalCounts(4);
+    }
+    if (name == "sparse_16") {
+        return equalCounts(16);
+    }
+    if (name == "geometric") {
+        return geometricCounts();
+    }
+    if (name == "two_sym_eq") {
+        return equalCounts(2);
+    }
+    if (name == "two_sym_90/10") {
+        std::array<uint32_t, 256> counts{};
+        counts[0] = 9;
+        counts[1] = 1;
+        return counts;
+    }
+    if (name == "flat_M3") {
+        return equalCounts(8);
+    }
+    if (name == "flat_M5") {
+        return equalCounts(32);
+    }
+    if (name == "flat_M6") {
+        return equalCounts(64);
+    }
+    if (name == "flat_M7") {
+        return equalCounts(128);
+    }
+    throw std::runtime_error("unknown synthetic distribution: " + name);
+}
+
+std::vector<std::string> syntheticNames()
+{
+    return {
+        "proba80",  "proba50",   "proba14",   "proba02",    "bell_s10",
+        "bell_s30", "bell_s80",  "uniform",   "english",    "zipfian",
+        "sparse_4", "sparse_16", "geometric", "two_sym_eq", "two_sym_90/10",
+        "flat_M3",  "flat_M5",   "flat_M6",   "flat_M7",
+    };
+}
+
+std::vector<uint8_t> repeatToSize(
+        const std::vector<uint8_t>& source,
+        size_t targetSize)
+{
+    if (source.empty()) {
+        throw std::runtime_error("cannot repeat empty dataset");
+    }
+    std::vector<uint8_t> data(targetSize);
+    size_t written = 0;
+    while (written < data.size()) {
+        const size_t chunk = std::min(source.size(), data.size() - written);
+        std::copy_n(source.data(), chunk, data.data() + written);
+        written += chunk;
+    }
+    return data;
+}
+
+DatasetInput
+makeSyntheticInput(const std::string& name, size_t targetSize, size_t blockSize)
+{
+    const size_t baseSize =
+            std::max(blockSize + 1, std::min(targetSize, kSyntheticBaseBytes));
+    std::vector<uint8_t> base =
+            sampleCounts(name, syntheticCounts(name), baseSize);
+    return DatasetInput{
+        name,
+        "synthetic",
+        base.size(),
+        repeatToSize(base, targetSize),
+    };
+}
+
+DatasetInput makeRealInput(
+        const std::string& dir,
+        const std::string& name,
+        size_t targetSize,
+        size_t blockSize)
+{
+    std::vector<uint8_t> file = readFile(pathJoin(dir, name));
+    if (file.size() <= blockSize) {
+        throw std::runtime_error(
+                "dataset file must be larger than block size: " + name);
+    }
+    const size_t sourceBytes = file.size();
+    return DatasetInput{
+        name,
+        "real",
+        sourceBytes,
+        repeatToSize(file, targetSize),
+    };
+}
+
+Weights buildWeights(const std::vector<uint8_t>& data)
+{
+    if (data.empty()) {
+        return Weights{};
+    }
+    if (data.size() > UINT32_MAX) {
+        throw std::runtime_error("input is too large to histogram");
+    }
+
+    ZL_Histogram8 hist;
+    ZL_Histogram_init(&hist.base, 255);
+    ZL_Histogram_build(&hist.base, data.data(), data.size(), 1);
+
+    const uint32_t maxSymbol = hist.base.maxSymbol;
+    std::vector<uint8_t> weights(static_cast<size_t>(maxSymbol) + 1);
+    if (hist.base.cardinality == 1) {
+        weights[maxSymbol] = 1;
+        return Weights{ std::move(weights), 0 };
+    }
+
+    HUF_CREATE_STATIC_CTABLE(ctable, HUF_SYMBOLVALUE_MAX);
+    unsigned tableLog =
+            HUF_optimalTableLog(ZL_PIVCO_MAX_TABLE_LOG, data.size(), maxSymbol);
+    const size_t hufRet =
+            HUF_buildCTable(ctable, hist.base.count, maxSymbol, tableLog);
+    if (HUF_isError(hufRet)) {
+        throw std::runtime_error("HUF_buildCTable failed");
+    }
+    tableLog = static_cast<unsigned>(hufRet);
+    if (tableLog > ZL_PIVCO_MAX_TABLE_LOG) {
+        throw std::runtime_error("Huffman tableLog exceeds PivCo limit");
+    }
+
+    for (uint32_t symbol = 0; symbol <= maxSymbol; ++symbol) {
+        const unsigned numBits = HUF_getNbBitsFromCTable(ctable, symbol);
+        weights[symbol] =
+                numBits == 0 ? 0 : static_cast<uint8_t>(tableLog + 1 - numBits);
+    }
+    return Weights{ std::move(weights), static_cast<int>(tableLog) };
+}
+
+Encoded cpuEncode(
+        const Weights& weights,
+        const std::vector<uint8_t>& data,
+        size_t blockSize)
+{
+    const size_t bound = ZL_PivCoHuffmanEncode_bound(data.size(), blockSize);
+    if (bound == SIZE_MAX) {
+        throw std::runtime_error("encode bound overflow");
+    }
+    std::vector<uint8_t> encoded(bound);
+    std::vector<uint8_t> scratch(
+            ZL_PivCoHuffmanEncode_scratchElements(data.size(), blockSize));
+    const size_t encodedSize = ZL_PivCoHuffman_encode(
+            encoded.data(),
+            encoded.size(),
+            scratch.data(),
+            scratch.size(),
+            weights.bytes.data(),
+            weights.bytes.size(),
+            weights.tableLog,
+            data.data(),
+            data.size(),
+            blockSize,
+            &ZL_PivCoHuffmanEncode_generic);
+    if (encodedSize == SIZE_MAX) {
+        throw std::runtime_error("CPU encode failed");
+    }
+    encoded.resize(encodedSize);
+
+    const size_t numBlocks = (data.size() + blockSize - 1) / blockSize;
+    std::vector<uint64_t> offsets(numBlocks + 1);
+    const ZL_Report report = pivcoFindBlockOffsets(
+            offsets.data(),
+            offsets.size(),
+            weights.bytes.data(),
+            weights.bytes.size(),
+            encoded.data(),
+            encoded.size(),
+            data.size(),
+            blockSize);
+    if (ZL_isError(report)) {
+        throw std::runtime_error("offset indexing failed");
+    }
+    return Encoded{ std::move(encoded), std::move(offsets) };
+}
+
+void checkCuda(cudaError_t err, const char* what)
+{
+    if (err != cudaSuccess) {
+        throw std::runtime_error(
+                std::string(what) + ": " + cudaGetErrorString(err));
+    }
+}
+
+void checkStatus(const PivCoGpuStatus& status, const char* what)
+{
+    if (status.code != PIVCO_GPU_STATUS_OK) {
+        throw std::runtime_error(
+                std::string(what) + " status=" + std::to_string(status.code));
+    }
+}
+
+template <typename Fn>
+double timeHostMs(Fn&& fn)
+{
+    const auto start = std::chrono::steady_clock::now();
+    fn();
+    const auto end = std::chrono::steady_clock::now();
+    return std::chrono::duration<double, std::milli>(end - start).count();
+}
+
+template <typename Fn>
+std::vector<float> timeCudaMs(int iterations, cudaStream_t stream, Fn&& fn)
+{
+    cudaEvent_t start;
+    cudaEvent_t stop;
+    checkCuda(cudaEventCreate(&start), "cudaEventCreate(start)");
+    checkCuda(cudaEventCreate(&stop), "cudaEventCreate(stop)");
+
+    std::vector<float> times;
+    times.reserve(iterations);
+    for (int i = 0; i < iterations; ++i) {
+        checkCuda(cudaEventRecord(start, stream), "cudaEventRecord(start)");
+        fn();
+        checkCuda(cudaEventRecord(stop, stream), "cudaEventRecord(stop)");
+        checkCuda(cudaEventSynchronize(stop), "cudaEventSynchronize(stop)");
+        float elapsedMs = 0.0f;
+        checkCuda(
+                cudaEventElapsedTime(&elapsedMs, start, stop),
+                "cudaEventElapsedTime");
+        times.push_back(elapsedMs);
+    }
+
+    checkCuda(cudaEventDestroy(stop), "cudaEventDestroy(stop)");
+    checkCuda(cudaEventDestroy(start), "cudaEventDestroy(start)");
+    return times;
+}
+
+double median(std::vector<float> values)
+{
+    std::sort(values.begin(), values.end());
+    return values[values.size() / 2];
+}
+
+double minimum(const std::vector<float>& values)
+{
+    return *std::min_element(values.begin(), values.end());
+}
+
+double gibPerSecond(size_t bytes, double milliseconds)
+{
+    return static_cast<double>(bytes) / (1ull << 30) / (milliseconds / 1000.0);
+}
+
+Result runDataset(const Args& args, const DatasetInput& input)
+{
+    const Weights weights   = buildWeights(input.data);
+    const Encoded encoded   = cpuEncode(weights, input.data, args.blockSize);
+    const size_t numOffsets = encoded.offsets.size();
+    const size_t encodeBound =
+            ZL_PivCoHuffmanEncode_bound(input.data.size(), args.blockSize);
+    const size_t workspaceBytes = std::max(
+            pivcoGpuEncodeWorkspaceBytes(input.data.size(), args.blockSize),
+            pivcoGpuDecodeWorkspaceBytes(input.data.size(), args.blockSize));
+
+    PivCoGpuContext* context      = nullptr;
+    const ZL_Report contextReport = pivcoGpuContextCreate(
+            &context,
+            weights.bytes.data(),
+            weights.bytes.size(),
+            weights.tableLog);
+    if (ZL_isError(contextReport)) {
+        throw std::runtime_error("context creation failed");
+    }
+
+    uint8_t* src_d           = nullptr;
+    uint8_t* encoded_d       = nullptr;
+    uint8_t* gpuEncoded_d    = nullptr;
+    uint8_t* decoded_d       = nullptr;
+    uint8_t* workspace_d     = nullptr;
+    uint64_t* offsets_d      = nullptr;
+    uint64_t* gpuOffsets_d   = nullptr;
+    PivCoGpuStatus* status_d = nullptr;
+    uint64_t* totalSize_d    = nullptr;
+    cudaStream_t stream      = nullptr;
+
+    checkCuda(cudaStreamCreate(&stream), "cudaStreamCreate");
+    checkCuda(cudaMalloc(&src_d, input.data.size()), "cudaMalloc(src)");
+    checkCuda(
+            cudaMalloc(
+                    &encoded_d,
+                    encoded.bytes.size() + PIVCO_GPU_DECODE_SRC_SLOP),
+            "cudaMalloc(encoded)");
+    checkCuda(cudaMalloc(&gpuEncoded_d, encodeBound), "cudaMalloc(gpuEncoded)");
+    checkCuda(
+            cudaMalloc(
+                    &decoded_d, input.data.size() + PIVCO_GPU_DECODE_DST_SLOP),
+            "cudaMalloc(decoded)");
+    checkCuda(
+            cudaMalloc(&workspace_d, workspaceBytes), "cudaMalloc(workspace)");
+    checkCuda(
+            cudaMalloc(&offsets_d, numOffsets * sizeof(uint64_t)),
+            "cudaMalloc(offsets)");
+    checkCuda(
+            cudaMalloc(&gpuOffsets_d, numOffsets * sizeof(uint64_t)),
+            "cudaMalloc(gpuOffsets)");
+    checkCuda(
+            cudaMalloc(&status_d, sizeof(PivCoGpuStatus)),
+            "cudaMalloc(status)");
+    checkCuda(cudaMalloc(&totalSize_d, sizeof(uint64_t)), "cudaMalloc(total)");
+
+    const double h2dMs = timeHostMs([&] {
+        checkCuda(
+                cudaMemcpyAsync(
+                        src_d,
+                        input.data.data(),
+                        input.data.size(),
+                        cudaMemcpyHostToDevice,
+                        stream),
+                "cudaMemcpyAsync(src)");
+        checkCuda(
+                cudaMemcpyAsync(
+                        encoded_d,
+                        encoded.bytes.data(),
+                        encoded.bytes.size(),
+                        cudaMemcpyHostToDevice,
+                        stream),
+                "cudaMemcpyAsync(encoded)");
+        checkCuda(
+                cudaMemcpyAsync(
+                        offsets_d,
+                        encoded.offsets.data(),
+                        numOffsets * sizeof(uint64_t),
+                        cudaMemcpyHostToDevice,
+                        stream),
+                "cudaMemcpyAsync(offsets)");
+        checkCuda(cudaStreamSynchronize(stream), "cudaStreamSynchronize(H2D)");
+    });
+
+    for (int i = 0; i < 3; ++i) {
+        checkCuda(
+                cudaMemsetAsync(status_d, 0, sizeof(PivCoGpuStatus), stream),
+                "warm status");
+        checkCuda(
+                pivcoGpuDecodeAsync(
+                        context,
+                        decoded_d,
+                        input.data.size(),
+                        encoded_d,
+                        encoded.bytes.size(),
+                        offsets_d,
+                        numOffsets,
+                        args.blockSize,
+                        workspace_d,
+                        workspaceBytes,
+                        status_d,
+                        stream),
+                "warm decode");
+    }
+    checkCuda(cudaStreamSynchronize(stream), "warm sync");
+
+    const auto decodeTimes = timeCudaMs(args.iterations, stream, [&] {
+        checkCuda(
+                cudaMemsetAsync(status_d, 0, sizeof(PivCoGpuStatus), stream),
+                "decode status");
+        checkCuda(
+                pivcoGpuDecodeAsync(
+                        context,
+                        decoded_d,
+                        input.data.size(),
+                        encoded_d,
+                        encoded.bytes.size(),
+                        offsets_d,
+                        numOffsets,
+                        args.blockSize,
+                        workspace_d,
+                        workspaceBytes,
+                        status_d,
+                        stream),
+                "decode");
+    });
+
+    PivCoGpuStatus status{};
+    checkCuda(
+            cudaMemcpy(
+                    &status, status_d, sizeof(status), cudaMemcpyDeviceToHost),
+            "copy status");
+    checkStatus(status, "decode");
+
+    const auto encodeTimes = timeCudaMs(args.iterations, stream, [&] {
+        checkCuda(
+                cudaMemsetAsync(status_d, 0, sizeof(PivCoGpuStatus), stream),
+                "encode status");
+        checkCuda(
+                cudaMemsetAsync(totalSize_d, 0, sizeof(uint64_t), stream),
+                "encode total");
+        checkCuda(
+                pivcoGpuEncodeAsync(
+                        context,
+                        gpuEncoded_d,
+                        encodeBound,
+                        gpuOffsets_d,
+                        numOffsets,
+                        src_d,
+                        input.data.size(),
+                        args.blockSize,
+                        workspace_d,
+                        workspaceBytes,
+                        status_d,
+                        totalSize_d,
+                        stream),
+                "encode");
+    });
+    checkCuda(
+            cudaMemcpy(
+                    &status, status_d, sizeof(status), cudaMemcpyDeviceToHost),
+            "copy encode status");
+    checkStatus(status, "encode");
+
+    uint64_t gpuEncodedSize = 0;
+    checkCuda(
+            cudaMemcpy(
+                    &gpuEncodedSize,
+                    totalSize_d,
+                    sizeof(gpuEncodedSize),
+                    cudaMemcpyDeviceToHost),
+            "copy encoded size");
+    if (gpuEncodedSize != encoded.bytes.size()) {
+        throw std::runtime_error("GPU encoded size differs from CPU size");
+    }
+
+    std::vector<uint8_t> decoded(input.data.size());
+    const double d2hMs = timeHostMs([&] {
+        checkCuda(
+                cudaMemcpyAsync(
+                        decoded.data(),
+                        decoded_d,
+                        decoded.size(),
+                        cudaMemcpyDeviceToHost,
+                        stream),
+                "cudaMemcpyAsync(decoded)");
+        checkCuda(cudaStreamSynchronize(stream), "cudaStreamSynchronize(D2H)");
+    });
+    if (decoded != input.data) {
+        throw std::runtime_error("decode verification failed");
+    }
+
+    cudaFree(totalSize_d);
+    cudaFree(status_d);
+    cudaFree(gpuOffsets_d);
+    cudaFree(offsets_d);
+    cudaFree(workspace_d);
+    cudaFree(decoded_d);
+    cudaFree(gpuEncoded_d);
+    cudaFree(encoded_d);
+    cudaFree(src_d);
+    cudaStreamDestroy(stream);
+    pivcoGpuContextDestroy(context);
+
+    const double decodeMedian = median(decodeTimes);
+    const double decodeMin    = minimum(decodeTimes);
+    const double encodeMedian = median(encodeTimes);
+    const double encodeMin    = minimum(encodeTimes);
+    return Result{
+        input.name,
+        input.kind,
+        input.sourceBytes,
+        input.data.size(),
+        encoded.bytes.size(),
+        numOffsets - 1,
+        weights.bytes.size(),
+        weights.tableLog,
+        static_cast<double>(encoded.bytes.size()) / input.data.size(),
+        decodeMedian,
+        decodeMin,
+        gibPerSecond(input.data.size(), decodeMedian),
+        gibPerSecond(input.data.size(), decodeMin),
+        encodeMedian,
+        encodeMin,
+        gibPerSecond(input.data.size(), encodeMedian),
+        gibPerSecond(input.data.size(), encodeMin),
+        h2dMs,
+        d2hMs,
+    };
+}
+
+void printResult(const Result& result)
+{
+    std::cout << "dataset=" << result.name << " kind=" << result.kind
+              << " sourceBytes=" << result.sourceBytes
+              << " expandedBytes=" << result.expandedBytes
+              << " blocks=" << result.blocks
+              << " compressedBytes=" << result.compressedBytes
+              << " ratio=" << std::fixed << std::setprecision(4) << result.ratio
+              << " weightsSize=" << result.weightsSize
+              << " tableLog=" << result.tableLog
+              << " decode_median_ms=" << result.decodeMedianMs
+              << " decode_min_ms=" << result.decodeMinMs
+              << " decode_median_GiBps=" << result.decodeMedianGiBps
+              << " decode_min_time_GiBps=" << result.decodeMinTimeGiBps
+              << " encode_median_ms=" << result.encodeMedianMs
+              << " encode_min_ms=" << result.encodeMinMs
+              << " encode_median_GiBps=" << result.encodeMedianGiBps
+              << " encode_min_time_GiBps=" << result.encodeMinTimeGiBps
+              << " host_h2d_ms=" << result.h2dMs
+              << " host_d2h_ms=" << result.d2hMs << "\n";
+}
+
+} // namespace
+
+int main(int argc, char** argv)
+{
+    try {
+        const Args args = parseArgs(argc, argv);
+        if (args.size == 0 || args.blockSize == 0 || args.iterations <= 0) {
+            throw std::runtime_error(
+                    "--size, --block-size, and --iterations must be positive");
+        }
+        const size_t targetSize      = std::max(args.size, args.blockSize + 1);
+        const std::string datasetDir = resolveDatasetDir(args.datasetDir);
+
+        cudaDeviceProp props;
+        int device = 0;
+        checkCuda(cudaGetDevice(&device), "cudaGetDevice");
+        checkCuda(
+                cudaGetDeviceProperties(&props, device),
+                "cudaGetDeviceProperties");
+        checkCuda(
+                cudaDeviceSetLimit(cudaLimitStackSize, 64 * 1024),
+                "cudaDeviceSetLimit(stack)");
+
+        const std::vector<std::string> realFiles = listDatasetFiles(datasetDir);
+        const std::vector<std::string> synthetic = syntheticNames();
+        std::cout << "device=" << props.name << " targetSize=" << targetSize
+                  << " blockSize=" << args.blockSize
+                  << " iterations=" << args.iterations
+                  << " syntheticDatasets=" << synthetic.size()
+                  << " realDatasets=" << realFiles.size()
+                  << " datasetDir=" << datasetDir << "\n";
+
+        for (const std::string& name : synthetic) {
+            if (!args.dataset.empty() && args.dataset != name) {
+                continue;
+            }
+            printResult(runDataset(
+                    args,
+                    makeSyntheticInput(name, targetSize, args.blockSize)));
+        }
+        for (const std::string& name : realFiles) {
+            if (!args.dataset.empty() && args.dataset != name) {
+                continue;
+            }
+            printResult(runDataset(
+                    args,
+                    makeRealInput(
+                            datasetDir, name, targetSize, args.blockSize)));
+        }
+        return 0;
+    } catch (const std::exception& ex) {
+        std::cerr << "error: " << ex.what() << "\n";
+        return 1;
+    }
+}

--- a/contrib/pivco-huffman/gpu/PivCoGpuTest.cpp
+++ b/contrib/pivco-huffman/gpu/PivCoGpuTest.cpp
@@ -1,0 +1,988 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#include "openzl/dev/contrib/pivco-huffman/gpu/pivco_gpu.h"
+
+#include <algorithm>
+#include <cstddef>
+#include <cstdint>
+#include <vector>
+
+#include <cuda_runtime.h>
+#include <gtest/gtest.h>
+
+#include "openzl/codecs/pivco_huffman/common_pivco_kernel.h"
+#include "openzl/codecs/pivco_huffman/decode_pivco_kernel.h"
+#include "openzl/codecs/pivco_huffman/encode_pivco_kernel.h"
+#include "openzl/dev/contrib/pivco-huffman/gpu/pivco_block_index.h"
+#include "openzl/dev/contrib/pivco-huffman/gpu/pivco_gpu_tree.h"
+#include "openzl/zl_errors.h"
+
+namespace {
+
+template <typename T>
+class DeviceBuffer {
+   public:
+    DeviceBuffer()                               = default;
+    DeviceBuffer(const DeviceBuffer&)            = delete;
+    DeviceBuffer& operator=(const DeviceBuffer&) = delete;
+
+    ~DeviceBuffer()
+    {
+        if (ptr_ != nullptr) {
+            // Cast away the result: cudaFree is ignorable, but its HIP
+            // counterpart hipFree is [[nodiscard]], so an ignored return trips
+            // -Werror on the AMD build.
+            (void)cudaFree(ptr_);
+        }
+    }
+
+    cudaError_t reset(size_t count)
+    {
+        if (ptr_ != nullptr) {
+            // Cast away the result: cudaFree is ignorable, but its HIP
+            // counterpart hipFree is [[nodiscard]], so an ignored return trips
+            // -Werror on the AMD build.
+            (void)cudaFree(ptr_);
+        }
+        ptr_   = nullptr;
+        count_ = count;
+        if (count == 0) {
+            return cudaSuccess;
+        }
+        return cudaMalloc(&ptr_, count * sizeof(T));
+    }
+
+    T* get() const
+    {
+        return ptr_;
+    }
+
+    size_t size() const
+    {
+        return count_;
+    }
+
+   private:
+    T* ptr_{ nullptr };
+    size_t count_{ 0 };
+};
+
+struct Encoded {
+    std::vector<uint8_t> bytes;
+    std::vector<uint64_t> offsets;
+};
+
+Encoded cpuEncode(
+        const std::vector<uint8_t>& weights,
+        const std::vector<uint8_t>& data,
+        size_t blockSize)
+{
+    const int tableLog =
+            ZL_PivCoHuffman_computeTableLog(weights.data(), weights.size());
+    EXPECT_GE(tableLog, 0);
+    const size_t bound = ZL_PivCoHuffmanEncode_bound(data.size(), blockSize);
+    EXPECT_NE(bound, SIZE_MAX);
+
+    std::vector<uint8_t> encoded(bound);
+    std::vector<uint8_t> scratch(
+            ZL_PivCoHuffmanEncode_scratchElements(data.size(), blockSize));
+    const size_t encodedSize = ZL_PivCoHuffman_encode(
+            encoded.data(),
+            encoded.size(),
+            scratch.data(),
+            scratch.size(),
+            weights.data(),
+            weights.size(),
+            tableLog,
+            data.data(),
+            data.size(),
+            blockSize,
+            &ZL_PivCoHuffmanEncode_generic);
+    EXPECT_NE(encodedSize, SIZE_MAX);
+    encoded.resize(encodedSize);
+
+    const size_t numBlocks =
+            data.empty() ? 0 : (data.size() + blockSize - 1) / blockSize;
+    std::vector<uint64_t> offsets(numBlocks + 1);
+    const ZL_Report indexReport = pivcoFindBlockOffsets(
+            offsets.data(),
+            offsets.size(),
+            weights.data(),
+            weights.size(),
+            encoded.data(),
+            encoded.size(),
+            data.size(),
+            blockSize);
+    EXPECT_FALSE(ZL_isError(indexReport));
+    return Encoded{ std::move(encoded), std::move(offsets) };
+}
+
+std::vector<uint8_t> cpuDecode(
+        const std::vector<uint8_t>& weights,
+        const std::vector<uint8_t>& encoded,
+        size_t decodedSize,
+        size_t blockSize)
+{
+    std::vector<uint8_t> decoded(decodedSize);
+    std::vector<uint8_t> scratch(
+            ZL_PivCoHuffmanDecode_scratchBytes(decodedSize, blockSize));
+    EXPECT_TRUE(ZL_PivCoHuffman_decode(
+            decoded.data(),
+            decoded.size(),
+            scratch.data(),
+            scratch.size(),
+            weights.data(),
+            weights.size(),
+            encoded.data(),
+            encoded.size(),
+            blockSize,
+            &ZL_PivCoHuffmanDecode_generic));
+    return decoded;
+}
+
+PivCoGpuContext* createContext(const std::vector<uint8_t>& weights)
+{
+    PivCoGpuContext* context = nullptr;
+    const int tableLog =
+            ZL_PivCoHuffman_computeTableLog(weights.data(), weights.size());
+    const ZL_Report report = pivcoGpuContextCreate(
+            &context, weights.data(), weights.size(), tableLog);
+    EXPECT_FALSE(ZL_isError(report));
+    return context;
+}
+
+void copyToDevice(DeviceBuffer<uint8_t>& dst, const std::vector<uint8_t>& src);
+void copyToDevice(
+        DeviceBuffer<uint64_t>& dst,
+        const std::vector<uint64_t>& src);
+std::vector<uint8_t> copyBytesFromDevice(DeviceBuffer<uint8_t>& src, size_t n);
+
+std::vector<uint8_t> makeThreeSymbolData(size_t size)
+{
+    std::vector<uint8_t> data(size);
+    uint64_t state = 0x9E3779B97F4A7C15ull;
+    for (uint8_t& value : data) {
+        state ^= state << 13;
+        state ^= state >> 7;
+        state ^= state << 17;
+        const uint8_t r = static_cast<uint8_t>(state);
+        value           = r < 160 ? 0 : (r < 220 ? 1 : 2);
+    }
+    return data;
+}
+
+std::vector<uint8_t> makeFlatRootData(size_t size)
+{
+    std::vector<uint8_t> data(size);
+    for (size_t i = 0; i < data.size(); ++i) {
+        data[i] = static_cast<uint8_t>((i * 5 + i / 7) & 7);
+    }
+    return data;
+}
+
+std::vector<uint8_t> makeRankSelectData(size_t size)
+{
+    std::vector<uint8_t> data(size);
+    uint64_t state = 0xD1B54A32D192ED03ull;
+    for (uint8_t& value : data) {
+        state ^= state << 13;
+        state ^= state >> 7;
+        state ^= state << 17;
+        const uint8_t sample = static_cast<uint8_t>(state);
+        value = sample < 128 ? 0 : (sample < 192 ? 1 : (sample < 224 ? 2 : 3));
+    }
+    return data;
+}
+
+std::vector<uint8_t> makeDataForWeights(
+        const std::vector<uint8_t>& weights,
+        size_t size)
+{
+    std::vector<uint8_t> symbols;
+    for (size_t symbol = 0; symbol < weights.size(); ++symbol) {
+        if (weights[symbol] != 0) {
+            symbols.push_back(static_cast<uint8_t>(symbol));
+        }
+    }
+    EXPECT_FALSE(symbols.empty());
+
+    std::vector<uint8_t> data;
+    data.reserve(size);
+    for (uint8_t symbol : symbols) {
+        if (data.size() == size) {
+            return data;
+        }
+        data.push_back(symbol);
+    }
+    uint64_t state = 0xA0761D6478BD642Full;
+    while (data.size() < size) {
+        state ^= state << 13;
+        state ^= state >> 7;
+        state ^= state << 17;
+        data.push_back(symbols[state % symbols.size()]);
+    }
+    return data;
+}
+
+uint32_t scheduleOpBit(uint8_t op)
+{
+    return uint32_t{ 1 } << op;
+}
+
+uint32_t flatOpMask()
+{
+    uint32_t mask = 0;
+    for (uint8_t op = PIVCO_GPU_SCHEDULE_OP_FLAT1;
+         op <= PIVCO_GPU_SCHEDULE_OP_FLAT8;
+         ++op) {
+        mask |= scheduleOpBit(op);
+    }
+    return mask;
+}
+
+uint32_t requiredMergeOpMask()
+{
+    return scheduleOpBit(PIVCO_GPU_SCHEDULE_OP_MERGE_VECTOR_VECTOR)
+            | scheduleOpBit(PIVCO_GPU_SCHEDULE_OP_MERGE_CONSTANT_VECTOR)
+            | scheduleOpBit(PIVCO_GPU_SCHEDULE_OP_MERGE_CONSTANT_CONSTANT);
+}
+
+bool coverageComplete(uint32_t opMask)
+{
+    return (opMask & flatOpMask()) != 0
+            && (opMask & requiredMergeOpMask()) == requiredMergeOpMask();
+}
+
+uint32_t scheduleOpsFor(const PivCoGpuContext* context)
+{
+    uint32_t mask                          = 0;
+    const PivCoGpuDecodeSchedule& schedule = context->decodeSchedule;
+    EXPECT_NE(schedule.enabled, 0);
+    for (size_t level = 0; level <= schedule.maxLevel; ++level) {
+        for (uint8_t op = 0; op < PIVCO_GPU_SCHEDULE_OP_COUNT; ++op) {
+            const size_t index = level * PIVCO_GPU_SCHEDULE_OP_COUNT + op;
+            if (schedule.stageCount[index] != 0) {
+                mask |= scheduleOpBit(op);
+            }
+        }
+    }
+    return mask;
+}
+
+void collectScheduledCoverageWeights(
+        int tableLog,
+        int weight,
+        int remaining,
+        size_t symbols,
+        std::vector<int>& counts,
+        uint32_t* opMask,
+        std::vector<std::vector<uint8_t>>* weightCases)
+{
+    if (coverageComplete(*opMask) || symbols > 32) {
+        return;
+    }
+    if (weight == 0) {
+        if (remaining != 0 || symbols < 2) {
+            return;
+        }
+
+        std::vector<uint8_t> weights;
+        weights.reserve(symbols);
+        for (int w = tableLog + 1; w >= 1; --w) {
+            for (int i = 0; i < counts[w]; ++i) {
+                weights.push_back(static_cast<uint8_t>(w));
+            }
+        }
+
+        const int computedTableLog =
+                ZL_PivCoHuffman_computeTableLog(weights.data(), weights.size());
+        if (computedTableLog != tableLog) {
+            return;
+        }
+
+        PivCoGpuContext* context = nullptr;
+        const ZL_Report report   = pivcoGpuContextCreate(
+                &context, weights.data(), weights.size(), tableLog);
+        if (ZL_isError(report) || context == nullptr) {
+            return;
+        }
+        if (context->hostTree.fastMode == PIVCO_GPU_FAST_NONE
+            && context->decodeSchedule.enabled != 0) {
+            const uint32_t caseMask = scheduleOpsFor(context)
+                    & (flatOpMask() | requiredMergeOpMask());
+            if (((*opMask) | caseMask) != *opMask) {
+                *opMask |= caseMask;
+                weightCases->push_back(std::move(weights));
+            }
+        }
+        pivcoGpuContextDestroy(context);
+        return;
+    }
+
+    const int value = 1 << (weight - 1);
+    const int maxCount =
+            std::min<int>(remaining / value, static_cast<int>(32 - symbols));
+    for (int count = 0; count <= maxCount; ++count) {
+        counts[weight] = count;
+        collectScheduledCoverageWeights(
+                tableLog,
+                weight - 1,
+                remaining - count * value,
+                symbols + count,
+                counts,
+                opMask,
+                weightCases);
+        if (coverageComplete(*opMask)) {
+            break;
+        }
+    }
+    counts[weight] = 0;
+}
+
+std::vector<std::vector<uint8_t>> findScheduledCoverageWeights()
+{
+    uint32_t opMask = 0;
+    std::vector<std::vector<uint8_t>> weightCases;
+    for (int tableLog = 1; tableLog <= 8 && !coverageComplete(opMask);
+         ++tableLog) {
+        std::vector<int> counts(tableLog + 2);
+        collectScheduledCoverageWeights(
+                tableLog,
+                tableLog + 1,
+                1 << tableLog,
+                0,
+                counts,
+                &opMask,
+                &weightCases);
+    }
+    return weightCases;
+}
+
+void expectGpuDecodeMatchesCpuEncode(
+        const std::vector<uint8_t>& weights,
+        const std::vector<uint8_t>& data,
+        size_t blockSize)
+{
+    const Encoded encoded = cpuEncode(weights, data, blockSize);
+
+    PivCoGpuContext* context = createContext(weights);
+    ASSERT_NE(context, nullptr);
+    ASSERT_EQ(context->hostTree.fastMode, PIVCO_GPU_FAST_NONE);
+    ASSERT_NE(context->decodeSchedule.enabled, 0);
+
+    DeviceBuffer<uint8_t> bitstream;
+    DeviceBuffer<uint64_t> offsets;
+    DeviceBuffer<uint8_t> decoded;
+    DeviceBuffer<uint8_t> workspace;
+    copyToDevice(bitstream, encoded.bytes);
+    copyToDevice(offsets, encoded.offsets);
+    ASSERT_EQ(
+            cudaSuccess,
+            decoded.reset(data.size() + PIVCO_GPU_DECODE_DST_SLOP));
+    ASSERT_EQ(
+            cudaSuccess,
+            workspace.reset(
+                    pivcoGpuDecodeWorkspaceBytes(data.size(), blockSize)));
+
+    const ZL_Report decodeReport = pivcoGpuDecode(
+            context,
+            decoded.get(),
+            data.size(),
+            bitstream.get(),
+            encoded.bytes.size(),
+            offsets.get(),
+            offsets.size(),
+            blockSize,
+            workspace.get(),
+            workspace.size(),
+            nullptr);
+    ASSERT_FALSE(ZL_isError(decodeReport));
+    EXPECT_EQ(copyBytesFromDevice(decoded, data.size()), data);
+
+    pivcoGpuContextDestroy(context);
+}
+
+void copyToDevice(DeviceBuffer<uint8_t>& dst, const std::vector<uint8_t>& src)
+{
+    // Reserve PIVCO_GPU_DECODE_SRC_SLOP trailing bytes so the decoder's
+    // loop-free bitmap over-read stays in bounds when this buffer holds the
+    // compressed input (harmless for other byte buffers).
+    ASSERT_EQ(cudaSuccess, dst.reset(src.size() + PIVCO_GPU_DECODE_SRC_SLOP));
+    if (!src.empty()) {
+        ASSERT_EQ(
+                cudaSuccess,
+                cudaMemcpy(
+                        dst.get(),
+                        src.data(),
+                        src.size(),
+                        cudaMemcpyHostToDevice));
+    }
+}
+
+void copyToDevice(DeviceBuffer<uint64_t>& dst, const std::vector<uint64_t>& src)
+{
+    ASSERT_EQ(cudaSuccess, dst.reset(src.size()));
+    if (!src.empty()) {
+        ASSERT_EQ(
+                cudaSuccess,
+                cudaMemcpy(
+                        dst.get(),
+                        src.data(),
+                        src.size() * sizeof(uint64_t),
+                        cudaMemcpyHostToDevice));
+    }
+}
+
+std::vector<uint8_t> copyBytesFromDevice(DeviceBuffer<uint8_t>& src, size_t n)
+{
+    std::vector<uint8_t> out(n);
+    if (n != 0) {
+        EXPECT_EQ(
+                cudaSuccess,
+                cudaMemcpy(out.data(), src.get(), n, cudaMemcpyDeviceToHost));
+    }
+    return out;
+}
+
+std::vector<uint64_t> copyOffsetsFromDevice(
+        DeviceBuffer<uint64_t>& src,
+        size_t n)
+{
+    std::vector<uint64_t> out(n);
+    if (n != 0) {
+        EXPECT_EQ(
+                cudaSuccess,
+                cudaMemcpy(
+                        out.data(),
+                        src.get(),
+                        n * sizeof(uint64_t),
+                        cudaMemcpyDeviceToHost));
+    }
+    return out;
+}
+
+TEST(PivCoGpuTest, CpuEncodeGpuDecode)
+{
+    const std::vector<uint8_t> weights{ 2, 1, 1 };
+    const std::vector<uint8_t> data{ 0, 1, 2, 0, 2, 1, 0, 0, 2,
+                                     1, 1, 0, 2, 0, 1, 2, 2 };
+    constexpr size_t kBlockSize = 5;
+    const Encoded encoded       = cpuEncode(weights, data, kBlockSize);
+
+    PivCoGpuContext* context = createContext(weights);
+    ASSERT_NE(context, nullptr);
+
+    DeviceBuffer<uint8_t> bitstream;
+    DeviceBuffer<uint64_t> offsets;
+    DeviceBuffer<uint8_t> decoded;
+    DeviceBuffer<uint8_t> workspace;
+    copyToDevice(bitstream, encoded.bytes);
+    copyToDevice(offsets, encoded.offsets);
+    ASSERT_EQ(
+            cudaSuccess,
+            decoded.reset(data.size() + PIVCO_GPU_DECODE_DST_SLOP));
+    ASSERT_EQ(
+            cudaSuccess,
+            workspace.reset(
+                    pivcoGpuDecodeWorkspaceBytes(data.size(), kBlockSize)));
+
+    const ZL_Report report = pivcoGpuDecode(
+            context,
+            decoded.get(),
+            data.size(),
+            bitstream.get(),
+            encoded.bytes.size(),
+            offsets.get(),
+            offsets.size(),
+            kBlockSize,
+            workspace.get(),
+            workspace.size(),
+            nullptr);
+    ASSERT_FALSE(ZL_isError(report));
+    EXPECT_EQ(ZL_validResult(report), data.size());
+    EXPECT_EQ(copyBytesFromDevice(decoded, data.size()), data);
+
+    pivcoGpuContextDestroy(context);
+}
+
+TEST(PivCoGpuTest, GpuEncodeMatchesCpuBytesAndOffsets)
+{
+    const std::vector<uint8_t> weights{ 2, 1, 1 };
+    const std::vector<uint8_t> data{ 0, 1, 2, 0, 2, 1, 0, 0, 2,
+                                     1, 1, 0, 2, 0, 1, 2, 2 };
+    constexpr size_t kBlockSize = 7;
+    const Encoded expected      = cpuEncode(weights, data, kBlockSize);
+
+    PivCoGpuContext* context = createContext(weights);
+    ASSERT_NE(context, nullptr);
+
+    DeviceBuffer<uint8_t> src;
+    DeviceBuffer<uint8_t> encoded;
+    DeviceBuffer<uint64_t> offsets;
+    DeviceBuffer<uint8_t> workspace;
+    copyToDevice(src, data);
+    ASSERT_EQ(
+            cudaSuccess,
+            encoded.reset(
+                    ZL_PivCoHuffmanEncode_bound(data.size(), kBlockSize)));
+    ASSERT_EQ(cudaSuccess, offsets.reset(expected.offsets.size()));
+    ASSERT_EQ(
+            cudaSuccess,
+            workspace.reset(
+                    pivcoGpuEncodeWorkspaceBytes(data.size(), kBlockSize)));
+
+    const ZL_Report report = pivcoGpuEncode(
+            context,
+            encoded.get(),
+            encoded.size(),
+            offsets.get(),
+            offsets.size(),
+            src.get(),
+            data.size(),
+            kBlockSize,
+            workspace.get(),
+            workspace.size(),
+            nullptr);
+
+    ASSERT_FALSE(ZL_isError(report));
+    ASSERT_EQ(ZL_validResult(report), expected.bytes.size());
+    EXPECT_EQ(
+            copyBytesFromDevice(encoded, expected.bytes.size()),
+            expected.bytes);
+    EXPECT_EQ(
+            copyOffsetsFromDevice(offsets, expected.offsets.size()),
+            expected.offsets);
+    EXPECT_EQ(
+            cpuDecode(
+                    weights,
+                    copyBytesFromDevice(encoded, expected.bytes.size()),
+                    data.size(),
+                    kBlockSize),
+            data);
+
+    pivcoGpuContextDestroy(context);
+}
+
+TEST(PivCoGpuTest, GpuEncodeGpuDecodeRoundTrip)
+{
+    const std::vector<uint8_t> weights{ 2, 1, 1 };
+    const std::vector<uint8_t> data{ 0, 0, 1, 2, 0, 1, 0, 2,
+                                     2, 1, 0, 0, 2, 1, 2, 0 };
+    constexpr size_t kBlockSize = 6;
+
+    PivCoGpuContext* context = createContext(weights);
+    ASSERT_NE(context, nullptr);
+
+    DeviceBuffer<uint8_t> src;
+    DeviceBuffer<uint8_t> encoded;
+    DeviceBuffer<uint8_t> decoded;
+    DeviceBuffer<uint64_t> offsets;
+    DeviceBuffer<uint8_t> workspace;
+    copyToDevice(src, data);
+    ASSERT_EQ(
+            cudaSuccess,
+            encoded.reset(
+                    ZL_PivCoHuffmanEncode_bound(data.size(), kBlockSize)));
+    ASSERT_EQ(
+            cudaSuccess,
+            offsets.reset((data.size() + kBlockSize - 1) / kBlockSize + 1));
+    ASSERT_EQ(
+            cudaSuccess,
+            workspace.reset(
+                    pivcoGpuEncodeWorkspaceBytes(data.size(), kBlockSize)));
+
+    const ZL_Report encodeReport = pivcoGpuEncode(
+            context,
+            encoded.get(),
+            encoded.size(),
+            offsets.get(),
+            offsets.size(),
+            src.get(),
+            data.size(),
+            kBlockSize,
+            workspace.get(),
+            workspace.size(),
+            nullptr);
+    ASSERT_FALSE(ZL_isError(encodeReport));
+
+    ASSERT_EQ(
+            cudaSuccess,
+            decoded.reset(data.size() + PIVCO_GPU_DECODE_DST_SLOP));
+    ASSERT_EQ(
+            cudaSuccess,
+            workspace.reset(
+                    pivcoGpuDecodeWorkspaceBytes(data.size(), kBlockSize)));
+    const ZL_Report decodeReport = pivcoGpuDecode(
+            context,
+            decoded.get(),
+            data.size(),
+            encoded.get(),
+            ZL_validResult(encodeReport),
+            offsets.get(),
+            offsets.size(),
+            kBlockSize,
+            workspace.get(),
+            workspace.size(),
+            nullptr);
+    ASSERT_FALSE(ZL_isError(decodeReport));
+    EXPECT_EQ(copyBytesFromDevice(decoded, data.size()), data);
+
+    pivcoGpuContextDestroy(context);
+}
+
+TEST(PivCoGpuTest, FastGpuEncodeMatchesCpuBytesAndOffsets)
+{
+    const std::vector<uint8_t> weights{ 2, 1, 1 };
+    constexpr size_t kBlockSize     = 32 * 1024;
+    const std::vector<uint8_t> data = makeThreeSymbolData(3 * kBlockSize + 17);
+    const Encoded expected          = cpuEncode(weights, data, kBlockSize);
+
+    PivCoGpuContext* context = createContext(weights);
+    ASSERT_NE(context, nullptr);
+
+    DeviceBuffer<uint8_t> src;
+    DeviceBuffer<uint8_t> encoded;
+    DeviceBuffer<uint8_t> decoded;
+    DeviceBuffer<uint64_t> offsets;
+    DeviceBuffer<uint8_t> workspace;
+    copyToDevice(src, data);
+    ASSERT_EQ(
+            cudaSuccess,
+            encoded.reset(
+                    ZL_PivCoHuffmanEncode_bound(data.size(), kBlockSize)));
+    ASSERT_EQ(cudaSuccess, offsets.reset(expected.offsets.size()));
+    ASSERT_EQ(
+            cudaSuccess,
+            workspace.reset(
+                    pivcoGpuEncodeWorkspaceBytes(data.size(), kBlockSize)));
+
+    const ZL_Report encodeReport = pivcoGpuEncode(
+            context,
+            encoded.get(),
+            encoded.size(),
+            offsets.get(),
+            offsets.size(),
+            src.get(),
+            data.size(),
+            kBlockSize,
+            workspace.get(),
+            workspace.size(),
+            nullptr);
+
+    ASSERT_FALSE(ZL_isError(encodeReport));
+    ASSERT_EQ(ZL_validResult(encodeReport), expected.bytes.size());
+    EXPECT_EQ(
+            copyBytesFromDevice(encoded, expected.bytes.size()),
+            expected.bytes);
+    EXPECT_EQ(
+            copyOffsetsFromDevice(offsets, expected.offsets.size()),
+            expected.offsets);
+
+    ASSERT_EQ(
+            cudaSuccess,
+            decoded.reset(data.size() + PIVCO_GPU_DECODE_DST_SLOP));
+    ASSERT_EQ(
+            cudaSuccess,
+            workspace.reset(
+                    pivcoGpuDecodeWorkspaceBytes(data.size(), kBlockSize)));
+    const ZL_Report decodeReport = pivcoGpuDecode(
+            context,
+            decoded.get(),
+            data.size(),
+            encoded.get(),
+            ZL_validResult(encodeReport),
+            offsets.get(),
+            offsets.size(),
+            kBlockSize,
+            workspace.get(),
+            workspace.size(),
+            nullptr);
+    ASSERT_FALSE(ZL_isError(decodeReport));
+    EXPECT_EQ(copyBytesFromDevice(decoded, data.size()), data);
+
+    pivcoGpuContextDestroy(context);
+}
+
+TEST(PivCoGpuTest, FlatRootGpuDecodeMatchesCpuEncode)
+{
+    const std::vector<uint8_t> weights{ 1, 1, 1, 1, 1, 1, 1, 1 };
+    constexpr size_t kBlockSize     = 32 * 1024;
+    const std::vector<uint8_t> data = makeFlatRootData(3 * kBlockSize + 11);
+    const Encoded encoded           = cpuEncode(weights, data, kBlockSize);
+
+    PivCoGpuContext* context = createContext(weights);
+    ASSERT_NE(context, nullptr);
+
+    DeviceBuffer<uint8_t> bitstream;
+    DeviceBuffer<uint64_t> offsets;
+    DeviceBuffer<uint8_t> decoded;
+    DeviceBuffer<uint8_t> workspace;
+    copyToDevice(bitstream, encoded.bytes);
+    copyToDevice(offsets, encoded.offsets);
+    ASSERT_EQ(
+            cudaSuccess,
+            decoded.reset(data.size() + PIVCO_GPU_DECODE_DST_SLOP));
+    ASSERT_EQ(
+            cudaSuccess,
+            workspace.reset(
+                    pivcoGpuDecodeWorkspaceBytes(data.size(), kBlockSize)));
+
+    const ZL_Report decodeReport = pivcoGpuDecode(
+            context,
+            decoded.get(),
+            data.size(),
+            bitstream.get(),
+            encoded.bytes.size(),
+            offsets.get(),
+            offsets.size(),
+            kBlockSize,
+            workspace.get(),
+            workspace.size(),
+            nullptr);
+    ASSERT_FALSE(ZL_isError(decodeReport));
+    EXPECT_EQ(copyBytesFromDevice(decoded, data.size()), data);
+
+    pivcoGpuContextDestroy(context);
+}
+
+TEST(PivCoGpuTest, RankSelectGpuDecodeMatchesCpuEncode)
+{
+    const std::vector<uint8_t> weights{ 3, 2, 1, 1 };
+    constexpr size_t kBlockSize     = 32 * 1024;
+    const std::vector<uint8_t> data = makeRankSelectData(2 * kBlockSize + 19);
+    const Encoded encoded           = cpuEncode(weights, data, kBlockSize);
+
+    PivCoGpuContext* context = createContext(weights);
+    ASSERT_NE(context, nullptr);
+
+    DeviceBuffer<uint8_t> bitstream;
+    DeviceBuffer<uint64_t> offsets;
+    DeviceBuffer<uint8_t> decoded;
+    DeviceBuffer<uint8_t> workspace;
+    copyToDevice(bitstream, encoded.bytes);
+    copyToDevice(offsets, encoded.offsets);
+    ASSERT_EQ(
+            cudaSuccess,
+            decoded.reset(data.size() + PIVCO_GPU_DECODE_DST_SLOP));
+    ASSERT_EQ(
+            cudaSuccess,
+            workspace.reset(
+                    pivcoGpuDecodeWorkspaceBytes(data.size(), kBlockSize)));
+
+    const ZL_Report decodeReport = pivcoGpuDecode(
+            context,
+            decoded.get(),
+            data.size(),
+            bitstream.get(),
+            encoded.bytes.size(),
+            offsets.get(),
+            offsets.size(),
+            kBlockSize,
+            workspace.get(),
+            workspace.size(),
+            nullptr);
+    ASSERT_FALSE(ZL_isError(decodeReport));
+    EXPECT_EQ(copyBytesFromDevice(decoded, data.size()), data);
+
+    pivcoGpuContextDestroy(context);
+}
+
+TEST(PivCoGpuTest, ScheduledGpuDecodeCoversMixedNodeKinds)
+{
+    const std::vector<std::vector<uint8_t>> weightCases =
+            findScheduledCoverageWeights();
+    constexpr size_t kBlockSize = 32 * 1024;
+
+    uint32_t opMask = 0;
+    for (const std::vector<uint8_t>& weights : weightCases) {
+        PivCoGpuContext* context = createContext(weights);
+        ASSERT_NE(context, nullptr);
+        ASSERT_EQ(context->hostTree.fastMode, PIVCO_GPU_FAST_NONE);
+        opMask |= scheduleOpsFor(context);
+        pivcoGpuContextDestroy(context);
+
+        expectGpuDecodeMatchesCpuEncode(
+                weights,
+                makeDataForWeights(weights, 2 * kBlockSize + 29),
+                kBlockSize);
+    }
+
+    EXPECT_NE(opMask & flatOpMask(), 0);
+    EXPECT_NE(
+            opMask & scheduleOpBit(PIVCO_GPU_SCHEDULE_OP_MERGE_VECTOR_VECTOR),
+            0);
+    EXPECT_NE(
+            opMask & scheduleOpBit(PIVCO_GPU_SCHEDULE_OP_MERGE_CONSTANT_VECTOR),
+            0);
+    EXPECT_NE(
+            opMask
+                    & scheduleOpBit(
+                            PIVCO_GPU_SCHEDULE_OP_MERGE_CONSTANT_CONSTANT),
+            0);
+}
+
+TEST(PivCoGpuTest, ConstantEncodeWritesRepeatedZeroOffsets)
+{
+    std::vector<uint8_t> weights(6);
+    weights[5] = 1;
+    const std::vector<uint8_t> data(17, 5);
+    constexpr size_t kBlockSize = 5;
+    const size_t numOffsets = (data.size() + kBlockSize - 1) / kBlockSize + 1;
+
+    PivCoGpuContext* context = createContext(weights);
+    ASSERT_NE(context, nullptr);
+
+    DeviceBuffer<uint8_t> src;
+    DeviceBuffer<uint8_t> encoded;
+    DeviceBuffer<uint64_t> offsets;
+    DeviceBuffer<uint8_t> workspace;
+    copyToDevice(src, data);
+    ASSERT_EQ(cudaSuccess, encoded.reset(1));
+    ASSERT_EQ(cudaSuccess, offsets.reset(numOffsets));
+
+    const ZL_Report report = pivcoGpuEncode(
+            context,
+            encoded.get(),
+            encoded.size(),
+            offsets.get(),
+            offsets.size(),
+            src.get(),
+            data.size(),
+            kBlockSize,
+            workspace.get(),
+            workspace.size(),
+            nullptr);
+    ASSERT_FALSE(ZL_isError(report));
+    EXPECT_EQ(ZL_validResult(report), 0);
+    EXPECT_EQ(
+            copyOffsetsFromDevice(offsets, numOffsets),
+            std::vector<uint64_t>(numOffsets, 0));
+
+    pivcoGpuContextDestroy(context);
+}
+
+TEST(PivCoGpuTest, GpuEncodeRejectsMissingSymbol)
+{
+    const std::vector<uint8_t> weights{ 1, 1 };
+    const std::vector<uint8_t> data{ 0, 2 };
+    constexpr size_t kBlockSize = 2;
+
+    PivCoGpuContext* context = createContext(weights);
+    ASSERT_NE(context, nullptr);
+
+    DeviceBuffer<uint8_t> src;
+    DeviceBuffer<uint8_t> encoded;
+    DeviceBuffer<uint64_t> offsets;
+    DeviceBuffer<uint8_t> workspace;
+    copyToDevice(src, data);
+    ASSERT_EQ(cudaSuccess, encoded.reset(16));
+    ASSERT_EQ(cudaSuccess, offsets.reset(2));
+    ASSERT_EQ(
+            cudaSuccess,
+            workspace.reset(
+                    pivcoGpuEncodeWorkspaceBytes(data.size(), kBlockSize)));
+
+    const ZL_Report report = pivcoGpuEncode(
+            context,
+            encoded.get(),
+            encoded.size(),
+            offsets.get(),
+            offsets.size(),
+            src.get(),
+            data.size(),
+            kBlockSize,
+            workspace.get(),
+            workspace.size(),
+            nullptr);
+    EXPECT_TRUE(ZL_isError(report));
+
+    pivcoGpuContextDestroy(context);
+}
+
+TEST(PivCoGpuTest, FastGpuEncodeRejectsMissingSymbol)
+{
+    const std::vector<uint8_t> weights{ 2, 1, 1 };
+    constexpr size_t kBlockSize = 1024;
+    std::vector<uint8_t> data   = makeThreeSymbolData(2 * kBlockSize);
+    data[kBlockSize + 11]       = 7;
+
+    PivCoGpuContext* context = createContext(weights);
+    ASSERT_NE(context, nullptr);
+
+    DeviceBuffer<uint8_t> src;
+    DeviceBuffer<uint8_t> encoded;
+    DeviceBuffer<uint64_t> offsets;
+    DeviceBuffer<uint8_t> workspace;
+    copyToDevice(src, data);
+    ASSERT_EQ(
+            cudaSuccess,
+            encoded.reset(
+                    ZL_PivCoHuffmanEncode_bound(data.size(), kBlockSize)));
+    ASSERT_EQ(
+            cudaSuccess,
+            offsets.reset((data.size() + kBlockSize - 1) / kBlockSize + 1));
+    ASSERT_EQ(
+            cudaSuccess,
+            workspace.reset(
+                    pivcoGpuEncodeWorkspaceBytes(data.size(), kBlockSize)));
+
+    const ZL_Report report = pivcoGpuEncode(
+            context,
+            encoded.get(),
+            encoded.size(),
+            offsets.get(),
+            offsets.size(),
+            src.get(),
+            data.size(),
+            kBlockSize,
+            workspace.get(),
+            workspace.size(),
+            nullptr);
+    EXPECT_TRUE(ZL_isError(report));
+
+    pivcoGpuContextDestroy(context);
+}
+
+TEST(PivCoGpuTest, GpuDecodeRejectsBadOffsets)
+{
+    const std::vector<uint8_t> weights{ 1, 1 };
+    const std::vector<uint8_t> data{ 0, 1, 1, 0, 1 };
+    constexpr size_t kBlockSize = 5;
+    Encoded encoded             = cpuEncode(weights, data, kBlockSize);
+    encoded.offsets[1]          = encoded.bytes.size() + 1;
+
+    PivCoGpuContext* context = createContext(weights);
+    ASSERT_NE(context, nullptr);
+
+    DeviceBuffer<uint8_t> bitstream;
+    DeviceBuffer<uint64_t> offsets;
+    DeviceBuffer<uint8_t> decoded;
+    DeviceBuffer<uint8_t> workspace;
+    copyToDevice(bitstream, encoded.bytes);
+    copyToDevice(offsets, encoded.offsets);
+    ASSERT_EQ(
+            cudaSuccess,
+            decoded.reset(data.size() + PIVCO_GPU_DECODE_DST_SLOP));
+    ASSERT_EQ(
+            cudaSuccess,
+            workspace.reset(
+                    pivcoGpuDecodeWorkspaceBytes(data.size(), kBlockSize)));
+
+    const ZL_Report report = pivcoGpuDecode(
+            context,
+            decoded.get(),
+            data.size(),
+            bitstream.get(),
+            encoded.bytes.size(),
+            offsets.get(),
+            offsets.size(),
+            kBlockSize,
+            workspace.get(),
+            workspace.size(),
+            nullptr);
+    EXPECT_TRUE(ZL_isError(report));
+
+    pivcoGpuContextDestroy(context);
+}
+
+} // namespace

--- a/contrib/pivco-huffman/gpu/README.md
+++ b/contrib/pivco-huffman/gpu/README.md
@@ -1,0 +1,299 @@
+# PivCo-Huffman GPU POC
+
+This directory contains an independent CUDA proof of concept for PivCo-Huffman
+block encode and decode. It does not change the production OpenZL codec under
+`src/openzl/`; callers still supply Huffman weights from the host, while the
+per-block PivCo work runs on the GPU.
+
+The public API is in `pivco_gpu.h`. Callers create an immutable
+`PivCoGpuContext` from host weights, allocate device buffers and device
+workspace, then call `pivcoGpuEncode()` or `pivcoGpuDecode()`. The blocking
+wrappers launch internal async kernels, copy device status/results back, and
+synchronize the supplied CUDA stream before returning a `ZL_Report`.
+
+## Current Performance Status
+
+This is a proof of concept, not a finished high-throughput GPU codec. The
+general Huffman-tree paths prioritize correctness and byte-identical wire output.
+
+Decode has two throughput regimes:
+
+- Flat and near-flat shapes hit dedicated fast paths and run very fast
+  (hundreds of GiB/s; incompressible/uniform data decodes at ~285 GiB/s).
+- Broad tree shapes run a schedule-driven decoder. The host context builds the
+  static Huffman-tree schedule once from the weights; each block parses against
+  that schedule, then CUDA kernels process the tree node-by-node across all
+  blocks. Real broad-tree files currently decode at ~100-190 GiB/s.
+
+Encode has a fast path for the narrow three-symbol shape and a
+correctness-oriented generic path that is much slower and is optimized for
+differential testing rather than peak throughput.
+
+Decode throughput is measured over decompressed bytes with CUDA events and
+excludes bulk H2D/D2H transfers. See `BENCHMARKS.md` for the latest checked-in
+result snapshot and `ROOFLINE.md` for per-kernel roofline analysis.
+
+## Wire Format
+
+The GPU code emits and consumes the same block-local PivCo-Huffman wire format
+as the CPU kernel:
+
+- Blocks are encoded independently, using the caller's `blockSize`.
+- Bit payloads are little-endian and LSB-first; the bitstream is not native
+  endian.
+- Internal tree nodes are emitted in CPU preorder.
+- Each internal node writes a byte-aligned partition bitmap for the current
+  stable rank stream.
+- If the internal node does not have two constant children, it then writes
+  `numOnes` using `nextPow2(count + 1)` unaligned bits.
+- Flat leaves with depth greater than zero write byte-aligned packed flat-leaf
+  indices.
+- Constant leaves write no payload.
+
+The block offset table uses `uint64_t` byte offsets and has `numBlocks + 1`
+entries. Constant blocks may legitimately consume zero bytes, so adjacent
+offsets can be equal.
+
+Callers must reserve a little slop past the logical buffer sizes:
+`PIVCO_GPU_DECODE_DST_SLOP` trailing bytes past `dstSize` (the decoder writes in
+aligned 8-byte groups) and `PIVCO_GPU_DECODE_SRC_SLOP` readable trailing bytes
+past `bitstreamSize` (the decoder over-reads a few masked-off bytes past the
+last block's bitmap).
+
+## Context And Workspace
+
+`pivcoGpuContextCreate()` builds the normal CPU PivCo-Huffman tree from the
+supplied weights and flattens the metadata needed by device code:
+
+- `symbolToRank` and `rankToSymbol`
+- `rankToFlatDepth` and `rankToCodeword`
+- symbol presence bits for encode-side validation
+- a small fast-path descriptor for the flat-root and three-symbol tree shapes
+- a preorder decode schedule plus stage lists grouped by tree level and node
+  operation
+
+The context stays host-owned and immutable. Each encode/decode call copies this
+small tree, and for generic decode the schedule, into the front of
+caller-provided device workspace. The remaining workspace is sized by
+`pivcoGpuEncodeWorkspaceBytes()` or `pivcoGpuDecodeWorkspaceBytes()`.
+
+The generic decode workspace is per block. It contains:
+
+- one state record per scheduled tree node
+- a 32-bit-stride rank directory stored as `uint16_t` prefix counts
+- two compact `uint8_t` symbol-stream ping-pong buffers
+
+## Decode Strategy
+
+Decode selects, in order, a fast path, the chunk-in-shared decoder, or the
+scheduled cascade. Both generic decoders require `tableLog <= 12` and block
+sizes up to 64 KiB (the schedule metadata is `uint16`, so larger blocks are out
+of range by design and return `cudaErrorNotSupported`).
+
+### Fast Paths
+
+The **flat-root fast path** is selected when the entire tree is one flat leaf.
+Each thread decodes independent packed flat-leaf indices directly to output.
+This is the path used by high-entropy flat trees such as uniform 256-symbol
+data. The leaf symbol table is cached in shared memory, and the common `depth
+== 8` case reads one byte per output directly.
+
+The **three-symbol fast path** is selected when the context describes a shape
+with a constant root-left symbol and a one-bit (or two-constant) right leaf.
+This is the special-case shape produced by weights such as `{2, 1, 1}`. One CTA
+owns one PivCo block:
+
+1. Cooperatively scan the root bitmap bytes into a shared prefix-popcount table.
+2. Validate the stored `numOnes` against the bitmap popcount.
+3. Validate the exact encoded block byte count from the root bitmap, count
+   field, and leaf bitmap size.
+4. Decode output bytes in parallel. A zero root bit emits the constant root
+   symbol; a one root bit uses the root-byte prefix to find the corresponding
+   leaf bit and emits one of the two right-leaf symbols.
+
+Both fast paths keep the input bitstream, offsets, and output fully
+device-resident.
+
+### Generic Parse
+
+Both generic decoders share one lightweight parse kernel. Each block replays the
+static preorder schedule with a single thread, validates its bitstream slice,
+and writes per-block/per-node state:
+
+- node count and rank range
+- bitmap byte base for internal nodes
+- flat-leaf bit base and depth for flat leaves
+- compact stream base for each materialized node at its level
+
+During parse it validates slice bounds, stored `numOnes`, child counts, and
+exact final block consumption. For each internal node it also reserves a
+per-node prefix-popcount rank directory in workspace: the number of one bits
+before each 32-bit bitmap word, used for O(1) `onesBefore` rank queries.
+
+### Chunk-In-Shared Decoder
+
+For small and medium inputs the chunk-in-shared decoder (`pivcoChunkTopDownKernel`)
+decodes the whole tree for one contiguous output chunk with all intermediate
+node streams resident in shared memory. Only the bitmaps/flat indices are read
+from global memory and only the final chunk output is written back. This pays
+about three kernel launches total instead of the cascade's roughly thirty
+per-level launches, and turns dependent child loads from L2 accesses into shared
+accesses.
+
+It relies on the monotone-rank property: a contiguous output chunk descends to a
+contiguous sub-range at every tree node, so all per-chunk node streams fit in a
+level-parity ping-pong pair. The kernel runs three phases per chunk:
+
+1. A top-down descent computes each node's chunk sub-range from the two boundary
+   ranks (using the per-node rank directories, built by a preceding directory
+   kernel).
+2. A bottom-up merge, deepest level first, materializes each node stream in
+   shared memory using the same byte-select merge as the cascade.
+3. A coalesced flush writes the root buffer to global output.
+
+Levels with many small nodes decode one node per lane; shallow, wide-node levels
+cooperate a whole warp per node.
+
+### Scheduled Cascade Decoder
+
+For large inputs the scheduled cascade walks tree levels from deepest to root.
+For each level it launches one kernel per operation kind present at that level.
+The grid maps `x = block` and `y = scheduled node within the stage`, so each CTA
+processes one node stream for one block. The operation kinds are:
+
+- flat leaves with depths 1 through 8
+- vector/vector merges
+- constant/vector and vector/constant merges
+- both-constant merges, decoded directly from the one-bit partition bitmap
+
+Each merge kernel builds its node's rank directory in shared memory at launch,
+so no standalone directory kernel and no global directory round-trip is needed.
+It then merges the child streams: for output position `j`, the bitmap bit
+chooses left or right, `onesBefore(j)` gives the right-child cursor, and `j -
+onesBefore(j)` gives the left-child cursor. Large nodes use a vectorized
+byte-select merge (`byteMerge8`, two `__byte_perm` per 8 outputs, reading child
+windows via aligned read-only loads); small nodes use a simple per-output loop.
+Constant leaves are never materialized; parent merges inject their symbols
+directly. The root writes directly to final output; intermediate nodes write to
+the compact ping-pong streams.
+
+The AVX512 CPU kernel performs the same logical merge with vector masked
+expand-loads, so this path mirrors the CPU generic decode closely. It is the
+production path for large data and the primary path measured in `BENCHMARKS.md`.
+
+### Path Selection
+
+The dispatcher uses the chunk-in-shared decoder up to a size crossover and the
+scheduled cascade above it. The crossover depends on tree depth: deep trees
+(`tableLog >= 10`) keep the chunk decoder up to 12 MiB, shallow trees up to
+4 MiB. Beyond that, the cascade's higher steady-state throughput wins.
+
+The `PIVCO_CHUNK_TD` environment variable overrides the automatic choice:
+setting it forces the chunk-in-shared decoder regardless of size; setting it to
+`0` forces the cascade. `PIVCO_KERNEL_TIMING` enables per-stage CUDA-event
+timing prints on the cascade path for diagnostics. Both are off by default.
+
+## Encode Strategy
+
+Encode has a generic path and a fast path.
+
+The generic encoder is the correctness/oracle implementation:
+
+1. `encodeLayoutKernel` maps source bytes to ranks, rejects symbols absent from
+   the supplied weights, and recursively measures the exact block payload size.
+2. `scanOffsetsKernel` converts per-block sizes into the `uint64_t` byte offset
+   table and total encoded size.
+3. `encodeEmitKernel` reruns the recursive stable partitions and emits the exact
+   CPU preorder bitstream for each block.
+
+This generic path is intentionally simple and currently optimized for
+differential testing rather than peak throughput.
+
+The optimized three-symbol path is selected for the same root-constant plus
+one-bit-leaf tree shape and block sizes from 1 KiB through 64 KiB. It is designed
+around a single source pass per block:
+
+1. `fastEncodePackRootConstFlat1Kernel` assigns one CTA per block and packs that
+   block into fixed-stride workspace at `block * blockSize`. Each thread owns a
+   contiguous range of root bitmap bytes; full 8-symbol groups use CUDA byte-lane
+   equality (`__vcmpeq4`) to build masks for the root symbol and the two leaf
+   symbols. A shared prefix over per-thread non-root counts gives each thread its
+   stable leaf-bit range, threads merge their leaf words into the shared leaf
+   bitmap, write the LSB-first `numOnes` field, and publish the exact block size.
+2. A parallel device scan converts block sizes into compact output offsets.
+3. `fastEncodeCopyRootConstFlat1Kernel` copies each fixed-stride temporary block
+   into its final compact position.
+
+The fast path still validates source symbols against the supplied weights and
+produces byte-identical CPU wire output and offsets.
+
+Empty input produces an empty bitstream and a single zero offset. Constant-input
+contexts with `tableLog == 0` produce zero encoded bytes and repeated zero
+offsets.
+
+## CPU Block Indexer
+
+`pivco_block_index.{h,cpp}` provides the CUDA-free helper
+`pivcoFindBlockOffsets()`. It structurally walks a CPU-produced bitstream and
+returns `uint64_t[numBlocks + 1]` offsets for independent GPU slice decode. The
+walker validates bounds, subtree structure, bitmap popcounts against stored
+`numOnes`, and exact final consumption.
+
+## Tests And Benchmark
+
+Correctness coverage lives in `PivCoBlockIndexTest.cpp` and `PivCoGpuTest.cpp`.
+The GPU tests compare:
+
+- CPU encode to GPU decode
+- GPU encode bytes and offsets to CPU encode plus the host block indexer
+- GPU encode to GPU decode
+- constant repeated offsets
+- missing-symbol and bad-offset failures
+- the optimized fast path, including a partial final block
+- scheduled decode across mixed node kinds (flat, vector/vector,
+  constant/vector, constant/constant)
+
+The unit tests use small inputs, so they exercise the fast paths and the
+chunk-in-shared decoder; the scheduled cascade is exercised by the large-input
+benchmark.
+
+Run the unit tests with:
+
+```bash
+buck test --local-only @fbcode//mode/dev-nosan fbcode//openzl/dev/contrib/pivco-huffman/gpu:pivco_block_index_test fbcode//openzl/dev/contrib/pivco-huffman/gpu:pivco_gpu_test
+```
+
+`PivCoGpuBench.cpp` reports CUDA-event kernel timing separately from host H2D,
+D2H, and wall-clock preparation. Bulk input/output transfers are not included in
+the `decode_*` or `encode_*` throughput numbers.
+
+The default benchmark expands every case to a 1 GiB device-resident input and
+uses 64 KiB blocks. It runs:
+
+- every synthetic distribution (generated in-process; no input files needed)
+- every regular file in the directory passed via `--dataset-dir`
+
+The real-world benchmark inputs are not checked in here. Fetch them from the
+upstream pivco-huffman repo's `extras/datasets` directory
+(https://github.com/MarcinZukowski/pivco-huffman/tree/main/extras/datasets),
+which also documents each file's provenance, then point `--dataset-dir` at your
+checkout (a valid directory is required even for synthetic-only runs):
+
+```bash
+git clone https://github.com/MarcinZukowski/pivco-huffman
+buck run --local-only @fbcode//mode/opt fbcode//openzl/dev/contrib/pivco-huffman/gpu:pivco_gpu_bench -- \
+    --dataset-dir=pivco-huffman/extras/datasets
+```
+
+Real files and generated synthetic bases are repeated to the requested benchmark
+size. Dataset source bytes must be larger than the block size, so every measured
+case spans at least two PivCo blocks before repetition.
+
+Useful benchmark options (all also take `--dataset-dir=<checkout>/extras/datasets`):
+
+```bash
+buck run --local-only @fbcode//mode/opt fbcode//openzl/dev/contrib/pivco-huffman/gpu:pivco_gpu_bench -- --size=268435456 --iterations=5 --dataset-dir=pivco-huffman/extras/datasets
+buck run --local-only @fbcode//mode/opt fbcode//openzl/dev/contrib/pivco-huffman/gpu:pivco_gpu_bench -- --dataset=proba80 --dataset-dir=pivco-huffman/extras/datasets
+```
+
+See `BENCHMARKS.md` for the latest checked-in result snapshot.

--- a/contrib/pivco-huffman/gpu/ROOFLINE.md
+++ b/contrib/pivco-huffman/gpu/ROOFLINE.md
@@ -1,0 +1,235 @@
+# PivCo-Huffman GPU Decode — Roofline Analysis
+
+Device: **NVIDIA A100 (SM 8.0)**. Measured with `ncu` (SpeedOfLight +
+MemoryWorkloadAnalysis), 64 KiB blocks, on the committed decoder. Goal: for each
+core kernel, place it on the roofline and flag the ones **below** their roofline
+(the optimization targets).
+
+## Method
+
+For these integer/byte-shuffle kernels there are no FLOPs, so the roofline is
+expressed in **output bytes/s vs arithmetic intensity AI = output bytes moved per
+DRAM byte moved**:
+
+```
+achievable_output_Bps(AI) = min( compute_roof , peak_DRAM_BW x AI )
+```
+
+A kernel is **at its roofline** when it saturates one ceiling, i.e. when
+`max(Compute-SOL, Memory-SOL) ~ 100%` (SOL = Speed-Of-Light = % of the hardware
+peak that ncu reports). The key identity that makes ncu's SOL numbers *be* the
+roofline position:
+
+```
+achieved_output_Bps / memory_roof
+   = (W/t) / (peak_BW x W/Q)          [W = output bytes, Q = DRAM bytes, t = time]
+   = Q/(t x peak_BW)
+   = achieved_DRAM_BW / peak_DRAM_BW
+   = DRAM-SOL %
+```
+
+So **DRAM-SOL % is the fraction of the memory roof achieved**, and **Compute-SOL %
+is the fraction of the compute roof**. `max` of the two = distance to the roofline;
+anything well under 100% is **latency-bound (below the roofline)**.
+
+### Measured peak
+
+`ncu` on the VV merge reports DRAM `1.12 TB/s at 57.69%` -> **peak DRAM BW =
+1.12/0.5769 = 1.94 TB/s** (this is an 80 GB A100). L2 BW is several x higher, so
+L2-resident traffic is not the binding roof for these kernels.
+
+## Arithmetic intensity (the math)
+
+`AI = 1 / (DRAM bytes moved per output byte)`. Minimum DRAM bytes/output `B_min`
+(the rank directory is built in shared from the bitmap, so it adds no DRAM beyond
+the one bitmap read):
+
+- **VV merge** `out[i] = bit ? right[rank1] : left[rank0]`: read both children
+  (`rank0`+`rank1` cover every output exactly once => **1 B/out**) + read bitmap
+  (**1/8 B/out**) + write parent (**1 B/out**) = **2.125 B/out**, AI = **0.471**.
+- **CV merge** `out[i] = bit ? right[rank1] : leftSym` (left constant): read only
+  the vector child (`numOnes` bytes => `p1 = numOnes/count` B/out, ~0.5 typical) +
+  bitmap (1/8) + write (1) = **~1.6 B/out**, AI = **~0.63**.
+- **flat<D>** `out[i] = symbols[ D-bit index i ]`: read the packed indices
+  (`D/8` B/out) + write (1) + the 2^D-byte table once (negligible) = **(1 + D/8)
+  B/out**, AI = **8/(8+D)**:
+
+| kernel | B_min (B/out) | AI (out-B/DRAM-B) | memory roof (output GB/s = 1.94 TB/s x AI) |
+|---|---|---|---|
+| VV merge | 2.125 | 0.471 | 913 |
+| CV merge | ~1.6 | ~0.63 | ~1210 |
+| flat1 | 1.125 | 0.889 | 1724 |
+| flat2 | 1.250 | 0.800 | 1552 |
+| flat3 | 1.375 | 0.727 | 1411 |
+| flat4 | 1.500 | 0.667 | 1293 |
+| flat5 | 1.625 | 0.615 | 1194 |
+| flat6 | 1.750 | 0.571 | 1109 |
+| flat7 | 1.875 | 0.533 | 1035 |
+| flat8 | 2.000 | 0.500 | 970 |
+
+Sanity check on the VV over-read: the aligned `__ldg` load fetches 16 B per 8-out
+window per child (nominal 4x over-read), but ncu shows the VV launch moves
+`1.12 TB/s x 258 us = 289 MB` DRAM for a 134 MB-output root launch = **2.15 B/out
+~= the 2.125 B/out minimum**. The 62% L2 hit absorbs the over-read; VV is **not**
+wasting DRAM bandwidth, so its AI is effectively the minimum.
+
+## Roofline position (measured, largest launch of each kernel)
+
+Measured at the 268 MB benchmark scale (largest launch of each cascade kernel).
+The per-kernel SOL below is a hardware-relative measure and these kernels are
+unchanged; a spot re-measure at 64 MiB (below, next to the top-down section)
+reproduces the same latency-bound story at slightly lower absolute SOL (fewer
+waves in the smaller launches).
+
+| kernel | Compute-SOL | Memory-SOL | DRAM-SOL | L2 hit | bound by | % of its roofline | at roofline? |
+|---|---|---|---|---|---|---|---|
+| **VV merge** | 48.6% | 57.7% | 57.7% | 62% | memory (DRAM), latency-limited | ~58% | **no** |
+| **CV merge** | 59.7% | 41.8% | 23.2% | 88% | compute, latency-limited | ~60% | **no** |
+| **flat1** (big, 145us) | 57.3% (ALU) | 54.5% | 54.5% | (L2 59%) | balanced, latency-limited | ~57% | **no** |
+| flat2 (big) | 43.1% | 33.2% | 30.2% | - | ALU-leaning, latency | ~43% | **no** |
+| flat3 (big) | 48.6% | 43.4% | 43.4% | - | balanced, latency | ~49% | **no** |
+| flat4 (big) | 45.8% | 52.3% | 52.3% | - | memory | ~52% | **no** |
+| flat5 (big) | 46.3% | **62.9%** | 53.9% | - | memory | ~63% | **no** (closest) |
+| flat6 (big) | 43.8% | 58.8% | 49.4% | - | memory | ~59% | **no** |
+| flat7 (big) | 46.0% | **63.5%** | 60.5% | - | memory | ~64% | **no** (closest) |
+| flat8 | (not exercised; extrapolates to flat7: memory, ~65%) | | | | | | |
+
+The flat1 numbers were re-measured directly on `dna` (the flat1-heaviest dataset):
+the one large flat1 launch (145 us, grid 4096) runs at **ALU 57.3% / DRAM 54.5% /
+L2 59.3%, IPC 2.17 of 4, issue-slots 53.6%** — i.e. **balanced and latency-limited**,
+with ALU the leading pipe but no pipe near its roof. (An earlier draft of this doc
+mis-recorded flat1 as "52% compute / 1.2% DRAM"; that was a transcription error and
+is corrected here.)
+
+Small flat launches (the common case — flat leaves are small subtrees) sit far
+lower: ~43% ALU / ~22% memory (e.g. the dozens of ~14 us dna flat1/2/3 launches).
+They are **latency-bound on small per-node work**, ALU-leaning but with the ALU pipe
+itself less than half busy.
+
+## Findings — nothing is at its roofline; where to look
+
+**Every core kernel is below its roofline** (all `max(Compute,Memory)-SOL` in the
+40-64% range). The reasons split into three groups:
+
+1. **Merges (VV, CV) — latency-bound at a genuine concurrency floor.** VV is at
+   ~58% of the memory roof (DRAM-bound at the minimum AI) and CV at ~60% of the
+   compute roof; both stall ~55% of cycles on the dependent rank->child-load chain
+   even at 64 warps/SM (max occupancy) with MLP=2 (register-capped). This is the
+   `bytes_in_flight = warps x MLP x bytes/load` ceiling (Little's Law). The one
+   structural lever to raise it (radix-4 level fusion, cutting dependent-load
+   levels) was implemented and **measured -37%** (unaligned fused-child ops
+   dominate; see DEVELOPMENT_LOG). **Verdict: at the practical floor; no cheap win.**
+
+2. **flat kernels — also latency-bound; ALU-leaning at low depth, memory-leaning
+   at high depth.** The single large flat1 launch (145 us on dna) runs balanced at
+   **ALU 57.3% / DRAM 54.5%, IPC 2.17 of 4, issue-slots 53.6%** — the ALU is the
+   leading pipe (the 8x shift+mask+lookup unpack) but no pipe is near its roof, so
+   it is latency-limited, not throughput-bound. High-depth flats (flat4-7, big
+   launches) shift to memory-leaning (52-64% DRAM) because they read more packed
+   bytes; flat5/flat7 at ~63% are the closest anything gets to a roof. flat1 is
+   **not** the compute-bound non-floor gap an earlier draft claimed.
+   - Still worth trying: cut the low-depth unpack instruction count (register
+     2-entry select for D=1 like the CC path; PRMT multi-symbol unpack for D=2-4).
+     Because these kernels are latency- not ALU-throughput-bound, expect a small
+     win at best. A prior register-LUT swap measured neutral overall.
+
+3. **Small flat launches (all depths) — latency-bound on tiny leaf subtrees**
+   (~43% ALU / ~22% memory, dozens of ~14 us launches). This is the common case and
+   the largest aggregate flat cost. Inherent to the tree shape; depth-2 MLP already
+   added. Not a roofline gap code can close (the work per node is just small); the
+   only lever is fewer/larger launches (batching sibling flat nodes).
+
+### Ranked optimization targets (from this analysis)
+
+Honestly, **all core kernels are latency-bound below their roofline**, and the two
+biggest (VV, CV) are at a genuine concurrency floor. There is no kernel sitting at a
+throughput roof with a clear structural win. Ordered by remaining (modest) ROI:
+
+1. **Small flat launches** — the largest aggregate cost that is *not* a concurrency
+   floor. The lever is launch/occupancy structure (batch sibling flat nodes into
+   fewer, larger launches), not the inner loop.
+2. **Low-depth flat unpack (flat1-3)** — trim unpack instructions (register select /
+   PRMT); latency-bound, so likely small.
+3. **VV/CV merges** — largest kernels but at the concurrency floor; only a
+   dependency-removing algorithm change would move them, and the one identified
+   (radix-4) measured -37%. Low ROI.
+4. **flat4-7** — near the memory roof; low ROI.
+
+## Top-down (chunk-in-shared) decoder at 64 MiB
+
+Roofline for `pivcoChunkTopDownKernel` (the merge-in-shared decoder), forced
+(`PIVCO_CHUNK_TD=1`) at 64 MiB, DCGM muted, one launch per dataset via
+`ncu --kernel-name regex:pivcoChunkTopDownKernel --launch-count 1`. At 64 MiB the
+chunk width is 2048 (dstSize > 6 MiB). Measured on the committed decoder:
+
+| dataset | Compute-SOL | Mem-SOL | DRAM-SOL | L2 hit | L1 hit | IPC (of 4) | issue-slots | occupancy (ach/theo) | decode GiB/s | bound by |
+|---|---|---|---|---|---|---|---|---|---|---|
+| json_api.json | 60.1% | 42.8% | 5.3% | 83.6% | 84.7% | 2.43 | 59.9% | 47.7% / 50% | 46 | compute, latency/occupancy |
+| dna_fasta.fa | 55.9% | 41.1% | 6.5% | 91.4% | 80.2% | 2.31 | 55.9% | 46.7% / 50% | 100 | compute, latency/occupancy |
+| calgary_pic | 53.5% | 38.4% | 4.7% | 92.3% | 84.4% | 2.22 | 53.5% | 43.5% / 50% | 74 | compute, latency/occupancy |
+
+Reg/thread = 40; dynamic shared = 36.1 KiB/block. ALU is the top pipe (41-49% of
+elapsed). The 36.1 KiB/block is `levelNodeBytes + 8 warps x perWarpBytes`, where
+`perWarpBytes = 2 x (chunkOutputs + 64) + 6 x nodeCount`. For json (~61 tree
+nodes; nodeCount << symbol count because FLAT leaves each decode 2^depth symbols):
+
+| component | size | share |
+|---|---|---|
+| ping-pong stream buffers: 8 warps x 2 x (2048+64) B | 33.8 KiB | 91% |
+| per-node metadata: 8 warps x 6 B (loBit/subLen/streamOff u16) x 61 nodes | 2.9 KiB | 8% |
+| CTA-wide level-node list: 2 B x 61 | 0.1 KiB | <1% |
+
+Each warp decodes one 2048-byte chunk by walking the tree bottom-up in shared,
+reading child streams from one buffer and writing parents into the other
+(ping-pong), so two chunk-sized buffers must be live -- and each holds a full
+chunk (the nodes at any level partition the chunk). The wide 2048 chunk is the
+whole reason it is 36 KiB: the 1024 chunk needs `8 x 2 x 1088 ~= 17.4 KiB` + meta
+~= 19 KiB. That doubling is exactly what drops the block limit from 6 (1024,
+register-bound) to 4 (2048, shared-bound) -> 72% -> 50% occupancy.
+
+### Arithmetic intensity and roofline position
+
+The kernel is designed to move the DRAM minimum: read the compressed slice once,
+write the 64 MiB output once, and keep every intermediate node stream in shared.
+`B_min` (DRAM bytes per output byte) = write (1) + read compressed (`ratio`):
+
+| dataset | ratio | B_min | AI = 1/B_min | memory roof (out GB/s) | achieved | % of memory roof | % of compute roof |
+|---|---|---|---|---|---|---|---|
+| json | 0.65 | 1.65 | 0.61 | 1180 | ~49 | ~4% | ~60% |
+| dna | 0.28 | 1.28 | 0.78 | 1516 | ~107 | ~7% | ~56% |
+| calgary | 0.21 | 1.21 | 0.83 | 1604 | ~80 | ~5% | ~53% |
+
+(memory roof = 1.94 TB/s x AI; achieved output Bps ~= decode GiB/s.) The measured
+DRAM-SOL (5-6%) matches this `B_min` estimate, confirming the design goal: the
+chunk decoder is **DRAM-idle** (5% of the HBM roof, no intermediate round-trips)
+and therefore **far to the right of the ridge -- deep in the compute-bound
+region**. But it is not at the compute roof either (Compute-SOL 53-60%), so like
+every kernel in this codec it sits **below its roofline, latency-bound**.
+
+### The binding constraint: shared-memory-limited occupancy
+
+Unlike the 1024-chunk kernel (rounds 9-10: 40 regs -> 6 blocks -> 72% occupancy,
+IPC 3.11), the 2048-chunk kernel's 36 KiB/block shared caps it at **4 blocks/SM ->
+50% theoretical occupancy** (Block Limit Shared Mem = 4 < Block Limit Registers =
+6). At 50% occupancy (~30 warps/SM) there are not enough warps to hide the
+dependent rank -> shared-load -> byte-merge chain, so IPC falls to 2.2-2.4 of 4
+(issue-slots 53-60%) and no pipe reaches its roof. This is the Little's-Law
+concurrency floor again, but reached at lower occupancy than the 1024 kernel.
+
+### Why top-down loses to the cascade at 64 MiB (roofline read)
+
+The cascade (bottom-up) runs the SAME total wavelet-tree ALU but is DRAM-latency
+bound at max occupancy (64 warps/SM), so that ALU executes for free in the shadow
+of memory stalls -- it decodes json/dna/calgary at 84/147/146 GiB/s. Its dominant
+kernel measured at 64 MiB (same conditions), the root VV merge on json, runs at
+**Compute-SOL 45.7% / DRAM-SOL 52.1% / L2 hit 61.8%, 76 us** -- DRAM-leaning and
+latency-bound, matching the 268 MB per-kernel table above (48.6% / 57.7% / 62%) at
+slightly lower absolute SOL. The chunk
+decoder deleted the DRAM traffic (63% -> ~5%) and thereby deleted the very thing
+that was hiding the ALU; the wide 2048 chunk that wins at medium sizes (it
+amortizes the fixed per-chunk descent) costs occupancy here (72% -> 50%), so at
+64 MiB the exposed O(depth) ALU runs at only ~55% compute-SOL / 50% occupancy and
+the kernel is ~1.5-2x slower. There is no roof to push against: raising throughput
+needs either fewer instructions (radix-4 = -37%, round 10) or more occupancy
+(blocked by the 36 KiB shared the wide chunk needs) -- the two trade off, which is
+exactly why the shipped decoder switches to the cascade above ~12 MiB.

--- a/contrib/pivco-huffman/gpu/pivco_block_index.cpp
+++ b/contrib/pivco-huffman/gpu/pivco_block_index.cpp
@@ -1,0 +1,264 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#include "openzl/dev/contrib/pivco-huffman/gpu/pivco_block_index.h"
+
+#include <algorithm>
+#include <cstddef>
+#include <cstdint>
+#include <cstring>
+
+#include "openzl/codecs/pivco_huffman/common_pivco_kernel.h"
+#include "openzl/shared/bits.h"
+
+namespace {
+
+ZL_Report parameterError()
+{
+    return ZL_returnError(ZL_ErrorCode_parameter_invalid);
+}
+
+ZL_Report corruptionError()
+{
+    return ZL_returnError(ZL_ErrorCode_corruption);
+}
+
+ZL_Report capacityError()
+{
+    return ZL_returnError(ZL_ErrorCode_dstCapacity_tooSmall);
+}
+
+bool addOverflows(size_t a, size_t b)
+{
+    return a > SIZE_MAX - b;
+}
+
+size_t bitmapBytes(size_t bits)
+{
+    return (bits + 7) / 8;
+}
+
+size_t popcountBitmap(const uint8_t* bitmap, size_t numBits)
+{
+    const size_t fullBytes = numBits / 8;
+    size_t count           = 0;
+    for (size_t i = 0; i < fullBytes; ++i) {
+        count += static_cast<size_t>(__builtin_popcount(bitmap[i]));
+    }
+
+    const size_t tailBits = numBits & 7;
+    if (tailBits != 0) {
+        const uint8_t mask = static_cast<uint8_t>((1u << tailBits) - 1u);
+        count += static_cast<size_t>(__builtin_popcount(
+                static_cast<unsigned>(bitmap[fullBytes] & mask)));
+    }
+    return count;
+}
+
+class BitReader {
+   public:
+    BitReader(const uint8_t* data, size_t size)
+            : data_(data), size_(size), bitSize_(size * 8)
+    {
+    }
+
+    bool popAlignedBits(size_t numBits, const uint8_t** out, size_t* outBytes)
+    {
+        if (numBits > SIZE_MAX - 7) {
+            return false;
+        }
+        byteAlign();
+        if (numBits > bitSize_ || bitPos_ > bitSize_ - numBits) {
+            return false;
+        }
+
+        *out      = data_ + bitPos_ / 8;
+        *outBytes = bitmapBytes(numBits);
+        bitPos_ += numBits;
+        return true;
+    }
+
+    bool read(size_t numBits, size_t* value)
+    {
+        if (numBits == 0) {
+            *value = 0;
+            return true;
+        }
+        if (numBits >= sizeof(size_t) * 8) {
+            return false;
+        }
+        if (numBits > bitSize_ || bitPos_ > bitSize_ - numBits) {
+            return false;
+        }
+
+        const size_t bytePos     = bitPos_ / 8;
+        const size_t bitOff      = bitPos_ & 7;
+        size_t word              = 0;
+        const size_t bytesToCopy = std::min<size_t>(
+                sizeof(word), size_ > bytePos ? size_ - bytePos : 0);
+        if (bytesToCopy != 0) {
+            std::memcpy(&word, data_ + bytePos, bytesToCopy);
+        }
+
+        *value = (word >> bitOff) & ((((size_t)1) << numBits) - 1);
+        bitPos_ += numBits;
+        return true;
+    }
+
+    size_t consumedBytes() const
+    {
+        return (bitPos_ + 7) / 8;
+    }
+
+   private:
+    void byteAlign()
+    {
+        const size_t misalignment = bitPos_ & 7;
+        if (misalignment != 0) {
+            bitPos_ += 8 - misalignment;
+        }
+    }
+
+    const uint8_t* data_;
+    size_t size_;
+    size_t bitSize_;
+    size_t bitPos_{ 0 };
+};
+
+bool parseNode(
+        const ZL_PivCoHuffmanTree* tree,
+        BitReader& reader,
+        size_t level,
+        size_t firstRank,
+        size_t rankEnd,
+        size_t count)
+{
+    if (firstRank >= rankEnd || rankEnd > tree->numRanks) {
+        return false;
+    }
+
+    if (ZL_PivCoHuffmanTree_rangeIsLeaf(tree, firstRank, rankEnd)) {
+        const size_t depth = ZL_PivCoHuffmanTree_leafFlatDepth(tree, firstRank);
+        if (depth == 0) {
+            return true;
+        }
+        if (count != 0 && depth > SIZE_MAX / count) {
+            return false;
+        }
+        const uint8_t* bitmap = nullptr;
+        size_t bitmapSize     = 0;
+        return reader.popAlignedBits(count * depth, &bitmap, &bitmapSize);
+    }
+
+    if (level >= tree->numLevels) {
+        return false;
+    }
+
+    const size_t splitRank =
+            ZL_PivCoHuffmanTree_splitRank(tree, level, firstRank, rankEnd);
+    const bool lhsIsConstant =
+            ZL_PivCoHuffmanTree_rangeIsConstantLeaf(tree, firstRank, splitRank);
+    const bool rhsIsConstant =
+            ZL_PivCoHuffmanTree_rangeIsConstantLeaf(tree, splitRank, rankEnd);
+
+    const uint8_t* bitmap = nullptr;
+    size_t bitmapSize     = 0;
+    if (!reader.popAlignedBits(count, &bitmap, &bitmapSize)) {
+        return false;
+    }
+    (void)bitmapSize;
+
+    size_t numOnes = popcountBitmap(bitmap, count);
+    if (!(lhsIsConstant && rhsIsConstant)) {
+        size_t storedNumOnes = 0;
+        if (!reader.read(
+                    static_cast<size_t>(ZL_nextPow2(count + 1)),
+                    &storedNumOnes)) {
+            return false;
+        }
+        if (storedNumOnes > count || storedNumOnes != numOnes) {
+            return false;
+        }
+        numOnes = storedNumOnes;
+    }
+
+    const size_t numZeros = count - numOnes;
+    return parseNode(tree, reader, level + 1, firstRank, splitRank, numZeros)
+            && parseNode(tree, reader, level + 1, splitRank, rankEnd, numOnes);
+}
+
+} // namespace
+
+extern "C" ZL_Report pivcoFindBlockOffsets(
+        uint64_t* offsets,
+        size_t offsetsCapacity,
+        const uint8_t* weights,
+        size_t weightsSize,
+        const uint8_t* bitstream,
+        size_t bitstreamSize,
+        size_t decodedSize,
+        size_t blockSize)
+{
+    if (offsets == nullptr) {
+        return parameterError();
+    }
+    if (weightsSize != 0 && weights == nullptr) {
+        return parameterError();
+    }
+    if (bitstreamSize != 0 && bitstream == nullptr) {
+        return parameterError();
+    }
+
+    if (decodedSize == 0) {
+        if (offsetsCapacity < 1) {
+            return capacityError();
+        }
+        if (weightsSize != 0 || bitstreamSize != 0) {
+            return corruptionError();
+        }
+        offsets[0] = 0;
+        return ZL_returnValue(1);
+    }
+
+    if (blockSize == 0 || blockSize > ZL_PIVCO_MAX_BLOCK_SIZE) {
+        return parameterError();
+    }
+    if (addOverflows(decodedSize, blockSize - 1)) {
+        return ZL_returnError(ZL_ErrorCode_integerOverflow);
+    }
+
+    const size_t numBlocks = (decodedSize + blockSize - 1) / blockSize;
+    if (offsetsCapacity < numBlocks + 1) {
+        return capacityError();
+    }
+
+    const int tableLog = ZL_PivCoHuffman_computeTableLog(weights, weightsSize);
+    if (tableLog < 0) {
+        return corruptionError();
+    }
+
+    ZL_PivCoHuffmanTree tree;
+    ZL_PivCoHuffmanTree_build(&tree, weights, weightsSize, tableLog);
+
+    BitReader reader(bitstream, bitstreamSize);
+    offsets[0] = 0;
+    for (size_t block = 0; block < numBlocks; ++block) {
+        const size_t blockOff = block * blockSize;
+        const size_t blockLen = std::min(blockSize, decodedSize - blockOff);
+        if (reader.consumedBytes() > UINT64_MAX) {
+            return ZL_returnError(ZL_ErrorCode_integerOverflow);
+        }
+        offsets[block] = static_cast<uint64_t>(reader.consumedBytes());
+        if (!parseNode(&tree, reader, 0, 0, tree.numRanks, blockLen)) {
+            return corruptionError();
+        }
+        if (reader.consumedBytes() > UINT64_MAX) {
+            return ZL_returnError(ZL_ErrorCode_integerOverflow);
+        }
+        offsets[block + 1] = static_cast<uint64_t>(reader.consumedBytes());
+    }
+
+    if (reader.consumedBytes() != bitstreamSize) {
+        return corruptionError();
+    }
+    return ZL_returnValue(numBlocks + 1);
+}

--- a/contrib/pivco-huffman/gpu/pivco_block_index.h
+++ b/contrib/pivco-huffman/gpu/pivco_block_index.h
@@ -1,0 +1,37 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#pragma once
+
+#include <stddef.h>
+#include <stdint.h>
+
+#include "openzl/zl_errors.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * Structurally walks a PivCo-Huffman bitstream and returns byte offsets for
+ * each independently encoded block.
+ *
+ * The weights are supplied out-of-band, matching the PivCo-Huffman kernel API.
+ * Offsets are byte positions in @p bitstream and the output shape is
+ * `numBlocks + 1`, where `numBlocks = ceil(decodedSize / blockSize)`.
+ *
+ * Constant blocks legitimately consume no bytes, so adjacent offsets may be
+ * equal.
+ */
+ZL_Report pivcoFindBlockOffsets(
+        uint64_t* offsets,
+        size_t offsetsCapacity,
+        const uint8_t* weights,
+        size_t weightsSize,
+        const uint8_t* bitstream,
+        size_t bitstreamSize,
+        size_t decodedSize,
+        size_t blockSize);
+
+#ifdef __cplusplus
+}
+#endif

--- a/contrib/pivco-huffman/gpu/pivco_gpu.cu
+++ b/contrib/pivco-huffman/gpu/pivco_gpu.cu
@@ -1,0 +1,3637 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#include "openzl/dev/contrib/pivco-huffman/gpu/pivco_gpu.cuh"
+
+#include <cstddef>
+#include <cstdint>
+#include <cstdio>
+#include <cstdlib>
+
+#include <cuda_runtime.h>
+
+#include "openzl/dev/contrib/pivco-huffman/gpu/pivco_gpu_tree.h"
+
+namespace {
+
+constexpr size_t kMaxGridX           = 2147483647u;
+constexpr size_t kTreeWorkspaceBytes = ((sizeof(PivCoGpuTree) + 7) / 8) * 8;
+constexpr size_t kScheduleWorkspaceBytes =
+        ((sizeof(PivCoGpuDecodeSchedule) + 7) / 8) * 8;
+constexpr size_t kDecodeStaticWorkspaceBytes =
+        kTreeWorkspaceBytes + kScheduleWorkspaceBytes;
+constexpr size_t kFastMaxBlockSize       = 64 * 1024;
+constexpr size_t kFastMaxRootBytes       = (kFastMaxBlockSize + 7) / 8;
+constexpr int kFastBlockThreads          = 256;
+constexpr int kMaxRankSelectNodes        = PIVCO_GPU_MAX_TREE_NODES;
+constexpr int kRankSelectThreads         = 256;
+constexpr size_t kRankSelectMaxBlockSize = 64 * 1024;
+constexpr size_t kRankSelectMaxTableLog  = 12;
+constexpr uint32_t kRankSelectMaxBitmapWords =
+        (kRankSelectMaxBlockSize + 31) / 32;
+constexpr uint32_t kBottomUpChunkedMergeThreshold = 1024;
+constexpr int kFastThreadLeafWords =
+        ((((kFastMaxRootBytes + kFastBlockThreads - 1) / kFastBlockThreads) * 8)
+         + 31)
+        / 32;
+constexpr int kScanItemsPerBlock = 256;
+// Trailing pad on each scheduled ping-pong buffer. Node streams are placed at
+// 8-byte-aligned offsets (up to 7 bytes of padding each, at most one per
+// materialized node per level, i.e. <= numRanks <= 256) and the byte merge
+// always stores a full aligned 8-byte group, so the buffer must hold blockSize
+// + 7*256 + 8 rounded up.
+constexpr size_t kMergeBufferPad = 2048;
+
+struct ScheduledNodeState {
+    uint32_t bitmapByteBase;
+    uint32_t leafBitBase;
+    uint32_t count;
+    uint32_t dirBase;
+    uint32_t streamBase;
+};
+
+ZL_Report cudaReport(cudaError_t err)
+{
+    return err == cudaSuccess ? ZL_returnSuccess()
+                              : ZL_returnError(ZL_ErrorCode_GENERIC);
+}
+
+ZL_Report statusReport(const PivCoGpuStatus& status)
+{
+    switch (status.code) {
+        case PIVCO_GPU_STATUS_OK:
+            return ZL_returnSuccess();
+        case PIVCO_GPU_STATUS_PARAMETER:
+            return ZL_returnError(ZL_ErrorCode_parameter_invalid);
+        case PIVCO_GPU_STATUS_CORRUPTION:
+            return ZL_returnError(ZL_ErrorCode_corruption);
+        case PIVCO_GPU_STATUS_CAPACITY:
+            return ZL_returnError(ZL_ErrorCode_dstCapacity_tooSmall);
+        case PIVCO_GPU_STATUS_MISSING_SYMBOL:
+            return ZL_returnError(ZL_ErrorCode_node_invalid_input);
+        default:
+            return ZL_returnError(ZL_ErrorCode_GENERIC);
+    }
+}
+
+bool addOverflows(size_t a, size_t b)
+{
+    return a > SIZE_MAX - b;
+}
+
+size_t numBlocksFor(size_t size, size_t blockSize)
+{
+    return size == 0 ? 0 : (size + blockSize - 1) / blockSize;
+}
+
+size_t alignUpSize(size_t value, size_t alignment);
+size_t rankSelectWorkspaceBytes(size_t blockSize, int tableLog);
+size_t scheduledDecodeBlockWorkspaceBytes(size_t blockSize);
+
+size_t workspaceBytesFor(size_t size, size_t blockSize)
+{
+    if (size == 0) {
+        return 0;
+    }
+    if (blockSize == 0 || addOverflows(size, blockSize - 1)) {
+        return SIZE_MAX;
+    }
+    const size_t numBlocks = numBlocksFor(size, blockSize);
+    if (numBlocks > SIZE_MAX / blockSize / 2) {
+        return SIZE_MAX;
+    }
+    const size_t blockWorkspaceBytes = 2 * numBlocks * blockSize;
+    if (addOverflows(kTreeWorkspaceBytes, blockWorkspaceBytes)) {
+        return SIZE_MAX;
+    }
+    return kTreeWorkspaceBytes + blockWorkspaceBytes;
+}
+
+// Per-block bytes for the main decode workspace (node states + rank directory +
+// the scheduled/chunk decoders' stream buffers).
+size_t decodeBlockWorkspaceBytes(size_t blockSize)
+{
+    const size_t scheduledWorkspace =
+            scheduledDecodeBlockWorkspaceBytes(blockSize);
+    return scheduledWorkspace == SIZE_MAX ? 2 * blockSize : scheduledWorkspace;
+}
+
+size_t decodeWorkspaceBytesFor(size_t size, size_t blockSize)
+{
+    if (size == 0) {
+        return 0;
+    }
+    if (blockSize == 0 || addOverflows(size, blockSize - 1)) {
+        return SIZE_MAX;
+    }
+    const size_t numBlocks      = numBlocksFor(size, blockSize);
+    const size_t blockWorkspace = decodeBlockWorkspaceBytes(blockSize);
+    if (numBlocks > SIZE_MAX / blockWorkspace) {
+        return SIZE_MAX;
+    }
+    const size_t blockWorkspaceBytes = numBlocks * blockWorkspace;
+    if (addOverflows(kDecodeStaticWorkspaceBytes, blockWorkspaceBytes)) {
+        return SIZE_MAX;
+    }
+    return kDecodeStaticWorkspaceBytes + blockWorkspaceBytes;
+}
+
+// The fast root-const-flat1 DECODE kernel handles any block size up to the max.
+bool canUseFastRootConstFlat1Decode(const PivCoGpuTree& tree, size_t blockSize)
+{
+    return tree.fastMode == PIVCO_GPU_FAST_ROOT_CONST_FLAT1
+            && blockSize <= kFastMaxBlockSize;
+}
+
+// The fast ENCODE path additionally requires blockSize >= 1024: its offset-scan
+// is only exercised at that scale, so smaller block counts use the general
+// encode path.
+bool canUseFastRootConstFlat1Encode(const PivCoGpuTree& tree, size_t blockSize)
+{
+    return canUseFastRootConstFlat1Decode(tree, blockSize) && blockSize >= 1024;
+}
+
+bool canUseFastFlatRoot(const PivCoGpuTree& tree)
+{
+    return tree.fastMode == PIVCO_GPU_FAST_FLAT_ROOT;
+}
+
+size_t alignUpSize(size_t value, size_t alignment)
+{
+    return (value + alignment - 1) / alignment * alignment;
+}
+
+size_t rankSelectWorkspaceBytes(size_t blockSize, int tableLog)
+{
+    if (tableLog <= 0 || blockSize > kRankSelectMaxBlockSize) {
+        return SIZE_MAX;
+    }
+    const size_t dirEntries =
+            ((blockSize * static_cast<size_t>(tableLog) + 31) / 32)
+            + kMaxRankSelectNodes;
+    return dirEntries * sizeof(uint16_t);
+}
+
+size_t scheduledDecodeBlockWorkspaceBytes(size_t blockSize)
+{
+    if (blockSize > kRankSelectMaxBlockSize) {
+        return SIZE_MAX;
+    }
+    const size_t nodeStateBytes = alignUpSize(
+            sizeof(ScheduledNodeState) * PIVCO_GPU_MAX_TREE_NODES,
+            alignof(ScheduledNodeState));
+    const size_t directoryBytes =
+            rankSelectWorkspaceBytes(blockSize, kRankSelectMaxTableLog);
+    if (directoryBytes == SIZE_MAX) {
+        return SIZE_MAX;
+    }
+    const size_t prefixBytes = alignUpSize(
+            nodeStateBytes + alignUpSize(directoryBytes, alignof(uint16_t)), 8);
+    const size_t bufBytes = blockSize + kMergeBufferPad;
+    if (bufBytes > (SIZE_MAX - prefixBytes) / 2) {
+        return SIZE_MAX;
+    }
+    return alignUpSize(prefixBytes + 2 * bufBytes, alignof(ScheduledNodeState));
+}
+
+bool canUseScheduledDecode(
+        const PivCoGpuTree& tree,
+        const PivCoGpuDecodeSchedule& schedule,
+        size_t blockSize)
+{
+    return tree.fastMode == PIVCO_GPU_FAST_NONE && schedule.enabled != 0
+            && tree.tableLog > 0
+            && static_cast<size_t>(tree.tableLog) <= kRankSelectMaxTableLog
+            && scheduledDecodeBlockWorkspaceBytes(blockSize) != SIZE_MAX;
+}
+
+size_t scheduleStageIndex(uint16_t level, uint8_t op)
+{
+    return static_cast<size_t>(level) * PIVCO_GPU_SCHEDULE_OP_COUNT + op;
+}
+
+__device__ void
+setStatus(PivCoGpuStatus* status, PivCoGpuStatusCode code, uint64_t detail)
+{
+    if (atomicCAS(&status->code, PIVCO_GPU_STATUS_OK, code)
+        == PIVCO_GPU_STATUS_OK) {
+        status->detail = detail;
+    }
+}
+
+__device__ size_t dMin(size_t a, size_t b)
+{
+    return a < b ? a : b;
+}
+
+__device__ size_t dBitmapBytes(size_t bits)
+{
+    return (bits + 7) / 8;
+}
+
+__device__ size_t dAlignUpSize(size_t value, size_t alignment)
+{
+    return (value + alignment - 1) / alignment * alignment;
+}
+
+__device__ size_t dScheduledDirectoryEntries(size_t blockSize)
+{
+    return ((blockSize * kRankSelectMaxTableLog + 31) / 32)
+            + kMaxRankSelectNodes;
+}
+
+__device__ size_t dScheduledBlockWorkspaceBytes(size_t blockSize)
+{
+    const size_t nodeStateBytes = dAlignUpSize(
+            sizeof(ScheduledNodeState) * PIVCO_GPU_MAX_TREE_NODES,
+            alignof(ScheduledNodeState));
+    const size_t directoryBytes =
+            dScheduledDirectoryEntries(blockSize) * sizeof(uint16_t);
+    const size_t prefixBytes = dAlignUpSize(
+            nodeStateBytes + dAlignUpSize(directoryBytes, alignof(uint16_t)),
+            8);
+    return dAlignUpSize(
+            prefixBytes + 2 * (blockSize + kMergeBufferPad),
+            alignof(ScheduledNodeState));
+}
+
+__device__ size_t dNextPow2(uint64_t upperBound)
+{
+    size_t bits    = 0;
+    uint64_t value = 1;
+    while (value < upperBound) {
+        value <<= 1;
+        ++bits;
+    }
+    return bits;
+}
+
+__device__ void scheduledDecodeWorkspace(
+        uint8_t* workspace,
+        size_t block,
+        size_t blockSize,
+        ScheduledNodeState** states,
+        uint16_t** directory,
+        uint32_t* directoryCapacity,
+        uint8_t** bufferA,
+        uint8_t** bufferB)
+{
+    uint8_t* const blockWorkspace =
+            workspace + block * dScheduledBlockWorkspaceBytes(blockSize);
+    const size_t nodeStateBytes = dAlignUpSize(
+            sizeof(ScheduledNodeState) * PIVCO_GPU_MAX_TREE_NODES,
+            alignof(ScheduledNodeState));
+    const size_t directoryEntries = dScheduledDirectoryEntries(blockSize);
+    const size_t directoryBytes   = directoryEntries * sizeof(uint16_t);
+    const size_t alignedDirectoryBytes =
+            dAlignUpSize(directoryBytes, alignof(uint16_t));
+    // 8-byte-align the buffers so the byte merge can store aligned 8-byte
+    // groups.
+    const size_t prefixBytes =
+            dAlignUpSize(nodeStateBytes + alignedDirectoryBytes, 8);
+
+    *states    = reinterpret_cast<ScheduledNodeState*>(blockWorkspace);
+    *directory = reinterpret_cast<uint16_t*>(blockWorkspace + nodeStateBytes);
+    *directoryCapacity = static_cast<uint32_t>(directoryEntries);
+    *bufferA           = blockWorkspace + prefixBytes;
+    *bufferB           = *bufferA + (blockSize + kMergeBufferPad);
+}
+
+__device__ bool
+dRangeIsLeaf(const PivCoGpuTree* tree, size_t firstRank, size_t rankEnd)
+{
+    if (firstRank >= rankEnd || rankEnd > tree->numRanks) {
+        return false;
+    }
+    return (static_cast<size_t>(1) << tree->rankToFlatDepth[firstRank])
+            == rankEnd - firstRank;
+}
+
+__device__ size_t dLeafFlatDepth(const PivCoGpuTree* tree, size_t firstRank)
+{
+    return tree->rankToFlatDepth[firstRank];
+}
+
+__device__ bool
+dRangeIsConstantLeaf(const PivCoGpuTree* tree, size_t firstRank, size_t rankEnd)
+{
+    return dRangeIsLeaf(tree, firstRank, rankEnd)
+            && dLeafFlatDepth(tree, firstRank) == 0;
+}
+
+__device__ size_t dSplitRank(
+        const PivCoGpuTree* tree,
+        size_t level,
+        size_t firstRank,
+        size_t rankEnd)
+{
+    const uint16_t mask = static_cast<uint16_t>(0x8000u >> level);
+    size_t splitRank    = firstRank + 1;
+    while (splitRank < rankEnd
+           && (tree->rankToCodeword[splitRank] & mask) == 0) {
+        ++splitRank;
+    }
+    return splitRank;
+}
+
+struct DeviceBitCounter {
+    uint64_t bitPos{ 0 };
+    bool ok{ true };
+
+    __device__ void reserveAlignedBits(uint64_t bits)
+    {
+        bitPos = (bitPos + 7u) & ~uint64_t{ 7 };
+        if (bits > UINT64_MAX - bitPos) {
+            ok = false;
+            return;
+        }
+        bitPos += bits;
+    }
+
+    __device__ void writeBits(uint64_t, size_t bits)
+    {
+        if (bits > UINT64_MAX - bitPos) {
+            ok = false;
+            return;
+        }
+        bitPos += bits;
+    }
+
+    __device__ uint64_t bytes() const
+    {
+        return (bitPos + 7u) / 8u;
+    }
+};
+
+struct DeviceBitWriter {
+    uint8_t* data;
+    uint64_t capacity;
+    uint64_t bitPos{ 0 };
+    bool ok{ true };
+
+    __device__ uint8_t* reserveAlignedBits(uint64_t bits)
+    {
+        bitPos = (bitPos + 7u) & ~uint64_t{ 7 };
+        if (bits > UINT64_MAX - bitPos || bitPos + bits > capacity * 8u) {
+            ok = false;
+            return nullptr;
+        }
+        uint8_t* out = data + bitPos / 8u;
+        bitPos += bits;
+        return out;
+    }
+
+    __device__ void writeBits(uint64_t value, size_t bits)
+    {
+        if (bits > UINT64_MAX - bitPos || bitPos + bits > capacity * 8u) {
+            ok = false;
+            return;
+        }
+        for (size_t i = 0; i < bits; ++i) {
+            if (((value >> i) & 1u) != 0) {
+                const uint64_t pos = bitPos + i;
+                data[pos / 8u] |= static_cast<uint8_t>(1u << (pos & 7u));
+            }
+        }
+        bitPos += bits;
+    }
+
+    __device__ uint64_t bytes() const
+    {
+        return (bitPos + 7u) / 8u;
+    }
+};
+
+__device__ size_t partitionRanks(
+        uint8_t* bitmap,
+        uint8_t* lhs,
+        uint8_t* rhs,
+        const uint8_t* ranks,
+        size_t count,
+        uint8_t rightRank)
+{
+    size_t zeros = 0;
+    size_t ones  = 0;
+    for (size_t i = 0; i < count; ++i) {
+        const uint8_t rank = ranks[i];
+        const bool isRight = rank >= rightRank;
+        if (bitmap != nullptr && isRight) {
+            bitmap[i / 8] |= static_cast<uint8_t>(1u << (i & 7));
+        }
+        if (isRight) {
+            if (rhs != nullptr) {
+                rhs[ones] = rank;
+            }
+            ++ones;
+        } else {
+            if (lhs != nullptr) {
+                lhs[zeros] = rank;
+            }
+            ++zeros;
+        }
+    }
+    return ones;
+}
+
+__device__ bool measureNode(
+        const PivCoGpuTree* tree,
+        DeviceBitCounter& writer,
+        uint8_t* nodeRanks,
+        uint8_t* nodeScratch,
+        size_t count,
+        size_t level,
+        size_t firstRank,
+        size_t rankEnd)
+{
+    if (dRangeIsLeaf(tree, firstRank, rankEnd)) {
+        const size_t depth = dLeafFlatDepth(tree, firstRank);
+        if (depth != 0) {
+            writer.reserveAlignedBits(static_cast<uint64_t>(count) * depth);
+        }
+        return writer.ok;
+    }
+    if (level >= tree->numLevels) {
+        return false;
+    }
+
+    const size_t splitRank   = dSplitRank(tree, level, firstRank, rankEnd);
+    const bool lhsIsConstant = dRangeIsConstantLeaf(tree, firstRank, splitRank);
+    const bool rhsIsConstant = dRangeIsConstantLeaf(tree, splitRank, rankEnd);
+
+    uint8_t* const lhsRanks = nodeScratch;
+    uint8_t* const rhsRanks = lhsIsConstant ? nodeScratch : nodeRanks;
+
+    writer.reserveAlignedBits(count);
+    const size_t numOnes = partitionRanks(
+            nullptr,
+            lhsIsConstant ? nullptr : lhsRanks,
+            rhsIsConstant ? nullptr : rhsRanks,
+            nodeRanks,
+            count,
+            static_cast<uint8_t>(splitRank));
+    if (!(lhsIsConstant && rhsIsConstant)) {
+        writer.writeBits(0, dNextPow2(count + 1));
+    }
+
+    const size_t numZeros     = count - numOnes;
+    uint8_t* const lhsScratch = rhsIsConstant ? nodeRanks : rhsRanks + numOnes;
+    uint8_t* const rhsScratch = lhsIsConstant ? nodeRanks : lhsRanks + numZeros;
+
+    if (!lhsIsConstant
+        && !measureNode(
+                tree,
+                writer,
+                lhsRanks,
+                lhsScratch,
+                numZeros,
+                level + 1,
+                firstRank,
+                splitRank)) {
+        return false;
+    }
+    if (!rhsIsConstant
+        && !measureNode(
+                tree,
+                writer,
+                rhsRanks,
+                rhsScratch,
+                numOnes,
+                level + 1,
+                splitRank,
+                rankEnd)) {
+        return false;
+    }
+    return writer.ok;
+}
+
+__device__ void packFlatDepth(
+        uint8_t* bitmap,
+        size_t depth,
+        const uint8_t* ranks,
+        size_t count,
+        uint8_t firstRank)
+{
+    for (size_t i = 0; i < count; ++i) {
+        const uint8_t index  = static_cast<uint8_t>(ranks[i] - firstRank);
+        const size_t bitBase = i * depth;
+        for (size_t bit = 0; bit < depth; ++bit) {
+            if (((index >> bit) & 1u) != 0) {
+                const size_t pos = bitBase + bit;
+                bitmap[pos / 8] |= static_cast<uint8_t>(1u << (pos & 7));
+            }
+        }
+    }
+}
+
+__device__ bool emitNode(
+        const PivCoGpuTree* tree,
+        DeviceBitWriter& writer,
+        uint8_t* nodeRanks,
+        uint8_t* nodeScratch,
+        size_t count,
+        size_t level,
+        size_t firstRank,
+        size_t rankEnd)
+{
+    if (dRangeIsLeaf(tree, firstRank, rankEnd)) {
+        const size_t depth = dLeafFlatDepth(tree, firstRank);
+        if (depth != 0) {
+            uint8_t* const bitmap = writer.reserveAlignedBits(
+                    static_cast<uint64_t>(count) * depth);
+            if (bitmap == nullptr && count * depth != 0) {
+                return false;
+            }
+            packFlatDepth(
+                    bitmap,
+                    depth,
+                    nodeRanks,
+                    count,
+                    static_cast<uint8_t>(firstRank));
+        }
+        return writer.ok;
+    }
+    if (level >= tree->numLevels) {
+        return false;
+    }
+
+    const size_t splitRank   = dSplitRank(tree, level, firstRank, rankEnd);
+    const bool lhsIsConstant = dRangeIsConstantLeaf(tree, firstRank, splitRank);
+    const bool rhsIsConstant = dRangeIsConstantLeaf(tree, splitRank, rankEnd);
+
+    uint8_t* const lhsRanks = nodeScratch;
+    uint8_t* const rhsRanks = lhsIsConstant ? nodeScratch : nodeRanks;
+
+    uint8_t* const bitmap = writer.reserveAlignedBits(count);
+    if (bitmap == nullptr && count != 0) {
+        return false;
+    }
+    const size_t numOnes = partitionRanks(
+            bitmap,
+            lhsIsConstant ? nullptr : lhsRanks,
+            rhsIsConstant ? nullptr : rhsRanks,
+            nodeRanks,
+            count,
+            static_cast<uint8_t>(splitRank));
+    if (!(lhsIsConstant && rhsIsConstant)) {
+        writer.writeBits(numOnes, dNextPow2(count + 1));
+    }
+
+    const size_t numZeros     = count - numOnes;
+    uint8_t* const lhsScratch = rhsIsConstant ? nodeRanks : rhsRanks + numOnes;
+    uint8_t* const rhsScratch = lhsIsConstant ? nodeRanks : lhsRanks + numZeros;
+
+    if (!lhsIsConstant
+        && !emitNode(
+                tree,
+                writer,
+                lhsRanks,
+                lhsScratch,
+                numZeros,
+                level + 1,
+                firstRank,
+                splitRank)) {
+        return false;
+    }
+    if (!rhsIsConstant
+        && !emitNode(
+                tree,
+                writer,
+                rhsRanks,
+                rhsScratch,
+                numOnes,
+                level + 1,
+                splitRank,
+                rankEnd)) {
+        return false;
+    }
+    return writer.ok;
+}
+
+struct DeviceBitReader {
+    const uint8_t* data;
+    uint64_t size;
+    uint64_t bitPos{ 0 };
+
+    __device__ void byteAlign()
+    {
+        bitPos = (bitPos + 7u) & ~uint64_t{ 7 };
+    }
+
+    __device__ bool
+    popAlignedBits(uint64_t bits, const uint8_t** out, uint64_t* outBytes)
+    {
+        byteAlign();
+        if (bits > size * 8u || bitPos > size * 8u - bits) {
+            return false;
+        }
+        *out      = data + bitPos / 8u;
+        *outBytes = (bits + 7u) / 8u;
+        bitPos += bits;
+        return true;
+    }
+
+    __device__ bool readBits(size_t bits, size_t* value)
+    {
+        if (bits == 0) {
+            *value = 0;
+            return true;
+        }
+        if (bits >= sizeof(size_t) * 8 || bits > size * 8u
+            || bitPos > size * 8u - bits) {
+            return false;
+        }
+        // Read the byte span holding the field into a chunk and shift/mask,
+        // instead of a bit-by-bit loop (this runs on the serial 1-thread
+        // parse).
+        const uint64_t bytePos = bitPos >> 3u;
+        const uint32_t bitOff  = static_cast<uint32_t>(bitPos & 7u);
+        const uint32_t nbytes =
+                static_cast<uint32_t>((bitOff + bits + 7u) >> 3u);
+        uint64_t chunk = 0;
+        for (uint32_t i = 0; i < nbytes; ++i) {
+            chunk |= static_cast<uint64_t>(data[bytePos + i]) << (i * 8u);
+        }
+        *value = static_cast<size_t>(
+                (chunk >> bitOff) & ((uint64_t{ 1 } << bits) - 1u));
+        bitPos += bits;
+        return true;
+    }
+
+    __device__ uint64_t consumedBytes() const
+    {
+        return (bitPos + 7u) / 8u;
+    }
+};
+
+__device__ uint8_t dGetBit(const uint8_t* bitmap, uint64_t bitBase)
+{
+    return static_cast<uint8_t>((bitmap[bitBase / 8] >> (bitBase & 7)) & 1u);
+}
+
+__device__ uint32_t
+dLoadLe32Masked(const uint8_t* data, size_t bitBase, size_t count)
+{
+    uint32_t value        = 0;
+    const size_t byteBase = bitBase / 8;
+    for (size_t i = 0; i < 4 && byteBase + i < dBitmapBytes(count); ++i) {
+        value |= static_cast<uint32_t>(data[byteBase + i]) << (i * 8);
+    }
+
+    const size_t remainingBits = count > bitBase ? count - bitBase : 0;
+    if (remainingBits < 32) {
+        const uint32_t mask =
+                remainingBits == 0 ? 0 : ((uint64_t{ 1 } << remainingBits) - 1);
+        value &= mask;
+    }
+    return value;
+}
+
+__device__ uint32_t dRankSelectOnesBefore(
+        const uint8_t* bitmap,
+        const uint16_t* directory,
+        uint32_t dirBase,
+        uint32_t bitPos)
+{
+    const uint32_t wordIndex = bitPos / 32u;
+    const uint32_t bit       = bitPos & 31u;
+    uint32_t count           = directory[dirBase + wordIndex];
+    if (bit != 0) {
+        const uint32_t word = dLoadLe32Masked(bitmap, wordIndex * 32u, bitPos);
+        count += static_cast<uint32_t>(__popc(word & ((1u << bit) - 1u)));
+    }
+    return count;
+}
+
+// Branchless/loop-free rank used inside the chunk decoder's hot descent: reads
+// the enclosing 32-bit word directly (over-reading a few bytes into the
+// bitstream's trailing slop, all masked off) instead of dLoadLe32Masked's
+// bounded byte loop.
+__device__ __forceinline__ uint32_t dRankOnesBeforeFast(
+        const uint8_t* bitmap,
+        const uint16_t* directory,
+        uint32_t dirBase,
+        uint32_t bitPos)
+{
+    const uint32_t wordIndex = bitPos >> 5u;
+    const uint32_t bit       = bitPos & 31u;
+    uint32_t count           = directory[dirBase + wordIndex];
+    if (bit != 0u) {
+        const uint32_t b = wordIndex << 2u;
+        const uint32_t w = static_cast<uint32_t>(bitmap[b])
+                | (static_cast<uint32_t>(bitmap[b + 1u]) << 8u)
+                | (static_cast<uint32_t>(bitmap[b + 2u]) << 16u)
+                | (static_cast<uint32_t>(bitmap[b + 3u]) << 24u);
+        count += static_cast<uint32_t>(__popc(w & ((1u << bit) - 1u)));
+    }
+    return count;
+}
+
+// Rank/select for a byte-aligned bit position (the merge kernels always query
+// at a byte boundary). The sub-word remainder is then 0-3 whole bytes, so the
+// partial popcount reads exactly those bytes -- no bit masking and, unlike a
+// 32-bit load, no read past the bitmap's last byte.
+__device__ __forceinline__ uint32_t dRankSelectOnesBeforeAligned(
+        const uint8_t* bitmap,
+        const uint16_t* directory,
+        uint32_t dirBase,
+        uint32_t bitPos)
+{
+    const uint32_t bytePos   = bitPos >> 3u;
+    const uint32_t wordIndex = bytePos >> 2u;
+    const uint32_t base      = wordIndex << 2u;
+    const uint32_t rem       = bytePos & 3u;
+    uint32_t count           = directory[dirBase + wordIndex];
+    if (rem > 0u) {
+        count += static_cast<uint32_t>(__popc(bitmap[base]));
+    }
+    if (rem > 1u) {
+        count += static_cast<uint32_t>(__popc(bitmap[base + 1u]));
+    }
+    if (rem > 2u) {
+        count += static_cast<uint32_t>(__popc(bitmap[base + 2u]));
+    }
+    return count;
+}
+
+template <bool ComputeOnes = true>
+__device__ bool buildRankSelectDirectoryCooperative(
+        const uint8_t* bitmap,
+        uint32_t count,
+        uint16_t* directory,
+        uint32_t directoryCapacity,
+        uint32_t dirBase,
+        uint16_t* prefixA,
+        uint16_t* prefixB,
+        uint32_t* ones)
+{
+    const uint32_t words = (count + 31u) / 32u;
+    if (dirBase > directoryCapacity || words + 1u > directoryCapacity - dirBase
+        || words > kRankSelectMaxBitmapWords) {
+        return false;
+    }
+
+    // Only prefixA[0] needs initializing: the popcount loop below writes every
+    // prefixA[1..words], and nothing reads prefixA before the scan (after the
+    // next barrier), so the old full-array zeroing pass + its barrier were
+    // redundant.
+    if (threadIdx.x == 0) {
+        prefixA[0] = 0;
+    }
+
+    // Two words per thread with both loads issued before either popcount, so
+    // the (latency-bound) bitmap loads overlap.
+    for (uint32_t word = threadIdx.x; word < words; word += blockDim.x * 2u) {
+        const uint32_t w1    = word + blockDim.x;
+        const uint32_t load0 = dLoadLe32Masked(bitmap, word * 32u, count);
+        const uint32_t load1 =
+                w1 < words ? dLoadLe32Masked(bitmap, w1 * 32u, count) : 0u;
+        prefixA[word + 1] = static_cast<uint16_t>(__popc(load0));
+        if (w1 < words) {
+            prefixA[w1 + 1] = static_cast<uint16_t>(__popc(load1));
+        }
+    }
+    __syncthreads();
+
+    // Work-efficient inclusive scan of prefixA[0..words] into the directory:
+    // each thread sums a contiguous tile, an exclusive scan of the per-thread
+    // tile sums (warp-scan + one warp of warp-totals) gives each tile's base,
+    // then each thread writes its tile's running prefix. O(entries) work with
+    // two barriers, versus the O(entries log entries) Hillis-Steele it
+    // replaces.
+    (void)prefixB;
+    const uint32_t entries = words + 1u;
+
+    // Small node: a single warp scans all entries with shuffles and no block
+    // barriers (the caller reads *ones only on thread 0). This avoids the
+    // two-barrier fixed cost of the block scan for the many tiny nodes.
+    if (entries <= 32u) {
+        if (threadIdx.x < 32u) {
+            const uint32_t lane = threadIdx.x;
+            uint32_t v          = lane < entries ? prefixA[lane] : 0u;
+#pragma unroll
+            for (uint32_t o = 1; o < 32u; o <<= 1u) {
+                const uint32_t n = __shfl_up_sync(0xFFFFFFFFu, v, o);
+                if (lane >= o) {
+                    v += n;
+                }
+            }
+            if (lane < entries) {
+                directory[dirBase + lane] = static_cast<uint16_t>(v);
+            }
+            if constexpr (ComputeOnes) {
+                const uint32_t total = __shfl_sync(0xFFFFFFFFu, v, words);
+                if (lane == 0u) {
+                    *ones = total;
+                }
+            }
+        }
+        return true;
+    }
+
+    const uint32_t tile  = (entries + blockDim.x - 1u) / blockDim.x;
+    const uint32_t start = threadIdx.x * tile;
+    const uint32_t stop  = start + tile < entries ? start + tile : entries;
+
+    uint32_t tileSum = 0;
+    for (uint32_t i = start; i < stop; ++i) {
+        tileSum += prefixA[i];
+    }
+
+    __shared__ uint32_t s_warpTotals[32];
+    const uint32_t lane     = threadIdx.x & 31u;
+    const uint32_t warp     = threadIdx.x >> 5u;
+    const uint32_t numWarps = blockDim.x >> 5u;
+    uint32_t incl           = tileSum;
+#pragma unroll
+    for (uint32_t o = 1; o < 32u; o <<= 1u) {
+        const uint32_t n = __shfl_up_sync(0xFFFFFFFFu, incl, o);
+        if (lane >= o) {
+            incl += n;
+        }
+    }
+    if (lane == 31u) {
+        s_warpTotals[warp] = incl;
+    }
+    __syncthreads();
+    if (warp == 0u) {
+        uint32_t w = lane < numWarps ? s_warpTotals[lane] : 0u;
+#pragma unroll
+        for (uint32_t o = 1; o < 32u; o <<= 1u) {
+            const uint32_t n = __shfl_up_sync(0xFFFFFFFFu, w, o);
+            if (lane >= o) {
+                w += n;
+            }
+        }
+        if (lane < numWarps) {
+            s_warpTotals[lane] = w; // inclusive warp totals
+        }
+    }
+    __syncthreads();
+
+    const uint32_t warpBase = warp == 0u ? 0u : s_warpTotals[warp - 1u];
+    uint32_t running        = warpBase + incl - tileSum; // exclusive tile base
+    for (uint32_t i = start; i < stop; ++i) {
+        running += prefixA[i];
+        directory[dirBase + i] = static_cast<uint16_t>(running);
+    }
+    // The caller (buildSharedDirectory / directory kernel) issues the barrier
+    // that publishes the directory to readers. `*ones` (a corruption check) is
+    // only needed by the top-down path, so its extra read + two barriers are
+    // skipped when ComputeOnes is false (the fused merge never reads it).
+    if constexpr (ComputeOnes) {
+        __syncthreads();
+        if (threadIdx.x == 0) {
+            *ones = directory[dirBase + words];
+        }
+        __syncthreads();
+    }
+    return true;
+}
+
+// Builds a node's rank directory directly into shared memory at the top of a
+// merge kernel (fusing the former standalone directory kernel): keeps the
+// directory off global memory, lets the merge's rank reads hit shared, and
+// reuses the bitmap that is already resident from this build for the merge's
+// own bitmap reads. All threads of the block must call this; it ends with a
+// barrier so the merge can read `s_dir` immediately.
+__device__ __forceinline__ void buildSharedDirectory(
+        const uint8_t* bitmap,
+        uint32_t count,
+        uint16_t* s_dir,
+        uint16_t* s_prefix,
+        uint32_t* s_ones)
+{
+    buildRankSelectDirectoryCooperative<false>(
+            bitmap,
+            count,
+            s_dir,
+            kRankSelectMaxBitmapWords + 1u,
+            0u,
+            s_prefix,
+            s_prefix,
+            s_ones);
+    __syncthreads();
+}
+
+__device__ void
+dOrBits(uint8_t* bitmap, uint64_t bitBase, uint64_t value, size_t bits)
+{
+    for (size_t i = 0; i < bits; ++i) {
+        if (((value >> i) & 1u) != 0) {
+            const uint64_t pos = bitBase + i;
+            bitmap[pos / 8] |= static_cast<uint8_t>(1u << (pos & 7));
+        }
+    }
+}
+
+__device__ void dAtomicOrSharedBits(
+        uint32_t* words,
+        uint32_t bitBase,
+        uint32_t value,
+        uint32_t bits)
+{
+    if (bits == 0) {
+        return;
+    }
+    const uint32_t wordIndex = bitBase / 32u;
+    const uint32_t shift     = bitBase & 31u;
+    atomicOr(&words[wordIndex], value << shift);
+    if (shift != 0 && shift + bits > 32u) {
+        atomicOr(&words[wordIndex + 1], value >> (32u - shift));
+    }
+}
+
+__device__ uint8_t dEqMask4(uint32_t word, uint8_t value)
+{
+    const uint32_t repeated = static_cast<uint32_t>(value) * 0x01010101u;
+    const uint32_t eq       = __vcmpeq4(word, repeated) & 0x01010101u;
+    return static_cast<uint8_t>(
+            (eq & 1u) | ((eq >> 7) & 2u) | ((eq >> 14) & 4u)
+            | ((eq >> 21) & 8u));
+}
+
+__device__ uint8_t dEqMask8(const uint8_t* ptr, uint8_t value)
+{
+    const auto* const words = reinterpret_cast<const uint32_t*>(ptr);
+    return static_cast<uint8_t>(
+            dEqMask4(words[0], value) | (dEqMask4(words[1], value) << 4));
+}
+
+__device__ size_t dFastCountBits(size_t blockLen)
+{
+    return dNextPow2(blockLen + 1);
+}
+
+__device__ uint64_t dFastLeafBitBase(size_t blockLen)
+{
+    return (static_cast<uint64_t>(blockLen) + dFastCountBits(blockLen) + 7u)
+            & ~uint64_t{ 7 };
+}
+
+__device__ uint64_t dFastEncodedBytes(size_t blockLen, uint32_t numOnes)
+{
+    return (dFastLeafBitBase(blockLen) + numOnes + 7u) / 8u;
+}
+
+__device__ uint8_t dRootByteMask(size_t byteIndex, size_t blockLen)
+{
+    const size_t remainingBits = blockLen - byteIndex * 8;
+    if (remainingBits >= 8) {
+        return 0xFF;
+    }
+    return static_cast<uint8_t>((1u << remainingBits) - 1u);
+}
+
+__device__ void fastScanRootPrefix(
+        uint32_t* prefix,
+        const uint8_t* rootBytes,
+        size_t rootBytesCount,
+        size_t blockLen)
+{
+    for (size_t i = threadIdx.x; i < rootBytesCount; i += blockDim.x) {
+        const uint8_t rootByte = rootBytes[i] & dRootByteMask(i, blockLen);
+        prefix[i + 1]          = static_cast<uint32_t>(__popc(rootByte));
+    }
+    if (threadIdx.x == 0) {
+        prefix[0] = 0;
+    }
+    __syncthreads();
+
+    if (threadIdx.x == 0) {
+        uint32_t running = 0;
+        for (size_t i = 0; i < rootBytesCount; ++i) {
+            const uint32_t count = prefix[i + 1];
+            prefix[i]            = running;
+            running += count;
+        }
+        prefix[rootBytesCount] = running;
+    }
+    __syncthreads();
+}
+
+__global__ void encodeLayoutKernel(
+        const PivCoGpuTree* tree,
+        const uint8_t* src,
+        size_t srcSize,
+        size_t blockSize,
+        uint8_t* workspace,
+        uint64_t* offsets,
+        PivCoGpuStatus* status)
+{
+    const size_t block    = blockIdx.x;
+    const size_t blockOff = block * blockSize;
+    if (blockOff >= srcSize) {
+        return;
+    }
+    const size_t blockLen  = dMin(blockSize, srcSize - blockOff);
+    uint8_t* const ranks   = workspace + block * 2 * blockSize;
+    uint8_t* const scratch = ranks + blockSize;
+
+    for (size_t i = 0; i < blockLen; ++i) {
+        const uint8_t symbol = src[blockOff + i];
+        if (tree->symbolPresent[symbol] == 0) {
+            setStatus(status, PIVCO_GPU_STATUS_MISSING_SYMBOL, symbol);
+            offsets[block + 1] = 0;
+            return;
+        }
+        ranks[i] = tree->symbolToRank[symbol];
+    }
+
+    DeviceBitCounter writer;
+    if (!measureNode(
+                tree, writer, ranks, scratch, blockLen, 0, 0, tree->numRanks)) {
+        setStatus(status, PIVCO_GPU_STATUS_CORRUPTION, block);
+        offsets[block + 1] = 0;
+        return;
+    }
+    offsets[block + 1] = writer.bytes();
+}
+
+__global__ void scanOffsetsKernel(
+        uint64_t* offsets,
+        size_t numBlocks,
+        uint64_t* totalSize,
+        PivCoGpuStatus* status)
+{
+    if (threadIdx.x != 0 || blockIdx.x != 0) {
+        return;
+    }
+
+    uint64_t running = 0;
+    for (size_t i = 0; i < numBlocks; ++i) {
+        const uint64_t blockSize = offsets[i + 1];
+        offsets[i]               = running;
+        if (UINT64_MAX - running < blockSize) {
+            setStatus(status, PIVCO_GPU_STATUS_CAPACITY, i);
+            *totalSize = running;
+            return;
+        }
+        running += blockSize;
+    }
+    offsets[numBlocks] = running;
+    *totalSize         = running;
+}
+
+__global__ void
+scanBlockSizesKernel(uint64_t* offsets, size_t numBlocks, uint64_t* chunkSums)
+{
+    __shared__ uint64_t values[kScanItemsPerBlock];
+
+    const size_t index =
+            blockIdx.x * static_cast<size_t>(kScanItemsPerBlock) + threadIdx.x;
+    const uint64_t value = index < numBlocks ? offsets[index + 1] : 0;
+    values[threadIdx.x]  = value;
+    __syncthreads();
+
+    for (int step = 1; step < kScanItemsPerBlock; step <<= 1) {
+        const uint64_t addend =
+                threadIdx.x >= step ? values[threadIdx.x - step] : 0;
+        __syncthreads();
+        values[threadIdx.x] += addend;
+        __syncthreads();
+    }
+
+    if (index < numBlocks) {
+        offsets[index] = values[threadIdx.x] - value;
+    }
+    if (threadIdx.x == kScanItemsPerBlock - 1) {
+        chunkSums[blockIdx.x] = values[threadIdx.x];
+    }
+}
+
+__global__ void scanChunkSumsKernel(
+        const uint64_t* chunkSums,
+        uint64_t* chunkOffsets,
+        size_t numChunks,
+        uint64_t* totalSize)
+{
+    __shared__ uint64_t values[kScanItemsPerBlock];
+
+    const size_t index   = threadIdx.x;
+    const uint64_t value = index < numChunks ? chunkSums[index] : 0;
+    values[threadIdx.x]  = value;
+    __syncthreads();
+
+    for (int step = 1; step < kScanItemsPerBlock; step <<= 1) {
+        const uint64_t addend =
+                threadIdx.x >= step ? values[threadIdx.x - step] : 0;
+        __syncthreads();
+        values[threadIdx.x] += addend;
+        __syncthreads();
+    }
+
+    if (index < numChunks) {
+        chunkOffsets[index] = values[threadIdx.x] - value;
+    }
+    if (threadIdx.x == kScanItemsPerBlock - 1) {
+        *totalSize = values[threadIdx.x];
+    }
+}
+
+__global__ void addChunkOffsetsKernel(
+        uint64_t* offsets,
+        size_t numBlocks,
+        const uint64_t* chunkOffsets,
+        const uint64_t* totalSize)
+{
+    const size_t index =
+            blockIdx.x * static_cast<size_t>(kScanItemsPerBlock) + threadIdx.x;
+    if (index < numBlocks) {
+        offsets[index] += chunkOffsets[blockIdx.x];
+    }
+    if (blockIdx.x == 0 && threadIdx.x == 0) {
+        offsets[numBlocks] = *totalSize;
+    }
+}
+
+__global__ void encodeEmitKernel(
+        const PivCoGpuTree* tree,
+        uint8_t* dst,
+        size_t dstCapacity,
+        const uint8_t* src,
+        size_t srcSize,
+        size_t blockSize,
+        uint8_t* workspace,
+        const uint64_t* offsets,
+        PivCoGpuStatus* status)
+{
+    const size_t block    = blockIdx.x;
+    const size_t blockOff = block * blockSize;
+    if (blockOff >= srcSize) {
+        return;
+    }
+
+    const uint64_t outBegin = offsets[block];
+    const uint64_t outEnd   = offsets[block + 1];
+    if (outBegin > outEnd || outEnd > dstCapacity) {
+        setStatus(status, PIVCO_GPU_STATUS_CAPACITY, block);
+        return;
+    }
+
+    uint8_t* const out     = dst + outBegin;
+    const uint64_t outSize = outEnd - outBegin;
+    for (uint64_t i = 0; i < outSize; ++i) {
+        out[i] = 0;
+    }
+
+    const size_t blockLen  = dMin(blockSize, srcSize - blockOff);
+    uint8_t* const ranks   = workspace + block * 2 * blockSize;
+    uint8_t* const scratch = ranks + blockSize;
+    for (size_t i = 0; i < blockLen; ++i) {
+        ranks[i] = tree->symbolToRank[src[blockOff + i]];
+    }
+
+    DeviceBitWriter writer;
+    writer.data     = out;
+    writer.capacity = outSize;
+    if (!emitNode(tree, writer, ranks, scratch, blockLen, 0, 0, tree->numRanks)
+        || writer.bytes() != outSize) {
+        setStatus(status, PIVCO_GPU_STATUS_CORRUPTION, block);
+    }
+}
+
+__device__ uint8_t* scheduledNodeOutput(
+        const PivCoGpuScheduleNode& node,
+        const ScheduledNodeState& state,
+        uint32_t maxLevel,
+        uint8_t* dst,
+        size_t blockOff,
+        uint8_t* bufferA,
+        uint8_t* bufferB)
+{
+    if (node.level == 0) {
+        return dst + blockOff;
+    }
+    const bool writeToA = ((maxLevel - node.level) & 1u) == 0;
+    return (writeToA ? bufferA : bufferB) + state.streamBase;
+}
+
+__device__ const uint8_t* scheduledChildOutput(
+        const PivCoGpuScheduleNode& parent,
+        const ScheduledNodeState& childState,
+        uint32_t maxLevel,
+        const uint8_t* bufferA,
+        const uint8_t* bufferB)
+{
+    const bool parentWritesToA = ((maxLevel - parent.level) & 1u) == 0;
+    return (parentWritesToA ? bufferB : bufferA) + childState.streamBase;
+}
+
+__global__ void scheduledParseKernel(
+        const PivCoGpuDecodeSchedule* schedule,
+        const uint8_t* bitstream,
+        size_t bitstreamSize,
+        const uint64_t* offsets,
+        size_t dstSize,
+        size_t blockSize,
+        uint8_t* workspace,
+        PivCoGpuStatus* status)
+{
+    if (threadIdx.x != 0) {
+        return;
+    }
+    if (status->code != PIVCO_GPU_STATUS_OK) {
+        return;
+    }
+
+    const size_t block    = blockIdx.x;
+    const size_t blockOff = block * blockSize;
+    if (blockOff >= dstSize) {
+        return;
+    }
+
+    const uint64_t sliceBegin = offsets[block];
+    const uint64_t sliceEnd   = offsets[block + 1];
+    if (sliceBegin > sliceEnd || sliceEnd > bitstreamSize) {
+        setStatus(status, PIVCO_GPU_STATUS_CORRUPTION, block);
+        return;
+    }
+
+    ScheduledNodeState* states = nullptr;
+    uint16_t* directory        = nullptr;
+    uint32_t dirCapacity       = 0;
+    uint8_t* bufferA           = nullptr;
+    uint8_t* bufferB           = nullptr;
+    scheduledDecodeWorkspace(
+            workspace,
+            block,
+            blockSize,
+            &states,
+            &directory,
+            &dirCapacity,
+            &bufferA,
+            &bufferB);
+    (void)bufferA;
+    (void)bufferB;
+
+    const size_t blockLen = dMin(blockSize, dstSize - blockOff);
+    if (blockLen > UINT32_MAX) {
+        setStatus(status, PIVCO_GPU_STATUS_CAPACITY, block);
+        return;
+    }
+    // Only `count` is read before being written (root set here, every other
+    // node by its parent), so the state array does not need zeroing; unread
+    // fields of constant/CC nodes are simply never touched.
+    states[0].count = static_cast<uint32_t>(blockLen);
+
+    const uint8_t* const slice = bitstream + sliceBegin;
+    const uint64_t sliceBytes  = sliceEnd - sliceBegin;
+    DeviceBitReader reader{ slice, sliceBytes, 0 };
+    uint32_t dirCursor = 0;
+    // Per-level stream cursors, so each materializing node's output offset is
+    // assigned in this single pass (8-byte aligned; `levelData` tracks the true
+    // byte total for the integrity check) instead of a second O(levels*nodes)
+    // pass over the schedule.
+    uint32_t levelCursor[PIVCO_GPU_MAX_LEVELS] = {};
+    uint32_t levelData[PIVCO_GPU_MAX_LEVELS]   = {};
+
+    for (uint32_t nodeIndex = 0; nodeIndex < schedule->nodeCount; ++nodeIndex) {
+        const PivCoGpuScheduleNode node = schedule->nodes[nodeIndex];
+        ScheduledNodeState& state       = states[nodeIndex];
+        const uint32_t count            = state.count;
+
+        if (node.kind == PIVCO_GPU_SCHEDULE_CONSTANT) {
+            continue;
+        }
+
+        const uint32_t level = node.level;
+        state.streamBase     = levelCursor[level];
+        levelData[level] += count;
+        if (levelData[level] > blockLen) {
+            setStatus(status, PIVCO_GPU_STATUS_CORRUPTION, block);
+            return;
+        }
+        levelCursor[level] += (count + 7u) & ~uint32_t{ 7 };
+
+        if (node.kind == PIVCO_GPU_SCHEDULE_FLAT) {
+            const uint8_t* bitmap = nullptr;
+            uint64_t bitmapBytes  = 0;
+            if (!reader.popAlignedBits(
+                        static_cast<uint64_t>(count) * node.flatDepth,
+                        &bitmap,
+                        &bitmapBytes)) {
+                setStatus(status, PIVCO_GPU_STATUS_CORRUPTION, block);
+                return;
+            }
+            (void)bitmapBytes;
+            state.leafBitBase = static_cast<uint32_t>(
+                    static_cast<uint64_t>(bitmap - slice) * 8u);
+            continue;
+        }
+
+        const uint8_t* bitmap = nullptr;
+        uint64_t bitmapBytes  = 0;
+        if (!reader.popAlignedBits(count, &bitmap, &bitmapBytes)) {
+            setStatus(status, PIVCO_GPU_STATUS_CORRUPTION, block);
+            return;
+        }
+        (void)bitmapBytes;
+        state.bitmapByteBase = static_cast<uint32_t>(bitmap - slice);
+
+        if (node.op != PIVCO_GPU_SCHEDULE_OP_MERGE_CONSTANT_CONSTANT) {
+            const uint32_t words = (count + 31u) / 32u;
+            if (dirCursor > dirCapacity
+                || words + 1u > dirCapacity - dirCursor) {
+                setStatus(status, PIVCO_GPU_STATUS_CAPACITY, block);
+                return;
+            }
+            state.dirBase = dirCursor;
+            dirCursor += words + 1u;
+
+            size_t storedNumOnes = 0;
+            if (!reader.readBits(dNextPow2(count + 1u), &storedNumOnes)
+                || storedNumOnes > count) {
+                setStatus(status, PIVCO_GPU_STATUS_CORRUPTION, block);
+                return;
+            }
+            const uint32_t numOnes       = static_cast<uint32_t>(storedNumOnes);
+            states[node.leftChild].count = count - numOnes;
+            states[node.rightChild].count = numOnes;
+        }
+    }
+
+    if (reader.consumedBytes() != sliceBytes) {
+        setStatus(status, PIVCO_GPU_STATUS_CORRUPTION, block);
+        return;
+    }
+}
+
+__global__ void __launch_bounds__(256, 8) scheduledDirectoryKernel(
+        const PivCoGpuDecodeSchedule* schedule,
+        const uint8_t* bitstream,
+        const uint64_t* offsets,
+        size_t dstSize,
+        size_t blockSize,
+        uint8_t* workspace,
+        PivCoGpuStatus* status)
+{
+    __shared__ uint16_t prefixA[kRankSelectMaxBitmapWords + 1];
+    __shared__ uint16_t prefixB[kRankSelectMaxBitmapWords + 1];
+    __shared__ uint32_t numOnes;
+
+    const size_t block    = blockIdx.x;
+    const size_t blockOff = block * blockSize;
+    if (blockOff >= dstSize) {
+        return;
+    }
+
+    ScheduledNodeState* states = nullptr;
+    uint16_t* directory        = nullptr;
+    uint32_t dirCapacity       = 0;
+    uint8_t* bufferA           = nullptr;
+    uint8_t* bufferB           = nullptr;
+    scheduledDecodeWorkspace(
+            workspace,
+            block,
+            blockSize,
+            &states,
+            &directory,
+            &dirCapacity,
+            &bufferA,
+            &bufferB);
+    (void)bufferA;
+    (void)bufferB;
+
+    const uint16_t nodeIndex        = schedule->internalItems[blockIdx.y].node;
+    const PivCoGpuScheduleNode node = schedule->nodes[nodeIndex];
+    if (node.op == PIVCO_GPU_SCHEDULE_OP_MERGE_CONSTANT_CONSTANT) {
+        return;
+    }
+
+    const ScheduledNodeState state = states[nodeIndex];
+    const uint8_t* const bitmap =
+            bitstream + offsets[block] + state.bitmapByteBase;
+    if (!buildRankSelectDirectoryCooperative(
+                bitmap,
+                state.count,
+                directory,
+                dirCapacity,
+                state.dirBase,
+                prefixA,
+                prefixB,
+                &numOnes)) {
+        if (threadIdx.x == 0) {
+            setStatus(status, PIVCO_GPU_STATUS_CAPACITY, block);
+        }
+        return;
+    }
+
+    if (threadIdx.x == 0 && numOnes != states[node.rightChild].count) {
+        setStatus(status, PIVCO_GPU_STATUS_CORRUPTION, block);
+    }
+}
+
+__device__ __forceinline__ uint64_t
+dLoad8Bounded(const uint8_t* p, uint32_t cursor, uint32_t total);
+
+template <int Depth>
+__global__ void scheduledFlatKernel(
+        const PivCoGpuTree* tree,
+        const PivCoGpuDecodeSchedule* schedule,
+        uint8_t* dst,
+        size_t dstSize,
+        const uint8_t* bitstream,
+        const uint64_t* offsets,
+        size_t blockSize,
+        uint8_t* workspace,
+        PivCoGpuStatus* status,
+        uint16_t stageOffset)
+{
+    if (status->code != PIVCO_GPU_STATUS_OK) {
+        return;
+    }
+
+    const size_t block    = blockIdx.x;
+    const size_t blockOff = block * blockSize;
+    if (blockOff >= dstSize) {
+        return;
+    }
+
+    ScheduledNodeState* states = nullptr;
+    uint16_t* directory        = nullptr;
+    uint32_t dirCapacity       = 0;
+    uint8_t* bufferA           = nullptr;
+    uint8_t* bufferB           = nullptr;
+    scheduledDecodeWorkspace(
+            workspace,
+            block,
+            blockSize,
+            &states,
+            &directory,
+            &dirCapacity,
+            &bufferA,
+            &bufferB);
+    (void)directory;
+    (void)dirCapacity;
+
+    const uint16_t nodeIndex =
+            schedule->stageItems[stageOffset + blockIdx.y].node;
+    const PivCoGpuScheduleNode node = schedule->nodes[nodeIndex];
+    const ScheduledNodeState state  = states[nodeIndex];
+    uint8_t* const out              = scheduledNodeOutput(
+            node, state, schedule->maxLevel, dst, blockOff, bufferA, bufferB);
+    const uint8_t* const bitmap =
+            bitstream + offsets[block] + state.leafBitBase / 8u;
+
+    // Cache the leaf's 2^Depth symbols in shared memory once, so the per-output
+    // table lookup hits shared instead of a dependent global load (this kernel
+    // is latency bound on that lookup).
+    constexpr uint32_t kNumSyms = 1u << Depth;
+    __shared__ uint8_t s_syms[kNumSyms];
+    for (uint32_t i = threadIdx.x; i < kNumSyms; i += blockDim.x) {
+        s_syms[i] = tree->rankToSymbol[node.firstRank + i];
+    }
+    __syncthreads();
+
+    // Eight outputs per thread. A group of 8 symbols starts at output byte
+    // `g*8`, i.e. bit `g*8*Depth` = byte `g*Depth` (always byte-aligned), and
+    // spans exactly `Depth` contiguous bitmap bytes. Load those bytes once,
+    // unpack the eight `Depth`-bit indices from the register, look each up in
+    // the shared symbol table, and write one coalesced 8-byte group -- instead
+    // of one dependent 1-2 byte load + byte store per output (which re-reads
+    // shared bytes across neighbouring threads for small depths). `out` is
+    // 8-byte aligned with trailing slop, matching the merge kernels' store
+    // contract.
+    constexpr uint32_t kMask = (1u << Depth) - 1u;
+    const uint32_t numGroups = (state.count + 7u) / 8u;
+    const uint32_t bitmapBytes =
+            (state.count * static_cast<uint32_t>(Depth) + 7u) / 8u;
+    // Depth-2 memory-level parallelism on the packed-index load (this kernel is
+    // latency bound on that dependent load): fetch two groups' packed words
+    // before unpacking either, so one load hides the other's latency.
+    for (uint32_t gg = threadIdx.x; gg < numGroups; gg += blockDim.x * 2u) {
+        const uint32_t g1 = gg + blockDim.x;
+        const bool has1   = g1 < numGroups;
+        const uint64_t p0 = dLoad8Bounded(
+                bitmap, gg * static_cast<uint32_t>(Depth), bitmapBytes);
+        const uint64_t p1 = has1 ? dLoad8Bounded(
+                                           bitmap,
+                                           g1 * static_cast<uint32_t>(Depth),
+                                           bitmapBytes)
+                                 : 0u;
+#pragma unroll
+        for (uint32_t half = 0; half < 2u; ++half) {
+            const uint32_t g      = half == 0u ? gg : g1;
+            const uint64_t packed = half == 0u ? p0 : p1;
+            if (half == 1u && !has1) {
+                break;
+            }
+            uint64_t outWord = 0;
+#pragma unroll
+            for (uint32_t k = 0; k < 8u; ++k) {
+                const uint32_t index =
+                        static_cast<uint32_t>(
+                                packed >> (k * static_cast<uint32_t>(Depth)))
+                        & kMask;
+                outWord |= static_cast<uint64_t>(s_syms[index]) << (k * 8u);
+            }
+            *reinterpret_cast<uint64_t*>(out + g * 8u) = outWord;
+        }
+    }
+}
+
+__global__ void scheduledMergeConstantConstantKernel(
+        const PivCoGpuDecodeSchedule* schedule,
+        uint8_t* dst,
+        size_t dstSize,
+        const uint8_t* bitstream,
+        const uint64_t* offsets,
+        size_t blockSize,
+        uint8_t* workspace,
+        PivCoGpuStatus* status,
+        uint16_t stageOffset)
+{
+    if (status->code != PIVCO_GPU_STATUS_OK) {
+        return;
+    }
+
+    const size_t block    = blockIdx.x;
+    const size_t blockOff = block * blockSize;
+    if (blockOff >= dstSize) {
+        return;
+    }
+
+    ScheduledNodeState* states = nullptr;
+    uint16_t* directory        = nullptr;
+    uint32_t dirCapacity       = 0;
+    uint8_t* bufferA           = nullptr;
+    uint8_t* bufferB           = nullptr;
+    scheduledDecodeWorkspace(
+            workspace,
+            block,
+            blockSize,
+            &states,
+            &directory,
+            &dirCapacity,
+            &bufferA,
+            &bufferB);
+    (void)directory;
+    (void)dirCapacity;
+
+    const uint16_t nodeIndex =
+            schedule->stageItems[stageOffset + blockIdx.y].node;
+    const PivCoGpuScheduleNode node = schedule->nodes[nodeIndex];
+    const ScheduledNodeState state  = states[nodeIndex];
+    uint8_t* const out              = scheduledNodeOutput(
+            node, state, schedule->maxLevel, dst, blockOff, bufferA, bufferB);
+    const uint8_t* const bitmap =
+            bitstream + offsets[block] + state.bitmapByteBase;
+
+    // Eight outputs per thread: load one bitmap byte, select left/right per bit
+    // from a 2-entry register table, and write one coalesced 8-byte group
+    // (instead of one dependent bit read + byte store per output, which
+    // re-reads the same bitmap byte across neighbouring threads). `out` is
+    // 8-byte aligned with trailing slop, matching the merge kernels' store
+    // contract.
+    const uint32_t regSyms =
+            node.leftSymbol | (static_cast<uint32_t>(node.rightSymbol) << 8u);
+    const uint32_t numGroups   = (state.count + 7u) / 8u;
+    const uint32_t bitmapBytes = numGroups;
+    for (uint32_t g = threadIdx.x; g < numGroups; g += blockDim.x) {
+        const uint32_t bits = g < bitmapBytes ? bitmap[g] : 0u;
+        uint64_t outWord    = 0;
+#pragma unroll
+        for (uint32_t k = 0; k < 8u; ++k) {
+            const uint32_t sym = (regSyms >> (((bits >> k) & 1u) * 8u)) & 0xFFu;
+            outWord |= static_cast<uint64_t>(sym) << (k * 8u);
+        }
+        *reinterpret_cast<uint64_t*>(out + g * 8u) = outWord;
+    }
+}
+
+// Reads 8 bytes starting at p[cursor] into a little-endian u64 (p[cursor] is
+// the low byte). Bounded so it never reads past the `total`-byte child stream:
+// the fast path (a full 8 bytes remain) is a single contiguous load, and only
+// the final partial group of the last node takes the byte tail.
+__device__ __forceinline__ uint64_t
+dLoad8Bounded(const uint8_t* p, uint32_t cursor, uint32_t total)
+{
+    uint64_t v = 0;
+    if (cursor + 8u <= total) {
+        __builtin_memcpy(&v, p + cursor, 8);
+    } else {
+        for (uint32_t i = cursor; i < total; ++i) {
+            v |= static_cast<uint64_t>(p[i]) << ((i - cursor) * 8u);
+        }
+    }
+    return v;
+}
+
+// Reads 8 little-endian bytes at p[cursor] using two *aligned* 8-byte read-only
+// (`__ldg`) loads of the enclosing 16-byte window plus a funnel shift. Aligned
+// loads let the overlapping windows of neighbouring threads share L2/read-only
+// sectors (killing the ~66% excess sectors of per-thread unaligned loads), and
+// the read-only path spares the L1 the rank loads use. Requires `p` 8-byte
+// aligned (child stream bases are alignUp8) and up to 16 bytes of trailing pad
+// past the stream (workspace buffers reserve kMergeBufferPad), so no bounds
+// branch is needed on the interior fast path.
+__device__ __forceinline__ uint64_t
+dLoad8Aligned(const uint8_t* p, uint32_t cursor)
+{
+    const uint32_t off = cursor & 7u;
+    const uint64_t* const pw =
+            reinterpret_cast<const uint64_t*>(p + (cursor & ~7u));
+    const uint64_t w0 = __ldg(pw);
+    if (off == 0u) {
+        return w0;
+    }
+    const uint64_t w1 = __ldg(pw + 1);
+    return (w0 >> (off * 8u)) | (w1 << ((8u - off) * 8u));
+}
+
+// `__byte_perm` selector per 4-bit partition mask: it merges 4 outputs from the
+// 8 bytes of {left(a):right(b)} in one instruction. Output nibble i selects a
+// left byte (index = zeros before i, in a's bytes 0-3) when mask bit i is
+// clear, or a right byte (index = ones before i, in b's bytes 4-7) when set.
+__device__ const uint32_t kMergeSel[16] = {
+    0x3210u, 0x2104u, 0x2140u, 0x1054u, 0x2410u, 0x1504u, 0x1540u, 0x0654u,
+    0x4210u, 0x5104u, 0x5140u, 0x6054u, 0x5410u, 0x6504u, 0x6540u, 0x7654u
+};
+
+// Merge 8 outputs from two contiguous child windows (each holding up to 8
+// little-endian bytes at its cursor) driven by `mask8`: output byte i takes the
+// next byte of `rightWin` if bit i is set, else of `leftWin`. Two `__byte_perm`
+// (one per 4-bit nibble), advancing each window by the nibble popcount. A
+// constant child is passed as a byte-replicated window.
+__device__ __forceinline__ uint64_t
+byteMerge8(uint64_t leftWin, uint64_t rightWin, uint32_t mask8)
+{
+    const uint32_t m0 = mask8 & 0xFu;
+    const uint32_t m1 = (mask8 >> 4u) & 0xFu;
+    const uint32_t o0 = __byte_perm(
+            static_cast<uint32_t>(leftWin),
+            static_cast<uint32_t>(rightWin),
+            kMergeSel[m0]);
+    leftWin >>= (4u - __popc(m0)) * 8u;
+    rightWin >>= __popc(m0) * 8u;
+    const uint32_t o1 = __byte_perm(
+            static_cast<uint32_t>(leftWin),
+            static_cast<uint32_t>(rightWin),
+            kMergeSel[m1]);
+    return static_cast<uint64_t>(o0) | (static_cast<uint64_t>(o1) << 32u);
+}
+
+// Reads 8 little-endian bytes at sp[off] from shared via two aligned 8-byte
+// shared loads + a funnel shift. `sp` must be 8-byte aligned (chunk stream
+// buffers are 16-aligned) and hold up to 15 bytes of readable slop past `off`
+// (the following metadata region provides it).
+__device__ __forceinline__ uint64_t
+dLoad8Shared(const uint8_t* sp, uint32_t off)
+{
+    const uint32_t a = off & 7u;
+    const uint64_t* const pw =
+            reinterpret_cast<const uint64_t*>(sp + (off & ~7u));
+    const uint64_t w0 = pw[0];
+    if (a == 0u) {
+        return w0;
+    }
+    const uint64_t w1 = pw[1];
+    return (w0 >> (a * 8u)) | (w1 << ((8u - a) * 8u));
+}
+
+// Thread-per-bitmap-byte merge shared by the vector/vector, constant/vector,
+// and vector/constant large-node paths. Each thread owns 8 outputs (one bitmap
+// byte). It reads the rank once (giving each child's cursor), pulls up to 8
+// contiguous bytes from each child stream into a register (the most either
+// child can supply for 8 outputs), then selects per bit by shifting the bottom
+// byte out of the chosen child -- all the branchiness stays in registers.
+// Result: two contiguous child loads + one coalesced 8-byte store per 8
+// outputs, instead of eight scattered, dependent child gathers. Constant
+// children need no load.
+template <bool LeftConst, bool RightConst, uint32_t Unroll>
+__device__ __forceinline__ void byteMergeThread(
+        uint8_t* out,
+        uint32_t count,
+        const uint8_t* bitmap,
+        const uint16_t* directory,
+        uint32_t dirBase,
+        const uint8_t* lhs,
+        const uint8_t* rhs,
+        uint8_t leftSym,
+        uint8_t rightSym)
+{
+    const uint32_t numBytes  = (count + 7u) / 8u;
+    const uint32_t stepBytes = blockDim.x * Unroll;
+    for (uint32_t bb = threadIdx.x; bb < numBytes; bb += stepBytes) {
+#pragma unroll
+        for (uint32_t u = 0; u < Unroll; ++u) {
+            const uint32_t b = bb + u * blockDim.x;
+            if (b >= numBytes) {
+                continue;
+            }
+            const uint32_t j = b * 8u;
+            const uint32_t rank =
+                    dRankSelectOnesBeforeAligned(bitmap, directory, dirBase, j);
+            // No tail masking: for the final partial group the high bits route
+            // only the outputs past `count`, which are over-stored into the
+            // buffer's 8-byte padding / dst slop (harmless). The rank -- and
+            // thus both child cursors -- is exact regardless.
+            const uint32_t rootBits = bitmap[b];
+            // A constant child is a byte-replicated window; a vector child is
+            // up to 8 contiguous bytes at its cursor, read via aligned
+            // read-only loads (see dLoad8Aligned; relies on the buffers'
+            // trailing pad).
+            const uint64_t leftWin  = LeftConst
+                     ? static_cast<uint64_t>(leftSym) * 0x0101010101010101ull
+                     : dLoad8Aligned(lhs, j - rank);
+            const uint64_t rightWin = RightConst
+                    ? static_cast<uint64_t>(rightSym) * 0x0101010101010101ull
+                    : dLoad8Aligned(rhs, rank);
+            // `out` is 8-byte aligned with trailing slop (workspace buffers are
+            // padded; dst reserves PIVCO_GPU_DECODE_DST_SLOP), so always store
+            // a full aligned 8-byte group -- any over-store lands in the slop.
+            *reinterpret_cast<uint64_t*>(out + j) =
+                    byteMerge8(leftWin, rightWin, rootBits);
+        }
+    }
+}
+
+constexpr uint32_t kMergeUnroll = 2;
+
+__global__ void scheduledMergeConstantVectorKernel(
+        const PivCoGpuDecodeSchedule* schedule,
+        uint8_t* dst,
+        size_t dstSize,
+        const uint8_t* bitstream,
+        const uint64_t* offsets,
+        size_t blockSize,
+        uint8_t* workspace,
+        PivCoGpuStatus* status,
+        uint16_t stageOffset)
+{
+    if (status->code != PIVCO_GPU_STATUS_OK) {
+        return;
+    }
+
+    const size_t block    = blockIdx.x;
+    const size_t blockOff = block * blockSize;
+    if (blockOff >= dstSize) {
+        return;
+    }
+
+    ScheduledNodeState* states = nullptr;
+    uint16_t* directory        = nullptr;
+    uint32_t dirCapacity       = 0;
+    uint8_t* bufferA           = nullptr;
+    uint8_t* bufferB           = nullptr;
+    scheduledDecodeWorkspace(
+            workspace,
+            block,
+            blockSize,
+            &states,
+            &directory,
+            &dirCapacity,
+            &bufferA,
+            &bufferB);
+    (void)dirCapacity;
+
+    const uint16_t nodeIndex =
+            schedule->stageItems[stageOffset + blockIdx.y].node;
+    const PivCoGpuScheduleNode node     = schedule->nodes[nodeIndex];
+    const ScheduledNodeState state      = states[nodeIndex];
+    const ScheduledNodeState rightState = states[node.rightChild];
+    uint8_t* const out                  = scheduledNodeOutput(
+            node, state, schedule->maxLevel, dst, blockOff, bufferA, bufferB);
+    const uint8_t* const rhs = scheduledChildOutput(
+            node, rightState, schedule->maxLevel, bufferA, bufferB);
+    const uint8_t* const bitmap =
+            bitstream + offsets[block] + state.bitmapByteBase;
+    const uint8_t leftSym = node.leftSymbol;
+    (void)directory;
+
+    __shared__ uint16_t s_dir[kRankSelectMaxBitmapWords + 1];
+    __shared__ uint16_t s_prefix[kRankSelectMaxBitmapWords + 1];
+    __shared__ uint32_t s_ones;
+    buildSharedDirectory(bitmap, state.count, s_dir, s_prefix, &s_ones);
+
+    if (state.count < kBottomUpChunkedMergeThreshold) {
+        for (uint32_t j = threadIdx.x; j < state.count; j += blockDim.x) {
+            const bool isRight = dGetBit(bitmap, j) != 0;
+            const uint32_t onesBefore =
+                    dRankSelectOnesBefore(bitmap, s_dir, 0u, j);
+            out[j] = isRight ? rhs[onesBefore] : leftSym;
+        }
+        return;
+    }
+
+    byteMergeThread<true, false, kMergeUnroll>(
+            out, state.count, bitmap, s_dir, 0u, nullptr, rhs, leftSym, 0u);
+}
+
+__global__ void scheduledMergeVectorConstantKernel(
+        const PivCoGpuDecodeSchedule* schedule,
+        uint8_t* dst,
+        size_t dstSize,
+        const uint8_t* bitstream,
+        const uint64_t* offsets,
+        size_t blockSize,
+        uint8_t* workspace,
+        PivCoGpuStatus* status,
+        uint16_t stageOffset)
+{
+    if (status->code != PIVCO_GPU_STATUS_OK) {
+        return;
+    }
+
+    const size_t block    = blockIdx.x;
+    const size_t blockOff = block * blockSize;
+    if (blockOff >= dstSize) {
+        return;
+    }
+
+    ScheduledNodeState* states = nullptr;
+    uint16_t* directory        = nullptr;
+    uint32_t dirCapacity       = 0;
+    uint8_t* bufferA           = nullptr;
+    uint8_t* bufferB           = nullptr;
+    scheduledDecodeWorkspace(
+            workspace,
+            block,
+            blockSize,
+            &states,
+            &directory,
+            &dirCapacity,
+            &bufferA,
+            &bufferB);
+    (void)dirCapacity;
+
+    const uint16_t nodeIndex =
+            schedule->stageItems[stageOffset + blockIdx.y].node;
+    const PivCoGpuScheduleNode node    = schedule->nodes[nodeIndex];
+    const ScheduledNodeState state     = states[nodeIndex];
+    const ScheduledNodeState leftState = states[node.leftChild];
+    uint8_t* const out                 = scheduledNodeOutput(
+            node, state, schedule->maxLevel, dst, blockOff, bufferA, bufferB);
+    const uint8_t* const lhs = scheduledChildOutput(
+            node, leftState, schedule->maxLevel, bufferA, bufferB);
+    const uint8_t* const bitmap =
+            bitstream + offsets[block] + state.bitmapByteBase;
+    const uint8_t rightSym = node.rightSymbol;
+    (void)directory;
+
+    __shared__ uint16_t s_dir[kRankSelectMaxBitmapWords + 1];
+    __shared__ uint16_t s_prefix[kRankSelectMaxBitmapWords + 1];
+    __shared__ uint32_t s_ones;
+    buildSharedDirectory(bitmap, state.count, s_dir, s_prefix, &s_ones);
+
+    if (state.count < kBottomUpChunkedMergeThreshold) {
+        for (uint32_t j = threadIdx.x; j < state.count; j += blockDim.x) {
+            const bool isRight = dGetBit(bitmap, j) != 0;
+            const uint32_t onesBefore =
+                    dRankSelectOnesBefore(bitmap, s_dir, 0u, j);
+            out[j] = isRight ? rightSym : lhs[j - onesBefore];
+        }
+        return;
+    }
+
+    byteMergeThread<false, true, kMergeUnroll>(
+            out, state.count, bitmap, s_dir, 0u, lhs, nullptr, 0u, rightSym);
+}
+
+__global__ void scheduledMergeVectorVectorKernel(
+        const PivCoGpuDecodeSchedule* schedule,
+        uint8_t* dst,
+        size_t dstSize,
+        const uint8_t* bitstream,
+        const uint64_t* offsets,
+        size_t blockSize,
+        uint8_t* workspace,
+        PivCoGpuStatus* status,
+        uint16_t stageOffset)
+{
+    if (status->code != PIVCO_GPU_STATUS_OK) {
+        return;
+    }
+
+    const size_t block    = blockIdx.x;
+    const size_t blockOff = block * blockSize;
+    if (blockOff >= dstSize) {
+        return;
+    }
+
+    ScheduledNodeState* states = nullptr;
+    uint16_t* directory        = nullptr;
+    uint32_t dirCapacity       = 0;
+    uint8_t* bufferA           = nullptr;
+    uint8_t* bufferB           = nullptr;
+    scheduledDecodeWorkspace(
+            workspace,
+            block,
+            blockSize,
+            &states,
+            &directory,
+            &dirCapacity,
+            &bufferA,
+            &bufferB);
+    (void)dirCapacity;
+
+    const uint16_t nodeIndex =
+            schedule->stageItems[stageOffset + blockIdx.y].node;
+    const PivCoGpuScheduleNode node     = schedule->nodes[nodeIndex];
+    const ScheduledNodeState state      = states[nodeIndex];
+    const ScheduledNodeState leftState  = states[node.leftChild];
+    const ScheduledNodeState rightState = states[node.rightChild];
+    uint8_t* const out                  = scheduledNodeOutput(
+            node, state, schedule->maxLevel, dst, blockOff, bufferA, bufferB);
+    const uint8_t* const lhs = scheduledChildOutput(
+            node, leftState, schedule->maxLevel, bufferA, bufferB);
+    const uint8_t* const rhs = scheduledChildOutput(
+            node, rightState, schedule->maxLevel, bufferA, bufferB);
+    const uint8_t* const bitmap =
+            bitstream + offsets[block] + state.bitmapByteBase;
+    (void)directory;
+
+    __shared__ uint16_t s_dir[kRankSelectMaxBitmapWords + 1];
+    __shared__ uint16_t s_prefix[kRankSelectMaxBitmapWords + 1];
+    __shared__ uint32_t s_ones;
+    buildSharedDirectory(bitmap, state.count, s_dir, s_prefix, &s_ones);
+
+    if (state.count < kBottomUpChunkedMergeThreshold) {
+        for (uint32_t j = threadIdx.x; j < state.count; j += blockDim.x) {
+            const bool isRight = dGetBit(bitmap, j) != 0;
+            const uint32_t onesBefore =
+                    dRankSelectOnesBefore(bitmap, s_dir, 0u, j);
+            out[j] = isRight ? rhs[onesBefore] : lhs[j - onesBefore];
+        }
+        return;
+    }
+
+    byteMergeThread<false, false, kMergeUnroll>(
+            out, state.count, bitmap, s_dir, 0u, lhs, rhs, 0u, 0u);
+}
+
+__global__ void fastDecodeRootConstFlat1Kernel(
+        const PivCoGpuTree* tree,
+        uint8_t* dst,
+        size_t dstSize,
+        const uint8_t* bitstream,
+        size_t bitstreamSize,
+        const uint64_t* offsets,
+        size_t blockSize,
+        PivCoGpuStatus* status)
+{
+    __shared__ uint32_t prefix[kFastMaxRootBytes + 1];
+    __shared__ uint32_t sharedNumOnes;
+    __shared__ uint64_t sharedLeafBitBase;
+    __shared__ int sharedValid;
+
+    const size_t block    = blockIdx.x;
+    const size_t blockOff = block * blockSize;
+    if (blockOff >= dstSize) {
+        return;
+    }
+
+    const uint64_t sliceBegin = offsets[block];
+    const uint64_t sliceEnd   = offsets[block + 1];
+    if (sliceBegin > sliceEnd || sliceEnd > bitstreamSize) {
+        setStatus(status, PIVCO_GPU_STATUS_CORRUPTION, block);
+        return;
+    }
+
+    const size_t blockLen  = dMin(blockSize, dstSize - blockOff);
+    const size_t rootBytes = dBitmapBytes(blockLen);
+    if (rootBytes > kFastMaxRootBytes) {
+        setStatus(status, PIVCO_GPU_STATUS_PARAMETER, blockSize);
+        return;
+    }
+
+    const uint8_t* const slice = bitstream + sliceBegin;
+    const uint64_t sliceBytes  = sliceEnd - sliceBegin;
+
+    fastScanRootPrefix(prefix, slice, rootBytes, blockLen);
+
+    if (threadIdx.x == 0) {
+        const size_t countBits = dFastCountBits(blockLen);
+        size_t storedNumOnes   = 0;
+        sharedValid            = 1;
+        if (sliceBytes < rootBytes
+            || !DeviceBitReader{ slice,
+                                 sliceBytes,
+                                 static_cast<uint64_t>(blockLen) }
+                        .readBits(countBits, &storedNumOnes)
+            || storedNumOnes > blockLen || storedNumOnes != prefix[rootBytes]) {
+            sharedValid = 0;
+        }
+        sharedNumOnes     = static_cast<uint32_t>(storedNumOnes);
+        sharedLeafBitBase = dFastLeafBitBase(blockLen);
+        if (sharedValid != 0
+            && dFastEncodedBytes(blockLen, sharedNumOnes) != sliceBytes) {
+            sharedValid = 0;
+        }
+    }
+    __syncthreads();
+
+    if (sharedValid == 0) {
+        setStatus(status, PIVCO_GPU_STATUS_CORRUPTION, block);
+        return;
+    }
+
+    for (size_t byteIndex = threadIdx.x; byteIndex < rootBytes;
+         byteIndex += blockDim.x) {
+        const uint8_t rootByte =
+                slice[byteIndex] & dRootByteMask(byteIndex, blockLen);
+        uint32_t rank        = prefix[byteIndex];
+        const size_t baseOut = blockOff + byteIndex * 8;
+        for (size_t bit = 0; bit < 8 && byteIndex * 8 + bit < blockLen; ++bit) {
+            uint8_t symbol = tree->fastZeroSymbol;
+            if (((rootByte >> bit) & 1u) != 0) {
+                symbol = dGetBit(slice, sharedLeafBitBase + rank) == 0
+                        ? tree->fastLeafZeroSymbol
+                        : tree->fastLeafOneSymbol;
+                ++rank;
+            }
+            dst[baseOut + bit] = symbol;
+        }
+    }
+}
+
+__global__ void fastDecodeFlatRootKernel(
+        const PivCoGpuTree* tree,
+        uint8_t* dst,
+        size_t dstSize,
+        const uint8_t* bitstream,
+        size_t bitstreamSize,
+        const uint64_t* offsets,
+        size_t blockSize,
+        PivCoGpuStatus* status)
+{
+    const size_t block    = blockIdx.x;
+    const size_t blockOff = block * blockSize;
+    if (blockOff >= dstSize) {
+        return;
+    }
+
+    const uint64_t sliceBegin = offsets[block];
+    const uint64_t sliceEnd   = offsets[block + 1];
+    if (sliceBegin > sliceEnd || sliceEnd > bitstreamSize) {
+        setStatus(status, PIVCO_GPU_STATUS_CORRUPTION, block);
+        return;
+    }
+
+    const size_t blockLen = dMin(blockSize, dstSize - blockOff);
+    const size_t depth    = dLeafFlatDepth(tree, 0);
+    const uint64_t encoded =
+            (static_cast<uint64_t>(blockLen) * depth + 7u) / 8u;
+    if (sliceEnd - sliceBegin != encoded) {
+        setStatus(status, PIVCO_GPU_STATUS_CORRUPTION, block);
+        return;
+    }
+
+    const uint8_t* const slice = bitstream + sliceBegin;
+
+    // Cache the flat root's symbols (numRanks == 2^depth <= 256) in shared, so
+    // the per-output lookup hits shared instead of a dependent global load.
+    __shared__ uint8_t s_syms[256];
+    const uint32_t numSyms = tree->numRanks;
+    for (uint32_t i = threadIdx.x; i < numSyms; i += blockDim.x) {
+        s_syms[i] = tree->rankToSymbol[i];
+    }
+    __syncthreads();
+
+    // Eight outputs per thread, mirroring scheduledFlatKernel: a group of 8
+    // symbols starts at output byte g*8, i.e. bit g*8*depth = byte g*depth
+    // (always byte-aligned), so load the group's packed bytes once, unpack the
+    // eight depth-bit indices from the register, look each up in the shared
+    // symbol table, and write one coalesced 8-byte group. This replaces the
+    // per-symbol path, which was latency-bound on a dependent 1-2 byte load +
+    // conflicted shared gather + byte store per output. `out` is 8-byte aligned
+    // (blockOff is a multiple of blockSize) with trailing slop, matching the
+    // merge kernels' store contract. The index is masked to `depth` bits and
+    // depth == flat depth, so index < 2^depth == numRanks; for depth == 8 the
+    // mask is 0xFF and each packed byte is one index directly.
+    const uint32_t mask         = depth >= 8 ? 0xFFu : ((1u << depth) - 1u);
+    uint8_t* const out          = dst + blockOff;
+    const uint32_t numGroups    = static_cast<uint32_t>((blockLen + 7) / 8);
+    const uint32_t encodedBytes = static_cast<uint32_t>(
+            (static_cast<uint64_t>(blockLen) * depth + 7u) / 8u);
+    // Depth-2 memory-level parallelism on the packed-index load: fetch two
+    // groups' packed words before unpacking either, so one load hides the
+    // other's latency (this path is latency bound on that dependent load).
+    for (uint32_t gg = threadIdx.x; gg < numGroups; gg += blockDim.x * 2u) {
+        const uint32_t g1 = gg + blockDim.x;
+        const bool has1   = g1 < numGroups;
+        const uint64_t p0 = dLoad8Bounded(
+                slice, gg * static_cast<uint32_t>(depth), encodedBytes);
+        const uint64_t p1 = has1 ? dLoad8Bounded(
+                                           slice,
+                                           g1 * static_cast<uint32_t>(depth),
+                                           encodedBytes)
+                                 : 0u;
+#pragma unroll
+        for (uint32_t half = 0; half < 2u; ++half) {
+            const uint32_t g      = half == 0u ? gg : g1;
+            const uint64_t packed = half == 0u ? p0 : p1;
+            if (half == 1u && !has1) {
+                break;
+            }
+            uint64_t outWord = 0;
+#pragma unroll
+            for (uint32_t k = 0; k < 8u; ++k) {
+                const uint32_t index =
+                        static_cast<uint32_t>(
+                                packed >> (k * static_cast<uint32_t>(depth)))
+                        & mask;
+                outWord |= static_cast<uint64_t>(s_syms[index]) << (k * 8u);
+            }
+            *reinterpret_cast<uint64_t*>(out + g * 8u) = outWord;
+        }
+    }
+}
+
+__global__ void fastEncodePackRootConstFlat1Kernel(
+        const PivCoGpuTree* tree,
+        const uint8_t* src,
+        size_t srcSize,
+        size_t blockSize,
+        uint8_t* blockBitstreams,
+        uint64_t* offsets,
+        PivCoGpuStatus* status)
+{
+    __shared__ uint32_t chunkPrefix[kFastBlockThreads + 1];
+    __shared__ uint32_t leafWords[(kFastMaxRootBytes + 7) / 4];
+    __shared__ uint32_t sharedNumOnes;
+    __shared__ uint64_t sharedLeafBitBase;
+    __shared__ uint64_t sharedOutSize;
+    __shared__ int sharedValid;
+
+    const size_t block    = blockIdx.x;
+    const size_t blockOff = block * blockSize;
+    if (blockOff >= srcSize) {
+        return;
+    }
+
+    const size_t blockLen  = dMin(blockSize, srcSize - blockOff);
+    const size_t rootBytes = dBitmapBytes(blockLen);
+    if (rootBytes > kFastMaxRootBytes) {
+        setStatus(status, PIVCO_GPU_STATUS_PARAMETER, blockSize);
+        return;
+    }
+
+    uint8_t* const out         = blockBitstreams + block * blockSize;
+    const uint64_t leafBitBase = dFastLeafBitBase(blockLen);
+    for (uint64_t byte = blockLen / 8u + threadIdx.x; byte < leafBitBase / 8u;
+         byte += blockDim.x) {
+        out[byte] = 0;
+    }
+
+    uint32_t localLeafWords[kFastThreadLeafWords] = {};
+    uint32_t localCount                           = 0;
+    const size_t chunkBegin = (rootBytes * threadIdx.x) / blockDim.x;
+    const size_t chunkEnd   = (rootBytes * (threadIdx.x + 1)) / blockDim.x;
+    for (size_t byteIndex = chunkBegin; byteIndex < chunkEnd; ++byteIndex) {
+        const size_t srcBase = byteIndex * 8;
+        uint8_t rootByte     = 0;
+        uint8_t leafOneMask  = 0;
+        if (srcBase + 8 <= blockLen) {
+            const uint8_t* const srcPtr = src + blockOff + srcBase;
+            const uint8_t zeroMask = dEqMask8(srcPtr, tree->fastZeroSymbol);
+            const uint8_t leafZeroMask =
+                    dEqMask8(srcPtr, tree->fastLeafZeroSymbol);
+            leafOneMask = dEqMask8(srcPtr, tree->fastLeafOneSymbol);
+            rootByte    = static_cast<uint8_t>(~zeroMask);
+            const uint8_t missingMask = rootByte
+                    & static_cast<uint8_t>(~(leafZeroMask | leafOneMask));
+            if (missingMask != 0) {
+                const uint32_t bit =
+                        static_cast<uint32_t>(__ffs(missingMask) - 1);
+                setStatus(status, PIVCO_GPU_STATUS_MISSING_SYMBOL, srcPtr[bit]);
+            }
+        } else {
+            for (size_t bit = 0; srcBase + bit < blockLen; ++bit) {
+                const uint8_t symbol = src[blockOff + srcBase + bit];
+                if (symbol == tree->fastZeroSymbol) {
+                    continue;
+                }
+                if (symbol != tree->fastLeafZeroSymbol
+                    && symbol != tree->fastLeafOneSymbol) {
+                    setStatus(status, PIVCO_GPU_STATUS_MISSING_SYMBOL, symbol);
+                    continue;
+                }
+                rootByte |= static_cast<uint8_t>(1u << bit);
+                if (symbol == tree->fastLeafOneSymbol) {
+                    leafOneMask |= static_cast<uint8_t>(1u << bit);
+                }
+            }
+        }
+        uint8_t pending = rootByte;
+        while (pending != 0) {
+            const uint32_t bit = static_cast<uint32_t>(__ffs(pending) - 1);
+            if ((leafOneMask & (1u << bit)) != 0) {
+                localLeafWords[localCount / 32u] |=
+                        static_cast<uint32_t>(1u << (localCount & 31u));
+            }
+            ++localCount;
+            pending &= static_cast<uint8_t>(pending - 1);
+        }
+        out[byteIndex] = rootByte;
+    }
+
+    chunkPrefix[threadIdx.x + 1] = localCount;
+    if (threadIdx.x == 0) {
+        chunkPrefix[0] = 0;
+    }
+    __syncthreads();
+
+    if (threadIdx.x == 0) {
+        uint32_t running = 0;
+        for (int i = 0; i < blockDim.x; ++i) {
+            const uint32_t count = chunkPrefix[i + 1];
+            chunkPrefix[i]       = running;
+            running += count;
+        }
+        chunkPrefix[blockDim.x] = running;
+        sharedNumOnes           = running;
+        sharedLeafBitBase       = leafBitBase;
+        sharedOutSize           = dFastEncodedBytes(blockLen, running);
+        sharedValid             = sharedOutSize <= blockSize;
+        offsets[block + 1]      = sharedOutSize;
+        dOrBits(out, blockLen, running, dFastCountBits(blockLen));
+    }
+    __syncthreads();
+
+    if (sharedValid == 0) {
+        setStatus(status, PIVCO_GPU_STATUS_CAPACITY, block);
+        return;
+    }
+
+    const uint32_t leafBytes     = (sharedNumOnes + 7u) / 8u;
+    const uint32_t leafWordCount = (leafBytes + 3u) / 4u;
+    for (uint32_t i = threadIdx.x; i < leafWordCount; i += blockDim.x) {
+        leafWords[i] = 0;
+    }
+    __syncthreads();
+
+    const uint32_t chunkBitBase = chunkPrefix[threadIdx.x];
+    uint32_t remaining          = localCount;
+    for (uint32_t i = 0; i < kFastThreadLeafWords && remaining != 0; ++i) {
+        const uint32_t bits = remaining < 32u ? remaining : 32u;
+        dAtomicOrSharedBits(
+                leafWords, chunkBitBase + i * 32u, localLeafWords[i], bits);
+        remaining -= bits;
+    }
+    __syncthreads();
+
+    const uint64_t leafByteBase = sharedLeafBitBase / 8u;
+    const uint8_t* const leafBytesPtr =
+            reinterpret_cast<const uint8_t*>(leafWords);
+    for (uint32_t i = threadIdx.x; i < leafBytes; i += blockDim.x) {
+        out[leafByteBase + i] = leafBytesPtr[i];
+    }
+}
+
+__global__ void fastEncodeCopyRootConstFlat1Kernel(
+        uint8_t* dst,
+        size_t dstCapacity,
+        const uint8_t* blockBitstreams,
+        size_t srcSize,
+        size_t blockSize,
+        const uint64_t* offsets,
+        PivCoGpuStatus* status)
+{
+    const size_t block    = blockIdx.x;
+    const size_t blockOff = block * blockSize;
+    if (blockOff >= srcSize) {
+        return;
+    }
+
+    const uint64_t outBegin = offsets[block];
+    const uint64_t outEnd   = offsets[block + 1];
+    if (outBegin > outEnd || outEnd > dstCapacity
+        || outEnd - outBegin > blockSize) {
+        setStatus(status, PIVCO_GPU_STATUS_CAPACITY, block);
+        return;
+    }
+
+    const uint8_t* const srcBlock = blockBitstreams + block * blockSize;
+    uint8_t* const dstBlock       = dst + outBegin;
+    const uint64_t outSize        = outEnd - outBegin;
+    for (uint64_t i = threadIdx.x; i < outSize; i += blockDim.x) {
+        dstBlock[i] = srcBlock[i];
+    }
+}
+
+cudaError_t launchScheduledDecodeStage(
+        uint8_t op,
+        uint16_t stageOffset,
+        uint16_t stageCount,
+        size_t numBlocks,
+        const PivCoGpuTree* tree_d,
+        const PivCoGpuDecodeSchedule* schedule_d,
+        uint8_t* dst,
+        size_t dstSize,
+        const uint8_t* bitstream,
+        const uint64_t* offsets,
+        size_t blockSize,
+        uint8_t* workspace,
+        PivCoGpuStatus* status,
+        cudaStream_t stream)
+{
+    if (stageCount == 0) {
+        return cudaSuccess;
+    }
+
+    const dim3 grid(
+            static_cast<unsigned>(numBlocks),
+            static_cast<unsigned>(stageCount));
+    switch (op) {
+        case PIVCO_GPU_SCHEDULE_OP_FLAT1:
+            scheduledFlatKernel<1><<<grid, kRankSelectThreads, 0, stream>>>(
+                    tree_d,
+                    schedule_d,
+                    dst,
+                    dstSize,
+                    bitstream,
+                    offsets,
+                    blockSize,
+                    workspace,
+                    status,
+                    stageOffset);
+            break;
+        case PIVCO_GPU_SCHEDULE_OP_FLAT2:
+            scheduledFlatKernel<2><<<grid, kRankSelectThreads, 0, stream>>>(
+                    tree_d,
+                    schedule_d,
+                    dst,
+                    dstSize,
+                    bitstream,
+                    offsets,
+                    blockSize,
+                    workspace,
+                    status,
+                    stageOffset);
+            break;
+        case PIVCO_GPU_SCHEDULE_OP_FLAT3:
+            scheduledFlatKernel<3><<<grid, kRankSelectThreads, 0, stream>>>(
+                    tree_d,
+                    schedule_d,
+                    dst,
+                    dstSize,
+                    bitstream,
+                    offsets,
+                    blockSize,
+                    workspace,
+                    status,
+                    stageOffset);
+            break;
+        case PIVCO_GPU_SCHEDULE_OP_FLAT4:
+            scheduledFlatKernel<4><<<grid, kRankSelectThreads, 0, stream>>>(
+                    tree_d,
+                    schedule_d,
+                    dst,
+                    dstSize,
+                    bitstream,
+                    offsets,
+                    blockSize,
+                    workspace,
+                    status,
+                    stageOffset);
+            break;
+        case PIVCO_GPU_SCHEDULE_OP_FLAT5:
+            scheduledFlatKernel<5><<<grid, kRankSelectThreads, 0, stream>>>(
+                    tree_d,
+                    schedule_d,
+                    dst,
+                    dstSize,
+                    bitstream,
+                    offsets,
+                    blockSize,
+                    workspace,
+                    status,
+                    stageOffset);
+            break;
+        case PIVCO_GPU_SCHEDULE_OP_FLAT6:
+            scheduledFlatKernel<6><<<grid, kRankSelectThreads, 0, stream>>>(
+                    tree_d,
+                    schedule_d,
+                    dst,
+                    dstSize,
+                    bitstream,
+                    offsets,
+                    blockSize,
+                    workspace,
+                    status,
+                    stageOffset);
+            break;
+        case PIVCO_GPU_SCHEDULE_OP_FLAT7:
+            scheduledFlatKernel<7><<<grid, kRankSelectThreads, 0, stream>>>(
+                    tree_d,
+                    schedule_d,
+                    dst,
+                    dstSize,
+                    bitstream,
+                    offsets,
+                    blockSize,
+                    workspace,
+                    status,
+                    stageOffset);
+            break;
+        case PIVCO_GPU_SCHEDULE_OP_FLAT8:
+            scheduledFlatKernel<8><<<grid, kRankSelectThreads, 0, stream>>>(
+                    tree_d,
+                    schedule_d,
+                    dst,
+                    dstSize,
+                    bitstream,
+                    offsets,
+                    blockSize,
+                    workspace,
+                    status,
+                    stageOffset);
+            break;
+        case PIVCO_GPU_SCHEDULE_OP_MERGE_VECTOR_VECTOR:
+            scheduledMergeVectorVectorKernel<<<
+                    grid,
+                    kRankSelectThreads,
+                    0,
+                    stream>>>(
+                    schedule_d,
+                    dst,
+                    dstSize,
+                    bitstream,
+                    offsets,
+                    blockSize,
+                    workspace,
+                    status,
+                    stageOffset);
+            break;
+        case PIVCO_GPU_SCHEDULE_OP_MERGE_CONSTANT_VECTOR:
+            scheduledMergeConstantVectorKernel<<<
+                    grid,
+                    kRankSelectThreads,
+                    0,
+                    stream>>>(
+                    schedule_d,
+                    dst,
+                    dstSize,
+                    bitstream,
+                    offsets,
+                    blockSize,
+                    workspace,
+                    status,
+                    stageOffset);
+            break;
+        case PIVCO_GPU_SCHEDULE_OP_MERGE_VECTOR_CONSTANT:
+            scheduledMergeVectorConstantKernel<<<
+                    grid,
+                    kRankSelectThreads,
+                    0,
+                    stream>>>(
+                    schedule_d,
+                    dst,
+                    dstSize,
+                    bitstream,
+                    offsets,
+                    blockSize,
+                    workspace,
+                    status,
+                    stageOffset);
+            break;
+        case PIVCO_GPU_SCHEDULE_OP_MERGE_CONSTANT_CONSTANT:
+            scheduledMergeConstantConstantKernel<<<
+                    grid,
+                    kRankSelectThreads,
+                    0,
+                    stream>>>(
+                    schedule_d,
+                    dst,
+                    dstSize,
+                    bitstream,
+                    offsets,
+                    blockSize,
+                    workspace,
+                    status,
+                    stageOffset);
+            break;
+        default:
+            return cudaErrorInvalidValue;
+    }
+    return cudaGetLastError();
+}
+
+// ===========================================================================
+// Chunked top-down / merge-in-shared decoder.
+//
+// A warp owns one contiguous CHUNK of a block's output (chunkOutputs bytes)
+// and decodes the WHOLE tree for that chunk with all intermediate node streams
+// resident in shared memory -- only the bitmaps/flat indices are read from
+// global (L2) and only the final chunk output is written to global (once). This
+// removes the per-level global round-trips and the ~30 per-level kernel
+// launches of the bottom-up cascade, and turns every dependent child load from
+// an L2
+// (~200 cyc) access into a shared (~30 cyc) access.
+//
+// The monotone-rank property makes it work: a contiguous output chunk [c0,c0+S)
+// descends to a CONTIGUOUS sub-range at every tree node, so all per-chunk node
+// streams together fit in 2*S bytes (level-parity ping-pong). Phase 1 is a
+// top-down descent (per node: its chunk sub-range [lo,lo+subLen) and its offset
+// in the level buffer), using the per-block rank directories for the two
+// boundary ranks per node. Phase 2 is the bottom-up merge (deepest level first)
+// with the proven byte-select, reading children from shared. Phase 3 flushes
+// the root buffer to global, coalesced.
+// ===========================================================================
+// Chunk size (outputs per warp-pass) is chosen at dispatch by input size and
+// passed to the kernel at runtime: tiny inputs use the small chunk (more chunks
+// -> more grid parallelism to fill the GPU), larger inputs use the big chunk
+// (each per-chunk tree descent is fixed overhead, so wider chunks amortize it;
+// measured +13-21% at >=8 MiB). The per-warp ping-pong buffer is sized from the
+// runtime chunk (kChunkTdBufBytesFor); the shared budget is set per launch.
+constexpr uint32_t kChunkTdSmallOutputs = 1024;
+constexpr uint32_t kChunkTdLargeOutputs = 2048;
+constexpr int kChunkTdWarps             = 8;
+constexpr int kChunkTdThreads           = kChunkTdWarps * 32;
+// Per-warp stream buffer size for a given chunk: the chunk's bytes plus the
+// 8-byte over-read slop dLoad8Shared/dRankOnesBeforeFast need at the buffer
+// end.
+__host__ __device__ inline uint32_t kChunkTdBufBytesFor(uint32_t chunkOutputs)
+{
+    return chunkOutputs + 64u;
+}
+// Levels with at least this many nodes use the node-per-lane merge (32 small
+// nodes decoded in parallel across the warp); shallower/wider-node levels use
+// the node-per-warp merge (the whole warp cooperates on each large node).
+constexpr uint32_t kChunkTdLaneThreshold = 8;
+
+// Decode one node's whole chunk sub-range on a SINGLE lane (used when a level
+// has many small nodes, so 32 nodes run in parallel across the warp). The
+// running child rank accumulates in a register -- no warp scan or directory
+// read.
+__device__ __forceinline__ void mergeNodeSingleLane(
+        const PivCoGpuScheduleNode& node,
+        const ScheduledNodeState& st,
+        uint8_t* out,
+        uint32_t lo,
+        uint32_t len,
+        const uint8_t* sbuf,
+        const uint16_t* streamOff,
+        const uint8_t* slice,
+        const PivCoGpuTree* tree)
+{
+    if (node.kind == PIVCO_GPU_SCHEDULE_CONSTANT) {
+        for (uint32_t j = 0; j < len; ++j) {
+            out[j] = node.symbol;
+        }
+    } else if (node.kind == PIVCO_GPU_SCHEDULE_FLAT) {
+        const uint32_t depth     = node.flatDepth;
+        const uint32_t firstRank = node.firstRank;
+        const uint32_t msk       = (1u << depth) - 1u;
+        for (uint32_t j = 0; j < len; ++j) {
+            const uint64_t bp = static_cast<uint64_t>(st.leafBitBase)
+                    + static_cast<uint64_t>(lo + j) * depth;
+            const uint32_t bi = static_cast<uint32_t>(bp >> 3u);
+            const uint32_t sh = static_cast<uint32_t>(bp & 7u);
+            uint32_t win      = slice[bi];
+            if (sh + depth > 8u) {
+                win |= static_cast<uint32_t>(slice[bi + 1u]) << 8u;
+            }
+            out[j] = tree->rankToSymbol[firstRank + ((win >> sh) & msk)];
+        }
+    } else if (node.op == PIVCO_GPU_SCHEDULE_OP_MERGE_CONSTANT_CONSTANT) {
+        const uint8_t ls        = node.leftSymbol;
+        const uint8_t rs        = node.rightSymbol;
+        const uint8_t* const bm = slice + st.bitmapByteBase;
+        for (uint32_t j = 0; j < len; ++j) {
+            out[j] = dGetBit(bm, lo + j) != 0 ? rs : ls;
+        }
+    } else {
+        const bool leftConst =
+                node.op == PIVCO_GPU_SCHEDULE_OP_MERGE_CONSTANT_VECTOR;
+        const bool rightConst =
+                node.op == PIVCO_GPU_SCHEDULE_OP_MERGE_VECTOR_CONSTANT;
+        const uint64_t leftB =
+                static_cast<uint64_t>(node.leftSymbol) * 0x0101010101010101ull;
+        const uint64_t rightB =
+                static_cast<uint64_t>(node.rightSymbol) * 0x0101010101010101ull;
+        const uint32_t leftOff  = leftConst ? 0u : streamOff[node.leftChild];
+        const uint32_t rightOff = rightConst ? 0u : streamOff[node.rightChild];
+        const uint8_t* const bm = slice + st.bitmapByteBase;
+        uint32_t r              = 0u;
+        for (uint32_t g = 0; g < len; g += 8u) {
+            const uint32_t bit = lo + g;
+            const uint32_t bi  = bit >> 3u;
+            const uint32_t sh  = bit & 7u;
+            uint32_t win       = bm[bi];
+            if (sh != 0u) {
+                win |= static_cast<uint32_t>(bm[bi + 1u]) << 8u;
+            }
+            const uint32_t valid = (len - g) < 8u ? (len - g) : 8u;
+            const uint32_t mask8 = ((win >> sh) & 0xFFu) & ((1u << valid) - 1u);
+            const uint64_t lw =
+                    leftConst ? leftB : dLoad8Shared(sbuf, leftOff + (g - r));
+            const uint64_t rw =
+                    rightConst ? rightB : dLoad8Shared(sbuf, rightOff + r);
+            const uint64_t res = byteMerge8(lw, rw, mask8);
+            for (uint32_t k = 0; k < valid; ++k) {
+                out[g + k] = static_cast<uint8_t>(res >> (k * 8u));
+            }
+            r += static_cast<uint32_t>(__popc(mask8));
+        }
+    }
+}
+
+__global__ void __launch_bounds__(kChunkTdThreads, 6) pivcoChunkTopDownKernel(
+        const PivCoGpuTree* tree,
+        const PivCoGpuDecodeSchedule* schedule,
+        uint8_t* dst,
+        size_t dstSize,
+        const uint8_t* bitstream,
+        const uint64_t* offsets,
+        size_t blockSize,
+        uint32_t chunkOutputs,
+        uint8_t* workspace,
+        PivCoGpuStatus* status)
+{
+    if (status->code != PIVCO_GPU_STATUS_OK) {
+        return;
+    }
+    __shared__ uint16_t s_levelBegin[PIVCO_GPU_MAX_LEVELS + 2];
+    extern __shared__ uint8_t s_dyn[];
+
+    const uint32_t S           = chunkOutputs;
+    const uint32_t bufBytes    = kChunkTdBufBytesFor(chunkOutputs);
+    const uint32_t nodeCount   = schedule->nodeCount;
+    const int maxLevel         = static_cast<int>(schedule->maxLevel);
+    const uint32_t warpInBlock = threadIdx.x >> 5u;
+    const uint32_t lane        = threadIdx.x & 31u;
+
+    // Shared layout: CTA-wide per-level node index list, then per-warp regions
+    // each holding a 2*S ping-pong stream pair + node metadata (loBit u32,
+    // subLen u16, streamOff u16).
+    // Per-node metadata is 6 bytes: loBit/subLen/streamOff are all <= blockLen
+    // <= 64 KiB, so uint16 each (loBit is a position < count <= 65536, i.e. <=
+    // 65535).
+    uint16_t* const s_levelNode = reinterpret_cast<uint16_t*>(s_dyn);
+    const uint32_t perWarpBytes = (2u * bufBytes + 6u * nodeCount + 15u) & ~15u;
+    uint8_t* const perWarpBase  = s_dyn + ((nodeCount * 2u + 15u) & ~15u);
+    uint8_t* const buf0         = perWarpBase + warpInBlock * perWarpBytes;
+    uint8_t* const buf1         = buf0 + bufBytes;
+    uint8_t* const myMeta       = buf0 + 2u * bufBytes;
+    uint16_t* const loBit       = reinterpret_cast<uint16_t*>(myMeta);
+    uint16_t* const subLen =
+            reinterpret_cast<uint16_t*>(myMeta + nodeCount * 2u);
+    uint16_t* const streamOff =
+            reinterpret_cast<uint16_t*>(myMeta + nodeCount * 4u);
+
+    // ---- Phase 0: build per-level node index lists (CTA-wide, once). Nodes
+    // are emitted in DFS pre-order, so bucket them by level for the per-level
+    // passes.
+    if (threadIdx.x == 0) {
+        uint16_t cnt[PIVCO_GPU_MAX_LEVELS + 1];
+        for (int l = 0; l <= maxLevel; ++l) {
+            cnt[l] = 0;
+        }
+        for (uint32_t n = 0; n < nodeCount; ++n) {
+            cnt[schedule->nodes[n].level]++;
+        }
+        uint32_t acc = 0;
+        for (int l = 0; l <= maxLevel; ++l) {
+            s_levelBegin[l] = static_cast<uint16_t>(acc);
+            acc += cnt[l];
+        }
+        s_levelBegin[maxLevel + 1] = static_cast<uint16_t>(acc);
+        uint16_t cur[PIVCO_GPU_MAX_LEVELS + 1];
+        for (int l = 0; l <= maxLevel; ++l) {
+            cur[l] = s_levelBegin[l];
+        }
+        for (uint32_t n = 0; n < nodeCount; ++n) {
+            const uint32_t l      = schedule->nodes[n].level;
+            s_levelNode[cur[l]++] = static_cast<uint16_t>(n);
+        }
+    }
+    __syncthreads();
+
+    const size_t block    = blockIdx.x;
+    const size_t blockOff = block * blockSize;
+    if (blockOff >= dstSize) {
+        return;
+    }
+    const uint32_t blockLen =
+            static_cast<uint32_t>(dMin(blockSize, dstSize - blockOff));
+    const uint32_t chunkInBlock = blockIdx.y * kChunkTdWarps + warpInBlock;
+    const uint32_t c0           = chunkInBlock * S;
+    if (c0 >= blockLen) {
+        return;
+    }
+    const uint32_t sLen = dMin(S, blockLen - c0);
+
+    ScheduledNodeState* states = nullptr;
+    uint16_t* directory        = nullptr;
+    uint32_t dirCap            = 0;
+    uint8_t* bA                = nullptr;
+    uint8_t* bB                = nullptr;
+    scheduledDecodeWorkspace(
+            workspace,
+            block,
+            blockSize,
+            &states,
+            &directory,
+            &dirCap,
+            &bA,
+            &bB);
+    (void)dirCap;
+    (void)bA;
+    (void)bB;
+    const uint8_t* const slice = bitstream + offsets[block];
+
+    // ---- Phase 1: warp-parallel top-down descent. Levels are serial (parent
+    // -> child), but all nodes within a level are independent, so the 32 lanes
+    // cover them in parallel -- the boundary-rank L2 reads overlap instead of
+    // stalling one lane. streamOff is a per-level exclusive prefix sum (warp
+    // scan).
+    for (uint32_t n = lane; n < nodeCount; n += 32u) {
+        subLen[n] = (n == 0u) ? static_cast<uint16_t>(sLen) : uint16_t{ 0 };
+    }
+    if (lane == 0u) {
+        loBit[0] = static_cast<uint16_t>(c0);
+    }
+    __syncwarp();
+    for (int L = 0; L <= maxLevel; ++L) {
+        const uint32_t begin = s_levelBegin[L];
+        const uint32_t end   = s_levelBegin[L + 1];
+        // Few-node levels use the node-per-warp merge with aligned uint64
+        // stores, so 8-byte-pad their per-node offsets; many-node levels stay
+        // byte-packed.
+        const bool padLevel = (end - begin) < kChunkTdLaneThreshold;
+        uint32_t running    = 0u;
+        for (uint32_t base = begin; base < end; base += 32u) {
+            const uint32_t idx = base + lane;
+            const uint32_t nid = idx < end ? s_levelNode[idx] : 0u;
+            uint32_t v         = idx < end ? subLen[nid] : 0u;
+            if (padLevel) {
+                v = (v + 7u) & ~7u;
+            }
+            uint32_t incl = v;
+#pragma unroll
+            for (int d = 1; d < 32; d <<= 1) {
+                const uint32_t t = __shfl_up_sync(0xFFFFFFFFu, incl, d);
+                if (static_cast<int>(lane) >= d) {
+                    incl += t;
+                }
+            }
+            if (idx < end) {
+                streamOff[nid] = static_cast<uint16_t>(running + incl - v);
+            }
+            running += __shfl_sync(0xFFFFFFFFu, incl, 31);
+        }
+        __syncwarp();
+        if (L < maxLevel) {
+            for (uint32_t idx = begin + lane; idx < end; idx += 32u) {
+                const uint32_t nid              = s_levelNode[idx];
+                const PivCoGpuScheduleNode node = schedule->nodes[nid];
+                if (node.kind != PIVCO_GPU_SCHEDULE_INTERNAL
+                    || node.op
+                            == PIVCO_GPU_SCHEDULE_OP_MERGE_CONSTANT_CONSTANT) {
+                    continue;
+                }
+                const uint32_t lo  = loBit[nid];
+                const uint32_t len = subLen[nid];
+                if (len == 0u) {
+                    continue;
+                }
+                const uint32_t hi           = lo + len;
+                const ScheduledNodeState st = states[nid];
+                const uint8_t* const bm     = slice + st.bitmapByteBase;
+                const uint32_t rlo =
+                        dRankOnesBeforeFast(bm, directory, st.dirBase, lo);
+                const uint32_t rhi =
+                        dRankOnesBeforeFast(bm, directory, st.dirBase, hi);
+                loBit[node.leftChild] = static_cast<uint16_t>(lo - rlo);
+                subLen[node.leftChild] =
+                        static_cast<uint16_t>((hi - rhi) - (lo - rlo));
+                loBit[node.rightChild]  = static_cast<uint16_t>(rlo);
+                subLen[node.rightChild] = static_cast<uint16_t>(rhi - rlo);
+                // A constant child is emitted directly by the parent's merge
+                // (leftSym/rightSym), so it never needs its own materialized
+                // stream -- zero its sub-length to skip that redundant fill.
+                if (node.op == PIVCO_GPU_SCHEDULE_OP_MERGE_CONSTANT_VECTOR) {
+                    subLen[node.leftChild] = 0u;
+                } else if (
+                        node.op
+                        == PIVCO_GPU_SCHEDULE_OP_MERGE_VECTOR_CONSTANT) {
+                    subLen[node.rightChild] = 0u;
+                }
+            }
+            __syncwarp();
+        }
+    }
+
+    // ---- Phase 2: bottom-up merge, deepest level first, all in shared.
+    for (int L = maxLevel; L >= 0; --L) {
+        uint8_t* const dbuf       = (L & 1) ? buf1 : buf0;
+        const uint8_t* const sbuf = (L & 1) ? buf0 : buf1;
+        const uint32_t begin      = s_levelBegin[L];
+        const uint32_t end        = s_levelBegin[L + 1];
+
+        if (end - begin >= kChunkTdLaneThreshold) {
+            // Many small nodes: one node per lane (32 nodes decoded in
+            // parallel).
+            for (uint32_t idx = begin + lane; idx < end; idx += 32u) {
+                const uint32_t nid = s_levelNode[idx];
+                const uint32_t len = subLen[nid];
+                if (len == 0u) {
+                    continue;
+                }
+                mergeNodeSingleLane(
+                        schedule->nodes[nid],
+                        states[nid],
+                        dbuf + streamOff[nid],
+                        loBit[nid],
+                        len,
+                        sbuf,
+                        streamOff,
+                        slice,
+                        tree);
+            }
+            __syncwarp();
+            continue;
+        }
+
+        for (uint32_t idx = begin; idx < end; ++idx) {
+            const uint32_t nid              = s_levelNode[idx];
+            const PivCoGpuScheduleNode node = schedule->nodes[nid];
+            const uint32_t len              = subLen[nid];
+            if (len == 0u) {
+                continue;
+            }
+            uint8_t* const out          = dbuf + streamOff[nid];
+            const uint32_t lo           = loBit[nid];
+            const ScheduledNodeState st = states[nid];
+
+            if (node.kind == PIVCO_GPU_SCHEDULE_CONSTANT) {
+                for (uint32_t j = lane; j < len; j += 32u) {
+                    out[j] = node.symbol;
+                }
+            } else if (node.kind == PIVCO_GPU_SCHEDULE_FLAT) {
+                const uint32_t depth     = node.flatDepth;
+                const uint32_t firstRank = node.firstRank;
+                const uint32_t msk       = (1u << depth) - 1u;
+                for (uint32_t j = lane; j < len; j += 32u) {
+                    const uint64_t bp = static_cast<uint64_t>(st.leafBitBase)
+                            + static_cast<uint64_t>(lo + j) * depth;
+                    const uint32_t bi = static_cast<uint32_t>(bp >> 3u);
+                    const uint32_t sh = static_cast<uint32_t>(bp & 7u);
+                    uint32_t win      = slice[bi];
+                    if (sh + depth > 8u) {
+                        win |= static_cast<uint32_t>(slice[bi + 1u]) << 8u;
+                    }
+                    out[j] =
+                            tree->rankToSymbol[firstRank + ((win >> sh) & msk)];
+                }
+            } else if (
+                    node.op == PIVCO_GPU_SCHEDULE_OP_MERGE_CONSTANT_CONSTANT) {
+                const uint8_t ls        = node.leftSymbol;
+                const uint8_t rs        = node.rightSymbol;
+                const uint8_t* const bm = slice + st.bitmapByteBase;
+                for (uint32_t j = lane; j < len; j += 32u) {
+                    out[j] = dGetBit(bm, lo + j) != 0 ? rs : ls;
+                }
+            } else {
+                // VV / CV / VC: 8 outputs per thread via byteMerge8 (two
+                // __byte_perm). The child cursors need the ones-count before
+                // each group; compute it with a warp scan of per-group popc (no
+                // per-group directory read), carrying the running total across
+                // iterations.
+                const bool leftConst =
+                        node.op == PIVCO_GPU_SCHEDULE_OP_MERGE_CONSTANT_VECTOR;
+                const bool rightConst =
+                        node.op == PIVCO_GPU_SCHEDULE_OP_MERGE_VECTOR_CONSTANT;
+                const uint64_t leftB = static_cast<uint64_t>(node.leftSymbol)
+                        * 0x0101010101010101ull;
+                const uint64_t rightB = static_cast<uint64_t>(node.rightSymbol)
+                        * 0x0101010101010101ull;
+                const uint32_t leftOff =
+                        leftConst ? 0u : streamOff[node.leftChild];
+                const uint32_t rightOff =
+                        rightConst ? 0u : streamOff[node.rightChild];
+                const uint8_t* const bm  = slice + st.bitmapByteBase;
+                const uint32_t numGroups = (len + 7u) / 8u;
+                uint32_t running         = 0u;
+                for (uint32_t base = 0; base < numGroups; base += 32u) {
+                    const uint32_t gb = base + lane;
+                    const bool active = gb < numGroups;
+                    const uint32_t g  = gb * 8u;
+                    uint32_t mask8    = 0u;
+                    if (active) {
+                        const uint32_t bit = lo + g;
+                        const uint32_t bi  = bit >> 3u;
+                        const uint32_t sh  = bit & 7u;
+                        uint32_t win       = bm[bi];
+                        if (sh != 0u) {
+                            win |= static_cast<uint32_t>(bm[bi + 1u]) << 8u;
+                        }
+                        const uint32_t valid = (len - g) < 8u ? (len - g) : 8u;
+                        mask8 = ((win >> sh) & 0xFFu) & ((1u << valid) - 1u);
+                    }
+                    const uint32_t ones = static_cast<uint32_t>(__popc(mask8));
+                    uint32_t incl       = ones;
+#pragma unroll
+                    for (int d = 1; d < 32; d <<= 1) {
+                        const uint32_t t = __shfl_up_sync(0xFFFFFFFFu, incl, d);
+                        if (static_cast<int>(lane) >= d) {
+                            incl += t;
+                        }
+                    }
+                    const uint32_t rankAtGroup = running + incl - ones;
+                    if (active) {
+                        const uint64_t lw  = leftConst
+                                 ? leftB
+                                 : dLoad8Shared(
+                                          sbuf, leftOff + (g - rankAtGroup));
+                        const uint64_t rw  = rightConst
+                                 ? rightB
+                                 : dLoad8Shared(sbuf, rightOff + rankAtGroup);
+                        const uint64_t res = byteMerge8(lw, rw, mask8);
+                        // streamOff is 8-byte padded for these few-node levels,
+                        // so out+g is aligned -> one uint64 store (over-store
+                        // into the node's pad is harmless).
+                        *reinterpret_cast<uint64_t*>(out + g) = res;
+                    }
+                    running += __shfl_sync(0xFFFFFFFFu, incl, 31);
+                }
+            }
+        }
+        __syncwarp();
+    }
+
+    // ---- Phase 3: coalesced flush of the root buffer (level 0 wrote buf0).
+    uint8_t* const gout          = dst + blockOff + c0;
+    const uint8_t* const rootBuf = buf0;
+    for (uint32_t i = lane * 8u; i < sLen; i += 32u * 8u) {
+        if (i + 8u <= sLen) {
+            *reinterpret_cast<uint64_t*>(gout + i) =
+                    *reinterpret_cast<const uint64_t*>(rootBuf + i);
+        } else {
+            for (uint32_t k = i; k < sLen; ++k) {
+                gout[k] = rootBuf[k];
+            }
+        }
+    }
+}
+
+bool chunkTopDownEnabled()
+{
+    static const bool enabled = [] {
+        const char* v = getenv("PIVCO_CHUNK_TD");
+        return v != nullptr && v[0] != '\0' && v[0] != '0';
+    }();
+    return enabled;
+}
+
+bool chunkTopDownDisabled()
+{
+    static const bool disabled = [] {
+        const char* v = getenv("PIVCO_CHUNK_TD");
+        return v != nullptr && v[0] == '0';
+    }();
+    return disabled;
+}
+
+// The single-kernel chunk-in-shared decoder decodes the whole tree per output
+// chunk with intermediates in shared, so it pays only 3 kernel launches vs the
+// bottom-up cascade's ~30. For small inputs that fixed launch overhead
+// dominates and the chunk decoder is faster; past the crossover the cascade's
+// higher steady-state throughput (its O(depth) ALU is hidden behind DRAM
+// latency) wins. The wider (2048) chunk lifts the chunk decoder's steady-state
+// enough to hold the win out to ~12 MiB (measured +19..+38% at 10 MiB) for the
+// deep trees that dominate real data. Shallow trees (small tableLog, e.g. an
+// incompressible .gz) have a fast baseline (few merge levels -> few launches)
+// and cross over earlier (~6 MiB), so gate the wider window on tree depth: deep
+// trees get 12 MiB; shallow ones only win to ~4 MiB (measured: an
+// incompressible .gz ties at 4 MiB and loses ~5% by 8 MiB), so cap them there.
+constexpr size_t kChunkTdMaxAutoBytesDeep    = 12u * 1024u * 1024u;
+constexpr size_t kChunkTdMaxAutoBytesShallow = 4u * 1024u * 1024u;
+constexpr int kChunkTdDeepTableLog           = 10;
+
+inline size_t chunkTdMaxAutoBytesFor(int tableLog)
+{
+    return tableLog >= kChunkTdDeepTableLog ? kChunkTdMaxAutoBytesDeep
+                                            : kChunkTdMaxAutoBytesShallow;
+}
+// Below this size the small (1024) chunk wins (its extra chunks give the grid
+// enough parallelism to fill the GPU); at/above it the wide (2048) chunk's
+// per-chunk-descent amortization wins. Between ~4 and ~8 MiB the small chunk is
+// still ahead, so keep the boundary at 6 MiB.
+constexpr size_t kChunkTdWideChunkBytes = 6u * 1024u * 1024u;
+
+// Pick the chunk size for a given output size (see the two constants above).
+inline uint32_t chunkTdOutputsFor(size_t dstSize)
+{
+    return dstSize <= kChunkTdWideChunkBytes ? kChunkTdSmallOutputs
+                                             : kChunkTdLargeOutputs;
+}
+
+} // namespace
+
+extern "C" size_t pivcoGpuEncodeWorkspaceBytes(size_t srcSize, size_t blockSize)
+{
+    return workspaceBytesFor(srcSize, blockSize);
+}
+
+extern "C" size_t pivcoGpuDecodeWorkspaceBytes(size_t dstSize, size_t blockSize)
+{
+    return decodeWorkspaceBytesFor(dstSize, blockSize);
+}
+
+cudaError_t pivcoGpuEncodeAsync(
+        const PivCoGpuContext* context,
+        void* dst_d,
+        size_t dstCapacity,
+        uint64_t* offsets_d,
+        size_t offsetsCapacity,
+        const void* src_d,
+        size_t srcSize,
+        size_t blockSize,
+        void* workspace_d,
+        size_t workspaceBytes,
+        PivCoGpuStatus* status_d,
+        uint64_t* totalSize_d,
+        cudaStream_t stream)
+{
+    if (context == nullptr || offsets_d == nullptr || status_d == nullptr
+        || totalSize_d == nullptr || blockSize == 0
+        || blockSize > PIVCO_GPU_MAX_BLOCK_SIZE
+        || addOverflows(srcSize, blockSize - 1)) {
+        return cudaErrorInvalidValue;
+    }
+
+    const size_t numBlocks = numBlocksFor(srcSize, blockSize);
+    if (offsetsCapacity < numBlocks + 1 || numBlocks > kMaxGridX) {
+        return cudaErrorInvalidValue;
+    }
+    if (srcSize == 0) {
+        return cudaMemsetAsync(offsets_d, 0, sizeof(uint64_t), stream);
+    }
+    if (src_d == nullptr) {
+        return cudaErrorInvalidValue;
+    }
+
+    if (context->hostTree.tableLog == 0) {
+        cudaError_t err =
+                cudaMemsetAsync(totalSize_d, 0, sizeof(uint64_t), stream);
+        if (err != cudaSuccess) {
+            return err;
+        }
+        return cudaMemsetAsync(
+                offsets_d, 0, sizeof(uint64_t) * (numBlocks + 1), stream);
+    }
+
+    if (dst_d == nullptr || workspace_d == nullptr
+        || workspaceBytes < workspaceBytesFor(srcSize, blockSize)) {
+        return cudaErrorInvalidValue;
+    }
+
+    auto* const tree_d = static_cast<PivCoGpuTree*>(workspace_d);
+    auto* const blockWorkspace =
+            static_cast<uint8_t*>(workspace_d) + kTreeWorkspaceBytes;
+    cudaError_t err = cudaMemcpyAsync(
+            tree_d,
+            &context->hostTree,
+            sizeof(context->hostTree),
+            cudaMemcpyHostToDevice,
+            stream);
+    if (err != cudaSuccess) {
+        return err;
+    }
+
+    if (canUseFastRootConstFlat1Encode(context->hostTree, blockSize)) {
+        auto* const blockBitstreams      = blockWorkspace;
+        const size_t blockBitstreamBytes = numBlocks * blockSize;
+        const size_t numScanChunks =
+                (numBlocks + kScanItemsPerBlock - 1) / kScanItemsPerBlock;
+        uint64_t* const scanChunkSums = reinterpret_cast<uint64_t*>(
+                blockWorkspace
+                + alignUpSize(blockBitstreamBytes, alignof(uint64_t)));
+        uint64_t* const scanChunkOffsets = scanChunkSums + numScanChunks;
+        fastEncodePackRootConstFlat1Kernel<<<
+                numBlocks,
+                kFastBlockThreads,
+                0,
+                stream>>>(
+                tree_d,
+                static_cast<const uint8_t*>(src_d),
+                srcSize,
+                blockSize,
+                blockBitstreams,
+                offsets_d,
+                status_d);
+        err = cudaGetLastError();
+        if (err != cudaSuccess) {
+            return err;
+        }
+
+        if (numScanChunks <= kScanItemsPerBlock) {
+            scanBlockSizesKernel<<<
+                    numScanChunks,
+                    kScanItemsPerBlock,
+                    0,
+                    stream>>>(offsets_d, numBlocks, scanChunkSums);
+            err = cudaGetLastError();
+            if (err != cudaSuccess) {
+                return err;
+            }
+            scanChunkSumsKernel<<<1, kScanItemsPerBlock, 0, stream>>>(
+                    scanChunkSums,
+                    scanChunkOffsets,
+                    numScanChunks,
+                    totalSize_d);
+            err = cudaGetLastError();
+            if (err != cudaSuccess) {
+                return err;
+            }
+            addChunkOffsetsKernel<<<
+                    numScanChunks,
+                    kScanItemsPerBlock,
+                    0,
+                    stream>>>(
+                    offsets_d, numBlocks, scanChunkOffsets, totalSize_d);
+            err = cudaGetLastError();
+            if (err != cudaSuccess) {
+                return err;
+            }
+        } else {
+            scanOffsetsKernel<<<1, 1, 0, stream>>>(
+                    offsets_d, numBlocks, totalSize_d, status_d);
+            err = cudaGetLastError();
+            if (err != cudaSuccess) {
+                return err;
+            }
+        }
+
+        fastEncodeCopyRootConstFlat1Kernel<<<
+                numBlocks,
+                kFastBlockThreads,
+                0,
+                stream>>>(
+                static_cast<uint8_t*>(dst_d),
+                dstCapacity,
+                blockBitstreams,
+                srcSize,
+                blockSize,
+                offsets_d,
+                status_d);
+        return cudaGetLastError();
+    }
+
+    encodeLayoutKernel<<<numBlocks, 1, 0, stream>>>(
+            tree_d,
+            static_cast<const uint8_t*>(src_d),
+            srcSize,
+            blockSize,
+            blockWorkspace,
+            offsets_d,
+            status_d);
+    err = cudaGetLastError();
+    if (err != cudaSuccess) {
+        return err;
+    }
+
+    scanOffsetsKernel<<<1, 1, 0, stream>>>(
+            offsets_d, numBlocks, totalSize_d, status_d);
+    err = cudaGetLastError();
+    if (err != cudaSuccess) {
+        return err;
+    }
+
+    encodeEmitKernel<<<numBlocks, 1, 0, stream>>>(
+            tree_d,
+            static_cast<uint8_t*>(dst_d),
+            dstCapacity,
+            static_cast<const uint8_t*>(src_d),
+            srcSize,
+            blockSize,
+            blockWorkspace,
+            offsets_d,
+            status_d);
+    return cudaGetLastError();
+}
+
+cudaError_t pivcoGpuDecodeAsync(
+        const PivCoGpuContext* context,
+        void* dst_d,
+        size_t dstSize,
+        const void* bitstream_d,
+        size_t bitstreamSize,
+        const uint64_t* offsets_d,
+        size_t offsetsCount,
+        size_t blockSize,
+        void* workspace_d,
+        size_t workspaceBytes,
+        PivCoGpuStatus* status_d,
+        cudaStream_t stream)
+{
+    if (context == nullptr || offsets_d == nullptr || status_d == nullptr
+        || blockSize == 0 || blockSize > PIVCO_GPU_MAX_BLOCK_SIZE
+        || addOverflows(dstSize, blockSize - 1)) {
+        return cudaErrorInvalidValue;
+    }
+
+    const size_t numBlocks = numBlocksFor(dstSize, blockSize);
+    if (offsetsCount < numBlocks + 1 || numBlocks > kMaxGridX) {
+        return cudaErrorInvalidValue;
+    }
+    if (dstSize == 0) {
+        return bitstreamSize == 0 ? cudaSuccess : cudaErrorInvalidValue;
+    }
+    if (dst_d == nullptr || workspace_d == nullptr
+        || workspaceBytes < decodeWorkspaceBytesFor(dstSize, blockSize)
+        || (bitstreamSize != 0 && bitstream_d == nullptr)) {
+        return cudaErrorInvalidValue;
+    }
+
+    if (context->hostTree.tableLog == 0 && bitstreamSize != 0) {
+        return cudaErrorInvalidValue;
+    }
+
+    auto* const workspaceBytesPtr = static_cast<uint8_t*>(workspace_d);
+    auto* const tree_d     = reinterpret_cast<PivCoGpuTree*>(workspaceBytesPtr);
+    auto* const schedule_d = reinterpret_cast<PivCoGpuDecodeSchedule*>(
+            workspaceBytesPtr + kTreeWorkspaceBytes);
+    auto* const blockWorkspace =
+            workspaceBytesPtr + kDecodeStaticWorkspaceBytes;
+    cudaError_t err = cudaMemcpyAsync(
+            tree_d,
+            &context->hostTree,
+            sizeof(context->hostTree),
+            cudaMemcpyHostToDevice,
+            stream);
+    if (err != cudaSuccess) {
+        return err;
+    }
+
+    if (canUseFastRootConstFlat1Decode(context->hostTree, blockSize)) {
+        fastDecodeRootConstFlat1Kernel<<<
+                numBlocks,
+                kFastBlockThreads,
+                0,
+                stream>>>(
+                tree_d,
+                static_cast<uint8_t*>(dst_d),
+                dstSize,
+                static_cast<const uint8_t*>(bitstream_d),
+                bitstreamSize,
+                offsets_d,
+                blockSize,
+                status_d);
+        return cudaGetLastError();
+    }
+
+    if (canUseFastFlatRoot(context->hostTree)) {
+        fastDecodeFlatRootKernel<<<numBlocks, kFastBlockThreads, 0, stream>>>(
+                tree_d,
+                static_cast<uint8_t*>(dst_d),
+                dstSize,
+                static_cast<const uint8_t*>(bitstream_d),
+                bitstreamSize,
+                offsets_d,
+                blockSize,
+                status_d);
+        return cudaGetLastError();
+    }
+
+    if ((chunkTopDownEnabled()
+         || (dstSize <= chunkTdMaxAutoBytesFor(context->hostTree.tableLog)
+             && !chunkTopDownDisabled()))
+        && canUseScheduledDecode(
+                context->hostTree, context->decodeSchedule, blockSize)) {
+        err = cudaMemcpyAsync(
+                schedule_d,
+                &context->decodeSchedule,
+                sizeof(context->decodeSchedule),
+                cudaMemcpyHostToDevice,
+                stream);
+        if (err != cudaSuccess) {
+            return err;
+        }
+
+        scheduledParseKernel<<<numBlocks, 1, 0, stream>>>(
+                schedule_d,
+                static_cast<const uint8_t*>(bitstream_d),
+                bitstreamSize,
+                offsets_d,
+                dstSize,
+                blockSize,
+                blockWorkspace,
+                status_d);
+        err = cudaGetLastError();
+        if (err != cudaSuccess) {
+            return err;
+        }
+
+        // Rank directories (per internal node) enable the O(1) boundary-rank
+        // lookups the per-chunk descent needs.
+        if (context->decodeSchedule.internalCount != 0) {
+            scheduledDirectoryKernel<<<
+                    dim3(static_cast<unsigned>(numBlocks),
+                         context->decodeSchedule.internalCount),
+                    kRankSelectThreads,
+                    0,
+                    stream>>>(
+                    schedule_d,
+                    static_cast<const uint8_t*>(bitstream_d),
+                    offsets_d,
+                    dstSize,
+                    blockSize,
+                    blockWorkspace,
+                    status_d);
+            err = cudaGetLastError();
+            if (err != cudaSuccess) {
+                return err;
+            }
+        }
+
+        const uint32_t chunkOutputs   = chunkTdOutputsFor(dstSize);
+        const uint32_t chunksPerBlock = static_cast<uint32_t>(
+                (blockSize + chunkOutputs - 1) / chunkOutputs);
+        const uint32_t gridY =
+                (chunksPerBlock + kChunkTdWarps - 1) / kChunkTdWarps;
+        const size_t nc             = context->decodeSchedule.nodeCount;
+        const size_t levelNodeBytes = (nc * 2u + 15u) & ~size_t{ 15 };
+        const size_t perWarpBytes =
+                (2u * kChunkTdBufBytesFor(chunkOutputs) + 6u * nc + 15u)
+                & ~size_t{ 15 };
+        const size_t sharedBytes = levelNodeBytes
+                + static_cast<size_t>(kChunkTdWarps) * perWarpBytes;
+        cudaFuncSetAttribute(
+                pivcoChunkTopDownKernel,
+                cudaFuncAttributeMaxDynamicSharedMemorySize,
+                static_cast<int>(sharedBytes));
+        pivcoChunkTopDownKernel<<<
+                dim3(static_cast<unsigned>(numBlocks), gridY),
+                kChunkTdThreads,
+                sharedBytes,
+                stream>>>(
+                tree_d,
+                schedule_d,
+                static_cast<uint8_t*>(dst_d),
+                dstSize,
+                static_cast<const uint8_t*>(bitstream_d),
+                offsets_d,
+                blockSize,
+                chunkOutputs,
+                blockWorkspace,
+                status_d);
+        return cudaGetLastError();
+    }
+
+    if (canUseScheduledDecode(
+                context->hostTree, context->decodeSchedule, blockSize)) {
+        err = cudaMemcpyAsync(
+                schedule_d,
+                &context->decodeSchedule,
+                sizeof(context->decodeSchedule),
+                cudaMemcpyHostToDevice,
+                stream);
+        if (err != cudaSuccess) {
+            return err;
+        }
+
+        // Optional per-kernel microbenchmark: when PIVCO_KERNEL_TIMING is set,
+        // each stage is timed in isolation (event record + sync per launch) so
+        // its own GPU time -- the "ideal" per-kernel cost with the prior
+        // stage's caches warm -- can be compared against the in-pipeline nsys
+        // time. This path serializes and is diagnostic only; it is off on the
+        // perf path.
+        static const bool kernelTiming = [] {
+            const char* v = getenv("PIVCO_KERNEL_TIMING");
+            return v != nullptr && v[0] != '\0' && v[0] != '0';
+        }();
+        cudaEvent_t evStart                      = nullptr;
+        cudaEvent_t evStop                       = nullptr;
+        double parseMs                           = 0.0;
+        double opMs[PIVCO_GPU_SCHEDULE_OP_COUNT] = {};
+        if (kernelTiming) {
+            cudaEventCreate(&evStart);
+            cudaEventCreate(&evStop);
+            cudaEventRecord(evStart, stream);
+        }
+
+        scheduledParseKernel<<<numBlocks, 1, 0, stream>>>(
+                schedule_d,
+                static_cast<const uint8_t*>(bitstream_d),
+                bitstreamSize,
+                offsets_d,
+                dstSize,
+                blockSize,
+                blockWorkspace,
+                status_d);
+        err = cudaGetLastError();
+        if (err != cudaSuccess) {
+            return err;
+        }
+        if (kernelTiming) {
+            cudaEventRecord(evStop, stream);
+            cudaEventSynchronize(evStop);
+            float ms = 0.0f;
+            cudaEventElapsedTime(&ms, evStart, evStop);
+            parseMs = ms;
+        }
+
+        // The rank directory is built in shared memory at the top of each merge
+        // kernel (buildSharedDirectory), so no standalone directory kernel is
+        // launched here -- this avoids the global directory write+read and the
+        // redundant bitmap re-read.
+
+        for (int level = static_cast<int>(context->decodeSchedule.maxLevel);
+             level >= 0;
+             --level) {
+            for (uint8_t op = 0; op < PIVCO_GPU_SCHEDULE_OP_COUNT; ++op) {
+                const size_t stageIndex =
+                        scheduleStageIndex(static_cast<uint16_t>(level), op);
+                if (kernelTiming
+                    && context->decodeSchedule.stageCount[stageIndex] != 0) {
+                    cudaEventRecord(evStart, stream);
+                }
+                err = launchScheduledDecodeStage(
+                        op,
+                        context->decodeSchedule.stageOffset[stageIndex],
+                        context->decodeSchedule.stageCount[stageIndex],
+                        numBlocks,
+                        tree_d,
+                        schedule_d,
+                        static_cast<uint8_t*>(dst_d),
+                        dstSize,
+                        static_cast<const uint8_t*>(bitstream_d),
+                        offsets_d,
+                        blockSize,
+                        blockWorkspace,
+                        status_d,
+                        stream);
+                if (err != cudaSuccess) {
+                    return err;
+                }
+                if (kernelTiming
+                    && context->decodeSchedule.stageCount[stageIndex] != 0) {
+                    cudaEventRecord(evStop, stream);
+                    cudaEventSynchronize(evStop);
+                    float ms = 0.0f;
+                    cudaEventElapsedTime(&ms, evStart, evStop);
+                    opMs[op] += ms;
+                }
+            }
+        }
+        if (kernelTiming) {
+            static const char* const kOpNames[PIVCO_GPU_SCHEDULE_OP_COUNT] = {
+                "flat1", "flat2", "flat3",   "flat4",   "flat5",   "flat6",
+                "flat7", "flat8", "mergeVV", "mergeCV", "mergeVC", "mergeCC"
+            };
+            fprintf(stderr, "[pivco kernel timing ms] parse=%.4f", parseMs);
+            for (uint8_t op = 0; op < PIVCO_GPU_SCHEDULE_OP_COUNT; ++op) {
+                if (opMs[op] > 0.0) {
+                    fprintf(stderr, " %s=%.4f", kOpNames[op], opMs[op]);
+                }
+            }
+            fprintf(stderr, "\n");
+            cudaEventDestroy(evStart);
+            cudaEventDestroy(evStop);
+        }
+        return cudaSuccess;
+    }
+
+    // No optimized decode path applies. The fast, scheduled-cascade, and
+    // chunk-in-shared decoders cover fastMode trees and every schedulable
+    // tree at blockSize <= kRankSelectMaxBlockSize (64 KiB); the chunk
+    // decoder's per-node metadata is uint16, so larger block sizes are out
+    // of range by design.
+    return cudaErrorNotSupported;
+}
+
+extern "C" ZL_Report pivcoGpuEncode(
+        const PivCoGpuContext* context,
+        void* dst_d,
+        size_t dstCapacity,
+        uint64_t* offsets_d,
+        size_t offsetsCapacity,
+        const void* src_d,
+        size_t srcSize,
+        size_t blockSize,
+        void* workspace_d,
+        size_t workspaceBytes,
+        ZL_GPU_Stream stream)
+{
+    PivCoGpuStatus* status_d = nullptr;
+    uint64_t* totalSize_d    = nullptr;
+    cudaError_t err          = cudaMalloc(&status_d, sizeof(PivCoGpuStatus));
+    if (err != cudaSuccess) {
+        return cudaReport(err);
+    }
+    err = cudaMalloc(&totalSize_d, sizeof(uint64_t));
+    if (err != cudaSuccess) {
+        cudaFree(status_d);
+        return cudaReport(err);
+    }
+    err = cudaMemsetAsync(status_d, 0, sizeof(PivCoGpuStatus), stream);
+    if (err == cudaSuccess) {
+        err = cudaMemsetAsync(totalSize_d, 0, sizeof(uint64_t), stream);
+    }
+    if (err == cudaSuccess) {
+        err = pivcoGpuEncodeAsync(
+                context,
+                dst_d,
+                dstCapacity,
+                offsets_d,
+                offsetsCapacity,
+                src_d,
+                srcSize,
+                blockSize,
+                workspace_d,
+                workspaceBytes,
+                status_d,
+                totalSize_d,
+                reinterpret_cast<cudaStream_t>(stream));
+    }
+
+    PivCoGpuStatus status{};
+    uint64_t totalSize = 0;
+    if (err == cudaSuccess) {
+        err = cudaMemcpyAsync(
+                &status,
+                status_d,
+                sizeof(status),
+                cudaMemcpyDeviceToHost,
+                reinterpret_cast<cudaStream_t>(stream));
+    }
+    if (err == cudaSuccess) {
+        err = cudaMemcpyAsync(
+                &totalSize,
+                totalSize_d,
+                sizeof(totalSize),
+                cudaMemcpyDeviceToHost,
+                reinterpret_cast<cudaStream_t>(stream));
+    }
+    if (err == cudaSuccess) {
+        err = cudaStreamSynchronize(reinterpret_cast<cudaStream_t>(stream));
+    }
+
+    cudaFree(totalSize_d);
+    cudaFree(status_d);
+
+    if (err != cudaSuccess) {
+        return cudaReport(err);
+    }
+    const ZL_Report statusResult = statusReport(status);
+    if (ZL_isError(statusResult)) {
+        return statusResult;
+    }
+    if (totalSize > SIZE_MAX) {
+        return ZL_returnError(ZL_ErrorCode_integerOverflow);
+    }
+    return ZL_returnValue(static_cast<size_t>(totalSize));
+}
+
+extern "C" ZL_Report pivcoGpuDecode(
+        const PivCoGpuContext* context,
+        void* dst_d,
+        size_t dstSize,
+        const void* bitstream_d,
+        size_t bitstreamSize,
+        const uint64_t* offsets_d,
+        size_t offsetsCount,
+        size_t blockSize,
+        void* workspace_d,
+        size_t workspaceBytes,
+        ZL_GPU_Stream stream)
+{
+    PivCoGpuStatus* status_d = nullptr;
+    cudaError_t err          = cudaMalloc(&status_d, sizeof(PivCoGpuStatus));
+    if (err != cudaSuccess) {
+        return cudaReport(err);
+    }
+    err = cudaMemsetAsync(status_d, 0, sizeof(PivCoGpuStatus), stream);
+    if (err == cudaSuccess) {
+        err = pivcoGpuDecodeAsync(
+                context,
+                dst_d,
+                dstSize,
+                bitstream_d,
+                bitstreamSize,
+                offsets_d,
+                offsetsCount,
+                blockSize,
+                workspace_d,
+                workspaceBytes,
+                status_d,
+                reinterpret_cast<cudaStream_t>(stream));
+    }
+
+    PivCoGpuStatus status{};
+    if (err == cudaSuccess) {
+        err = cudaMemcpyAsync(
+                &status,
+                status_d,
+                sizeof(status),
+                cudaMemcpyDeviceToHost,
+                reinterpret_cast<cudaStream_t>(stream));
+    }
+    if (err == cudaSuccess) {
+        err = cudaStreamSynchronize(reinterpret_cast<cudaStream_t>(stream));
+    }
+
+    cudaFree(status_d);
+
+    if (err != cudaSuccess) {
+        return cudaReport(err);
+    }
+    const ZL_Report statusResult = statusReport(status);
+    if (ZL_isError(statusResult)) {
+        return statusResult;
+    }
+    return ZL_returnValue(dstSize);
+}

--- a/contrib/pivco-huffman/gpu/pivco_gpu.cuh
+++ b/contrib/pivco-huffman/gpu/pivco_gpu.cuh
@@ -1,0 +1,52 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#pragma once
+
+#include <stddef.h>
+#include <stdint.h>
+
+#include <cuda_runtime.h>
+
+#include "openzl/dev/contrib/pivco-huffman/gpu/pivco_gpu.h"
+
+struct PivCoGpuStatus {
+    unsigned code;
+    uint64_t detail;
+};
+
+enum PivCoGpuStatusCode : unsigned {
+    PIVCO_GPU_STATUS_OK             = 0,
+    PIVCO_GPU_STATUS_PARAMETER      = 1,
+    PIVCO_GPU_STATUS_CORRUPTION     = 2,
+    PIVCO_GPU_STATUS_CAPACITY       = 3,
+    PIVCO_GPU_STATUS_MISSING_SYMBOL = 4,
+};
+
+cudaError_t pivcoGpuEncodeAsync(
+        const PivCoGpuContext* context,
+        void* dst_d,
+        size_t dstCapacity,
+        uint64_t* offsets_d,
+        size_t offsetsCapacity,
+        const void* src_d,
+        size_t srcSize,
+        size_t blockSize,
+        void* workspace_d,
+        size_t workspaceBytes,
+        PivCoGpuStatus* status_d,
+        uint64_t* totalSize_d,
+        cudaStream_t stream);
+
+cudaError_t pivcoGpuDecodeAsync(
+        const PivCoGpuContext* context,
+        void* dst_d,
+        size_t dstSize,
+        const void* bitstream_d,
+        size_t bitstreamSize,
+        const uint64_t* offsets_d,
+        size_t offsetsCount,
+        size_t blockSize,
+        void* workspace_d,
+        size_t workspaceBytes,
+        PivCoGpuStatus* status_d,
+        cudaStream_t stream);

--- a/contrib/pivco-huffman/gpu/pivco_gpu.h
+++ b/contrib/pivco-huffman/gpu/pivco_gpu.h
@@ -1,0 +1,75 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#pragma once
+
+#include <stddef.h>
+#include <stdint.h>
+
+#include "openzl/zl_errors.h"
+
+typedef struct CUstream_st* ZL_GPU_Stream;
+
+/**
+ * The decoder writes output in aligned 8-byte groups, so the destination buffer
+ * must reserve this many extra trailing bytes past `dstSize` for the final
+ * group's over-write (the trailing bytes are written with unspecified values).
+ */
+#define PIVCO_GPU_DECODE_DST_SLOP 8
+
+/**
+ * The chunk-in-shared decoder reads bitmap words with a loop-free over-read of
+ * a few bytes past a node's bitmap (the extra bytes are always masked off). For
+ * interior blocks that lands in the next block's slice; for the last block the
+ * input buffer must reserve this many readable trailing bytes past
+ * `bitstreamSize` (their contents are irrelevant). Callers should allocate the
+ * compressed input with this much slop.
+ */
+#define PIVCO_GPU_DECODE_SRC_SLOP 8
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef struct PivCoGpuContext PivCoGpuContext;
+
+ZL_Report pivcoGpuContextCreate(
+        PivCoGpuContext** context,
+        const uint8_t* weights,
+        size_t weightsSize,
+        int tableLog);
+
+void pivcoGpuContextDestroy(PivCoGpuContext* context);
+
+size_t pivcoGpuEncodeWorkspaceBytes(size_t srcSize, size_t blockSize);
+
+size_t pivcoGpuDecodeWorkspaceBytes(size_t dstSize, size_t blockSize);
+
+ZL_Report pivcoGpuEncode(
+        const PivCoGpuContext* context,
+        void* dst_d,
+        size_t dstCapacity,
+        uint64_t* offsets_d,
+        size_t offsetsCapacity,
+        const void* src_d,
+        size_t srcSize,
+        size_t blockSize,
+        void* workspace_d,
+        size_t workspaceBytes,
+        ZL_GPU_Stream stream);
+
+ZL_Report pivcoGpuDecode(
+        const PivCoGpuContext* context,
+        void* dst_d,
+        size_t dstSize,
+        const void* bitstream_d,
+        size_t bitstreamSize,
+        const uint64_t* offsets_d,
+        size_t offsetsCount,
+        size_t blockSize,
+        void* workspace_d,
+        size_t workspaceBytes,
+        ZL_GPU_Stream stream);
+
+#ifdef __cplusplus
+}
+#endif

--- a/contrib/pivco-huffman/gpu/pivco_gpu_context.cpp
+++ b/contrib/pivco-huffman/gpu/pivco_gpu_context.cpp
@@ -1,0 +1,285 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#include "openzl/dev/contrib/pivco-huffman/gpu/pivco_gpu.h"
+
+#include <cstddef>
+#include <cstdint>
+#include <cstring>
+#include <new>
+
+#include "openzl/codecs/pivco_huffman/common_pivco_kernel.h"
+#include "openzl/dev/contrib/pivco-huffman/gpu/pivco_gpu_tree.h"
+
+namespace {
+
+constexpr uint16_t kNoScheduleChild = UINT16_MAX;
+
+size_t scheduleStageIndex(uint16_t level, uint8_t op)
+{
+    return static_cast<size_t>(level) * PIVCO_GPU_SCHEDULE_OP_COUNT + op;
+}
+
+bool scheduleNodeMaterializes(const PivCoGpuScheduleNode& node)
+{
+    return node.kind != PIVCO_GPU_SCHEDULE_CONSTANT;
+}
+
+PivCoGpuScheduleOp flatOpForDepth(size_t depth)
+{
+    return static_cast<PivCoGpuScheduleOp>(
+            PIVCO_GPU_SCHEDULE_OP_FLAT1 + depth - 1);
+}
+
+uint16_t buildScheduleNode(
+        PivCoGpuDecodeSchedule* schedule,
+        const ZL_PivCoHuffmanTree* tree,
+        size_t level,
+        size_t firstRank,
+        size_t rankEnd,
+        bool* ok)
+{
+    if (!*ok || schedule->nodeCount >= PIVCO_GPU_MAX_TREE_NODES
+        || level >= PIVCO_GPU_MAX_LEVELS || firstRank >= rankEnd
+        || rankEnd > tree->numRanks) {
+        *ok = false;
+        return 0;
+    }
+
+    const uint16_t nodeIndex   = schedule->nodeCount++;
+    PivCoGpuScheduleNode& node = schedule->nodes[nodeIndex];
+    node.leftChild             = kNoScheduleChild;
+    node.rightChild            = kNoScheduleChild;
+    node.firstRank             = static_cast<uint16_t>(firstRank);
+    node.rankEnd               = static_cast<uint16_t>(rankEnd);
+    node.kind                  = PIVCO_GPU_SCHEDULE_INTERNAL;
+    node.op                    = 0;
+    node.level                 = static_cast<uint8_t>(level);
+    node.flatDepth             = 0;
+    node.symbol                = 0;
+    node.leftSymbol            = 0;
+    node.rightSymbol           = 0;
+    node.reserved              = 0;
+    if (schedule->maxLevel < level) {
+        schedule->maxLevel = static_cast<uint16_t>(level);
+    }
+
+    if (ZL_PivCoHuffmanTree_rangeIsLeaf(tree, firstRank, rankEnd)) {
+        const size_t depth = ZL_PivCoHuffmanTree_leafFlatDepth(tree, firstRank);
+        if (depth == 0) {
+            node.kind   = PIVCO_GPU_SCHEDULE_CONSTANT;
+            node.symbol = tree->rankToSymbol[firstRank];
+            return nodeIndex;
+        }
+        if (depth > 8) {
+            *ok = false;
+            return nodeIndex;
+        }
+        node.kind      = PIVCO_GPU_SCHEDULE_FLAT;
+        node.flatDepth = static_cast<uint8_t>(depth);
+        node.op        = static_cast<uint8_t>(flatOpForDepth(depth));
+        return nodeIndex;
+    }
+
+    if (level >= tree->numLevels) {
+        *ok = false;
+        return nodeIndex;
+    }
+
+    const size_t splitRank =
+            ZL_PivCoHuffmanTree_splitRank(tree, level, firstRank, rankEnd);
+    if (splitRank <= firstRank || splitRank >= rankEnd) {
+        *ok = false;
+        return nodeIndex;
+    }
+
+    const uint16_t leftChild = buildScheduleNode(
+            schedule, tree, level + 1, firstRank, splitRank, ok);
+    const uint16_t rightChild = buildScheduleNode(
+            schedule, tree, level + 1, splitRank, rankEnd, ok);
+    if (!*ok) {
+        return nodeIndex;
+    }
+
+    node.leftChild  = leftChild;
+    node.rightChild = rightChild;
+
+    const PivCoGpuScheduleNode& left  = schedule->nodes[leftChild];
+    const PivCoGpuScheduleNode& right = schedule->nodes[rightChild];
+    const bool leftIsConstant  = left.kind == PIVCO_GPU_SCHEDULE_CONSTANT;
+    const bool rightIsConstant = right.kind == PIVCO_GPU_SCHEDULE_CONSTANT;
+    if (leftIsConstant) {
+        node.leftSymbol = left.symbol;
+    }
+    if (rightIsConstant) {
+        node.rightSymbol = right.symbol;
+    }
+
+    if (leftIsConstant && rightIsConstant) {
+        node.op = PIVCO_GPU_SCHEDULE_OP_MERGE_CONSTANT_CONSTANT;
+    } else if (leftIsConstant) {
+        node.op = PIVCO_GPU_SCHEDULE_OP_MERGE_CONSTANT_VECTOR;
+    } else if (rightIsConstant) {
+        node.op = PIVCO_GPU_SCHEDULE_OP_MERGE_VECTOR_CONSTANT;
+    } else {
+        node.op = PIVCO_GPU_SCHEDULE_OP_MERGE_VECTOR_VECTOR;
+    }
+    return nodeIndex;
+}
+
+void buildScheduleStages(PivCoGpuDecodeSchedule* schedule)
+{
+    uint16_t counts[PIVCO_GPU_MAX_LEVELS * PIVCO_GPU_SCHEDULE_OP_COUNT] = {};
+    for (uint16_t i = 0; i < schedule->nodeCount; ++i) {
+        const PivCoGpuScheduleNode& node = schedule->nodes[i];
+        if (node.kind == PIVCO_GPU_SCHEDULE_INTERNAL) {
+            schedule->internalItems[schedule->internalCount++] =
+                    PivCoGpuScheduleStageItem{ i };
+        }
+        if (scheduleNodeMaterializes(node)) {
+            ++counts[scheduleStageIndex(node.level, node.op)];
+        }
+    }
+
+    uint16_t cursor = 0;
+    for (size_t i = 0; i < PIVCO_GPU_MAX_LEVELS * PIVCO_GPU_SCHEDULE_OP_COUNT;
+         ++i) {
+        schedule->stageOffset[i] = cursor;
+        schedule->stageCount[i]  = counts[i];
+        cursor += counts[i];
+        counts[i] = schedule->stageOffset[i];
+    }
+
+    for (uint16_t i = 0; i < schedule->nodeCount; ++i) {
+        const PivCoGpuScheduleNode& node = schedule->nodes[i];
+        if (!scheduleNodeMaterializes(node)) {
+            continue;
+        }
+        const size_t index = scheduleStageIndex(node.level, node.op);
+        schedule->stageItems[counts[index]++] = PivCoGpuScheduleStageItem{ i };
+    }
+}
+
+void fillDecodeSchedule(
+        PivCoGpuDecodeSchedule* schedule,
+        const ZL_PivCoHuffmanTree* tree)
+{
+    std::memset(schedule, 0, sizeof(*schedule));
+    if (tree->numRanks == 0) {
+        return;
+    }
+
+    bool ok = true;
+    const uint16_t root =
+            buildScheduleNode(schedule, tree, 0, 0, tree->numRanks, &ok);
+    if (!ok || root != 0 || schedule->nodeCount > PIVCO_GPU_MAX_TREE_NODES) {
+        std::memset(schedule, 0, sizeof(*schedule));
+        return;
+    }
+    buildScheduleStages(schedule);
+    schedule->enabled = 1;
+}
+
+void fillGpuTree(
+        PivCoGpuTree* dst,
+        const ZL_PivCoHuffmanTree* src,
+        const uint8_t* weights,
+        size_t weightsSize)
+{
+    std::memset(dst, 0, sizeof(*dst));
+    std::memcpy(
+            dst->symbolToRank, src->symbolToRank, sizeof(src->symbolToRank));
+    std::memcpy(
+            dst->rankToSymbol, src->rankToSymbol, sizeof(src->rankToSymbol));
+    std::memcpy(
+            dst->rankToFlatDepth,
+            src->rankToFlatDepth,
+            sizeof(src->rankToFlatDepth));
+    std::memcpy(
+            dst->rankToCodeword,
+            src->rankToCodeword,
+            sizeof(src->rankToCodeword));
+    for (size_t i = 0; i < weightsSize; ++i) {
+        dst->symbolPresent[i] = weights[i] != 0;
+    }
+    dst->numLevels = src->numLevels;
+    dst->numRanks  = src->numRanks;
+    dst->tableLog  = src->tableLog;
+
+    if (src->numRanks > 1
+        && ZL_PivCoHuffmanTree_rangeIsLeaf(src, 0, src->numRanks)) {
+        dst->fastMode = PIVCO_GPU_FAST_FLAT_ROOT;
+        return;
+    }
+
+    if (src->numRanks == 3
+        && !ZL_PivCoHuffmanTree_rangeIsLeaf(src, 0, src->numRanks)) {
+        const uint16_t splitRank =
+                ZL_PivCoHuffmanTree_splitRank(src, 0, 0, src->numRanks);
+        const bool rhsIsFlatOneBit =
+                ZL_PivCoHuffmanTree_rangeIsLeaf(src, splitRank, src->numRanks)
+                && ZL_PivCoHuffmanTree_leafFlatDepth(src, splitRank) == 1;
+        bool rhsIsTwoConstants = false;
+        if (!rhsIsFlatOneBit
+            && !ZL_PivCoHuffmanTree_rangeIsLeaf(
+                    src, splitRank, src->numRanks)) {
+            const uint16_t rhsSplitRank = ZL_PivCoHuffmanTree_splitRank(
+                    src, 1, splitRank, src->numRanks);
+            rhsIsTwoConstants = rhsSplitRank == 2
+                    && ZL_PivCoHuffmanTree_rangeIsConstantLeaf(
+                                        src, splitRank, rhsSplitRank)
+                    && ZL_PivCoHuffmanTree_rangeIsConstantLeaf(
+                                        src, rhsSplitRank, src->numRanks);
+        }
+
+        if (splitRank == 1
+            && ZL_PivCoHuffmanTree_rangeIsConstantLeaf(src, 0, splitRank)
+            && (rhsIsFlatOneBit || rhsIsTwoConstants)) {
+            dst->fastMode           = PIVCO_GPU_FAST_ROOT_CONST_FLAT1;
+            dst->fastZeroSymbol     = src->rankToSymbol[0];
+            dst->fastLeafZeroSymbol = src->rankToSymbol[1];
+            dst->fastLeafOneSymbol  = src->rankToSymbol[2];
+        }
+    }
+}
+
+} // namespace
+
+extern "C" ZL_Report pivcoGpuContextCreate(
+        PivCoGpuContext** context,
+        const uint8_t* weights,
+        size_t weightsSize,
+        int tableLog)
+{
+    if (context == nullptr || weights == nullptr || weightsSize == 0
+        || weightsSize > PIVCO_GPU_MAX_SYMBOLS) {
+        return ZL_returnError(ZL_ErrorCode_parameter_invalid);
+    }
+
+    const int computedTableLog =
+            ZL_PivCoHuffman_computeTableLog(weights, weightsSize);
+    if (computedTableLog < 0
+        || (tableLog >= 0 && tableLog != computedTableLog)) {
+        return ZL_returnError(ZL_ErrorCode_corruption);
+    }
+
+    ZL_PivCoHuffmanTree cpuTree;
+    ZL_PivCoHuffmanTree_build(&cpuTree, weights, weightsSize, computedTableLog);
+
+    PivCoGpuContext* created = new (std::nothrow) PivCoGpuContext{};
+    if (created == nullptr) {
+        return ZL_returnError(ZL_ErrorCode_allocation);
+    }
+    fillGpuTree(&created->hostTree, &cpuTree, weights, weightsSize);
+    fillDecodeSchedule(&created->decodeSchedule, &cpuTree);
+
+    *context = created;
+    return ZL_returnSuccess();
+}
+
+extern "C" void pivcoGpuContextDestroy(PivCoGpuContext* context)
+{
+    if (context == nullptr) {
+        return;
+    }
+    delete context;
+}

--- a/contrib/pivco-huffman/gpu/pivco_gpu_tree.h
+++ b/contrib/pivco-huffman/gpu/pivco_gpu_tree.h
@@ -1,0 +1,90 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#pragma once
+
+#include <stddef.h>
+#include <stdint.h>
+
+constexpr size_t PIVCO_GPU_MAX_BLOCK_SIZE = size_t{ 1 } << 28;
+constexpr size_t PIVCO_GPU_MAX_SYMBOLS    = 256;
+constexpr size_t PIVCO_GPU_MAX_TREE_NODES = 2 * PIVCO_GPU_MAX_SYMBOLS - 1;
+constexpr size_t PIVCO_GPU_MAX_LEVELS     = 16;
+
+enum PivCoGpuFastMode : uint8_t {
+    PIVCO_GPU_FAST_NONE             = 0,
+    PIVCO_GPU_FAST_ROOT_CONST_FLAT1 = 1,
+    PIVCO_GPU_FAST_FLAT_ROOT        = 2,
+};
+
+struct PivCoGpuTree {
+    uint8_t symbolToRank[PIVCO_GPU_MAX_SYMBOLS];
+    uint8_t symbolPresent[PIVCO_GPU_MAX_SYMBOLS];
+    uint8_t rankToSymbol[PIVCO_GPU_MAX_SYMBOLS];
+    uint8_t rankToFlatDepth[PIVCO_GPU_MAX_SYMBOLS];
+    uint16_t rankToCodeword[PIVCO_GPU_MAX_SYMBOLS];
+    uint16_t numLevels;
+    uint16_t numRanks;
+    int tableLog;
+    uint8_t fastMode;
+    uint8_t fastZeroSymbol;
+    uint8_t fastLeafZeroSymbol;
+    uint8_t fastLeafOneSymbol;
+};
+
+enum PivCoGpuScheduleNodeKind : uint8_t {
+    PIVCO_GPU_SCHEDULE_CONSTANT = 0,
+    PIVCO_GPU_SCHEDULE_FLAT     = 1,
+    PIVCO_GPU_SCHEDULE_INTERNAL = 2,
+};
+
+enum PivCoGpuScheduleOp : uint8_t {
+    PIVCO_GPU_SCHEDULE_OP_FLAT1                   = 0,
+    PIVCO_GPU_SCHEDULE_OP_FLAT2                   = 1,
+    PIVCO_GPU_SCHEDULE_OP_FLAT3                   = 2,
+    PIVCO_GPU_SCHEDULE_OP_FLAT4                   = 3,
+    PIVCO_GPU_SCHEDULE_OP_FLAT5                   = 4,
+    PIVCO_GPU_SCHEDULE_OP_FLAT6                   = 5,
+    PIVCO_GPU_SCHEDULE_OP_FLAT7                   = 6,
+    PIVCO_GPU_SCHEDULE_OP_FLAT8                   = 7,
+    PIVCO_GPU_SCHEDULE_OP_MERGE_VECTOR_VECTOR     = 8,
+    PIVCO_GPU_SCHEDULE_OP_MERGE_CONSTANT_VECTOR   = 9,
+    PIVCO_GPU_SCHEDULE_OP_MERGE_VECTOR_CONSTANT   = 10,
+    PIVCO_GPU_SCHEDULE_OP_MERGE_CONSTANT_CONSTANT = 11,
+    PIVCO_GPU_SCHEDULE_OP_COUNT                   = 12,
+};
+
+struct PivCoGpuScheduleNode {
+    uint16_t leftChild;
+    uint16_t rightChild;
+    uint16_t firstRank;
+    uint16_t rankEnd;
+    uint8_t kind;
+    uint8_t op;
+    uint8_t level;
+    uint8_t flatDepth;
+    uint8_t symbol;
+    uint8_t leftSymbol;
+    uint8_t rightSymbol;
+    uint8_t reserved;
+};
+
+struct PivCoGpuScheduleStageItem {
+    uint16_t node;
+};
+
+struct PivCoGpuDecodeSchedule {
+    PivCoGpuScheduleNode nodes[PIVCO_GPU_MAX_TREE_NODES];
+    PivCoGpuScheduleStageItem stageItems[PIVCO_GPU_MAX_TREE_NODES];
+    PivCoGpuScheduleStageItem internalItems[PIVCO_GPU_MAX_TREE_NODES];
+    uint16_t stageOffset[PIVCO_GPU_MAX_LEVELS * PIVCO_GPU_SCHEDULE_OP_COUNT];
+    uint16_t stageCount[PIVCO_GPU_MAX_LEVELS * PIVCO_GPU_SCHEDULE_OP_COUNT];
+    uint16_t nodeCount;
+    uint16_t internalCount;
+    uint16_t maxLevel;
+    uint8_t enabled;
+};
+
+struct PivCoGpuContext {
+    PivCoGpuTree hostTree;
+    PivCoGpuDecodeSchedule decodeSchedule;
+};


### PR DESCRIPTION
Summary:

Vibe coded a PivCo-Huffman GPU decoder over the weekend (GPU encoder is included but not optimized). The results are okay, they aren't terrible, but they aren't as fast as I'd like them to be. Ideally we'd be able to improve decompression speed by 1.5x-2x from here.

I believe that the code-length tuning from [PivCo Issue#20](https://github.com/MarcinZukowski/pivco-huffman/issues/20) will be especially helpful in improving GPU decoding speed, likely even more so than on the CPU.

## Benchmarks

Ran on **NVIDIA A100 (SM 8.0, 80 GB)**.

### Real datasets

| dataset | ratio | decode GiB/s (median) |
|---|---|---|
| gzip_random.gz | 1.000 | 654.5 |
| calgary_pic | 0.209 | 194.7 |
| dna_fasta.fa | 0.283 | 193.9 |
| cat-image.jpg | 0.990 | 152.7 |
| csv_numeric.csv | 0.418 | 145.4 |
| log_apache.log | 0.692 | 118.3 |
| chinese_text.txt | 0.731 | 114.2 |
| source_c.c | 0.623 | 112.5 |
| cat-wiki.html | 0.691 | 105.6 |
| pride.txt | 0.573 | 105.5 |
| json_api.json | 0.654 | 102.7 |

### Synthetic datasets

| dataset | ratio | decode GiB/s (median) |
|---|---|---|
| two_sym_eq | 0.125 | 935.4 |
| two_sym_90/10 | 0.125 | 931.8 |
| sparse_4 | 0.250 | 884.6 |
| flat_M3 | 0.375 | 827.6 |
| sparse_16 | 0.500 | 790.1 |
| flat_M5 | 0.625 | 722.3 |
| flat_M6 | 0.750 | 682.0 |
| flat_M7 | 0.875 | 652.8 |
| uniform | 1.000 | 626.0 |
| proba80 | 0.156 | 408.9 |
| proba50 | 0.250 | 227.1 |
| bell_s80 | 0.995 | 191.6 |
| geometric | 0.265 | 185.2 |
| english | 0.530 | 155.9 |
| bell_s10 | 0.685 | 124.8 |
| proba14 | 0.527 | 119.9 |
| zipfian | 0.783 | 112.2 |
| bell_s30 | 0.877 | 106.8 |
| proba02 | 0.891 | 101.4 |

Reviewed By: mmandina

Differential Revision: D112890856


