### PR TITLE
bf16 float_deconstruct decode benchmark (#892)

### DIFF
--- a/contrib/gpu/source/bench/BUCK
+++ b/contrib/gpu/source/bench/BUCK
@@ -1,0 +1,18 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+
+load("@fbcode_macros//build_defs:cpp_library.bzl", "cpp_library")
+
+oncall("data_compression")
+
+# Kernel-agnostic GPU benchmark driver: times a list of KernelCase variants over
+# their own on-device workload and reports latency, bandwidth, %peak, and
+# occupancy. Codec-agnostic; shared by any GPU decode benchmark.
+cpp_library(
+    name = "gpu_bench",
+    headers = ["gpu_bench.cuh"],
+    exported_deps = [
+        "../common:cuda_error",
+        "../common:cuda_raii",
+    ],
+    exported_external_deps = [("cuda", None, "cuda-lazy")],
+)

--- a/contrib/gpu/source/bench/gpu_bench.cuh
+++ b/contrib/gpu/source/bench/gpu_bench.cuh
@@ -1,0 +1,259 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#pragma once
+
+#include <algorithm>
+#include <cstddef>
+#include <cstdint>
+#include <cstdio>
+#include <memory>
+#include <string>
+#include <vector>
+
+#include <cuda_runtime.h>
+
+#include "openzl/dev/contrib/gpu/source/common/cuda_error.cuh"
+#include "openzl/dev/contrib/gpu/source/common/cuda_raii.cuh"
+
+// Kernel-agnostic GPU decompression benchmark driver: time a list of kernel
+// variants over their own on-device workload and report execution time,
+// throughput, and theoretical occupancy so multiple versions can be compared
+// directly. Each variant is a KernelCase that stages its own data in setup()
+// and moves it in launch(). Codec-agnostic: no dependency on any codec header.
+
+namespace openzl::gpu::bench {
+
+// Internal constants: SI unit conversions, the HBM peak-bandwidth model, and
+// default sampling knobs
+namespace detail {
+constexpr double kGiga    = 1e9;
+constexpr double kKilo    = 1e3;
+constexpr double kPercent = 100.0;
+
+constexpr double kMemTransfersPerClock = 2.0; // DDR: two transfers per clock
+constexpr int kBitsPerByte             = 8;
+constexpr double kFallbackPeakGBs =
+        2039.0; // A100 80GB, if clock/bus unavailable
+
+constexpr int kDefaultWarmup          = 3;
+constexpr int kDefaultIters           = 20;
+constexpr size_t kDefaultL2FlushBytes = 64ull * 1024 * 1024;
+} // namespace detail
+
+// Workload size, used to turn a time into throughput numbers
+struct Workload {
+    size_t bytesMoved; // bytes read+written per run, for effective bandwidth
+    size_t numElts;    // decoded elements per run, for G-elem/s
+};
+
+// One kernel variant to benchmark. A subclass stages its data in setup() (run
+// once before timing) and moves it in launch() over the given stream;
+// workload() reports the bytes/elements one launch touches. Optionally override
+// verify() to check correctness (a wrong-but-fast variant is flagged, not timed
+// away) and the occupancy hints (compute maxActiveBlocksPerSM in the kernel's
+// own translation unit).
+class KernelCase {
+   public:
+    virtual ~KernelCase() = default;
+
+    virtual std::string name() const         = 0;
+    virtual void launch(cudaStream_t stream) = 0;
+    virtual Workload workload() const        = 0;
+
+    virtual void setup() {}
+    virtual bool verify()
+    {
+        return true;
+    }
+    virtual int blockSize() const
+    {
+        return 0;
+    }
+    virtual int maxActiveBlocksPerSM() const
+    {
+        return 0;
+    }
+};
+
+struct BenchConfig {
+    int warmup          = detail::kDefaultWarmup;
+    int iters           = detail::kDefaultIters;
+    size_t l2FlushBytes = detail::kDefaultL2FlushBytes;
+};
+
+struct BenchResult {
+    std::string name;
+    bool correct        = true;
+    double medianMs     = 0.0;
+    double gbps         = 0.0;
+    double pctPeak      = 0.0;
+    double gElemPerS    = 0.0;
+    double occupancyPct = 0.0; // 0 if occupancy inputs not provided
+    int maxActiveBlocks = 0;   // per SM; 0 if not provided
+};
+
+// Theoretical peak HBM bandwidth (GB/s) from device memory clock + bus width
+inline double peakBandwidthGBs(int dev)
+{
+    int memClockKHz = 0, busWidthBits = 0;
+    cudaDeviceGetAttribute(&memClockKHz, cudaDevAttrMemoryClockRate, dev);
+    cudaDeviceGetAttribute(&busWidthBits, cudaDevAttrGlobalMemoryBusWidth, dev);
+    if (memClockKHz <= 0 || busWidthBits <= 0) {
+        return detail::kFallbackPeakGBs;
+    }
+    return detail::kMemTransfersPerClock * (double)memClockKHz * detail::kKilo
+            * ((double)busWidthBits / detail::kBitsPerByte) / detail::kGiga;
+}
+
+// Theoretical occupancy (% of max warps per SM) from a kernel's block size and
+// its max active blocks per SM (computed in-TU by the kernel owner)
+inline double occupancyPct(int blockSize, int maxActiveBlocksPerSM)
+{
+    int dev = 0;
+    cudaGetDevice(&dev);
+    int maxThreadsPerSM = 0;
+    cudaDeviceGetAttribute(
+            &maxThreadsPerSM, cudaDevAttrMaxThreadsPerMultiProcessor, dev);
+    if (maxThreadsPerSM <= 0) {
+        return 0.0;
+    }
+    return detail::kPercent * (double)maxActiveBlocksPerSM * (double)blockSize
+            / (double)maxThreadsPerSM;
+}
+
+// Times one kernel: warmup, then `iters` timed launches each preceded by an L2
+// flush (so reads hit HBM), taking the median. Returns 0 if timing is disabled.
+inline double medianKernelMs(KernelCase& kc, const BenchConfig& cfg)
+{
+    if (cfg.iters <= 0) {
+        return 0.0;
+    }
+    const cudaStream_t stream = 0;
+
+    uint8_t* flushRaw = nullptr;
+    ZL_CUDA_CHECK(cudaMalloc(&flushRaw, cfg.l2FlushBytes));
+    std::unique_ptr<uint8_t, CudaFreeDeleter> flush(flushRaw);
+
+    for (int i = 0; i < cfg.warmup; ++i) {
+        kc.launch(stream);
+    }
+    ZL_CUDA_CHECK(cudaGetLastError());
+    ZL_CUDA_CHECK(cudaDeviceSynchronize());
+
+    std::vector<CudaEvent> starts(cfg.iters), stops(cfg.iters);
+    for (int i = 0; i < cfg.iters; ++i) {
+        ZL_CUDA_CHECK(
+                cudaMemsetAsync(flush.get(), 0, cfg.l2FlushBytes, stream));
+        starts[i].record(stream);
+        kc.launch(stream);
+        stops[i].record(stream);
+    }
+    ZL_CUDA_CHECK(cudaDeviceSynchronize());
+
+    std::vector<double> ms(cfg.iters);
+    for (int i = 0; i < cfg.iters; ++i) {
+        ms[i] = stops[i].elapsedMsSince(starts[i]);
+    }
+    std::sort(ms.begin(), ms.end());
+    return ms[cfg.iters / 2];
+}
+
+// Runs every case over its own workload; one result per case. Each case is set
+// up once, verified once, then timed. Throughput is zeroed (not inf/NaN) when
+// timing is disabled or the peak model is unavailable.
+inline std::vector<BenchResult> runKernelBench(
+        const std::vector<std::unique_ptr<KernelCase>>& cases,
+        BenchConfig cfg = {})
+{
+    int dev = 0;
+    ZL_CUDA_CHECK(cudaGetDevice(&dev));
+    const double peak = peakBandwidthGBs(dev);
+
+    std::vector<BenchResult> out;
+    out.reserve(cases.size());
+    for (const std::unique_ptr<KernelCase>& kc : cases) {
+        kc->setup();
+
+        // Correctness once (one launch populates the outputs), then time.
+        kc->launch(0);
+        ZL_CUDA_CHECK_LAST();
+        ZL_CUDA_CHECK(cudaDeviceSynchronize());
+
+        const Workload work = kc->workload();
+        BenchResult r;
+        r.name         = kc->name();
+        r.correct      = kc->verify();
+        r.medianMs     = medianKernelMs(*kc, cfg);
+        const double s = r.medianMs / detail::kKilo;
+        r.gbps = s > 0.0 ? (double)work.bytesMoved / s / detail::kGiga : 0.0;
+        r.gElemPerS = s > 0.0 ? (double)work.numElts / s / detail::kGiga : 0.0;
+        r.pctPeak   = peak > 0.0 ? detail::kPercent * r.gbps / peak : 0.0;
+        if (kc->blockSize() > 0 && kc->maxActiveBlocksPerSM() > 0) {
+            r.maxActiveBlocks = kc->maxActiveBlocksPerSM();
+            r.occupancyPct =
+                    occupancyPct(kc->blockSize(), kc->maxActiveBlocksPerSM());
+        }
+        out.push_back(std::move(r));
+    }
+    return out;
+}
+
+// Prints one row per case, labelled with `label` (e.g. the workload shape)
+inline void printResults(const char* label, const std::vector<BenchResult>& rs)
+{
+    for (const BenchResult& r : rs) {
+        printf("%-10s | %-18s | %s | %8.3f ms | %7.1f GB/s (%5.1f%% peak) |"
+               " %6.1f G-elem/s | occ %5.1f%% (%d blk/SM)\n",
+               label,
+               r.name.c_str(),
+               r.correct ? "OK  " : "FAIL",
+               r.medianMs,
+               r.gbps,
+               r.pctPeak,
+               r.gElemPerS,
+               r.occupancyPct,
+               r.maxActiveBlocks);
+    }
+}
+
+// Sanity case: a plain device-to-device copy of `bytes` bytes, which should run
+// near peak HBM bandwidth. Use it to validate that the reported GB/s and %peak
+// are sane before trusting a kernel's numbers. Moves 2x bytes (read + write).
+class PeakBandwidthCase : public KernelCase {
+   public:
+    explicit PeakBandwidthCase(size_t bytes) : bytes_(bytes) {}
+
+    std::string name() const override
+    {
+        return "peakBW(copy)";
+    }
+
+    void setup() override
+    {
+        src_ = deviceAlloc<uint8_t>(bytes_);
+        dst_ = deviceAlloc<uint8_t>(bytes_);
+        ZL_CUDA_CHECK(cudaMemset(src_.get(), 0, bytes_));
+    }
+
+    void launch(cudaStream_t stream) override
+    {
+        ZL_CUDA_CHECK(cudaMemcpyAsync(
+                dst_.get(),
+                src_.get(),
+                bytes_,
+                cudaMemcpyDeviceToDevice,
+                stream));
+    }
+
+    Workload workload() const override
+    {
+        return { 2 * bytes_, 0 };
+    }
+
+   private:
+    size_t bytes_;
+    DevicePtr<uint8_t> src_;
+    DevicePtr<uint8_t> dst_;
+};
+
+} // namespace openzl::gpu::bench

--- a/contrib/gpu/source/codecs/float_deconstruct/BUCK
+++ b/contrib/gpu/source/codecs/float_deconstruct/BUCK
@@ -13,3 +13,17 @@ cpp_library(
     nvcc_flags = get_nvcc_arch_args() + ["-lineinfo"],
     exported_external_deps = [("cuda", None, "cuda-lazy")],
 )
+
+# Header-only float_deconstruct-specific device staging shared by the benchmark
+# and the differential test. The generic benchmark driver lives in
+# ../../bench:gpu_bench.
+cpp_library(
+    name = "gpu_chunk_harness",
+    headers = ["gpu_chunk_harness.cuh"],
+    exported_deps = [
+        "../../common:cuda_error",
+        "../../common:cuda_raii",
+        ":decode_float_deconstruct_bf16",
+    ],
+    exported_external_deps = [("cuda", None, "cuda-lazy")],
+)

--- a/contrib/gpu/source/codecs/float_deconstruct/BUCK
+++ b/contrib/gpu/source/codecs/float_deconstruct/BUCK
@@ -1,5 +1,6 @@
 # Copyright (c) Meta Platforms, Inc. and affiliates.
 
+load("@fbcode_macros//build_defs:cpp_binary.bzl", "cpp_binary")
 load("@fbcode_macros//build_defs:cpp_library.bzl", "cpp_library")
 load("//tools/build/buck:nvcc_flags.bzl", "get_nvcc_arch_args")
 
@@ -26,4 +27,19 @@ cpp_library(
         ":decode_float_deconstruct_bf16",
     ],
     exported_external_deps = [("cuda", None, "cuda-lazy")],
+)
+
+# Kernel-only throughput benchmark (bandwidth, %peak, latency, occupancy).
+cpp_binary(
+    name = "bench_decode_bf16",
+    srcs = ["bench/bench_decode_bf16.cu"],
+    nvcc_flags = get_nvcc_arch_args() + ["-lineinfo"],
+    deps = [
+        "../../../../..:zstronglib",
+        "../../bench:gpu_bench",
+        "../../common:cuda_error",
+        ":decode_float_deconstruct_bf16",
+        ":gpu_chunk_harness",
+    ],
+    external_deps = [("cuda", None, "cuda-lazy")],
 )

--- a/contrib/gpu/source/codecs/float_deconstruct/bench/bench_decode_bf16.cu
+++ b/contrib/gpu/source/codecs/float_deconstruct/bench/bench_decode_bf16.cu
@@ -1,0 +1,284 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+// Benchmark for the bf16 float_deconstruct GPU decode kernel.
+//
+// Uses the kernel-agnostic driver in bench/gpu_bench.cuh: for each workload
+// shape we stage the chunks on the device (DeviceChunkSet), then benchmark a
+// list of KernelCase variants (currently just the one production kernel) and
+// report latency, throughput, %peak, and occupancy. The `cases` list is the
+// extension point for comparing future kernel versions against each other. Each
+// case verifies itself before timing, and a single-threaded CPU baseline is
+// printed for reference. A device-to-device copy (PeakBandwidthCase) is run
+// once up front to sanity-check the reported %peak.
+//
+// Decode is branchless, so input *values* do not affect timing (only sizes) --
+// synthetic random bytes are sufficient here.
+
+#include <cstdint>
+#include <cstdio>
+#include <ctime>
+#include <functional>
+#include <memory>
+#include <random>
+#include <string>
+#include <vector>
+
+#include <cuda_runtime.h>
+
+#include "openzl/dev/contrib/gpu/source/bench/gpu_bench.cuh"
+#include "openzl/dev/contrib/gpu/source/codecs/float_deconstruct/decode_float_deconstruct_bf16.cuh"
+#include "openzl/dev/contrib/gpu/source/codecs/float_deconstruct/gpu_chunk_harness.cuh"
+#include "openzl/dev/contrib/gpu/source/common/cuda_error.cuh"
+
+// Forward-declared instead of including its header, which pulls in SIMD
+// intrinsics nvcc cannot compile; linked from //openzl/dev:zstronglib.
+extern "C" void FLTDECON_bfloat16_deconstruct_decode(
+        uint16_t* dst16,
+        const uint8_t* exponent,
+        const uint8_t* signFrac,
+        size_t nbElts);
+
+using openzl::gpu::DeviceChunkSet;
+using openzl::gpu::OwnedHostChunk;
+using openzl::gpu::toHostChunks;
+using openzl::gpu::bench::KernelCase;
+using openzl::gpu::bench::PeakBandwidthCase;
+using openzl::gpu::bench::printResults;
+using openzl::gpu::bench::runKernelBench;
+using openzl::gpu::bench::Workload;
+
+namespace {
+
+constexpr unsigned kRngSeed        = 1234;
+constexpr size_t kBytesPerElt      = 4;
+constexpr size_t kMinBf16ChunkElts = 16384;
+constexpr size_t kSanityCopyBytes  = 256ull * 1024 * 1024;
+constexpr size_t kBatchedSweepElts = 32ull * 1024 * 1024;
+
+// Host-side random source bytes for one set of chunks; kept for the CPU
+// baseline and for verification.
+struct HostData {
+    size_t totalElts = 0;
+    std::vector<OwnedHostChunk> chunks;
+};
+
+HostData makeHostData(const std::vector<size_t>& sizes, std::mt19937& rng)
+{
+    HostData d;
+    d.chunks.resize(sizes.size());
+    std::uniform_int_distribution<int> byteDist(0, 255);
+    for (size_t c = 0; c < sizes.size(); ++c) {
+        const size_t nb = sizes[c];
+        d.totalElts += nb;
+        d.chunks[c].exponent.resize(nb);
+        d.chunks[c].signFrac.resize(nb);
+        for (size_t i = 0; i < nb; ++i) {
+            d.chunks[c].exponent[i] = (uint8_t)byteDist(rng);
+            d.chunks[c].signFrac[i] = (uint8_t)byteDist(rng);
+        }
+    }
+    return d;
+}
+
+// Single-threaded CPU reference decode, timed with the monotonic clock.
+double cpuDecodeMs(const HostData& hd)
+{
+    std::vector<std::vector<uint16_t>> out(hd.chunks.size());
+    for (size_t c = 0; c < hd.chunks.size(); ++c) {
+        out[c].resize(hd.chunks[c].exponent.size());
+    }
+    struct timespec t0, t1;
+    clock_gettime(CLOCK_MONOTONIC, &t0);
+    for (size_t c = 0; c < hd.chunks.size(); ++c) {
+        FLTDECON_bfloat16_deconstruct_decode(
+                out[c].data(),
+                hd.chunks[c].exponent.data(),
+                hd.chunks[c].signFrac.data(),
+                hd.chunks[c].exponent.size());
+    }
+    clock_gettime(CLOCK_MONOTONIC, &t1);
+    return (t1.tv_sec - t0.tv_sec) * 1e3 + (t1.tv_nsec - t0.tv_nsec) * 1e-6;
+}
+
+// Copies each chunk's dst back and checks it against the scalar golden.
+// Returns the number of mismatching elements (0 == correct).
+size_t countMismatches(const HostData& hd, const DeviceChunkSet& dev)
+{
+    size_t bad = 0;
+    for (uint32_t c = 0; c < dev.numInBatch(); ++c) {
+        const OwnedHostChunk& chunk     = hd.chunks[c];
+        const size_t nb                 = chunk.exponent.size();
+        const std::vector<uint16_t> out = dev.download(c);
+        std::vector<uint16_t> want(nb);
+        FLTDECON_bfloat16_deconstruct_decode(
+                want.data(), chunk.exponent.data(), chunk.signFrac.data(), nb);
+        for (size_t i = 0; i < nb; ++i) {
+            bad += (out[i] != want[i]);
+        }
+    }
+    return bad;
+}
+
+// One decode-kernel variant over an already-staged DeviceChunkSet. `launch`
+// selects the kernel version; verify() compares the device output against the
+// scalar golden. No setup() override: all variants share the one DeviceChunkSet
+// fixture staged once per shape, so a case has no private device state to set
+// up (unlike PeakBandwidthCase, which owns its buffers).
+class Bf16DecodeCase : public KernelCase {
+   public:
+    Bf16DecodeCase(
+            std::string name,
+            std::function<void(cudaStream_t)> launch,
+            openzl::gpu::KernelLaunchInfo info,
+            const HostData& hd,
+            const DeviceChunkSet& dev)
+            : name_(std::move(name)),
+              launch_(std::move(launch)),
+              info_(info),
+              hd_(hd),
+              dev_(dev)
+    {
+    }
+
+    std::string name() const override
+    {
+        return name_;
+    }
+    void launch(cudaStream_t stream) override
+    {
+        launch_(stream);
+    }
+    Workload workload() const override
+    {
+        return { kBytesPerElt * hd_.totalElts, hd_.totalElts };
+    }
+    bool verify() override
+    {
+        return countMismatches(hd_, dev_) == 0;
+    }
+    int blockSize() const override
+    {
+        return info_.blockSize;
+    }
+    int maxActiveBlocksPerSM() const override
+    {
+        return info_.maxActiveBlocksPerSM;
+    }
+
+   private:
+    std::string name_;
+    std::function<void(cudaStream_t)> launch_;
+    openzl::gpu::KernelLaunchInfo info_;
+    const HostData& hd_;
+    const DeviceChunkSet& dev_;
+};
+
+std::vector<size_t> jaggedShape(
+        std::mt19937& rng,
+        size_t bigElts,
+        int nSmall,
+        size_t minElts,
+        size_t spread)
+{
+    std::vector<size_t> v{ bigElts };
+    std::uniform_int_distribution<size_t> offsetDist(0, spread - 1);
+    for (int i = 0; i < nSmall; ++i) {
+        v.push_back(minElts + offsetDist(rng));
+    }
+    return v;
+}
+
+void runShape(
+        const char* name,
+        const std::vector<size_t>& sizes,
+        std::mt19937& rng)
+{
+    const HostData hd = makeHostData(sizes, rng);
+    DeviceChunkSet dev(toHostChunks(hd.chunks));
+
+    // One KernelCase per kernel version under test; add more to compare.
+    std::vector<std::unique_ptr<KernelCase>> cases;
+    cases.push_back(
+            std::make_unique<Bf16DecodeCase>(
+                    "naive",
+                    [&dev](cudaStream_t s) {
+                        openzl::gpu::bf16DeconDecode(
+                                dev.numInBatch(), dev.deviceChunks(), s);
+                    },
+                    openzl::gpu::bf16DeconDecodeLaunchInfo(),
+                    hd,
+                    dev));
+
+    const std::vector<openzl::gpu::bench::BenchResult> results =
+            runKernelBench(cases);
+
+    const double cpuMs = cpuDecodeMs(hd);
+    printf("[%-10s] chunks=%-6u totalElts=%-9zu  CPU %8.2f ms\n",
+           name,
+           dev.numInBatch(),
+           hd.totalElts,
+           cpuMs);
+    printResults(name, results);
+}
+
+} // namespace
+
+int main()
+{
+    int dev = 0;
+    ZL_CUDA_CHECK(cudaGetDevice(&dev));
+    cudaDeviceProp prop;
+    ZL_CUDA_CHECK(cudaGetDeviceProperties(&prop, dev));
+    printf("GPU: %s | SMs: %d | peak HBM ~ %.0f GB/s\n\n",
+           prop.name,
+           prop.multiProcessorCount,
+           openzl::gpu::bench::peakBandwidthGBs(dev));
+
+    std::mt19937 rng(kRngSeed);
+
+    // Sanity check: a plain device-to-device copy should run near peak HBM, so
+    // its %peak validates the bandwidth model before we trust the decode rows.
+    {
+        std::vector<std::unique_ptr<KernelCase>> sanity;
+        sanity.push_back(std::make_unique<PeakBandwidthCase>(kSanityCopyBytes));
+        printResults("sanity", runKernelBench(sanity));
+        printf("\n");
+    }
+
+    // One big 64Mi-element chunk.
+    runShape("oneLarge", { 64ull * 1024 * 1024 }, rng);
+
+    // Batched chunk-size sweep: same total elements, varying per-chunk size, to
+    // show how finely the work can be partitioned before throughput drops. bf16
+    // input is 1 byte/elt, so an N-KiB chunk is N * 1024 elements. 32Mi total
+    // keeps the 1KiB case at 32768 chunks, under the kMaxNumInBatch cap that a
+    // 64Mi total would exceed.
+    constexpr size_t kBatchedChunkKiB[] = { 1, 4, 32, 128, 512 };
+    for (const size_t chunkKiB : kBatchedChunkKiB) {
+        const size_t chunkElts = chunkKiB * 1024;
+        const std::string name = "batched-" + std::to_string(chunkKiB) + "KiB";
+        std::vector<size_t> v(kBatchedSweepElts / chunkElts, chunkElts);
+        runShape(name.c_str(), v, rng);
+    }
+
+    // One big chunk plus many mid-size chunks, like a real uneven frame. Every
+    // small chunk stays at or above the smallest real chunk size (16384 elts).
+    runShape(
+            "jagged",
+            jaggedShape(
+                    rng,
+                    32ull * 1024 * 1024,
+                    200,
+                    kMinBf16ChunkElts,
+                    256 * 1024),
+            rng);
+
+    // One big chunk plus thousands of tiny chunks. This cannot happen in a real
+    // frame; it stresses the many-chunk path.
+    runShape(
+            "jaggedTiny",
+            jaggedShape(rng, 32ull * 1024 * 1024, 4000, 1, 8),
+            rng);
+
+    return 0;
+}

--- a/contrib/gpu/source/codecs/float_deconstruct/gpu_chunk_harness.cuh
+++ b/contrib/gpu/source/codecs/float_deconstruct/gpu_chunk_harness.cuh
@@ -1,0 +1,140 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#pragma once
+
+#include <cassert>
+#include <cstddef>
+#include <cstdint>
+#include <vector>
+
+#include <cuda_runtime.h>
+
+#include "openzl/dev/contrib/gpu/source/codecs/float_deconstruct/decode_float_deconstruct_bf16.cuh"
+#include "openzl/dev/contrib/gpu/source/common/cuda_error.cuh"
+#include "openzl/dev/contrib/gpu/source/common/cuda_raii.cuh"
+
+// float_deconstruct-specific host-side staging for driving bf16DeconDecode from
+// the benchmark and the differential test: stages a chunk batch on the device
+// and owns the device memory. Header-only; both consumers are compiled by nvcc.
+// Generic CUDA RAII helpers (DevicePtr, deviceAlloc, CudaEvent) live in
+// common/cuda_raii.cuh.
+
+namespace openzl::gpu {
+
+// Non-owning view of one chunk's two host source streams; `exponent` and
+// `signFrac` each point to `nbElts` bytes owned by the caller
+struct HostChunk {
+    const uint8_t* exponent;
+    const uint8_t* signFrac;
+    size_t nbElts;
+};
+
+// Owning host storage for one chunk's two source streams; pairs with the
+// non-owning HostChunk view. bf16 is 1 byte/elt, so nbElts == exponent.size().
+struct OwnedHostChunk {
+    std::vector<uint8_t> exponent;
+    std::vector<uint8_t> signFrac;
+    HostChunk view() const
+    {
+        // Both streams must have one byte per element; DeviceChunkSet copies
+        // nbElts bytes from each, so a mismatch would read past signFrac.
+        assert(exponent.size() == signFrac.size());
+        return { exponent.data(), signFrac.data(), exponent.size() };
+    }
+};
+
+// Builds the non-owning view array DeviceChunkSet consumes from owning chunks.
+inline std::vector<HostChunk> toHostChunks(
+        const std::vector<OwnedHostChunk>& chunks)
+{
+    std::vector<HostChunk> views;
+    views.reserve(chunks.size());
+    for (const OwnedHostChunk& c : chunks) {
+        views.push_back(c.view());
+    }
+    return views;
+}
+
+// Stages a batch of chunks onto the device and owns all the device memory:
+// per-chunk exponent/signFrac/dst buffers plus the FloatDeconChunk descriptor
+// array that bf16DeconDecode consumes. Frees everything on destruction
+class DeviceChunkSet {
+   public:
+    explicit DeviceChunkSet(const std::vector<HostChunk>& chunks)
+    {
+        numInBatch_ = (uint32_t)chunks.size();
+        sizes_.resize(numInBatch_);
+        dExp_.resize(numInBatch_);
+        dSf_.resize(numInBatch_);
+        dDst_.resize(numInBatch_);
+
+        std::vector<FloatDeconChunk> host(numInBatch_);
+        for (uint32_t c = 0; c < numInBatch_; ++c) {
+            const size_t nb = chunks[c].nbElts;
+            sizes_[c]       = nb;
+            if (nb) {
+                dExp_[c] = deviceAlloc<uint8_t>(nb);
+                dSf_[c]  = deviceAlloc<uint8_t>(nb);
+                dDst_[c] = deviceAlloc<uint16_t>(nb);
+                ZL_CUDA_CHECK(cudaMemcpy(
+                        dExp_[c].get(),
+                        chunks[c].exponent,
+                        nb,
+                        cudaMemcpyHostToDevice));
+                ZL_CUDA_CHECK(cudaMemcpy(
+                        dSf_[c].get(),
+                        chunks[c].signFrac,
+                        nb,
+                        cudaMemcpyHostToDevice));
+            }
+            host[c] = { dExp_[c].get(), dSf_[c].get(), dDst_[c].get(), nb };
+        }
+        if (numInBatch_) {
+            dChunks_ = deviceAlloc<FloatDeconChunk>(numInBatch_);
+            ZL_CUDA_CHECK(cudaMemcpy(
+                    dChunks_.get(),
+                    host.data(),
+                    numInBatch_ * sizeof(FloatDeconChunk),
+                    cudaMemcpyHostToDevice));
+        }
+    }
+
+    DeviceChunkSet(const DeviceChunkSet&)            = delete;
+    DeviceChunkSet& operator=(const DeviceChunkSet&) = delete;
+    DeviceChunkSet(DeviceChunkSet&&)                 = delete;
+    DeviceChunkSet& operator=(DeviceChunkSet&&)      = delete;
+
+    uint32_t numInBatch() const
+    {
+        return numInBatch_;
+    }
+    const FloatDeconChunk* deviceChunks() const
+    {
+        return dChunks_.get();
+    }
+
+    // Copies chunk c's decoded output back to host. The caller must have
+    // synchronized the stream the decode launched on (the copy runs on the
+    // default stream); otherwise the result may be stale or partial.
+    std::vector<uint16_t> download(uint32_t c) const
+    {
+        std::vector<uint16_t> out(sizes_[c]);
+        if (sizes_[c]) {
+            ZL_CUDA_CHECK(cudaMemcpy(
+                    out.data(),
+                    dDst_[c].get(),
+                    sizes_[c] * sizeof(uint16_t),
+                    cudaMemcpyDeviceToHost));
+        }
+        return out;
+    }
+
+   private:
+    uint32_t numInBatch_ = 0;
+    std::vector<size_t> sizes_;
+    std::vector<DevicePtr<uint8_t>> dExp_, dSf_;
+    std::vector<DevicePtr<uint16_t>> dDst_;
+    DevicePtr<FloatDeconChunk> dChunks_;
+};
+
+} // namespace openzl::gpu

--- a/contrib/gpu/source/common/BUCK
+++ b/contrib/gpu/source/common/BUCK
@@ -10,3 +10,12 @@ cpp_library(
     headers = ["cuda_error.cuh"],
     exported_external_deps = [("cuda", None, "cuda-lazy")],
 )
+
+# Generic CUDA RAII helpers (owning device pointers, timing events) shared by
+# the device-staging harness and the benchmark driver.
+cpp_library(
+    name = "cuda_raii",
+    headers = ["cuda_raii.cuh"],
+    exported_deps = [":cuda_error"],
+    exported_external_deps = [("cuda", None, "cuda-lazy")],
+)

--- a/contrib/gpu/source/common/cuda_raii.cuh
+++ b/contrib/gpu/source/common/cuda_raii.cuh
@@ -1,0 +1,72 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#pragma once
+
+#include <cstddef>
+#include <memory>
+
+#include <cuda_runtime.h>
+
+#include "openzl/dev/contrib/gpu/source/common/cuda_error.cuh"
+
+// Generic CUDA RAII helpers for GPU host code: owning device allocations and a
+// timing event. Header-only, codec-agnostic; shared by the device-staging
+// harness and the benchmark driver.
+
+namespace openzl::gpu {
+
+// Deleter for owning device allocations via std::unique_ptr
+struct CudaFreeDeleter {
+    void operator()(void* p) const noexcept
+    {
+        cudaFree(p);
+    }
+};
+
+template <typename T>
+using DevicePtr = std::unique_ptr<T, CudaFreeDeleter>;
+
+// Allocates `n` T's on the device, returning an owning pointer so the memory is
+// freed even if a later allocation in the same scope throws
+template <typename T>
+inline DevicePtr<T> deviceAlloc(size_t n)
+{
+    T* p = nullptr;
+    ZL_CUDA_CHECK(cudaMalloc(&p, n * sizeof(T)));
+    return DevicePtr<T>(p);
+}
+
+// A CUDA timing event. Record one at the start and one at the end of a stream
+// region, then call elapsedMsSince to read the elapsed time in milliseconds.
+class CudaEvent {
+   public:
+    CudaEvent()
+    {
+        ZL_CUDA_CHECK(cudaEventCreate(&ev_));
+    }
+    ~CudaEvent()
+    {
+        cudaEventDestroy(ev_);
+    }
+
+    CudaEvent(const CudaEvent&)            = delete;
+    CudaEvent& operator=(const CudaEvent&) = delete;
+
+    void record(cudaStream_t stream = 0)
+    {
+        ZL_CUDA_CHECK(cudaEventRecord(ev_, stream));
+    }
+
+    // Milliseconds from `from` to this event (both must have been recorded).
+    float elapsedMsSince(const CudaEvent& from) const
+    {
+        float ms = 0.f;
+        ZL_CUDA_CHECK(cudaEventElapsedTime(&ms, from.ev_, ev_));
+        return ms;
+    }
+
+   private:
+    cudaEvent_t ev_{};
+};
+
+} // namespace openzl::gpu


### PR DESCRIPTION
Summary:

## What

**Problem:** There is no way to measure GPU decode throughput or compare it against the CPU decoder.

**Changes made:** `bench_decode_bf16.cu` (`cpp_binary`) drives the kernel through the shared harness over four chunk shapes (oneLarge, batched, jagged, jaggedTiny), printing per-shape latency / throughput / %peak / occupancy plus a CPU baseline. The CPU baseline and the pre-timing correctness check both call OpenZL's production decoder (`FLTDECON_bfloat16_deconstruct_decode`), so the comparison is against the real codec and verification is an independent oracle. Synthetic inputs use the C++11 `<random>` library.

## Why

Gives an apples-to-apples GPU-vs-CPU number, and the harness `KernelCase` list is the extension point for comparing the faster kernels added later in the stack.

## Stack Context

- **Previous diff:** shared GPU decode + benchmark harness.
- **Where we are in the stack:** the throughput benchmark.
- **Next diff:** bf16 float_deconstruct decode differential correctness test.

## Clarifications & Assumptions

N/A - all important items clarified in comments.

Reviewed By: terrelln

Differential Revision: D110379491


