### PR TITLE
Add `NoTrainableGraphError` (#895)

### DIFF
--- a/tools/training/tests/BUCK
+++ b/tools/training/tests/BUCK
@@ -1,6 +1,7 @@
 # Copyright (c) Meta Platforms, Inc. and affiliates.
 
 load("@fbcode_macros//build_defs:cpp_unittest.bzl", "cpp_unittest")
+load("@fbsource//tools/build_defs/testinfra:network_access_utils.bzl", "network_access_utils")
 load("../../../defs.bzl", "relative_headers")
 
 oncall("data_compression")
@@ -19,11 +20,13 @@ cpp_unittest(
         "test_sample_collection.cpp",
         "test_sample_limiter.cpp",
         "test_thread_pool.cpp",
+        "test_train.cpp",
     ],
     headers = relative_headers([
         "benchmark_files/ppmf_unit_segment.h",
     ]),
     header_namespace = "",
+    network_access = network_access_utils.none(),
     deps = [
         "..:train",
         "../../..:zstronglib",

--- a/tools/training/tests/test_train.cpp
+++ b/tools/training/tests/test_train.cpp
@@ -1,0 +1,34 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#include <gtest/gtest.h>
+
+#include <memory>
+#include <vector>
+
+#include "openzl/cpp/Compressor.hpp"
+#include "tools/training/train.h"
+
+namespace openzl::tests {
+namespace {
+
+TEST(TrainTest, ThrowsTypedErrorWithoutTrainableGraph)
+{
+    const std::vector<training::MultiInput> inputs;
+    Compressor compressor;
+    compressor.selectStartingGraph(ZL_GRAPH_STORE);
+    const training::TrainParams trainParams = {
+        .compressorGenFunc =
+                [](poly::string_view, poly::string_view) {
+                    return std::make_unique<Compressor>();
+                },
+    };
+
+    // This verifies train() exposes a typed signal for a compressor with no
+    // trainable graph; it fails if that condition becomes a generic exception.
+    EXPECT_THROW(
+            training::train(inputs, compressor, trainParams),
+            training::NoTrainableGraphError);
+}
+
+} // namespace
+} // namespace openzl::tests

--- a/tools/training/train.cpp
+++ b/tools/training/train.cpp
@@ -78,7 +78,7 @@ std::vector<TrainedCandidate> train(
     }
 
     if (dictTrainedCandidates.empty()) {
-        throw Exception("No trainable graph found in compressor.");
+        throw NoTrainableGraphError("No trainable graph found in compressor.");
     }
 
     auto endTime = std::chrono::steady_clock::now();

--- a/tools/training/train.h
+++ b/tools/training/train.h
@@ -3,11 +3,18 @@
 #pragma once
 
 #include "openzl/cpp/Compressor.hpp"
+#include "openzl/cpp/Exception.hpp"
 #include "tools/training/train_params.h"
 #include "tools/training/trained_candidate.h"
 #include "tools/training/utils/utils.h"
 
 namespace openzl::training {
+
+/** Thrown when a compressor has no graph that can be trained. */
+class NoTrainableGraphError : public Exception {
+   public:
+    using Exception::Exception;
+};
 
 /**
  * This function trains compressor graphs (clustering and/or ACE graphs).


### PR DESCRIPTION
Summary:

OpenZL training reports a valid compressor with no trainable graph as a generic `openzl::Exception`. Callers cannot distinguish that expected outcome without matching the exception message.

Add `openzl::training::NoTrainableGraphError`, derived from `openzl::Exception`, and throw it when `train()` produces no candidates. Add a focused test for the typed contract and explicitly mark the local test target as requiring no network access.

This change is limited to `openzl/dev`.

Reviewed By: daniellerozenblit

Differential Revision: D113263277


