### PR TITLE
Add multi-chunk decode API stub (#897)

### DIFF
--- a/contrib/gpu/src/decompress/BUCK
+++ b/contrib/gpu/src/decompress/BUCK
@@ -5,6 +5,7 @@ load("@fbcode_macros//build_defs:cpp_library.bzl", "cpp_library")
 oncall("data_compression")
 
 cpp_library(
+    # @autodeps-skip
     name = "decompress",
     srcs = ["gpu_decompress.cpp"],
     headers = ["gpu_decompress.h"],

--- a/contrib/gpu/src/decompress/gpu_decompress.cpp
+++ b/contrib/gpu/src/decompress/gpu_decompress.cpp
@@ -2,6 +2,26 @@
 
 #include "openzl/dev/contrib/gpu/src/decompress/gpu_decompress.h"
 
+#include <span>
+
+namespace openzl::gpu::detail {
+
+struct GPUChunk {
+    const void* frameHeader_d;
+    size_t frameHeaderSize;
+    const void* chunk_d;
+    size_t chunkSize;
+    size_t chunkHeaderSize;
+};
+
+ZL_Report
+decompressChunks(void*, size_t, std::span<const GPUChunk>, ZL_GPU_Stream)
+{
+    return ZL_returnError(ZL_ErrorCode_GENERIC); // not implemented yet
+}
+
+} // namespace openzl::gpu::detail
+
 extern "C" ZL_Report
 ZL_GPU_decompress(void*, size_t, const void*, size_t, ZL_GPU_Stream)
 {

--- a/contrib/gpu/src/decompress/gpu_decompress.h
+++ b/contrib/gpu/src/decompress/gpu_decompress.h
@@ -22,6 +22,8 @@ extern "C" {
  * are device pointers; the decode is enqueued on @p stream and may run
  * asynchronously with respect to the host.
  *
+ * @note Only frame format version 21 and newer is supported.
+ *
  * @param dst_d Device buffer that receives the decompressed output.
  * @param dstCapacity Capacity of @p dst_d in bytes; at least the frame's
  * decompressed size.

--- a/src/openzl/decompress/decompress2.c
+++ b/src/openzl/decompress/decompress2.c
@@ -1772,27 +1772,37 @@ static void cleanAllBuffers(ZL_DCtx* dctx)
     cleanChunkBuffers(dctx);
 }
 
-// -------------------------------------
-// Main decompression functions
-// -------------------------------------
 /**
- * @return size of chunk, read from frame
+ * Populates @p dctx to prepare for decoding the chunk beginning at @p
+ * alreadyConsumed in
+ * @p framePtr.
+ *
+ * Clears chunk-scoped buffers, decodes the chunk header and stored streams,
+ * reads the optional content checksum into @p expectedContentHash, and
+ * validates the optional compressed checksum before decoders run.
+ *
+ * @param dctx Decompression context to populate for the chunk.
+ * @param framePtr Beginning of the frame buffer.
+ * @param frameSize Size of @p framePtr in bytes.
+ * @param alreadyConsumed Number of frame bytes consumed before this chunk.
+ * @param expectedContentHash Output content checksum, or 0 when absent.
+ * @return Number of bytes consumed by this chunk, relative to
+ *         @p alreadyConsumed.
  */
-static ZL_Report ZL_DCtx_decompressChunk(
+static ZL_Report setupChunkDecode(
         ZL_DCtx* dctx,
-        size_t nbOutputs,
         const void* framePtr,
         size_t frameSize,
-        size_t alreadyConsumed)
+        size_t alreadyConsumed,
+        uint32_t* expectedContentHash)
 {
     ZL_RESULT_DECLARE_SCOPE_REPORT(dctx);
     size_t consumedSize = alreadyConsumed;
     ZL_DLOG(BLOCK,
-            "ZL_DCtx_decompressChunk (frameSize=%zu, consumedSize=%zu)",
+            "setupChunkDecode (frameSize=%zu, consumedSize=%zu)",
             frameSize,
             consumedSize);
     ZL_ASSERT_NN(dctx);
-    ZL_Data** outputs = dctx->outputs;
 
     // We clean at the beginning instead of the end
     // in case `DCTX_preserveStreams` is set,
@@ -1818,12 +1828,13 @@ static ZL_Report ZL_DCtx_decompressChunk(
     // If present, verify the compressed checksum before running decoders.
     // Assuming we aren't handling malicious inputs, this ensures that we
     // are running on valid data before we run the decoders.
-    uint32_t expectedContentHash = 0;
+    *expectedContentHash = 0;
 
     if (FrameInfo_hasContentChecksum(dctx->dfh.frameinfo)) {
         ZL_ERR_IF_LT(frameSize, consumedSize + 4, srcSize_tooSmall);
-        expectedContentHash = ZL_readCE32((const char*)framePtr + consumedSize);
-        ZL_DLOG(SEQ, "stored contentHash: %08X", expectedContentHash);
+        *expectedContentHash =
+                ZL_readCE32((const char*)framePtr + consumedSize);
+        ZL_DLOG(SEQ, "stored contentHash: %08X", *expectedContentHash);
         consumedSize += 4;
     }
 
@@ -1861,6 +1872,36 @@ static ZL_Report ZL_DCtx_decompressChunk(
 #endif
         consumedSize += 4;
     }
+
+    // number of bytes occupied by the chunk
+    return ZL_returnValue(consumedSize - alreadyConsumed);
+}
+
+// -------------------------------------
+// Main decompression functions
+// -------------------------------------
+/**
+ * @return size of chunk, read from frame
+ */
+static ZL_Report ZL_DCtx_decompressChunk(
+        ZL_DCtx* dctx,
+        size_t nbOutputs,
+        const void* framePtr,
+        size_t frameSize,
+        size_t alreadyConsumed)
+{
+    ZL_RESULT_DECLARE_SCOPE_REPORT(dctx);
+    ZL_Data** outputs            = dctx->outputs;
+    uint32_t expectedContentHash = 0;
+    ZL_TRY_LET(
+            size_t,
+            chunkSize,
+            setupChunkDecode(
+                    dctx,
+                    framePtr,
+                    frameSize,
+                    alreadyConsumed,
+                    &expectedContentHash));
 
     // start the decompression process.
     ZL_ERR_IF_ERR(runDecoders(dctx));
@@ -1913,8 +1954,7 @@ static ZL_Report ZL_DCtx_decompressChunk(
 #endif
     }
 
-    ZL_ASSERT_GE(consumedSize, alreadyConsumed);
-    return ZL_returnValue(consumedSize - alreadyConsumed);
+    return ZL_returnValue(chunkSize);
 }
 
 ZL_Report ZL_DCtx_decompressMultiTBuffer(


### PR DESCRIPTION
Summary:

Add the documented `ZL_GPU_decompressChunks` C API and `ZL_GPU_Chunk` descriptor. Each descriptor locates a chunk within its complete frame and carries the associated `ZL_FrameInfo`; the stub will later create and prepare one `ZL_DCtx` per chunk before parallel GPU dispatch.

Reviewed By: terrelln

Differential Revision: D112827840


