### PR TITLE
Initialize DCTX from frame metadata (#898)

### DIFF
--- a/contrib/gpu/src/decompress/BUCK
+++ b/contrib/gpu/src/decompress/BUCK
@@ -5,6 +5,7 @@ load("@fbcode_macros//build_defs:cpp_library.bzl", "cpp_library")
 oncall("data_compression")
 
 cpp_library(
+    # @autodeps-skip
     name = "decompress",
     srcs = ["gpu_decompress.cpp"],
     headers = ["gpu_decompress.h"],

--- a/contrib/gpu/src/decompress/gpu_decompress.cpp
+++ b/contrib/gpu/src/decompress/gpu_decompress.cpp
@@ -2,6 +2,26 @@
 
 #include "openzl/dev/contrib/gpu/src/decompress/gpu_decompress.h"
 
+#include <span>
+
+namespace openzl::gpu::detail {
+
+struct GPUChunk {
+    const void* frameHeader_d;
+    size_t frameHeaderSize;
+    const void* chunk_d;
+    size_t chunkSize;
+    size_t chunkHeaderSize;
+};
+
+ZL_Report
+decompressChunks(void*, size_t, std::span<const GPUChunk>, ZL_GPU_Stream)
+{
+    return ZL_returnError(ZL_ErrorCode_GENERIC); // not implemented yet
+}
+
+} // namespace openzl::gpu::detail
+
 extern "C" ZL_Report
 ZL_GPU_decompress(void*, size_t, const void*, size_t, ZL_GPU_Stream)
 {

--- a/contrib/gpu/src/decompress/gpu_decompress.h
+++ b/contrib/gpu/src/decompress/gpu_decompress.h
@@ -22,6 +22,8 @@ extern "C" {
  * are device pointers; the decode is enqueued on @p stream and may run
  * asynchronously with respect to the host.
  *
+ * @note Only frame format version 21 and newer is supported.
+ *
  * @param dst_d Device buffer that receives the decompressed output.
  * @param dstCapacity Capacity of @p dst_d in bytes; at least the frame's
  * decompressed size.

--- a/src/openzl/decompress/dctx2.h
+++ b/src/openzl/decompress/dctx2.h
@@ -165,6 +165,12 @@ ZL_Report DCTX_registerDecoderFusion(
 /// @see ZL_DecoderFusionState_clearFusions()
 void DCTX_clearDecoderFusions(ZL_DCtx* dctx);
 
+/**
+ * Initializes a newly created decompression context from frame metadata.
+ * The context owns an independent copy of @p frameInfo.
+ */
+ZL_Report DCTX_initFromFrameInfo(ZL_DCtx* dctx, const ZL_FrameInfo* frameInfo);
+
 ZL_END_C_DECLS
 
 #endif // ZSTRONG_DECOMPRESS_DCTX2_H

--- a/src/openzl/decompress/decode_frameheader.c
+++ b/src/openzl/decompress/decode_frameheader.c
@@ -514,6 +514,66 @@ ZL_Report ZL_FrameInfo_getNumElts(const ZL_FrameInfo* zfi, int outputID)
     return ZL_returnValue(zfi->numElts[outputID]);
 }
 
+static ZL_FrameInfo* FrameInfo_clone(const ZL_FrameInfo* src)
+{
+    ZL_FrameInfo* const copy = ZL_malloc(sizeof(*copy));
+    if (copy == NULL)
+        return NULL;
+
+    *copy                   = *src;
+    copy->types             = NULL;
+    copy->decompressedSizes = NULL;
+    copy->numElts           = NULL;
+    copy->comment           = NULL;
+
+    copy->types = ZL_malloc(src->nbOutputs * sizeof(*copy->types));
+    copy->decompressedSizes =
+            ZL_malloc(src->nbOutputs * sizeof(*copy->decompressedSizes));
+    copy->numElts = ZL_malloc(src->nbOutputs * sizeof(*copy->numElts));
+    if (copy->types == NULL || copy->decompressedSizes == NULL
+        || copy->numElts == NULL) {
+        ZL_FrameInfo_free(copy);
+        return NULL;
+    }
+
+    memcpy(copy->types, src->types, src->nbOutputs * sizeof(*copy->types));
+    memcpy(copy->decompressedSizes,
+           src->decompressedSizes,
+           src->nbOutputs * sizeof(*copy->decompressedSizes));
+    memcpy(copy->numElts,
+           src->numElts,
+           src->nbOutputs * sizeof(*copy->numElts));
+
+    if (src->commentSize != 0) {
+        copy->comment = ZL_malloc(src->commentSize);
+        if (copy->comment == NULL) {
+            ZL_FrameInfo_free(copy);
+            return NULL;
+        }
+        memcpy(copy->comment, src->comment, src->commentSize);
+    }
+
+    return copy;
+}
+
+ZL_Report DFH_setFrameInfo(
+        DFH_Struct* dfh,
+        const ZL_FrameInfo* frameInfo,
+        ZL_OperationContext* opCtx)
+{
+    ZL_RESULT_DECLARE_SCOPE_REPORT(opCtx);
+    ZL_ASSERT_NN(dfh);
+    ZL_ASSERT_NN(frameInfo);
+
+    ZL_FrameInfo* const copy = FrameInfo_clone(frameInfo);
+    ZL_ERR_IF_NULL(copy, allocation);
+
+    ZL_FrameInfo_free(dfh->frameinfo);
+    dfh->frameinfo     = copy;
+    dfh->formatVersion = (uint32_t)copy->formatVersion;
+    return ZL_returnSuccess();
+}
+
 ZL_RESULT_OF(ZL_Comment) ZL_FrameInfo_getComment(const ZL_FrameInfo* zfi)
 {
     ZL_RESULT_DECLARE_SCOPE(ZL_Comment, NULL);

--- a/src/openzl/decompress/decode_frameheader.h
+++ b/src/openzl/decompress/decode_frameheader.h
@@ -80,6 +80,17 @@ void DFH_init(DFH_Struct* dfh);
 void DFH_destroy(DFH_Struct* dfh);
 
 /**
+ * Deep-copies @p frameInfo into @p dfh.
+ *
+ * @p dfh must have been initialized with DFH_init().
+ * @p opCtx receives any error details generated while copying.
+ */
+ZL_Report DFH_setFrameInfo(
+        DFH_Struct* dfh,
+        const ZL_FrameInfo* frameInfo,
+        ZL_OperationContext* opCtx);
+
+/**
  * Decode the frame header starting at @src
  * and fill @p dfh with corresponding information.
  *

--- a/src/openzl/decompress/decompress2.c
+++ b/src/openzl/decompress/decompress2.c
@@ -1772,27 +1772,37 @@ static void cleanAllBuffers(ZL_DCtx* dctx)
     cleanChunkBuffers(dctx);
 }
 
-// -------------------------------------
-// Main decompression functions
-// -------------------------------------
 /**
- * @return size of chunk, read from frame
+ * Populates @p dctx to prepare for decoding the chunk beginning at @p
+ * alreadyConsumed in
+ * @p framePtr.
+ *
+ * Clears chunk-scoped buffers, decodes the chunk header and stored streams,
+ * reads the optional content checksum into @p expectedContentHash, and
+ * validates the optional compressed checksum before decoders run.
+ *
+ * @param dctx Decompression context to populate for the chunk.
+ * @param framePtr Beginning of the frame buffer.
+ * @param frameSize Size of @p framePtr in bytes.
+ * @param alreadyConsumed Number of frame bytes consumed before this chunk.
+ * @param expectedContentHash Output content checksum, or 0 when absent.
+ * @return Number of bytes consumed by this chunk, relative to
+ *         @p alreadyConsumed.
  */
-static ZL_Report ZL_DCtx_decompressChunk(
+static ZL_Report setupChunkDecode(
         ZL_DCtx* dctx,
-        size_t nbOutputs,
         const void* framePtr,
         size_t frameSize,
-        size_t alreadyConsumed)
+        size_t alreadyConsumed,
+        uint32_t* expectedContentHash)
 {
     ZL_RESULT_DECLARE_SCOPE_REPORT(dctx);
     size_t consumedSize = alreadyConsumed;
     ZL_DLOG(BLOCK,
-            "ZL_DCtx_decompressChunk (frameSize=%zu, consumedSize=%zu)",
+            "setupChunkDecode (frameSize=%zu, consumedSize=%zu)",
             frameSize,
             consumedSize);
     ZL_ASSERT_NN(dctx);
-    ZL_Data** outputs = dctx->outputs;
 
     // We clean at the beginning instead of the end
     // in case `DCTX_preserveStreams` is set,
@@ -1818,12 +1828,13 @@ static ZL_Report ZL_DCtx_decompressChunk(
     // If present, verify the compressed checksum before running decoders.
     // Assuming we aren't handling malicious inputs, this ensures that we
     // are running on valid data before we run the decoders.
-    uint32_t expectedContentHash = 0;
+    *expectedContentHash = 0;
 
     if (FrameInfo_hasContentChecksum(dctx->dfh.frameinfo)) {
         ZL_ERR_IF_LT(frameSize, consumedSize + 4, srcSize_tooSmall);
-        expectedContentHash = ZL_readCE32((const char*)framePtr + consumedSize);
-        ZL_DLOG(SEQ, "stored contentHash: %08X", expectedContentHash);
+        *expectedContentHash =
+                ZL_readCE32((const char*)framePtr + consumedSize);
+        ZL_DLOG(SEQ, "stored contentHash: %08X", *expectedContentHash);
         consumedSize += 4;
     }
 
@@ -1861,6 +1872,36 @@ static ZL_Report ZL_DCtx_decompressChunk(
 #endif
         consumedSize += 4;
     }
+
+    // number of bytes occupied by the chunk
+    return ZL_returnValue(consumedSize - alreadyConsumed);
+}
+
+// -------------------------------------
+// Main decompression functions
+// -------------------------------------
+/**
+ * @return size of chunk, read from frame
+ */
+static ZL_Report ZL_DCtx_decompressChunk(
+        ZL_DCtx* dctx,
+        size_t nbOutputs,
+        const void* framePtr,
+        size_t frameSize,
+        size_t alreadyConsumed)
+{
+    ZL_RESULT_DECLARE_SCOPE_REPORT(dctx);
+    ZL_Data** outputs            = dctx->outputs;
+    uint32_t expectedContentHash = 0;
+    ZL_TRY_LET(
+            size_t,
+            chunkSize,
+            setupChunkDecode(
+                    dctx,
+                    framePtr,
+                    frameSize,
+                    alreadyConsumed,
+                    &expectedContentHash));
 
     // start the decompression process.
     ZL_ERR_IF_ERR(runDecoders(dctx));
@@ -1913,8 +1954,7 @@ static ZL_Report ZL_DCtx_decompressChunk(
 #endif
     }
 
-    ZL_ASSERT_GE(consumedSize, alreadyConsumed);
-    return ZL_returnValue(consumedSize - alreadyConsumed);
+    return ZL_returnValue(chunkSize);
 }
 
 ZL_Report ZL_DCtx_decompressMultiTBuffer(

--- a/src/openzl/decompress/decompress2.c
+++ b/src/openzl/decompress/decompress2.c
@@ -2374,3 +2374,14 @@ ZL_Report ZL_DCtx_detachAllDecompressIntrospectionHooks(ZL_DCtx* dctx)
     oc->hasDecompressionHooks = false;
     return ZL_returnSuccess();
 }
+
+ZL_Report DCTX_initFromFrameInfo(ZL_DCtx* dctx, const ZL_FrameInfo* frameInfo)
+{
+    ZL_RESULT_DECLARE_SCOPE_REPORT(dctx);
+    ZL_ASSERT_NN(dctx);
+    ZL_TRY_LET(size_t, nbOutputs, ZL_FrameInfo_getNumOutputs(frameInfo));
+    ZL_ERR_IF_ERR(DFH_setFrameInfo(
+            &dctx->dfh, frameInfo, ZL_DCtx_getOperationContext(dctx)));
+    dctx->nbOutputs = nbOutputs;
+    return DCtx_setAppliedParameters(dctx);
+}

--- a/tests/decompress/test_decode_frameheader.cpp
+++ b/tests/decompress/test_decode_frameheader.cpp
@@ -3,9 +3,11 @@
 #include <gtest/gtest.h>
 #include <numeric>
 #include <random>
+#include <string_view>
 
 #include "openzl/common/assertion.h"
 #include "openzl/common/errors_internal.h"
+#include "openzl/decompress/dctx2.h"
 #include "openzl/zl_compress.h"
 #include "openzl/zl_compressor.h"
 #include "tests/utils.h" // @manual
@@ -14,7 +16,10 @@ using namespace ::testing;
 
 // push @nbInputs random serial strings of size @inputSizeEach through a concat
 // + zstd graph
-static std::string randomCompress(size_t nbInputs, size_t inputSizeEach)
+static std::string randomCompress(
+        size_t nbInputs,
+        size_t inputSizeEach,
+        std::string_view comment = {})
 {
     // TODO(T210132483): use generalized rand input generator
     const auto genRand = [](size_t size, long seed) -> std::string {
@@ -62,6 +67,10 @@ static std::string randomCompress(size_t nbInputs, size_t inputSizeEach)
 
     ZL_REQUIRE_SUCCESS(ZL_Compressor_selectStartingGraphID(cgraph, gid));
     ZL_REQUIRE_SUCCESS(ZL_CCtx_refCompressor(cctx, cgraph));
+    if (!comment.empty()) {
+        ZL_REQUIRE_SUCCESS(
+                ZL_CCtx_addHeaderComment(cctx, comment.data(), comment.size()));
+    }
 
     // TODO(T210132483): add to ZStrongTest fixture
     ZL_Report const r = ZL_CCtx_compressMultiTypedRef(
@@ -104,4 +113,53 @@ TEST(DecodeFrameheaderTest, NbOutputsTest)
     rep             = ZL_getNumOutputs(c10.data(), c10.size());
     EXPECT_EQ(ZL_isError(rep), false);
     ASSERT_EQ(ZL_validResult(rep), 10ul);
+}
+
+TEST(DecodeFrameheaderTest, InitDCtxOwnsIndependentFrameMetadataCopy)
+{
+    constexpr size_t kNumOutputs        = 3;
+    constexpr size_t kOutputSize        = 4000;
+    constexpr std::string_view kComment = "copied frame metadata";
+    std::string compressed = randomCompress(kNumOutputs, kOutputSize, kComment);
+    ZL_FrameInfo* frameInfo =
+            ZL_FrameInfo_create(compressed.data(), compressed.size());
+    ASSERT_NE(frameInfo, nullptr);
+
+    ZL_DCtx* dctx = ZL_DCtx_create();
+    ASSERT_NE(dctx, nullptr);
+    ZL_Report const setResult = DCTX_initFromFrameInfo(dctx, frameInfo);
+    ZL_FrameInfo_free(frameInfo);
+
+    // This fails under ASAN if DCTX_initFromFrameInfo borrows or shallow-copies
+    // dynamically allocated frame metadata from the now-freed source.
+    EXPECT_FALSE(ZL_isError(setResult));
+    if (!ZL_isError(setResult)) {
+        DFH_Struct const* dfh = DCtx_getFrameHeader(dctx);
+        ASSERT_NE(dfh, nullptr);
+        EXPECT_EQ(dfh->formatVersion, ZL_MAX_FORMAT_VERSION);
+        EXPECT_EQ(
+                ZL_validResult(ZL_FrameInfo_getNumOutputs(dfh->frameinfo)),
+                kNumOutputs);
+        for (size_t output = 0; output < kNumOutputs; ++output) {
+            EXPECT_EQ(
+                    ZL_validResult(ZL_FrameInfo_getOutputType(
+                            dfh->frameinfo, static_cast<int>(output))),
+                    ZL_Type_serial);
+            EXPECT_EQ(
+                    ZL_validResult(ZL_FrameInfo_getDecompressedSize(
+                            dfh->frameinfo, static_cast<int>(output))),
+                    kOutputSize);
+            EXPECT_EQ(
+                    ZL_validResult(ZL_FrameInfo_getNumElts(
+                            dfh->frameinfo, static_cast<int>(output))),
+                    kOutputSize);
+        }
+        ZL_Comment const comment =
+                ZL_RES_value(ZL_FrameInfo_getComment(dfh->frameinfo));
+        EXPECT_EQ(
+                std::string_view(
+                        static_cast<const char*>(comment.data), comment.size),
+                kComment);
+    }
+    ZL_DCtx_free(dctx);
 }


### PR DESCRIPTION
Summary:

Add internal `DCTX_initFromFrameInfo()` support that deep-copies owned `ZL_FrameInfo` metadata, initializes the context output count, and preserves allocation error context.

Reviewed By: terrelln

Differential Revision: D112827954


