### PR TITLE
Remove partitionLeft / mergeVectorConstant (#900)

### DIFF
--- a/benchmark/micro/micro_pivco_huffman.cpp
+++ b/benchmark/micro/micro_pivco_huffman.cpp
@@ -216,30 +216,6 @@ void verifyPartitionFull(const EncodeArch& arch, const PartitionData& data)
     requireEqualPrefix(rhs, expectedRhs, expectedOnes);
 }
 
-void verifyPartitionLeft(const EncodeArch& arch, const PartitionData& data)
-{
-    std::vector<uint8_t> expectedBitmap(data.bitmap.size());
-    std::vector<uint8_t> expectedLhs(data.lhs.size());
-    size_t const expectedOnes = ZL_PivCoHuffmanEncode_generic.partitionLeft(
-            expectedBitmap.data(),
-            expectedLhs.data(),
-            data.ranks.data(),
-            data.size,
-            data.rightRank);
-
-    std::vector<uint8_t> bitmap(data.bitmap.size());
-    std::vector<uint8_t> lhs(data.lhs.size());
-    size_t const ones = arch.kernels->partitionLeft(
-            bitmap.data(),
-            lhs.data(),
-            data.ranks.data(),
-            data.size,
-            data.rightRank);
-    ZL_REQUIRE_EQ(ones, expectedOnes);
-    requireEqualPrefix(bitmap, expectedBitmap, bitmapBytes(data.size));
-    requireEqualPrefix(lhs, expectedLhs, data.size - expectedOnes);
-}
-
 void verifyPartitionRight(const EncodeArch& arch, const PartitionData& data)
 {
     std::vector<uint8_t> expectedBitmap(data.bitmap.size());
@@ -356,35 +332,6 @@ void verifyMergeConstantVector(const DecodeArch& arch, const MergeData& data)
     requireEqualPrefix(out, expectedOut, data.totalSize);
 }
 
-void verifyMergeVectorConstant(const DecodeArch& arch, const MergeData& data)
-{
-    std::vector<uint8_t> expectedOut(data.out.size());
-    uint8_t const rhs = 0xC3;
-    size_t const expectedOnes =
-            ZL_PivCoHuffmanDecode_generic.mergeVectorConstant(
-                    expectedOut.data(),
-                    expectedOut.size(),
-                    data.bitmap.data(),
-                    data.bitmap.size(),
-                    data.lhs.data(),
-                    data.lhsSize,
-                    rhs,
-                    data.rhsSize);
-
-    std::vector<uint8_t> out(data.out.size());
-    size_t const ones = arch.kernels->mergeVectorConstant(
-            out.data(),
-            out.size(),
-            data.bitmap.data(),
-            data.bitmap.size(),
-            data.lhs.data(),
-            data.lhsSize,
-            rhs,
-            data.rhsSize);
-    ZL_REQUIRE_EQ(ones, expectedOnes);
-    requireEqualPrefix(out, expectedOut, data.totalSize);
-}
-
 void verifyMergeFlatDepth(const DecodeArch& arch, const FlatData& data)
 {
     std::vector<uint8_t> expectedOut(data.out.size());
@@ -427,28 +374,6 @@ void registerPartitionFullBenchmark(EncodeArch arch)
                             data->bitmap.data(),
                             data->lhs.data(),
                             data->rhs.data(),
-                            data->ranks.data(),
-                            data->size,
-                            data->rightRank);
-                }
-                benchmark::DoNotOptimize(ones);
-                state.SetBytesProcessed(
-                        (int64_t)data->size * (int64_t)state.iterations());
-            });
-}
-
-void registerPartitionLeftBenchmark(EncodeArch arch)
-{
-    auto data = std::make_shared<PartitionData>(64 * 1024);
-    verifyPartitionLeft(arch, *data);
-    RegisterBenchmark(
-            benchName(arch.name, "partitionLeft"),
-            [arch, data](benchmark::State& state) {
-                size_t ones = 0;
-                for (auto _ : state) {
-                    ones += arch.kernels->partitionLeft(
-                            data->bitmap.data(),
-                            data->lhs.data(),
                             data->ranks.data(),
                             data->size,
                             data->rightRank);
@@ -574,32 +499,6 @@ void registerMergeConstantVectorBenchmark(DecodeArch arch)
             });
 }
 
-void registerMergeVectorConstantBenchmark(DecodeArch arch)
-{
-    auto data = std::make_shared<MergeData>(64 * 1024);
-    verifyMergeVectorConstant(arch, *data);
-    RegisterBenchmark(
-            benchName(arch.name, "mergeVectorConstant"),
-            [arch, data](benchmark::State& state) {
-                size_t ones       = 0;
-                uint8_t const rhs = 0xC3;
-                for (auto _ : state) {
-                    ones += arch.kernels->mergeVectorConstant(
-                            data->out.data(),
-                            data->out.size(),
-                            data->bitmap.data(),
-                            data->bitmap.size(),
-                            data->lhs.data(),
-                            data->lhsSize,
-                            rhs,
-                            data->rhsSize);
-                }
-                benchmark::DoNotOptimize(ones);
-                state.SetBytesProcessed(
-                        (int64_t)data->totalSize * (int64_t)state.iterations());
-            });
-}
-
 void registerMergeFlatDepthBenchmark(DecodeArch arch, size_t depth)
 {
     auto data = std::make_shared<FlatData>(64 * 1024, depth);
@@ -628,12 +527,10 @@ void registerMergeFlatDepthBenchmark(DecodeArch arch, size_t depth)
 void registerEncodeBenchmarks(EncodeArch arch)
 {
     ZL_REQUIRE_NN(arch.kernels->partitionFull);
-    ZL_REQUIRE_NN(arch.kernels->partitionLeft);
     ZL_REQUIRE_NN(arch.kernels->partitionRight);
     ZL_REQUIRE_NN(arch.kernels->partitionNone);
     ZL_REQUIRE_NN(arch.kernels->packFlatDepth);
     registerPartitionFullBenchmark(arch);
-    registerPartitionLeftBenchmark(arch);
     registerPartitionRightBenchmark(arch);
     registerPartitionNoneBenchmark(arch);
     for (size_t depth = 1; depth <= 8; ++depth) {
@@ -645,11 +542,9 @@ void registerDecodeBenchmarks(DecodeArch arch)
 {
     ZL_REQUIRE_NN(arch.kernels->mergeVectorVector);
     ZL_REQUIRE_NN(arch.kernels->mergeConstantVector);
-    ZL_REQUIRE_NN(arch.kernels->mergeVectorConstant);
     ZL_REQUIRE_NN(arch.kernels->mergeFlatDepth);
     registerMergeVectorVectorBenchmark(arch);
     registerMergeConstantVectorBenchmark(arch);
-    registerMergeVectorConstantBenchmark(arch);
     for (size_t depth = 1; depth <= 8; ++depth) {
         registerMergeFlatDepthBenchmark(arch, depth);
     }

--- a/src/openzl/codecs/pivco_huffman/arch/decode_pivco_arch.c
+++ b/src/openzl/codecs/pivco_huffman/arch/decode_pivco_arch.c
@@ -143,25 +143,6 @@ static size_t mergeConstantVector(
             vectorSource(rhs, rhsSize));
 }
 
-static size_t mergeVectorConstant(
-        uint8_t* out,
-        size_t outCapacity,
-        const uint8_t* bitmap,
-        size_t bitmapCapacity,
-        const uint8_t* lhs,
-        size_t lhsSize,
-        uint8_t rhs,
-        size_t rhsSize)
-{
-    return mergeGeneric(
-            out,
-            outCapacity,
-            bitmap,
-            bitmapCapacity,
-            vectorSource(lhs, lhsSize),
-            constantSource(rhs, rhsSize));
-}
-
 // Expands a flat leaf: reads one @p depth-bit index per output and looks it up
 // in @p symbols (which has 2^depth entries).
 static void mergeFlatDepth(
@@ -199,6 +180,5 @@ const ZL_PivCoHuffmanDecode ZL_PivCoHuffmanDecode_generic = {
     .supported           = supported,
     .mergeVectorVector   = mergeVectorVector,
     .mergeConstantVector = mergeConstantVector,
-    .mergeVectorConstant = mergeVectorConstant,
     .mergeFlatDepth      = mergeFlatDepth,
 };

--- a/src/openzl/codecs/pivco_huffman/arch/decode_pivco_arch.h
+++ b/src/openzl/codecs/pivco_huffman/arch/decode_pivco_arch.h
@@ -70,31 +70,6 @@ typedef struct {
             size_t rhsSize);
 
     /**
-     * Merges @p lhs and @p rhs into @p out based on the bits in @p bitmap,
-     * where @p rhs is a constant.
-     *
-     * @param outCapacity    Must be at least `lhsSize + rhsSize` bytes, but may
-     *                       be larger to indicate that over-writes are okay.
-     * @param bitmapCapacity Must be at least `(lhsSize + rhsSize + 7) / 8`
-     *                       bytes, but may be larger to indicate that
-     *                       over-reads are okay.
-     * @param lhs            Must be at least `lhsSize + SLOP` bytes,
-     *                       where the first @p lhsSize bytes are valid.
-     *
-     * @returns The number of ones in the bitmap. If this is not equal to
-     * @p rhsSize then the data was corrupt, and the output is unspecified.
-     */
-    size_t (*mergeVectorConstant)(
-            uint8_t* out,
-            size_t outCapacity,
-            const uint8_t* bitmap,
-            size_t bitmapCapacity,
-            const uint8_t* lhs,
-            size_t lhsSize,
-            uint8_t rhs,
-            size_t rhsSize);
-
-    /**
      * Reads @p outSize packed indices of @p depth bits each from @p bitmap and
      * fills @p out with `symbols[idx]` for each packed index.
      *

--- a/src/openzl/codecs/pivco_huffman/arch/encode_pivco_arch.c
+++ b/src/openzl/codecs/pivco_huffman/arch/encode_pivco_arch.c
@@ -76,16 +76,6 @@ static size_t partitionGeneric(
     return ones;
 }
 
-static size_t partitionLeft(
-        uint8_t* bitmap,
-        uint8_t* lhs,
-        const uint8_t* ranks,
-        size_t numRanks,
-        uint8_t rightRank)
-{
-    return partitionGeneric(bitmap, lhs, NULL, ranks, numRanks, rightRank);
-}
-
 static size_t partitionRight(
         uint8_t* bitmap,
         uint8_t* rhs,
@@ -140,7 +130,6 @@ static bool supported(const ZL_cpuid_t* cpuid)
 const ZL_PivCoHuffmanEncode ZL_PivCoHuffmanEncode_generic = {
     .supported      = supported,
     .partitionFull  = partitionGeneric,
-    .partitionLeft  = partitionLeft,
     .partitionRight = partitionRight,
     .partitionNone  = partitionNone,
     .packFlatDepth  = packFlatDepth,

--- a/src/openzl/codecs/pivco_huffman/arch/encode_pivco_arch.h
+++ b/src/openzl/codecs/pivco_huffman/arch/encode_pivco_arch.h
@@ -43,26 +43,6 @@ typedef struct {
             uint8_t rightRank);
 
     /**
-     * Partitions @p ranks into @p lhs based on @p rightRank. If the rank is
-     * below @p rightRank, then it goes to @p lhs. The partition decision is for
-     * each rank is written as a bit in @p bitmap, 0 for left and 1 for
-     * right.
-     *
-     * @param bitmap Must be `(numRanks + 7) / 8 + SLOP` bytes
-     * @param lhs    Must be `numRanks + SLOP` elements large
-     * @param ranks  Must be `numRanks + SLOP` elements large,
-     *               where the first @p numRanks elements are valid.
-     *
-     * @returns the number of ones in the bitmap
-     */
-    size_t (*partitionLeft)(
-            uint8_t* bitmap,
-            uint8_t* lhs,
-            const uint8_t* ranks,
-            size_t numRanks,
-            uint8_t rightRank);
-
-    /**
      * Partitions @p ranks into @p rhs based on @p rightRank. If the rank is
      * at least @p rightRank, then it goes to @p rhs. The partition decision is
      * for each rank is written as a bit in @p bitmap, 0 for left and 1 for

--- a/src/openzl/codecs/pivco_huffman/decode_pivco_kernel.c
+++ b/src/openzl/codecs/pivco_huffman/decode_pivco_kernel.c
@@ -93,17 +93,9 @@ static bool mergeDecodeResults(
                 lhsSize,
                 rhs->output,
                 rhsSize);
-    } else if (rhs->isConstant) {
-        ones = kernels->mergeVectorConstant(
-                output,
-                outputCapacity,
-                bitmap,
-                bitmapBytes,
-                lhs->output,
-                lhsSize,
-                rhs->symbol,
-                rhsSize);
     } else {
+        // rhs cannot be constant in canonical Huffman codes.
+        assert(!rhs->isConstant);
         ones = kernels->mergeVectorVector(
                 output,
                 outputCapacity,

--- a/src/openzl/codecs/pivco_huffman/encode_pivco_kernel.c
+++ b/src/openzl/codecs/pivco_huffman/encode_pivco_kernel.c
@@ -174,10 +174,9 @@ static bool encodeNode(
     } else if (lhsIsConstant) {
         numOnes = kernels->partitionRight(
                 bitmap, rhsRanks, nodeRanks, numRanks, (uint8_t)splitRank);
-    } else if (rhsIsConstant) {
-        numOnes = kernels->partitionLeft(
-                bitmap, lhsRanks, nodeRanks, numRanks, (uint8_t)splitRank);
     } else {
+        // rhs cannot be constant in canonical Huffman codes.
+        assert(!rhsIsConstant);
         numOnes = kernels->partitionFull(
                 bitmap,
                 lhsRanks,

--- a/tests/unittest/transforms/test_pivco_huffman.cpp
+++ b/tests/unittest/transforms/test_pivco_huffman.cpp
@@ -431,7 +431,6 @@ TEST(PivCoHuffmanArchTest, PartitionKernelsMatchReference)
 {
     for (auto const& arch : supportedEncodeArchs()) {
         ASSERT_NE(arch.kernels->partitionFull, nullptr) << arch.name;
-        ASSERT_NE(arch.kernels->partitionLeft, nullptr) << arch.name;
         ASSERT_NE(arch.kernels->partitionRight, nullptr) << arch.name;
         ASSERT_NE(arch.kernels->partitionNone, nullptr) << arch.name;
 
@@ -462,19 +461,6 @@ TEST(PivCoHuffmanArchTest, PartitionKernelsMatchReference)
                 expectBitmapPrefix(bitmap, ref.bitmap);
                 EXPECT_EQ(firstN(lhs, ref.lhs.size()), ref.lhs);
                 EXPECT_EQ(firstN(rhs, ref.rhs.size()), ref.rhs);
-
-                std::fill(bitmap.begin(), bitmap.end(), 0xCC);
-                std::fill(lhs.begin(), lhs.end(), 0xEE);
-                EXPECT_EQ(
-                        arch.kernels->partitionLeft(
-                                bitmap.data(),
-                                lhs.data(),
-                                ranks.data(),
-                                size,
-                                rightRank),
-                        ref.rhs.size());
-                expectBitmapPrefix(bitmap, ref.bitmap);
-                EXPECT_EQ(firstN(lhs, ref.lhs.size()), ref.lhs);
 
                 std::fill(bitmap.begin(), bitmap.end(), 0xCC);
                 std::fill(rhs.begin(), rhs.end(), 0xDD);
@@ -609,7 +595,6 @@ TEST(PivCoHuffmanArchTest, MergeKernelsMatchReference)
     for (auto const& arch : supportedDecodeArchs()) {
         ASSERT_NE(arch.kernels->mergeVectorVector, nullptr) << arch.name;
         ASSERT_NE(arch.kernels->mergeConstantVector, nullptr) << arch.name;
-        ASSERT_NE(arch.kernels->mergeVectorConstant, nullptr) << arch.name;
 
         for (TopBitPattern pattern : { TopBitPattern::AllZero,
                                        TopBitPattern::AllOne,
@@ -621,14 +606,10 @@ TEST(PivCoHuffmanArchTest, MergeKernelsMatchReference)
                 // The expected outputs depend only on `bits`/`inputs`, so build
                 // them once here rather than inside the capacity loops below.
                 uint8_t const lhsConstant = 0x3C;
-                uint8_t const rhsConstant = 0xC3;
                 std::vector<uint8_t> expectedConstantVector(size);
-                std::vector<uint8_t> expectedVectorConstant(size);
-                for (size_t i = 0, lhsPos = 0, rhsPos = 0; i < size; ++i) {
+                for (size_t i = 0, rhsPos = 0; i < size; ++i) {
                     expectedConstantVector[i] =
                             bits[i] ? inputs.rhs[rhsPos++] : lhsConstant;
-                    expectedVectorConstant[i] =
-                            bits[i] ? rhsConstant : inputs.lhs[lhsPos++];
                 }
 
                 for (size_t outExtra :
@@ -673,22 +654,6 @@ TEST(PivCoHuffmanArchTest, MergeKernelsMatchReference)
                                                 - ZL_PIVCO_HUFFMAN_SLOP),
                                 inputs.ones);
                         EXPECT_EQ(firstN(out, size), expectedConstantVector);
-
-                        std::fill(out.begin(), out.end(), 0xCC);
-                        EXPECT_EQ(
-                                arch.kernels->mergeVectorConstant(
-                                        out.data(),
-                                        out.size(),
-                                        bitmap.data(),
-                                        bitmap.size(),
-                                        inputs.lhs.data(),
-                                        inputs.lhs.size()
-                                                - ZL_PIVCO_HUFFMAN_SLOP,
-                                        rhsConstant,
-                                        inputs.rhs.size()
-                                                - ZL_PIVCO_HUFFMAN_SLOP),
-                                inputs.ones);
-                        EXPECT_EQ(firstN(out, size), expectedVectorConstant);
                     }
                 }
             }


### PR DESCRIPTION
Summary:

Canonical Huffman trees always emit shallower leaves left of deeper leaves. Therefore these methods are not needed, and are dead code.

Differential Revision: D113463813


