### PR TITLE
Generic SegmentPlan preprocessing for balanced GPU decode (#908)

### DIFF
--- a/contrib/gpu/source/bench/gpu_bench.cuh
+++ b/contrib/gpu/source/bench/gpu_bench.cuh
@@ -13,8 +13,8 @@
 
 #include <cuda_runtime.h>
 
-#include "openzl/dev/contrib/gpu/source/common/cuda_error.cuh"
-#include "openzl/dev/contrib/gpu/source/common/cuda_raii.cuh"
+#include "contrib/gpu/source/common/cuda_error.cuh"
+#include "contrib/gpu/source/common/cuda_raii.cuh"
 
 // Kernel-agnostic GPU decompression benchmark driver: time a list of kernel
 // variants over their own on-device workload and report execution time,
@@ -180,11 +180,9 @@ inline SampleStats sampleKernel(KernelCase& kc, const BenchConfig& cfg)
     if (cfg.maxSamples <= 0) {
         return st;
     }
-    const cudaStream_t stream = 0;
-    const size_t flushBytes   = l2FlushBytes(cfg);
-    uint8_t* flushRaw         = nullptr;
-    ZL_CUDA_CHECK(cudaMalloc(&flushRaw, flushBytes));
-    std::unique_ptr<uint8_t, CudaFreeDeleter> flush(flushRaw);
+    const cudaStream_t stream      = 0;
+    const size_t flushBytes        = l2FlushBytes(cfg);
+    const DevicePtr<uint8_t> flush = deviceAlloc<uint8_t>(flushBytes);
 
     for (int i = 0; i < cfg.warmup; ++i) {
         kc.launch(stream);

--- a/contrib/gpu/source/codecs/float_deconstruct/BUCK
+++ b/contrib/gpu/source/codecs/float_deconstruct/BUCK
@@ -16,10 +16,13 @@ cpp_library(
     srcs = ["decode_float_deconstruct_bf16.cu"],
     headers = ["decode_float_deconstruct_bf16.cuh"],
     nvcc_flags = get_nvcc_arch_args() + ["-lineinfo"],
-    deps = ["../../common:cuda_error"],
+    deps = [
+        "../../common:cuda_error",
+        "../../common:cuda_raii",
+    ],
     exported_deps = [
         "../../common:cuda_launch",
-        "../../common:cuda_raii",
+        "../../common:segment_plan",
     ],
     exported_external_deps = [("cuda", None, "cuda-lazy")],
 )

--- a/contrib/gpu/source/codecs/float_deconstruct/BUCK
+++ b/contrib/gpu/source/codecs/float_deconstruct/BUCK
@@ -17,7 +17,10 @@ cpp_library(
     headers = ["decode_float_deconstruct_bf16.cuh"],
     nvcc_flags = get_nvcc_arch_args() + ["-lineinfo"],
     deps = ["../../common:cuda_error"],
-    exported_deps = ["../../common:cuda_raii"],
+    exported_deps = [
+        "../../common:cuda_launch",
+        "../../common:cuda_raii",
+    ],
     exported_external_deps = [("cuda", None, "cuda-lazy")],
 )
 

--- a/contrib/gpu/source/codecs/float_deconstruct/bench/bench_decode_bf16.cu
+++ b/contrib/gpu/source/codecs/float_deconstruct/bench/bench_decode_bf16.cu
@@ -25,10 +25,10 @@
 
 #include <cuda_runtime.h>
 
+#include "contrib/gpu/source/common/cuda_error.cuh"
 #include "openzl/dev/contrib/gpu/source/bench/gpu_bench.cuh"
 #include "openzl/dev/contrib/gpu/source/codecs/float_deconstruct/decode_float_deconstruct_bf16.cuh"
 #include "openzl/dev/contrib/gpu/source/codecs/float_deconstruct/gpu_chunk_harness.cuh"
-#include "openzl/dev/contrib/gpu/source/common/cuda_error.cuh"
 
 // Forward-declared instead of including its header, which pulls in SIMD
 // intrinsics nvcc cannot compile; linked from //openzl/dev:zstronglib.

--- a/contrib/gpu/source/codecs/float_deconstruct/decode_float_deconstruct_bf16.cu
+++ b/contrib/gpu/source/codecs/float_deconstruct/decode_float_deconstruct_bf16.cu
@@ -9,7 +9,9 @@
 #include <string>
 #include <vector>
 
-#include "openzl/dev/contrib/gpu/source/common/cuda_error.cuh"
+#include "contrib/gpu/source/common/cuda_error.cuh"
+#include "contrib/gpu/source/common/cuda_launch.cuh"
+#include "contrib/gpu/source/common/cuda_raii.cuh"
 
 namespace openzl::gpu {
 
@@ -199,21 +201,6 @@ __global__ void decodeSegmentsKernel(
     }
 }
 
-// 1D grid size that fills the GPU for a given kernel at kThreads.
-uint32_t fillGpuGrid(const void* kernel)
-{
-    int maxBlocksPerSM = 0;
-    ZL_CUDA_CHECK(cudaOccupancyMaxActiveBlocksPerMultiprocessor(
-            &maxBlocksPerSM, kernel, kThreads, 0));
-    int dev    = 0;
-    int numSMs = 0;
-    ZL_CUDA_CHECK(cudaGetDevice(&dev));
-    ZL_CUDA_CHECK(cudaDeviceGetAttribute(
-            &numSMs, cudaDevAttrMultiProcessorCount, dev));
-    const uint32_t grid = (uint32_t)maxBlocksPerSM * (uint32_t)numSMs;
-    return grid == 0 ? 1 : grid;
-}
-
 // Host-side. Peels the first min(n, c.nbElts) elements off c as a new segment
 // and advances c past them. Only advances device pointers, so the segment
 // aliases the original device buffers, no data is copied.
@@ -255,34 +242,6 @@ rechunk(const FloatDeconChunk* chunks_h, uint32_t numInBatch, size_t maxSegElts)
     return out;
 }
 
-// Stream-ordered device scratch: frees on the same stream at scope exit, so an
-// exception between allocation and launch cannot leak it.
-template <typename T>
-class StreamScratch {
-   public:
-    StreamScratch(size_t n, cudaStream_t stream) : stream_(stream)
-    {
-        ZL_CUDA_CHECK(cudaMallocAsync(&p_, n * sizeof(T), stream));
-    }
-    ~StreamScratch()
-    {
-        if (p_) {
-            cudaFreeAsync(p_, stream_);
-        }
-    }
-    StreamScratch(const StreamScratch&)            = delete;
-    StreamScratch& operator=(const StreamScratch&) = delete;
-
-    T* get() const
-    {
-        return p_;
-    }
-
-   private:
-    T* p_ = nullptr;
-    cudaStream_t stream_;
-};
-
 // Throws unless maxSegElts is a positive multiple of kVec (the alignment
 // invariant the vectorized loads/stores rely on).
 void validateMaxSegElts(size_t maxSegElts)
@@ -301,8 +260,9 @@ void launchSegments(
         uint32_t numSegs,
         cudaStream_t stream)
 {
-    const uint32_t target = fillGpuGrid((const void*)decodeSegmentsKernel);
-    const uint32_t grid   = (uint32_t)std::min<size_t>(numSegs, target);
+    const uint32_t target =
+            fillGpuGrid((const void*)decodeSegmentsKernel, kThreads);
+    const uint32_t grid = (uint32_t)std::min<size_t>(numSegs, target);
     decodeSegmentsKernel<<<grid, kThreads, 0, stream>>>(segs_d, numSegs);
     ZL_CUDA_CHECK_LAST();
 }
@@ -325,7 +285,8 @@ void bf16DeconDecode(
     }
     // Oversubscribe x so blocksPerChunk * numInBatch roughly fills the GPU;
     // grid-stride in x then covers any per-chunk size.
-    const uint32_t target = fillGpuGrid((const void*)decodeChunksKernel);
+    const uint32_t target =
+            fillGpuGrid((const void*)decodeChunksKernel, kThreads);
     const uint32_t blocksPerChunk = (target + numInBatch - 1) / numInBatch;
     const dim3 grid(blocksPerChunk, numInBatch);
     decodeChunksKernel<<<grid, kThreads, 0, stream>>>(chunks_d, numInBatch);
@@ -334,13 +295,7 @@ void bf16DeconDecode(
 
 KernelLaunchInfo bf16DeconDecodeLaunchInfo()
 {
-    int maxActiveBlocksPerSM = 0;
-    ZL_CUDA_CHECK(cudaOccupancyMaxActiveBlocksPerMultiprocessor(
-            &maxActiveBlocksPerSM,
-            (const void*)decodeChunksKernel,
-            kThreads,
-            0));
-    return { kThreads, maxActiveBlocksPerSM };
+    return launchInfoFor((const void*)decodeChunksKernel, kThreads);
 }
 
 void bf16DeconDecodeV2(
@@ -352,28 +307,20 @@ void bf16DeconDecodeV2(
         return;
     }
     // Stream-ordered scratch for the flat-space offsets prefix sum.
-    size_t* offsets = nullptr;
-    ZL_CUDA_CHECK(cudaMallocAsync(
-            &offsets, (size_t)(numInBatch + 1) * sizeof(size_t), stream));
-    computeOffsetsKernel<<<1, 1, 0, stream>>>(chunks_d, numInBatch, offsets);
+    StreamScratch<size_t> offsets(numInBatch + 1, stream);
+    computeOffsetsKernel<<<1, 1, 0, stream>>>(
+            chunks_d, numInBatch, offsets.get());
     ZL_CUDA_CHECK_LAST();
 
-    const uint32_t grid = fillGpuGrid((const void*)decodeTiledKernel);
+    const uint32_t grid = fillGpuGrid((const void*)decodeTiledKernel, kThreads);
     decodeTiledKernel<<<grid, kThreads, 0, stream>>>(
-            chunks_d, offsets, numInBatch);
+            chunks_d, offsets.get(), numInBatch);
     ZL_CUDA_CHECK_LAST();
-    ZL_CUDA_CHECK(cudaFreeAsync(offsets, stream));
 }
 
 KernelLaunchInfo bf16DeconDecodeV2LaunchInfo()
 {
-    int maxActiveBlocksPerSM = 0;
-    ZL_CUDA_CHECK(cudaOccupancyMaxActiveBlocksPerMultiprocessor(
-            &maxActiveBlocksPerSM,
-            (const void*)decodeTiledKernel,
-            kThreads,
-            0));
-    return { kThreads, maxActiveBlocksPerSM };
+    return launchInfoFor((const void*)decodeTiledKernel, kThreads);
 }
 
 void bf16DeconDecodeVec(
@@ -390,7 +337,8 @@ void bf16DeconDecodeVec(
                 + " exceeds kMaxNumInBatch " + std::to_string(kMaxNumInBatch)
                 + " (gridDim.y limit); split the batch across calls");
     }
-    const uint32_t target = fillGpuGrid((const void*)decodeChunksVecKernel);
+    const uint32_t target =
+            fillGpuGrid((const void*)decodeChunksVecKernel, kThreads);
     const uint32_t blocksPerChunk = (target + numInBatch - 1) / numInBatch;
     const dim3 grid(blocksPerChunk, numInBatch);
     decodeChunksVecKernel<<<grid, kThreads, 0, stream>>>(chunks_d, numInBatch);
@@ -399,13 +347,7 @@ void bf16DeconDecodeVec(
 
 KernelLaunchInfo bf16DeconDecodeVecLaunchInfo()
 {
-    int maxActiveBlocksPerSM = 0;
-    ZL_CUDA_CHECK(cudaOccupancyMaxActiveBlocksPerMultiprocessor(
-            &maxActiveBlocksPerSM,
-            (const void*)decodeChunksVecKernel,
-            kThreads,
-            0));
-    return { kThreads, maxActiveBlocksPerSM };
+    return launchInfoFor((const void*)decodeChunksVecKernel, kThreads);
 }
 
 UnifiedDecodePlan::UnifiedDecodePlan(
@@ -475,13 +417,7 @@ void bf16DeconDecodeUnified(
 
 KernelLaunchInfo bf16DeconDecodeUnifiedLaunchInfo()
 {
-    int maxActiveBlocksPerSM = 0;
-    ZL_CUDA_CHECK(cudaOccupancyMaxActiveBlocksPerMultiprocessor(
-            &maxActiveBlocksPerSM,
-            (const void*)decodeSegmentsKernel,
-            kThreads,
-            0));
-    return { kThreads, maxActiveBlocksPerSM };
+    return launchInfoFor((const void*)decodeSegmentsKernel, kThreads);
 }
 
 } // namespace openzl::gpu

--- a/contrib/gpu/source/codecs/float_deconstruct/decode_float_deconstruct_bf16.cu
+++ b/contrib/gpu/source/codecs/float_deconstruct/decode_float_deconstruct_bf16.cu
@@ -4,7 +4,6 @@
 
 #include <algorithm>
 #include <cassert>
-#include <limits>
 #include <stdexcept>
 #include <string>
 #include <vector>
@@ -12,6 +11,7 @@
 #include "contrib/gpu/source/common/cuda_error.cuh"
 #include "contrib/gpu/source/common/cuda_launch.cuh"
 #include "contrib/gpu/source/common/cuda_raii.cuh"
+#include "contrib/gpu/source/common/segment_plan.cuh"
 
 namespace openzl::gpu {
 
@@ -201,47 +201,6 @@ __global__ void decodeSegmentsKernel(
     }
 }
 
-// Host-side. Peels the first min(n, c.nbElts) elements off c as a new segment
-// and advances c past them. Only advances device pointers, so the segment
-// aliases the original device buffers, no data is copied.
-FloatDeconChunk peel(FloatDeconChunk& c, size_t n)
-{
-    n                   = std::min(n, c.nbElts);
-    FloatDeconChunk seg = c;
-    seg.nbElts          = n;
-    c.exponent += n;
-    c.signFrac += n;
-    c.dst += n;
-    c.nbElts -= n;
-    return seg;
-}
-
-// Host-side. Splits each chunk into segments of at most maxSegElts, so all
-// segments carry roughly equal work regardless of the input shape.
-std::vector<FloatDeconChunk>
-rechunk(const FloatDeconChunk* chunks_h, uint32_t numInBatch, size_t maxSegElts)
-{
-    size_t numSegs = 0;
-    for (uint32_t c = 0; c < numInBatch; ++c) {
-        const size_t nb = chunks_h[c].nbElts;
-        numSegs += (nb + maxSegElts - 1) / maxSegElts;
-    }
-    if (numSegs > std::numeric_limits<uint32_t>::max()) {
-        throw std::runtime_error(
-                "bf16 unified decode: segment count " + std::to_string(numSegs)
-                + " exceeds uint32_t limit; use a larger maxSegElts");
-    }
-    std::vector<FloatDeconChunk> out;
-    out.reserve(numSegs);
-    for (uint32_t c = 0; c < numInBatch; ++c) {
-        FloatDeconChunk cur = chunks_h[c];
-        while (cur.nbElts > 0) {
-            out.push_back(peel(cur, maxSegElts));
-        }
-    }
-    return out;
-}
-
 // Throws unless maxSegElts is a positive multiple of kVec (the alignment
 // invariant the vectorized loads/stores rely on).
 void validateMaxSegElts(size_t maxSegElts)
@@ -350,41 +309,22 @@ KernelLaunchInfo bf16DeconDecodeVecLaunchInfo()
     return launchInfoFor((const void*)decodeChunksVecKernel, kThreads);
 }
 
+// segAlignElts = kVec keeps every segment start aligned for the vectorized
+// loads/stores.
 UnifiedDecodePlan::UnifiedDecodePlan(
         const FloatDeconChunk* chunks_h,
         uint32_t numInBatch,
         size_t maxSegElts)
+        : plan_(chunks_h, numInBatch, maxSegElts, kVec)
 {
-    if (numInBatch == 0) {
-        return;
-    }
-    validateMaxSegElts(maxSegElts);
-
-    // Split on the host into equal-sized segments (device pointers advanced, no
-    // copy) and stage the segment descriptors once. Segment starts land at
-    // multiples of maxSegElts from cudaMalloc-aligned bases, so with maxSegElts
-    // % kVec == 0 every segment start is 4/8-aligned for the vectorized
-    // loads/stores.
-    const std::vector<FloatDeconChunk> segs =
-            rechunk(chunks_h, numInBatch, maxSegElts);
-    if (segs.empty()) {
-        return;
-    }
-    numSegs_ = (uint32_t)segs.size();
-    segs_d_  = deviceAlloc<FloatDeconChunk>(numSegs_);
-    ZL_CUDA_CHECK(cudaMemcpy(
-            segs_d_.get(),
-            segs.data(),
-            (size_t)numSegs_ * sizeof(FloatDeconChunk),
-            cudaMemcpyHostToDevice));
 }
 
 void UnifiedDecodePlan::launch(cudaStream_t stream) const
 {
-    if (numSegs_ == 0) {
+    if (plan_.numSegs() == 0) {
         return;
     }
-    launchSegments(segs_d_.get(), numSegs_, stream);
+    launchSegments(plan_.deviceSegments(), plan_.numSegs(), stream);
 }
 
 void bf16DeconDecodeUnified(

--- a/contrib/gpu/source/codecs/float_deconstruct/decode_float_deconstruct_bf16.cuh
+++ b/contrib/gpu/source/codecs/float_deconstruct/decode_float_deconstruct_bf16.cuh
@@ -7,7 +7,8 @@
 
 #include <cuda_runtime.h>
 
-#include "openzl/dev/contrib/gpu/source/common/cuda_raii.cuh"
+#include "contrib/gpu/source/common/cuda_launch.cuh"
+#include "contrib/gpu/source/common/cuda_raii.cuh"
 
 namespace openzl::gpu {
 
@@ -46,11 +47,8 @@ void bf16DeconDecode(
         cudaStream_t stream);
 
 // Occupancy/launch metadata for the main decode kernel, so a benchmark harness
-// can report theoretical occupancy without seeing the kernel internals
-struct KernelLaunchInfo {
-    int blockSize;
-    int maxActiveBlocksPerSM;
-};
+// can report theoretical occupancy without seeing the kernel internals.
+// KernelLaunchInfo is the shared descriptor from common/cuda_launch.cuh.
 KernelLaunchInfo bf16DeconDecodeLaunchInfo();
 
 // v2 decode: tiled and load-balanced across chunks (fixes the jagged case).

--- a/contrib/gpu/source/codecs/float_deconstruct/decode_float_deconstruct_bf16.cuh
+++ b/contrib/gpu/source/codecs/float_deconstruct/decode_float_deconstruct_bf16.cuh
@@ -8,7 +8,7 @@
 #include <cuda_runtime.h>
 
 #include "contrib/gpu/source/common/cuda_launch.cuh"
-#include "contrib/gpu/source/common/cuda_raii.cuh"
+#include "contrib/gpu/source/common/segment_plan.cuh"
 
 namespace openzl::gpu {
 
@@ -21,6 +21,20 @@ struct FloatDeconChunk {
     const uint8_t* signFrac;
     uint16_t* dst;
     size_t nbElts;
+
+    // Peels the first min(n, nbElts) elements off as a new segment and advances
+    // *this past them, advancing device pointers only (no data copy).
+    FloatDeconChunk peel(size_t n)
+    {
+        n                   = n < nbElts ? n : nbElts;
+        FloatDeconChunk seg = *this;
+        seg.nbElts          = n;
+        exponent += n;
+        signFrac += n;
+        dst += n;
+        nbElts -= n;
+        return seg;
+    }
 };
 
 // Canonical single element decode
@@ -103,12 +117,11 @@ class UnifiedDecodePlan {
 
     uint32_t numSegments() const
     {
-        return numSegs_;
+        return plan_.numSegs();
     }
 
    private:
-    DevicePtr<FloatDeconChunk> segs_d_;
-    uint32_t numSegs_ = 0;
+    SegmentPlan<FloatDeconChunk> plan_;
 };
 
 // One-shot convenience: prepare a UnifiedDecodePlan and launch it on `stream`.

--- a/contrib/gpu/source/codecs/float_deconstruct/gpu_chunk_harness.cuh
+++ b/contrib/gpu/source/codecs/float_deconstruct/gpu_chunk_harness.cuh
@@ -9,9 +9,9 @@
 
 #include <cuda_runtime.h>
 
+#include "contrib/gpu/source/common/cuda_error.cuh"
+#include "contrib/gpu/source/common/cuda_raii.cuh"
 #include "openzl/dev/contrib/gpu/source/codecs/float_deconstruct/decode_float_deconstruct_bf16.cuh"
-#include "openzl/dev/contrib/gpu/source/common/cuda_error.cuh"
-#include "openzl/dev/contrib/gpu/source/common/cuda_raii.cuh"
 
 // float_deconstruct-specific host-side staging for driving bf16DeconDecode from
 // the benchmark and the differential test: stages a chunk batch on the device

--- a/contrib/gpu/source/codecs/float_deconstruct/tests/DecodeBf16Test.cu
+++ b/contrib/gpu/source/codecs/float_deconstruct/tests/DecodeBf16Test.cu
@@ -23,9 +23,9 @@
 #include "openzl/openzl.hpp"
 #include "openzl/zl_reflection.h"
 
+#include "contrib/gpu/source/common/cuda_error.cuh"
 #include "openzl/dev/contrib/gpu/source/codecs/float_deconstruct/decode_float_deconstruct_bf16.cuh"
 #include "openzl/dev/contrib/gpu/source/codecs/float_deconstruct/gpu_chunk_harness.cuh"
-#include "openzl/dev/contrib/gpu/source/common/cuda_error.cuh"
 #include "openzl/dev/contrib/gpu/testkit/frame_factory.h"
 
 namespace openzl::gpu {

--- a/contrib/gpu/source/common/BUCK
+++ b/contrib/gpu/source/common/BUCK
@@ -1,21 +1,34 @@
 # Copyright (c) Meta Platforms, Inc. and affiliates.
 
 load("@fbcode_macros//build_defs:cpp_library.bzl", "cpp_library")
+load("../../../../defs.bzl", "relative_headers")
 
 oncall("data_compression")
 
 # Shared CUDA error-check macros for GPU host code.
 cpp_library(
     name = "cuda_error",
-    headers = ["cuda_error.cuh"],
+    headers = relative_headers(["cuda_error.cuh"]),
+    header_namespace = "",
     exported_external_deps = [("cuda", None, "cuda-lazy")],
 )
 
-# Generic CUDA RAII helpers (owning device pointers, timing events) shared by
-# the device-staging harness and the benchmark driver.
+# Generic CUDA RAII helpers (owning device pointers, timing events, stream-ordered
+# scratch) shared by the device-staging harness and the benchmark driver.
 cpp_library(
     name = "cuda_raii",
-    headers = ["cuda_raii.cuh"],
+    headers = relative_headers(["cuda_raii.cuh"]),
+    header_namespace = "",
+    exported_deps = [":cuda_error"],
+    exported_external_deps = [("cuda", None, "cuda-lazy")],
+)
+
+# Kernel launch/occupancy helpers (grid sizing, occupancy metadata) for GPU host
+# code; kernel-agnostic.
+cpp_library(
+    name = "cuda_launch",
+    headers = relative_headers(["cuda_launch.cuh"]),
+    header_namespace = "",
     exported_deps = [":cuda_error"],
     exported_external_deps = [("cuda", None, "cuda-lazy")],
 )

--- a/contrib/gpu/source/common/BUCK
+++ b/contrib/gpu/source/common/BUCK
@@ -32,3 +32,16 @@ cpp_library(
     exported_deps = [":cuda_error"],
     exported_external_deps = [("cuda", None, "cuda-lazy")],
 )
+
+# Balanced-segment preprocessing (host split + device staging) shared by GPU
+# decode kernels; codec-agnostic (templated on the chunk descriptor).
+cpp_library(
+    name = "segment_plan",
+    headers = relative_headers(["segment_plan.cuh"]),
+    header_namespace = "",
+    exported_deps = [
+        ":cuda_error",
+        ":cuda_raii",
+    ],
+    exported_external_deps = [("cuda", None, "cuda-lazy")],
+)

--- a/contrib/gpu/source/common/cuda_launch.cuh
+++ b/contrib/gpu/source/common/cuda_launch.cuh
@@ -1,0 +1,46 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#pragma once
+
+#include <cstdint>
+
+#include <cuda_runtime.h>
+
+#include "contrib/gpu/source/common/cuda_error.cuh"
+
+// Grid sizing and occupancy metadata for GPU kernel launches.
+
+namespace openzl::gpu {
+
+// A kernel's block size and its max active blocks per SM.
+struct KernelLaunchInfo {
+    int blockSize;
+    int maxActiveBlocksPerSM;
+};
+
+// 1D grid size that fills the GPU for `kernel` launched at `blockSize` threads.
+inline uint32_t fillGpuGrid(const void* kernel, int blockSize)
+{
+    int maxBlocksPerSM = 0;
+    ZL_CUDA_CHECK(cudaOccupancyMaxActiveBlocksPerMultiprocessor(
+            &maxBlocksPerSM, kernel, blockSize, 0));
+    int dev    = 0;
+    int numSMs = 0;
+    ZL_CUDA_CHECK(cudaGetDevice(&dev));
+    ZL_CUDA_CHECK(cudaDeviceGetAttribute(
+            &numSMs, cudaDevAttrMultiProcessorCount, dev));
+    const uint32_t grid = (uint32_t)maxBlocksPerSM * (uint32_t)numSMs;
+    return grid == 0 ? 1 : grid;
+}
+
+// Occupancy metadata for `kernel` at `blockSize`: block size + max active
+// blocks per SM.
+inline KernelLaunchInfo launchInfoFor(const void* kernel, int blockSize)
+{
+    int maxActiveBlocksPerSM = 0;
+    ZL_CUDA_CHECK(cudaOccupancyMaxActiveBlocksPerMultiprocessor(
+            &maxActiveBlocksPerSM, kernel, blockSize, 0));
+    return { blockSize, maxActiveBlocksPerSM };
+}
+
+} // namespace openzl::gpu

--- a/contrib/gpu/source/common/cuda_raii.cuh
+++ b/contrib/gpu/source/common/cuda_raii.cuh
@@ -7,11 +7,11 @@
 
 #include <cuda_runtime.h>
 
-#include "openzl/dev/contrib/gpu/source/common/cuda_error.cuh"
+#include "contrib/gpu/source/common/cuda_error.cuh"
 
-// Generic CUDA RAII helpers for GPU host code: owning device allocations and a
-// timing event. Header-only, codec-agnostic; shared by the device-staging
-// harness and the benchmark driver.
+// Generic CUDA RAII helpers for GPU host code: owning device allocations, a
+// timing event, and stream-ordered scratch. Header-only, codec-agnostic; shared
+// by the device-staging harness, the benchmark driver, and the decode kernels.
 
 namespace openzl::gpu {
 
@@ -67,6 +67,34 @@ class CudaEvent {
 
    private:
     cudaEvent_t ev_{};
+};
+
+// Stream-ordered device scratch: frees on the same stream at scope exit, so an
+// exception between allocation and launch cannot leak it.
+template <typename T>
+class StreamScratch {
+   public:
+    StreamScratch(size_t n, cudaStream_t stream) : stream_(stream)
+    {
+        ZL_CUDA_CHECK(cudaMallocAsync(&p_, n * sizeof(T), stream));
+    }
+    ~StreamScratch()
+    {
+        if (p_) {
+            cudaFreeAsync(p_, stream_);
+        }
+    }
+    StreamScratch(const StreamScratch&)            = delete;
+    StreamScratch& operator=(const StreamScratch&) = delete;
+
+    T* get() const
+    {
+        return p_;
+    }
+
+   private:
+    T* p_ = nullptr;
+    cudaStream_t stream_;
 };
 
 } // namespace openzl::gpu

--- a/contrib/gpu/source/common/segment_plan.cuh
+++ b/contrib/gpu/source/common/segment_plan.cuh
@@ -1,0 +1,109 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+#include <limits>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+#include <cuda_runtime.h>
+
+#include "contrib/gpu/source/common/cuda_error.cuh"
+#include "contrib/gpu/source/common/cuda_raii.cuh"
+
+// Splits a batch of chunks into equal-work segments on the host (advancing
+// device pointers only, no copy) and stages the segment descriptors on the
+// device once; the codec launches its own kernel over deviceSegments().
+//
+// A Chunk must expose:
+//   size_t nbElts;         // elements left in this chunk
+//   Chunk  peel(size_t n); // take the first min(n, nbElts) elements as a new
+//                          // segment and advance *this past them (device
+//                          // pointers only, no copy)
+
+namespace openzl::gpu {
+
+// Splits each chunk into segments of at most maxSegElts.
+template <typename Chunk>
+std::vector<Chunk>
+rechunk(const Chunk* chunks_h, uint32_t numInBatch, size_t maxSegElts)
+{
+    size_t numSegs = 0;
+    for (uint32_t c = 0; c < numInBatch; ++c) {
+        const size_t nb = chunks_h[c].nbElts;
+        numSegs += (nb + maxSegElts - 1) / maxSegElts;
+    }
+    if (numSegs > std::numeric_limits<uint32_t>::max()) {
+        throw std::runtime_error(
+                "SegmentPlan: segment count " + std::to_string(numSegs)
+                + " exceeds uint32_t limit; use a larger maxSegElts");
+    }
+    std::vector<Chunk> out;
+    out.reserve(numSegs);
+    for (uint32_t c = 0; c < numInBatch; ++c) {
+        Chunk cur = chunks_h[c];
+        while (cur.nbElts > 0) {
+            out.push_back(cur.peel(maxSegElts));
+        }
+    }
+    return out;
+}
+
+// Splits `chunks_h` into segments and stages the descriptors on the device
+// once; owns that memory. The codec launches its kernel over
+// deviceSegments()/numSegs().
+template <typename Chunk>
+class SegmentPlan {
+   public:
+    // segAlignElts: segment sizes must be a positive multiple of this (e.g. the
+    // codec's vector width, so segment starts stay aligned). 1 = no constraint.
+    SegmentPlan(
+            const Chunk* chunks_h,
+            uint32_t numInBatch,
+            size_t maxSegElts,
+            size_t segAlignElts = 1)
+    {
+        if (maxSegElts == 0 || segAlignElts == 0
+            || maxSegElts % segAlignElts != 0) {
+            throw std::runtime_error(
+                    "SegmentPlan: maxSegElts " + std::to_string(maxSegElts)
+                    + " must be a positive multiple of "
+                    + std::to_string(segAlignElts));
+        }
+        if (numInBatch == 0) {
+            return;
+        }
+        const std::vector<Chunk> segs =
+                rechunk(chunks_h, numInBatch, maxSegElts);
+        if (segs.empty()) {
+            return;
+        }
+        numSegs_ = (uint32_t)segs.size();
+        segs_d_  = deviceAlloc<Chunk>(numSegs_);
+        ZL_CUDA_CHECK(cudaMemcpy(
+                segs_d_.get(),
+                segs.data(),
+                (size_t)numSegs_ * sizeof(Chunk),
+                cudaMemcpyHostToDevice));
+    }
+
+    // Device array of segment descriptors, numSegs() long. Valid until *this is
+    // destroyed.
+    const Chunk* deviceSegments() const
+    {
+        return segs_d_.get();
+    }
+    uint32_t numSegs() const
+    {
+        return numSegs_;
+    }
+
+   private:
+    DevicePtr<Chunk> segs_d_;
+    uint32_t numSegs_ = 0;
+};
+
+} // namespace openzl::gpu

--- a/contrib/gpu/src/decompress/tests/GpuDecompressFullCopyTest.cu
+++ b/contrib/gpu/src/decompress/tests/GpuDecompressFullCopyTest.cu
@@ -10,9 +10,9 @@
 
 #include <cuda_runtime.h>
 
+#include "contrib/gpu/source/common/cuda_error.cuh"
+#include "contrib/gpu/source/common/cuda_raii.cuh"
 #include "contrib/gpu/src/decompress/gpu_decompress.hpp"
-#include "openzl/dev/contrib/gpu/source/common/cuda_error.cuh"
-#include "openzl/dev/contrib/gpu/source/common/cuda_raii.cuh"
 #include "openzl/dev/contrib/gpu/testkit/multichunk_frame.h"
 #include "openzl/openzl.hpp"
 


### PR DESCRIPTION
Summary:

## What
Extract the fused decode's host split + device descriptor staging into a
codec-agnostic `common/segment_plan.cuh`:

- `SegmentPlan<Chunk>`: given host chunk descriptors, splits each into equal
  `maxSegElts` segments and stages the segment descriptor array on the device once. Exposes `deviceSegments()` /
  `numSegs()` and owns the memory; the codec launches its own kernel over the
  segments. Split once, launch many.
- `rechunk<Chunk>`: the generic split, calling `Chunk::peel`.
- `Chunk` concept: a descriptor exposing `nbElts` + `peel(n)`

`FloatDeconChunk` gains a `peel` member; `FusedDecodePlan` becomes a thin wrapper
owning a `SegmentPlan<FloatDeconChunk>`, which
enforces the 4/8-byte segment-start alignment the vectorized loads/stores need).
The free `peel`/`rechunk` move out of the codec TU.

Reusable for other per-element, multi-stream GPU codecs (e.g. bitsplit): supply a
`Chunk` + kernel and reuse the split/stage scaffold.

## Scratch predictability
The scratch `SegmentPlan` holds is exactly `numSegs * sizeof(Chunk)`, fully
predictable from the chunk sizes. A caller owned workspace
overload is a deliberate future seam (add when a second codec needs a shared
pool)

Reviewed By: terrelln

Differential Revision: D113350834


