### PR TITLE
Unified tiled+vectorized bf16 decode kernel

### DIFF
--- a/contrib/gpu/source/codecs/float_deconstruct/BUCK
+++ b/contrib/gpu/source/codecs/float_deconstruct/BUCK
@@ -17,6 +17,7 @@ cpp_library(
     headers = ["decode_float_deconstruct_bf16.cuh"],
     nvcc_flags = get_nvcc_arch_args() + ["-lineinfo"],
     deps = ["../../common:cuda_error"],
+    exported_deps = ["../../common:cuda_raii"],
     exported_external_deps = [("cuda", None, "cuda-lazy")],
 )
 

--- a/contrib/gpu/source/codecs/float_deconstruct/bench/bench_decode_bf16.cu
+++ b/contrib/gpu/source/codecs/float_deconstruct/bench/bench_decode_bf16.cu
@@ -173,6 +173,62 @@ class Bf16DecodeCase : public KernelCase {
     const DeviceChunkSet& dev_;
 };
 
+// Unified-kernel case. Builds the segment plan once in setup() (host split +
+// descriptor upload) so only the kernel launch is timed, then launches it per
+// iteration. Shares the DeviceChunkSet fixture like Bf16DecodeCase.
+class UnifiedDecodeCase : public KernelCase {
+   public:
+    UnifiedDecodeCase(
+            std::string name,
+            size_t maxSegElts,
+            const HostData& hd,
+            const DeviceChunkSet& dev)
+            : name_(std::move(name)),
+              maxSegElts_(maxSegElts),
+              hd_(hd),
+              dev_(dev)
+    {
+    }
+
+    std::string name() const override
+    {
+        return name_;
+    }
+    void setup() override
+    {
+        plan_ = std::make_unique<openzl::gpu::UnifiedDecodePlan>(
+                dev_.hostChunks().data(), dev_.numInBatch(), maxSegElts_);
+    }
+    void launch(cudaStream_t stream) override
+    {
+        plan_->launch(stream);
+    }
+    Workload workload() const override
+    {
+        return { kBytesPerElt * hd_.totalElts, hd_.totalElts };
+    }
+    bool verify() override
+    {
+        return countMismatches(hd_, dev_) == 0;
+    }
+    int blockSize() const override
+    {
+        return openzl::gpu::bf16DeconDecodeUnifiedLaunchInfo().blockSize;
+    }
+    int maxActiveBlocksPerSM() const override
+    {
+        return openzl::gpu::bf16DeconDecodeUnifiedLaunchInfo()
+                .maxActiveBlocksPerSM;
+    }
+
+   private:
+    std::string name_;
+    size_t maxSegElts_;
+    const HostData& hd_;
+    const DeviceChunkSet& dev_;
+    std::unique_ptr<openzl::gpu::UnifiedDecodePlan> plan_;
+};
+
 std::vector<size_t> jaggedShape(
         std::mt19937& rng,
         size_t bigElts,
@@ -226,6 +282,16 @@ void runShape(
                                 dev.numInBatch(), dev.deviceChunks(), s);
                     },
                     openzl::gpu::bf16DeconDecodeVecLaunchInfo(),
+                    hd,
+                    dev));
+    // Unified kernel at the production default segment size: element-balanced
+    // and vectorized, so it tracks the best specialist on every shape. The plan
+    // is built in setup(), so only the kernel launch is timed (the host peel
+    // and descriptor upload are one-time and excluded).
+    cases.push_back(
+            std::make_unique<UnifiedDecodeCase>(
+                    "unified",
+                    openzl::gpu::kUnifiedDefaultMaxSegElts,
                     hd,
                     dev));
 

--- a/contrib/gpu/source/codecs/float_deconstruct/decode_float_deconstruct_bf16.cu
+++ b/contrib/gpu/source/codecs/float_deconstruct/decode_float_deconstruct_bf16.cu
@@ -2,8 +2,12 @@
 
 #include "decode_float_deconstruct_bf16.cuh"
 
+#include <algorithm>
+#include <cassert>
+#include <limits>
 #include <stdexcept>
 #include <string>
+#include <vector>
 
 #include "openzl/dev/contrib/gpu/source/common/cuda_error.cuh"
 
@@ -13,7 +17,8 @@ namespace {
 
 constexpr int kThreads       = 256;
 constexpr int kEltsPerThread = 8; // v2 tile = kThreads * kEltsPerThread elts
-constexpr int kVec = 4; // v3 elements per thread (uchar4 in/ushort4 out)
+constexpr int kVec    = 4; // v3 elements per thread (uchar4 in/ushort4 out)
+constexpr int kUnroll = 2; // independent uchar4 loads/stream in flight (MLP)
 
 // chunk = blockIdx.y; each block's threads grid-stride over that chunk along x.
 // One chunk is just numInBatch == 1, so this handles single and multi chunk.
@@ -34,11 +39,67 @@ __global__ void decodeChunksKernel(
     }
 }
 
-// v3 decode: same chunk = blockIdx.y mapping as the naive kernel, but each
-// thread processes kVec elements with vectorized transactions (uchar4 in,
-// ushort4 out) instead of one byte at a time, so both input streams and the
-// output move in wide, fully-coalesced transactions. A scalar tail handles the
-// last nbElts % kVec elements. This raises throughput on the single/uniform
+// Reassembles one uchar4 of exponent + one uchar4 of signFrac into a ushort4.
+__device__ __forceinline__ ushort4 joinVec4(uchar4 e, uchar4 s)
+{
+    ushort4 out;
+    out.x = decodeBf16Elt(e.x, s.x);
+    out.y = decodeBf16Elt(e.y, s.y);
+    out.z = decodeBf16Elt(e.z, s.z);
+    out.w = decodeBf16Elt(e.w, s.w);
+    return out;
+}
+
+// Vectorized decode of one chunk: the threads [start, start+stride, ...) cover
+// the chunk, each handling kVec elements per step via wide transactions (uchar4
+// in, ushort4 out) so both input streams and the output move in wide, fully-
+// coalesced transactions. The main loop is unrolled by kUnroll so several
+// independent loads from each stream are in flight before the stores, hiding
+// DRAM latency (memory-level parallelism). A remainder loop and then a scalar
+// tail (last nbElts % kVec) finish the chunk. Shared by the v3 and unified
+// kernels. Requires exponent/signFrac/dst 4-aligned (true for real chunks and
+// for unified segments by construction; see bf16DeconDecodeUnified).
+__device__ __forceinline__ void
+decodeChunkVec(const FloatDeconChunk& c, size_t start, size_t stride)
+{
+    // The vectorized loads/stores below require these base pointers aligned to
+    // their vector types; misalignment is UB on CUDA. Real chunks (cudaMalloc)
+    // and unified segments (starts at multiples of maxSegElts % kVec) satisfy
+    // it.
+    assert(reinterpret_cast<uintptr_t>(c.exponent) % alignof(uchar4) == 0);
+    assert(reinterpret_cast<uintptr_t>(c.signFrac) % alignof(uchar4) == 0);
+    assert(reinterpret_cast<uintptr_t>(c.dst) % alignof(ushort4) == 0);
+    const size_t nVec = c.nbElts / kVec;
+    size_t v          = start;
+    for (; v + (size_t)(kUnroll - 1) * stride < nVec;
+         v += (size_t)kUnroll * stride) {
+        uchar4 e[kUnroll];
+        uchar4 s[kUnroll];
+#pragma unroll
+        for (int u = 0; u < kUnroll; ++u) {
+            const size_t base = (v + (size_t)u * stride) * kVec;
+            e[u] = *reinterpret_cast<const uchar4*>(c.exponent + base);
+            s[u] = *reinterpret_cast<const uchar4*>(c.signFrac + base);
+        }
+#pragma unroll
+        for (int u = 0; u < kUnroll; ++u) {
+            const size_t base = (v + (size_t)u * stride) * kVec;
+            *reinterpret_cast<ushort4*>(c.dst + base) = joinVec4(e[u], s[u]);
+        }
+    }
+    for (; v < nVec; v += stride) {
+        const size_t base = v * kVec;
+        const uchar4 e    = *reinterpret_cast<const uchar4*>(c.exponent + base);
+        const uchar4 s    = *reinterpret_cast<const uchar4*>(c.signFrac + base);
+        *reinterpret_cast<ushort4*>(c.dst + base) = joinVec4(e, s);
+    }
+    for (size_t i = nVec * kVec + start; i < c.nbElts; i += stride) {
+        c.dst[i] = decodeBf16Elt(c.exponent[i], c.signFrac[i]);
+    }
+}
+
+// v3 decode: same chunk = blockIdx.y mapping as the naive kernel, but
+// vectorized via decodeChunkVec. This raises throughput on the single/uniform
 // shapes; jagged still starves like the naive kernel, so use v2 there.
 __global__ void decodeChunksVecKernel(
         const FloatDeconChunk* __restrict__ chunks,
@@ -48,25 +109,9 @@ __global__ void decodeChunksVecKernel(
     if (b >= numInBatch) {
         return;
     }
-    const FloatDeconChunk c = chunks[b];
-    const size_t nVec       = c.nbElts / kVec;
-    const size_t stride     = (size_t)gridDim.x * blockDim.x;
-    const size_t start      = (size_t)blockIdx.x * blockDim.x + threadIdx.x;
-    for (size_t v = start; v < nVec; v += stride) {
-        const size_t base = v * kVec;
-        const uchar4 e    = *reinterpret_cast<const uchar4*>(c.exponent + base);
-        const uchar4 s    = *reinterpret_cast<const uchar4*>(c.signFrac + base);
-        ushort4 out;
-        out.x                                     = decodeBf16Elt(e.x, s.x);
-        out.y                                     = decodeBf16Elt(e.y, s.y);
-        out.z                                     = decodeBf16Elt(e.z, s.z);
-        out.w                                     = decodeBf16Elt(e.w, s.w);
-        *reinterpret_cast<ushort4*>(c.dst + base) = out;
-    }
-    // Scalar tail: the last nbElts % kVec elements.
-    for (size_t i = nVec * kVec + start; i < c.nbElts; i += stride) {
-        c.dst[i] = decodeBf16Elt(c.exponent[i], c.signFrac[i]);
-    }
+    const size_t stride = (size_t)gridDim.x * blockDim.x;
+    const size_t start  = (size_t)blockIdx.x * blockDim.x + threadIdx.x;
+    decodeChunkVec(chunks[b], start, stride);
 }
 
 // Largest c in [0, numInBatch) with offsets[c] <= g (upper_bound - 1).
@@ -140,6 +185,20 @@ __global__ void decodeTiledKernel(
     }
 }
 
+// Unified decode: element-balanced like v2 and vectorized like v3. The host has
+// already split the input into equal-sized segments (each a contiguous run of
+// one chunk); one block owns a segment and grid-strides over the segment array,
+// so equal segments balance the work. A 1D grid means numSegs is not bound by
+// the gridDim.y cap the naive/v3 kernels hit.
+__global__ void decodeSegmentsKernel(
+        const FloatDeconChunk* __restrict__ segments,
+        uint32_t numSegs)
+{
+    for (uint32_t s = blockIdx.x; s < numSegs; s += gridDim.x) {
+        decodeChunkVec(segments[s], threadIdx.x, blockDim.x);
+    }
+}
+
 // 1D grid size that fills the GPU for a given kernel at kThreads.
 uint32_t fillGpuGrid(const void* kernel)
 {
@@ -153,6 +212,99 @@ uint32_t fillGpuGrid(const void* kernel)
             &numSMs, cudaDevAttrMultiProcessorCount, dev));
     const uint32_t grid = (uint32_t)maxBlocksPerSM * (uint32_t)numSMs;
     return grid == 0 ? 1 : grid;
+}
+
+// Host-side. Peels the first min(n, c.nbElts) elements off c as a new segment
+// and advances c past them. Only advances device pointers, so the segment
+// aliases the original device buffers, no data is copied.
+FloatDeconChunk peel(FloatDeconChunk& c, size_t n)
+{
+    n                   = std::min(n, c.nbElts);
+    FloatDeconChunk seg = c;
+    seg.nbElts          = n;
+    c.exponent += n;
+    c.signFrac += n;
+    c.dst += n;
+    c.nbElts -= n;
+    return seg;
+}
+
+// Host-side. Splits each chunk into segments of at most maxSegElts, so all
+// segments carry roughly equal work regardless of the input shape.
+std::vector<FloatDeconChunk>
+rechunk(const FloatDeconChunk* chunks_h, uint32_t numInBatch, size_t maxSegElts)
+{
+    size_t numSegs = 0;
+    for (uint32_t c = 0; c < numInBatch; ++c) {
+        const size_t nb = chunks_h[c].nbElts;
+        numSegs += (nb + maxSegElts - 1) / maxSegElts;
+    }
+    if (numSegs > std::numeric_limits<uint32_t>::max()) {
+        throw std::runtime_error(
+                "bf16 unified decode: segment count " + std::to_string(numSegs)
+                + " exceeds uint32_t limit; use a larger maxSegElts");
+    }
+    std::vector<FloatDeconChunk> out;
+    out.reserve(numSegs);
+    for (uint32_t c = 0; c < numInBatch; ++c) {
+        FloatDeconChunk cur = chunks_h[c];
+        while (cur.nbElts > 0) {
+            out.push_back(peel(cur, maxSegElts));
+        }
+    }
+    return out;
+}
+
+// Stream-ordered device scratch: frees on the same stream at scope exit, so an
+// exception between allocation and launch cannot leak it.
+template <typename T>
+class StreamScratch {
+   public:
+    StreamScratch(size_t n, cudaStream_t stream) : stream_(stream)
+    {
+        ZL_CUDA_CHECK(cudaMallocAsync(&p_, n * sizeof(T), stream));
+    }
+    ~StreamScratch()
+    {
+        if (p_) {
+            cudaFreeAsync(p_, stream_);
+        }
+    }
+    StreamScratch(const StreamScratch&)            = delete;
+    StreamScratch& operator=(const StreamScratch&) = delete;
+
+    T* get() const
+    {
+        return p_;
+    }
+
+   private:
+    T* p_ = nullptr;
+    cudaStream_t stream_;
+};
+
+// Throws unless maxSegElts is a positive multiple of kVec (the alignment
+// invariant the vectorized loads/stores rely on).
+void validateMaxSegElts(size_t maxSegElts)
+{
+    if (maxSegElts == 0 || maxSegElts % kVec != 0) {
+        throw std::runtime_error(
+                "bf16 unified decode: maxSegElts " + std::to_string(maxSegElts)
+                + " must be a positive multiple of " + std::to_string(kVec));
+    }
+}
+
+// Sizes a 1D grid that fills the GPU (capped at numSegs) and launches the
+// unified kernel over the staged segment array.
+void launchSegments(
+        const FloatDeconChunk* segs_d,
+        uint32_t numSegs,
+        cudaStream_t stream)
+{
+    const uint32_t target = fillGpuGrid((const void*)decodeSegmentsKernel);
+    const uint32_t grid   = (uint32_t)std::min<size_t>(numSegs, target);
+    decodeSegmentsKernel<<<grid, kThreads, 0, stream>>>(segs_d, numSegs);
+    ZL_CUDA_CHECK_LAST();
 }
 
 } // namespace
@@ -238,11 +390,8 @@ void bf16DeconDecodeVec(
                 + " exceeds kMaxNumInBatch " + std::to_string(kMaxNumInBatch)
                 + " (gridDim.y limit); split the batch across calls");
     }
-    const uint32_t target   = fillGpuGrid((const void*)decodeChunksVecKernel);
-    uint32_t blocksPerChunk = (target + numInBatch - 1) / numInBatch;
-    if (blocksPerChunk == 0) {
-        blocksPerChunk = 1;
-    }
+    const uint32_t target = fillGpuGrid((const void*)decodeChunksVecKernel);
+    const uint32_t blocksPerChunk = (target + numInBatch - 1) / numInBatch;
     const dim3 grid(blocksPerChunk, numInBatch);
     decodeChunksVecKernel<<<grid, kThreads, 0, stream>>>(chunks_d, numInBatch);
     ZL_CUDA_CHECK_LAST();
@@ -254,6 +403,82 @@ KernelLaunchInfo bf16DeconDecodeVecLaunchInfo()
     ZL_CUDA_CHECK(cudaOccupancyMaxActiveBlocksPerMultiprocessor(
             &maxActiveBlocksPerSM,
             (const void*)decodeChunksVecKernel,
+            kThreads,
+            0));
+    return { kThreads, maxActiveBlocksPerSM };
+}
+
+UnifiedDecodePlan::UnifiedDecodePlan(
+        const FloatDeconChunk* chunks_h,
+        uint32_t numInBatch,
+        size_t maxSegElts)
+{
+    if (numInBatch == 0) {
+        return;
+    }
+    validateMaxSegElts(maxSegElts);
+
+    // Split on the host into equal-sized segments (device pointers advanced, no
+    // copy) and stage the segment descriptors once. Segment starts land at
+    // multiples of maxSegElts from cudaMalloc-aligned bases, so with maxSegElts
+    // % kVec == 0 every segment start is 4/8-aligned for the vectorized
+    // loads/stores.
+    const std::vector<FloatDeconChunk> segs =
+            rechunk(chunks_h, numInBatch, maxSegElts);
+    if (segs.empty()) {
+        return;
+    }
+    numSegs_ = (uint32_t)segs.size();
+    segs_d_  = deviceAlloc<FloatDeconChunk>(numSegs_);
+    ZL_CUDA_CHECK(cudaMemcpy(
+            segs_d_.get(),
+            segs.data(),
+            (size_t)numSegs_ * sizeof(FloatDeconChunk),
+            cudaMemcpyHostToDevice));
+}
+
+void UnifiedDecodePlan::launch(cudaStream_t stream) const
+{
+    if (numSegs_ == 0) {
+        return;
+    }
+    launchSegments(segs_d_.get(), numSegs_, stream);
+}
+
+void bf16DeconDecodeUnified(
+        const FloatDeconChunk* chunks_h,
+        uint32_t numInBatch,
+        size_t maxSegElts,
+        cudaStream_t stream)
+{
+    if (numInBatch == 0) {
+        return;
+    }
+    validateMaxSegElts(maxSegElts);
+    const std::vector<FloatDeconChunk> segs =
+            rechunk(chunks_h, numInBatch, maxSegElts);
+    if (segs.empty()) {
+        return;
+    }
+    const uint32_t numSegs = (uint32_t)segs.size();
+
+    // Stream-ordered scratch so the one-shot path stays async and leak-free.
+    StreamScratch<FloatDeconChunk> segs_d(numSegs, stream);
+    ZL_CUDA_CHECK(cudaMemcpyAsync(
+            segs_d.get(),
+            segs.data(),
+            (size_t)numSegs * sizeof(FloatDeconChunk),
+            cudaMemcpyHostToDevice,
+            stream));
+    launchSegments(segs_d.get(), numSegs, stream);
+}
+
+KernelLaunchInfo bf16DeconDecodeUnifiedLaunchInfo()
+{
+    int maxActiveBlocksPerSM = 0;
+    ZL_CUDA_CHECK(cudaOccupancyMaxActiveBlocksPerMultiprocessor(
+            &maxActiveBlocksPerSM,
+            (const void*)decodeSegmentsKernel,
             kThreads,
             0));
     return { kThreads, maxActiveBlocksPerSM };

--- a/contrib/gpu/source/codecs/float_deconstruct/decode_float_deconstruct_bf16.cuh
+++ b/contrib/gpu/source/codecs/float_deconstruct/decode_float_deconstruct_bf16.cuh
@@ -7,10 +7,14 @@
 
 #include <cuda_runtime.h>
 
+#include "openzl/dev/contrib/gpu/source/common/cuda_raii.cuh"
+
 namespace openzl::gpu {
 
 // Describes one bf16 float-deconstruct chunk. All pointers are device pointers.
-// bf16DeconDecodeVec needs them aligned (see its comment).
+// The vectorized paths (bf16DeconDecodeVec and the unified decode) require
+// exponent and signFrac 4-byte aligned and dst 8-byte aligned; cudaMalloc'd
+// buffers and unified segment starts satisfy this by construction.
 struct FloatDeconChunk {
     const uint8_t* exponent;
     const uint8_t* signFrac;
@@ -66,5 +70,57 @@ void bf16DeconDecodeVec(
         const FloatDeconChunk* chunks_d,
         cudaStream_t stream);
 KernelLaunchInfo bf16DeconDecodeVecLaunchInfo();
+
+// Default segment size for the unified decode, in elements. From the
+// benchmark's granularity sweep, kernel throughput keeps improving down to
+// ~4Ki-element segments; 16Ki stays within a few percent of that peak on every
+// shape while producing 4x fewer segments (less descriptor upload for the
+// one-shot path). Tunable; must be a positive multiple of 4 (see the alignment
+// note below).
+constexpr size_t kUnifiedDefaultMaxSegElts = 16384;
+
+// Prepared unified decode: element-balanced (like v2) AND vectorized (like v3),
+// good across oneLarge/batched/jagged from one kernel. Construction splits
+// every chunk into segments of at most maxSegElts on the host (advancing device
+// pointers, zero copy) and stages the segment descriptors on the device once;
+// launch() then runs a 1D-grid vectorized kernel over them. Equal-sized
+// segments balance the work and the wide transactions recover bandwidth.
+// Splitting once and launching repeatedly keeps the host split and the
+// descriptor upload out of the per-launch cost.
+//
+// Takes HOST-side descriptors `chunks_h` (device pointers + sizes), since the
+// split runs on the host. Uses a 1D grid, so there is NO kMaxNumInBatch cap.
+// maxSegElts must be a positive multiple of 4 (segment starts are then
+// 4/8-aligned by construction); the constructor throws otherwise.
+class UnifiedDecodePlan {
+   public:
+    UnifiedDecodePlan(
+            const FloatDeconChunk* chunks_h,
+            uint32_t numInBatch,
+            size_t maxSegElts);
+
+    // Launches the decode on `stream`. This object must stay alive until the
+    // stream work completes (it owns the device segment descriptors).
+    void launch(cudaStream_t stream) const;
+
+    uint32_t numSegments() const
+    {
+        return numSegs_;
+    }
+
+   private:
+    DevicePtr<FloatDeconChunk> segs_d_;
+    uint32_t numSegs_ = 0;
+};
+
+// One-shot convenience: prepare a UnifiedDecodePlan and launch it on `stream`.
+// Prefer UnifiedDecodePlan directly when decoding the same shape repeatedly.
+void bf16DeconDecodeUnified(
+        const FloatDeconChunk* chunks_h,
+        uint32_t numInBatch,
+        size_t maxSegElts,
+        cudaStream_t stream);
+
+KernelLaunchInfo bf16DeconDecodeUnifiedLaunchInfo();
 
 } // namespace openzl::gpu

--- a/contrib/gpu/source/codecs/float_deconstruct/gpu_chunk_harness.cuh
+++ b/contrib/gpu/source/codecs/float_deconstruct/gpu_chunk_harness.cuh
@@ -68,7 +68,7 @@ class DeviceChunkSet {
         dSf_.resize(numInBatch_);
         dDst_.resize(numInBatch_);
 
-        std::vector<FloatDeconChunk> host(numInBatch_);
+        hostChunks_.resize(numInBatch_);
         for (uint32_t c = 0; c < numInBatch_; ++c) {
             const size_t nb = chunks[c].nbElts;
             sizes_[c]       = nb;
@@ -87,13 +87,15 @@ class DeviceChunkSet {
                         nb,
                         cudaMemcpyHostToDevice));
             }
-            host[c] = { dExp_[c].get(), dSf_[c].get(), dDst_[c].get(), nb };
+            hostChunks_[c] = {
+                dExp_[c].get(), dSf_[c].get(), dDst_[c].get(), nb
+            };
         }
         if (numInBatch_) {
             dChunks_ = deviceAlloc<FloatDeconChunk>(numInBatch_);
             ZL_CUDA_CHECK(cudaMemcpy(
                     dChunks_.get(),
-                    host.data(),
+                    hostChunks_.data(),
                     numInBatch_ * sizeof(FloatDeconChunk),
                     cudaMemcpyHostToDevice));
         }
@@ -111,6 +113,13 @@ class DeviceChunkSet {
     const FloatDeconChunk* deviceChunks() const
     {
         return dChunks_.get();
+    }
+
+    // Host-side descriptor array (device pointers + sizes), for launchers that
+    // partition on the host such as bf16DeconDecodeUnified.
+    const std::vector<FloatDeconChunk>& hostChunks() const
+    {
+        return hostChunks_;
     }
 
     // Copies chunk c's decoded output back to host. The caller must have
@@ -134,6 +143,7 @@ class DeviceChunkSet {
     std::vector<size_t> sizes_;
     std::vector<DevicePtr<uint8_t>> dExp_, dSf_;
     std::vector<DevicePtr<uint16_t>> dDst_;
+    std::vector<FloatDeconChunk> hostChunks_;
     DevicePtr<FloatDeconChunk> dChunks_;
 };
 

--- a/contrib/gpu/source/codecs/float_deconstruct/tests/DecodeBf16Test.cu
+++ b/contrib/gpu/source/codecs/float_deconstruct/tests/DecodeBf16Test.cu
@@ -106,21 +106,43 @@ OwnedHostChunk extractBf16Chunk(const std::string& frame)
     return out;
 }
 
-// Runs bf16DeconDecode over the given per-chunk streams; writes host outputs to
-// `outs`.
+// Stages the streams, runs `launch` (which selects the decode kernel), and
+// writes the per-chunk host outputs to `outs`.
+template <typename LaunchFn>
 void gpuDecode(
         const std::vector<OwnedHostChunk>& chunks,
-        std::vector<std::vector<uint16_t>>& outs)
+        std::vector<std::vector<uint16_t>>& outs,
+        LaunchFn&& launch)
 {
     DeviceChunkSet dev(toHostChunks(chunks));
 
-    bf16DeconDecode(dev.numInBatch(), dev.deviceChunks(), 0);
+    launch(dev);
     ZL_CUDA_CHECK(cudaDeviceSynchronize());
 
     outs.resize(dev.numInBatch());
     for (uint32_t c = 0; c < dev.numInBatch(); ++c) {
         outs[c] = dev.download(c);
     }
+}
+
+void gpuDecodeNaive(
+        const std::vector<OwnedHostChunk>& chunks,
+        std::vector<std::vector<uint16_t>>& outs)
+{
+    gpuDecode(chunks, outs, [](DeviceChunkSet& dev) {
+        bf16DeconDecode(dev.numInBatch(), dev.deviceChunks(), 0);
+    });
+}
+
+void gpuDecodeUnified(
+        const std::vector<OwnedHostChunk>& chunks,
+        std::vector<std::vector<uint16_t>>& outs,
+        size_t maxSegElts)
+{
+    gpuDecode(chunks, outs, [maxSegElts](DeviceChunkSet& dev) {
+        bf16DeconDecodeUnified(
+                dev.hostChunks().data(), dev.numInBatch(), maxSegElts, 0);
+    });
 }
 
 // The GPU decode of the real OpenZL-encoded streams must reproduce the original
@@ -151,7 +173,7 @@ TEST(DecodeBf16Test, SingleChunkMatchesOpenZLDecoder)
     ASSERT_EQ(s.signFrac.size(), vals.size());
 
     std::vector<std::vector<uint16_t>> gpu;
-    gpuDecode({ s }, gpu);
+    gpuDecodeNaive({ s }, gpu);
     expectMatches(frame, gpu[0], vals);
 }
 
@@ -170,10 +192,64 @@ TEST(DecodeBf16Test, MultiChunkBatchMatchesOpenZLDecoder)
         ASSERT_EQ(streams.back().exponent.size(), sizes[k]);
     }
     std::vector<std::vector<uint16_t>> gpu;
-    gpuDecode(streams, gpu);
+    gpuDecodeNaive(streams, gpu);
     for (size_t k = 0; k < sizes.size(); ++k) {
         expectMatches(frames[k], gpu[k], vals[k]);
     }
+}
+
+// Unified decode of a single chunk whose size is not a multiple of the vector
+// width, with a small segment size that forces many segments plus a ragged
+// tail: exercises both the vectorized body and the scalar tail.
+TEST(DecodeBf16Test, UnifiedSingleChunkMatchesOpenZLDecoder)
+{
+    const std::vector<uint16_t> vals = makeBf16(100002, 3);
+    const std::string frame          = mintBf16Frame(vals);
+
+    const OwnedHostChunk s = extractBf16Chunk(frame);
+    ASSERT_EQ(s.exponent.size(), vals.size());
+    ASSERT_EQ(s.signFrac.size(), vals.size());
+
+    std::vector<std::vector<uint16_t>> gpu;
+    gpuDecodeUnified({ s }, gpu, 4096);
+    expectMatches(frame, gpu[0], vals);
+}
+
+// Unified decode over uneven chunks with a small segment size: the big chunk
+// peels into many segments while tiny chunks stay whole, and several sizes are
+// not a multiple of the vector width. Checks segments alias the right output
+// offsets.
+TEST(DecodeBf16Test, UnifiedMultiChunkMatchesOpenZLDecoder)
+{
+    const std::vector<size_t> sizes = { 50000, 1, 200000, 12345, 7 };
+    std::vector<std::vector<uint16_t>> vals;
+    std::vector<std::string> frames;
+    std::vector<OwnedHostChunk> streams;
+    for (size_t k = 0; k < sizes.size(); ++k) {
+        vals.push_back(makeBf16(sizes[k], (unsigned)(k + 20)));
+        frames.push_back(mintBf16Frame(vals.back()));
+        streams.push_back(extractBf16Chunk(frames.back()));
+        ASSERT_EQ(streams.back().exponent.size(), sizes[k]);
+    }
+    std::vector<std::vector<uint16_t>> gpu;
+    gpuDecodeUnified(streams, gpu, 4096);
+    for (size_t k = 0; k < sizes.size(); ++k) {
+        expectMatches(frames[k], gpu[k], vals[k]);
+    }
+}
+
+// Unified decode with the production default segment size.
+TEST(DecodeBf16Test, UnifiedDefaultSegSizeMatchesOpenZLDecoder)
+{
+    const std::vector<uint16_t> vals = makeBf16(300000, 4);
+    const std::string frame          = mintBf16Frame(vals);
+
+    const OwnedHostChunk s = extractBf16Chunk(frame);
+    ASSERT_EQ(s.exponent.size(), vals.size());
+
+    std::vector<std::vector<uint16_t>> gpu;
+    gpuDecodeUnified({ s }, gpu, kUnifiedDefaultMaxSegElts);
+    expectMatches(frame, gpu[0], vals);
 }
 
 } // namespace


### PR DESCRIPTION
Summary:
## What

**Problem:** Each specialist kernel collapses on some shape: the naive and v3 vectorized kernels starve on jagged inputs, while the v2 tiled kernel gives up the wide transaction bandwidth v3 gets on uniform shapes. No single kernel stays near peak across `oneLarge`, `batched`, and `jagged`.

**Changes made:** Add `bf16DeconDecodeUnified` / `UnifiedDecodePlan`: one decode kernel that is both element-balanced (like the v2 tiled kernel) and vectorized (like v3). The host splits each chunk into equal `maxSegElts` segments (`peel`/`rechunk`, advancing device pointers only, zero copy), stages the segment descriptors once, and a 1D-grid kernel (`decodeSegmentsKernel`, one block per segment, grid-strided) runs v3's `uchar4`->`ushort4` body over them. Equal segments balance the work; the 1D grid removes the `kMaxNumInBatch` (gridDim.y) cap. v3's per-segment loop is factored into a shared `decodeChunkVec` device helper used by both `decodeChunksVecKernel` and the unified kernel, so there is no copied kernel body. `decodeChunkVec` is unrolled by `kUnroll` so several independent loads from each input stream are in flight before the stores; this lifts both the unified and v3 kernels a few points across all shapes at unchanged 100% occupancy. `UnifiedDecodePlan` splits and uploads once and can launch many times, keeping the host split and descriptor upload out of the per-launch cost.

## Why

Nick's ask on D110379491: one kernel good across all shapes.

Measured on an A100 (kernel time, % of 1935 GB/s peak; sanity copy 85%):

| shape          | naive | tiled | vec  | unified |
|----------------|-------|-------|------|---------|
| oneLarge       | 45%   | 35%   | 75%  | 77%     |
| batched-4KiB   | 44%   | 8%    | 73%  | 73%     |
| batched-512KiB | 34%   | 31%   | 72%  | 77%     |
| jagged         | 1%    | 33%   | 5%   | 78%     |
| jaggedTiny     | 0.1%  | 11%   | 0.7% | 71%     |

`unified` matches or beats the best specialist on every uniform shape and is ~2-70x the next best on jagged/jaggedTiny, with no catastrophic shape. Segment size is tunable (`kUnifiedDefaultMaxSegElts`); kernel throughput keeps improving down to ~4Ki segments, and 16Ki stays within a few percent while producing 4x fewer segments. The ~77% plateau is the structural limit of a two-input-stream (exponent+signFrac) reassembly against the 85% device-to-device copy roofline.

## Stack Context

- **Previous diff:** v3 vectorized decode kernel.
- **Where we are in the stack:** the unified kernel that stays near peak across all shapes (top of the stack).

## Clarifications & Assumptions

N/A - all important items clarified in comments.

Reviewed By: terrelln

Differential Revision: D112950180


