### PR TITLE
Stage chunk headers on host

### DIFF
--- a/contrib/gpu/src/decompress/BUCK
+++ b/contrib/gpu/src/decompress/BUCK
@@ -5,6 +5,7 @@ load("@fbcode_macros//build_defs:cpp_library.bzl", "cpp_library")
 oncall("data_compression")
 
 cpp_library(
+    # @autodeps-skip
     name = "decompress",
     srcs = ["gpu_decompress.cpp"],
     headers = ["gpu_decompress.h"],

--- a/contrib/gpu/src/decompress/BUCK
+++ b/contrib/gpu/src/decompress/BUCK
@@ -1,6 +1,14 @@
 # Copyright (c) Meta Platforms, Inc. and affiliates.
 
 load("@fbcode_macros//build_defs:cpp_library.bzl", "cpp_library")
+load("@fbcode_macros//build_defs:cpp_unittest.bzl", "cpp_unittest")
+load("@fbcode_macros//build_defs:sanitizers.bzl", "sanitizers")
+load("@fbcode_macros//build_defs/lib:re_test_utils.bzl", "re_test_utils")
+load("@fbsource//tools/build_defs:testpilot_defs.bzl", "tpx_labels")
+load("@fbsource//tools/build_defs/testinfra:network_access_utils.bzl", "network_access_utils")
+load("@fbsource//tools/target_determinator/macros:ci.bzl", "ci")
+load("//tools/build/buck:nvcc_flags.bzl", "get_nvcc_arch_args")
+load("../../../../defs.bzl", "relative_headers")
 
 oncall("data_compression")
 
@@ -8,6 +16,57 @@ cpp_library(
     # @autodeps-skip
     name = "decompress",
     srcs = ["gpu_decompress.cpp"],
-    headers = ["gpu_decompress.h"],
-    exported_deps = ["../../../..:zstronglib"],
+    headers = relative_headers([
+        "gpu_decompress.h",
+        "gpu_decompress.hpp",
+    ]),
+    header_namespace = "",
+    exported_deps = [
+        "../../../..:zstronglib",
+        "../../../../cpp:openzl_cpp",
+    ],
+    external_deps = ["cuda"],
+)
+
+cpp_unittest(
+    # @autodeps-skip
+    name = "gpu_decompress_test",
+    srcs = ["tests/GpuDecompressTest.cpp"],
+    network_access = network_access_utils.none(),
+    deps = [
+        "../../testkit:testkit",
+        "fbsource//third-party/googletest:gtest",
+        ":decompress",
+    ],
+)
+
+# Temporary full-frame D2H discovery path. Keep its GPU-dependent coverage
+# separate so both the implementation and test can be removed together.
+cpp_unittest(
+    # @autodeps-skip
+    name = "gpu_decompress_full_copy_test",
+    srcs = ["tests/GpuDecompressFullCopyTest.cu"],
+    keep_gpu_sections = True,
+    labels = [tpx_labels.serialize]
+    + ci.labels(
+        ci.replace({ci.linux(ci.dev()): ci.linux(ci.mode("fbcode//mode/dev-nosan"))}),
+        ci.remove(ci.linux(ci.coverage(ci.mode("fbcode//mode/dev-cov")))),
+    ),
+    network_access = network_access_utils.none(),
+    nvcc_flags = get_nvcc_arch_args() + ["-lineinfo"],
+    remote_execution = re_test_utils.remote_execution(
+        platform = "gpu-remote-execution",
+        use_case = "tpx-default",
+    ),
+    target_compatible_with = sanitizers.sanitizer_enabled(
+        no = [],
+        yes = ["ovr_config//:none"],
+    ),
+    deps = [
+        "../../source/common:cuda_raii",
+        "../../testkit:testkit",
+        "fbsource//third-party/googletest:gtest",
+        ":decompress",
+    ],
+    external_deps = [("cuda", None, "cuda-lazy")],
 )

--- a/contrib/gpu/src/decompress/gpu_decompress.cpp
+++ b/contrib/gpu/src/decompress/gpu_decompress.cpp
@@ -2,6 +2,26 @@
 
 #include "openzl/dev/contrib/gpu/src/decompress/gpu_decompress.h"
 
+#include <span>
+
+namespace openzl::gpu::detail {
+
+struct GPUChunk {
+    const void* frameHeader_d;
+    size_t frameHeaderSize;
+    const void* chunk_d;
+    size_t chunkSize;
+    size_t chunkHeaderSize;
+};
+
+ZL_Report
+decompressChunks(void*, size_t, std::span<const GPUChunk>, ZL_GPU_Stream)
+{
+    return ZL_returnError(ZL_ErrorCode_GENERIC); // not implemented yet
+}
+
+} // namespace openzl::gpu::detail
+
 extern "C" ZL_Report
 ZL_GPU_decompress(void*, size_t, const void*, size_t, ZL_GPU_Stream)
 {

--- a/contrib/gpu/src/decompress/gpu_decompress.cpp
+++ b/contrib/gpu/src/decompress/gpu_decompress.cpp
@@ -1,29 +1,187 @@
 // Copyright (c) Meta Platforms, Inc. and affiliates.
 
-#include "openzl/dev/contrib/gpu/src/decompress/gpu_decompress.h"
+#include <cuda_runtime_api.h>
 
+#include <cstddef>
+#include <new>
 #include <span>
+#include <string_view>
+#include <vector>
 
-namespace openzl::gpu::detail {
+#include "contrib/gpu/src/decompress/gpu_decompress.hpp"
+#include "openzl/cpp/DCtx.hpp"
+#include "openzl/cpp/FrameInfo.hpp"
+#include "openzl/decompress/dctx2.h"
+#include "openzl/zl_decompress.h"
+#include "openzl/zl_version.h"
 
-struct GPUChunk {
-    const void* frameHeader_d;
-    size_t frameHeaderSize;
-    const void* chunk_d;
-    size_t chunkSize;
-    size_t chunkHeaderSize;
-};
+namespace openzl::gpu {
 
-ZL_Report
-decompressChunks(void*, size_t, std::span<const GPUChunk>, ZL_GPU_Stream)
+namespace {
+
+std::string_view asStringView(std::span<const std::byte> bytes)
 {
-    return ZL_returnError(ZL_ErrorCode_GENERIC); // not implemented yet
+    return {
+        reinterpret_cast<const char*>(bytes.data()),
+        bytes.size(),
+    };
 }
 
-} // namespace openzl::gpu::detail
+} // namespace
 
-extern "C" ZL_Report
-ZL_GPU_decompress(void*, size_t, const void*, size_t, ZL_GPU_Stream)
+ZL_Report decompressChunks(
+        void*,
+        size_t,
+        std::span<const GPUFrameHeaderForChunks>,
+        std::span<const GPUChunk>,
+        ZL_GPU_Stream)
 {
-    return ZL_returnError(ZL_ErrorCode_GENERIC); // not implemented yet
+    ZL_RESULT_DECLARE_SCOPE_REPORT(nullptr);
+    ZL_ERR(GENERIC, "GPU decompression is not implemented");
+}
+
+ZL_Report collectGPUChunksFromFrame(
+        const void* src_d,
+        std::span<const std::byte> src_h,
+        std::vector<GPUChunk>& chunks,
+        std::vector<GPUFrameHeaderForChunks>& frameHeaders)
+{
+    ZL_RESULT_DECLARE_SCOPE_REPORT(nullptr);
+    ZL_TRY_LET_CONST(
+            size_t,
+            frameHeaderSize,
+            ZL_getHeaderSize(src_h.data(), src_h.size()));
+
+    FrameInfo frameInfo{ asStringView(src_h) };
+    size_t const formatVersion = frameInfo.formatVersion();
+    ZL_ERR_IF_LT(
+            formatVersion, ZL_CHUNK_VERSION_MIN, formatVersion_unsupported);
+
+    DCtx dctx;
+
+    ZL_ERR_IF_ERR(DCTX_initFromFrameInfo(dctx.get(), frameInfo.get()));
+
+    const std::byte* const frame_d = static_cast<const std::byte*>(src_d);
+    const GPUFrameHeaderForChunks collectedFrameHeader{
+        .frameHeader_d   = frame_d,
+        .frameHeaderSize = frameHeaderSize,
+    };
+    size_t const frameHeaderIdx = frameHeaders.size();
+    std::vector<GPUChunk> collectedChunks;
+    // look for first chunk after frame header ends
+    size_t chunkOffset = frameHeaderSize;
+    while (true) {
+        ZL_ERR_IF_GE(chunkOffset, src_h.size(), srcSize_tooSmall);
+
+        // end of frame
+        if (src_h[chunkOffset] == std::byte{ 0 }) {
+            ++chunkOffset;
+            break;
+        }
+
+        ZL_TRY_LET_CONST(
+                DCTX_FrameChunkInfo,
+                chunkInfo,
+                DCTX_prepareFrameChunk(
+                        dctx.get(), src_h.data(), src_h.size(), chunkOffset));
+        ZL_ERR_IF_EQ(chunkInfo.chunkSize, 0, corruption);
+        ZL_ERR_IF_GT(
+                chunkInfo.chunkSize,
+                src_h.size() - chunkOffset,
+                srcSize_tooSmall);
+
+        collectedChunks.push_back(
+                {
+                        .frameHeaderIdx  = frameHeaderIdx,
+                        .chunk_d         = frame_d + chunkOffset,
+                        .chunkSize       = chunkInfo.chunkSize,
+                        .chunkHeaderSize = chunkInfo.chunkHeaderSize,
+                });
+        chunkOffset += chunkInfo.chunkSize;
+    }
+    ZL_ERR_IF_NE(chunkOffset, src_h.size(), srcSize_tooLarge);
+
+    ZL_ERR_IF_EQ(frameHeaders.size(), frameHeaders.max_size(), allocation);
+    ZL_ERR_IF_GT(
+            collectedChunks.size(),
+            chunks.max_size() - chunks.size(),
+            allocation);
+    frameHeaders.reserve(frameHeaders.size() + 1);
+    chunks.reserve(chunks.size() + collectedChunks.size());
+    frameHeaders.push_back(collectedFrameHeader);
+    chunks.insert(chunks.end(), collectedChunks.begin(), collectedChunks.end());
+    return ZL_returnValue(chunkOffset);
+}
+
+namespace {
+
+// temporary until we can replace with jump table
+ZL_Report collectGPUChunksFromFullCopy(
+        std::span<const std::byte> src_d,
+        ZL_GPU_Stream stream,
+        std::vector<GPUChunk>& chunks,
+        std::vector<GPUFrameHeaderForChunks>& frameHeaders)
+{
+    ZL_RESULT_DECLARE_SCOPE_REPORT(nullptr);
+    std::vector<std::byte> src_h;
+    ZL_ERR_IF_GT(src_d.size(), src_h.max_size(), srcSize_tooLarge);
+    src_h.resize(src_d.size());
+
+    cudaError_t cudaResult = cudaMemcpyAsync(
+            src_h.data(),
+            src_d.data(),
+            src_d.size(),
+            cudaMemcpyDeviceToHost,
+            stream);
+    ZL_ERR_IF_NE(cudaResult, cudaSuccess, GENERIC);
+    cudaResult = cudaStreamSynchronize(stream);
+    ZL_ERR_IF_NE(cudaResult, cudaSuccess, GENERIC);
+
+    return collectGPUChunksFromFrame(src_d.data(), src_h, chunks, frameHeaders);
+}
+
+} // namespace
+
+ZL_Report collectGPUChunks(
+        std::span<const std::byte> src_d,
+        ZL_GPU_Stream stream,
+        std::vector<GPUChunk>& chunks,
+        std::vector<GPUFrameHeaderForChunks>& frameHeaders)
+{
+    // Not inline so we can replace with jump table later
+    return collectGPUChunksFromFullCopy(src_d, stream, chunks, frameHeaders);
+}
+
+} // namespace openzl::gpu
+
+extern "C" ZL_Report ZL_GPU_decompress(
+        void* dst_d,
+        size_t dstCapacity,
+        const void* src_d,
+        size_t srcSize,
+        ZL_GPU_Stream stream)
+{
+    ZL_RESULT_DECLARE_SCOPE_REPORT(nullptr);
+    try {
+        std::vector<openzl::gpu::GPUChunk> chunks;
+        std::vector<openzl::gpu::GPUFrameHeaderForChunks> frameHeaders;
+        ZL_Report const collectResult = openzl::gpu::collectGPUChunks(
+                std::span<const std::byte>{
+                        static_cast<const std::byte*>(src_d),
+                        srcSize,
+                },
+                stream,
+                chunks,
+                frameHeaders);
+        if (ZL_isError(collectResult)) {
+            return collectResult;
+        }
+
+        return openzl::gpu::decompressChunks(
+                dst_d, dstCapacity, frameHeaders, chunks, stream);
+    } catch (const std::bad_alloc&) {
+        ZL_ERR(allocation, "GPU decompression allocation failed");
+    } catch (...) {
+        ZL_ERR(GENERIC, "GPU decompression failed with an exception");
+    }
 }

--- a/contrib/gpu/src/decompress/gpu_decompress.cpp
+++ b/contrib/gpu/src/decompress/gpu_decompress.cpp
@@ -12,6 +12,7 @@
 #include "openzl/cpp/DCtx.hpp"
 #include "openzl/cpp/FrameInfo.hpp"
 #include "openzl/decompress/dctx2.h"
+#include "openzl/shared/overflow.h"
 #include "openzl/zl_decompress.h"
 #include "openzl/zl_version.h"
 
@@ -29,14 +30,146 @@ std::string_view asStringView(std::span<const std::byte> bytes)
 
 } // namespace
 
+namespace {
+
+struct StagedChunkHeader {
+    std::span<const std::byte> bytes_h;
+    size_t frameHeaderIdx;
+};
+
+struct StagedHeaders {
+    // TODO(maxmandina): Explore context-owned pinned staging if header-copy
+    // latency becomes worth amortizing.
+    std::vector<std::byte> storage_h;
+    std::vector<std::span<const std::byte>> frameHeaders_h;
+    std::vector<StagedChunkHeader> chunkHeaders_h;
+};
+
+ZL_Report copyHeadersToHost(
+        std::span<const GPUFrameHeaderForChunks> frameHeaders,
+        std::span<const GPUChunk> chunks,
+        ZL_GPU_Stream stream,
+        StagedHeaders& stagedHeaders)
+{
+    ZL_RESULT_DECLARE_SCOPE_REPORT(nullptr);
+
+    size_t stagingSize = 0;
+    for (const GPUFrameHeaderForChunks& frameHeader : frameHeaders) {
+        ZL_ERR_IF(
+                frameHeader.frameHeader_d == nullptr
+                        || frameHeader.frameHeaderSize == 0,
+                parameter_invalid);
+        ZL_ERR_IF(
+                ZL_overflowAddST(
+                        stagingSize, frameHeader.frameHeaderSize, &stagingSize),
+                allocation);
+    }
+    for (const GPUChunk& chunk : chunks) {
+        ZL_ERR_IF(
+                chunk.frameHeaderIdx >= frameHeaders.size()
+                        || chunk.chunk_d == nullptr
+                        || chunk.chunkHeaderSize == 0
+                        || chunk.chunkHeaderSize > chunk.chunkSize,
+                parameter_invalid);
+        ZL_ERR_IF(
+                ZL_overflowAddST(
+                        stagingSize, chunk.chunkHeaderSize, &stagingSize),
+                allocation);
+    }
+
+    stagedHeaders.frameHeaders_h.reserve(frameHeaders.size());
+    stagedHeaders.chunkHeaders_h.reserve(chunks.size());
+
+    // Allocate the host buffer before starting copies or creating views into
+    // it, so its address cannot move.
+    stagedHeaders.storage_h.resize(stagingSize);
+
+    size_t dstOffset  = 0;
+    bool copyEnqueued = false;
+    for (const GPUFrameHeaderForChunks& frameHeader : frameHeaders) {
+        cudaError_t const result = cudaMemcpyAsync(
+                stagedHeaders.storage_h.data() + dstOffset,
+                frameHeader.frameHeader_d,
+                frameHeader.frameHeaderSize,
+                cudaMemcpyDeviceToHost,
+                stream);
+        if (result != cudaSuccess) {
+            if (copyEnqueued) {
+                // The destination buffer must outlive any queued D2H copies.
+                (void)cudaStreamSynchronize(stream);
+            }
+            ZL_ERR(GENERIC,
+                   "cudaMemcpyAsync failed: %s",
+                   cudaGetErrorString(result));
+        }
+        copyEnqueued = true;
+        dstOffset += frameHeader.frameHeaderSize;
+    }
+    for (const GPUChunk& chunk : chunks) {
+        cudaError_t const result = cudaMemcpyAsync(
+                stagedHeaders.storage_h.data() + dstOffset,
+                chunk.chunk_d,
+                chunk.chunkHeaderSize,
+                cudaMemcpyDeviceToHost,
+                stream);
+        if (result != cudaSuccess) {
+            if (copyEnqueued) {
+                // The destination buffer must outlive any queued D2H copies.
+                (void)cudaStreamSynchronize(stream);
+            }
+            ZL_ERR(GENERIC,
+                   "cudaMemcpyAsync failed: %s",
+                   cudaGetErrorString(result));
+        }
+        copyEnqueued = true;
+        dstOffset += chunk.chunkHeaderSize;
+    }
+    if (copyEnqueued) {
+        cudaError_t const result = cudaStreamSynchronize(stream);
+        ZL_ERR_IF_NE(result, cudaSuccess, GENERIC);
+    }
+
+    // Preserve frame-header order so each chunk index also identifies the
+    // corresponding staged header.
+    size_t headerOffset = 0;
+    for (const GPUFrameHeaderForChunks& frameHeader : frameHeaders) {
+        stagedHeaders.frameHeaders_h.emplace_back(
+                stagedHeaders.storage_h.data() + headerOffset,
+                frameHeader.frameHeaderSize);
+        headerOffset += frameHeader.frameHeaderSize;
+    }
+    for (const GPUChunk& chunk : chunks) {
+        std::span<const std::byte> const headerBytes_h{
+            stagedHeaders.storage_h.data() + headerOffset,
+            chunk.chunkHeaderSize,
+        };
+        stagedHeaders.chunkHeaders_h.push_back(
+                {
+                        .bytes_h        = headerBytes_h,
+                        .frameHeaderIdx = chunk.frameHeaderIdx,
+                });
+        headerOffset += chunk.chunkHeaderSize;
+    }
+
+    return ZL_returnSuccess();
+}
+
+} // namespace
+
 ZL_Report decompressChunks(
         void*,
         size_t,
-        std::span<const GPUFrameHeaderForChunks>,
-        std::span<const GPUChunk>,
-        ZL_GPU_Stream)
+        std::span<const GPUFrameHeaderForChunks> frameHeaders,
+        std::span<const GPUChunk> chunks,
+        ZL_GPU_Stream stream)
 {
     ZL_RESULT_DECLARE_SCOPE_REPORT(nullptr);
+    StagedHeaders stagedHeaders;
+    ZL_Report const copyResult =
+            copyHeadersToHost(frameHeaders, chunks, stream, stagedHeaders);
+    if (ZL_isError(copyResult)) {
+        return copyResult;
+    }
     ZL_ERR(GENERIC, "GPU decompression is not implemented");
 }
 

--- a/contrib/gpu/src/decompress/gpu_decompress.h
+++ b/contrib/gpu/src/decompress/gpu_decompress.h
@@ -22,6 +22,8 @@ extern "C" {
  * are device pointers; the decode is enqueued on @p stream and may run
  * asynchronously with respect to the host.
  *
+ * @note Only frame format version 21 and newer is supported.
+ *
  * @param dst_d Device buffer that receives the decompressed output.
  * @param dstCapacity Capacity of @p dst_d in bytes; at least the frame's
  * decompressed size.

--- a/contrib/gpu/src/decompress/gpu_decompress.hpp
+++ b/contrib/gpu/src/decompress/gpu_decompress.hpp
@@ -1,0 +1,101 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#pragma once
+
+#include <cstddef>
+#include <span>
+#include <vector>
+
+#include "contrib/gpu/src/decompress/gpu_decompress.h"
+#include "openzl/zl_errors.h"
+
+namespace openzl::gpu {
+
+/** Non-owning metadata for one compressed frame header in device memory. */
+struct GPUFrameHeaderForChunks {
+    /// Beginning of the encoded frame header.
+    const void* frameHeader_d;
+    /// Number of bytes in the frame header.
+    size_t frameHeaderSize;
+};
+
+/**
+ * Non-owning metadata for one compressed chunk in device memory.
+ *
+ * @p chunk_d refers into a device allocation owned by the caller. Its storage
+ * must remain valid until work using this descriptor has completed on its CUDA
+ * stream. @p frameHeaderIdx identifies the frame-header descriptor supplied
+ * alongside this chunk.
+ */
+struct GPUChunk {
+    /// Index of this chunk's frame header in the accompanying descriptor list.
+    size_t frameHeaderIdx;
+    /// Beginning of the encoded chunk, including its formal header.
+    const void* chunk_d;
+    /// Total encoded chunk size, including headers and checksums.
+    size_t chunkSize;
+    /// Number of bytes in the formal chunk header.
+    size_t chunkHeaderSize;
+};
+
+/**
+ * Enumerates the chunks in one host-readable frame. A temporary solution until
+ * we have a jump table supported by ZL frame format footer.
+ *
+ * @param src_d Beginning of the device frame. This function does not read the
+ * device allocation; it uses the address as the base for each descriptor.
+ * @param src_h Byte-identical host view of the complete frame at @p src_d.
+ * @param chunks Output descriptors. Appended on success and unchanged on
+ * error.
+ * @param frameHeaders Output containing the frame-header descriptor referenced
+ * by the appended chunks. Appended on success and unchanged on error.
+ * @returns The compressed frame size on success, or an error.
+ *
+ * @note Only frame format version 21 and newer is supported.
+ */
+ZL_Report collectGPUChunksFromFrame(
+        const void* src_d,
+        std::span<const std::byte> src_h,
+        std::vector<GPUChunk>& chunks,
+        std::vector<GPUFrameHeaderForChunks>& frameHeaders);
+
+/**
+ * Copies one device frame to host and enumerates its chunks.
+ *
+ * @param src_d Device allocation containing one complete compressed frame.
+ * @param stream CUDA stream used for the device-to-host copy. The copy is
+ * synchronized before this function returns.
+ * @param chunks Output descriptors. Appended on success and unchanged on
+ * error. Their pointers remain valid only while @p src_d remains valid.
+ * @param frameHeaders Output containing the frame-header descriptor referenced
+ * by the appended chunks. Appended on success and unchanged on error. Its
+ * pointer remains valid only while @p src_d remains valid.
+ * @returns The compressed frame size on success, or an error.
+ */
+ZL_Report collectGPUChunks(
+        std::span<const std::byte> src_d,
+        ZL_GPU_Stream stream,
+        std::vector<GPUChunk>& chunks,
+        std::vector<GPUFrameHeaderForChunks>& frameHeaders);
+
+/**
+ * Decompresses independently prepared chunks on @p stream.
+ *
+ * @param dst_d Device allocation that receives decompressed output.
+ * @param dstCapacity Capacity of @p dst_d in bytes.
+ * @param frameHeaders Non-owning frame-header descriptors referenced by
+ * @p chunks.
+ * @param chunks Non-owning descriptors for the chunks to decompress. All
+ * frame-header indices must refer to @p frameHeaders, and all referenced device
+ * storage must remain valid until the enqueued work has completed on @p stream.
+ * @param stream CUDA stream on which decompression is enqueued.
+ * @returns The decompressed size on success, or an error.
+ */
+ZL_Report decompressChunks(
+        void* dst_d,
+        size_t dstCapacity,
+        std::span<const GPUFrameHeaderForChunks> frameHeaders,
+        std::span<const GPUChunk> chunks,
+        ZL_GPU_Stream stream);
+
+} // namespace openzl::gpu

--- a/contrib/gpu/src/decompress/tests/GpuDecompressFullCopyTest.cu
+++ b/contrib/gpu/src/decompress/tests/GpuDecompressFullCopyTest.cu
@@ -1,0 +1,102 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#include <gtest/gtest.h>
+
+#include <cstddef>
+#include <cstdint>
+#include <span>
+#include <string>
+#include <vector>
+
+#include <cuda_runtime.h>
+
+#include "contrib/gpu/src/decompress/gpu_decompress.hpp"
+#include "openzl/dev/contrib/gpu/source/common/cuda_error.cuh"
+#include "openzl/dev/contrib/gpu/source/common/cuda_raii.cuh"
+#include "openzl/dev/contrib/gpu/testkit/multichunk_frame.h"
+#include "openzl/openzl.hpp"
+
+namespace openzl {
+namespace tests {
+namespace {
+
+constexpr size_t kEltsPerChunk = 20000;
+
+std::string makeTwoChunkFrame()
+{
+    std::vector<int32_t> values(2 * kEltsPerChunk);
+    for (size_t i = 0; i < values.size(); ++i) {
+        values[i] = static_cast<int32_t>(i % 8);
+    }
+
+    const Input input =
+            Input::refNumeric<int32_t>(values.data(), values.size());
+    Compressor compressor;
+    const GraphID bitpack = graphs::Bitpack{}();
+    return gpu::testkit::makeMultiChunkFrame(
+            compressor,
+            {
+                    gpu::testkit::ChunkSpec{ kEltsPerChunk, bitpack },
+                    gpu::testkit::ChunkSpec{ kEltsPerChunk, bitpack },
+            },
+            input);
+}
+
+std::span<const std::byte> bytes(const std::string& frame)
+{
+    return {
+        reinterpret_cast<const std::byte*>(frame.data()),
+        frame.size(),
+    };
+}
+
+TEST(GPUDecompressFullCopyTest, MatchesDirectHostEnumeration)
+{
+    // This test verifies the temporary provider copies a complete device frame
+    // to host before parsing it; it fails if D2H staging changes chunk count,
+    // sizes, frame associations, or device-relative pointers.
+    const std::string frame = makeTwoChunkFrame();
+    gpu::DevicePtr<std::byte> deviceFrame_d =
+            gpu::deviceAlloc<std::byte>(frame.size());
+    ZL_CUDA_CHECK(cudaMemcpy(
+            deviceFrame_d.get(),
+            frame.data(),
+            frame.size(),
+            cudaMemcpyHostToDevice));
+
+    std::vector<gpu::GPUChunk> expected;
+    std::vector<gpu::GPUFrameHeaderForChunks> expectedFrameHeaders;
+    ZL_Report const expectedResult = gpu::collectGPUChunksFromFrame(
+            deviceFrame_d.get(), bytes(frame), expected, expectedFrameHeaders);
+    ASSERT_FALSE(ZL_isError(expectedResult));
+
+    std::vector<gpu::GPUChunk> actual;
+    std::vector<gpu::GPUFrameHeaderForChunks> actualFrameHeaders;
+    ZL_Report const actualResult = gpu::collectGPUChunks(
+            { deviceFrame_d.get(), frame.size() },
+            nullptr,
+            actual,
+            actualFrameHeaders);
+    ASSERT_FALSE(ZL_isError(actualResult));
+    EXPECT_EQ(ZL_validResult(actualResult), ZL_validResult(expectedResult));
+    ASSERT_EQ(actualFrameHeaders.size(), expectedFrameHeaders.size());
+    ASSERT_EQ(actualFrameHeaders.size(), 1);
+    EXPECT_EQ(
+            actualFrameHeaders[0].frameHeader_d,
+            expectedFrameHeaders[0].frameHeader_d);
+    EXPECT_EQ(
+            actualFrameHeaders[0].frameHeaderSize,
+            expectedFrameHeaders[0].frameHeaderSize);
+    ASSERT_EQ(actual.size(), expected.size());
+
+    for (size_t i = 0; i < actual.size(); ++i) {
+        EXPECT_EQ(actual[i].frameHeaderIdx, expected[i].frameHeaderIdx);
+        EXPECT_EQ(actual[i].chunk_d, expected[i].chunk_d);
+        EXPECT_EQ(actual[i].chunkSize, expected[i].chunkSize);
+        EXPECT_EQ(actual[i].chunkHeaderSize, expected[i].chunkHeaderSize);
+    }
+}
+
+} // namespace
+} // namespace tests
+} // namespace openzl

--- a/contrib/gpu/src/decompress/tests/GpuDecompressTest.cpp
+++ b/contrib/gpu/src/decompress/tests/GpuDecompressTest.cpp
@@ -1,0 +1,233 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#include <gtest/gtest.h>
+
+#include <cstddef>
+#include <cstdint>
+#include <limits>
+#include <span>
+#include <string>
+#include <vector>
+
+#include "contrib/gpu/src/decompress/gpu_decompress.hpp"
+#include "openzl/dev/contrib/gpu/testkit/frame_verifier.h"
+#include "openzl/dev/contrib/gpu/testkit/multichunk_frame.h"
+#include "openzl/openzl.hpp"
+#include "openzl/zl_decompress.h"
+#include "openzl/zl_version.h"
+
+namespace openzl {
+namespace tests {
+namespace {
+
+constexpr size_t kEltsPerChunk = 20000;
+
+std::string makeTwoChunkFrameWithMultiCodecChunk()
+{
+    std::vector<int32_t> values(2 * kEltsPerChunk);
+    for (size_t i = 0; i < kEltsPerChunk; ++i) {
+        values[i]                 = static_cast<int32_t>(i % 8);
+        values[kEltsPerChunk + i] = static_cast<int32_t>(i) * 3;
+    }
+
+    const Input input =
+            Input::refNumeric<int32_t>(values.data(), values.size());
+    Compressor compressor;
+    const GraphID bitpack      = graphs::Bitpack{}();
+    const GraphID deltaToStore = ZL_Compressor_registerStaticGraph_fromNode1o(
+            compressor.get(), nodes::DeltaInt::node, graphs::Store{}());
+    return gpu::testkit::makeMultiChunkFrame(
+            compressor,
+            {
+                    gpu::testkit::ChunkSpec{ kEltsPerChunk, bitpack },
+                    gpu::testkit::ChunkSpec{ kEltsPerChunk, deltaToStore },
+            },
+            input);
+}
+
+std::string makeLegacyFrame()
+{
+    const std::string input(1000, 'x');
+    Compressor compressor;
+    compressor.selectStartingGraph(graphs::Store{}());
+
+    CCtx cctx;
+    cctx.refCompressor(compressor);
+    cctx.setParameter(CParam::FormatVersion, ZL_CHUNK_VERSION_MIN - 1);
+    return cctx.compressOne(Input::refSerial(input));
+}
+
+std::span<const std::byte> bytes(const std::string& frame)
+{
+    return {
+        reinterpret_cast<const std::byte*>(frame.data()),
+        frame.size(),
+    };
+}
+
+TEST(GPUDecompressTest, CollectGPUChunksFromFrameEnumeratesEveryChunk)
+{
+    // This test verifies that one frame produces an ordered descriptor for
+    // every chunk; it fails if enumeration skips a chunk or miscomputes a
+    // device pointer, frame-header association, or chunk boundary. The second
+    // chunk uses two codecs so its formal header exercises multiple decoder
+    // nodes.
+    const std::string frame = makeTwoChunkFrameWithMultiCodecChunk();
+    const std::vector<std::vector<uint32_t>> codecsPerChunk =
+            gpu::testkit::standardCodecsPerChunk(frame);
+    ASSERT_EQ(codecsPerChunk.size(), 2);
+    EXPECT_EQ(codecsPerChunk[0].size(), 1);
+    EXPECT_EQ(codecsPerChunk[1].size(), 2);
+    std::vector<std::byte> deviceFrame(frame.size());
+    std::vector<gpu::GPUChunk> chunks;
+    std::vector<gpu::GPUFrameHeaderForChunks> frameHeaders;
+
+    ZL_Report const result = gpu::collectGPUChunksFromFrame(
+            deviceFrame.data(), bytes(frame), chunks, frameHeaders);
+    ASSERT_FALSE(ZL_isError(result));
+    EXPECT_EQ(ZL_validResult(result), frame.size());
+    ASSERT_EQ(chunks.size(), 2);
+    ASSERT_EQ(frameHeaders.size(), 1);
+
+    ZL_Report const headerResult = ZL_getHeaderSize(frame.data(), frame.size());
+    ASSERT_FALSE(ZL_isError(headerResult));
+    size_t const frameHeaderSize = ZL_validResult(headerResult);
+    EXPECT_EQ(frameHeaders[0].frameHeader_d, deviceFrame.data());
+    EXPECT_EQ(frameHeaders[0].frameHeaderSize, frameHeaderSize);
+
+    size_t chunkOffset = frameHeaderSize;
+    for (const gpu::GPUChunk& chunk : chunks) {
+        EXPECT_EQ(chunk.frameHeaderIdx, 0);
+        EXPECT_EQ(chunk.chunk_d, deviceFrame.data() + chunkOffset);
+        EXPECT_GT(chunk.chunkHeaderSize, 0);
+        EXPECT_LE(chunk.chunkHeaderSize, chunk.chunkSize);
+        chunkOffset += chunk.chunkSize;
+    }
+    ASSERT_EQ(chunkOffset + 1, frame.size());
+    EXPECT_EQ(frame[chunkOffset], '\0');
+}
+
+TEST(GPUDecompressTest, CollectGPUChunksFromFrameAppendsToExistingBatch)
+{
+    // This test verifies that frames can be collected into one batch across
+    // repeated calls; it fails if a later frame replaces earlier descriptors
+    // or its chunks reference the wrong frame-header index.
+    const std::string frame = makeTwoChunkFrameWithMultiCodecChunk();
+    std::vector<std::byte> firstDeviceFrame(frame.size());
+    std::vector<std::byte> secondDeviceFrame(frame.size());
+    std::vector<gpu::GPUChunk> chunks;
+    std::vector<gpu::GPUFrameHeaderForChunks> frameHeaders;
+
+    ZL_Report const firstResult = gpu::collectGPUChunksFromFrame(
+            firstDeviceFrame.data(), bytes(frame), chunks, frameHeaders);
+    ASSERT_FALSE(ZL_isError(firstResult));
+    ZL_Report const secondResult = gpu::collectGPUChunksFromFrame(
+            secondDeviceFrame.data(), bytes(frame), chunks, frameHeaders);
+    ASSERT_FALSE(ZL_isError(secondResult));
+
+    ASSERT_EQ(frameHeaders.size(), 2);
+    EXPECT_EQ(frameHeaders[0].frameHeader_d, firstDeviceFrame.data());
+    EXPECT_EQ(frameHeaders[1].frameHeader_d, secondDeviceFrame.data());
+    ASSERT_EQ(chunks.size(), 4);
+    EXPECT_EQ(chunks[0].frameHeaderIdx, 0);
+    EXPECT_EQ(chunks[1].frameHeaderIdx, 0);
+    EXPECT_EQ(chunks[2].frameHeaderIdx, 1);
+    EXPECT_EQ(chunks[3].frameHeaderIdx, 1);
+
+    ZL_Report const headerResult = ZL_getHeaderSize(frame.data(), frame.size());
+    ASSERT_FALSE(ZL_isError(headerResult));
+    size_t const frameHeaderSize = ZL_validResult(headerResult);
+    EXPECT_EQ(chunks[0].chunk_d, firstDeviceFrame.data() + frameHeaderSize);
+    EXPECT_EQ(chunks[2].chunk_d, secondDeviceFrame.data() + frameHeaderSize);
+}
+
+TEST(GPUDecompressTest, CApiRejectsImpossibleSourceSize)
+{
+    // This test verifies that a source size no host allocation can represent
+    // produces an error report; it fails if the input is accepted or terminates
+    // the process.
+    ZL_Report const result = ZL_GPU_decompress(
+            nullptr, 0, nullptr, std::numeric_limits<size_t>::max(), nullptr);
+
+    EXPECT_EQ(ZL_errorCode(result), ZL_ErrorCode_srcSize_tooLarge);
+}
+
+TEST(GPUDecompressTest, CollectGPUChunksFromFrameRejectsLegacyFormat)
+{
+    // This test verifies the documented v21 format floor; it fails if a legacy
+    // frame reaches chunk enumeration even though it has no separate chunks.
+    const std::string frame = makeLegacyFrame();
+    std::vector<std::byte> deviceFrame(frame.size());
+    std::vector<gpu::GPUChunk> chunks;
+    std::vector<gpu::GPUFrameHeaderForChunks> frameHeaders;
+
+    ZL_Report const result = gpu::collectGPUChunksFromFrame(
+            deviceFrame.data(), bytes(frame), chunks, frameHeaders);
+
+    EXPECT_EQ(ZL_errorCode(result), ZL_ErrorCode_formatVersion_unsupported);
+    EXPECT_TRUE(chunks.empty());
+    EXPECT_TRUE(frameHeaders.empty());
+}
+
+TEST(GPUDecompressTest, CollectGPUChunksFromFrameRejectsTrailingBytes)
+{
+    // This test verifies that enumeration consumes exactly one frame and only
+    // appends to its outputs on success; it fails if trailing bytes are
+    // accepted or either output is partially modified on error.
+    std::string frame = makeTwoChunkFrameWithMultiCodecChunk();
+    frame.push_back('\x7f');
+    std::vector<std::byte> deviceFrame(frame.size());
+    std::byte sentinel{};
+    const gpu::GPUChunk expectedChunk{
+        .frameHeaderIdx  = 7,
+        .chunk_d         = &sentinel,
+        .chunkSize       = 11,
+        .chunkHeaderSize = 3,
+    };
+    const gpu::GPUFrameHeaderForChunks expectedFrameHeader{
+        .frameHeader_d   = &sentinel,
+        .frameHeaderSize = 5,
+    };
+    std::vector<gpu::GPUChunk> chunks{ expectedChunk };
+    std::vector<gpu::GPUFrameHeaderForChunks> frameHeaders{
+        expectedFrameHeader
+    };
+
+    ZL_Report const result = gpu::collectGPUChunksFromFrame(
+            deviceFrame.data(), bytes(frame), chunks, frameHeaders);
+
+    EXPECT_EQ(ZL_errorCode(result), ZL_ErrorCode_srcSize_tooLarge);
+    ASSERT_EQ(chunks.size(), 1);
+    EXPECT_EQ(chunks[0].frameHeaderIdx, expectedChunk.frameHeaderIdx);
+    EXPECT_EQ(chunks[0].chunk_d, expectedChunk.chunk_d);
+    EXPECT_EQ(chunks[0].chunkSize, expectedChunk.chunkSize);
+    EXPECT_EQ(chunks[0].chunkHeaderSize, expectedChunk.chunkHeaderSize);
+    ASSERT_EQ(frameHeaders.size(), 1);
+    EXPECT_EQ(frameHeaders[0].frameHeader_d, expectedFrameHeader.frameHeader_d);
+    EXPECT_EQ(
+            frameHeaders[0].frameHeaderSize,
+            expectedFrameHeader.frameHeaderSize);
+}
+
+TEST(GPUDecompressTest, CollectGPUChunksFromFrameRejectsMissingEndMarker)
+{
+    // This test verifies that a frame must include its terminating marker; it
+    // fails if a truncated frame is reported as successfully enumerated.
+    std::string frame = makeTwoChunkFrameWithMultiCodecChunk();
+    ASSERT_EQ(frame.back(), '\0');
+    frame.pop_back();
+    std::vector<std::byte> deviceFrame(frame.size());
+    std::vector<gpu::GPUChunk> chunks;
+    std::vector<gpu::GPUFrameHeaderForChunks> frameHeaders;
+
+    ZL_Report const result = gpu::collectGPUChunksFromFrame(
+            deviceFrame.data(), bytes(frame), chunks, frameHeaders);
+
+    EXPECT_EQ(ZL_errorCode(result), ZL_ErrorCode_srcSize_tooSmall);
+    EXPECT_TRUE(chunks.empty());
+    EXPECT_TRUE(frameHeaders.empty());
+}
+
+} // namespace
+} // namespace tests
+} // namespace openzl

--- a/contrib/gpu/src/decompress/tests/GpuDecompressTest.cpp
+++ b/contrib/gpu/src/decompress/tests/GpuDecompressTest.cpp
@@ -141,6 +141,32 @@ TEST(GPUDecompressTest, CollectGPUChunksFromFrameAppendsToExistingBatch)
     EXPECT_EQ(chunks[2].chunk_d, secondDeviceFrame.data() + frameHeaderSize);
 }
 
+TEST(GPUDecompressTest, DecompressChunksRejectsUnknownFrameHeader)
+{
+    // This test verifies that every chunk names a supplied frame header; it
+    // fails if an out-of-range index reaches device-to-host staging.
+    std::byte sentinel{};
+    const std::vector<gpu::GPUFrameHeaderForChunks> frameHeaders{
+        {
+                .frameHeader_d   = &sentinel,
+                .frameHeaderSize = 1,
+        },
+    };
+    const std::vector<gpu::GPUChunk> chunks{
+        {
+                .frameHeaderIdx  = frameHeaders.size(),
+                .chunk_d         = &sentinel,
+                .chunkSize       = 1,
+                .chunkHeaderSize = 1,
+        },
+    };
+
+    ZL_Report const result =
+            gpu::decompressChunks(nullptr, 0, frameHeaders, chunks, nullptr);
+
+    EXPECT_EQ(ZL_errorCode(result), ZL_ErrorCode_parameter_invalid);
+}
+
 TEST(GPUDecompressTest, CApiRejectsImpossibleSourceSize)
 {
     // This test verifies that a source size no host allocation can represent

--- a/src/openzl/decompress/dctx2.h
+++ b/src/openzl/decompress/dctx2.h
@@ -171,6 +171,41 @@ void DCTX_clearDecoderFusions(ZL_DCtx* dctx);
  */
 ZL_Report DCTX_initFromFrameInfo(ZL_DCtx* dctx, const ZL_FrameInfo* frameInfo);
 
+typedef struct {
+    size_t chunkHeaderSize;
+    size_t chunkSize;
+} DCTX_FrameChunkInfo;
+ZL_RESULT_DECLARE_TYPE(DCTX_FrameChunkInfo);
+
+/**
+ * Prepares one chunk without running its decoders.
+ *
+ * @p dctx must first be initialized.
+ * @returns The prepared chunk metadata, or an error.
+ */
+ZL_RESULT_OF(DCTX_FrameChunkInfo)
+DCTX_prepareFrameChunk(
+        ZL_DCtx* dctx,
+        const void* framePtr,
+        size_t frameSize,
+        size_t chunkOffset);
+
+/**
+ * Prepares one chunk from a separately readable formal chunk header.
+ *
+ * Stream references are bound against @p chunkRef, whose contents are not
+ * accessed. Payload and checksum validation are left to the caller.
+ * @p dctx must first be initialized.
+ * @returns Success, or an errors if the stream layout exceeds @p chunkSize
+ * or an error from decoding the header.
+ */
+ZL_Report DCTX_prepareFrameChunkFromHeader(
+        ZL_DCtx* dctx,
+        const void* chunkHeader,
+        size_t chunkHeaderSize,
+        const void* chunkRef,
+        size_t chunkSize);
+
 ZL_END_C_DECLS
 
 #endif // ZSTRONG_DECOMPRESS_DCTX2_H

--- a/src/openzl/decompress/dctx2.h
+++ b/src/openzl/decompress/dctx2.h
@@ -165,6 +165,12 @@ ZL_Report DCTX_registerDecoderFusion(
 /// @see ZL_DecoderFusionState_clearFusions()
 void DCTX_clearDecoderFusions(ZL_DCtx* dctx);
 
+/**
+ * Initializes a newly created decompression context from frame metadata.
+ * The context owns an independent copy of @p frameInfo.
+ */
+ZL_Report DCTX_initFromFrameInfo(ZL_DCtx* dctx, const ZL_FrameInfo* frameInfo);
+
 ZL_END_C_DECLS
 
 #endif // ZSTRONG_DECOMPRESS_DCTX2_H

--- a/src/openzl/decompress/decode_frameheader.c
+++ b/src/openzl/decompress/decode_frameheader.c
@@ -514,6 +514,66 @@ ZL_Report ZL_FrameInfo_getNumElts(const ZL_FrameInfo* zfi, int outputID)
     return ZL_returnValue(zfi->numElts[outputID]);
 }
 
+static ZL_FrameInfo* FrameInfo_clone(const ZL_FrameInfo* src)
+{
+    ZL_FrameInfo* const copy = ZL_malloc(sizeof(*copy));
+    if (copy == NULL)
+        return NULL;
+
+    *copy                   = *src;
+    copy->types             = NULL;
+    copy->decompressedSizes = NULL;
+    copy->numElts           = NULL;
+    copy->comment           = NULL;
+
+    copy->types = ZL_malloc(src->nbOutputs * sizeof(*copy->types));
+    copy->decompressedSizes =
+            ZL_malloc(src->nbOutputs * sizeof(*copy->decompressedSizes));
+    copy->numElts = ZL_malloc(src->nbOutputs * sizeof(*copy->numElts));
+    if (copy->types == NULL || copy->decompressedSizes == NULL
+        || copy->numElts == NULL) {
+        ZL_FrameInfo_free(copy);
+        return NULL;
+    }
+
+    memcpy(copy->types, src->types, src->nbOutputs * sizeof(*copy->types));
+    memcpy(copy->decompressedSizes,
+           src->decompressedSizes,
+           src->nbOutputs * sizeof(*copy->decompressedSizes));
+    memcpy(copy->numElts,
+           src->numElts,
+           src->nbOutputs * sizeof(*copy->numElts));
+
+    if (src->commentSize != 0) {
+        copy->comment = ZL_malloc(src->commentSize);
+        if (copy->comment == NULL) {
+            ZL_FrameInfo_free(copy);
+            return NULL;
+        }
+        memcpy(copy->comment, src->comment, src->commentSize);
+    }
+
+    return copy;
+}
+
+ZL_Report DFH_setFrameInfo(
+        DFH_Struct* dfh,
+        const ZL_FrameInfo* frameInfo,
+        ZL_OperationContext* opCtx)
+{
+    ZL_RESULT_DECLARE_SCOPE_REPORT(opCtx);
+    ZL_ASSERT_NN(dfh);
+    ZL_ASSERT_NN(frameInfo);
+
+    ZL_FrameInfo* const copy = FrameInfo_clone(frameInfo);
+    ZL_ERR_IF_NULL(copy, allocation);
+
+    ZL_FrameInfo_free(dfh->frameinfo);
+    dfh->frameinfo     = copy;
+    dfh->formatVersion = (uint32_t)copy->formatVersion;
+    return ZL_returnSuccess();
+}
+
 ZL_RESULT_OF(ZL_Comment) ZL_FrameInfo_getComment(const ZL_FrameInfo* zfi)
 {
     ZL_RESULT_DECLARE_SCOPE(ZL_Comment, NULL);

--- a/src/openzl/decompress/decode_frameheader.h
+++ b/src/openzl/decompress/decode_frameheader.h
@@ -80,6 +80,17 @@ void DFH_init(DFH_Struct* dfh);
 void DFH_destroy(DFH_Struct* dfh);
 
 /**
+ * Deep-copies @p frameInfo into @p dfh.
+ *
+ * @p dfh must have been initialized with DFH_init().
+ * @p opCtx receives any error details generated while copying.
+ */
+ZL_Report DFH_setFrameInfo(
+        DFH_Struct* dfh,
+        const ZL_FrameInfo* frameInfo,
+        ZL_OperationContext* opCtx);
+
+/**
  * Decode the frame header starting at @src
  * and fill @p dfh with corresponding information.
  *

--- a/src/openzl/decompress/decompress2.c
+++ b/src/openzl/decompress/decompress2.c
@@ -1786,17 +1786,16 @@ static void cleanAllBuffers(ZL_DCtx* dctx)
  * @param frameSize Size of @p framePtr in bytes.
  * @param alreadyConsumed Number of frame bytes consumed before this chunk.
  * @param expectedContentHash Output content checksum, or 0 when absent.
- * @return Number of bytes consumed by this chunk, relative to
- *         @p alreadyConsumed.
+ * @return DCTX_FrameChunkInfo metadata for the prepared chunk.
  */
-static ZL_Report setupChunkDecode(
+static ZL_RESULT_OF(DCTX_FrameChunkInfo) setupChunkDecode(
         ZL_DCtx* dctx,
         const void* framePtr,
         size_t frameSize,
         size_t alreadyConsumed,
         uint32_t* expectedContentHash)
 {
-    ZL_RESULT_DECLARE_SCOPE_REPORT(dctx);
+    ZL_RESULT_DECLARE_SCOPE(DCTX_FrameChunkInfo, dctx);
     size_t consumedSize = alreadyConsumed;
     ZL_DLOG(BLOCK,
             "setupChunkDecode (frameSize=%zu, consumedSize=%zu)",
@@ -1873,10 +1872,69 @@ static ZL_Report setupChunkDecode(
         consumedSize += 4;
     }
 
-    // number of bytes occupied by the chunk
-    return ZL_returnValue(consumedSize - alreadyConsumed);
+    DCTX_FrameChunkInfo const chunkInfo = {
+        .chunkHeaderSize = chunkHeaderSize,
+        .chunkSize       = consumedSize - alreadyConsumed,
+    };
+    return ZL_WRAP_VALUE(chunkInfo);
 }
 
+ZL_RESULT_OF(DCTX_FrameChunkInfo)
+DCTX_prepareFrameChunk(
+        ZL_DCtx* dctx,
+        const void* framePtr,
+        size_t frameSize,
+        size_t chunkOffset)
+{
+    ZL_RESULT_DECLARE_SCOPE(DCTX_FrameChunkInfo, dctx);
+    ZL_ASSERT_NN(dctx);
+
+    // Parse-only setup has no output buffers. Temporarily hide final outputs
+    // so fillStoredStreams skips output-backed append optimizations.
+    size_t const nbOutputs = dctx->nbOutputs;
+    dctx->nbOutputs        = 0;
+
+    uint32_t dummyHash = 0;
+    ZL_RESULT_OF(DCTX_FrameChunkInfo)
+    const chunkResult = setupChunkDecode(
+            dctx, framePtr, frameSize, chunkOffset, &dummyHash);
+
+    dctx->nbOutputs = nbOutputs;
+    ZL_ERR_IF_ERR(chunkResult);
+    return chunkResult;
+}
+
+ZL_Report DCTX_prepareFrameChunkFromHeader(
+        ZL_DCtx* dctx,
+        const void* chunkHeader,
+        size_t chunkHeaderSize,
+        const void* chunkRef,
+        size_t chunkSize)
+{
+    ZL_RESULT_DECLARE_SCOPE_REPORT(dctx);
+    ZL_ASSERT_NN(dctx);
+    ZL_ASSERT_NN(chunkHeader);
+    ZL_ASSERT_NN(chunkRef);
+
+    // We clean at the beginning instead of the end
+    // in case `DCTX_preserveStreams` is set,
+    // requiring to preserve some results for StreamDump2
+    cleanChunkBuffers(dctx);
+
+    ZL_TRY_LET(
+            size_t,
+            decodedChunkHeaderSize,
+            DFH_decodeChunkHeader(&dctx->dfh, chunkHeader, chunkHeaderSize));
+
+    size_t const nbOutputs        = dctx->nbOutputs;
+    dctx->nbOutputs               = 0;
+    ZL_Report const streamsResult = fillStoredStreams(
+            dctx, chunkRef, chunkSize, decodedChunkHeaderSize);
+
+    dctx->nbOutputs = nbOutputs;
+    ZL_ERR_IF_ERR(streamsResult);
+    return ZL_returnSuccess();
+}
 // -------------------------------------
 // Main decompression functions
 // -------------------------------------
@@ -1894,14 +1952,15 @@ static ZL_Report ZL_DCtx_decompressChunk(
     ZL_Data** outputs            = dctx->outputs;
     uint32_t expectedContentHash = 0;
     ZL_TRY_LET(
-            size_t,
-            chunkSize,
+            DCTX_FrameChunkInfo,
+            chunkInfo,
             setupChunkDecode(
                     dctx,
                     framePtr,
                     frameSize,
                     alreadyConsumed,
                     &expectedContentHash));
+    size_t const chunkSize = chunkInfo.chunkSize;
 
     // start the decompression process.
     ZL_ERR_IF_ERR(runDecoders(dctx));

--- a/src/openzl/decompress/decompress2.c
+++ b/src/openzl/decompress/decompress2.c
@@ -1772,27 +1772,37 @@ static void cleanAllBuffers(ZL_DCtx* dctx)
     cleanChunkBuffers(dctx);
 }
 
-// -------------------------------------
-// Main decompression functions
-// -------------------------------------
 /**
- * @return size of chunk, read from frame
+ * Populates @p dctx to prepare for decoding the chunk beginning at @p
+ * alreadyConsumed in
+ * @p framePtr.
+ *
+ * Clears chunk-scoped buffers, decodes the chunk header and stored streams,
+ * reads the optional content checksum into @p expectedContentHash, and
+ * validates the optional compressed checksum before decoders run.
+ *
+ * @param dctx Decompression context to populate for the chunk.
+ * @param framePtr Beginning of the frame buffer.
+ * @param frameSize Size of @p framePtr in bytes.
+ * @param alreadyConsumed Number of frame bytes consumed before this chunk.
+ * @param expectedContentHash Output content checksum, or 0 when absent.
+ * @return Number of bytes consumed by this chunk, relative to
+ *         @p alreadyConsumed.
  */
-static ZL_Report ZL_DCtx_decompressChunk(
+static ZL_Report setupChunkDecode(
         ZL_DCtx* dctx,
-        size_t nbOutputs,
         const void* framePtr,
         size_t frameSize,
-        size_t alreadyConsumed)
+        size_t alreadyConsumed,
+        uint32_t* expectedContentHash)
 {
     ZL_RESULT_DECLARE_SCOPE_REPORT(dctx);
     size_t consumedSize = alreadyConsumed;
     ZL_DLOG(BLOCK,
-            "ZL_DCtx_decompressChunk (frameSize=%zu, consumedSize=%zu)",
+            "setupChunkDecode (frameSize=%zu, consumedSize=%zu)",
             frameSize,
             consumedSize);
     ZL_ASSERT_NN(dctx);
-    ZL_Data** outputs = dctx->outputs;
 
     // We clean at the beginning instead of the end
     // in case `DCTX_preserveStreams` is set,
@@ -1818,12 +1828,13 @@ static ZL_Report ZL_DCtx_decompressChunk(
     // If present, verify the compressed checksum before running decoders.
     // Assuming we aren't handling malicious inputs, this ensures that we
     // are running on valid data before we run the decoders.
-    uint32_t expectedContentHash = 0;
+    *expectedContentHash = 0;
 
     if (FrameInfo_hasContentChecksum(dctx->dfh.frameinfo)) {
         ZL_ERR_IF_LT(frameSize, consumedSize + 4, srcSize_tooSmall);
-        expectedContentHash = ZL_readCE32((const char*)framePtr + consumedSize);
-        ZL_DLOG(SEQ, "stored contentHash: %08X", expectedContentHash);
+        *expectedContentHash =
+                ZL_readCE32((const char*)framePtr + consumedSize);
+        ZL_DLOG(SEQ, "stored contentHash: %08X", *expectedContentHash);
         consumedSize += 4;
     }
 
@@ -1861,6 +1872,36 @@ static ZL_Report ZL_DCtx_decompressChunk(
 #endif
         consumedSize += 4;
     }
+
+    // number of bytes occupied by the chunk
+    return ZL_returnValue(consumedSize - alreadyConsumed);
+}
+
+// -------------------------------------
+// Main decompression functions
+// -------------------------------------
+/**
+ * @return size of chunk, read from frame
+ */
+static ZL_Report ZL_DCtx_decompressChunk(
+        ZL_DCtx* dctx,
+        size_t nbOutputs,
+        const void* framePtr,
+        size_t frameSize,
+        size_t alreadyConsumed)
+{
+    ZL_RESULT_DECLARE_SCOPE_REPORT(dctx);
+    ZL_Data** outputs            = dctx->outputs;
+    uint32_t expectedContentHash = 0;
+    ZL_TRY_LET(
+            size_t,
+            chunkSize,
+            setupChunkDecode(
+                    dctx,
+                    framePtr,
+                    frameSize,
+                    alreadyConsumed,
+                    &expectedContentHash));
 
     // start the decompression process.
     ZL_ERR_IF_ERR(runDecoders(dctx));
@@ -1913,8 +1954,7 @@ static ZL_Report ZL_DCtx_decompressChunk(
 #endif
     }
 
-    ZL_ASSERT_GE(consumedSize, alreadyConsumed);
-    return ZL_returnValue(consumedSize - alreadyConsumed);
+    return ZL_returnValue(chunkSize);
 }
 
 ZL_Report ZL_DCtx_decompressMultiTBuffer(

--- a/src/openzl/decompress/decompress2.c
+++ b/src/openzl/decompress/decompress2.c
@@ -2374,3 +2374,14 @@ ZL_Report ZL_DCtx_detachAllDecompressIntrospectionHooks(ZL_DCtx* dctx)
     oc->hasDecompressionHooks = false;
     return ZL_returnSuccess();
 }
+
+ZL_Report DCTX_initFromFrameInfo(ZL_DCtx* dctx, const ZL_FrameInfo* frameInfo)
+{
+    ZL_RESULT_DECLARE_SCOPE_REPORT(dctx);
+    ZL_ASSERT_NN(dctx);
+    ZL_TRY_LET(size_t, nbOutputs, ZL_FrameInfo_getNumOutputs(frameInfo));
+    ZL_ERR_IF_ERR(DFH_setFrameInfo(
+            &dctx->dfh, frameInfo, ZL_DCtx_getOperationContext(dctx)));
+    dctx->nbOutputs = nbOutputs;
+    return DCtx_setAppliedParameters(dctx);
+}

--- a/tests/decompress/test_decode_frameheader.cpp
+++ b/tests/decompress/test_decode_frameheader.cpp
@@ -3,9 +3,11 @@
 #include <gtest/gtest.h>
 #include <numeric>
 #include <random>
+#include <string_view>
 
 #include "openzl/common/assertion.h"
 #include "openzl/common/errors_internal.h"
+#include "openzl/decompress/dctx2.h"
 #include "openzl/zl_compress.h"
 #include "openzl/zl_compressor.h"
 #include "tests/utils.h" // @manual
@@ -14,7 +16,10 @@ using namespace ::testing;
 
 // push @nbInputs random serial strings of size @inputSizeEach through a concat
 // + zstd graph
-static std::string randomCompress(size_t nbInputs, size_t inputSizeEach)
+static std::string randomCompress(
+        size_t nbInputs,
+        size_t inputSizeEach,
+        std::string_view comment = {})
 {
     // TODO(T210132483): use generalized rand input generator
     const auto genRand = [](size_t size, long seed) -> std::string {
@@ -62,6 +67,10 @@ static std::string randomCompress(size_t nbInputs, size_t inputSizeEach)
 
     ZL_REQUIRE_SUCCESS(ZL_Compressor_selectStartingGraphID(cgraph, gid));
     ZL_REQUIRE_SUCCESS(ZL_CCtx_refCompressor(cctx, cgraph));
+    if (!comment.empty()) {
+        ZL_REQUIRE_SUCCESS(
+                ZL_CCtx_addHeaderComment(cctx, comment.data(), comment.size()));
+    }
 
     // TODO(T210132483): add to ZStrongTest fixture
     ZL_Report const r = ZL_CCtx_compressMultiTypedRef(
@@ -104,4 +113,53 @@ TEST(DecodeFrameheaderTest, NbOutputsTest)
     rep             = ZL_getNumOutputs(c10.data(), c10.size());
     EXPECT_EQ(ZL_isError(rep), false);
     ASSERT_EQ(ZL_validResult(rep), 10ul);
+}
+
+TEST(DecodeFrameheaderTest, InitDCtxOwnsIndependentFrameMetadataCopy)
+{
+    constexpr size_t kNumOutputs        = 3;
+    constexpr size_t kOutputSize        = 4000;
+    constexpr std::string_view kComment = "copied frame metadata";
+    std::string compressed = randomCompress(kNumOutputs, kOutputSize, kComment);
+    ZL_FrameInfo* frameInfo =
+            ZL_FrameInfo_create(compressed.data(), compressed.size());
+    ASSERT_NE(frameInfo, nullptr);
+
+    ZL_DCtx* dctx = ZL_DCtx_create();
+    ASSERT_NE(dctx, nullptr);
+    ZL_Report const setResult = DCTX_initFromFrameInfo(dctx, frameInfo);
+    ZL_FrameInfo_free(frameInfo);
+
+    // This fails under ASAN if DCTX_initFromFrameInfo borrows or shallow-copies
+    // dynamically allocated frame metadata from the now-freed source.
+    EXPECT_FALSE(ZL_isError(setResult));
+    if (!ZL_isError(setResult)) {
+        DFH_Struct const* dfh = DCtx_getFrameHeader(dctx);
+        ASSERT_NE(dfh, nullptr);
+        EXPECT_EQ(dfh->formatVersion, ZL_MAX_FORMAT_VERSION);
+        EXPECT_EQ(
+                ZL_validResult(ZL_FrameInfo_getNumOutputs(dfh->frameinfo)),
+                kNumOutputs);
+        for (size_t output = 0; output < kNumOutputs; ++output) {
+            EXPECT_EQ(
+                    ZL_validResult(ZL_FrameInfo_getOutputType(
+                            dfh->frameinfo, static_cast<int>(output))),
+                    ZL_Type_serial);
+            EXPECT_EQ(
+                    ZL_validResult(ZL_FrameInfo_getDecompressedSize(
+                            dfh->frameinfo, static_cast<int>(output))),
+                    kOutputSize);
+            EXPECT_EQ(
+                    ZL_validResult(ZL_FrameInfo_getNumElts(
+                            dfh->frameinfo, static_cast<int>(output))),
+                    kOutputSize);
+        }
+        ZL_Comment const comment =
+                ZL_RES_value(ZL_FrameInfo_getComment(dfh->frameinfo));
+        EXPECT_EQ(
+                std::string_view(
+                        static_cast<const char*>(comment.data), comment.size),
+                kComment);
+    }
+    ZL_DCtx_free(dctx);
 }


### PR DESCRIPTION
Summary: Copies per-frame and per-chunk headers from device to pageable host staging storage before per-chunk decode preparation. Keeps the GPU decompress entry point exception-safe for host allocation failures.

Reviewed By: terrelln

Differential Revision: D113553787


