### PR TITLE
Memoize standard codec outputs (#919)

### DIFF
--- a/include/openzl/openzl.h
+++ b/include/openzl/openzl.h
@@ -4,6 +4,7 @@
 #define OPENZL_OPENZL_H
 
 #include "openzl/zl_buffer.h"                   // IWYU pragma: export
+#include "openzl/zl_codec_output_cache.h"       // IWYU pragma: export
 #include "openzl/zl_common_types.h"             // IWYU pragma: export
 #include "openzl/zl_compress.h"                 // IWYU pragma: export
 #include "openzl/zl_compressor.h"               // IWYU pragma: export

--- a/include/openzl/zl_codec_output_cache.h
+++ b/include/openzl/zl_codec_output_cache.h
@@ -1,0 +1,64 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#ifndef OPENZL_ZL_CODEC_OUTPUT_CACHE_H
+#define OPENZL_ZL_CODEC_OUTPUT_CACHE_H
+
+#include <stddef.h>
+
+#include "openzl/zl_errors.h"
+#include "openzl/zl_opaque_types.h"
+
+#if defined(__cplusplus)
+extern "C" {
+#endif
+
+/**
+ * Memoizes deterministic standard-codec invocations.
+ *
+ * A cache is disabled until attached to a compression context with
+ * ZL_CCtx_setCodecOutputCache(). Cache hits reproduce the same codec outputs
+ * and transform header without invoking the codec again. Custom codecs,
+ * dictionary-backed codecs, codecs with reference or materialized parameters,
+ * codecs consuming or producing string streams, and codecs that do not take
+ * exactly one input are not cached. Non-single-input invocations run normally
+ * without a cache lookup or insertion.
+ *
+ * Copy parameters are keyed by their copied bytes only. State reachable
+ * through pointers embedded in those bytes is not part of the key.
+ * Callback-backed parameterized standard nodes, including custom tokenize and
+ * dispatch nodes, are therefore unsupported.
+ *
+ * The cache is mutable and single-writer. It may be reused by multiple
+ * compression contexts sequentially, but must not be used concurrently.
+ */
+typedef struct ZL_CodecOutputCache_s ZL_CodecOutputCache;
+
+/** Creates an empty cache with the default 256 MiB entry-payload budget. */
+ZL_CodecOutputCache* ZL_CodecOutputCache_create(void);
+
+/**
+ * Creates an empty cache with the specified entry-payload budget.
+ * Zero prevents entries from being stored. Reaching @p maxBytes skips new
+ * entries; it does not fail compression.
+ */
+ZL_CodecOutputCache* ZL_CodecOutputCache_createWithBudget(size_t maxBytes);
+
+/** Frees a cache and all stored entries. Accepts NULL. */
+void ZL_CodecOutputCache_free(ZL_CodecOutputCache* cache);
+
+/** Drops all cached results. Accepts NULL. */
+void ZL_CodecOutputCache_reset(ZL_CodecOutputCache* cache);
+
+/**
+ * Attaches a borrowed cache to @p cctx. Passing NULL disables caching.
+ * The cache must outlive every compression that uses the context.
+ */
+ZL_Report ZL_CCtx_setCodecOutputCache(
+        ZL_CCtx* cctx,
+        ZL_CodecOutputCache* cache);
+
+#if defined(__cplusplus)
+}
+#endif
+
+#endif // OPENZL_ZL_CODEC_OUTPUT_CACHE_H

--- a/src/openzl/common/stream.c
+++ b/src/openzl/common/stream.c
@@ -15,12 +15,7 @@
 #include "openzl/zl_data.h"                   // ZL_DataID
 #include "openzl/zl_errors.h"                 // ZL_Report
 
-typedef struct {
-    int mId;
-    int mValue;
-} IntMeta;
-
-DECLARE_VECTOR_TYPE(IntMeta)
+DECLARE_VECTOR_TYPE(Stream_IntMetadata)
 
 struct Stream_s { // exposed publicly as ZL_Data
     ZL_Refcount buffer;
@@ -33,8 +28,8 @@ struct Stream_s { // exposed publicly as ZL_Data
     size_t bufferUsed;      // in bytes
     ZL_Refcount stringLens; // ZL_Type_string only.
     int writeCommitted;
-    size_t lastCommmited;     // tracks the eltCount of most recent commit
-    VECTOR(IntMeta) intMetas; // Metadata (arbitrary ID+Ints)
+    size_t lastCommmited; // tracks the eltCount of most recent commit
+    VECTOR(Stream_IntMetadata) intMetas; // Metadata (arbitrary ID+Ints)
     Arena* alloc;
 };
 
@@ -417,7 +412,7 @@ ZL_Report STREAM_refStreamWithoutRefCount(Stream* s, const Stream* ref)
         return ZL_REPORT_ERROR(allocation, "Failed to reserve metadata");
     }
     for (size_t pos = 0; pos < meta_size; pos++) {
-        IntMeta e = VECTOR_AT(ref->intMetas, pos);
+        Stream_IntMetadata e = VECTOR_AT(ref->intMetas, pos);
         if (!VECTOR_PUSHBACK(s->intMetas, e)) {
             return ZL_REPORT_ERROR(allocation, "Failed to copy metadata");
         }
@@ -1011,7 +1006,7 @@ static ZL_Report STREAM_copyIntMetas(Stream* dst, const Stream* src)
             VECTOR_RESERVE(dst->intMetas, meta_size), meta_size, allocation);
 
     for (size_t pos = 0; pos < meta_size; pos++) {
-        IntMeta e = VECTOR_AT(src->intMetas, pos);
+        Stream_IntMetadata e = VECTOR_AT(src->intMetas, pos);
         ZL_ERR_IF_NOT(VECTOR_PUSHBACK(dst->intMetas, e), allocation);
     }
 
@@ -1070,12 +1065,12 @@ ZL_Report STREAM_consume(Stream* data, size_t eltCount)
 // findIntMeta() :
 // @return index of the Int Metadata of provided @id
 // @return -1 if not found
-static int findIntMeta(VECTOR(IntMeta) m, int id)
+static int findIntMeta(VECTOR(Stream_IntMetadata) m, int id)
 {
     size_t const nbIntMetas = VECTOR_SIZE(m);
     // Scan backward, find latest .id if multiple present
     for (int pos = (int)nbIntMetas - 1; pos >= 0; pos--) {
-        if (VECTOR_DATA(m)[pos].mId == id)
+        if (VECTOR_DATA(m)[pos].id == id)
             return pos;
     }
     // not found
@@ -1093,7 +1088,9 @@ ZL_Report STREAM_setIntMetadata(Stream* s, int mId, int mValue)
             streamParameter_invalid,
             "Int Metadata ID already present");
     ZL_ERR_IF_NOT(
-            VECTOR_PUSHBACK(s->intMetas, ((IntMeta){ mId, mValue })),
+            VECTOR_PUSHBACK(
+                    s->intMetas,
+                    ((Stream_IntMetadata){ .id = mId, .value = mValue })),
             allocation);
     return ZL_returnSuccess();
 }
@@ -1110,8 +1107,39 @@ ZL_IntMetadata STREAM_getIntMetadata(const Stream* s, int mId)
         };
     return (ZL_IntMetadata){
         .isPresent = 1,
-        .mValue    = VECTOR_DATA(s->intMetas)[idx].mValue,
+        .mValue    = VECTOR_DATA(s->intMetas)[idx].value,
     };
+}
+
+size_t STREAM_numIntMetadata(const Stream* s)
+{
+    ZL_ASSERT_NN(s);
+    return VECTOR_SIZE(s->intMetas);
+}
+
+ZL_Report STREAM_copyIntMetadata(
+        Stream_IntMetadata* dst,
+        const Stream* src,
+        size_t expectedEntries)
+{
+    ZL_RESULT_DECLARE_SCOPE_REPORT(NULL);
+    ZL_ASSERT_NN(src);
+    ZL_ERR_IF_NE(
+            expectedEntries,
+            VECTOR_SIZE(src->intMetas),
+            streamParameter_invalid,
+            "Metadata entry count does not match the stream");
+    if (expectedEntries == 0) {
+        return ZL_returnSuccess();
+    }
+    ZL_ERR_IF_NULL(
+            dst,
+            streamParameter_invalid,
+            "Metadata destination is NULL for a non-empty stream");
+    for (size_t i = 0; i < expectedEntries; ++i) {
+        dst[i] = VECTOR_AT(src->intMetas, i);
+    }
+    return ZL_returnSuccess();
 }
 
 int STREAM_hasBuffer(const Stream* s)

--- a/src/openzl/common/stream.h
+++ b/src/openzl/common/stream.h
@@ -23,6 +23,20 @@ DECLARE_VECTOR_POINTERS_TYPE(ZL_Data)
 DECLARE_VECTOR_CONST_POINTERS_TYPE(ZL_Data)
 
 /**
+ * One integer metadata entry attached to a Stream.
+ *
+ * This type is exposed by the internal Stream interface so callers that need
+ * to snapshot a stream can preserve both the metadata identifier and value.
+ * The public lookup API returns only the value for a caller-supplied ID.
+ */
+typedef struct {
+    /** Identifier passed to STREAM_setIntMetadata(). */
+    int id;
+    /** Integer value associated with this entry's identifier. */
+    int value;
+} Stream_IntMetadata;
+
+/**
  * Internal Stream interface.
  *
  * Public callers should continue to rely on the ZL_Data_* façade declared in
@@ -237,6 +251,26 @@ size_t STREAM_byteCapacity(const Stream* s);
  */
 ZL_Report STREAM_setIntMetadata(Stream* s, int mId, int mValue);
 ZL_IntMetadata STREAM_getIntMetadata(const Stream* s, int mId);
+
+/** Number of integer metadata entries attached to @p s. */
+size_t STREAM_numIntMetadata(const Stream* s);
+
+/**
+ * Copy every integer metadata entry from @p src into @p dst.
+ *
+ * @p dst must have capacity for at least @p expectedEntries entries.
+ * @p expectedEntries must exactly equal STREAM_numIntMetadata(src). @p dst
+ * may be NULL only when @p expectedEntries is zero. Invalid arguments return
+ * an error without modifying @p dst.
+ *
+ * Metadata lookup semantics do not depend on entry order. This function
+ * nevertheless preserves stable stream order, so callers that hash or compare
+ * the copied representation bytewise will distinguish different orders.
+ */
+ZL_Report STREAM_copyIntMetadata(
+        Stream_IntMetadata* dst,
+        const Stream* src,
+        size_t expectedEntries);
 
 /**
  * Hash the content of all streams provided in @p streams.

--- a/src/openzl/compress/cctx.c
+++ b/src/openzl/compress/cctx.c
@@ -16,6 +16,7 @@
 #include "openzl/compress/cctx.h"               // ZS2_CCtx_*
 #include "openzl/compress/cgraph.h"             // CGRAPH_*
 #include "openzl/compress/cnode.h"              // CNODE_*
+#include "openzl/compress/codec_output_cache.h" // ZL_CodecOutputCache
 #include "openzl/compress/dyngraph_interface.h" // GCtx
 #include "openzl/compress/enc_interface.h"      // ENC_*
 #include "openzl/compress/gcparams.h"           // GCParams
@@ -129,10 +130,11 @@ struct ZL_CCtx_s {
     const ZL_Compressor* cgraph;
     ZL_Compressor* internal_cgraph;
     RTGraph rtgraph;
-    CachedStates cachedCodecStates; // @note valid for single-thread only
-    GCParams requestedGCParams;     // User selection, at CCtx level
-    GCParams appliedGCParams;       // Employed at compression time;
-                                    // CCtx > Compressor > default
+    CachedStates cachedCodecStates;        // @note valid for single-thread only
+    ZL_CodecOutputCache* codecOutputCache; // borrowed; NULL means disabled
+    GCParams requestedGCParams;            // User selection, at CCtx level
+    GCParams appliedGCParams;              // Employed at compression time;
+                                           // CCtx > Compressor > default
     /// Comment to be added to the header. Is not added when size is 0.
     ZL_Comment comment;
     CCTX_TransformHeaders trHeaders;
@@ -416,6 +418,33 @@ ZL_Report CCTX_sendTrHeader(ZL_CCtx* cctx, RTNodeID rtnodeid, ZL_RBuffer trh)
             &cctx->rtgraph,
             rtnodeid,
             (NodeHeaderSegment){ headerPos, trh.size });
+    return ZL_returnSuccess();
+}
+
+ZL_RBuffer CCTX_getNodeHeader(const ZL_CCtx* cctx, RTNodeID rtnodeid)
+{
+    ZL_ASSERT_NN(cctx);
+    const NodeHeaderSegment segment =
+            RTGM_nodeHeaderSegment(&cctx->rtgraph, rtnodeid);
+    if (segment.len == 0) {
+        return (ZL_RBuffer){ NULL, 0 };
+    }
+    const uint8_t* const headers =
+            VECTOR_DATA(cctx->trHeaders.stagingHeaderStream);
+    ZL_ASSERT_NN(headers);
+    return (ZL_RBuffer){ headers + segment.startPos, segment.len };
+}
+
+ZL_CodecOutputCache* CCTX_getCodecOutputCache(const ZL_CCtx* cctx)
+{
+    ZL_ASSERT_NN(cctx);
+    return cctx->codecOutputCache;
+}
+
+ZL_Report ZL_CCtx_setCodecOutputCache(ZL_CCtx* cctx, ZL_CodecOutputCache* cache)
+{
+    ZL_ASSERT_NN(cctx);
+    cctx->codecOutputCache = cache;
     return ZL_returnSuccess();
 }
 

--- a/src/openzl/compress/cctx.h
+++ b/src/openzl/compress/cctx.h
@@ -6,6 +6,7 @@
 #include "openzl/compress/encode_frameheader.h" // EFH_FrameInfo, GraphInfo
 #include "openzl/compress/rtgraphs.h"           // RTNodeID
 #include "openzl/shared/portability.h"
+#include "openzl/zl_codec_output_cache.h"
 #include "openzl/zl_compress.h" // ZL_CCtx, ZL_GraphFn, ZL_Report
 
 ZL_BEGIN_C_DECLS
@@ -233,6 +234,12 @@ unsigned CCTX_getSegmenterDepth(const ZL_CCtx* cctx);
  * @see RTNodeID for runtime node identification
  */
 ZL_Report CCTX_sendTrHeader(ZL_CCtx* cctx, RTNodeID rtnodeid, ZL_RBuffer trh);
+
+/** Returns the transform header staged for @p rtnodeid, or an empty buffer. */
+ZL_RBuffer CCTX_getNodeHeader(const ZL_CCtx* cctx, RTNodeID rtnodeid);
+
+/** Returns the borrowed codec output cache attached to @p cctx, if any. */
+ZL_CodecOutputCache* CCTX_getCodecOutputCache(const ZL_CCtx* cctx);
 
 /**
  * @brief Start the compression process with the provided input data.

--- a/src/openzl/compress/codec_output_cache.c
+++ b/src/openzl/compress/codec_output_cache.c
@@ -322,19 +322,31 @@ static bool CodecCache_getStandardNodeID(
  */
 static bool CodecCache_buildKey(
         CodecCache_Key* key,
+        ZL_CodecOutputCache* cache,
         ZL_Encoder* encoder,
         ZL_NodeID node,
         const ZL_Data* input)
 {
     ZL_IDType standardNodeID;
-    if (!CodecCache_getStandardNodeID(&standardNodeID, encoder, node)
-        || CNODE_getDictIndex(encoder->cnode) != ZL_DICT_INDEX_NONE
-        || CNODE_getMParamObj(encoder->cnode) != NULL
-        || (encoder->lparams != NULL
-            && encoder->lparams->refParams.nbRefParams != 0)) {
+    if (!CodecCache_getStandardNodeID(&standardNodeID, encoder, node)) {
+        CodecCache_recordSkip(cache, CodecCache_SkipReason_customCodec);
+        return false;
+    }
+    if (CNODE_getDictIndex(encoder->cnode) != ZL_DICT_INDEX_NONE) {
+        CodecCache_recordSkip(cache, CodecCache_SkipReason_dict);
+        return false;
+    }
+    if (CNODE_getMParamObj(encoder->cnode) != NULL) {
+        CodecCache_recordSkip(cache, CodecCache_SkipReason_mparam);
+        return false;
+    }
+    if (encoder->lparams != NULL
+        && encoder->lparams->refParams.nbRefParams != 0) {
+        CodecCache_recordSkip(cache, CodecCache_SkipReason_refParam);
         return false;
     }
     if (ZL_Data_type(input) == ZL_Type_string) {
+        CodecCache_recordSkip(cache, CodecCache_SkipReason_string);
         return false;
     }
 
@@ -434,6 +446,53 @@ CodecCache_Stats CodecCache_getStats(const ZL_CodecOutputCache* cache)
     return stats;
 }
 
+void CodecCache_recordSkip(
+        ZL_CodecOutputCache* cache,
+        CodecCache_SkipReason reason)
+{
+    ZL_ASSERT_NN(cache);
+    switch (reason) {
+        case CodecCache_SkipReason_customCodec:
+            ++cache->stats.customCodecSkips;
+            break;
+        case CodecCache_SkipReason_refParam:
+            ++cache->stats.refParamSkips;
+            break;
+        case CodecCache_SkipReason_dict:
+            ++cache->stats.dictSkips;
+            break;
+        case CodecCache_SkipReason_mparam:
+            ++cache->stats.mparamSkips;
+            break;
+        case CodecCache_SkipReason_string:
+            ++cache->stats.stringSkips;
+            break;
+        case CodecCache_SkipReason_nonSingleInput:
+            ++cache->stats.nonSingleInputSkips;
+            break;
+    }
+}
+
+ZL_CodecOutputCache* ZL_CodecOutputCache_create(void)
+{
+    return CodecCache_createDefault();
+}
+
+ZL_CodecOutputCache* ZL_CodecOutputCache_createWithBudget(size_t maxBytes)
+{
+    return CodecCache_create(maxBytes);
+}
+
+void ZL_CodecOutputCache_free(ZL_CodecOutputCache* cache)
+{
+    CodecCache_free(cache);
+}
+
+void ZL_CodecOutputCache_reset(ZL_CodecOutputCache* cache)
+{
+    CodecCache_reset(cache);
+}
+
 CodecCache_Lookup* CodecCache_lookup(
         ZL_CodecOutputCache* cache,
         ZL_Encoder* encoder,
@@ -445,7 +504,7 @@ CodecCache_Lookup* CodecCache_lookup(
     CodecCache_Lookup* const lookup =
             ALLOC_Arena_malloc(encoder->wkspArena, sizeof(*lookup));
     if (lookup == NULL
-        || !CodecCache_buildKey(&lookup->key, encoder, node, input)) {
+        || !CodecCache_buildKey(&lookup->key, cache, encoder, node, input)) {
         return NULL;
     }
     lookup->cache = cache;
@@ -646,6 +705,13 @@ CodecCache_InsertResult CodecCache_store(
     ZL_ASSERT_NN(result);
     ZL_CodecOutputCache* const cache = lookup->cache;
     const CodecCache_Key* const key  = &lookup->key;
+
+    for (size_t i = 0; i < result->nbOutputs; ++i) {
+        if (result->outputs[i].type == ZL_Type_string) {
+            CodecCache_recordSkip(cache, CodecCache_SkipReason_string);
+            return CodecCache_InsertResult_notCacheable;
+        }
+    }
 
     if (CodecCache_Map_find(&cache->map, key) != NULL) {
         if (cache->statsEnabled) {

--- a/src/openzl/compress/codec_output_cache.c
+++ b/src/openzl/compress/codec_output_cache.c
@@ -1,0 +1,726 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#include "openzl/compress/codec_output_cache.h"
+
+#include <string.h>
+
+#include "openzl/common/allocation.h"
+#include "openzl/common/assertion.h"
+#include "openzl/common/map.h"
+#include "openzl/common/stream.h"
+#include "openzl/compress/cctx.h"
+#include "openzl/compress/cgraph.h"
+#include "openzl/compress/cnode.h"
+#include "openzl/compress/enc_interface.h"
+#include "openzl/compress/nodemgr.h"
+#include "openzl/dict/dict_constants.h"
+#include "openzl/shared/overflow.h"
+#include "openzl/shared/xxhash.h"
+
+#define CODEC_CACHE_DEFAULT_MAX_BYTES ((size_t)256 << 20)
+#define CODEC_CACHE_MAX_ENTRIES (1u << 24)
+
+typedef struct {
+    ZL_Type type;
+    size_t eltWidth;
+    size_t numElts;
+    size_t contentSize;
+    const void* content;
+    size_t nbIntMetadata;
+    const Stream_IntMetadata* intMetadata;
+} CodecCache_Input;
+
+typedef struct {
+    uint64_t contentHash64;
+    ZL_IDType standardNodeID;
+    uint32_t formatVersion;
+    int32_t compressionLevel;
+    int32_t decompressionLevel;
+    CodecCache_Input input;
+    size_t localParamsSize;
+    const void* localParams;
+} CodecCache_Key;
+
+static size_t CodecCache_Map_hash(const CodecCache_Key* key);
+static bool CodecCache_Map_eq(
+        const CodecCache_Key* lhs,
+        const CodecCache_Key* rhs);
+
+ZL_DECLARE_CUSTOM_MAP_TYPE(
+        CodecCache_Map,
+        CodecCache_Key,
+        const CodecCache_Result*);
+
+struct ZL_CodecOutputCache_s {
+    Arena* cacheArena;
+    CodecCache_Map map;
+    size_t maxBytes;
+    size_t bytesStored;
+    bool statsEnabled;
+    CodecCache_Stats stats;
+};
+
+struct CodecCache_Lookup_s {
+    ZL_CodecOutputCache* cache;
+    CodecCache_Key key;
+    const CodecCache_Result* result;
+};
+
+static bool CodecCache_equalBytes(const void* lhs, const void* rhs, size_t size)
+{
+    return size == 0 || memcmp(lhs, rhs, size) == 0;
+}
+
+static size_t CodecCache_Map_hash(const CodecCache_Key* key)
+{
+    XXH3_state_t state;
+    XXH3_INITSTATE(&state);
+    XXH3_64bits_reset(&state);
+    XXH3_64bits_update(&state, &key->contentHash64, sizeof(key->contentHash64));
+    XXH3_64bits_update(
+            &state, &key->standardNodeID, sizeof(key->standardNodeID));
+    XXH3_64bits_update(&state, &key->formatVersion, sizeof(key->formatVersion));
+    XXH3_64bits_update(
+            &state, &key->compressionLevel, sizeof(key->compressionLevel));
+    XXH3_64bits_update(
+            &state, &key->decompressionLevel, sizeof(key->decompressionLevel));
+    XXH3_64bits_update(
+            &state, &key->localParamsSize, sizeof(key->localParamsSize));
+    if (key->localParamsSize != 0) {
+        XXH3_64bits_update(&state, key->localParams, key->localParamsSize);
+    }
+    return (size_t)XXH3_64bits_digest(&state);
+}
+
+static bool CodecCache_Input_eq(
+        const CodecCache_Input* lhs,
+        const CodecCache_Input* rhs)
+{
+    if (lhs->type != rhs->type || lhs->eltWidth != rhs->eltWidth
+        || lhs->numElts != rhs->numElts || lhs->contentSize != rhs->contentSize
+        || lhs->nbIntMetadata != rhs->nbIntMetadata) {
+        return false;
+    }
+    size_t metadataSize;
+    if (ZL_overflowMulST(
+                lhs->nbIntMetadata,
+                sizeof(Stream_IntMetadata),
+                &metadataSize)) {
+        return false;
+    }
+    return CodecCache_equalBytes(lhs->content, rhs->content, lhs->contentSize)
+            && CodecCache_equalBytes(
+                    lhs->intMetadata, rhs->intMetadata, metadataSize);
+}
+
+static bool CodecCache_Map_eq(
+        const CodecCache_Key* lhs,
+        const CodecCache_Key* rhs)
+{
+    if (lhs->contentHash64 != rhs->contentHash64
+        || lhs->standardNodeID != rhs->standardNodeID
+        || lhs->formatVersion != rhs->formatVersion
+        || lhs->compressionLevel != rhs->compressionLevel
+        || lhs->decompressionLevel != rhs->decompressionLevel
+        || lhs->localParamsSize != rhs->localParamsSize
+        || !CodecCache_equalBytes(
+                lhs->localParams, rhs->localParams, lhs->localParamsSize)) {
+        return false;
+    }
+    return CodecCache_Input_eq(&lhs->input, &rhs->input);
+}
+
+static bool CodecCache_addSize(size_t* total, size_t amount)
+{
+    size_t result;
+    if (ZL_overflowAddST(*total, amount, &result)) {
+        return false;
+    }
+    *total = result;
+    return true;
+}
+
+static bool CodecCache_addArraySize(size_t* total, size_t count, size_t eltSize)
+{
+    size_t size;
+    return !ZL_overflowMulST(count, eltSize, &size)
+            && CodecCache_addSize(total, size);
+}
+
+static void CodecCache_updateInputHash(
+        XXH3_state_t* state,
+        const CodecCache_Input* input)
+{
+    XXH3_64bits_update(state, &input->type, sizeof(input->type));
+    XXH3_64bits_update(state, &input->eltWidth, sizeof(input->eltWidth));
+    XXH3_64bits_update(state, &input->numElts, sizeof(input->numElts));
+    XXH3_64bits_update(state, &input->contentSize, sizeof(input->contentSize));
+    if (input->contentSize != 0) {
+        XXH3_64bits_update(state, input->content, input->contentSize);
+    }
+    XXH3_64bits_update(
+            state, &input->nbIntMetadata, sizeof(input->nbIntMetadata));
+    if (input->nbIntMetadata != 0) {
+        XXH3_64bits_update(
+                state,
+                input->intMetadata,
+                input->nbIntMetadata * sizeof(input->intMetadata[0]));
+    }
+}
+
+static bool CodecCache_buildInput(
+        CodecCache_Input* cacheInput,
+        uint64_t* contentHash,
+        Arena* scratchArena,
+        const ZL_Data* input)
+{
+    *cacheInput = (CodecCache_Input){
+        .type        = ZL_Data_type(input),
+        .eltWidth    = ZL_Data_eltWidth(input),
+        .numElts     = ZL_Data_numElts(input),
+        .contentSize = ZL_Data_contentSize(input),
+        .content     = ZL_Data_rPtr(input),
+    };
+    cacheInput->nbIntMetadata = STREAM_numIntMetadata(input);
+    if (cacheInput->nbIntMetadata != 0) {
+        size_t metadataSize;
+        if (ZL_overflowMulST(
+                    cacheInput->nbIntMetadata,
+                    sizeof(Stream_IntMetadata),
+                    &metadataSize)) {
+            return false;
+        }
+        Stream_IntMetadata* const metadata =
+                ALLOC_Arena_malloc(scratchArena, metadataSize);
+        if (metadata == NULL
+            || ZL_isError(STREAM_copyIntMetadata(
+                    metadata, input, cacheInput->nbIntMetadata))) {
+            return false;
+        }
+        cacheInput->intMetadata = metadata;
+    }
+
+    XXH3_state_t state;
+    XXH3_INITSTATE(&state);
+    XXH3_64bits_reset(&state);
+    CodecCache_updateInputHash(&state, cacheInput);
+    *contentHash = XXH3_64bits_digest(&state);
+    return true;
+}
+
+static bool CodecCache_serializeLocalParams(
+        void** serialized,
+        size_t* serializedSize,
+        Arena* scratchArena,
+        const ZL_LocalParams* params)
+{
+    *serialized     = NULL;
+    *serializedSize = 0;
+    if (params == NULL) {
+        return true;
+    }
+
+    const ZL_LocalIntParams* const intParams   = &params->intParams;
+    const ZL_LocalCopyParams* const copyParams = &params->copyParams;
+    if (intParams->nbIntParams == 0 && copyParams->nbCopyParams == 0) {
+        return true;
+    }
+    if (!CodecCache_addSize(serializedSize, sizeof(intParams->nbIntParams))
+        || !CodecCache_addSize(serializedSize, sizeof(copyParams->nbCopyParams))
+        || !CodecCache_addArraySize(
+                serializedSize,
+                intParams->nbIntParams,
+                sizeof(int) + sizeof(int))) {
+        return false;
+    }
+    for (size_t i = 0; i < copyParams->nbCopyParams; ++i) {
+        if (!CodecCache_addSize(serializedSize, sizeof(int) + sizeof(size_t))
+            || !CodecCache_addSize(
+                    serializedSize, copyParams->copyParams[i].paramSize)) {
+            return false;
+        }
+    }
+    *serialized = ALLOC_Arena_malloc(scratchArena, *serializedSize);
+    if (*serialized == NULL) {
+        return false;
+    }
+    uint8_t* dst = *serialized;
+    memcpy(dst, &intParams->nbIntParams, sizeof(intParams->nbIntParams));
+    dst += sizeof(intParams->nbIntParams);
+    memcpy(dst, &copyParams->nbCopyParams, sizeof(copyParams->nbCopyParams));
+    dst += sizeof(copyParams->nbCopyParams);
+    for (size_t i = 0; i < intParams->nbIntParams; ++i) {
+        const int id    = intParams->intParams[i].paramId;
+        const int value = intParams->intParams[i].paramValue;
+        memcpy(dst, &id, sizeof(id));
+        dst += sizeof(id);
+        memcpy(dst, &value, sizeof(value));
+        dst += sizeof(value);
+    }
+    for (size_t i = 0; i < copyParams->nbCopyParams; ++i) {
+        const ZL_CopyParam* const param = &copyParams->copyParams[i];
+        memcpy(dst, &param->paramId, sizeof(param->paramId));
+        dst += sizeof(param->paramId);
+        memcpy(dst, &param->paramSize, sizeof(param->paramSize));
+        dst += sizeof(param->paramSize);
+        if (param->paramSize != 0) {
+            memcpy(dst, param->paramPtr, param->paramSize);
+            dst += param->paramSize;
+        }
+    }
+    ZL_ASSERT_EQ((size_t)(dst - (uint8_t*)*serialized), *serializedSize);
+    return true;
+}
+
+static bool CodecCache_getStandardNodeID(
+        ZL_IDType* standardNodeID,
+        const ZL_Encoder* encoder,
+        ZL_NodeID node)
+{
+    const ZL_Compressor* const compressor = CCTX_getCGraph(encoder->cctx);
+    ZL_ASSERT_NN(compressor);
+    ZL_ASSERT_EQ(CGRAPH_getCNode(compressor, node), encoder->cnode);
+    while (!NM_isStandardNode(node)) {
+        const ZL_NodeID base =
+                CNODE_getBaseNodeID(CGRAPH_getCNode(compressor, node));
+        if (base.nid == ZL_NODE_ILLEGAL.nid) {
+            return false;
+        }
+        node = base;
+    }
+    *standardNodeID = node.nid;
+    return true;
+}
+
+/*
+ * Key-completeness audit:
+ * - standardNodeID identifies the built-in encoder implementation and output
+ *   schema. Parameterized nodes can only change the state covered below.
+ * - input includes its type, element width and count, content, and integer
+ *   metadata. Multi-input codecs are outside the cache's scope.
+ * - localParams includes every integer and the copied bytes of every copy
+ *   parameter. Reference parameters, dictionaries, materialized parameters,
+ *   custom codecs, and string streams are rejected because their complete
+ *   state is unavailable.
+ * - Known limitation: state reachable through pointers embedded in copy
+ *   parameters is not keyed. Custom tokenize and dispatch nodes use this
+ *   pattern and are unsupported until their callback state is represented by
+ *   reference parameters or explicit cache eligibility.
+ * - formatVersion, compressionLevel, and decompressionLevel are the only
+ *   global parameters currently consulted by built-in codecs. Other global
+ *   parameters affect graph or frame behavior outside a codec invocation.
+ *
+ * Input IDs, addresses, and runtime graph position are intentionally not key
+ * fields: built-in codecs must treat them as non-semantic. Cached codec state
+ * is also not keyed or advanced on replay. The only built-in encoder using it
+ * today is zstd, which resets it before every invocation and uses it strictly
+ * as reusable workspace.
+ *
+ * Any new encoder-visible state, or any new dependency of a built-in codec on
+ * existing state, must be added to CodecCache_Key or make that invocation
+ * uncacheable here.
+ */
+static bool CodecCache_buildKey(
+        CodecCache_Key* key,
+        ZL_Encoder* encoder,
+        ZL_NodeID node,
+        const ZL_Data* input)
+{
+    ZL_IDType standardNodeID;
+    if (!CodecCache_getStandardNodeID(&standardNodeID, encoder, node)
+        || CNODE_getDictIndex(encoder->cnode) != ZL_DICT_INDEX_NONE
+        || CNODE_getMParamObj(encoder->cnode) != NULL
+        || (encoder->lparams != NULL
+            && encoder->lparams->refParams.nbRefParams != 0)) {
+        return false;
+    }
+    if (ZL_Data_type(input) == ZL_Type_string) {
+        return false;
+    }
+
+    CodecCache_Input cacheInput;
+    uint64_t contentHash;
+    if (!CodecCache_buildInput(
+                &cacheInput, &contentHash, encoder->wkspArena, input)) {
+        return false;
+    }
+    void* localParams;
+    size_t localParamsSize;
+    if (!CodecCache_serializeLocalParams(
+                &localParams,
+                &localParamsSize,
+                encoder->wkspArena,
+                encoder->lparams)) {
+        return false;
+    }
+
+    *key = (CodecCache_Key){
+        .contentHash64  = contentHash,
+        .standardNodeID = standardNodeID,
+        .formatVersion  = (uint32_t)ZL_Encoder_getCParam(
+                encoder, ZL_CParam_formatVersion),
+        .compressionLevel =
+                ZL_Encoder_getCParam(encoder, ZL_CParam_compressionLevel),
+        .decompressionLevel =
+                ZL_Encoder_getCParam(encoder, ZL_CParam_decompressionLevel),
+        .input           = cacheInput,
+        .localParamsSize = localParamsSize,
+        .localParams     = localParams,
+    };
+    return true;
+}
+
+ZL_CodecOutputCache* CodecCache_create(size_t maxBytes)
+{
+    ZL_CodecOutputCache* const cache = ZL_calloc(sizeof(*cache));
+    if (cache == NULL) {
+        return NULL;
+    }
+    cache->cacheArena = ALLOC_HeapArena_create();
+    if (cache->cacheArena == NULL) {
+        ZL_free(cache);
+        return NULL;
+    }
+    cache->maxBytes = maxBytes;
+    cache->map      = CodecCache_Map_createInArena(
+            cache->cacheArena, CODEC_CACHE_MAX_ENTRIES);
+    return cache;
+}
+
+ZL_CodecOutputCache* CodecCache_createDefault(void)
+{
+    return CodecCache_create(CODEC_CACHE_DEFAULT_MAX_BYTES);
+}
+
+void CodecCache_free(ZL_CodecOutputCache* cache)
+{
+    if (cache == NULL) {
+        return;
+    }
+    ALLOC_Arena_freeArena(cache->cacheArena);
+    ZL_free(cache);
+}
+
+void CodecCache_reset(ZL_CodecOutputCache* cache)
+{
+    if (cache == NULL) {
+        return;
+    }
+    ALLOC_Arena_freeAll(cache->cacheArena);
+    cache->map = CodecCache_Map_createInArena(
+            cache->cacheArena, CODEC_CACHE_MAX_ENTRIES);
+    cache->bytesStored = 0;
+    if (cache->statsEnabled) {
+        memset(&cache->stats, 0, sizeof(cache->stats));
+    }
+}
+
+void CodecCache_setStatsEnabled(ZL_CodecOutputCache* cache, bool enabled)
+{
+    ZL_ASSERT_NN(cache);
+    cache->statsEnabled = enabled;
+    memset(&cache->stats, 0, sizeof(cache->stats));
+}
+
+CodecCache_Stats CodecCache_getStats(const ZL_CodecOutputCache* cache)
+{
+    ZL_ASSERT_NN(cache);
+    if (!cache->statsEnabled) {
+        return (CodecCache_Stats){ 0 };
+    }
+    CodecCache_Stats stats = cache->stats;
+    stats.bytesStored      = cache->bytesStored;
+    stats.arenaBytes       = ALLOC_Arena_memAllocated(cache->cacheArena);
+    return stats;
+}
+
+CodecCache_Lookup* CodecCache_lookup(
+        ZL_CodecOutputCache* cache,
+        ZL_Encoder* encoder,
+        ZL_NodeID node,
+        const ZL_Data* input)
+{
+    ZL_ASSERT_NN(cache);
+    ZL_ASSERT_NN(encoder);
+    CodecCache_Lookup* const lookup =
+            ALLOC_Arena_malloc(encoder->wkspArena, sizeof(*lookup));
+    if (lookup == NULL
+        || !CodecCache_buildKey(&lookup->key, encoder, node, input)) {
+        return NULL;
+    }
+    lookup->cache = cache;
+    const CodecCache_Map_Entry* const found =
+            CodecCache_Map_find(&cache->map, &lookup->key);
+    if (found == NULL) {
+        if (cache->statsEnabled) {
+            ++cache->stats.misses;
+        }
+        lookup->result = NULL;
+    } else {
+        if (cache->statsEnabled) {
+            ++cache->stats.hits;
+        }
+        lookup->result = found->val;
+    }
+    return lookup;
+}
+
+const CodecCache_Result* CodecCache_Lookup_getResult(
+        const CodecCache_Lookup* lookup)
+{
+    ZL_ASSERT_NN(lookup);
+    return lookup->result;
+}
+
+static bool CodecCache_storedSize(
+        const CodecCache_Key* key,
+        const CodecCache_Result* result,
+        size_t* storedSize)
+{
+    size_t size = 0;
+    if (!CodecCache_addSize(&size, key->localParamsSize)
+        || !CodecCache_addSize(&size, sizeof(key->input))
+        || !CodecCache_addArraySize(
+                &size, result->nbOutputs, sizeof(result->outputs[0]))
+        || !CodecCache_addSize(&size, result->headerSize)
+        || !CodecCache_addSize(&size, key->input.contentSize)
+        || !CodecCache_addArraySize(
+                &size, key->input.nbIntMetadata, sizeof(Stream_IntMetadata))) {
+        return false;
+    }
+    for (size_t i = 0; i < result->nbOutputs; ++i) {
+        if (!CodecCache_addSize(&size, result->outputs[i].contentSize)
+            || !CodecCache_addArraySize(
+                    &size,
+                    result->outputs[i].nbIntMetadata,
+                    sizeof(Stream_IntMetadata))) {
+            return false;
+        }
+    }
+    *storedSize = size;
+    return true;
+}
+
+static void*
+CodecCache_copyBytes(Arena* cacheArena, const void* src, size_t size)
+{
+    if (size == 0) {
+        return NULL;
+    }
+    ZL_ASSERT_NN(src);
+    void* const dst = ALLOC_Arena_malloc(cacheArena, size);
+    if (dst != NULL) {
+        memcpy(dst, src, size);
+    }
+    return dst;
+}
+
+static void CodecCache_freeCopy(Arena* cacheArena, const void* copy)
+{
+    /* Stored descriptors expose their cache-owned buffers as read-only. */
+    void* allocation;
+    memcpy(&allocation, &copy, sizeof(allocation));
+    ALLOC_Arena_free(cacheArena, allocation);
+}
+
+static void CodecCache_freeInput(
+        Arena* cacheArena,
+        const CodecCache_Input* input)
+{
+    CodecCache_freeCopy(cacheArena, input->content);
+    CodecCache_freeCopy(cacheArena, input->intMetadata);
+}
+
+static bool CodecCache_copyInput(
+        Arena* cacheArena,
+        const CodecCache_Input* src,
+        CodecCache_Input* dst)
+{
+    *dst             = *src;
+    dst->content     = NULL;
+    dst->intMetadata = NULL;
+    dst->content =
+            CodecCache_copyBytes(cacheArena, src->content, src->contentSize);
+    if (src->contentSize != 0 && dst->content == NULL) {
+        return false;
+    }
+    size_t metadataSize;
+    if (ZL_overflowMulST(
+                src->nbIntMetadata,
+                sizeof(Stream_IntMetadata),
+                &metadataSize)) {
+        return false;
+    }
+    dst->intMetadata =
+            CodecCache_copyBytes(cacheArena, src->intMetadata, metadataSize);
+    if (metadataSize != 0 && dst->intMetadata == NULL) {
+        return false;
+    }
+    return true;
+}
+
+static void CodecCache_freeOutputs(
+        Arena* cacheArena,
+        const CodecCache_Output* outputs,
+        size_t nbOutputs)
+{
+    if (outputs == NULL) {
+        return;
+    }
+    for (size_t i = 0; i < nbOutputs; ++i) {
+        CodecCache_freeCopy(cacheArena, outputs[i].content);
+        CodecCache_freeCopy(cacheArena, outputs[i].intMetadata);
+    }
+    CodecCache_freeCopy(cacheArena, outputs);
+}
+
+static bool CodecCache_copyOutputs(
+        Arena* cacheArena,
+        const CodecCache_Result* src,
+        CodecCache_Result* dst)
+{
+    if (src->nbOutputs == 0) {
+        dst->outputs = NULL;
+        return true;
+    }
+    size_t outputsSize;
+    if (ZL_overflowMulST(
+                src->nbOutputs, sizeof(src->outputs[0]), &outputsSize)) {
+        return false;
+    }
+    CodecCache_Output* const outputs =
+            ALLOC_Arena_malloc(cacheArena, outputsSize);
+    if (outputs == NULL) {
+        return false;
+    }
+    for (size_t i = 0; i < src->nbOutputs; ++i) {
+        outputs[i]             = src->outputs[i];
+        outputs[i].content     = NULL;
+        outputs[i].intMetadata = NULL;
+        outputs[i].content     = CodecCache_copyBytes(
+                cacheArena,
+                src->outputs[i].content,
+                src->outputs[i].contentSize);
+        if (src->outputs[i].contentSize != 0 && outputs[i].content == NULL) {
+            CodecCache_freeOutputs(cacheArena, outputs, i + 1);
+            return false;
+        }
+        size_t metadataSize;
+        if (ZL_overflowMulST(
+                    src->outputs[i].nbIntMetadata,
+                    sizeof(Stream_IntMetadata),
+                    &metadataSize)) {
+            CodecCache_freeOutputs(cacheArena, outputs, i + 1);
+            return false;
+        }
+        outputs[i].intMetadata = CodecCache_copyBytes(
+                cacheArena, src->outputs[i].intMetadata, metadataSize);
+        if (metadataSize != 0 && outputs[i].intMetadata == NULL) {
+            CodecCache_freeOutputs(cacheArena, outputs, i + 1);
+            return false;
+        }
+    }
+    dst->outputs = outputs;
+    return true;
+}
+
+static void CodecCache_freeStoredEntry(
+        Arena* cacheArena,
+        CodecCache_Key* key,
+        CodecCache_Result* result)
+{
+    CodecCache_freeCopy(cacheArena, key->localParams);
+    CodecCache_freeInput(cacheArena, &key->input);
+    if (result != NULL) {
+        CodecCache_freeOutputs(cacheArena, result->outputs, result->nbOutputs);
+        CodecCache_freeCopy(cacheArena, result->header);
+        ALLOC_Arena_free(cacheArena, result);
+    }
+}
+
+CodecCache_InsertResult CodecCache_store(
+        const CodecCache_Lookup* lookup,
+        const CodecCache_Result* result)
+{
+    ZL_ASSERT_NN(lookup);
+    ZL_ASSERT_NN(result);
+    ZL_CodecOutputCache* const cache = lookup->cache;
+    const CodecCache_Key* const key  = &lookup->key;
+
+    if (CodecCache_Map_find(&cache->map, key) != NULL) {
+        if (cache->statsEnabled) {
+            ++cache->stats.duplicateInserts;
+        }
+        return CodecCache_InsertResult_duplicate;
+    }
+
+    size_t storedSize;
+    size_t newBytesStored;
+    if (!CodecCache_storedSize(key, result, &storedSize)
+        || ZL_overflowAddST(cache->bytesStored, storedSize, &newBytesStored)
+        || newBytesStored > cache->maxBytes) {
+        if (cache->statsEnabled) {
+            ++cache->stats.budgetSkips;
+        }
+        return CodecCache_InsertResult_budgetExceeded;
+    }
+
+    CodecCache_Key storedKey        = *key;
+    storedKey.localParams           = NULL;
+    storedKey.input.content         = NULL;
+    storedKey.input.intMetadata     = NULL;
+    CodecCache_Result* storedResult = NULL;
+
+    storedKey.localParams = CodecCache_copyBytes(
+            cache->cacheArena, key->localParams, key->localParamsSize);
+    if ((key->localParamsSize != 0 && storedKey.localParams == NULL)
+        || !CodecCache_copyInput(
+                cache->cacheArena, &key->input, &storedKey.input)) {
+        goto allocationFailure;
+    }
+
+    storedResult = ALLOC_Arena_malloc(cache->cacheArena, sizeof(*storedResult));
+    if (storedResult == NULL) {
+        goto allocationFailure;
+    }
+    *storedResult         = *result;
+    storedResult->outputs = NULL;
+    storedResult->header  = NULL;
+    if (!CodecCache_copyOutputs(cache->cacheArena, result, storedResult)) {
+        goto allocationFailure;
+    }
+    storedResult->header = CodecCache_copyBytes(
+            cache->cacheArena, result->header, result->headerSize);
+    if (result->headerSize != 0 && storedResult->header == NULL) {
+        goto allocationFailure;
+    }
+
+    const CodecCache_Map_Entry mapEntry = {
+        .key = storedKey,
+        .val = storedResult,
+    };
+    const CodecCache_Map_Insert inserted =
+            CodecCache_Map_insert(&cache->map, &mapEntry);
+    if (inserted.badAlloc) {
+        goto allocationFailure;
+    }
+    if (!inserted.inserted) {
+        CodecCache_freeStoredEntry(cache->cacheArena, &storedKey, storedResult);
+        if (cache->statsEnabled) {
+            ++cache->stats.duplicateInserts;
+        }
+        return CodecCache_InsertResult_duplicate;
+    }
+    cache->bytesStored = newBytesStored;
+    if (cache->statsEnabled) {
+        ++cache->stats.inserts;
+    }
+    return CodecCache_InsertResult_inserted;
+
+allocationFailure:
+    CodecCache_freeStoredEntry(cache->cacheArena, &storedKey, storedResult);
+    if (cache->statsEnabled) {
+        ++cache->stats.allocationFailures;
+    }
+    return CodecCache_InsertResult_allocationFailure;
+}

--- a/src/openzl/compress/codec_output_cache.h
+++ b/src/openzl/compress/codec_output_cache.h
@@ -9,6 +9,7 @@
 
 #include "openzl/common/stream.h" // Stream_IntMetadata
 #include "openzl/shared/portability.h"
+#include "openzl/zl_codec_output_cache.h"
 #include "openzl/zl_data.h"
 
 ZL_BEGIN_C_DECLS
@@ -29,8 +30,8 @@ ZL_BEGIN_C_DECLS
  * A hash is used to locate candidates quickly, but a hit is accepted only
  * after exact comparison of every output-affecting key field. Hash collisions
  * therefore cannot turn one codec invocation into another invocation's result.
+ * The opaque ZL_CodecOutputCache handle is declared by the public cache header.
  */
-typedef struct ZL_CodecOutputCache_s ZL_CodecOutputCache;
 typedef struct CodecCache_Lookup_s CodecCache_Lookup;
 
 /**
@@ -85,27 +86,59 @@ typedef struct {
     size_t hits;
     /** Cacheable lookups for which no exact invocation matched. */
     size_t misses;
-    /** New entries successfully stored. */
+    /** New results successfully stored. */
     size_t inserts;
     /** Insertions skipped because an exact key was already present. */
     size_t duplicateInserts;
-    /**
-     * Insertions skipped because size accounting overflowed or hit the budget.
+    /** Invocations skipped because the transform is registered by the caller.
+     */
+    size_t customCodecSkips;
+    /** Invocations skipped because they have a local reference parameter. */
+    size_t refParamSkips;
+    /** Invocations skipped because they reference a dictionary. */
+    size_t dictSkips;
+    /** Invocations skipped because they have a materialized parameter. */
+    size_t mparamSkips;
+    /** Invocations skipped because they consume or produce string streams. */
+    size_t stringSkips;
+    /** Invocations skipped because they do not consume exactly one input. */
+    size_t nonSingleInputSkips;
+    /** Insertions skipped because size accounting overflowed or hit the budget.
      */
     size_t budgetSkips;
     /** Insertions skipped after an allocation failure. */
     size_t allocationFailures;
     /**
-     * Budgeted bytes owned by entries. Includes copied descriptors, contents,
-     * metadata, parameters, and headers, but excludes map and arena overhead.
+     * Budgeted bytes owned by cached invocations. Includes copied descriptors,
+     * contents, metadata, parameters, and headers, but excludes map and arena
+     * overhead.
      */
     size_t bytesStored;
     /** Total bytes currently held by the cache arena, including overhead. */
     size_t arenaBytes;
 } CodecCache_Stats;
 
+/** Reason an otherwise encountered codec invocation was not cacheable. */
+typedef enum {
+    /** The transform is registered by the caller rather than OpenZL. */
+    CodecCache_SkipReason_customCodec,
+    /** A local reference parameter can affect output without entering the key.
+     */
+    CodecCache_SkipReason_refParam,
+    /** A referenced dictionary can affect output without entering the key. */
+    CodecCache_SkipReason_dict,
+    /** A materialized parameter can affect output without entering the key. */
+    CodecCache_SkipReason_mparam,
+    /** String streams include length data not represented by this cache key. */
+    CodecCache_SkipReason_string,
+    /** The cache only represents single-input codec invocations. */
+    CodecCache_SkipReason_nonSingleInput,
+} CodecCache_SkipReason;
+
 /** Outcome of CodecCache_store(). All non-stored outcomes are non-fatal. */
 typedef enum {
+    /** The completed invocation has an output the cache cannot represent. */
+    CodecCache_InsertResult_notCacheable,
     /** A deep-copied entry was added. */
     CodecCache_InsertResult_inserted,
     /** The key already existed; the original entry was retained. */
@@ -142,6 +175,11 @@ void CodecCache_setStatsEnabled(ZL_CodecOutputCache* cache, bool enabled);
  * statistics collection is disabled. @p cache is non-NULL.
  */
 CodecCache_Stats CodecCache_getStats(const ZL_CodecOutputCache* cache);
+
+/** Increments the skip counter corresponding to @p reason. */
+void CodecCache_recordSkip(
+        ZL_CodecOutputCache* cache,
+        CodecCache_SkipReason reason);
 
 /**
  * Looks up one single-input codec invocation and records a hit or miss.

--- a/src/openzl/compress/codec_output_cache.h
+++ b/src/openzl/compress/codec_output_cache.h
@@ -1,0 +1,182 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#ifndef OPENZL_COMPRESS_CODEC_OUTPUT_CACHE_H
+#define OPENZL_COMPRESS_CODEC_OUTPUT_CACHE_H
+
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+
+#include "openzl/common/stream.h" // Stream_IntMetadata
+#include "openzl/shared/portability.h"
+#include "openzl/zl_data.h"
+
+ZL_BEGIN_C_DECLS
+
+/**
+ * Internal cache used by the compression engine to memoize complete codec
+ * invocations.
+ *
+ * CodecCache_lookup() derives the complete identity of an invocation from the
+ * encoder context, invoked node, and input stream. Callers cannot manufacture
+ * partial cache keys or confuse an encoder-node identity with its wire-format
+ * transform ID.
+ *
+ * CodecCache_store() deep-copies every variable-length result field, so a
+ * stored result remains valid independently of the caller's buffers. The cache
+ * owns those copies until CodecCache_reset() or CodecCache_free().
+ *
+ * A hash is used to locate candidates quickly, but a hit is accepted only
+ * after exact comparison of every output-affecting key field. Hash collisions
+ * therefore cannot turn one codec invocation into another invocation's result.
+ */
+typedef struct ZL_CodecOutputCache_s ZL_CodecOutputCache;
+typedef struct CodecCache_Lookup_s CodecCache_Lookup;
+
+/**
+ * Exact description of one fixed-width output produced by a codec invocation.
+ *
+ * `ZL_Type_string` is not representable because `content` does not include the
+ * stream's separate string-length array. String outputs must not be stored.
+ */
+typedef struct {
+    /** Logical stream type, checked against the output port during replay. */
+    ZL_Type type;
+    /** Codec output port that produced the stream, including VO ports. */
+    int outcomeIndex;
+    /** Width in bytes of one logical output element. */
+    size_t eltWidth;
+    /** Number of logical elements produced. */
+    size_t numElts;
+    /** Number of bytes readable from `content`. */
+    size_t contentSize;
+    /**
+     * Borrowed output bytes. Must be non-NULL when `contentSize` is nonzero;
+     * may be NULL for an empty output. Insertion deep-copies these bytes.
+     */
+    const void* content;
+    /** Number of elements in `intMetadata`. */
+    size_t nbIntMetadata;
+    /**
+     * Borrowed output metadata in stream order. Must be non-NULL when
+     * `nbIntMetadata` is nonzero; deep-copied on insertion.
+     */
+    const Stream_IntMetadata* intMetadata;
+} CodecCache_Output;
+
+/** Complete result of one successful codec invocation. */
+typedef struct {
+    /** Number of output descriptors in `outputs`; zero is valid. */
+    size_t nbOutputs;
+    /** Borrowed ordered outputs; NULL only when `nbOutputs` is zero. */
+    const CodecCache_Output* outputs;
+    /** Number of bytes readable from `header`; zero means no header. */
+    size_t headerSize;
+    /**
+     * Borrowed transform-header bytes, deep-copied on insertion. Must be
+     * non-NULL when `headerSize` is nonzero and NULL otherwise.
+     */
+    const void* header;
+} CodecCache_Result;
+
+/** Cache activity and memory accounting since creation or the last reset. */
+typedef struct {
+    /** Lookups that found an exact invocation match. */
+    size_t hits;
+    /** Cacheable lookups for which no exact invocation matched. */
+    size_t misses;
+    /** New entries successfully stored. */
+    size_t inserts;
+    /** Insertions skipped because an exact key was already present. */
+    size_t duplicateInserts;
+    /**
+     * Insertions skipped because size accounting overflowed or hit the budget.
+     */
+    size_t budgetSkips;
+    /** Insertions skipped after an allocation failure. */
+    size_t allocationFailures;
+    /**
+     * Budgeted bytes owned by entries. Includes copied descriptors, contents,
+     * metadata, parameters, and headers, but excludes map and arena overhead.
+     */
+    size_t bytesStored;
+    /** Total bytes currently held by the cache arena, including overhead. */
+    size_t arenaBytes;
+} CodecCache_Stats;
+
+/** Outcome of CodecCache_store(). All non-stored outcomes are non-fatal. */
+typedef enum {
+    /** A deep-copied entry was added. */
+    CodecCache_InsertResult_inserted,
+    /** The key already existed; the original entry was retained. */
+    CodecCache_InsertResult_duplicate,
+    /** The entry did not fit the configured budget or its size overflowed. */
+    CodecCache_InsertResult_budgetExceeded,
+    /** The entry could not be copied into cache-owned storage. */
+    CodecCache_InsertResult_allocationFailure,
+} CodecCache_InsertResult;
+
+/**
+ * Creates an empty cache with the exact @p maxBytes entry-payload budget.
+ * Returns NULL on allocation failure.
+ */
+ZL_CodecOutputCache* CodecCache_create(size_t maxBytes);
+
+/** Creates an empty cache with the default entry-payload budget. */
+ZL_CodecOutputCache* CodecCache_createDefault(void);
+
+/** Frees the cache and all owned entries. Accepts NULL. */
+void CodecCache_free(ZL_CodecOutputCache* cache);
+
+/** Removes all entries and clears all counters. Accepts NULL. */
+void CodecCache_reset(ZL_CodecOutputCache* cache);
+
+/**
+ * Enables or disables statistics collection and clears all statistics.
+ * Call only while the cache is not in use.
+ */
+void CodecCache_setStatsEnabled(ZL_CodecOutputCache* cache, bool enabled);
+
+/**
+ * Returns a snapshot of cache counters and memory use, or zeros when
+ * statistics collection is disabled. @p cache is non-NULL.
+ */
+CodecCache_Stats CodecCache_getStats(const ZL_CodecOutputCache* cache);
+
+/**
+ * Looks up one single-input codec invocation and records a hit or miss.
+ *
+ * @p node is the node the engine is about to invoke, not its wire transform
+ * ID or a caller-derived base node. The cache resolves the stable built-in
+ * encoder identity and all other output-affecting key fields internally.
+ *
+ * Returns NULL when the invocation is not cacheable or temporary key
+ * construction fails. Otherwise, the returned lookup is allocated in @p
+ * encoder's workspace and remains valid for that encoder invocation.
+ */
+CodecCache_Lookup* CodecCache_lookup(
+        ZL_CodecOutputCache* cache,
+        ZL_Encoder* encoder,
+        ZL_NodeID node,
+        const ZL_Data* input);
+
+/**
+ * Returns the immutable cache-owned result found by @p lookup, or NULL for a
+ * miss. A non-NULL result remains valid until the cache is reset or freed.
+ */
+const CodecCache_Result* CodecCache_Lookup_getResult(
+        const CodecCache_Lookup* lookup);
+
+/**
+ * Stores a deep copy of @p result for the invocation represented by @p lookup
+ * if it is new and fits the budget. The caller retains ownership of every
+ * supplied buffer. Failure to cache is reported by the return value and must
+ * not fail compression.
+ */
+CodecCache_InsertResult CodecCache_store(
+        const CodecCache_Lookup* lookup,
+        const CodecCache_Result* result);
+
+ZL_END_C_DECLS
+
+#endif // OPENZL_COMPRESS_CODEC_OUTPUT_CACHE_H

--- a/src/openzl/compress/enc_interface.c
+++ b/src/openzl/compress/enc_interface.c
@@ -7,15 +7,19 @@
 #include "openzl/common/introspection.h" // WAYPOINT, ZL_CompressIntrospectionHooks
 #include "openzl/common/limits.h"
 #include "openzl/common/operation_context.h"
+#include "openzl/common/stream.h"
 #include "openzl/compress/cctx.h"   // CCTX_*
 #include "openzl/compress/cgraph.h" // CGRAPH_getDictObj
 #include "openzl/compress/cnode.h"
+#include "openzl/compress/codec_output_cache.h"
 #include "openzl/compress/localparams.h"
 #include "openzl/compress/trStates.h"   // TRS_getState
 #include "openzl/dict/dict_constants.h" // ZL_DICT_INDEX_NONE
-#include "openzl/zl_common_types.h"     // ZL_TernaryParam_disable
+#include "openzl/shared/overflow.h"
+#include "openzl/zl_common_types.h" // ZL_TernaryParam_disable
 #include "openzl/zl_compressor.h"
 #include "openzl/zl_data.h"
+#include "openzl/zl_output.h"
 #include "openzl/zl_version.h"
 
 ZL_Report ENC_initEICtx(
@@ -262,6 +266,108 @@ ZL_Output* ENC_refTypedStream(
             offsetBytes));
 }
 
+static ZL_Report ENC_replayCodecOutputCacheResult(
+        ZL_Encoder* eictx,
+        const CodecCache_Result* result)
+{
+    ZL_RESULT_DECLARE_SCOPE_REPORT(eictx);
+    for (size_t i = 0; i < result->nbOutputs; ++i) {
+        const CodecCache_Output* const cached = &result->outputs[i];
+        ZL_Output* const output               = ZL_Encoder_createTypedStream(
+                eictx, cached->outcomeIndex, cached->numElts, cached->eltWidth);
+        ZL_ERR_IF_NULL(output, allocation);
+        ZL_ERR_IF_NE(
+                ZL_Output_type(output),
+                cached->type,
+                corruption,
+                "Cached codec output type does not match its output port");
+        if (cached->contentSize != 0) {
+            void* const dst = ZL_Output_ptr(output);
+            ZL_ERR_IF_NULL(dst, allocation);
+            memcpy(dst, cached->content, cached->contentSize);
+        }
+        ZL_ERR_IF_ERR(ZL_Output_commit(output, cached->numElts));
+        for (size_t m = 0; m < cached->nbIntMetadata; ++m) {
+            ZL_ERR_IF_ERR(ZL_Output_setIntMetadata(
+                    output,
+                    cached->intMetadata[m].id,
+                    cached->intMetadata[m].value));
+        }
+    }
+    if (result->headerSize != 0) {
+        ZL_Encoder_sendCodecHeader(eictx, result->header, result->headerSize);
+    }
+    return ZL_returnSuccess();
+}
+
+static void ENC_snapshotCodecOutputCacheResult(
+        ZL_Encoder* eictx,
+        const CodecCache_Lookup* lookup)
+{
+    const RTGraph* const rtgraph = CCTX_getRTGraph(eictx->cctx);
+    const size_t nbOutputs = RTGM_getNbOutStreams(rtgraph, eictx->rtnodeid);
+    size_t outputsSize;
+    if (ZL_overflowMulST(nbOutputs, sizeof(CodecCache_Output), &outputsSize)) {
+        return;
+    }
+    CodecCache_Output* outputs = NULL;
+    if (outputsSize != 0) {
+        outputs = ALLOC_Arena_malloc(eictx->wkspArena, outputsSize);
+        if (outputs == NULL) {
+            return;
+        }
+    }
+    for (size_t i = 0; i < nbOutputs; ++i) {
+        const RTStreamID streamID =
+                RTGM_getOutStreamID(rtgraph, eictx->rtnodeid, (int)i);
+        const ZL_Data* const stream = RTGM_getRStream(rtgraph, streamID);
+        outputs[i]                  = (CodecCache_Output){
+                             .type = ZL_Data_type(stream),
+                             .outcomeIndex =
+                    (int)RTGM_getOutcomeID_fromRtstream(rtgraph, streamID),
+                             .eltWidth    = ZL_Data_eltWidth(stream),
+                             .numElts     = ZL_Data_numElts(stream),
+                             .contentSize = ZL_Data_contentSize(stream),
+                             .content     = ZL_Data_rPtr(stream),
+        };
+        outputs[i].nbIntMetadata = STREAM_numIntMetadata(stream);
+        if (outputs[i].nbIntMetadata == 0) {
+            continue;
+        }
+        size_t metadataSize;
+        if (ZL_overflowMulST(
+                    outputs[i].nbIntMetadata,
+                    sizeof(Stream_IntMetadata),
+                    &metadataSize)) {
+            return;
+        }
+        Stream_IntMetadata* const metadata =
+                ALLOC_Arena_malloc(eictx->wkspArena, metadataSize);
+        if (metadata == NULL) {
+            return;
+        }
+        if (ZL_isError(STREAM_copyIntMetadata(
+                    metadata, stream, outputs[i].nbIntMetadata))) {
+            return;
+        }
+        outputs[i].intMetadata = metadata;
+    }
+
+    CodecCache_Result result = {
+        .nbOutputs = nbOutputs,
+        .outputs   = outputs,
+    };
+    if (eictx->hasSentTrHeader) {
+        const ZL_RBuffer header =
+                CCTX_getNodeHeader(eictx->cctx, eictx->rtnodeid);
+        if (header.size != 0) {
+            result.headerSize = header.size;
+            result.header     = header.start;
+        }
+    }
+    (void)CodecCache_store(lookup, &result);
+}
+
 static ZL_Report ENC_runTransform_internal(
         ZL_Encoder* eictx,
         ZL_NodeID nodeid,
@@ -283,8 +389,20 @@ static ZL_Report ENC_runTransform_internal(
     eictx->opaquePtr                = trDesc->publicDesc.opaque.ptr;
     eictx->sendTransformHeaderError = ZL_returnSuccess();
 
-    // Run transform
-    ZL_ASSERT_NN(trDesc->publicDesc.transform_f);
+    ZL_CodecOutputCache* const cache = CCTX_getCodecOutputCache(eictx->cctx);
+    CodecCache_Lookup* cacheLookup   = NULL;
+    const CodecCache_Result* cachedResult = NULL;
+    if (cache != NULL) {
+        if (nbInStreams == 1) {
+            cacheLookup = CodecCache_lookup(cache, eictx, nodeid, inStreams[0]);
+            if (cacheLookup != NULL) {
+                cachedResult = CodecCache_Lookup_getResult(cacheLookup);
+            }
+        } else {
+            CodecCache_recordSkip(cache, CodecCache_SkipReason_nonSingleInput);
+        }
+    }
+
     IF_CWAYPOINT_ENABLED(on_codecEncode_start, eictx)
     {
         CWAYPOINT(
@@ -295,8 +413,14 @@ static ZL_Report ENC_runTransform_internal(
                 ZL_codemodDatasAsInputs(inStreams),
                 nbInStreams);
     }
-    ZL_Report codecExecResult = (trDesc->publicDesc.transform_f(
-            eictx, ZL_codemodDatasAsInputs(inStreams), nbInStreams));
+    ZL_Report codecExecResult;
+    if (cachedResult != NULL) {
+        codecExecResult = ENC_replayCodecOutputCacheResult(eictx, cachedResult);
+    } else {
+        ZL_ASSERT_NN(trDesc->publicDesc.transform_f);
+        codecExecResult = (trDesc->publicDesc.transform_f(
+                eictx, ZL_codemodDatasAsInputs(inStreams), nbInStreams));
+    }
     if (ZL_isError(codecExecResult)) {
         CWAYPOINT(on_codecEncode_end, eictx, NULL, 0, codecExecResult);
         ZL_ERR_IF_ERR_COERCE(
@@ -306,7 +430,6 @@ static ZL_Report ENC_runTransform_internal(
     const size_t nbOutStreams = RTGM_getNbOutStreams(rtgm, eictx->rtnodeid);
     IF_CWAYPOINT_ENABLED(on_codecEncode_end, eictx)
     {
-        DECLARE_VECTOR_CONST_POINTERS_TYPE(ZL_Data);
         VECTOR_CONST_POINTERS(ZL_Data) odata = { 0 };
         VECTOR_INIT(odata, nbOutStreams);
         for (size_t i = 0; i < nbOutStreams; ++i) {
@@ -356,6 +479,10 @@ static ZL_Report ENC_runTransform_internal(
             nbOutStreams,
             ZL_transformOutStreamsLimit(formatVersion),
             formatVersion_unsupported);
+
+    if (cacheLookup != NULL && cachedResult == NULL) {
+        ENC_snapshotCodecOutputCacheResult(eictx, cacheLookup);
+    }
 
     return ZL_returnValue(nbOutStreams);
 }

--- a/tests/unittest/common/test_stream.cpp
+++ b/tests/unittest/common/test_stream.cpp
@@ -29,7 +29,30 @@ TEST(Stream, intMetadata)
     // test what happens when requesting a non-present metadata id
     ASSERT_EQ(ZL_Data_getIntMetadata(s, 3).isPresent, 0);
 
+    ASSERT_EQ(STREAM_numIntMetadata(s), 2u);
+    Stream_IntMetadata metadata[2];
+    ASSERT_ZS_VALID(STREAM_copyIntMetadata(metadata, s, 2));
+    EXPECT_EQ(metadata[0].id, 1);
+    EXPECT_EQ(metadata[0].value, 1001);
+    EXPECT_EQ(metadata[1].id, 2);
+    EXPECT_EQ(metadata[1].value, 2002);
+
+    const Stream_IntMetadata sentinel = { 7, 7007 };
+    Stream_IntMetadata rejected       = sentinel;
+    EXPECT_TRUE(ZL_isError(STREAM_copyIntMetadata(&rejected, s, 1)));
+    EXPECT_EQ(rejected.id, sentinel.id);
+    EXPECT_EQ(rejected.value, sentinel.value);
+    EXPECT_TRUE(ZL_isError(STREAM_copyIntMetadata(&rejected, s, 3)));
+    EXPECT_EQ(rejected.id, sentinel.id);
+    EXPECT_EQ(rejected.value, sentinel.value);
+    EXPECT_TRUE(ZL_isError(STREAM_copyIntMetadata(nullptr, s, 2)));
+
     STREAM_free(s);
+
+    ZL_Data* const empty = STREAM_create(kZeroID);
+    ASSERT_NE(empty, nullptr);
+    EXPECT_ZS_VALID(STREAM_copyIntMetadata(nullptr, empty, 0));
+    STREAM_free(empty);
 }
 
 // check byteSize function

--- a/tests/unittest/compress/test_codec_output_cache.cpp
+++ b/tests/unittest/compress/test_codec_output_cache.cpp
@@ -1,0 +1,641 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#include <array>
+#include <cstring>
+#include <memory>
+
+#include <gtest/gtest.h>
+
+#include "openzl/codecs/zl_sparse_num.h"
+#include "openzl/common/allocation.h"
+#include "openzl/common/stream.h"
+#include "openzl/compress/cctx.h"
+#include "openzl/compress/cgraph.h"
+#include "openzl/compress/cnode.h"
+#include "openzl/compress/codec_output_cache.h"
+#include "openzl/compress/enc_interface.h"
+#include "openzl/compress/private_nodes.h"
+#include "openzl/zl_compress.h"
+#include "openzl/zl_compressor.h"
+#include "openzl/zl_version.h"
+
+namespace {
+
+class Cache {
+   public:
+    Cache() : cache_(CodecCache_createDefault())
+    {
+        if (cache_ != nullptr) {
+            CodecCache_setStatsEnabled(cache_, true);
+        }
+    }
+
+    explicit Cache(size_t maxBytes) : cache_(CodecCache_create(maxBytes))
+    {
+        if (cache_ != nullptr) {
+            CodecCache_setStatsEnabled(cache_, true);
+        }
+    }
+
+    ~Cache()
+    {
+        CodecCache_free(cache_);
+    }
+
+    ZL_CodecOutputCache* get() const
+    {
+        return cache_;
+    }
+
+   private:
+    ZL_CodecOutputCache* cache_;
+};
+
+CodecCache_Output makeOutput(const void* content, size_t size)
+{
+    return CodecCache_Output{
+        .type         = ZL_Type_serial,
+        .outcomeIndex = 0,
+        .eltWidth     = 1,
+        .numElts      = size,
+        .contentSize  = size,
+        .content      = content,
+    };
+}
+
+CodecCache_Result makeResult(
+        const CodecCache_Output* outputs,
+        size_t nbOutputs,
+        const void* header = nullptr,
+        size_t headerSize  = 0)
+{
+    return CodecCache_Result{
+        .nbOutputs  = nbOutputs,
+        .outputs    = outputs,
+        .headerSize = headerSize,
+        .header     = header,
+    };
+}
+
+class CodecOutputCacheTest : public testing::Test {
+   protected:
+    void SetUp() override
+    {
+        compressor_   = ZL_Compressor_create();
+        cctx_         = ZL_CCtx_create();
+        scratchArena_ = ALLOC_HeapArena_create();
+        ASSERT_NE(compressor_, nullptr);
+        ASSERT_NE(cctx_, nullptr);
+        ASSERT_NE(scratchArena_, nullptr);
+        ASSERT_FALSE(ZL_isError(ZL_Compressor_selectStartingGraphID(
+                compressor_, ZL_GRAPH_RANGE_PACK_ZSTD)));
+        ASSERT_FALSE(ZL_isError(ZL_CCtx_refCompressor(cctx_, compressor_)));
+        encoder_.cctx      = cctx_;
+        encoder_.wkspArena = scratchArena_;
+    }
+
+    void TearDown() override
+    {
+        ALLOC_Arena_freeArena(scratchArena_);
+        ZL_CCtx_free(cctx_);
+        ZL_Compressor_free(compressor_);
+    }
+
+    Stream* makeInput(const void* content, size_t size)
+    {
+        Stream* const input =
+                STREAM_createInArena(scratchArena_, ZL_DATA_ID_INPUTSTREAM);
+        if (input == nullptr
+            || ZL_isError(STREAM_refConstBuffer(
+                    input, content, ZL_Type_serial, 1, size))) {
+            return nullptr;
+        }
+        return input;
+    }
+
+    CodecCache_Lookup* lookupWithParams(
+            ZL_CodecOutputCache* cache,
+            ZL_NodeID node,
+            const ZL_Data* input,
+            const ZL_LocalParams* localParams)
+    {
+        encoder_.cnode   = CGRAPH_getCNode(compressor_, node);
+        encoder_.lparams = localParams;
+        return CodecCache_lookup(cache, &encoder_, node, input);
+    }
+
+    CodecCache_Lookup*
+    lookup(ZL_CodecOutputCache* cache, ZL_NodeID node, const ZL_Data* input)
+    {
+        const CNode* const cnode = CGRAPH_getCNode(compressor_, node);
+        return lookupWithParams(
+                cache,
+                node,
+                input,
+                &cnode->transformDesc.publicDesc.localParams);
+    }
+
+    bool setCodecCParams(
+            int formatVersion,
+            int compressionLevel,
+            int decompressionLevel)
+    {
+        return !ZL_isError(ZL_CCtx_setParameter(
+                       cctx_, ZL_CParam_formatVersion, formatVersion))
+                && !ZL_isError(ZL_CCtx_setParameter(
+                        cctx_, ZL_CParam_compressionLevel, compressionLevel))
+                && !ZL_isError(ZL_CCtx_setParameter(
+                        cctx_,
+                        ZL_CParam_decompressionLevel,
+                        decompressionLevel))
+                && !ZL_isError(CCTX_setAppliedParameters(cctx_));
+    }
+
+    ZL_Compressor* compressor_{ nullptr };
+    ZL_CCtx* cctx_{ nullptr };
+    Arena* scratchArena_{ nullptr };
+    ZL_Encoder encoder_{};
+};
+
+TEST_F(CodecOutputCacheTest, CreateEmpty)
+{
+    Cache cache;
+    ASSERT_NE(cache.get(), nullptr);
+    const CodecCache_Stats stats = CodecCache_getStats(cache.get());
+    EXPECT_EQ(stats.hits, 0);
+    EXPECT_EQ(stats.misses, 0);
+    EXPECT_EQ(stats.inserts, 0);
+    EXPECT_EQ(stats.bytesStored, 0);
+}
+
+TEST_F(CodecOutputCacheTest, StatisticsAreDisabledByDefault)
+{
+    std::unique_ptr<ZL_CodecOutputCache, decltype(&CodecCache_free)> cache(
+            CodecCache_createDefault(), &CodecCache_free);
+    ASSERT_NE(cache, nullptr);
+    const Stream* const input = makeInput("input", 5);
+    ASSERT_NE(input, nullptr);
+    CodecCache_Lookup* const miss =
+            lookup(cache.get(), ZL_NODE_SPARSE_NUM, input);
+    ASSERT_NE(miss, nullptr);
+    const CodecCache_Output output = makeOutput("A", 1);
+    const CodecCache_Result result = makeResult(&output, 1);
+    ASSERT_EQ(
+            CodecCache_store(miss, &result), CodecCache_InsertResult_inserted);
+    CodecCache_Lookup* const hit =
+            lookup(cache.get(), ZL_NODE_SPARSE_NUM, input);
+    ASSERT_NE(hit, nullptr);
+    ASSERT_NE(CodecCache_Lookup_getResult(hit), nullptr);
+
+    const CodecCache_Stats stats = CodecCache_getStats(cache.get());
+    EXPECT_EQ(stats.hits, 0);
+    EXPECT_EQ(stats.misses, 0);
+    EXPECT_EQ(stats.inserts, 0);
+    EXPECT_EQ(stats.bytesStored, 0);
+    EXPECT_EQ(stats.arenaBytes, 0);
+}
+
+TEST_F(CodecOutputCacheTest, StoreThenLookupReturnsResult)
+{
+    Cache cache;
+    const char inputBytes[]   = "input";
+    const char outputBytes[]  = "output";
+    const char header[]       = "header";
+    const Stream* const input = makeInput(inputBytes, sizeof(inputBytes));
+    ASSERT_NE(input, nullptr);
+    CodecCache_Lookup* const miss =
+            lookup(cache.get(), ZL_NODE_SPARSE_NUM, input);
+    ASSERT_NE(miss, nullptr);
+    EXPECT_EQ(CodecCache_Lookup_getResult(miss), nullptr);
+    const CodecCache_Output output =
+            makeOutput(outputBytes, sizeof(outputBytes));
+    const CodecCache_Result result =
+            makeResult(&output, 1, header, sizeof(header));
+    ASSERT_EQ(
+            CodecCache_store(miss, &result), CodecCache_InsertResult_inserted);
+
+    CodecCache_Lookup* const hit =
+            lookup(cache.get(), ZL_NODE_SPARSE_NUM, input);
+    ASSERT_NE(hit, nullptr);
+    const CodecCache_Result* const cachedResult =
+            CodecCache_Lookup_getResult(hit);
+    ASSERT_NE(cachedResult, nullptr);
+    ASSERT_EQ(cachedResult->nbOutputs, 1);
+    EXPECT_EQ(cachedResult->outputs[0].contentSize, sizeof(outputBytes));
+    EXPECT_EQ(
+            std::memcmp(
+                    cachedResult->outputs[0].content,
+                    outputBytes,
+                    sizeof(outputBytes)),
+            0);
+    EXPECT_EQ(cachedResult->headerSize, sizeof(header));
+    EXPECT_EQ(std::memcmp(cachedResult->header, header, sizeof(header)), 0);
+}
+
+TEST_F(CodecOutputCacheTest, DifferentInputsDoNotShareResult)
+{
+    Cache cache;
+    const Stream* const firstInput  = makeInput("first", 5);
+    const Stream* const secondInput = makeInput("other", 5);
+    ASSERT_NE(firstInput, nullptr);
+    ASSERT_NE(secondInput, nullptr);
+    CodecCache_Lookup* const first =
+            lookup(cache.get(), ZL_NODE_SPARSE_NUM, firstInput);
+    ASSERT_NE(first, nullptr);
+    const CodecCache_Output output = makeOutput("A", 1);
+    const CodecCache_Result result = makeResult(&output, 1);
+    ASSERT_EQ(
+            CodecCache_store(first, &result), CodecCache_InsertResult_inserted);
+
+    CodecCache_Lookup* const second =
+            lookup(cache.get(), ZL_NODE_SPARSE_NUM, secondInput);
+    ASSERT_NE(second, nullptr);
+    EXPECT_EQ(CodecCache_Lookup_getResult(second), nullptr);
+}
+
+TEST_F(CodecOutputCacheTest, DifferentInputMetadataDoesNotShareResult)
+{
+    Cache cache;
+    Stream* const firstInput  = makeInput("input", 5);
+    Stream* const secondInput = makeInput("input", 5);
+    ASSERT_NE(firstInput, nullptr);
+    ASSERT_NE(secondInput, nullptr);
+    ASSERT_FALSE(ZL_isError(STREAM_setIntMetadata(firstInput, 1, 2)));
+    ASSERT_FALSE(ZL_isError(STREAM_setIntMetadata(secondInput, 1, 3)));
+
+    CodecCache_Lookup* const first =
+            lookup(cache.get(), ZL_NODE_SPARSE_NUM, firstInput);
+    ASSERT_NE(first, nullptr);
+    const CodecCache_Output output = makeOutput("A", 1);
+    const CodecCache_Result result = makeResult(&output, 1);
+    ASSERT_EQ(
+            CodecCache_store(first, &result), CodecCache_InsertResult_inserted);
+
+    CodecCache_Lookup* const second =
+            lookup(cache.get(), ZL_NODE_SPARSE_NUM, secondInput);
+    ASSERT_NE(second, nullptr);
+    EXPECT_EQ(CodecCache_Lookup_getResult(second), nullptr);
+    STREAM_free(firstInput);
+    STREAM_free(secondInput);
+}
+
+TEST_F(CodecOutputCacheTest, DifferentCodecCParamsDoNotShareResult)
+{
+    constexpr int kFormatVersion           = ZL_MAX_FORMAT_VERSION;
+    constexpr int kCompressionLevel        = 6;
+    constexpr int kDecompressionLevel      = 3;
+    constexpr int kOtherFormatVersion      = ZL_MIN_FORMAT_VERSION;
+    constexpr int kOtherCompressionLevel   = 5;
+    constexpr int kOtherDecompressionLevel = 2;
+    static_assert(kFormatVersion != kOtherFormatVersion);
+
+    ASSERT_TRUE(setCodecCParams(
+            kFormatVersion, kCompressionLevel, kDecompressionLevel));
+    Cache cache;
+    const Stream* const input = makeInput("input", 5);
+    ASSERT_NE(input, nullptr);
+    CodecCache_Lookup* const first =
+            lookup(cache.get(), ZL_NODE_SPARSE_NUM, input);
+    ASSERT_NE(first, nullptr);
+    const CodecCache_Output output = makeOutput("A", 1);
+    const CodecCache_Result result = makeResult(&output, 1);
+    ASSERT_EQ(
+            CodecCache_store(first, &result), CodecCache_InsertResult_inserted);
+
+    const std::array<std::array<int, 3>, 3> alternatives = { {
+            { kOtherFormatVersion, kCompressionLevel, kDecompressionLevel },
+            { kFormatVersion, kOtherCompressionLevel, kDecompressionLevel },
+            { kFormatVersion, kCompressionLevel, kOtherDecompressionLevel },
+    } };
+    for (const auto& params : alternatives) {
+        ASSERT_TRUE(setCodecCParams(params[0], params[1], params[2]));
+        CodecCache_Lookup* const lookupResult =
+                lookup(cache.get(), ZL_NODE_SPARSE_NUM, input);
+        ASSERT_NE(lookupResult, nullptr);
+        EXPECT_EQ(CodecCache_Lookup_getResult(lookupResult), nullptr);
+    }
+}
+
+TEST_F(CodecOutputCacheTest, ReferenceParamsAreNotCacheable)
+{
+    const int referencedValue  = 42;
+    const ZL_RefParam refParam = {
+        .paramId   = 1,
+        .paramRef  = &referencedValue,
+        .paramSize = sizeof(referencedValue),
+    };
+    ZL_LocalParams localParams{};
+    localParams.refParams = { &refParam, 1 };
+
+    Cache cache;
+    const Stream* const input = makeInput("input", 5);
+    ASSERT_NE(input, nullptr);
+    EXPECT_EQ(
+            lookupWithParams(
+                    cache.get(), ZL_NODE_SPARSE_NUM, input, &localParams),
+            nullptr);
+}
+
+TEST_F(CodecOutputCacheTest, CustomCodecIsNotCacheable)
+{
+    const ZL_Type outputType = ZL_Type_serial;
+    const ZL_TypedEncoderDesc desc = {
+        .gd = {
+            .CTid = 1,
+            .inStreamType = ZL_Type_serial,
+            .outStreamTypes = &outputType,
+            .nbOutStreams = 1,
+        },
+        .transform_f =
+                [](ZL_Encoder*, const ZL_Input*) noexcept {
+                    return ZL_returnSuccess();
+                },
+        .name = "custom_codec_cache_test",
+    };
+    const ZL_NodeID customNode =
+            ZL_Compressor_registerTypedEncoder(compressor_, &desc);
+    ASSERT_NE(customNode.nid, ZL_NODE_ILLEGAL.nid);
+
+    Cache cache;
+    const Stream* const input = makeInput("input", 5);
+    ASSERT_NE(input, nullptr);
+    EXPECT_EQ(lookup(cache.get(), customNode, input), nullptr);
+}
+
+TEST_F(CodecOutputCacheTest, DifferentLocalParamPlanesDoNotShareResult)
+{
+    constexpr size_t kIntsPerSizeT = sizeof(size_t) / sizeof(int);
+    static_assert(sizeof(size_t) % sizeof(int) == 0);
+    // These are the words produced by two zero-sized copy parameters.
+    std::array<int, 2 * (1 + kIntsPerSizeT)> serializedWords{};
+    serializedWords[0]                 = 7;
+    serializedWords[1 + kIntsPerSizeT] = 11;
+
+    std::array<ZL_IntParam, 1 + kIntsPerSizeT> intParams{};
+    for (size_t i = 0; i < intParams.size(); ++i) {
+        intParams[i] = { serializedWords[2 * i], serializedWords[2 * i + 1] };
+    }
+    ZL_LocalParams intLocalParams{};
+    intLocalParams.intParams = { intParams.data(), intParams.size() };
+
+    const std::array<ZL_CopyParam, 2> copyParams = {
+        ZL_CopyParam{ 7, nullptr, 0 },
+        ZL_CopyParam{ 11, nullptr, 0 },
+    };
+    ZL_LocalParams copyLocalParams{};
+    copyLocalParams.copyParams = { copyParams.data(), copyParams.size() };
+
+    Cache cache;
+    const Stream* const input = makeInput("input", 5);
+    ASSERT_NE(input, nullptr);
+    CodecCache_Lookup* const first = lookupWithParams(
+            cache.get(), ZL_NODE_SPARSE_NUM, input, &intLocalParams);
+    ASSERT_NE(first, nullptr);
+    const CodecCache_Output output = makeOutput("A", 1);
+    const CodecCache_Result result = makeResult(&output, 1);
+    ASSERT_EQ(
+            CodecCache_store(first, &result), CodecCache_InsertResult_inserted);
+
+    CodecCache_Lookup* const second = lookupWithParams(
+            cache.get(), ZL_NODE_SPARSE_NUM, input, &copyLocalParams);
+    ASSERT_NE(second, nullptr);
+    EXPECT_EQ(CodecCache_Lookup_getResult(second), nullptr);
+}
+
+TEST_F(CodecOutputCacheTest, DifferentIntParamValuesDoNotShareResult)
+{
+    const ZL_IntParam firstParam  = { 7, 11 };
+    const ZL_IntParam secondParam = { 7, 12 };
+    ZL_LocalParams firstParams{};
+    firstParams.intParams = { &firstParam, 1 };
+    ZL_LocalParams secondParams{};
+    secondParams.intParams = { &secondParam, 1 };
+
+    Cache cache;
+    const Stream* const input = makeInput("input", 5);
+    ASSERT_NE(input, nullptr);
+    CodecCache_Lookup* const first = lookupWithParams(
+            cache.get(), ZL_NODE_SPARSE_NUM, input, &firstParams);
+    ASSERT_NE(first, nullptr);
+    const CodecCache_Output output = makeOutput("A", 1);
+    const CodecCache_Result result = makeResult(&output, 1);
+    ASSERT_EQ(
+            CodecCache_store(first, &result), CodecCache_InsertResult_inserted);
+
+    CodecCache_Lookup* const second = lookupWithParams(
+            cache.get(), ZL_NODE_SPARSE_NUM, input, &secondParams);
+    ASSERT_NE(second, nullptr);
+    EXPECT_EQ(CodecCache_Lookup_getResult(second), nullptr);
+}
+
+TEST_F(CodecOutputCacheTest, DifferentCopyParamValuesDoNotShareResult)
+{
+    const char firstValue[]        = "first";
+    const char secondValue[]       = "other";
+    const ZL_CopyParam firstParam  = { 7, firstValue, sizeof(firstValue) };
+    const ZL_CopyParam secondParam = { 7, secondValue, sizeof(secondValue) };
+    ZL_LocalParams firstParams{};
+    firstParams.copyParams = { &firstParam, 1 };
+    ZL_LocalParams secondParams{};
+    secondParams.copyParams = { &secondParam, 1 };
+
+    Cache cache;
+    const Stream* const input = makeInput("input", 5);
+    ASSERT_NE(input, nullptr);
+    CodecCache_Lookup* const first = lookupWithParams(
+            cache.get(), ZL_NODE_SPARSE_NUM, input, &firstParams);
+    ASSERT_NE(first, nullptr);
+    const CodecCache_Output output = makeOutput("A", 1);
+    const CodecCache_Result result = makeResult(&output, 1);
+    ASSERT_EQ(
+            CodecCache_store(first, &result), CodecCache_InsertResult_inserted);
+
+    CodecCache_Lookup* const second = lookupWithParams(
+            cache.get(), ZL_NODE_SPARSE_NUM, input, &secondParams);
+    ASSERT_NE(second, nullptr);
+    EXPECT_EQ(CodecCache_Lookup_getResult(second), nullptr);
+}
+
+TEST_F(CodecOutputCacheTest, EncoderNodeNotWireTransformIdentifiesInvocation)
+{
+    Cache cache;
+    ASSERT_EQ(
+            ZL_Compressor_Node_getCodecID(compressor_, ZL_NODE_SPARSE_NUM),
+            ZL_Compressor_Node_getCodecID(
+                    compressor_, ZL_NODE_SPARSE_NUM_AUTO));
+    const Stream* const input = makeInput("same input", 10);
+    ASSERT_NE(input, nullptr);
+    CodecCache_Lookup* const sparse =
+            lookup(cache.get(), ZL_NODE_SPARSE_NUM, input);
+    ASSERT_NE(sparse, nullptr);
+    const CodecCache_Output output = makeOutput("A", 1);
+    const CodecCache_Result result = makeResult(&output, 1);
+    ASSERT_EQ(
+            CodecCache_store(sparse, &result),
+            CodecCache_InsertResult_inserted);
+
+    CodecCache_Lookup* const sparseAuto =
+            lookup(cache.get(), ZL_NODE_SPARSE_NUM_AUTO, input);
+    ASSERT_NE(sparseAuto, nullptr);
+    EXPECT_EQ(CodecCache_Lookup_getResult(sparseAuto), nullptr);
+}
+
+TEST_F(CodecOutputCacheTest, StoredInvocationAndResultOwnBorrowedData)
+{
+    Cache cache;
+    char inputBytes[]                   = "input";
+    char outputBytes[]                  = "output";
+    char header[]                       = "header";
+    Stream_IntMetadata outputMetadata[] = { { 3, 4 } };
+    Stream* const input = makeInput(inputBytes, sizeof(inputBytes));
+    ASSERT_NE(input, nullptr);
+    ASSERT_FALSE(ZL_isError(STREAM_setIntMetadata(input, 1, 2)));
+    CodecCache_Lookup* const miss =
+            lookup(cache.get(), ZL_NODE_SPARSE_NUM, input);
+    ASSERT_NE(miss, nullptr);
+    CodecCache_Output output = makeOutput(outputBytes, sizeof(outputBytes));
+    output.nbIntMetadata     = 1;
+    output.intMetadata       = outputMetadata;
+    const CodecCache_Result result =
+            makeResult(&output, 1, header, sizeof(header));
+    ASSERT_EQ(
+            CodecCache_store(miss, &result), CodecCache_InsertResult_inserted);
+
+    std::memset(inputBytes, 'x', sizeof(inputBytes));
+    std::memset(outputBytes, 'x', sizeof(outputBytes));
+    std::memset(header, 'x', sizeof(header));
+    outputMetadata[0] = { 9, 9 };
+    STREAM_free(input);
+    ALLOC_Arena_freeAll(scratchArena_);
+
+    const char originalInput[] = "input";
+    Stream* const lookupInput = makeInput(originalInput, sizeof(originalInput));
+    ASSERT_NE(lookupInput, nullptr);
+    ASSERT_FALSE(ZL_isError(STREAM_setIntMetadata(lookupInput, 1, 2)));
+    CodecCache_Lookup* const hit =
+            lookup(cache.get(), ZL_NODE_SPARSE_NUM, lookupInput);
+    ASSERT_NE(hit, nullptr);
+    const CodecCache_Result* const cachedResult =
+            CodecCache_Lookup_getResult(hit);
+    ASSERT_NE(cachedResult, nullptr);
+    const char originalOutput[] = "output";
+    const char originalHeader[] = "header";
+    EXPECT_EQ(
+            std::memcmp(
+                    cachedResult->outputs[0].content,
+                    originalOutput,
+                    sizeof(originalOutput)),
+            0);
+    EXPECT_EQ(cachedResult->outputs[0].intMetadata[0].id, 3);
+    EXPECT_EQ(cachedResult->outputs[0].intMetadata[0].value, 4);
+    EXPECT_EQ(
+            std::memcmp(
+                    cachedResult->header,
+                    originalHeader,
+                    sizeof(originalHeader)),
+            0);
+    STREAM_free(lookupInput);
+}
+
+TEST_F(CodecOutputCacheTest, DuplicateStoreKeepsOriginal)
+{
+    Cache cache;
+    const Stream* const input = makeInput("input", 5);
+    ASSERT_NE(input, nullptr);
+    CodecCache_Lookup* const miss =
+            lookup(cache.get(), ZL_NODE_SPARSE_NUM, input);
+    ASSERT_NE(miss, nullptr);
+    const CodecCache_Output firstOutput  = makeOutput("A", 1);
+    const CodecCache_Output secondOutput = makeOutput("B", 1);
+    const CodecCache_Result firstResult  = makeResult(&firstOutput, 1);
+    const CodecCache_Result secondResult = makeResult(&secondOutput, 1);
+    EXPECT_EQ(
+            CodecCache_store(miss, &firstResult),
+            CodecCache_InsertResult_inserted);
+    EXPECT_EQ(
+            CodecCache_store(miss, &secondResult),
+            CodecCache_InsertResult_duplicate);
+    const CodecCache_Stats stats = CodecCache_getStats(cache.get());
+
+    CodecCache_Lookup* const hit =
+            lookup(cache.get(), ZL_NODE_SPARSE_NUM, input);
+    ASSERT_NE(hit, nullptr);
+    const CodecCache_Result* const cachedResult =
+            CodecCache_Lookup_getResult(hit);
+    ASSERT_NE(cachedResult, nullptr);
+    EXPECT_EQ(*static_cast<const char*>(cachedResult->outputs[0].content), 'A');
+    EXPECT_EQ(stats.duplicateInserts, 1);
+}
+
+TEST_F(CodecOutputCacheTest, BudgetExhaustionSkipsStore)
+{
+    Cache cache(8);
+    const Stream* const input = makeInput("input", 5);
+    ASSERT_NE(input, nullptr);
+    CodecCache_Lookup* const miss =
+            lookup(cache.get(), ZL_NODE_SPARSE_NUM, input);
+    ASSERT_NE(miss, nullptr);
+    const CodecCache_Output output = makeOutput("output", 6);
+    const CodecCache_Result result = makeResult(&output, 1);
+    EXPECT_EQ(
+            CodecCache_store(miss, &result),
+            CodecCache_InsertResult_budgetExceeded);
+    const CodecCache_Stats stats = CodecCache_getStats(cache.get());
+    EXPECT_EQ(stats.budgetSkips, 1);
+    EXPECT_EQ(stats.bytesStored, 0);
+}
+
+TEST_F(CodecOutputCacheTest, ResetDropsEntriesAndCounters)
+{
+    Cache cache;
+    const Stream* const input = makeInput("input", 5);
+    ASSERT_NE(input, nullptr);
+    CodecCache_Lookup* const miss =
+            lookup(cache.get(), ZL_NODE_SPARSE_NUM, input);
+    ASSERT_NE(miss, nullptr);
+    const CodecCache_Output output = makeOutput("output", 6);
+    const CodecCache_Result result = makeResult(&output, 1);
+    ASSERT_EQ(
+            CodecCache_store(miss, &result), CodecCache_InsertResult_inserted);
+
+    CodecCache_reset(cache.get());
+    const CodecCache_Stats stats = CodecCache_getStats(cache.get());
+    EXPECT_EQ(stats.hits, 0);
+    EXPECT_EQ(stats.misses, 0);
+    EXPECT_EQ(stats.inserts, 0);
+    EXPECT_EQ(stats.bytesStored, 0);
+    CodecCache_Lookup* const afterReset =
+            lookup(cache.get(), ZL_NODE_SPARSE_NUM, input);
+    ASSERT_NE(afterReset, nullptr);
+    EXPECT_EQ(CodecCache_Lookup_getResult(afterReset), nullptr);
+}
+
+TEST_F(CodecOutputCacheTest, ZeroOutputResult)
+{
+    Cache cache;
+    const Stream* const input = makeInput("input", 5);
+    ASSERT_NE(input, nullptr);
+    CodecCache_Lookup* const miss =
+            lookup(cache.get(), ZL_NODE_SPARSE_NUM, input);
+    ASSERT_NE(miss, nullptr);
+    const CodecCache_Result result = makeResult(nullptr, 0);
+    ASSERT_EQ(
+            CodecCache_store(miss, &result), CodecCache_InsertResult_inserted);
+    CodecCache_Lookup* const hit =
+            lookup(cache.get(), ZL_NODE_SPARSE_NUM, input);
+    ASSERT_NE(hit, nullptr);
+    const CodecCache_Result* const cachedResult =
+            CodecCache_Lookup_getResult(hit);
+    ASSERT_NE(cachedResult, nullptr);
+    EXPECT_EQ(cachedResult->nbOutputs, 0);
+    EXPECT_EQ(cachedResult->headerSize, 0);
+    EXPECT_EQ(cachedResult->header, nullptr);
+}
+
+TEST(CodecOutputCacheLifecycleTest, NullOperationsAreSafe)
+{
+    CodecCache_free(nullptr);
+    CodecCache_reset(nullptr);
+}
+
+} // namespace

--- a/tests/unittest/compress/test_codec_output_cache.cpp
+++ b/tests/unittest/compress/test_codec_output_cache.cpp
@@ -2,7 +2,10 @@
 
 #include <array>
 #include <cstring>
+#include <limits>
 #include <memory>
+#include <string>
+#include <vector>
 
 #include <gtest/gtest.h>
 
@@ -15,8 +18,10 @@
 #include "openzl/compress/codec_output_cache.h"
 #include "openzl/compress/enc_interface.h"
 #include "openzl/compress/private_nodes.h"
+#include "openzl/zl_codec_output_cache.h"
 #include "openzl/zl_compress.h"
 #include "openzl/zl_compressor.h"
+#include "openzl/zl_public_nodes.h"
 #include "openzl/zl_version.h"
 
 namespace {
@@ -334,6 +339,7 @@ TEST_F(CodecOutputCacheTest, ReferenceParamsAreNotCacheable)
             lookupWithParams(
                     cache.get(), ZL_NODE_SPARSE_NUM, input, &localParams),
             nullptr);
+    EXPECT_EQ(CodecCache_getStats(cache.get()).refParamSkips, 1);
 }
 
 TEST_F(CodecOutputCacheTest, CustomCodecIsNotCacheable)
@@ -360,6 +366,7 @@ TEST_F(CodecOutputCacheTest, CustomCodecIsNotCacheable)
     const Stream* const input = makeInput("input", 5);
     ASSERT_NE(input, nullptr);
     EXPECT_EQ(lookup(cache.get(), customNode, input), nullptr);
+    EXPECT_EQ(CodecCache_getStats(cache.get()).customCodecSkips, 1);
 }
 
 TEST_F(CodecOutputCacheTest, DifferentLocalParamPlanesDoNotShareResult)
@@ -585,6 +592,32 @@ TEST_F(CodecOutputCacheTest, BudgetExhaustionSkipsStore)
     EXPECT_EQ(stats.bytesStored, 0);
 }
 
+TEST_F(CodecOutputCacheTest, StringOutputIsNotCacheable)
+{
+    Cache cache;
+    const Stream* const input = makeInput("input", 5);
+    ASSERT_NE(input, nullptr);
+    CodecCache_Lookup* const miss =
+            lookup(cache.get(), ZL_NODE_SPARSE_NUM, input);
+    ASSERT_NE(miss, nullptr);
+    CodecCache_Output output       = makeOutput("output", 6);
+    output.type                    = ZL_Type_string;
+    const CodecCache_Result result = makeResult(&output, 1);
+
+    EXPECT_EQ(
+            CodecCache_store(miss, &result),
+            CodecCache_InsertResult_notCacheable);
+    const CodecCache_Stats stats = CodecCache_getStats(cache.get());
+    EXPECT_EQ(stats.stringSkips, 1);
+    EXPECT_EQ(stats.inserts, 0);
+    EXPECT_EQ(stats.bytesStored, 0);
+
+    CodecCache_Lookup* const afterStore =
+            lookup(cache.get(), ZL_NODE_SPARSE_NUM, input);
+    ASSERT_NE(afterStore, nullptr);
+    EXPECT_EQ(CodecCache_Lookup_getResult(afterStore), nullptr);
+}
+
 TEST_F(CodecOutputCacheTest, ResetDropsEntriesAndCounters)
 {
     Cache cache;
@@ -636,6 +669,98 @@ TEST(CodecOutputCacheLifecycleTest, NullOperationsAreSafe)
 {
     CodecCache_free(nullptr);
     CodecCache_reset(nullptr);
+}
+
+TEST(CodecOutputCacheIntegrationTest,
+     AttachedCacheReplaysByteIdenticalCodecOutput)
+{
+    ZL_Compressor* const compressor = ZL_Compressor_create();
+    ASSERT_NE(compressor, nullptr);
+    ASSERT_FALSE(ZL_isError(
+            ZL_Compressor_selectStartingGraphID(compressor, ZL_GRAPH_ZSTD)));
+    ZL_CCtx* const cctx = ZL_CCtx_create();
+    ASSERT_NE(cctx, nullptr);
+    ASSERT_FALSE(ZL_isError(ZL_CCtx_refCompressor(cctx, compressor)));
+    ASSERT_FALSE(ZL_isError(ZL_CCtx_setParameter(
+            cctx, ZL_CParam_formatVersion, ZL_MAX_FORMAT_VERSION)));
+    ASSERT_FALSE(ZL_isError(
+            ZL_CCtx_setParameter(cctx, ZL_CParam_stickyParameters, 1)));
+    ZL_CodecOutputCache* const cache = ZL_CodecOutputCache_create();
+    ASSERT_NE(cache, nullptr);
+    CodecCache_setStatsEnabled(cache, true);
+    ASSERT_FALSE(ZL_isError(ZL_CCtx_setCodecOutputCache(cctx, cache)));
+
+    const std::string input(64 * 1024, 'a');
+    std::vector<char> first(ZL_compressBound(input.size()));
+    std::vector<char> second(first.size());
+    const ZL_Report firstResult = ZL_CCtx_compress(
+            cctx, first.data(), first.size(), input.data(), input.size());
+    ASSERT_FALSE(ZL_isError(firstResult));
+    const CodecCache_Stats afterFirst = CodecCache_getStats(cache);
+    EXPECT_GT(afterFirst.misses, 0);
+    EXPECT_GT(afterFirst.inserts, 0);
+
+    const ZL_Report secondResult = ZL_CCtx_compress(
+            cctx, second.data(), second.size(), input.data(), input.size());
+    ASSERT_FALSE(ZL_isError(secondResult));
+    ASSERT_EQ(ZL_validResult(firstResult), ZL_validResult(secondResult));
+    EXPECT_EQ(
+            std::memcmp(
+                    first.data(), second.data(), ZL_validResult(firstResult)),
+            0);
+    const CodecCache_Stats afterSecond = CodecCache_getStats(cache);
+    EXPECT_GT(afterSecond.hits, afterFirst.hits);
+
+    ZL_CCtx_free(cctx);
+    ZL_CodecOutputCache_free(cache);
+    ZL_Compressor_free(compressor);
+}
+
+TEST(CodecOutputCacheIntegrationTest, MultiInputCodecBypassesCache)
+{
+    ZL_Compressor* const compressor = ZL_Compressor_create();
+    ASSERT_NE(compressor, nullptr);
+    const ZL_GraphID successors[] = { ZL_GRAPH_STORE, ZL_GRAPH_STORE };
+    const ZL_GraphID graph        = ZL_Compressor_registerStaticGraph_fromNode(
+            compressor, ZL_NODE_CONCAT_SERIAL, successors, 2);
+    ASSERT_TRUE(ZL_GraphID_isValid(graph));
+    ASSERT_FALSE(
+            ZL_isError(ZL_Compressor_selectStartingGraphID(compressor, graph)));
+
+    ZL_CCtx* const cctx = ZL_CCtx_create();
+    ASSERT_NE(cctx, nullptr);
+    ASSERT_FALSE(ZL_isError(ZL_CCtx_refCompressor(cctx, compressor)));
+    ASSERT_FALSE(ZL_isError(ZL_CCtx_setParameter(
+            cctx, ZL_CParam_formatVersion, ZL_MAX_FORMAT_VERSION)));
+    ZL_CodecOutputCache* const cache =
+            ZL_CodecOutputCache_createWithBudget(1 << 20);
+    ASSERT_NE(cache, nullptr);
+    CodecCache_setStatsEnabled(cache, true);
+    ASSERT_FALSE(ZL_isError(ZL_CCtx_setCodecOutputCache(cctx, cache)));
+
+    const std::string firstData(1024, 'a');
+    const std::string secondData(1024, 'b');
+    ZL_TypedRef* const first =
+            ZL_TypedRef_createSerial(firstData.data(), firstData.size());
+    ZL_TypedRef* const second =
+            ZL_TypedRef_createSerial(secondData.data(), secondData.size());
+    ASSERT_NE(first, nullptr);
+    ASSERT_NE(second, nullptr);
+    const ZL_TypedRef* inputs[] = { first, second };
+    std::vector<char> compressed(
+            2 * ZL_compressBound(firstData.size() + secondData.size()));
+    const ZL_Report result = ZL_CCtx_compressMultiTypedRef(
+            cctx, compressed.data(), compressed.size(), inputs, 2);
+    ASSERT_FALSE(ZL_isError(result));
+
+    const CodecCache_Stats stats = CodecCache_getStats(cache);
+    EXPECT_EQ(stats.nonSingleInputSkips, 1);
+
+    ZL_TypedRef_free(second);
+    ZL_TypedRef_free(first);
+    ZL_CCtx_free(cctx);
+    ZL_CodecOutputCache_free(cache);
+    ZL_Compressor_free(compressor);
 }
 
 } // namespace

--- a/tests/unittest/public_api/test_public_headers.cpp
+++ b/tests/unittest/public_api/test_public_headers.cpp
@@ -1,0 +1,11 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#include "openzl/openzl.h"
+
+#include <gtest/gtest.h>
+
+namespace openzl::tests {
+
+TEST(PublicHeadersTest, UmbrellaHeaderIsSelfContained) {}
+
+} // namespace openzl::tests


### PR DESCRIPTION
Summary:

Expose an opt-in codec output cache and use it when running standard codecs. A cache hit reproduces the codec’s output streams, metadata, and transform header without running the codec again.

Only single-input standard codecs are cached. Custom codecs, dictionaries, reference or materialized parameters, and string streams are not cached. Unsupported invocations run normally. Reaching the cache budget only skips insertion; compression continues normally.

Reviewed By: terrelln

Differential Revision: D114094700


