### PR TITLE
Remove noisy trained graph logging

### DIFF
--- a/tools/training/train.cpp
+++ b/tools/training/train.cpp
@@ -88,14 +88,6 @@ std::vector<TrainedCandidate> train(
             dictTrainedCandidates.size(),
             std::chrono::duration<double, std::ratio<60>>(endTime - startTime)
                     .count());
-    // TODO pretty print just the graphs (exclude params etc)
-    Logger::log(
-            INFO,
-            "Smallest trained graph:",
-            std::string(
-                    Compressor::convertSerializedToJson(
-                            dictTrainedCandidates[0].serializedCompressor))
-                    .c_str());
 
     return dictTrainedCandidates;
 }


### PR DESCRIPTION
Summary: Remove the post-training log that prints the full serialized compressor JSON for the smallest trained graph. Serialized-graph training calls this in-process and can produce large logs; the aggregate trained-candidate count and wall time remain logged.

Reviewed By: kevinjzhang

Differential Revision: D113907192


