### PR TITLE
Wire zli verbosity through to the SDDL2 compiler (#925)

### DIFF
--- a/cli/args/CompressArgs.h
+++ b/cli/args/CompressArgs.h
@@ -104,6 +104,7 @@ struct CompressArgs : public GlobalArgs, public ProfileArgs {
             tools::io::InputFile bundleInput(bundlePath.value());
             bundleData = bundleInput.contents();
         }
+        setVerbosityLevel(verbosity);
         setCompressor(createCompressorFromArgs(
                 *this, parsed.cmdFlag(cmd(), kCompressor), bundleData));
 

--- a/cli/utils/compress_profiles.cpp
+++ b/cli/utils/compress_profiles.cpp
@@ -438,8 +438,17 @@ compressProfiles()
                                 "The Simple Data Description Language v2 profile requires a data description file. Pass a path to the description file with --profile-arg.");
                     }
                     auto description = tools::io::InputFile(it->second);
-                    auto compiled    = sddl2::Compiler{}.compile(
-                            description.contents(), description.name());
+                    // Map the CLI log level onto the compiler's scale: INFO
+                    // (the default) keeps the compiler quiet, and each -v above
+                    // INFO raises compiler verbosity by one.
+                    auto compiled =
+                            sddl2::Compiler{
+                                sddl2::Compiler::Options{}.with_verbosity(
+                                        args.verbosityLevel() - 3)
+                            }
+                                    .compile(
+                                            description.contents(),
+                                            description.name());
                     auto bytecode   = sddl2::Assembler{}.assemble(compiled);
                     auto clustering = ZS2_createGraph_genericClustering(comp);
                     auto graph      = ZL_Compressor_registerSDDL2Graph_advanced(

--- a/cli/utils/compress_profiles.h
+++ b/cli/utils/compress_profiles.h
@@ -43,6 +43,19 @@ class ProfileArgs {
         return argmap_;
     }
 
+    // CLI log level (0=NOTHING .. 3=INFO (default) .. 7=EVERYTHING), mirroring
+    // GlobalArgs::verbosity. Profiles that drive a sub-tool with its own log
+    // level (e.g. the SDDL2 compiler) map this onto that tool's scale.
+    int verbosityLevel() const
+    {
+        return verbosityLevel_;
+    }
+
+    void setVerbosityLevel(int verbosityLevel)
+    {
+        verbosityLevel_ = verbosityLevel;
+    }
+
     const std::shared_ptr<Compressor>& compressor() const
     {
         return compressor_;
@@ -62,6 +75,7 @@ class ProfileArgs {
 
     poly::optional<std::string> name_;
     poly::optional<size_t> chunkSize_;
+    int verbosityLevel_{ 3 };
     // Arbitrary (K,V) arguments provided on the command line.
     std::map<std::string, std::string> argmap_;
 };


### PR DESCRIPTION
Summary:

# Stack

Improves debuggability of the SDDL2 compiler's codegen pipeline. This stack adds richer diagnostics -- printing inferred AST annotations, verbose codegen logging, and a dump of the code generator's symbol tables on failure -- to make codegen errors easier to diagnose.

# Diff

Exposes the SDDL2 compiler's verbosity through the `zli compress --profile sddl2` path. Previously this path always built the compiler with default (quiet) `Options`, so none of the compiler's logging was reachable from `zli` -- only the standalone compiler `main.cpp` (`-v`/`-q`) could raise it.

Reviewed By: Cyan4973

Differential Revision: D114390443
