### PR TITLE
Print optimized AST after optimization pass (#927)

### DIFF
--- a/cli/args/CompressArgs.h
+++ b/cli/args/CompressArgs.h
@@ -104,6 +104,7 @@ struct CompressArgs : public GlobalArgs, public ProfileArgs {
             tools::io::InputFile bundleInput(bundlePath.value());
             bundleData = bundleInput.contents();
         }
+        setVerbosityLevel(verbosity);
         setCompressor(createCompressorFromArgs(
                 *this, parsed.cmdFlag(cmd(), kCompressor), bundleData));
 

--- a/cli/utils/compress_profiles.cpp
+++ b/cli/utils/compress_profiles.cpp
@@ -438,8 +438,17 @@ compressProfiles()
                                 "The Simple Data Description Language v2 profile requires a data description file. Pass a path to the description file with --profile-arg.");
                     }
                     auto description = tools::io::InputFile(it->second);
-                    auto compiled    = sddl2::Compiler{}.compile(
-                            description.contents(), description.name());
+                    // Map the CLI log level onto the compiler's scale: INFO
+                    // (the default) keeps the compiler quiet, and each -v above
+                    // INFO raises compiler verbosity by one.
+                    auto compiled =
+                            sddl2::Compiler{
+                                sddl2::Compiler::Options{}.with_verbosity(
+                                        args.verbosityLevel() - 3)
+                            }
+                                    .compile(
+                                            description.contents(),
+                                            description.name());
                     auto bytecode   = sddl2::Assembler{}.assemble(compiled);
                     auto clustering = ZS2_createGraph_genericClustering(comp);
                     auto graph      = ZL_Compressor_registerSDDL2Graph_advanced(

--- a/cli/utils/compress_profiles.h
+++ b/cli/utils/compress_profiles.h
@@ -43,6 +43,19 @@ class ProfileArgs {
         return argmap_;
     }
 
+    // CLI log level (0=NOTHING .. 3=INFO (default) .. 7=EVERYTHING), mirroring
+    // GlobalArgs::verbosity. Profiles that drive a sub-tool with its own log
+    // level (e.g. the SDDL2 compiler) map this onto that tool's scale.
+    int verbosityLevel() const
+    {
+        return verbosityLevel_;
+    }
+
+    void setVerbosityLevel(int verbosityLevel)
+    {
+        verbosityLevel_ = verbosityLevel;
+    }
+
     const std::shared_ptr<Compressor>& compressor() const
     {
         return compressor_;
@@ -62,6 +75,7 @@ class ProfileArgs {
 
     poly::optional<std::string> name_;
     poly::optional<size_t> chunkSize_;
+    int verbosityLevel_{ 3 };
     // Arbitrary (K,V) arguments provided on the command line.
     std::map<std::string, std::string> argmap_;
 };

--- a/tools/sddl2/compiler/optimizer/Optimizer.cpp
+++ b/tools/sddl2/compiler/optimizer/Optimizer.cpp
@@ -6,7 +6,7 @@
 
 namespace openzl::sddl2 {
 
-Optimizer::Optimizer(const detail::Logger& logger)
+Optimizer::Optimizer(const detail::Logger& logger) : log_(logger)
 {
     passes_.push_back(std::make_unique<ConstFoldPass>(logger));
     passes_.push_back(std::make_unique<DeadVarPass>(logger));
@@ -18,6 +18,14 @@ ASTVec Optimizer::optimize(const ASTVec& ast) const
     for (const auto& pass : passes_) {
         result = pass->optimize(result);
     }
+
+    auto& log = log_(1);
+    log << "Optimized AST:" << std::endl;
+    for (const auto& node : result) {
+        node->print(log, 2);
+    }
+    log << std::endl;
+
     return result;
 }
 

--- a/tools/sddl2/compiler/optimizer/Optimizer.h
+++ b/tools/sddl2/compiler/optimizer/Optimizer.h
@@ -18,6 +18,7 @@ class Optimizer {
     ASTVec optimize(const ASTVec& ast) const;
 
    private:
+    const detail::Logger& log_;
     std::vector<std::unique_ptr<const OptimizationPass>> passes_;
 };
 

--- a/tools/sddl2/compiler/parser/AST.cpp
+++ b/tools/sddl2/compiler/parser/AST.cpp
@@ -253,6 +253,15 @@ bool ASTVar::is_last_reference() const
     return is_last_reference_;
 }
 
+void ASTField::print_inferred_annotations(std::ostream& os, size_t indent) const
+{
+    const auto& ann = inferred_annotations_;
+    if (ann.requires_scan) {
+        os << std::string(indent, ' ') << "Inferred: requires_scan"
+           << std::endl;
+    }
+}
+
 ASTBuiltinField::ASTBuiltinField(const SourceLocation& loc, const Symbol& sym)
         : ASTField(loc), kw_(sym)
 {
@@ -267,6 +276,7 @@ void ASTBuiltinField::print(std::ostream& os, size_t indent) const
 {
     os << std::string(indent, ' ') << "Field: " << sym_to_debug_str(kw_)
        << std::endl;
+    print_inferred_annotations(os, indent + 2);
 }
 
 const Symbol& ASTBuiltinField::kw() const
@@ -287,6 +297,7 @@ const ASTBytes* ASTBytes::as_bytes() const
 void ASTBytes::print(std::ostream& os, size_t indent) const
 {
     os << std::string(indent, ' ') << "Field: BYTES:" << std::endl;
+    print_inferred_annotations(os, indent + 2);
     os << std::string(indent + 2, ' ') << "Len: " << std::endl;
     len_->print(os, indent + 4);
 }
@@ -337,6 +348,14 @@ const ASTRecord* ASTRecord::as_record() const
 void ASTRecord::print(std::ostream& os, size_t indent) const
 {
     os << std::string(indent, ' ') << "Field: RECORD:" << std::endl;
+    print_inferred_annotations(os, indent + 2);
+    if (!annotations_.names.empty()) {
+        os << std::string(indent + 2, ' ') << "Annotations:";
+        for (const auto& name : annotations_.names) {
+            os << " @" << name;
+        }
+        os << std::endl;
+    }
     os << std::string(indent + 2, ' ') << "Captures: " << std::endl;
     for (const auto& capture : params_) {
         capture->print(os, indent + 4);
@@ -423,6 +442,7 @@ const ASTCall* ASTCall::as_call() const
 void ASTCall::print(std::ostream& os, size_t indent) const
 {
     os << std::string(indent, ' ') << "Field: CALL:" << std::endl;
+    print_inferred_annotations(os, indent + 2);
     os << std::string(indent + 2, ' ') << "Target: " << std::endl;
     target_->print(os, indent + 4);
     os << std::string(indent + 2, ' ') << "Args: " << std::endl;
@@ -494,6 +514,7 @@ const ASTArray* ASTArray::as_array() const
 void ASTArray::print(std::ostream& os, size_t indent) const
 {
     os << std::string(indent, ' ') << "Field: ARRAY:" << std::endl;
+    print_inferred_annotations(os, indent + 2);
     field_->print(os, indent + 2);
     if (len_) {
         len_->print(os, indent + 2);

--- a/tools/sddl2/compiler/parser/AST.h
+++ b/tools/sddl2/compiler/parser/AST.h
@@ -235,6 +235,11 @@ class ASTField : public ASTConverted {
         return inferred_annotations_;
     }
 
+   protected:
+    // Prints any set inferred annotations, one labeled line per set flag.
+    // No-op when nothing is set, so callers can invoke it unconditionally.
+    void print_inferred_annotations(std::ostream& os, size_t indent) const;
+
    private:
     mutable InferredAnnotations inferred_annotations_;
 };


### PR DESCRIPTION
Summary:

# Stack

Improves debuggability of the SDDL2 compiler's codegen pipeline. This stack adds richer diagnostics -- printing inferred AST annotations, verbose codegen logging, and a dump of the code generator's symbol tables on failure -- to make codegen errors easier to diagnose.

# Diff

Dumps the optimized, annotated AST at verbosity 1 after the optimization passes.

Reviewed By: Cyan4973

Differential Revision: D114393231


