### PR TITLE
Prepare per-chunk decode contexts (#935)

### DIFF
--- a/contrib/gpu/src/common/BUCK
+++ b/contrib/gpu/src/common/BUCK
@@ -22,7 +22,6 @@ cpp_library(
     exported_deps = [":cuda_error"],
     exported_external_deps = [("cuda", None, "cuda-lazy")],
 )
-
 # Kernel launch/occupancy helpers (grid sizing, occupancy metadata) for GPU host
 # code; kernel-agnostic.
 cpp_library(
@@ -41,6 +40,25 @@ cpp_library(
     header_namespace = "",
     exported_deps = [
         ":cuda_error",
+        ":cuda_raii",
+    ],
+    exported_external_deps = [("cuda", None, "cuda-lazy")],
+)
+
+cpp_library(
+    name = "cuda_error_relative_headers",
+    headers = relative_headers(["cuda_error.cuh"]),
+    header_namespace = "",
+    exported_deps = [],
+    exported_external_deps = [("cuda", None, "cuda-lazy")],
+)
+
+cpp_library(
+    name = "cuda_raii_relative_headers",
+    headers = relative_headers(["cuda_raii.cuh"]),
+    header_namespace = "",
+    exported_deps = [
+        ":cuda_error_relative_headers",
         ":cuda_raii",
     ],
     exported_external_deps = [("cuda", None, "cuda-lazy")],

--- a/contrib/gpu/src/decompress/BUCK
+++ b/contrib/gpu/src/decompress/BUCK
@@ -70,3 +70,32 @@ cpp_unittest(
     ],
     external_deps = [("cuda", None, "cuda-lazy")],
 )
+
+cpp_unittest(
+    # @autodeps-skip
+    name = "gpu_decompress_preparation_test",
+    srcs = ["tests/GpuDecompressPreparationTest.cpp"],
+    keep_gpu_sections = True,
+    labels = [tpx_labels.serialize]
+    + ci.labels(
+        ci.replace({ci.linux(ci.dev()): ci.linux(ci.mode("fbcode//mode/dev-nosan"))}),
+        ci.remove(ci.linux(ci.coverage(ci.mode("fbcode//mode/dev-cov")))),
+    ),
+    network_access = network_access_utils.none(),
+    nvcc_flags = get_nvcc_arch_args() + ["-lineinfo"],
+    remote_execution = re_test_utils.remote_execution(
+        platform = "gpu-remote-execution",
+        use_case = "tpx-default",
+    ),
+    target_compatible_with = sanitizers.sanitizer_enabled(
+        no = [],
+        yes = ["ovr_config//:none"],
+    ),
+    deps = [
+        "../../testkit:testkit_relative_headers",
+        "../common:cuda_raii_relative_headers",
+        "fbsource//third-party/googletest:gtest",
+        ":decompress",
+    ],
+    external_deps = [("cuda", None, "cuda-lazy")],
+)

--- a/contrib/gpu/src/decompress/gpu_decompress.cpp
+++ b/contrib/gpu/src/decompress/gpu_decompress.cpp
@@ -28,6 +28,56 @@ std::string_view asStringView(std::span<const std::byte> bytes)
     };
 }
 
+struct DeviceToHostCopy {
+    std::span<std::byte> dst_h;
+    const std::byte* src_d;
+};
+
+ZL_Report copyDeviceToHostAndSynchronize(
+        std::span<const DeviceToHostCopy> copies,
+        ZL_GPU_Stream stream,
+        ZL_OperationContext* opCtx)
+{
+    ZL_RESULT_DECLARE_SCOPE_REPORT(opCtx);
+
+    for (const DeviceToHostCopy& copy : copies) {
+        if (copy.dst_h.empty()) {
+            continue;
+        }
+        ZL_ERR_IF_NULL(copy.dst_h.data(), parameter_invalid);
+        ZL_ERR_IF_NULL(copy.src_d, parameter_invalid);
+    }
+
+    bool copyEnqueued = false;
+    for (const DeviceToHostCopy& copy : copies) {
+        if (copy.dst_h.empty()) {
+            continue;
+        }
+        cudaError_t const result = cudaMemcpyAsync(
+                copy.dst_h.data(),
+                copy.src_d,
+                copy.dst_h.size(),
+                cudaMemcpyDeviceToHost,
+                stream);
+        if (result != cudaSuccess) {
+            if (copyEnqueued) {
+                // Destinations must outlive any copies queued before failure.
+                (void)cudaStreamSynchronize(stream);
+            }
+            ZL_ERR(GENERIC,
+                   "cudaMemcpyAsync failed: %s",
+                   cudaGetErrorString(result));
+        }
+        copyEnqueued = true;
+    }
+    if (copyEnqueued) {
+        cudaError_t const result = cudaStreamSynchronize(stream);
+        ZL_ERR_IF_NE(result, cudaSuccess, GENERIC);
+    }
+
+    return ZL_returnSuccess();
+}
+
 } // namespace
 
 namespace {
@@ -84,50 +134,33 @@ ZL_Report copyHeadersToHost(
     // it, so its address cannot move.
     stagedHeaders.storage_h.resize(stagingSize);
 
-    size_t dstOffset  = 0;
-    bool copyEnqueued = false;
+    std::vector<DeviceToHostCopy> copies;
+    copies.reserve(frameHeaders.size() + chunks.size());
+    size_t dstOffset = 0;
     for (const GPUFrameHeaderForChunks& frameHeader : frameHeaders) {
-        cudaError_t const result = cudaMemcpyAsync(
-                stagedHeaders.storage_h.data() + dstOffset,
-                frameHeader.frameHeader_d,
-                frameHeader.frameHeaderSize,
-                cudaMemcpyDeviceToHost,
-                stream);
-        if (result != cudaSuccess) {
-            if (copyEnqueued) {
-                // The destination buffer must outlive any queued D2H copies.
-                (void)cudaStreamSynchronize(stream);
-            }
-            ZL_ERR(GENERIC,
-                   "cudaMemcpyAsync failed: %s",
-                   cudaGetErrorString(result));
-        }
-        copyEnqueued = true;
+        copies.push_back(
+                {
+                        .dst_h = std::span<std::byte>{ stagedHeaders.storage_h }
+                                         .subspan(
+                                                 dstOffset,
+                                                 frameHeader.frameHeaderSize),
+                        .src_d = static_cast<const std::byte*>(
+                                frameHeader.frameHeader_d),
+                });
         dstOffset += frameHeader.frameHeaderSize;
     }
     for (const GPUChunk& chunk : chunks) {
-        cudaError_t const result = cudaMemcpyAsync(
-                stagedHeaders.storage_h.data() + dstOffset,
-                chunk.chunk_d,
-                chunk.chunkHeaderSize,
-                cudaMemcpyDeviceToHost,
-                stream);
-        if (result != cudaSuccess) {
-            if (copyEnqueued) {
-                // The destination buffer must outlive any queued D2H copies.
-                (void)cudaStreamSynchronize(stream);
-            }
-            ZL_ERR(GENERIC,
-                   "cudaMemcpyAsync failed: %s",
-                   cudaGetErrorString(result));
-        }
-        copyEnqueued = true;
+        copies.push_back(
+                {
+                        .dst_h = std::span<std::byte>{ stagedHeaders.storage_h }
+                                         .subspan(
+                                                 dstOffset,
+                                                 chunk.chunkHeaderSize),
+                        .src_d = static_cast<const std::byte*>(chunk.chunk_d),
+                });
         dstOffset += chunk.chunkHeaderSize;
     }
-    if (copyEnqueued) {
-        cudaError_t const result = cudaStreamSynchronize(stream);
-        ZL_ERR_IF_NE(result, cudaSuccess, GENERIC);
-    }
+    ZL_ERR_IF_ERR(copyDeviceToHostAndSynchronize(copies, stream, nullptr));
 
     // Preserve frame-header order so each chunk index also identifies the
     // corresponding staged header.
@@ -154,7 +187,141 @@ ZL_Report copyHeadersToHost(
     return ZL_returnSuccess();
 }
 
+ZL_Report createDctxsForChunks(
+        const StagedHeaders& stagedHeaders,
+        std::span<const GPUChunk> chunks,
+        std::vector<PreparedGPUChunk>& preparedChunks)
+{
+    // No shared DCTX exists until each per-chunk context is created.
+    ZL_RESULT_DECLARE_SCOPE_REPORT(nullptr);
+
+    std::vector<FrameInfo> frameInfos;
+    frameInfos.reserve(stagedHeaders.frameHeaders_h.size());
+    for (std::span<const std::byte> frameHeader_h :
+         stagedHeaders.frameHeaders_h) {
+        frameInfos.emplace_back(asStringView(frameHeader_h));
+    }
+
+    ZL_ERR_IF_NE(stagedHeaders.chunkHeaders_h.size(), chunks.size(), GENERIC);
+    std::vector<PreparedGPUChunk> result;
+    result.reserve(chunks.size());
+    auto chunkHeaderIt = stagedHeaders.chunkHeaders_h.begin();
+    for (const GPUChunk& chunk : chunks) {
+        const StagedChunkHeader& chunkHeader = *chunkHeaderIt++;
+        DCtx dctx;
+
+        ZL_Report const setParameterResult = ZL_DCtx_setParameter(
+                dctx.get(),
+                ZL_DParam_enableCodecFusion,
+                ZL_TernaryParam_disable);
+        if (ZL_isError(setParameterResult)) {
+            return setParameterResult;
+        }
+
+        ZL_ERR_IF_GE(
+                chunkHeader.frameHeaderIdx,
+                frameInfos.size(),
+                parameter_invalid);
+        ZL_Report const initResult = DCTX_initFromFrameInfo(
+                dctx.get(), frameInfos.at(chunkHeader.frameHeaderIdx).get());
+        if (ZL_isError(initResult)) {
+            return initResult;
+        }
+
+        ZL_Report const prepareResult = DCTX_prepareFrameChunkFromHeader(
+                dctx.get(),
+                chunkHeader.bytes_h.data(),
+                chunkHeader.bytes_h.size(),
+                chunk.chunk_d,
+                chunk.chunkSize);
+        if (ZL_isError(prepareResult)) {
+            return prepareResult;
+        }
+
+        result.push_back(
+                {
+                        .chunk = chunk,
+                        .dctx  = std::move(dctx),
+                });
+    }
+
+    preparedChunks = std::move(result);
+    return ZL_returnSuccess();
+}
+
+ZL_Report copyTransformHeadersToHost(
+        std::span<PreparedGPUChunk> preparedChunks,
+        ZL_GPU_Stream stream)
+{
+    ZL_DCtx* const dctx = preparedChunks.empty()
+            ? nullptr
+            : preparedChunks.front().dctx.get();
+    ZL_RESULT_DECLARE_SCOPE_REPORT(dctx);
+
+    for (PreparedGPUChunk& prepared : preparedChunks) {
+        const DFH_Struct* const frameHeader =
+                DCtx_getFrameHeader(prepared.dctx.get());
+        ZL_ERR_IF_NULL(frameHeader, logicError);
+        ZL_ERR_IF_GT(
+                prepared.chunk.chunkHeaderSize,
+                prepared.chunk.chunkSize,
+                parameter_invalid);
+        ZL_ERR_IF_GT(
+                frameHeader->totalTHSize,
+                prepared.chunk.chunkSize - prepared.chunk.chunkHeaderSize,
+                srcSize_tooSmall);
+        prepared.transformHeaders_h.resize(frameHeader->totalTHSize);
+    }
+
+    std::vector<DeviceToHostCopy> copies;
+    copies.reserve(preparedChunks.size());
+    for (PreparedGPUChunk& prepared : preparedChunks) {
+        if (prepared.transformHeaders_h.empty()) {
+            continue;
+        }
+        const auto* const transformHeaders_d =
+                static_cast<const std::byte*>(prepared.chunk.chunk_d)
+                + prepared.chunk.chunkHeaderSize;
+        copies.push_back(
+                {
+                        .dst_h = prepared.transformHeaders_h,
+                        .src_d = transformHeaders_d,
+                });
+    }
+    return copyDeviceToHostAndSynchronize(
+            copies, stream, ZL_GET_OPERATION_CONTEXT(dctx));
+}
+
 } // namespace
+
+ZL_Report prepareChunksForPlanning(
+        std::span<const GPUFrameHeaderForChunks> frameHeaders,
+        std::span<const GPUChunk> chunks,
+        std::vector<PreparedGPUChunk>& preparedChunks,
+        ZL_GPU_Stream stream)
+{
+    preparedChunks.clear();
+    ZL_RESULT_DECLARE_SCOPE_REPORT(nullptr);
+    StagedHeaders stagedHeaders;
+    ZL_Report const copyResult =
+            copyHeadersToHost(frameHeaders, chunks, stream, stagedHeaders);
+    if (ZL_isError(copyResult)) {
+        return copyResult;
+    }
+    std::vector<PreparedGPUChunk> result;
+    ZL_Report const createResult =
+            createDctxsForChunks(stagedHeaders, chunks, result);
+    if (ZL_isError(createResult)) {
+        return createResult;
+    }
+    ZL_Report const copyTransformHeadersResult =
+            copyTransformHeadersToHost(result, stream);
+    if (ZL_isError(copyTransformHeadersResult)) {
+        return copyTransformHeadersResult;
+    }
+    preparedChunks = std::move(result);
+    return ZL_returnSuccess();
+}
 
 ZL_Report decompressChunks(
         void*,
@@ -164,11 +331,11 @@ ZL_Report decompressChunks(
         ZL_GPU_Stream stream)
 {
     ZL_RESULT_DECLARE_SCOPE_REPORT(nullptr);
-    StagedHeaders stagedHeaders;
-    ZL_Report const copyResult =
-            copyHeadersToHost(frameHeaders, chunks, stream, stagedHeaders);
-    if (ZL_isError(copyResult)) {
-        return copyResult;
+    std::vector<PreparedGPUChunk> preparedChunks;
+    ZL_Report const prepareResult = prepareChunksForPlanning(
+            frameHeaders, chunks, preparedChunks, stream);
+    if (ZL_isError(prepareResult)) {
+        return prepareResult;
     }
     ZL_ERR(GENERIC, "GPU decompression is not implemented");
 }
@@ -260,15 +427,12 @@ ZL_Report collectGPUChunksFromFullCopy(
     ZL_ERR_IF_GT(src_d.size(), src_h.max_size(), srcSize_tooLarge);
     src_h.resize(src_d.size());
 
-    cudaError_t cudaResult = cudaMemcpyAsync(
-            src_h.data(),
-            src_d.data(),
-            src_d.size(),
-            cudaMemcpyDeviceToHost,
-            stream);
-    ZL_ERR_IF_NE(cudaResult, cudaSuccess, GENERIC);
-    cudaResult = cudaStreamSynchronize(stream);
-    ZL_ERR_IF_NE(cudaResult, cudaSuccess, GENERIC);
+    const DeviceToHostCopy copy{
+        .dst_h = src_h,
+        .src_d = src_d.data(),
+    };
+    ZL_ERR_IF_ERR(copyDeviceToHostAndSynchronize(
+            std::span<const DeviceToHostCopy>{ &copy, 1 }, stream, nullptr));
 
     return collectGPUChunksFromFrame(src_d.data(), src_h, chunks, frameHeaders);
 }

--- a/contrib/gpu/src/decompress/gpu_decompress.hpp
+++ b/contrib/gpu/src/decompress/gpu_decompress.hpp
@@ -7,6 +7,7 @@
 #include <vector>
 
 #include "contrib/gpu/src/decompress/gpu_decompress.h"
+#include "openzl/cpp/DCtx.hpp"
 #include "openzl/zl_errors.h"
 
 namespace openzl::gpu {
@@ -37,6 +38,26 @@ struct GPUChunk {
     /// Number of bytes in the formal chunk header.
     size_t chunkHeaderSize;
 };
+
+/** One device chunk prepared for GPU decode planning. */
+struct PreparedGPUChunk {
+    GPUChunk chunk;
+    DCtx dctx;
+    /// Concatenated private transform headers copied from the device chunk.
+    std::vector<std::byte> transformHeaders_h;
+};
+
+/**
+ * Copies frame, formal chunk, and transform headers to host and prepares one
+ * DCTX per chunk.
+ * Stored-stream references remain bound to the device addresses in @p chunks.
+ * @p preparedChunks is cleared before preparation and populated on success.
+ */
+ZL_Report prepareChunksForPlanning(
+        std::span<const GPUFrameHeaderForChunks> frameHeaders,
+        std::span<const GPUChunk> chunks,
+        std::vector<PreparedGPUChunk>& preparedChunks,
+        ZL_GPU_Stream stream);
 
 /**
  * Enumerates the chunks in one host-readable frame. A temporary solution until

--- a/contrib/gpu/src/decompress/tests/GpuDecompressPreparationTest.cpp
+++ b/contrib/gpu/src/decompress/tests/GpuDecompressPreparationTest.cpp
@@ -1,0 +1,177 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#include <gtest/gtest.h>
+
+#include <cstddef>
+#include <cstdint>
+#include <span>
+#include <string>
+#include <vector>
+
+#include <cuda_runtime.h>
+
+#include "contrib/gpu/src/common/cuda_error.cuh"
+#include "contrib/gpu/src/common/cuda_raii.cuh"
+#include "contrib/gpu/src/decompress/gpu_decompress.hpp"
+#include "contrib/gpu/testkit/frame_verifier.h"
+#include "contrib/gpu/testkit/multichunk_frame.h"
+#include "openzl/decompress/dctx2.h"
+#include "openzl/openzl.hpp"
+
+namespace openzl {
+namespace tests {
+namespace {
+
+constexpr size_t kEltsPerChunk = 20000;
+
+std::string makeTwoChunkFrame()
+{
+    std::vector<int32_t> values(2 * kEltsPerChunk);
+    for (size_t i = 0; i < kEltsPerChunk; ++i) {
+        values[i]                 = static_cast<int32_t>(i % 8);
+        values[kEltsPerChunk + i] = static_cast<int32_t>(i) * 3;
+    }
+
+    const Input input =
+            Input::refNumeric<int32_t>(values.data(), values.size());
+    Compressor compressor;
+    const GraphID bitpack      = graphs::Bitpack{}();
+    const GraphID deltaToStore = ZL_Compressor_registerStaticGraph_fromNode1o(
+            compressor.get(), nodes::DeltaInt::node, graphs::Store{}());
+    return gpu::testkit::makeMultiChunkFrame(
+            compressor,
+            {
+                    gpu::testkit::ChunkSpec{ kEltsPerChunk, bitpack },
+                    gpu::testkit::ChunkSpec{ kEltsPerChunk, deltaToStore },
+            },
+            input);
+}
+
+std::span<const std::byte> bytes(const std::string& frame)
+{
+    return {
+        reinterpret_cast<const std::byte*>(frame.data()),
+        frame.size(),
+    };
+}
+
+TEST(GPUDecompressPreparationTest, BuildsContextsWithoutReadingPayload)
+{
+    // This fails if preparation reads payload/checksum bytes on the CPU, loses
+    // decoded graph metadata, stages the wrong transform-header bytes, or binds
+    // stored streams outside its device chunk.
+    const std::string frame = makeTwoChunkFrame();
+    const std::vector<std::vector<uint32_t>> codecsPerChunk =
+            gpu::testkit::standardCodecsPerChunk(frame);
+    gpu::DevicePtr<std::byte> deviceFrame_d =
+            gpu::deviceAlloc<std::byte>(frame.size());
+    ZL_CUDA_CHECK(cudaMemcpy(
+            deviceFrame_d.get(),
+            frame.data(),
+            frame.size(),
+            cudaMemcpyHostToDevice));
+
+    std::vector<gpu::GPUChunk> chunks;
+    std::vector<gpu::GPUFrameHeaderForChunks> frameHeaders;
+    ZL_Report const directoryResult = gpu::collectGPUChunksFromFrame(
+            deviceFrame_d.get(), bytes(frame), chunks, frameHeaders);
+    ASSERT_FALSE(ZL_isError(directoryResult));
+    ASSERT_EQ(chunks.size(), codecsPerChunk.size());
+    ASSERT_FALSE(chunks.empty());
+    ASSERT_LT(chunks[0].chunkHeaderSize, chunks[0].chunkSize);
+
+    auto* const payloadOrChecksum_d =
+            static_cast<std::byte*>(const_cast<void*>(chunks[0].chunk_d))
+            + chunks[0].chunkSize - 1;
+    ZL_CUDA_CHECK(cudaMemset(payloadOrChecksum_d, 0xA5, 1));
+
+    std::vector<gpu::PreparedGPUChunk> preparedChunks;
+    ZL_Report const prepareResult = gpu::prepareChunksForPlanning(
+            frameHeaders, chunks, preparedChunks, nullptr);
+    ASSERT_FALSE(ZL_isError(prepareResult));
+    ASSERT_EQ(preparedChunks.size(), chunks.size());
+
+    for (size_t i = 0; i < preparedChunks.size(); ++i) {
+        const gpu::PreparedGPUChunk& prepared = preparedChunks[i];
+        EXPECT_EQ(prepared.chunk.frameHeaderIdx, chunks[i].frameHeaderIdx);
+        EXPECT_EQ(prepared.chunk.chunk_d, chunks[i].chunk_d);
+        EXPECT_EQ(prepared.chunk.chunkSize, chunks[i].chunkSize);
+        EXPECT_EQ(prepared.chunk.chunkHeaderSize, chunks[i].chunkHeaderSize);
+        EXPECT_EQ(
+                ZL_DCtx_getParameter(
+                        prepared.dctx.get(), ZL_DParam_enableCodecFusion),
+                ZL_TernaryParam_disable);
+
+        const DFH_Struct* const frameHeader =
+                DCtx_getFrameHeader(prepared.dctx.get());
+        ASSERT_NE(frameHeader, nullptr);
+        EXPECT_EQ(VECTOR_SIZE(frameHeader->nodes), codecsPerChunk[i].size());
+
+        const uintptr_t deviceFrameBegin_d =
+                reinterpret_cast<uintptr_t>(deviceFrame_d.get());
+        const uintptr_t chunkBegin_d =
+                reinterpret_cast<uintptr_t>(prepared.chunk.chunk_d);
+        ASSERT_GE(chunkBegin_d, deviceFrameBegin_d);
+        const size_t chunkOffset = chunkBegin_d - deviceFrameBegin_d;
+        const size_t transformHeaderOffset =
+                chunkOffset + prepared.chunk.chunkHeaderSize;
+        ASSERT_LE(transformHeaderOffset, frame.size());
+        ASSERT_LE(
+                frameHeader->totalTHSize, frame.size() - transformHeaderOffset);
+        const auto* const frameBytes =
+                reinterpret_cast<const std::byte*>(frame.data());
+        const std::vector<std::byte> expectedTransformHeaders{
+            frameBytes + transformHeaderOffset,
+            frameBytes + transformHeaderOffset + frameHeader->totalTHSize,
+        };
+        EXPECT_EQ(prepared.transformHeaders_h, expectedTransformHeaders);
+
+        const uintptr_t payloadBegin_d = chunkBegin_d
+                + prepared.chunk.chunkHeaderSize + frameHeader->totalTHSize;
+        const uintptr_t chunkEnd_d = chunkBegin_d + prepared.chunk.chunkSize;
+        size_t boundStreamCount    = 0;
+        for (size_t streamIdx = 0;
+             streamIdx < ZL_DCtx_getNumStreams(prepared.dctx.get());
+             ++streamIdx) {
+            const ZL_Data* const stream = ZL_DCtx_getConstStream(
+                    prepared.dctx.get(), static_cast<ZL_IDType>(streamIdx));
+            if (stream == nullptr || ZL_Data_rPtr(stream) == nullptr) {
+                continue;
+            }
+
+            const uintptr_t streamBegin_d =
+                    reinterpret_cast<uintptr_t>(ZL_Data_rPtr(stream));
+            EXPECT_GE(streamBegin_d, payloadBegin_d);
+            ASSERT_LE(streamBegin_d, chunkEnd_d);
+            EXPECT_LE(ZL_Data_contentSize(stream), chunkEnd_d - streamBegin_d);
+            ++boundStreamCount;
+        }
+        EXPECT_GT(boundStreamCount, 0);
+    }
+}
+
+TEST(GPUDecompressPreparationTest, ClearsOutputOnFailure)
+{
+    // This fails if a rejected preparation exposes contexts retained from an
+    // earlier successful call.
+    std::vector<gpu::PreparedGPUChunk> preparedChunks;
+    preparedChunks.push_back(
+            { .chunk = {}, .dctx = {}, .transformHeaders_h = {} });
+    const gpu::GPUFrameHeaderForChunks invalidFrameHeader{
+        .frameHeader_d   = nullptr,
+        .frameHeaderSize = 1,
+    };
+
+    ZL_Report const result = gpu::prepareChunksForPlanning(
+            std::span{ &invalidFrameHeader, 1 },
+            std::span<const gpu::GPUChunk>{},
+            preparedChunks,
+            nullptr);
+
+    EXPECT_TRUE(ZL_isError(result));
+    EXPECT_TRUE(preparedChunks.empty());
+}
+
+} // namespace
+} // namespace tests
+} // namespace openzl

--- a/contrib/gpu/testkit/BUCK
+++ b/contrib/gpu/testkit/BUCK
@@ -31,6 +31,17 @@ cpp_library(
     ],
 )
 
+cpp_library(
+    name = "testkit_relative_headers",
+    headers = relative_headers([
+        "frame_factory.h",
+        "frame_verifier.h",
+        "multichunk_frame.h",
+    ]),
+    header_namespace = "",
+    exported_deps = [":testkit"],
+)
+
 cpp_unittest(
     # @autodeps-skip
     name = "frame_factory_test",


### PR DESCRIPTION
Summary:

Retain host and device chunk pointers, create an independently initialized DCTX for each chunk, disable CPU codec fusion, and parse chunk metadata using chunk-local offsets before GPU decoding.

Reviewed By: terrelln

Differential Revision: D112832627


