### PR TITLE
Add format versioning to clustering training (#941)

### DIFF
--- a/cli/args/TrainArgs.h
+++ b/cli/args/TrainArgs.h
@@ -7,6 +7,7 @@
 
 #include "custom_parsers/dependency_registration.h"
 #include "openzl/cpp/Compressor.hpp"
+#include "openzl/zl_version.h"
 
 #include "tools/io/InputSetBuilder.h"
 #include "tools/io/OutputFile.h"
@@ -133,6 +134,7 @@ class TrainArgs : public GlobalArgs, public ProfileArgs {
         // Create the compressor
         setCompressor(createCompressorFromArgs(
                 *this, parsed.cmdFlag(cmd(), kCompressor)));
+        applyDefaultFormatVersion();
         auto outputPath = parsed.cmdFlag(cmd(), kOutput);
         if (outputPath) {
             checkOutput(outputPath.value(), parsed.cmdHasFlag(cmd(), kForce));
@@ -228,6 +230,7 @@ class TrainArgs : public GlobalArgs, public ProfileArgs {
         // Inline training (e.g. `compress --train-inline`) produces a
         // standalone compressor only; dictionary training is opt-in via
         // --dict-bundle-output.
+        applyDefaultFormatVersion();
         trainParams.dictTraining = false;
         trainParams.compressorGenFunc =
                 custom_parsers::createCompressorFromSerialized;
@@ -246,6 +249,17 @@ class TrainArgs : public GlobalArgs, public ProfileArgs {
     training::TrainParams trainParams;
 
    private:
+    // The trained (and serialized) compressor must carry a format version so
+    // that downstream training can target it. Default to the maximum supported
+    // version when the compressor does not already specify one.
+    void applyDefaultFormatVersion()
+    {
+        if (compressor()->getParameter(CParam::FormatVersion) == 0) {
+            compressor()->setParameter(
+                    CParam::FormatVersion, ZL_MAX_FORMAT_VERSION);
+        }
+    }
+
     inline static const std::string kSampleDir  = "sample-dir";
     inline static const std::string kCompressor = "compressor";
 

--- a/cli/args/TrainArgs.h
+++ b/cli/args/TrainArgs.h
@@ -126,6 +126,13 @@ class TrainArgs : public GlobalArgs, public ProfileArgs {
                 0,
                 false,
                 "Save the ACE state as a local parameter in the trained compressor.");
+        parser.addCommandFlag(
+                cmd(),
+                kFormatVersion,
+                0,
+                true,
+                "Target format version for training. If not provided, defaults "
+                "to the maximum supported format version.");
     }
 
     explicit TrainArgs(const arg::ParsedArgs& parsed)
@@ -134,7 +141,14 @@ class TrainArgs : public GlobalArgs, public ProfileArgs {
         // Create the compressor
         setCompressor(createCompressorFromArgs(
                 *this, parsed.cmdFlag(cmd(), kCompressor)));
-        applyDefaultFormatVersion();
+        auto formatVersion = parsed.cmdFlag(cmd(), kFormatVersion);
+        if (formatVersion) {
+            compressor()->setParameter(
+                    CParam::FormatVersion,
+                    util::checkedstoi(formatVersion.value()));
+        } else {
+            applyDefaultFormatVersion();
+        }
         auto outputPath = parsed.cmdFlag(cmd(), kOutput);
         if (outputPath) {
             checkOutput(outputPath.value(), parsed.cmdHasFlag(cmd(), kForce));
@@ -254,10 +268,8 @@ class TrainArgs : public GlobalArgs, public ProfileArgs {
     // version when the compressor does not already specify one.
     void applyDefaultFormatVersion()
     {
-        if (compressor()->getParameter(CParam::FormatVersion) == 0) {
-            compressor()->setParameter(
-                    CParam::FormatVersion, ZL_MAX_FORMAT_VERSION);
-        }
+        compressor()->setParameter(
+                CParam::FormatVersion, ZL_MAX_FORMAT_VERSION);
     }
 
     inline static const std::string kSampleDir  = "sample-dir";
@@ -279,6 +291,7 @@ class TrainArgs : public GlobalArgs, public ProfileArgs {
     inline static const std::string kMaxTotalSizeMb  = "max-total-size-mb";
     inline static const std::string kParetoFrontier  = "pareto-frontier";
     inline static const std::string kSaveAceState    = "save-ace-state";
+    inline static const std::string kFormatVersion   = "format-version";
 };
 
 } // namespace openzl::cli

--- a/tools/training/BUCK
+++ b/tools/training/BUCK
@@ -34,6 +34,7 @@ zs_cxxlibrary(
         "trained_candidate.cpp",
     ],
     headers = [
+        "train_exceptions.h",
         "train_params.h",
         "trained_candidate.h",
     ],

--- a/tools/training/clustering/clustering_graph_trainer.cpp
+++ b/tools/training/clustering/clustering_graph_trainer.cpp
@@ -15,6 +15,7 @@
 #include "tools/training/clustering/train_api.h"
 #include "tools/training/graph_mutation/graph_mutation_utils.h"
 #include "tools/training/sample_collection/training_sample_collector.h"
+#include "tools/training/train_exceptions.h"
 #include "tools/training/utils/serialized_compressor_internal.h"
 #include "tools/training/utils/utils.h"
 
@@ -26,6 +27,10 @@ namespace openzl::training {
 const std::string CLUSTERING_GRAPH_NAME = "zl.cluster";
 
 namespace {
+
+// Minimum format version at which all concat codecs required by clustering are
+// available (CONCAT_SERIAL=16, _NUMERIC/_STRUCT=17, _STRING=18).
+constexpr int kMinClusteringFormatVersion = 18;
 
 /**
  * Add a new parameterized version of the clustering graph to the compressor
@@ -69,15 +74,33 @@ ZL_GraphID clusterSuccessors(
         const TrainParams& trainParams,
         GraphID clusteringGraphUniqueIDUntrained)
 {
+    const auto formatVersion = compressor.getParameter(CParam::FormatVersion);
+    // Clustering relies on concat codecs; if any required clustering codec is
+    // missing at this format version, training is unsupported.
+    if (formatVersion < kMinClusteringFormatVersion) {
+        throw FormatVersionUnsupportedError(
+                "clustering requires concat codecs unavailable at format version "
+                + std::to_string(formatVersion));
+    }
+
     auto cctx = refCCtxForTraining(compressor);
 
     const std::string clusteringGraphUniqueNameUntrained =
             ZL_Compressor_Graph_getName(
                     compressor.get(), clusteringGraphUniqueIDUntrained);
 
-    // Get successors for training
-    const auto successorsVec =
-            getCustomGraphs(compressor, clusteringGraphUniqueIDUntrained);
+    // Get successors for training, dropping any that cannot compress at the
+    // target format version.
+    const auto successorsVec = filterGraphsByFormatVersion(
+            compressor,
+            getCustomGraphs(compressor, clusteringGraphUniqueIDUntrained),
+            inputs);
+
+    if (successorsVec.size() == 0) {
+        throw FormatVersionUnsupportedError(
+                "No compatible successors chosen in clustering graph at format version "
+                + std::to_string(formatVersion));
+    }
 
     // Get clustering codecs for training
     std::vector<ZL_NodeID> clusteringCodecs =

--- a/tools/training/tests/BUCK
+++ b/tools/training/tests/BUCK
@@ -21,6 +21,7 @@ cpp_unittest(
         "test_sample_limiter.cpp",
         "test_thread_pool.cpp",
         "test_train.cpp",
+        "test_utils.cpp",
     ],
     headers = relative_headers([
         "benchmark_files/ppmf_unit_segment.h",

--- a/tools/training/tests/test_clustering.cpp
+++ b/tools/training/tests/test_clustering.cpp
@@ -5,15 +5,18 @@
 #include <thread>
 
 #include "openzl/codecs/zl_clustering.h"
+#include "openzl/codecs/zl_lz.h"
 #include "openzl/common/a1cbor_helpers.h"
 #include "openzl/common/allocation.h"
 #include "openzl/cpp/Input.hpp"
 #include "openzl/zl_reflection.h"
 #include "src/openzl/compress/graphs/generic_clustering_graph.h"
 #include "tests/datagen/DataGen.h"
+#include "tools/training/clustering/clustering_graph_trainer.h"
 #include "tools/training/clustering/train_api.h"
 #include "tools/training/clustering/utils.h"
 #include "tools/training/train.h"
+#include "tools/training/train_exceptions.h"
 #include "tools/training/utils/utils.h"
 
 namespace openzl::tests {
@@ -89,6 +92,7 @@ class TestTraining : public testing::Test {
     {
         // Register the base clustering graph as the starting graph
         compressor_.selectStartingGraph(ZL_GRAPH_CLUSTERING);
+        compressor_.setParameter(CParam::FormatVersion, ZL_MAX_FORMAT_VERSION);
 
         successors_.push_back(ZL_GRAPH_STORE);
         successors_.push_back(ZL_GRAPH_FIELD_LZ);
@@ -386,6 +390,38 @@ TEST_F(TestTraining, TestTrainingDifferentTypeSameTag)
             compressor_.get(), trainedGraphId);
     auto r = deserializeToClusteringConfig(lparam);
     EXPECT_TRUE(!ZL_RES_isError(r));
+}
+
+TEST(ClusteringTrainerFormatVersionTest, ThrowsWhenNoSuccessorSupportsVersion)
+{
+    // ZL_GRAPH_LZ is unavailable before format version 24, so targeting an
+    // earlier version (still above the clustering minimum) filters out every
+    // successor and leaves the clustering trainer with nothing to train.
+    constexpr uint32_t kLzFormatVersion       = 24;
+    constexpr uint32_t kFormatVersionBeforeLz = kLzFormatVersion - 1;
+
+    Compressor compressor;
+    compressor.setParameter(CParam::FormatVersion, kFormatVersionBeforeLz);
+    std::vector<ZL_GraphID> successors = { ZL_GRAPH_LZ };
+    ZL_ClusteringConfig config = { .nbClusters = 0, .nbTypeDefaults = 0 };
+    auto clusteringGraph       = ZL_Clustering_registerGraph(
+            compressor.get(), &config, successors.data(), successors.size());
+    compressor.selectStartingGraph(clusteringGraph);
+
+    const training::TrainParams trainParams = {
+        .clusteringTrainer = training::ClusteringTrainer::Greedy,
+    };
+
+    std::vector<uint8_t> data(1024);
+    for (size_t i = 0; i < data.size(); ++i) {
+        data[i] = static_cast<uint8_t>(i);
+    }
+    training::MultiInput input;
+    input.add(Input::refSerial(data.data(), data.size()));
+    const std::vector<training::MultiInput> inputs = { std::move(input) };
+    EXPECT_THROW(
+            training::trainClusteringGraph(inputs, compressor, trainParams),
+            training::FormatVersionUnsupportedError);
 }
 
 } // namespace

--- a/tools/training/tests/test_clustering_benchmarks.cpp
+++ b/tools/training/tests/test_clustering_benchmarks.cpp
@@ -26,6 +26,7 @@ class TestClusteringBenchmarks : public testing::Test {
     {
         // Register the graph to train in the compressor
         trainingGraphFn(compressor.get());
+        compressor.setParameter(CParam::FormatVersion, ZL_MAX_FORMAT_VERSION);
         // Train the compressor and serialize it
         auto serialized = training::train(inputs_, compressor, params_);
         // Compress the data using the trained compressor

--- a/tools/training/tests/test_dict_training.cpp
+++ b/tools/training/tests/test_dict_training.cpp
@@ -107,6 +107,7 @@ TEST(BaseDictTrainer, DuplicateDictsAreDeduped)
     // Generate a compressor that splits an input into 3, and sends each to a
     // trainable zstd node
     Compressor compressor;
+    compressor.setParameter(CParam::FormatVersion, ZL_MAX_FORMAT_VERSION);
     {
         constexpr size_t kNumSegments                = 3;
         constexpr size_t kSegmentSizes[kNumSegments] = { 1024, 1024, 0 };

--- a/tools/training/tests/test_train.cpp
+++ b/tools/training/tests/test_train.cpp
@@ -15,6 +15,7 @@ TEST(TrainTest, ThrowsTypedErrorWithoutTrainableGraph)
 {
     const std::vector<training::MultiInput> inputs;
     Compressor compressor;
+    compressor.setParameter(CParam::FormatVersion, ZL_MAX_FORMAT_VERSION);
     compressor.selectStartingGraph(ZL_GRAPH_STORE);
     const training::TrainParams trainParams = {
         .compressorGenFunc =
@@ -28,6 +29,26 @@ TEST(TrainTest, ThrowsTypedErrorWithoutTrainableGraph)
     EXPECT_THROW(
             training::train(inputs, compressor, trainParams),
             training::NoTrainableGraphError);
+}
+
+TEST(TrainTest, ThrowsWhenCompressorFormatVersionIsNotSet)
+{
+    const std::vector<training::MultiInput> inputs;
+    Compressor compressor;
+    compressor.selectStartingGraph(ZL_GRAPH_STORE);
+    const training::TrainParams trainParams = {
+        .compressorGenFunc =
+                [](poly::string_view, poly::string_view) {
+                    return std::make_unique<Compressor>();
+                },
+    };
+
+    try {
+        training::train(inputs, compressor, trainParams);
+        FAIL() << "Expected unset compressor format version to throw";
+    } catch (const training::FormatVersionUnsupportedError& e) {
+        EXPECT_EQ(e.msg(), "Compressor format version is not set.");
+    }
 }
 
 } // namespace

--- a/tools/training/tests/test_utils.cpp
+++ b/tools/training/tests/test_utils.cpp
@@ -1,0 +1,144 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#include <gtest/gtest.h>
+
+#include <array>
+#include <vector>
+
+#include "openzl/codecs/zl_concat.h"
+#include "openzl/codecs/zl_conversion.h"
+#include "openzl/codecs/zl_lz.h"
+#include "openzl/codecs/zl_store.h"
+#include "openzl/codecs/zl_zstd.h"
+#include "openzl/cpp/Compressor.hpp"
+#include "openzl/zl_version.h"
+#include "tools/training/utils/utils.h"
+
+namespace openzl::training {
+namespace {
+
+std::vector<ZL_IDType> graphIds(const std::vector<GraphID>& graphs)
+{
+    std::vector<ZL_IDType> ids;
+    ids.reserve(graphs.size());
+    for (const auto graph : graphs) {
+        ids.push_back(graph.gid);
+    }
+    return ids;
+}
+
+std::vector<MultiInput> serialInputs()
+{
+    static const std::array<uint8_t, 1024> data = [] {
+        std::array<uint8_t, 1024> result{};
+        for (size_t i = 0; i < result.size(); ++i) {
+            result[i] = static_cast<uint8_t>(i);
+        }
+        return result;
+    }();
+    MultiInput input;
+    input.add(Input::refSerial(data.data(), data.size()));
+    return { std::move(input) };
+}
+
+TEST(CompressorIsFormatCompatibleTest, UsesCompressorFormatVersion)
+{
+    Compressor compressor;
+    compressor.selectStartingGraph(ZL_GRAPH_LZ);
+    compressor.setParameter(CParam::FormatVersion, 23);
+    EXPECT_FALSE(compressorIsFormatCompatible(compressor, serialInputs()));
+
+    compressor.setParameter(CParam::FormatVersion, 24);
+    EXPECT_TRUE(compressorIsFormatCompatible(compressor, serialInputs()));
+}
+
+TEST(FilterGraphsByFormatVersionTest, ThrowsWhenFormatVersionBelowMinimum)
+{
+    Compressor compressor;
+    const auto customGraph = compressor.buildStaticGraph(
+            ZL_NODE_CONVERT_STRUCT_TO_SERIAL, { ZL_GRAPH_STORE });
+    compressor.selectStartingGraph(ZL_GRAPH_STORE);
+    const std::vector<GraphID> graphs = { ZL_GRAPH_STORE,
+                                          ZL_GRAPH_ZSTD,
+                                          customGraph };
+
+    // Leaving the format version unset reads back as 0, which is below
+    // ZL_MIN_FORMAT_VERSION. setParameter rejects any explicit value below the
+    // minimum, so an unset compressor is the way to exercise the guard.
+    EXPECT_THROW(
+            filterGraphsByFormatVersion(compressor, graphs, serialInputs()),
+            Exception);
+}
+
+TEST(FilterGraphsByFormatVersionTest, FiltersLZByVersion)
+{
+    Compressor compressor;
+    compressor.setParameter(CParam::FormatVersion, 23);
+    const auto beforeVersion24 = filterGraphsByFormatVersion(
+            compressor, { ZL_GRAPH_LZ }, serialInputs());
+    EXPECT_TRUE(beforeVersion24.empty());
+
+    compressor.setParameter(CParam::FormatVersion, 24);
+    const auto atVersion24 = filterGraphsByFormatVersion(
+            compressor, { ZL_GRAPH_LZ }, serialInputs());
+    EXPECT_EQ(graphIds(atVersion24), graphIds({ ZL_GRAPH_LZ }));
+    EXPECT_EQ(compressor.getParameter(CParam::FormatVersion), 24);
+}
+
+TEST(FilterGraphsByFormatVersionTest, RestoresCompressorStateAfterException)
+{
+    Compressor compressor;
+    compressor.selectStartingGraph(ZL_GRAPH_STORE);
+    compressor.setParameter(CParam::FormatVersion, ZL_MAX_FORMAT_VERSION);
+
+    EXPECT_THROW(
+            filterGraphsByFormatVersion(
+                    compressor, { ZL_GRAPH_ILLEGAL }, serialInputs()),
+            Exception);
+
+    EXPECT_EQ(
+            compressor.getParameter(CParam::FormatVersion),
+            ZL_MAX_FORMAT_VERSION);
+    EXPECT_EQ(compressor.getStartingGraph(), ZL_GRAPH_STORE);
+}
+
+TEST(FilterGraphsByFormatVersionTest, FiltersCustomGraphByConversionVersion)
+{
+    Compressor compressor;
+    const auto graph = compressor.buildStaticGraph(
+            ZL_NODE_CONVERT_STRUCT_TO_NUM_BE, { ZL_GRAPH_STORE });
+    const std::array<uint32_t, 64> data{};
+    MultiInput input;
+    input.add(Input::refStruct(data.data(), data.size()));
+    const std::vector<MultiInput> inputs = { std::move(input) };
+
+    compressor.setParameter(CParam::FormatVersion, 20);
+    const auto beforeVersion21 =
+            filterGraphsByFormatVersion(compressor, { graph }, inputs);
+    EXPECT_TRUE(beforeVersion21.empty());
+
+    compressor.setParameter(CParam::FormatVersion, 21);
+    const auto atVersion21 =
+            filterGraphsByFormatVersion(compressor, { graph }, inputs);
+    EXPECT_EQ(graphIds(atVersion21), graphIds({ graph }));
+}
+
+TEST(FilterGraphsByFormatVersionTest, SupportsMultiInputGraphs)
+{
+    Compressor compressor;
+    compressor.setParameter(CParam::FormatVersion, ZL_MAX_FORMAT_VERSION);
+    const auto graph = compressor.buildStaticGraph(
+            ZL_NODE_CONCAT_SERIAL, { ZL_GRAPH_STORE, ZL_GRAPH_STORE });
+    MultiInput input;
+    input.add(Input::refSerial("first", 5));
+    input.add(Input::refSerial("second", 6));
+    const std::vector<MultiInput> inputs = { std::move(input) };
+
+    const auto supported =
+            filterGraphsByFormatVersion(compressor, { graph }, inputs);
+
+    EXPECT_EQ(graphIds(supported), graphIds({ graph }));
+}
+
+} // namespace
+} // namespace openzl::training

--- a/tools/training/train.cpp
+++ b/tools/training/train.cpp
@@ -28,6 +28,22 @@ std::vector<TrainedCandidate> train(
         throw Exception("Compressor generator function is not set.");
     }
 
+    const auto formatVersion = compressor.getParameter(CParam::FormatVersion);
+    if (formatVersion == 0) {
+        throw FormatVersionUnsupportedError(
+                "Compressor format version is not set.");
+    }
+
+    // Try compressing with the base graph to train. This is not exhaustive
+    // because function graphs may select different nodes for other inputs.
+    if (!compressorIsFormatCompatible(compressor, inputs)) {
+        throw FormatVersionUnsupportedError(
+                "Base graph failed to compress at format version "
+                + std::to_string(formatVersion)
+                + "; the format version is unsupported for the graph "
+                  "getting trained.");
+    }
+
     if (graph_mutation::hasTargetGraph(compressor, CLUSTERING_GRAPH_NAME)) {
         serializedTrainedCompressors.clear();
         serializedTrainedCompressors.push_back(

--- a/tools/training/train.h
+++ b/tools/training/train.h
@@ -3,18 +3,12 @@
 #pragma once
 
 #include "openzl/cpp/Compressor.hpp"
-#include "openzl/cpp/Exception.hpp"
+#include "tools/training/train_exceptions.h"
 #include "tools/training/train_params.h"
 #include "tools/training/trained_candidate.h"
 #include "tools/training/utils/utils.h"
 
 namespace openzl::training {
-
-/** Thrown when a compressor has no graph that can be trained. */
-class NoTrainableGraphError : public Exception {
-   public:
-    using Exception::Exception;
-};
 
 /**
  * This function trains compressor graphs (clustering and/or ACE graphs).

--- a/tools/training/train_exceptions.h
+++ b/tools/training/train_exceptions.h
@@ -1,0 +1,25 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#pragma once
+
+#include "openzl/cpp/Exception.hpp"
+
+namespace openzl::training {
+
+/** Thrown when a compressor has no graph that can be trained. */
+class NoTrainableGraphError : public Exception {
+   public:
+    using Exception::Exception;
+};
+
+/**
+ * Thrown by a trainer when it cannot produce a graph that supports the target
+ * format version (e.g. all of its required codecs are below the target
+ * version). The orchestrator catches this to fall the trainer back to zstd.
+ */
+class FormatVersionUnsupportedError : public Exception {
+   public:
+    using Exception::Exception;
+};
+
+} // namespace openzl::training

--- a/tools/training/train_params.h
+++ b/tools/training/train_params.h
@@ -4,6 +4,7 @@
 #include <cstdint>
 #include <functional>
 #include "openzl/cpp/Compressor.hpp"
+#include "openzl/cpp/Exception.hpp"
 #include "openzl/cpp/poly/Optional.hpp"
 
 namespace openzl::training {

--- a/tools/training/utils/BUCK
+++ b/tools/training/utils/BUCK
@@ -17,6 +17,7 @@ zs_cxxlibrary(
         "utils.h",
     ],
     exported_deps = [
+        "..:train_common",
         "../..:io",
         "../..:logger",
         "../../..:common",

--- a/tools/training/utils/utils.cpp
+++ b/tools/training/utils/utils.cpp
@@ -3,17 +3,30 @@
 #include "tools/training/utils/utils.h"
 #include "openzl/cpp/CCtx.hpp"
 #include "openzl/cpp/Compressor.hpp"
-#include "tools/io/InputSetStatic.h"
+#include "openzl/cpp/Exception.hpp"
+#include "openzl/zl_reflection.h"
 
 namespace openzl::training {
 
 CCtx refCCtxForTraining(const Compressor& compressor)
 {
     openzl::CCtx cctx;
-    cctx.setParameter(openzl::CParam::FormatVersion, ZL_MAX_FORMAT_VERSION);
-    cctx.setParameter(openzl::CParam::StickyParameters, ZL_MAX_FORMAT_VERSION);
+    cctx.setParameter(openzl::CParam::StickyParameters, 1);
     cctx.refCompressor(compressor);
     return cctx;
+}
+
+size_t MultiInput::compressBound() const
+{
+    size_t totalSrcSize = 0;
+    for (const auto& input : *inputs_) {
+        totalSrcSize += input.contentSize();
+        if (input.type() == Type::String) {
+            totalSrcSize += input.numElts() * sizeof(*input.stringLens());
+        }
+    }
+    totalSrcSize += inputs_->size() * 256;
+    return 2 * ZL_compressBound(totalSrcSize) + 1024;
 }
 
 std::vector<MultiInput> inputSetToMultiInputs(tools::io::InputSet& inputs)
@@ -26,6 +39,56 @@ std::vector<MultiInput> inputSetToMultiInputs(tools::io::InputSet& inputs)
         multiInputs.push_back(std::move(mi));
     }
     return multiInputs;
+}
+
+bool compressorIsFormatCompatible(
+        const Compressor& compressor,
+        const std::vector<MultiInput>& inputs)
+{
+    CCtx cctx;
+    cctx.refCompressor(compressor);
+    for (const auto& input : inputs) {
+        const size_t outputCapacity = input.compressBound();
+        std::string output(outputCapacity, '\0');
+        try {
+            cctx.compress(output, *input);
+        } catch (const Exception& e) {
+            // Catch only format version unsupported errors. Otherwise it is
+            // failing compression on the input but is actually supported format
+            // version-wise.
+            if (e.code() == ZL_ErrorCode_formatVersion_unsupported
+                || e.code() == ZL_ErrorCode_node_versionMismatch) {
+                return false;
+            }
+        }
+    }
+    return true;
+}
+
+std::vector<GraphID> filterGraphsByFormatVersion(
+        Compressor& compressor,
+        const std::vector<GraphID>& graphs,
+        const std::vector<MultiInput>& inputs)
+{
+    const auto formatVersion = compressor.getParameter(CParam::FormatVersion);
+    if (formatVersion < ZL_MIN_FORMAT_VERSION) {
+        throw Exception("Format version is below ZL_MIN_FORMAT_VERSION");
+    }
+    GraphID originalStartingGraph = ZL_GRAPH_ILLEGAL;
+    const bool hadStartingGraph   = ZL_Compressor_getStartingGraphID(
+            compressor.get(), &originalStartingGraph);
+    std::vector<GraphID> supported;
+    supported.reserve(graphs.size());
+    for (const auto graph : graphs) {
+        compressor.selectStartingGraph(graph);
+        if (compressorIsFormatCompatible(compressor, inputs)) {
+            supported.push_back(graph);
+        }
+    }
+    if (hadStartingGraph) {
+        compressor.selectStartingGraph(originalStartingGraph);
+    }
+    return supported;
 }
 
 } // namespace openzl::training

--- a/tools/training/utils/utils.h
+++ b/tools/training/utils/utils.h
@@ -11,7 +11,7 @@ namespace openzl::training {
 /**
  * @brief Create a CCtx for training the compressor. The cctx is configured
  * so that if training is called multiple times, the parameters will not be
- * reset.
+ * reset. Targets ZL_MAX_FORMAT_VERSION.
  */
 CCtx refCCtxForTraining(const Compressor& compressor);
 
@@ -42,6 +42,12 @@ class MultiInput {
         return inputs_.get();
     }
 
+    /**
+     * @brief Returns maximum compressed size after compression using these
+     * inputs.
+     */
+    size_t compressBound() const;
+
     // Adds input while not owning the buffer the input references
     void add(Input&& input)
     {
@@ -66,5 +72,49 @@ class MultiInput {
  * each input is serial in @p inputs.
  */
 std::vector<MultiInput> inputSetToMultiInputs(tools::io::InputSet& inputs);
+
+/**
+ * @brief Returns whether @p compressor is compatible with its configured
+ * format version for every sample in @p inputs.
+ *
+ * It is the caller's responsibility to configure the compressor's format
+ * version, select its starting graph, and provide inputs that exercise every
+ * graph path whose compatibility must be tested. Compression errors unrelated
+ * to format compatibility are ignored.
+ */
+bool compressorIsFormatCompatible(
+        const Compressor& compressor,
+        const std::vector<MultiInput>& inputs);
+
+/**
+ * @brief Filter @p graphs down to those able to compress @p inputs at the
+ * target @p formatVersion.
+ *
+ * Each candidate graph is used to compress every sample in @p inputs. A graph
+ * is filtered out if any compression reports a format-version incompatibility.
+ * Supported graphs are returned in their original order.
+ *
+ * It is the caller's responsibility to provide inputs capable of exercising
+ * every graph path whose format-version compatibility must be tested. A graph
+ * that is incompatible with @p formatVersion may be retained if @p inputs do
+ * not exercise the incompatible path.
+ *
+ * @throws Exception if @p formatVersion is less than ZL_MIN_FORMAT_VERSION.
+ *
+ * Standard graphs follow the guidelines which are required for this function to
+ * work. Custom graphs are also required to follow these guidelines. These are
+ * that graphs must either:
+ * - Always select the same nodes and may not work on older format versions.
+ * - Dynamically select which nodes to run, in which case they should be
+ * format-version aware, meaning they should never execute a codec which
+ * requires a format version above the library's format version.
+ *
+ * If these guidelines are not followed, the function may not correctly filter
+ * out the graph.
+ */
+std::vector<GraphID> filterGraphsByFormatVersion(
+        Compressor& compressor,
+        const std::vector<GraphID>& graphs,
+        const std::vector<MultiInput>& inputs);
 
 } // namespace openzl::training


### PR DESCRIPTION
Summary:

Threads the resolved target format version through the clustering trainer. Also moves format version to be required to be set on the compressor that is getting trained.

Details:
- clusterSuccessors() now filters the clustering (concat) codecs by
  ZL_Compressor_Node_getMinVersion against the target version and throws
  FormatVersionUnsupportedError if none survive (so the orchestrator can fall
  clustering back to zstd), and builds its round-trip CCtx at the target version.
- train_cluster() resolves the version from TrainParams and passes it through
  Trainer::getTrainedClusteringConfig into CompressionUtils, whose per-sample
  benchmark CCtx now targets that version instead of ZL_MAX_FORMAT_VERSION.
- FormatVersionUnsupportedError moved to train_params.h (train_common) so it is
visible to every trainer and the orchestrator without a BUCK dependency cycle.

Reviewed By: terrelln

Differential Revision: D113974921


