### PR TITLE
Add format versioning to ACE training (#946)

### DIFF
--- a/cli/args/TrainArgs.h
+++ b/cli/args/TrainArgs.h
@@ -7,6 +7,7 @@
 
 #include "custom_parsers/dependency_registration.h"
 #include "openzl/cpp/Compressor.hpp"
+#include "openzl/zl_version.h"
 
 #include "tools/io/InputSetBuilder.h"
 #include "tools/io/OutputFile.h"
@@ -133,6 +134,7 @@ class TrainArgs : public GlobalArgs, public ProfileArgs {
         // Create the compressor
         setCompressor(createCompressorFromArgs(
                 *this, parsed.cmdFlag(cmd(), kCompressor)));
+        applyDefaultFormatVersion();
         auto outputPath = parsed.cmdFlag(cmd(), kOutput);
         if (outputPath) {
             checkOutput(outputPath.value(), parsed.cmdHasFlag(cmd(), kForce));
@@ -228,6 +230,7 @@ class TrainArgs : public GlobalArgs, public ProfileArgs {
         // Inline training (e.g. `compress --train-inline`) produces a
         // standalone compressor only; dictionary training is opt-in via
         // --dict-bundle-output.
+        applyDefaultFormatVersion();
         trainParams.dictTraining = false;
         trainParams.compressorGenFunc =
                 custom_parsers::createCompressorFromSerialized;
@@ -246,6 +249,17 @@ class TrainArgs : public GlobalArgs, public ProfileArgs {
     training::TrainParams trainParams;
 
    private:
+    // The trained (and serialized) compressor must carry a format version so
+    // that downstream training can target it. Default to the maximum supported
+    // version when the compressor does not already specify one.
+    void applyDefaultFormatVersion()
+    {
+        if (compressor()->getParameter(CParam::FormatVersion) == 0) {
+            compressor()->setParameter(
+                    CParam::FormatVersion, ZL_MAX_FORMAT_VERSION);
+        }
+    }
+
     inline static const std::string kSampleDir  = "sample-dir";
     inline static const std::string kCompressor = "compressor";
 

--- a/cli/args/TrainArgs.h
+++ b/cli/args/TrainArgs.h
@@ -126,6 +126,13 @@ class TrainArgs : public GlobalArgs, public ProfileArgs {
                 0,
                 false,
                 "Save the ACE state as a local parameter in the trained compressor.");
+        parser.addCommandFlag(
+                cmd(),
+                kFormatVersion,
+                0,
+                true,
+                "Target format version for training. If not provided, defaults "
+                "to the maximum supported format version.");
     }
 
     explicit TrainArgs(const arg::ParsedArgs& parsed)
@@ -134,7 +141,14 @@ class TrainArgs : public GlobalArgs, public ProfileArgs {
         // Create the compressor
         setCompressor(createCompressorFromArgs(
                 *this, parsed.cmdFlag(cmd(), kCompressor)));
-        applyDefaultFormatVersion();
+        auto formatVersion = parsed.cmdFlag(cmd(), kFormatVersion);
+        if (formatVersion) {
+            compressor()->setParameter(
+                    CParam::FormatVersion,
+                    util::checkedstoi(formatVersion.value()));
+        } else {
+            applyDefaultFormatVersion();
+        }
         auto outputPath = parsed.cmdFlag(cmd(), kOutput);
         if (outputPath) {
             checkOutput(outputPath.value(), parsed.cmdHasFlag(cmd(), kForce));
@@ -254,10 +268,8 @@ class TrainArgs : public GlobalArgs, public ProfileArgs {
     // version when the compressor does not already specify one.
     void applyDefaultFormatVersion()
     {
-        if (compressor()->getParameter(CParam::FormatVersion) == 0) {
-            compressor()->setParameter(
-                    CParam::FormatVersion, ZL_MAX_FORMAT_VERSION);
-        }
+        compressor()->setParameter(
+                CParam::FormatVersion, ZL_MAX_FORMAT_VERSION);
     }
 
     inline static const std::string kSampleDir  = "sample-dir";
@@ -279,6 +291,7 @@ class TrainArgs : public GlobalArgs, public ProfileArgs {
     inline static const std::string kMaxTotalSizeMb  = "max-total-size-mb";
     inline static const std::string kParetoFrontier  = "pareto-frontier";
     inline static const std::string kSaveAceState    = "save-ace-state";
+    inline static const std::string kFormatVersion   = "format-version";
 };
 
 } // namespace openzl::cli

--- a/src/openzl/compress/graphmgr.c
+++ b/src/openzl/compress/graphmgr.c
@@ -709,9 +709,9 @@ static ZL_Report GM_checkInputTypesAreCompatible(
             graph_invalid,
             "Graphs have different number of inputs");
     for (size_t i = 0; i < meta0.nbInputs; ++i) {
-        ZL_ERR_IF_EQ(
-                meta0.inputTypeMasks[i] & meta1.inputTypeMasks[i],
-                0,
+        ZL_ERR_IF_NOT(
+                ICONV_isCompatible(
+                        meta0.inputTypeMasks[i], meta1.inputTypeMasks[i]),
                 graph_invalid,
                 "Input %zu types are not compatible",
                 i);

--- a/tests/unittest/compress/CompressorUnitTest.cpp
+++ b/tests/unittest/compress/CompressorUnitTest.cpp
@@ -1718,6 +1718,17 @@ TEST_F(CompressorTest, OverrideBaseGraph)
             ZL_Compressor_getGraphType(compressor_.get(), paramGraph));
 }
 
+TEST_F(CompressorTest, OverrideBaseGraphAllowsImplicitInputConversion)
+{
+    auto paramGraph = makeParameterizedGraph();
+
+    EXPECT_ZS_VALID(ZL_Compressor_overrideBaseGraph(
+            compressor_.get(), paramGraph, ZL_GRAPH_ZSTD));
+    EXPECT_EQ(
+            ZL_Compressor_Graph_getBaseGraphID(compressor_.get(), paramGraph),
+            ZL_GRAPH_ZSTD);
+}
+
 TEST_F(CompressorTest, OverrideBaseGraphRejectsStandardGraph)
 {
     EXPECT_ZS_ERROR(ZL_Compressor_overrideBaseGraph(

--- a/tools/training/BUCK
+++ b/tools/training/BUCK
@@ -34,6 +34,7 @@ zs_cxxlibrary(
         "trained_candidate.cpp",
     ],
     headers = [
+        "train_exceptions.h",
         "train_params.h",
         "trained_candidate.h",
     ],

--- a/tools/training/ace/ace.cpp
+++ b/tools/training/ace/ace.cpp
@@ -32,7 +32,8 @@ std::string trainBackend(
         std::vector<MultiInput>& samples,
         const TrainParams& trainParams,
         size_t graphIdx,
-        size_t numGraphs)
+        size_t numGraphs,
+        uint32_t formatVersion)
 {
     if (samples.empty()) {
         throw Exception(
@@ -55,7 +56,8 @@ std::string trainBackend(
                 ? trainParams.threads.value()
                 : std::thread::hardware_concurrency() / 2,
     };
-    params.maxTime = maxTime;
+    params.maxTime       = maxTime;
+    params.formatVersion = formatVersion;
     AutomatedCompressorExplorer ace(flattened, params);
     for (;;) {
         Logger::logProgress(
@@ -131,8 +133,14 @@ std::vector<SerializedCompressorInternal> ACETrainer::train(
                     "): no training samples");
             continue;
         }
+        const auto formatVersion = static_cast<uint32_t>(
+                compressor.getParameter(CParam::FormatVersion));
         auto aceState = trainBackend(
-                samples[backendGraph], trainParams, graphIdx, numGraphs);
+                samples[backendGraph],
+                trainParams,
+                graphIdx,
+                numGraphs,
+                formatVersion);
         auto localParams = LocalParams();
         localParams.addCopyParam(
                 AutomatedCompressorExplorer::kAceStateParamId,

--- a/tools/training/ace/ace_combination.cpp
+++ b/tools/training/ace/ace_combination.cpp
@@ -173,8 +173,12 @@ std::vector<std::pair<ACECompressor, ACECompressionResult>> benchmarkAce(
     auto inputs = ace.inputs();
     std::vector<std::pair<ACECompressor, ACECompressionResult>> result;
     for (auto&& [candidate, _] : solutions) {
-        auto benchmark = *candidate.benchmark(inputs);
-        result.emplace_back(std::move(candidate), std::move(benchmark));
+        auto benchmark = candidate.benchmark(inputs, ace.formatVersion());
+        // Do not add nullopt to list of benchmark results
+        if (!benchmark.has_value()) {
+            continue;
+        }
+        result.emplace_back(std::move(candidate), std::move(*benchmark));
         if (!trainParams.paretoFrontier) {
             break;
         }
@@ -183,8 +187,13 @@ std::vector<std::pair<ACECompressor, ACECompressionResult>> benchmarkAce(
         Logger::log(
                 WARNINGS,
                 "No solution found that meets speed constraints: Falling back to store");
-        auto store = buildStoreCompressor();
-        return { { store, *store.benchmark(inputs) } };
+        auto store          = buildStoreCompressor();
+        auto storeBenchmark = store.benchmark(inputs, ace.formatVersion());
+        if (!storeBenchmark.has_value()) {
+            throw Exception(
+                    "Store compressor failed to compress at the target format version");
+        }
+        return { { store, std::move(*storeBenchmark) } };
     }
 
     // Register the new graph on the compressor and return the new graph ID
@@ -290,7 +299,9 @@ std::vector<SerializedCompressorInternal> getCombinedCompressors(
                 *trainedSerializedCompressor, ""));
     };
 
-    auto compressor = makeCompressor();
+    auto compressor          = makeCompressor();
+    const auto formatVersion = static_cast<uint32_t>(
+            compressor.getParameter(CParam::FormatVersion));
     auto cctx       = refCCtxForTraining(compressor);
     auto serialized = compressor.serialize();
 
@@ -341,7 +352,10 @@ std::vector<SerializedCompressorInternal> getCombinedCompressors(
         }
         auto aceState = std::string(
                 (const char*)copyParam->paramPtr, copyParam->paramSize);
-        AutomatedCompressorExplorer ace(flattened, aceState);
+        AutomatedCompressorExplorer::Parameters aceParams;
+        // ACE snapshots contain the population, but not the run configuration.
+        aceParams.formatVersion = formatVersion;
+        AutomatedCompressorExplorer ace(flattened, aceState, aceParams);
         auto benchmarks = benchmarkAce(ace, trainParams);
         allCandidates.emplace(backendGraph, std::move(benchmarks));
     }

--- a/tools/training/ace/ace_compressor.cpp
+++ b/tools/training/ace/ace_compressor.cpp
@@ -692,7 +692,6 @@ poly::optional<ACECompressionResult> benchmark(
         auto cStart = std::chrono::steady_clock::now();
         try {
             cctx.refCompressor(compressor);
-            cctx.setParameter(CParam::FormatVersion, ZL_MAX_FORMAT_VERSION);
             compressed = cctx.compress(input);
         } catch (const Exception&) {
             return poly::nullopt;
@@ -744,11 +743,16 @@ poly::optional<ACECompressionResult> benchmark(
 }
 
 poly::optional<ACECompressionResult> ACECompressor::benchmark(
-        poly::span<const Input> inputs) const
+        poly::span<const Input> inputs,
+        uint32_t formatVersion) const
 {
     Compressor compressor;
     // TODO(terrelln): Allow parameterization
     compressor.selectStartingGraph(build(compressor));
+    // Format version is carried on the compressor, however benchmark builds the
+    // compressor from an empty compressor. So the format version must be set
+    // here.
+    compressor.setParameter(CParam::FormatVersion, formatVersion);
     return openzl::training::benchmark(compressor, inputs);
 }
 } // namespace training

--- a/tools/training/ace/ace_compressor.h
+++ b/tools/training/ace/ace_compressor.h
@@ -18,6 +18,8 @@ struct ACENode {
     poly::optional<NodeParameters> params;
     Type inputType;
     std::vector<Type> outputTypes;
+    /// Minimum format version this node requires; 0 means unconstrained.
+    unsigned minFormatVersion{ 0 };
 };
 
 struct ACEGraph {
@@ -271,9 +273,11 @@ class ACECompressor {
     }
 
     /// @returns The benchmark result of the compressor on the @p inputs or
-    /// poly::nullopt if the compressor fails to compress.
+    /// poly::nullopt if the compressor fails to compress (including when it
+    /// requires a newer format version than @p formatVersion).
     poly::optional<ACECompressionResult> benchmark(
-            poly::span<const Input> inputs) const;
+            poly::span<const Input> inputs,
+            uint32_t formatVersion) const;
 
    private:
     uint64_t computeHash() const;

--- a/tools/training/ace/ace_compressors.cpp
+++ b/tools/training/ace/ace_compressors.cpp
@@ -45,11 +45,15 @@ ACENode buildNode(const NodeT& node)
     for (const auto& meta : NodeT::metadata.variableOutputs) {
         outputTypes.push_back(meta.type);
     }
+    Compressor compressor;
+    const unsigned minFormatVersion =
+            ZL_Compressor_Node_getMinVersion(compressor.get(), NodeT::node);
     return ACENode{
-        .name        = getName(NodeT::node),
-        .params      = node.parameters(),
-        .inputType   = NodeT::metadata.inputs[0].type,
-        .outputTypes = std::move(outputTypes),
+        .name             = getName(NodeT::node),
+        .params           = node.parameters(),
+        .inputType        = NodeT::metadata.inputs[0].type,
+        .outputTypes      = std::move(outputTypes),
+        .minFormatVersion = minFormatVersion,
     };
 }
 
@@ -308,7 +312,12 @@ poly::span<const ACEGraph> getAllGraphs()
     return *graphs;
 }
 
-poly::span<const ACENode> getNodesComptabileWith(Type inputType)
+// Returns the type-compatible nodes further restricted to those usable at
+// @p formatVersion (nodes with minFormatVersion 0 are treated as
+// unconstrained).
+std::vector<ACENode> getNodesComptabileWith(
+        Type inputType,
+        uint32_t formatVersion)
 {
     static auto nodes = new std::unordered_map<Type, std::vector<ACENode>>([] {
         std::unordered_map<Type, std::vector<ACENode>> m;
@@ -322,7 +331,13 @@ poly::span<const ACENode> getNodesComptabileWith(Type inputType)
         }
         return m;
     }());
-    return nodes->at(inputType);
+    std::vector<ACENode> compatible;
+    for (const auto& n : nodes->at(inputType)) {
+        if (n.minFormatVersion == 0 || n.minFormatVersion <= formatVersion) {
+            compatible.push_back(n);
+        }
+    }
+    return compatible;
 }
 
 poly::span<const ACEGraph> getGraphsComptabileWith(Type inputType)
@@ -367,26 +382,43 @@ ACECompressor buildRandomGraphCompressor(std::mt19937_64& rng, Type inputType)
             randomChoice(rng, getGraphsComptabileWith(inputType)));
 }
 
-ACECompressor
-buildRandomNodeCompressor(std::mt19937_64& rng, Type inputType, size_t maxDepth)
+ACECompressor buildRandomNodeCompressor(
+        std::mt19937_64& rng,
+        Type inputType,
+        uint32_t formatVersion,
+        size_t maxDepth)
 {
     if (maxDepth == 0) {
         return buildRandomGraphCompressor(rng, inputType);
     }
-    auto node = randomChoice(rng, getNodesComptabileWith(inputType));
+    const auto compatible = getNodesComptabileWith(inputType, formatVersion);
+    if (compatible.empty()) {
+        // No node is available at the target format version; fall back to a
+        // single graph.
+        return buildRandomGraphCompressor(rng, inputType);
+    }
+    auto node = randomChoice(
+            rng,
+            poly::span<const ACENode>(compatible.data(), compatible.size()));
     assert(isCompatible(node.inputType, inputType));
     std::vector<std::unique_ptr<ACECompressor>> successors;
     successors.reserve(node.outputTypes.size());
     for (size_t i = 0; i < node.outputTypes.size(); ++i) {
         successors.push_back(
                 std::make_unique<ACECompressor>(buildRandomCompressor(
-                        rng, node.outputTypes[i], maxDepth - 1)));
+                        rng,
+                        node.outputTypes[i],
+                        formatVersion,
+                        maxDepth - 1)));
     }
     return ACENodeCompressor(std::move(node), std::move(successors));
 }
 
-ACECompressor
-buildRandomCompressor(std::mt19937_64& rng, Type inputType, size_t maxDepth)
+ACECompressor buildRandomCompressor(
+        std::mt19937_64& rng,
+        Type inputType,
+        uint32_t formatVersion,
+        size_t maxDepth)
 {
     std::bernoulli_distribution dist(0.5);
     if (dist(rng)) {
@@ -394,8 +426,8 @@ buildRandomCompressor(std::mt19937_64& rng, Type inputType, size_t maxDepth)
         assert(compressor.acceptsInputType(inputType));
         return compressor;
     } else {
-        auto compressor =
-                buildRandomNodeCompressor(rng, inputType, maxDepth - 1);
+        auto compressor = buildRandomNodeCompressor(
+                rng, inputType, formatVersion, maxDepth - 1);
         assert(compressor.acceptsInputType(inputType));
         return compressor;
     }

--- a/tools/training/ace/ace_compressors.h
+++ b/tools/training/ace/ace_compressors.h
@@ -2,7 +2,9 @@
 
 #pragma once
 
+#include <cstdint>
 #include <random>
+#include <vector>
 
 #include "openzl/cpp/poly/Span.hpp"
 #include "tools/training/ace/ace_compressor.h"
@@ -20,8 +22,11 @@ poly::span<const ACENode> getAllNodes();
 poly::span<const ACEGraph> getAllGraphs();
 
 /// @returns the subset of `getAllNodes()` that are compatible with the given
-/// @p inputType
-poly::span<const ACENode> getNodesComptabileWith(Type inputType);
+/// @p inputType and usable at @p formatVersion (nodes whose minFormatVersion is
+/// 0 are treated as unconstrained).
+std::vector<ACENode> getNodesComptabileWith(
+        Type inputType,
+        uint32_t formatVersion);
 /// @returns the subset of `getAllGraphs()` that are compatible with the given
 /// @p inputType
 poly::span<const ACEGraph> getGraphsComptabileWith(Type inputType);
@@ -37,16 +42,20 @@ poly::span<const ACECompressor> getPrebuiltCompressors(Type inputType);
 ACECompressor buildRandomGraphCompressor(std::mt19937_64& rng, Type inputType);
 
 /// @returns A random compressor that is compatible with the given @p inputType
-/// that is a single node followed by ACECompressor successors.
+/// that is a single node followed by ACECompressor successors. Only nodes
+/// usable at @p formatVersion are considered.
 ACECompressor buildRandomNodeCompressor(
         std::mt19937_64& rng,
         Type inputType,
+        uint32_t formatVersion,
         size_t maxDepth = kDefaultMaxDepth);
 
 /// @returns A random compressor that is compatible with the given @p inputType.
+/// Only nodes usable at @p formatVersion are considered.
 ACECompressor buildRandomCompressor(
         std::mt19937_64& rng,
         Type inputType,
+        uint32_t formatVersion,
         size_t maxDepth = kDefaultMaxDepth);
 
 ACECompressor buildStoreCompressor();

--- a/tools/training/ace/ace_crossover.h
+++ b/tools/training/ace/ace_crossover.h
@@ -13,8 +13,8 @@ namespace training {
 /// a comination of their traits.
 class ACECrossover {
    public:
-    ACECrossover(std::mt19937_64& rng, Type inputType)
-            : rng_(rng), inputType_(inputType)
+    ACECrossover(std::mt19937_64& rng, Type inputType, uint32_t formatVersion)
+            : rng_(rng), inputType_(inputType), formatVersion_(formatVersion)
     {
     }
 
@@ -44,7 +44,7 @@ class ACECrossover {
                 return std::move(*child);
             }
         }
-        return ACEMutate(rng_, inputType_)(recipient);
+        return ACEMutate(rng_, inputType_, formatVersion_)(recipient);
     }
 
     ACECompressor getRandomComponent(const ACECompressor& donor)
@@ -88,6 +88,7 @@ class ACECrossover {
 
     std::mt19937_64& rng_;
     Type inputType_;
+    uint32_t formatVersion_;
 };
 
 } // namespace training

--- a/tools/training/ace/ace_mutate.h
+++ b/tools/training/ace/ace_mutate.h
@@ -16,8 +16,12 @@ class ACEMutate {
     ACEMutate(
             std::mt19937_64& rng,
             Type inputType,
+            uint32_t formatVersion,
             size_t maxDepth = kDefaultMaxDepth)
-            : rng_(rng), inputType_(inputType), maxDepth_(maxDepth)
+            : rng_(rng),
+              inputType_(inputType),
+              formatVersion_(formatVersion),
+              maxDepth_(maxDepth)
     {
     }
 
@@ -68,7 +72,8 @@ class ACEMutate {
         if (depth > maxDepth_) {
             return buildRandomGraphCompressor(rng_, inputType);
         } else {
-            return buildRandomCompressor(rng_, inputType, maxDepth_ - depth);
+            return buildRandomCompressor(
+                    rng_, inputType, formatVersion_, maxDepth_ - depth);
         }
     }
 
@@ -107,7 +112,12 @@ class ACEMutate {
             return randomSimpleCompressor(inputType);
         }
         ACEReservoirSampler<const ACENode> sampler(rng_);
-        for (const auto& node : getNodesComptabileWith(inputType)) {
+        // Bind to a named local: getNodesComptabileWith returns a vector by
+        // value, and the sampler stores pointers into it that are dereferenced
+        // after the loop.
+        const auto compatibleNodes =
+                getNodesComptabileWith(inputType, formatVersion_);
+        for (const auto& node : compatibleNodes) {
             if (node.outputTypes.size() == 1
                 && compressor.acceptsInputType(node.outputTypes[0])) {
                 sampler.update(node);
@@ -122,6 +132,7 @@ class ACEMutate {
 
     std::mt19937_64& rng_;
     Type inputType_;
+    uint32_t formatVersion_;
     size_t maxDepth_;
 };
 

--- a/tools/training/ace/automated_compressor_explorer.cpp
+++ b/tools/training/ace/automated_compressor_explorer.cpp
@@ -21,7 +21,8 @@ std::vector<ACECompressor> AutomatedCompressorExplorer::initialPopulation()
 
     // Use populationSize() random compressors
     for (size_t i = 0; i < populationSize(); ++i) {
-        population.push_back(buildRandomCompressor(rng(), inputType()));
+        population.push_back(
+                buildRandomCompressor(rng(), inputType(), formatVersion_));
     }
     return population;
 }
@@ -43,9 +44,10 @@ void adjustResults(const ACECompressor& gene, std::vector<float>& results)
 
 /* static */ std::vector<float> AutomatedCompressorExplorer::computeFitness(
         const ACECompressor& gene,
-        poly::span<const Input> inputs)
+        poly::span<const Input> inputs,
+        uint32_t formatVersion)
 {
-    auto result = gene.benchmark(inputs);
+    auto result = gene.benchmark(inputs, formatVersion);
     std::vector<float> fitness(3, std::numeric_limits<float>::infinity());
     if (result.has_value()) {
         fitness[0] = result->compressedSize;
@@ -59,7 +61,7 @@ void adjustResults(const ACECompressor& gene, std::vector<float>& results)
 std::vector<float> AutomatedCompressorExplorer::computeFitness(
         const ACECompressor& gene)
 {
-    return computeFitness(gene, inputs_);
+    return computeFitness(gene, inputs_, formatVersion_);
 }
 
 std::vector<std::vector<float>> AutomatedCompressorExplorer::computeFitness(
@@ -78,9 +80,10 @@ std::vector<std::vector<float>> AutomatedCompressorExplorer::computeFitness(
                 continue;
             }
         }
-        futures.emplace_back(threadPool_.run([&inputs = inputs_, &gene] {
-            return computeFitness(gene, inputs);
-        }));
+        futures.emplace_back(threadPool_.run(
+                [&inputs = inputs_, &gene, formatVersion = formatVersion_] {
+                    return computeFitness(gene, inputs, formatVersion);
+                }));
     }
 
     std::vector<std::vector<float>> results;

--- a/tools/training/ace/automated_compressor_explorer.h
+++ b/tools/training/ace/automated_compressor_explorer.h
@@ -54,6 +54,9 @@ class AutomatedCompressorExplorer : public GeneticAlgorithm<ACECompressor> {
 
     struct Parameters : public Base::Parameters {
         size_t numThreads{ std::thread::hardware_concurrency() / 2 };
+        /// Target format version. Must be set explicitly; a value of 0 is
+        /// rejected at construction.
+        uint32_t formatVersion{ 0 };
     };
 
     /**
@@ -78,10 +81,14 @@ class AutomatedCompressorExplorer : public GeneticAlgorithm<ACECompressor> {
             const Parameters& params)
             : Base(params),
               inputs_(std::move(inputs)),
+              formatVersion_(params.formatVersion),
               threadPool_(params.numThreads),
-              crossover_(rng(), inputType()),
-              mutate_(rng(), inputType())
+              crossover_(rng(), inputType(), formatVersion_),
+              mutate_(rng(), inputType(), formatVersion_)
     {
+        if (formatVersion_ == 0) {
+            throw Exception("Format version must be set in the parameters");
+        }
         for (auto const& input : inputs_) {
             if (input.type() != inputType()) {
                 throw Exception("All inputs must have the same type");
@@ -89,10 +96,18 @@ class AutomatedCompressorExplorer : public GeneticAlgorithm<ACECompressor> {
         }
     }
 
-    explicit AutomatedCompressorExplorer(
+    AutomatedCompressorExplorer(
             poly::span<const Input> inputs,
             poly::string_view snapshot)
-            : AutomatedCompressorExplorer(inputs, Parameters{})
+            : AutomatedCompressorExplorer(inputs, snapshot, Parameters{})
+    {
+    }
+
+    AutomatedCompressorExplorer(
+            poly::span<const Input> inputs,
+            poly::string_view snapshot,
+            const Parameters& params)
+            : AutomatedCompressorExplorer(inputs, params)
     {
         loadPopulation(snapshot);
     }
@@ -108,6 +123,11 @@ class AutomatedCompressorExplorer : public GeneticAlgorithm<ACECompressor> {
     poly::span<const Input> inputs() const
     {
         return inputs_;
+    }
+
+    uint32_t formatVersion() const
+    {
+        return formatVersion_;
     }
 
     /**
@@ -152,9 +172,11 @@ class AutomatedCompressorExplorer : public GeneticAlgorithm<ACECompressor> {
    private:
     static std::vector<float> computeFitness(
             const ACECompressor& compressor,
-            poly::span<const Input> inputs);
+            poly::span<const Input> inputs,
+            uint32_t formatVersion);
 
     poly::span<const Input> inputs_;
+    uint32_t formatVersion_;
     ThreadPool threadPool_;
     ACECrossover crossover_;
     ACEMutate mutate_;

--- a/tools/training/clustering/clustering_graph_trainer.cpp
+++ b/tools/training/clustering/clustering_graph_trainer.cpp
@@ -15,6 +15,7 @@
 #include "tools/training/clustering/train_api.h"
 #include "tools/training/graph_mutation/graph_mutation_utils.h"
 #include "tools/training/sample_collection/training_sample_collector.h"
+#include "tools/training/train_exceptions.h"
 #include "tools/training/utils/serialized_compressor_internal.h"
 #include "tools/training/utils/utils.h"
 
@@ -26,6 +27,10 @@ namespace openzl::training {
 const std::string CLUSTERING_GRAPH_NAME = "zl.cluster";
 
 namespace {
+
+// Minimum format version at which all concat codecs required by clustering are
+// available (CONCAT_SERIAL=16, _NUMERIC/_STRUCT=17, _STRING=18).
+constexpr int kMinClusteringFormatVersion = 18;
 
 /**
  * Add a new parameterized version of the clustering graph to the compressor
@@ -69,15 +74,33 @@ ZL_GraphID clusterSuccessors(
         const TrainParams& trainParams,
         GraphID clusteringGraphUniqueIDUntrained)
 {
+    const auto formatVersion = compressor.getParameter(CParam::FormatVersion);
+    // Clustering relies on concat codecs; if any required clustering codec is
+    // missing at this format version, training is unsupported.
+    if (formatVersion < kMinClusteringFormatVersion) {
+        throw FormatVersionUnsupportedError(
+                "clustering requires concat codecs unavailable at format version "
+                + std::to_string(formatVersion));
+    }
+
     auto cctx = refCCtxForTraining(compressor);
 
     const std::string clusteringGraphUniqueNameUntrained =
             ZL_Compressor_Graph_getName(
                     compressor.get(), clusteringGraphUniqueIDUntrained);
 
-    // Get successors for training
-    const auto successorsVec =
-            getCustomGraphs(compressor, clusteringGraphUniqueIDUntrained);
+    // Get successors for training, dropping any that cannot compress at the
+    // target format version.
+    const auto successorsVec = filterGraphsByFormatVersion(
+            compressor,
+            getCustomGraphs(compressor, clusteringGraphUniqueIDUntrained),
+            inputs);
+
+    if (successorsVec.size() == 0) {
+        throw FormatVersionUnsupportedError(
+                "No compatible successors chosen in clustering graph at format version "
+                + std::to_string(formatVersion));
+    }
 
     // Get clustering codecs for training
     std::vector<ZL_NodeID> clusteringCodecs =

--- a/tools/training/tests/BUCK
+++ b/tools/training/tests/BUCK
@@ -21,6 +21,7 @@ cpp_unittest(
         "test_sample_limiter.cpp",
         "test_thread_pool.cpp",
         "test_train.cpp",
+        "test_utils.cpp",
     ],
     headers = relative_headers([
         "benchmark_files/ppmf_unit_segment.h",

--- a/tools/training/tests/test_ace.cpp
+++ b/tools/training/tests/test_ace.cpp
@@ -1,5 +1,6 @@
 // Copyright (c) Meta Platforms, Inc. and affiliates.
 
+#include <algorithm>
 #include <numeric>
 #include <random>
 #include <string>
@@ -53,6 +54,7 @@ class ACETest : public testing::Test {
         params.numThreads     = 4;
         params.populationSize = 50;
         params.maxGenerations = 100;
+        params.formatVersion  = ZL_MAX_FORMAT_VERSION;
     }
 
     ACECompressor runOnInput(poly::span<const Input> input)
@@ -74,6 +76,44 @@ class ACETest : public testing::Test {
     AutomatedCompressorExplorer::Parameters params;
     std::unique_ptr<AutomatedCompressorExplorer> ace;
 };
+
+TEST_F(ACETest, FormatVersionMustBeSet)
+{
+    auto data = tripleDeltaData();
+    std::vector<Input> inputs;
+    inputs.push_back(
+            Input::refSerial(data.data(), data.size() * sizeof(data[0])));
+
+    const AutomatedCompressorExplorer::Parameters defaultParams;
+    EXPECT_EQ(defaultParams.formatVersion, 0);
+
+    EXPECT_THROW(
+            AutomatedCompressorExplorer defaultAce(inputs, defaultParams),
+            Exception);
+}
+
+TEST_F(ACETest, CompressesAtAllFormatVersions)
+{
+    // A compressor trained for a specific, non-default format version must
+    // actually compress at that version.
+
+    for (uint32_t version = ZL_MIN_FORMAT_VERSION;
+         version < ZL_MAX_FORMAT_VERSION;
+         version++) {
+        params.formatVersion = version;
+
+        auto data = tripleDeltaData();
+        auto input =
+                Input::refSerial(data.data(), data.size() * sizeof(data[0]));
+        auto solution = runOnInput(input);
+
+        EXPECT_EQ(ace->formatVersion(), version);
+
+        auto result = solution.benchmark(ace->inputs(), version);
+        ASSERT_TRUE(result.has_value());
+        ASSERT_GT(result->compressedSize, 0u);
+    }
+}
 
 TEST_F(ACETest, ACEReservoirSampler)
 {
@@ -108,15 +148,17 @@ TEST_F(ACETest, SerializeDeserialize)
     std::mt19937_64 rng(0xdeadbeef);
     for (auto type :
          { Type::Serial, Type::Struct, Type::Numeric, Type::String }) {
-        ACEMutate mutator(rng, type);
+        ACEMutate mutator(rng, type, ZL_MAX_FORMAT_VERSION);
         for (const auto& compressor : getPrebuiltCompressors(type)) {
             testRoundTrip(compressor);
             auto mutated = mutator(compressor);
             testRoundTrip(mutated);
         }
         testRoundTrip(buildRandomGraphCompressor(rng, type));
-        testRoundTrip(buildRandomNodeCompressor(rng, type));
-        testRoundTrip(buildRandomCompressor(rng, type));
+        testRoundTrip(buildRandomNodeCompressor(
+                rng, type, ZL_MAX_FORMAT_VERSION, kDefaultMaxDepth));
+        testRoundTrip(buildRandomCompressor(
+                rng, type, ZL_MAX_FORMAT_VERSION, kDefaultMaxDepth));
     }
 }
 
@@ -125,7 +167,7 @@ TEST_F(ACETest, TripleDeltaNumeric)
     auto data     = tripleDeltaData();
     auto input    = Input::refNumeric(poly::span<const uint64_t>(data));
     auto solution = runOnInput(input);
-    auto result   = solution.benchmark(ace->inputs());
+    auto result   = solution.benchmark(ace->inputs(), ZL_MAX_FORMAT_VERSION);
     ASSERT_TRUE(result.has_value());
     ASSERT_LE(result->compressedSize, 90);
 }
@@ -135,7 +177,7 @@ TEST_F(ACETest, TripleDeltaSerial)
     auto data  = tripleDeltaData();
     auto input = Input::refSerial(data.data(), data.size() * sizeof(data[0]));
     auto solution = runOnInput(input);
-    auto result   = solution.benchmark(ace->inputs());
+    auto result   = solution.benchmark(ace->inputs(), ZL_MAX_FORMAT_VERSION);
     ASSERT_TRUE(result.has_value());
     ASSERT_LE(result->compressedSize, 90);
 }
@@ -145,7 +187,7 @@ TEST_F(ACETest, TripleDeltaStruct)
     auto data     = tripleDeltaData();
     auto input    = Input::refStruct(poly::span<const uint64_t>(data));
     auto solution = runOnInput(input);
-    auto result   = solution.benchmark(ace->inputs());
+    auto result   = solution.benchmark(ace->inputs(), ZL_MAX_FORMAT_VERSION);
     ASSERT_TRUE(result.has_value());
     ASSERT_LE(result->compressedSize, 90);
 }
@@ -155,7 +197,7 @@ TEST_F(ACETest, TripleDeltaString)
     auto [content, lengths] = tripleDeltaStringData();
     auto input              = Input::refString(content, lengths);
     auto solution           = runOnInput(input);
-    auto result             = solution.benchmark(ace->inputs());
+    auto result = solution.benchmark(ace->inputs(), ZL_MAX_FORMAT_VERSION);
     ASSERT_TRUE(result.has_value());
     ASSERT_LE(result->compressedSize, 110);
 }
@@ -165,7 +207,7 @@ TEST_F(ACETest, savePopulation)
     auto data  = tripleDeltaData();
     auto input = Input::refSerial(data.data(), data.size() * sizeof(data[0]));
     auto solution = runOnInput(input);
-    auto result   = solution.benchmark(ace->inputs());
+    auto result   = solution.benchmark(ace->inputs(), ZL_MAX_FORMAT_VERSION);
     ASSERT_TRUE(result.has_value());
     ASSERT_LE(result->compressedSize, 90);
     auto snapshot = ace->savePopulation();
@@ -178,7 +220,8 @@ TEST_F(ACETest, savePopulation)
     // Initial population doesn't have a good solution
     {
         auto solution2 = ace2.solution()[0].first;
-        auto result2   = solution2.benchmark(ace->inputs());
+        auto result2 =
+                solution2.benchmark(ace->inputs(), ZL_MAX_FORMAT_VERSION);
         ASSERT_TRUE(result2.has_value());
         ASSERT_GT(result2->compressedSize, 90);
         ASSERT_NE(solution, solution2);
@@ -188,7 +231,8 @@ TEST_F(ACETest, savePopulation)
     ace2.loadPopulation(snapshot);
     {
         auto solution2 = ace2.solution()[0].first;
-        auto result2   = solution2.benchmark(ace->inputs());
+        auto result2 =
+                solution2.benchmark(ace->inputs(), ZL_MAX_FORMAT_VERSION);
         ASSERT_TRUE(result2.has_value());
         ASSERT_LE(result2->compressedSize, 90);
     }

--- a/tools/training/tests/test_clustering.cpp
+++ b/tools/training/tests/test_clustering.cpp
@@ -5,15 +5,18 @@
 #include <thread>
 
 #include "openzl/codecs/zl_clustering.h"
+#include "openzl/codecs/zl_lz.h"
 #include "openzl/common/a1cbor_helpers.h"
 #include "openzl/common/allocation.h"
 #include "openzl/cpp/Input.hpp"
 #include "openzl/zl_reflection.h"
 #include "src/openzl/compress/graphs/generic_clustering_graph.h"
 #include "tests/datagen/DataGen.h"
+#include "tools/training/clustering/clustering_graph_trainer.h"
 #include "tools/training/clustering/train_api.h"
 #include "tools/training/clustering/utils.h"
 #include "tools/training/train.h"
+#include "tools/training/train_exceptions.h"
 #include "tools/training/utils/utils.h"
 
 namespace openzl::tests {
@@ -89,6 +92,7 @@ class TestTraining : public testing::Test {
     {
         // Register the base clustering graph as the starting graph
         compressor_.selectStartingGraph(ZL_GRAPH_CLUSTERING);
+        compressor_.setParameter(CParam::FormatVersion, ZL_MAX_FORMAT_VERSION);
 
         successors_.push_back(ZL_GRAPH_STORE);
         successors_.push_back(ZL_GRAPH_FIELD_LZ);
@@ -386,6 +390,38 @@ TEST_F(TestTraining, TestTrainingDifferentTypeSameTag)
             compressor_.get(), trainedGraphId);
     auto r = deserializeToClusteringConfig(lparam);
     EXPECT_TRUE(!ZL_RES_isError(r));
+}
+
+TEST(ClusteringTrainerFormatVersionTest, ThrowsWhenNoSuccessorSupportsVersion)
+{
+    // ZL_GRAPH_LZ is unavailable before format version 24, so targeting an
+    // earlier version (still above the clustering minimum) filters out every
+    // successor and leaves the clustering trainer with nothing to train.
+    constexpr uint32_t kLzFormatVersion       = 24;
+    constexpr uint32_t kFormatVersionBeforeLz = kLzFormatVersion - 1;
+
+    Compressor compressor;
+    compressor.setParameter(CParam::FormatVersion, kFormatVersionBeforeLz);
+    std::vector<ZL_GraphID> successors = { ZL_GRAPH_LZ };
+    ZL_ClusteringConfig config = { .nbClusters = 0, .nbTypeDefaults = 0 };
+    auto clusteringGraph       = ZL_Clustering_registerGraph(
+            compressor.get(), &config, successors.data(), successors.size());
+    compressor.selectStartingGraph(clusteringGraph);
+
+    const training::TrainParams trainParams = {
+        .clusteringTrainer = training::ClusteringTrainer::Greedy,
+    };
+
+    std::vector<uint8_t> data(1024);
+    for (size_t i = 0; i < data.size(); ++i) {
+        data[i] = static_cast<uint8_t>(i);
+    }
+    training::MultiInput input;
+    input.add(Input::refSerial(data.data(), data.size()));
+    const std::vector<training::MultiInput> inputs = { std::move(input) };
+    EXPECT_THROW(
+            training::trainClusteringGraph(inputs, compressor, trainParams),
+            training::FormatVersionUnsupportedError);
 }
 
 } // namespace

--- a/tools/training/tests/test_clustering_benchmarks.cpp
+++ b/tools/training/tests/test_clustering_benchmarks.cpp
@@ -26,6 +26,7 @@ class TestClusteringBenchmarks : public testing::Test {
     {
         // Register the graph to train in the compressor
         trainingGraphFn(compressor.get());
+        compressor.setParameter(CParam::FormatVersion, ZL_MAX_FORMAT_VERSION);
         // Train the compressor and serialize it
         auto serialized = training::train(inputs_, compressor, params_);
         // Compress the data using the trained compressor

--- a/tools/training/tests/test_dict_training.cpp
+++ b/tools/training/tests/test_dict_training.cpp
@@ -107,6 +107,7 @@ TEST(BaseDictTrainer, DuplicateDictsAreDeduped)
     // Generate a compressor that splits an input into 3, and sends each to a
     // trainable zstd node
     Compressor compressor;
+    compressor.setParameter(CParam::FormatVersion, ZL_MAX_FORMAT_VERSION);
     {
         constexpr size_t kNumSegments                = 3;
         constexpr size_t kSegmentSizes[kNumSegments] = { 1024, 1024, 0 };

--- a/tools/training/tests/test_train.cpp
+++ b/tools/training/tests/test_train.cpp
@@ -15,6 +15,7 @@ TEST(TrainTest, ThrowsTypedErrorWithoutTrainableGraph)
 {
     const std::vector<training::MultiInput> inputs;
     Compressor compressor;
+    compressor.setParameter(CParam::FormatVersion, ZL_MAX_FORMAT_VERSION);
     compressor.selectStartingGraph(ZL_GRAPH_STORE);
     const training::TrainParams trainParams = {
         .compressorGenFunc =
@@ -28,6 +29,26 @@ TEST(TrainTest, ThrowsTypedErrorWithoutTrainableGraph)
     EXPECT_THROW(
             training::train(inputs, compressor, trainParams),
             training::NoTrainableGraphError);
+}
+
+TEST(TrainTest, ThrowsWhenCompressorFormatVersionIsNotSet)
+{
+    const std::vector<training::MultiInput> inputs;
+    Compressor compressor;
+    compressor.selectStartingGraph(ZL_GRAPH_STORE);
+    const training::TrainParams trainParams = {
+        .compressorGenFunc =
+                [](poly::string_view, poly::string_view) {
+                    return std::make_unique<Compressor>();
+                },
+    };
+
+    try {
+        training::train(inputs, compressor, trainParams);
+        FAIL() << "Expected unset compressor format version to throw";
+    } catch (const training::FormatVersionUnsupportedError& e) {
+        EXPECT_EQ(e.msg(), "Compressor format version is not set.");
+    }
 }
 
 } // namespace

--- a/tools/training/tests/test_utils.cpp
+++ b/tools/training/tests/test_utils.cpp
@@ -1,0 +1,144 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#include <gtest/gtest.h>
+
+#include <array>
+#include <vector>
+
+#include "openzl/codecs/zl_concat.h"
+#include "openzl/codecs/zl_conversion.h"
+#include "openzl/codecs/zl_lz.h"
+#include "openzl/codecs/zl_store.h"
+#include "openzl/codecs/zl_zstd.h"
+#include "openzl/cpp/Compressor.hpp"
+#include "openzl/zl_version.h"
+#include "tools/training/utils/utils.h"
+
+namespace openzl::training {
+namespace {
+
+std::vector<ZL_IDType> graphIds(const std::vector<GraphID>& graphs)
+{
+    std::vector<ZL_IDType> ids;
+    ids.reserve(graphs.size());
+    for (const auto graph : graphs) {
+        ids.push_back(graph.gid);
+    }
+    return ids;
+}
+
+std::vector<MultiInput> serialInputs()
+{
+    static const std::array<uint8_t, 1024> data = [] {
+        std::array<uint8_t, 1024> result{};
+        for (size_t i = 0; i < result.size(); ++i) {
+            result[i] = static_cast<uint8_t>(i);
+        }
+        return result;
+    }();
+    MultiInput input;
+    input.add(Input::refSerial(data.data(), data.size()));
+    return { std::move(input) };
+}
+
+TEST(CompressorIsFormatCompatibleTest, UsesCompressorFormatVersion)
+{
+    Compressor compressor;
+    compressor.selectStartingGraph(ZL_GRAPH_LZ);
+    compressor.setParameter(CParam::FormatVersion, 23);
+    EXPECT_FALSE(compressorIsFormatCompatible(compressor, serialInputs()));
+
+    compressor.setParameter(CParam::FormatVersion, 24);
+    EXPECT_TRUE(compressorIsFormatCompatible(compressor, serialInputs()));
+}
+
+TEST(FilterGraphsByFormatVersionTest, ThrowsWhenFormatVersionBelowMinimum)
+{
+    Compressor compressor;
+    const auto customGraph = compressor.buildStaticGraph(
+            ZL_NODE_CONVERT_STRUCT_TO_SERIAL, { ZL_GRAPH_STORE });
+    compressor.selectStartingGraph(ZL_GRAPH_STORE);
+    const std::vector<GraphID> graphs = { ZL_GRAPH_STORE,
+                                          ZL_GRAPH_ZSTD,
+                                          customGraph };
+
+    // Leaving the format version unset reads back as 0, which is below
+    // ZL_MIN_FORMAT_VERSION. setParameter rejects any explicit value below the
+    // minimum, so an unset compressor is the way to exercise the guard.
+    EXPECT_THROW(
+            filterGraphsByFormatVersion(compressor, graphs, serialInputs()),
+            Exception);
+}
+
+TEST(FilterGraphsByFormatVersionTest, FiltersLZByVersion)
+{
+    Compressor compressor;
+    compressor.setParameter(CParam::FormatVersion, 23);
+    const auto beforeVersion24 = filterGraphsByFormatVersion(
+            compressor, { ZL_GRAPH_LZ }, serialInputs());
+    EXPECT_TRUE(beforeVersion24.empty());
+
+    compressor.setParameter(CParam::FormatVersion, 24);
+    const auto atVersion24 = filterGraphsByFormatVersion(
+            compressor, { ZL_GRAPH_LZ }, serialInputs());
+    EXPECT_EQ(graphIds(atVersion24), graphIds({ ZL_GRAPH_LZ }));
+    EXPECT_EQ(compressor.getParameter(CParam::FormatVersion), 24);
+}
+
+TEST(FilterGraphsByFormatVersionTest, RestoresCompressorStateAfterException)
+{
+    Compressor compressor;
+    compressor.selectStartingGraph(ZL_GRAPH_STORE);
+    compressor.setParameter(CParam::FormatVersion, ZL_MAX_FORMAT_VERSION);
+
+    EXPECT_THROW(
+            filterGraphsByFormatVersion(
+                    compressor, { ZL_GRAPH_ILLEGAL }, serialInputs()),
+            Exception);
+
+    EXPECT_EQ(
+            compressor.getParameter(CParam::FormatVersion),
+            ZL_MAX_FORMAT_VERSION);
+    EXPECT_EQ(compressor.getStartingGraph(), ZL_GRAPH_STORE);
+}
+
+TEST(FilterGraphsByFormatVersionTest, FiltersCustomGraphByConversionVersion)
+{
+    Compressor compressor;
+    const auto graph = compressor.buildStaticGraph(
+            ZL_NODE_CONVERT_STRUCT_TO_NUM_BE, { ZL_GRAPH_STORE });
+    const std::array<uint32_t, 64> data{};
+    MultiInput input;
+    input.add(Input::refStruct(data.data(), data.size()));
+    const std::vector<MultiInput> inputs = { std::move(input) };
+
+    compressor.setParameter(CParam::FormatVersion, 20);
+    const auto beforeVersion21 =
+            filterGraphsByFormatVersion(compressor, { graph }, inputs);
+    EXPECT_TRUE(beforeVersion21.empty());
+
+    compressor.setParameter(CParam::FormatVersion, 21);
+    const auto atVersion21 =
+            filterGraphsByFormatVersion(compressor, { graph }, inputs);
+    EXPECT_EQ(graphIds(atVersion21), graphIds({ graph }));
+}
+
+TEST(FilterGraphsByFormatVersionTest, SupportsMultiInputGraphs)
+{
+    Compressor compressor;
+    compressor.setParameter(CParam::FormatVersion, ZL_MAX_FORMAT_VERSION);
+    const auto graph = compressor.buildStaticGraph(
+            ZL_NODE_CONCAT_SERIAL, { ZL_GRAPH_STORE, ZL_GRAPH_STORE });
+    MultiInput input;
+    input.add(Input::refSerial("first", 5));
+    input.add(Input::refSerial("second", 6));
+    const std::vector<MultiInput> inputs = { std::move(input) };
+
+    const auto supported =
+            filterGraphsByFormatVersion(compressor, { graph }, inputs);
+
+    EXPECT_EQ(graphIds(supported), graphIds({ graph }));
+}
+
+} // namespace
+} // namespace openzl::training

--- a/tools/training/train.cpp
+++ b/tools/training/train.cpp
@@ -28,6 +28,22 @@ std::vector<TrainedCandidate> train(
         throw Exception("Compressor generator function is not set.");
     }
 
+    const auto formatVersion = compressor.getParameter(CParam::FormatVersion);
+    if (formatVersion == 0) {
+        throw FormatVersionUnsupportedError(
+                "Compressor format version is not set.");
+    }
+
+    // Try compressing with the base graph to train. This is not exhaustive
+    // because function graphs may select different nodes for other inputs.
+    if (!compressorIsFormatCompatible(compressor, inputs)) {
+        throw FormatVersionUnsupportedError(
+                "Base graph failed to compress at format version "
+                + std::to_string(formatVersion)
+                + "; the format version is unsupported for the graph "
+                  "getting trained.");
+    }
+
     if (graph_mutation::hasTargetGraph(compressor, CLUSTERING_GRAPH_NAME)) {
         serializedTrainedCompressors.clear();
         serializedTrainedCompressors.push_back(

--- a/tools/training/train.h
+++ b/tools/training/train.h
@@ -3,18 +3,12 @@
 #pragma once
 
 #include "openzl/cpp/Compressor.hpp"
-#include "openzl/cpp/Exception.hpp"
+#include "tools/training/train_exceptions.h"
 #include "tools/training/train_params.h"
 #include "tools/training/trained_candidate.h"
 #include "tools/training/utils/utils.h"
 
 namespace openzl::training {
-
-/** Thrown when a compressor has no graph that can be trained. */
-class NoTrainableGraphError : public Exception {
-   public:
-    using Exception::Exception;
-};
 
 /**
  * This function trains compressor graphs (clustering and/or ACE graphs).

--- a/tools/training/train_exceptions.h
+++ b/tools/training/train_exceptions.h
@@ -1,0 +1,25 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#pragma once
+
+#include "openzl/cpp/Exception.hpp"
+
+namespace openzl::training {
+
+/** Thrown when a compressor has no graph that can be trained. */
+class NoTrainableGraphError : public Exception {
+   public:
+    using Exception::Exception;
+};
+
+/**
+ * Thrown by a trainer when it cannot produce a graph that supports the target
+ * format version (e.g. all of its required codecs are below the target
+ * version). The orchestrator catches this to fall the trainer back to zstd.
+ */
+class FormatVersionUnsupportedError : public Exception {
+   public:
+    using Exception::Exception;
+};
+
+} // namespace openzl::training

--- a/tools/training/train_params.h
+++ b/tools/training/train_params.h
@@ -4,6 +4,7 @@
 #include <cstdint>
 #include <functional>
 #include "openzl/cpp/Compressor.hpp"
+#include "openzl/cpp/Exception.hpp"
 #include "openzl/cpp/poly/Optional.hpp"
 
 namespace openzl::training {

--- a/tools/training/utils/BUCK
+++ b/tools/training/utils/BUCK
@@ -17,6 +17,7 @@ zs_cxxlibrary(
         "utils.h",
     ],
     exported_deps = [
+        "..:train_common",
         "../..:io",
         "../..:logger",
         "../../..:common",

--- a/tools/training/utils/utils.cpp
+++ b/tools/training/utils/utils.cpp
@@ -3,17 +3,30 @@
 #include "tools/training/utils/utils.h"
 #include "openzl/cpp/CCtx.hpp"
 #include "openzl/cpp/Compressor.hpp"
-#include "tools/io/InputSetStatic.h"
+#include "openzl/cpp/Exception.hpp"
+#include "openzl/zl_reflection.h"
 
 namespace openzl::training {
 
 CCtx refCCtxForTraining(const Compressor& compressor)
 {
     openzl::CCtx cctx;
-    cctx.setParameter(openzl::CParam::FormatVersion, ZL_MAX_FORMAT_VERSION);
-    cctx.setParameter(openzl::CParam::StickyParameters, ZL_MAX_FORMAT_VERSION);
+    cctx.setParameter(openzl::CParam::StickyParameters, 1);
     cctx.refCompressor(compressor);
     return cctx;
+}
+
+size_t MultiInput::compressBound() const
+{
+    size_t totalSrcSize = 0;
+    for (const auto& input : *inputs_) {
+        totalSrcSize += input.contentSize();
+        if (input.type() == Type::String) {
+            totalSrcSize += input.numElts() * sizeof(*input.stringLens());
+        }
+    }
+    totalSrcSize += inputs_->size() * 256;
+    return 2 * ZL_compressBound(totalSrcSize) + 1024;
 }
 
 std::vector<MultiInput> inputSetToMultiInputs(tools::io::InputSet& inputs)
@@ -26,6 +39,56 @@ std::vector<MultiInput> inputSetToMultiInputs(tools::io::InputSet& inputs)
         multiInputs.push_back(std::move(mi));
     }
     return multiInputs;
+}
+
+bool compressorIsFormatCompatible(
+        const Compressor& compressor,
+        const std::vector<MultiInput>& inputs)
+{
+    CCtx cctx;
+    cctx.refCompressor(compressor);
+    for (const auto& input : inputs) {
+        const size_t outputCapacity = input.compressBound();
+        std::string output(outputCapacity, '\0');
+        try {
+            cctx.compress(output, *input);
+        } catch (const Exception& e) {
+            // Catch only format version unsupported errors. Otherwise it is
+            // failing compression on the input but is actually supported format
+            // version-wise.
+            if (e.code() == ZL_ErrorCode_formatVersion_unsupported
+                || e.code() == ZL_ErrorCode_node_versionMismatch) {
+                return false;
+            }
+        }
+    }
+    return true;
+}
+
+std::vector<GraphID> filterGraphsByFormatVersion(
+        Compressor& compressor,
+        const std::vector<GraphID>& graphs,
+        const std::vector<MultiInput>& inputs)
+{
+    const auto formatVersion = compressor.getParameter(CParam::FormatVersion);
+    if (formatVersion < ZL_MIN_FORMAT_VERSION) {
+        throw Exception("Format version is below ZL_MIN_FORMAT_VERSION");
+    }
+    GraphID originalStartingGraph = ZL_GRAPH_ILLEGAL;
+    const bool hadStartingGraph   = ZL_Compressor_getStartingGraphID(
+            compressor.get(), &originalStartingGraph);
+    std::vector<GraphID> supported;
+    supported.reserve(graphs.size());
+    for (const auto graph : graphs) {
+        compressor.selectStartingGraph(graph);
+        if (compressorIsFormatCompatible(compressor, inputs)) {
+            supported.push_back(graph);
+        }
+    }
+    if (hadStartingGraph) {
+        compressor.selectStartingGraph(originalStartingGraph);
+    }
+    return supported;
 }
 
 } // namespace openzl::training

--- a/tools/training/utils/utils.h
+++ b/tools/training/utils/utils.h
@@ -11,7 +11,7 @@ namespace openzl::training {
 /**
  * @brief Create a CCtx for training the compressor. The cctx is configured
  * so that if training is called multiple times, the parameters will not be
- * reset.
+ * reset. Targets ZL_MAX_FORMAT_VERSION.
  */
 CCtx refCCtxForTraining(const Compressor& compressor);
 
@@ -42,6 +42,12 @@ class MultiInput {
         return inputs_.get();
     }
 
+    /**
+     * @brief Returns maximum compressed size after compression using these
+     * inputs.
+     */
+    size_t compressBound() const;
+
     // Adds input while not owning the buffer the input references
     void add(Input&& input)
     {
@@ -66,5 +72,49 @@ class MultiInput {
  * each input is serial in @p inputs.
  */
 std::vector<MultiInput> inputSetToMultiInputs(tools::io::InputSet& inputs);
+
+/**
+ * @brief Returns whether @p compressor is compatible with its configured
+ * format version for every sample in @p inputs.
+ *
+ * It is the caller's responsibility to configure the compressor's format
+ * version, select its starting graph, and provide inputs that exercise every
+ * graph path whose compatibility must be tested. Compression errors unrelated
+ * to format compatibility are ignored.
+ */
+bool compressorIsFormatCompatible(
+        const Compressor& compressor,
+        const std::vector<MultiInput>& inputs);
+
+/**
+ * @brief Filter @p graphs down to those able to compress @p inputs at the
+ * target @p formatVersion.
+ *
+ * Each candidate graph is used to compress every sample in @p inputs. A graph
+ * is filtered out if any compression reports a format-version incompatibility.
+ * Supported graphs are returned in their original order.
+ *
+ * It is the caller's responsibility to provide inputs capable of exercising
+ * every graph path whose format-version compatibility must be tested. A graph
+ * that is incompatible with @p formatVersion may be retained if @p inputs do
+ * not exercise the incompatible path.
+ *
+ * @throws Exception if @p formatVersion is less than ZL_MIN_FORMAT_VERSION.
+ *
+ * Standard graphs follow the guidelines which are required for this function to
+ * work. Custom graphs are also required to follow these guidelines. These are
+ * that graphs must either:
+ * - Always select the same nodes and may not work on older format versions.
+ * - Dynamically select which nodes to run, in which case they should be
+ * format-version aware, meaning they should never execute a codec which
+ * requires a format version above the library's format version.
+ *
+ * If these guidelines are not followed, the function may not correctly filter
+ * out the graph.
+ */
+std::vector<GraphID> filterGraphsByFormatVersion(
+        Compressor& compressor,
+        const std::vector<GraphID>& graphs,
+        const std::vector<MultiInput>& inputs);
 
 } // namespace openzl::training


### PR DESCRIPTION
Summary:

Adds format versioning to ACE training by filtering the list of graphs per format version.

- Since it is useful to store both the format version and the per format version/ input type list of compatible graphs, refactor the stateless API to a ACECompressorBuilder class. This contains a cache and versions.
- Additionally fix a minor bug with graph replacement

Reviewed By: terrelln

Differential Revision: D113974924


