### PR TITLE
Fix ZL_Compressor_overrideBaseGraph (#948)

### DIFF
--- a/src/openzl/compress/graphmgr.c
+++ b/src/openzl/compress/graphmgr.c
@@ -750,16 +750,37 @@ GM_overrideBaseGraph(GraphsMgr* gm, ZL_GraphID graph, ZL_GraphID newBaseGraph)
     // Validate that newBaseGraph does not depend on graph
     ZL_ERR_IF_ERR(GM_checkDoesNotDependOn(
             gm, /* needle */ graph, /* haystack */ newBaseGraph));
-    // Set the new base graph and check for infinite loops
-    VECTOR_AT(gm->gdv, lid).baseGraphID = newBaseGraph;
 
-    // Clear the custom graphs, custom nodes, and local params
-    VECTOR_AT(gm->gdv, lid).migd.customGraphs   = NULL;
-    VECTOR_AT(gm->gdv, lid).migd.nbCustomGraphs = 0;
-    VECTOR_AT(gm->gdv, lid).migd.customNodes    = NULL;
-    VECTOR_AT(gm->gdv, lid).migd.nbCustomNodes  = 0;
-    ZL_LocalParams* localParams = &VECTOR_AT(gm->gdv, lid).migd.localParams;
-    memset(localParams, 0, sizeof(*localParams));
+    // A parameterized graph is registered with its own copy of the description
+    // it was created from, and that copy is what runs at compression time.
+    // Adopt the new base's description, otherwise the override would only be
+    // visible to serialization, which rebuilds the graph from baseGraphID.
+    const ZL_FunctionGraphDesc* const newBaseDesc =
+            GM_getMultiInputGraphDesc(gm, newBaseGraph);
+    ZL_ERR_IF_NULL(
+            newBaseDesc,
+            graph_invalid,
+            "New base graph is not a function graph");
+
+    // The graph keeps only its own name. Everything else now comes from the
+    // new base, including its custom graphs, custom nodes and local params,
+    // which it may need to run: a static graph, for example, is driven by its
+    // custom nodes. This matches what deserialization rebuilds, since
+    // GM_registerParameterizedGraph keeps the base's when no override is given.
+    // The new base is already registered, so everything its description points
+    // at is owned by this manager's arena or is static, and outlives it. There
+    // is nothing to transfer.
+    ZL_FunctionGraphDesc migd = *newBaseDesc;
+    migd.name                 = VECTOR_AT(gm->gdv, lid).migd.name;
+    const void* mparamObj     = NULL;
+    ZL_ERR_IF_ERR(GM_materializeMParam(
+            gm, &migd.mparam, &migd.mparamMat, &mparamObj));
+
+    // Commit only once everything that can fail has succeeded
+    VECTOR_AT(gm->gdv, lid).migd         = migd;
+    VECTOR_AT(gm->gdv, lid).mparamObj    = mparamObj;
+    VECTOR_AT(gm->gdv, lid).privateParam = GM_getPrivateParam(gm, newBaseGraph);
+    VECTOR_AT(gm->gdv, lid).baseGraphID  = newBaseGraph;
 
     return ZL_returnSuccess();
 }
@@ -1217,9 +1238,10 @@ const void* GM_getPrivateParam(const GraphsMgr* gm, ZL_GraphID graphid)
 {
     if (GR_isStandardGraph(graphid)) {
         ZL_ASSERT(GR_isStandardGraph(graphid));
-        if (GR_standardGraphs[graphid.gid].type == GR_segmenter)
-            return NULL; /* segmenters have no private params */
-        ZL_ASSERT_EQ(GR_standardGraphs[graphid.gid].type, GR_dynamicGraph);
+        if (GR_standardGraphs[graphid.gid].type != GR_dynamicGraph) {
+            /* store & segmenters have no private params */
+            return NULL;
+        }
         return GR_standardGraphs[graphid.gid].gdi.privateParam;
     }
     ZL_ASSERT_NN(gm);

--- a/tests/unittest/compress/CompressorUnitTest.cpp
+++ b/tests/unittest/compress/CompressorUnitTest.cpp
@@ -5,6 +5,7 @@
 #include <unordered_map>
 #include <vector>
 
+#include "openzl/codecs/zl_lz4.h"
 #include "openzl/common/assertion.h"
 #include "openzl/common/errors_internal.h"
 #include "openzl/compress/cgraph.h"
@@ -1700,17 +1701,23 @@ TEST_F(CompressorTest, OverrideBaseGraph)
             ZL_Compressor_Graph_getBaseGraphID(compressor_.get(), paramGraph),
             newBaseGraph);
 
-    // Custom graphs, custom nodes, and local params should be cleared
-    EXPECT_EQ(
-            ZL_Compressor_Graph_getCustomGraphs(compressor_.get(), paramGraph)
-                    .nbGraphIDs,
-            0u);
-    EXPECT_EQ(
-            ZL_Compressor_Graph_getCustomNodes(compressor_.get(), paramGraph)
-                    .nbNodeIDs,
-            0u);
-    expectParamsEmpty(
-            ZL_Compressor_Graph_getLocalParams(compressor_.get(), paramGraph));
+    // The parameterization's custom graphs, custom nodes and local params are
+    // replaced by the new base's, which is what the graph now runs as. Here
+    // the new base is a static graph, so it brings its own head node and
+    // successor and has no local params.
+    const auto newCustomGraphs =
+            ZL_Compressor_Graph_getCustomGraphs(compressor_.get(), paramGraph);
+    ASSERT_EQ(newCustomGraphs.nbGraphIDs, 1u);
+    EXPECT_EQ(newCustomGraphs.graphids[0], ZL_GRAPH_ZSTD);
+    const auto newCustomNodes =
+            ZL_Compressor_Graph_getCustomNodes(compressor_.get(), paramGraph);
+    ASSERT_EQ(newCustomNodes.nbNodeIDs, 1u);
+    EXPECT_EQ(newCustomNodes.nodeids[0], ZL_NODE_ZIGZAG);
+    const auto newLocalParams =
+            ZL_Compressor_Graph_getLocalParams(compressor_.get(), paramGraph);
+    EXPECT_EQ(newLocalParams.intParams.nbIntParams, 0u);
+    EXPECT_EQ(newLocalParams.copyParams.nbCopyParams, 0u);
+    EXPECT_EQ(newLocalParams.refParams.nbRefParams, 0u);
 
     // Graph type should still be parameterized
     EXPECT_EQ(
@@ -1775,6 +1782,74 @@ TEST_F(CompressorTest, OverrideBaseGraphRejectsSelfLoop)
     auto paramGraph = makeParameterizedGraph();
     EXPECT_ZS_ERROR(ZL_Compressor_overrideBaseGraph(
             compressor_.get(), paramGraph, paramGraph));
+}
+
+TEST_F(CompressorTest, OverrideBaseGraphTakesEffectImmediately)
+{
+    // A parameterized graph holds its own copy of the description it was
+    // created from, and that copy is what runs at compression time. Overriding
+    // the base graph must update it, rather than only changing what a
+    // serialized copy of the compressor would rebuild.
+    const auto paramGraph = compressor_.parameterizeGraph(
+            ZL_GRAPH_COMPRESS_GENERIC, openzl::GraphParameters{});
+    compressor_.selectStartingGraph(paramGraph);
+
+    const std::string data(10000, 'a');
+    const auto compressedSize = [&]() {
+        cctx_.refCompressor(compressor_);
+        auto input = openzl::Input::refSerial(data);
+        return cctx_.compressOne(input).size();
+    };
+    ASSERT_LT(compressedSize(), data.size() / 2);
+
+    EXPECT_ZS_VALID(ZL_Compressor_overrideBaseGraph(
+            compressor_.get(), paramGraph, ZL_GRAPH_STORE));
+
+    // Storing cannot compress, so the override must be visible right away
+    EXPECT_GE(compressedSize(), data.size());
+}
+
+TEST_F(CompressorTest, OverrideBaseGraphWithStaticGraph)
+{
+    // A static graph runs off its own custom nodes & successors, so adopting
+    // it as a base must bring those along.
+    const auto paramGraph = compressor_.parameterizeGraph(
+            ZL_GRAPH_COMPRESS_GENERIC, openzl::GraphParameters{});
+    compressor_.selectStartingGraph(paramGraph);
+    // lz4 is a standard static graph over serial input
+    EXPECT_ZS_VALID(ZL_Compressor_overrideBaseGraph(
+            compressor_.get(), paramGraph, ZL_GRAPH_LZ4));
+
+    const std::string data(10000, 'a');
+    auto input = openzl::Input::refSerial(data);
+    cctx_.refCompressor(compressor_);
+    const auto inMemory = cctx_.compressOne(input).size();
+
+    openzl::Compressor roundTripped;
+    roundTripped.deserialize(compressor_.serialize());
+    cctx_.refCompressor(roundTripped);
+    EXPECT_EQ(cctx_.compressOne(input).size(), inMemory);
+}
+
+TEST_F(CompressorTest, OverrideBaseGraphMatchesSerializedBehavior)
+{
+    // Whatever the override does in memory, a serialized round trip of the
+    // compressor must do the same.
+    const auto paramGraph = compressor_.parameterizeGraph(
+            ZL_GRAPH_COMPRESS_GENERIC, openzl::GraphParameters{});
+    compressor_.selectStartingGraph(paramGraph);
+    EXPECT_ZS_VALID(ZL_Compressor_overrideBaseGraph(
+            compressor_.get(), paramGraph, ZL_GRAPH_STORE));
+
+    const std::string data(10000, 'a');
+    auto input = openzl::Input::refSerial(data);
+    cctx_.refCompressor(compressor_);
+    const auto inMemory = cctx_.compressOne(input).size();
+
+    openzl::Compressor roundTripped;
+    roundTripped.deserialize(compressor_.serialize());
+    cctx_.refCompressor(roundTripped);
+    EXPECT_EQ(cctx_.compressOne(input).size(), inMemory);
 }
 
 TEST_F(CompressorTest, OverrideBaseGraphRejectsIncompatibleInputTypes)


### PR DESCRIPTION
Summary:

`ZL_Compressor_overrideBaseGraph()` only worked correctly after serialization. It updated the `baseGraphID`, but that wasn't actually consulted during compression. It was only consulted during serialization.

Fix `ZL_Compressor_overrideBaseGraph()` so that it works as expected, and transfer all properties of the `newBaseGraph` immediately.

Reviewed By: kevinjzhang

Differential Revision: D116047130


