### PR TITLE
AArch64: Add Neon optimized bitSplit codecs

### DIFF
--- a/src/openzl/codecs/bitSplit/decode_bitSplit_kernel.c
+++ b/src/openzl/codecs/bitSplit/decode_bitSplit_kernel.c
@@ -4,6 +4,7 @@
 #include <stdbool.h> /* bool */
 
 #include "openzl/codecs/bitSplit/decode_bitSplit_kernel.h"
+#include "openzl/shared/portability.h"
 
 /*
  * Specialized decoder for bf16 pattern:
@@ -100,6 +101,229 @@ decodeFp64(void* dst, size_t nbElts, const void* const srcPtrs[])
         dst64[e] = value;
     }
 }
+
+#if ZL_HAS_NEON
+
+#    include <arm_neon.h>
+
+/*
+ * Specialized decoder for bf16 pattern:
+ * - 3 streams with bitWidths {7, 8, 1}
+ * - All srcEltWidths are 1 (uint8_t)
+ * - dstEltWidth is 2 (uint16_t)
+ *
+ * Layout: [mantissa:7][exponent:8][sign:1] = 16 bits
+ */
+static inline void
+decodeBf16_neon(void* dst, size_t nbElts, const void* const srcPtrs[])
+{
+    uint16_t* const dst16         = (uint16_t*)dst;
+    const uint8_t* const mantissa = (const uint8_t*)srcPtrs[0];
+    const uint8_t* const exponent = (const uint8_t*)srcPtrs[1];
+    const uint8_t* const sign     = (const uint8_t*)srcPtrs[2];
+
+    size_t e = 0;
+    for (; e + 16 <= nbElts; e += 16) {
+        uint8x16_t const vs = vld1q_u8(sign + e);
+        uint8x16_t const ve = vld1q_u8(exponent + e);
+        uint8x16_t const vm = vld1q_u8(mantissa + e);
+
+        uint8x16x2_t const ves = vzipq_u8(ve, vs);
+        uint8x16x2_t const vmz = vzipq_u8(vm, vdupq_n_u8(0));
+        uint16x8_t ves0        = vreinterpretq_u16_u8(ves.val[0]);
+        uint16x8_t ves1        = vreinterpretq_u16_u8(ves.val[1]);
+
+        ves0 = vsliq_n_u16(vreinterpretq_u16_u8(vmz.val[0]), ves0, 7);
+        ves1 = vsliq_n_u16(vreinterpretq_u16_u8(vmz.val[1]), ves1, 7);
+        vst1q_u16(dst16 + e + 0, ves0);
+        vst1q_u16(dst16 + e + 8, ves1);
+    }
+
+    ZL_UNROLL_LOOP(1)
+    for (; e < nbElts; e++) {
+        uint16_t value = (uint16_t)mantissa[e]; /* bits 0-6 */
+        value |= (uint16_t)exponent[e] << 7;    /* bits 7-14 */
+        value |= (uint16_t)sign[e] << 15;       /* bit 15 */
+        dst16[e] = value;
+    }
+}
+
+/*
+ * Specialized decoder for fp16 pattern:
+ * - 3 streams with bitWidths {10, 5, 1}
+ * - srcEltWidths are {2, 1, 1} (uint16_t, uint8_t, uint8_t)
+ * - dstEltWidth is 2 (uint16_t)
+ *
+ * Layout: [mantissa:10][exponent:5][sign:1] = 16 bits
+ */
+static inline void
+decodeFp16_neon(void* dst, size_t nbElts, const void* const srcPtrs[])
+{
+    uint16_t* const dst16          = (uint16_t*)dst;
+    const uint16_t* const mantissa = (const uint16_t*)srcPtrs[0];
+    const uint8_t* const exponent  = (const uint8_t*)srcPtrs[1];
+    const uint8_t* const sign      = (const uint8_t*)srcPtrs[2];
+
+    size_t e = 0;
+    for (; e + 16 <= nbElts; e += 16) {
+        uint8x16_t const ve    = vld1q_u8(exponent + e);
+        uint8x16_t const vs    = vld1q_u8(sign + e);
+        uint16x8_t vm0         = vld1q_u16(mantissa + e + 0);
+        uint16x8_t vm1         = vld1q_u16(mantissa + e + 8);
+        uint8x16x2_t const vez = vzipq_u8(ve, vdupq_n_u8(0));
+        uint8x16x2_t const vsz = vzipq_u8(vs, vdupq_n_u8(0));
+
+        vm0 = vsliq_n_u16(vm0, vreinterpretq_u16_u8(vez.val[0]), 10);
+        vm1 = vsliq_n_u16(vm1, vreinterpretq_u16_u8(vez.val[1]), 10);
+        vm0 = vsliq_n_u16(vm0, vreinterpretq_u16_u8(vsz.val[0]), 15);
+        vm1 = vsliq_n_u16(vm1, vreinterpretq_u16_u8(vsz.val[1]), 15);
+        vst1q_u16(dst16 + e + 0, vm0);
+        vst1q_u16(dst16 + e + 8, vm1);
+    }
+
+    ZL_UNROLL_LOOP(1)
+    for (; e < nbElts; e++) {
+        uint16_t value = mantissa[e];         /* bits 0-9 */
+        value |= (uint16_t)exponent[e] << 10; /* bits 10-14 */
+        value |= (uint16_t)sign[e] << 15;     /* bit 15 */
+        dst16[e] = value;
+    }
+}
+
+/*
+ * Specialized decoder for fp32 pattern:
+ * - 3 streams with bitWidths {23, 8, 1}
+ * - srcEltWidths are {4, 1, 1} (uint32_t, uint8_t, uint8_t)
+ * - dstEltWidth is 4 (uint32_t)
+ *
+ * Layout: [mantissa:23][exponent:8][sign:1] = 32 bits
+ */
+static inline void
+decodeFp32_neon(void* dst, size_t nbElts, const void* const srcPtrs[])
+{
+    static const ZL_ALIGNED(16) int8_t shuffle[] = {
+        0,  16, -1, -1, 1,  17, -1, -1, 2,  18, -1, -1, 3,  19, -1, -1,
+        4,  20, -1, -1, 5,  21, -1, -1, 6,  22, -1, -1, 7,  23, -1, -1,
+        8,  24, -1, -1, 9,  25, -1, -1, 10, 26, -1, -1, 11, 27, -1, -1,
+        12, 28, -1, -1, 13, 29, -1, -1, 14, 30, -1, -1, 15, 31, -1, -1,
+    };
+
+    uint32_t* const dst32          = (uint32_t*)dst;
+    const uint32_t* const mantissa = (const uint32_t*)srcPtrs[0];
+    const uint8_t* const exponent  = (const uint8_t*)srcPtrs[1];
+    const uint8_t* const sign      = (const uint8_t*)srcPtrs[2];
+
+    size_t e = 0;
+    if (nbElts >= 16) {
+        uint8x16_t const shuf0 = vld1q_u8((const uint8_t*)shuffle + 0);
+        uint8x16_t const shuf1 = vld1q_u8((const uint8_t*)shuffle + 16);
+        uint8x16_t const shuf2 = vld1q_u8((const uint8_t*)shuffle + 32);
+        uint8x16_t const shuf3 = vld1q_u8((const uint8_t*)shuffle + 48);
+
+        for (; e + 16 <= nbElts; e += 16) {
+            uint8x16x2_t ves;
+            ves.val[0] = vld1q_u8(exponent + e);
+            ves.val[1] = vld1q_u8(sign + e);
+
+            uint32x4_t const vm0 = vld1q_u32(mantissa + e + 0);
+            uint32x4_t const vm1 = vld1q_u32(mantissa + e + 4);
+            uint32x4_t const vm2 = vld1q_u32(mantissa + e + 8);
+            uint32x4_t const vm3 = vld1q_u32(mantissa + e + 12);
+
+            uint32x4_t const ves0 =
+                    vreinterpretq_u32_u8(vqtbl2q_u8(ves, shuf0));
+            uint32x4_t const ves1 =
+                    vreinterpretq_u32_u8(vqtbl2q_u8(ves, shuf1));
+            uint32x4_t const ves2 =
+                    vreinterpretq_u32_u8(vqtbl2q_u8(ves, shuf2));
+            uint32x4_t const ves3 =
+                    vreinterpretq_u32_u8(vqtbl2q_u8(ves, shuf3));
+
+            vst1q_u32(dst32 + e + 0, vsliq_n_u32(vm0, ves0, 23));
+            vst1q_u32(dst32 + e + 4, vsliq_n_u32(vm1, ves1, 23));
+            vst1q_u32(dst32 + e + 8, vsliq_n_u32(vm2, ves2, 23));
+            vst1q_u32(dst32 + e + 12, vsliq_n_u32(vm3, ves3, 23));
+        }
+    }
+
+    ZL_UNROLL_LOOP(1)
+    for (; e < nbElts; e++) {
+        uint32_t value = mantissa[e];         /* bits 0-22 */
+        value |= (uint32_t)exponent[e] << 23; /* bits 23-30 */
+        value |= (uint32_t)sign[e] << 31;     /* bit 31 */
+        dst32[e] = value;
+    }
+}
+
+/*
+ * Specialized decoder for fp64 pattern:
+ * - 3 streams with bitWidths {52, 11, 1}
+ * - srcEltWidths are {8, 2, 1} (uint64_t, uint16_t, uint8_t)
+ * - dstEltWidth is 8 (uint64_t)
+ *
+ * Layout: [mantissa:52][exponent:11][sign:1] = 64 bits
+ */
+static inline void
+decodeFp64_neon(void* dst, size_t nbElts, const void* const srcPtrs[])
+{
+    static const ZL_ALIGNED(16) int8_t shuffle[] = {
+        0,  1,  -1, -1, -1, -1, -1, -1, 2,  3,  -1, -1, -1, -1, -1, -1,
+        4,  5,  -1, -1, -1, -1, -1, -1, 6,  7,  -1, -1, -1, -1, -1, -1,
+        8,  9,  -1, -1, -1, -1, -1, -1, 10, 11, -1, -1, -1, -1, -1, -1,
+        12, 13, -1, -1, -1, -1, -1, -1, 14, 15, -1, -1, -1, -1, -1, -1,
+    };
+
+    uint64_t* const dst64          = (uint64_t*)dst;
+    const uint64_t* const mantissa = (const uint64_t*)srcPtrs[0];
+    const uint16_t* const exponent = (const uint16_t*)srcPtrs[1];
+    const uint8_t* const sign      = (const uint8_t*)srcPtrs[2];
+
+    size_t e = 0;
+    if (nbElts >= 8) {
+        uint8x16_t const shuf0 = vld1q_u8((const uint8_t*)shuffle + 0);
+        uint8x16_t const shuf1 = vld1q_u8((const uint8_t*)shuffle + 16);
+        uint8x16_t const shuf2 = vld1q_u8((const uint8_t*)shuffle + 32);
+        uint8x16_t const shuf3 = vld1q_u8((const uint8_t*)shuffle + 48);
+
+        for (; e + 8 <= nbElts; e += 8) {
+            uint8x16_t const vslo =
+                    vcombine_u8(vld1_u8(sign + e), vdup_n_u8(0));
+            uint16x8_t const vs =
+                    vreinterpretq_u16_u8(vzip1q_u8(vdupq_n_u8(0), vslo));
+            uint16x8_t const ve  = vld1q_u16(exponent + e);
+            uint8x16_t const ves = vreinterpretq_u8_u16(vmlaq_n_u16(ve, vs, 8));
+
+            uint64x2_t const vm0 = vld1q_u64(mantissa + e + 0);
+            uint64x2_t const vm1 = vld1q_u64(mantissa + e + 2);
+            uint64x2_t const vm2 = vld1q_u64(mantissa + e + 4);
+            uint64x2_t const vm3 = vld1q_u64(mantissa + e + 6);
+
+            uint64x2_t const ves0 =
+                    vreinterpretq_u64_u8(vqtbl1q_u8(ves, shuf0));
+            uint64x2_t const ves1 =
+                    vreinterpretq_u64_u8(vqtbl1q_u8(ves, shuf1));
+            uint64x2_t const ves2 =
+                    vreinterpretq_u64_u8(vqtbl1q_u8(ves, shuf2));
+            uint64x2_t const ves3 =
+                    vreinterpretq_u64_u8(vqtbl1q_u8(ves, shuf3));
+
+            vst1q_u64(dst64 + e + 0, vsliq_n_u64(vm0, ves0, 52));
+            vst1q_u64(dst64 + e + 2, vsliq_n_u64(vm1, ves1, 52));
+            vst1q_u64(dst64 + e + 4, vsliq_n_u64(vm2, ves2, 52));
+            vst1q_u64(dst64 + e + 6, vsliq_n_u64(vm3, ves3, 52));
+        }
+    }
+
+    ZL_UNROLL_LOOP(1)
+    for (; e < nbElts; e++) {
+        uint64_t value = mantissa[e];         /* bits 0-51 */
+        value |= (uint64_t)exponent[e] << 52; /* bits 52-62 */
+        value |= (uint64_t)sign[e] << 63;     /* bit 63 */
+        dst64[e] = value;
+    }
+}
+
+#endif // ZL_HAS_NEON
 
 /*
  * Check if parameters match the bf16 pattern.
@@ -278,19 +502,35 @@ void ZL_bitSplitDecode(
 
     /* Check for specialized patterns and dispatch */
     if (isBf16Pattern(dstEltWidth, srcEltWidths, bitWidths, nbWidths)) {
+#if ZL_HAS_NEON
+        decodeBf16_neon(dst, nbElts, srcPtrs);
+#else
         decodeBf16(dst, nbElts, srcPtrs);
+#endif
         return;
     }
     if (isFp16Pattern(dstEltWidth, srcEltWidths, bitWidths, nbWidths)) {
+#if ZL_HAS_NEON
+        decodeFp16_neon(dst, nbElts, srcPtrs);
+#else
         decodeFp16(dst, nbElts, srcPtrs);
+#endif
         return;
     }
     if (isFp32Pattern(dstEltWidth, srcEltWidths, bitWidths, nbWidths)) {
+#if ZL_HAS_NEON
+        decodeFp32_neon(dst, nbElts, srcPtrs);
+#else
         decodeFp32(dst, nbElts, srcPtrs);
+#endif
         return;
     }
     if (isFp64Pattern(dstEltWidth, srcEltWidths, bitWidths, nbWidths)) {
+#if ZL_HAS_NEON
+        decodeFp64_neon(dst, nbElts, srcPtrs);
+#else
         decodeFp64(dst, nbElts, srcPtrs);
+#endif
         return;
     }
 

--- a/src/openzl/codecs/bitSplit/encode_bitSplit_kernel.c
+++ b/src/openzl/codecs/bitSplit/encode_bitSplit_kernel.c
@@ -1,6 +1,7 @@
 // Copyright (c) Meta Platforms, Inc. and affiliates.
 
 #include "openzl/codecs/bitSplit/encode_bitSplit_kernel.h"
+#include "openzl/shared/portability.h"
 
 #include <assert.h> /* assert */
 #include <string.h>
@@ -157,6 +158,243 @@ bitSplit_fp64(void* const dstPtrs[], size_t nbElts, const void* src)
         sign[e]     = (uint8_t)((value >> 63) & 0x1);      /* bit 63 */
     }
 }
+
+#if ZL_HAS_NEON
+
+#    include <arm_neon.h>
+
+/*
+ * Extract the sign+exponent fields from eight IEEE-754 double-precision values
+ * packed in four uint64x2_t vectors.
+ *
+ * The shuffle table selects the two most significant bytes of each 64-bit
+ * element (containing the sign bit and the 11-bit exponent) using two
+ * table lookups. The extracted 16-bit sign+exponent values are returned as
+ * a uint16x8_t, ready for the subsequent bit-splitting stage.
+ */
+static inline uint16x8_t
+sign_exponent_u64x8(uint64x2_t v0, uint64x2_t v1, uint64x2_t v2, uint64x2_t v3)
+{
+    uint32x4_t vlo =
+            vuzp2q_u32(vreinterpretq_u32_u64(v0), vreinterpretq_u32_u64(v1));
+    uint32x4_t vhi =
+            vuzp2q_u32(vreinterpretq_u32_u64(v2), vreinterpretq_u32_u64(v3));
+
+    return vuzp2q_u16(vreinterpretq_u16_u32(vlo), vreinterpretq_u16_u32(vhi));
+}
+
+/*
+ * Specialized encoder for bf16 pattern:
+ * - srcEltWidth is 2 (uint16_t)
+ * - 3 streams with bitWidths {7, 8, 1}
+ * - All dstEltWidths are 1 (uint8_t)
+ *
+ * bf16 layout: [mantissa:7][exponent:8][sign:1] = 16 bits
+ */
+static inline void
+bitSplit_bf16_neon(void* const dstPtrs[], size_t nbElts, const void* src)
+{
+    uint8_t* restrict const mantissa     = (uint8_t*)dstPtrs[0];
+    uint8_t* restrict const exponent     = (uint8_t*)dstPtrs[1];
+    uint8_t* restrict const sign         = (uint8_t*)dstPtrs[2];
+    const uint16_t* restrict const src16 = (const uint16_t*)src;
+
+    size_t e = 0;
+    for (; e + 32 < nbElts; e += 32) {
+        uint16x8_t const v0 = vld1q_u16(src16 + e + 0);
+        uint16x8_t const v1 = vld1q_u16(src16 + e + 8);
+        uint16x8_t const v2 = vld1q_u16(src16 + e + 16);
+        uint16x8_t const v3 = vld1q_u16(src16 + e + 24);
+
+        uint8x16x2_t const vms0 =
+                vuzpq_u8(vreinterpretq_u8_u16(v0), vreinterpretq_u8_u16(v1));
+        uint8x16x2_t const vms1 =
+                vuzpq_u8(vreinterpretq_u8_u16(v2), vreinterpretq_u8_u16(v3));
+
+        uint8x16x2_t ve, vm, vs;
+        ve.val[0] = vaddhn_high_u16(vaddhn_u16(v0, v0), v1, v1);
+        ve.val[1] = vaddhn_high_u16(vaddhn_u16(v2, v2), v3, v3);
+        vm.val[0] = vandq_u8(vms0.val[0], vdupq_n_u8(0x7F));
+        vm.val[1] = vandq_u8(vms1.val[0], vdupq_n_u8(0x7F));
+        vs.val[0] = vshrq_n_u8(vms0.val[1], 7);
+        vs.val[1] = vshrq_n_u8(vms1.val[1], 7);
+
+        vst1q_u8_x2(exponent + e, ve);
+        vst1q_u8_x2(mantissa + e, vm);
+        vst1q_u8_x2(sign + e, vs);
+    }
+
+    ZL_UNROLL_LOOP(1)
+    for (; e < nbElts; e++) {
+        uint16_t const value = src16[e];
+        mantissa[e]          = (uint8_t)(value & 0x7F);         /* bits 0-6 */
+        exponent[e]          = (uint8_t)((value >> 7) & 0xFF);  /* bits 7-14 */
+        sign[e]              = (uint8_t)((value >> 15) & 0x01); /* bit 15 */
+    }
+}
+
+/*
+ * Specialized encoder for fp16 pattern:
+ * - srcEltWidth is 2 (uint16_t)
+ * - 3 streams with bitWidths {10, 5, 1}
+ * - dstEltWidths are {2, 1, 1} (uint16_t, uint8_t, uint8_t)
+ *
+ * fp16 layout: [mantissa:10][exponent:5][sign:1] = 16 bits
+ */
+static inline void
+bitSplit_fp16_neon(void* const dstPtrs[], size_t nbElts, const void* src)
+{
+    uint16_t* restrict const mantissa    = (uint16_t*)dstPtrs[0];
+    uint8_t* restrict const exponent     = (uint8_t*)dstPtrs[1];
+    uint8_t* restrict const sign         = (uint8_t*)dstPtrs[2];
+    const uint16_t* restrict const src16 = (const uint16_t*)src;
+
+    size_t e = 0;
+    for (; e + 32 < nbElts; e += 32) {
+        uint16x8_t const v0 = vld1q_u16(src16 + e + 0);
+        uint16x8_t const v1 = vld1q_u16(src16 + e + 8);
+        uint16x8_t const v2 = vld1q_u16(src16 + e + 16);
+        uint16x8_t const v3 = vld1q_u16(src16 + e + 24);
+
+        uint8x16_t const ves0 =
+                vuzp2q_u8(vreinterpretq_u8_u16(v0), vreinterpretq_u8_u16(v1));
+        uint8x16_t const ves1 =
+                vuzp2q_u8(vreinterpretq_u8_u16(v2), vreinterpretq_u8_u16(v3));
+
+        uint8x16x2_t ve, vs;
+        ve.val[0] = vandq_u8(vshrq_n_u8(ves0, 2), vdupq_n_u8(0x1F));
+        ve.val[1] = vandq_u8(vshrq_n_u8(ves1, 2), vdupq_n_u8(0x1F));
+        vs.val[0] = vshrq_n_u8(ves0, 7);
+        vs.val[1] = vshrq_n_u8(ves1, 7);
+
+        vst1q_u16(mantissa + e + 0, vandq_u16(v0, vdupq_n_u16(0x3FF)));
+        vst1q_u16(mantissa + e + 8, vandq_u16(v1, vdupq_n_u16(0x3FF)));
+        vst1q_u16(mantissa + e + 16, vandq_u16(v2, vdupq_n_u16(0x3FF)));
+        vst1q_u16(mantissa + e + 24, vandq_u16(v3, vdupq_n_u16(0x3FF)));
+        vst1q_u8_x2(exponent + e, ve);
+        vst1q_u8_x2(sign + e, vs);
+    }
+
+    ZL_UNROLL_LOOP(1)
+    for (; e < nbElts; e++) {
+        uint16_t const value = src16[e];
+        mantissa[e]          = (uint16_t)(value & 0x3FF);       /* bits 0-9 */
+        exponent[e]          = (uint8_t)((value >> 10) & 0x1F); /* bits 10-14 */
+        sign[e]              = (uint8_t)((value >> 15) & 0x1);  /* bit 15 */
+    }
+}
+
+/*
+ * Specialized encoder for fp32 pattern:
+ * - srcEltWidth is 4 (uint32_t)
+ * - 3 streams with bitWidths {23, 8, 1}
+ * - dstEltWidths are {4, 1, 1} (uint32_t, uint8_t, uint8_t)
+ *
+ * fp32 layout: [mantissa:23][exponent:8][sign:1] = 32 bits
+ */
+static inline void
+bitSplit_fp32_neon(void* const dstPtrs[], size_t nbElts, const void* src)
+{
+    uint32_t* restrict const mantissa    = (uint32_t*)dstPtrs[0];
+    uint8_t* restrict const exponent     = (uint8_t*)dstPtrs[1];
+    uint8_t* restrict const sign         = (uint8_t*)dstPtrs[2];
+    const uint32_t* restrict const src32 = (const uint32_t*)src;
+    uint32x4_t const mantmask            = vdupq_n_u32(0x7FFFFF);
+
+    size_t e = 0;
+    for (; e + 16 < nbElts; e += 16) {
+        uint32x4_t const v0 = vld1q_u32(src32 + e + 0);
+        uint32x4_t const v1 = vld1q_u32(src32 + e + 4);
+        uint32x4_t const v2 = vld1q_u32(src32 + e + 8);
+        uint32x4_t const v3 = vld1q_u32(src32 + e + 12);
+
+        uint16x8_t const v01 = vuzp2q_u16(
+                vreinterpretq_u16_u32(v0), vreinterpretq_u16_u32(v1));
+        uint16x8_t const v23 = vuzp2q_u16(
+                vreinterpretq_u16_u32(v2), vreinterpretq_u16_u32(v3));
+
+        uint8x16_t const ves0  = vreinterpretq_u8_u16(vshrq_n_u16(v01, 7));
+        uint8x16_t const ves1  = vreinterpretq_u8_u16(vshrq_n_u16(v23, 7));
+        uint8x16x2_t const ves = vuzpq_u8(ves0, ves1);
+
+        vst1q_u32(mantissa + e + 0, vandq_u32(v0, mantmask));
+        vst1q_u32(mantissa + e + 4, vandq_u32(v1, mantmask));
+        vst1q_u32(mantissa + e + 8, vandq_u32(v2, mantmask));
+        vst1q_u32(mantissa + e + 12, vandq_u32(v3, mantmask));
+        vst1q_u8(exponent + e, ves.val[0]);
+        vst1q_u8(sign + e, ves.val[1]);
+    }
+
+    ZL_UNROLL_LOOP(1)
+    for (; e < nbElts; e++) {
+        uint32_t const value = src32[e];
+        mantissa[e]          = (uint32_t)(value & 0x7FFFFF);    /* bits 0-22 */
+        exponent[e]          = (uint8_t)((value >> 23) & 0xFF); /* bits 23-30 */
+        sign[e]              = (uint8_t)((value >> 31) & 0x1);  /* bit 31 */
+    }
+}
+
+/*
+ * Specialized encoder for fp64 pattern:
+ * - srcEltWidth is 8 (uint64_t)
+ * - 3 streams with bitWidths {52, 11, 1}
+ * - dstEltWidths are {8, 2, 1} (uint64_t, uint16_t, uint8_t)
+ *
+ * fp64 layout: [mantissa:52][exponent:11][sign:1] = 64 bits
+ */
+static inline void
+bitSplit_fp64_neon(void* const dstPtrs[], size_t nbElts, const void* src)
+{
+    uint64_t* restrict const mantissa    = (uint64_t*)dstPtrs[0];
+    uint16_t* restrict const exponent    = (uint16_t*)dstPtrs[1];
+    uint8_t* restrict const sign         = (uint8_t*)dstPtrs[2];
+    const uint64_t* restrict const src64 = (const uint64_t*)src;
+    uint64x2_t const mantmask            = vdupq_n_u64(0xFFFFFFFFFFFFF);
+
+    size_t e = 0;
+    for (; e + 16 < nbElts; e += 16) {
+        uint64x2_t const v0 = vld1q_u64(src64 + e + 0);
+        uint64x2_t const v1 = vld1q_u64(src64 + e + 2);
+        uint64x2_t const v2 = vld1q_u64(src64 + e + 4);
+        uint64x2_t const v3 = vld1q_u64(src64 + e + 6);
+        uint64x2_t const v4 = vld1q_u64(src64 + e + 8);
+        uint64x2_t const v5 = vld1q_u64(src64 + e + 10);
+        uint64x2_t const v6 = vld1q_u64(src64 + e + 12);
+        uint64x2_t const v7 = vld1q_u64(src64 + e + 14);
+
+        uint16x8_t const ves0 = sign_exponent_u64x8(v0, v1, v2, v3);
+        uint16x8_t const ves1 = sign_exponent_u64x8(v4, v5, v6, v7);
+
+        uint16x8_t const ve0 =
+                vandq_u16(vshrq_n_u16(ves0, 4), vdupq_n_u16(0x7FF));
+        uint16x8_t const ve1 =
+                vandq_u16(vshrq_n_u16(ves1, 4), vdupq_n_u16(0x7FF));
+        uint8x16_t const vs = vuzp2q_u8(
+                vreinterpretq_u8_u16(ves0), vreinterpretq_u8_u16(ves1));
+
+        vst1q_u64(mantissa + e + 0, vandq_u64(v0, mantmask));
+        vst1q_u64(mantissa + e + 2, vandq_u64(v1, mantmask));
+        vst1q_u64(mantissa + e + 4, vandq_u64(v2, mantmask));
+        vst1q_u64(mantissa + e + 6, vandq_u64(v3, mantmask));
+        vst1q_u64(mantissa + e + 8, vandq_u64(v4, mantmask));
+        vst1q_u64(mantissa + e + 10, vandq_u64(v5, mantmask));
+        vst1q_u64(mantissa + e + 12, vandq_u64(v6, mantmask));
+        vst1q_u64(mantissa + e + 14, vandq_u64(v7, mantmask));
+        vst1q_u16(exponent + e + 0, ve0);
+        vst1q_u16(exponent + e + 8, ve1);
+        vst1q_u8(sign + e, vshrq_n_u8(vs, 7));
+    }
+
+    ZL_UNROLL_LOOP(1)
+    for (; e < nbElts; e++) {
+        uint64_t const value = src64[e];
+        mantissa[e] = (uint64_t)(value & 0xFFFFFFFFFFFFF); /* bits 0-51 */
+        exponent[e] = (uint16_t)((value >> 52) & 0x7FF);   /* bits 52-62 */
+        sign[e]     = (uint8_t)((value >> 63) & 0x1);      /* bit 63 */
+    }
+}
+
+#endif // ZL_HAS_NEON
 
 /*
  * Check if parameters match the bf16 encode pattern:
@@ -382,19 +620,35 @@ void ZL_bitSplitEncode(
 
     /* Check for specialized patterns and dispatch */
     if (isEncodeBf16Pattern(srcEltWidth, dstEltWidths, bitWidths, nbWidths)) {
+#if ZL_HAS_NEON
+        bitSplit_bf16_neon(dstPtrs, nbElts, src);
+#else
         bitSplit_bf16(dstPtrs, nbElts, src);
+#endif
         return;
     }
     if (isEncodeFp16Pattern(srcEltWidth, dstEltWidths, bitWidths, nbWidths)) {
+#if ZL_HAS_NEON
+        bitSplit_fp16_neon(dstPtrs, nbElts, src);
+#else
         bitSplit_fp16(dstPtrs, nbElts, src);
+#endif
         return;
     }
     if (isEncodeFp32Pattern(srcEltWidth, dstEltWidths, bitWidths, nbWidths)) {
+#if ZL_HAS_NEON
+        bitSplit_fp32_neon(dstPtrs, nbElts, src);
+#else
         bitSplit_fp32(dstPtrs, nbElts, src);
+#endif
         return;
     }
     if (isEncodeFp64Pattern(srcEltWidth, dstEltWidths, bitWidths, nbWidths)) {
+#if ZL_HAS_NEON
+        bitSplit_fp64_neon(dstPtrs, nbElts, src);
+#else
         bitSplit_fp64(dstPtrs, nbElts, src);
+#endif
         return;
     }
 

--- a/src/openzl/shared/portability.h
+++ b/src/openzl/shared/portability.h
@@ -289,8 +289,38 @@ ZL_INLINE bool ZL_addressIsPoisoned(const void* ptr)
 #    define ZL_HAS_BMI2 0
 #endif
 
+#if defined(__aarch64__) && defined(__ARM_NEON)
+#    define ZL_HAS_NEON 1
+#else
+#    define ZL_HAS_NEON 0
+#endif
+
+#if ZL_HAS_NEON && defined(__ARM_FEATURE_DOTPROD)
+#    define ZL_HAS_NEON_DOTPROD 1
+#else
+#    define ZL_HAS_NEON_DOTPROD 0
+#endif
+
+#if ZL_HAS_NEON_DOTPROD && defined(__ARM_FEATURE_MATMUL_INT8)
+#    define ZL_HAS_NEON_I8MM 1
+#else
+#    define ZL_HAS_NEON_I8MM 0
+#endif
+
 #if defined(__aarch64__) && defined(__ARM_FEATURE_SVE) \
-        && defined(__ARM_FEATURE_SVE2_BITPERM) && ZL_HAS_INCLUDE(<arm_sve.h>)
+        && ZL_HAS_INCLUDE(<arm_sve.h>)
+#    define ZL_HAS_SVE 1
+#else
+#    define ZL_HAS_SVE 0
+#endif
+
+#if ZL_HAS_SVE && defined(__ARM_FEATURE_SVE2)
+#    define ZL_HAS_SVE2 1
+#else
+#    define ZL_HAS_SVE2 0
+#endif
+
+#if ZL_HAS_SVE2 && defined(__ARM_FEATURE_SVE2_BITPERM)
 #    define ZL_HAS_SVE2_BITPERM 1
 #else
 #    define ZL_HAS_SVE2_BITPERM 0

--- a/src/openzl/shared/simd_wrapper.h
+++ b/src/openzl/shared/simd_wrapper.h
@@ -10,14 +10,11 @@
 #include "openzl/shared/portability.h"
 #include "openzl/shared/utils.h"
 
+#if ZL_HAS_NEON
+#    include <arm_neon.h>
+#endif
 #if ZL_ARCH_X86_64
 #    include <emmintrin.h>
-#elif ZL_ARCH_ARM64
-#    include <arm_neon.h>
-#    if ZL_HAS_SVE2_BITPERM
-#        include <arm_neon_sve_bridge.h>
-#        include <arm_sve.h>
-#    endif
 #endif
 #ifdef __AVX2__
 #    include <immintrin.h>
@@ -114,7 +111,7 @@ ZL_INLINE ZL_VecMask ZL_Vec128_mask8(ZL_Vec128 v)
     return (ZL_VecMask)_mm_movemask_epi8(v);
 }
 
-#elif ZL_ARCH_ARM64
+#elif ZL_HAS_NEON
 
 typedef uint8x16_t ZL_Vec128;
 
@@ -143,23 +140,33 @@ ZL_INLINE ZL_Vec128 ZL_Vec128_and(ZL_Vec128 x, ZL_Vec128 y)
     return vandq_u8(x, y);
 }
 
+/*
+ * Convert a byte comparison mask to a 16-bit bitmask.
+ *
+ * The input must contain only 0x00 or 0xFF bytes (e.g. the output of
+ * ZL_Vec128_cmp8()). The implementation relies on this representation.
+ */
 ZL_INLINE ZL_VecMask ZL_Vec128_mask8(ZL_Vec128 v)
 {
-#    if ZL_HAS_SVE2_BITPERM
-    uint64x2_t const neon64 = vreinterpretq_u64_u8(v);
-    svuint64_t const sve64  = svset_neonq_u64(svundef_u64(), neon64);
-    svuint64_t const mask64 =
-            svbext_u64(sve64, svdup_n_u64(0x8080808080808080ULL));
-    uint64x2_t const out64 = svget_neonq_u64(mask64);
-    return (ZL_VecMask)vgetq_lane_u64(out64, 0)
-            | ((ZL_VecMask)vgetq_lane_u64(out64, 1) << 8);
+#    if ZL_HAS_NEON_DOTPROD
+    int8x16_t const weights_s8 =
+            vreinterpretq_s8_u64(vdupq_n_u64(0x80C0E0F0F8FCFEFFull));
+    int8x16_t const v_s8 = vreinterpretq_s8_u8(v);
+#        if ZL_HAS_NEON_I8MM
+    int32x4_t const acc_s32 = vmmlaq_s32(vdupq_n_s32(0), v_s8, weights_s8);
+#        else
+    int32x4_t acc_s32 = vdotq_s32(vdupq_n_s32(0), v_s8, weights_s8);
+    acc_s32           = vreinterpretq_s32_s64(vpaddlq_s32(acc_s32));
+#        endif
+    uint8x16_t acc_u8 = vreinterpretq_u8_s32(acc_s32);
+    acc_u8            = vcopyq_laneq_u8(acc_u8, 1, acc_u8, 8);
+    return vgetq_lane_u32(vreinterpretq_u32_u8(acc_u8), 0);
 #    else
-    static uint8_t const weights[16] = { 1, 2, 4, 8, 16, 32, 64, 128,
-                                         1, 2, 4, 8, 16, 32, 64, 128 };
-    uint8x16_t const highBits        = vshrq_n_u8(v, 7);
-    uint8x16_t const weighted        = vmulq_u8(highBits, vld1q_u8(weights));
-    uint8_t const loAcc              = vaddv_u8(vget_low_u8(weighted));
-    uint8_t const hiAcc              = vaddv_u8(vget_high_u8(weighted));
+    uint8x16_t const weights =
+            vreinterpretq_u8_u64(vdupq_n_u64(0x8040201008040201ull));
+    uint8x16_t const weighted = vandq_u8(v, weights);
+    uint8_t const loAcc       = vaddv_u8(vget_low_u8(weighted));
+    uint8_t const hiAcc       = vaddv_u8(vget_high_u8(weighted));
     return (ZL_VecMask)loAcc | ((ZL_VecMask)hiAcc << 8);
 #    endif
 }
@@ -282,6 +289,73 @@ ZL_INLINE ZL_Vec256 ZL_Vec256_and(ZL_Vec256 x, ZL_Vec256 y)
 ZL_INLINE ZL_VecMask ZL_Vec256_mask8(ZL_Vec256 v)
 {
     return (ZL_VecMask)_mm256_movemask_epi8(v);
+}
+
+#elif ZL_HAS_NEON
+
+typedef uint8x16x2_t ZL_Vec256;
+
+ZL_INLINE ZL_Vec256 ZL_Vec256_read(void const* ptr)
+{
+    return vld1q_u8_x2((uint8_t const*)ptr);
+}
+
+ZL_INLINE void ZL_Vec256_write(void* ptr, ZL_Vec256 v)
+{
+    vst1q_u8_x2((uint8_t*)ptr, v);
+}
+
+ZL_INLINE ZL_Vec256 ZL_Vec256_set8(uint8_t val)
+{
+    ZL_Vec256 v;
+    v.val[0] = v.val[1] = vdupq_n_u8(val);
+    return v;
+}
+
+ZL_INLINE ZL_Vec256 ZL_Vec256_cmp8(ZL_Vec256 x, ZL_Vec256 y)
+{
+    x.val[0] = vceqq_u8(x.val[0], y.val[0]);
+    x.val[1] = vceqq_u8(x.val[1], y.val[1]);
+    return x;
+}
+
+ZL_INLINE ZL_Vec256 ZL_Vec256_and(ZL_Vec256 x, ZL_Vec256 y)
+{
+    x.val[0] = vandq_u8(x.val[0], y.val[0]);
+    x.val[1] = vandq_u8(x.val[1], y.val[1]);
+    return x;
+}
+
+/*
+ * Convert a byte comparison mask to a 32-bit bitmask.
+ *
+ * The input must contain only 0x00 or 0xFF bytes (e.g. the output of
+ * ZL_Vec256_cmp8()). The implementation relies on this representation.
+ */
+ZL_INLINE ZL_VecMask ZL_Vec256_mask8(ZL_Vec256 v)
+{
+#    if ZL_HAS_NEON_DOTPROD
+    int8x16_t const weights_s8 =
+            vreinterpretq_s8_u64(vdupq_n_u64(0x80C0E0F0F8FCFEFFull));
+    int8x16_t const lo_s8 = vreinterpretq_s8_u8(v.val[0]);
+    int8x16_t const hi_s8 = vreinterpretq_s8_u8(v.val[1]);
+#        if ZL_HAS_NEON_I8MM
+    int32x4_t const loAcc_s32 = vmmlaq_s32(vdupq_n_s32(0), lo_s8, weights_s8);
+    int32x4_t const hiAcc_s32 = vmmlaq_s32(vdupq_n_s32(0), hi_s8, weights_s8);
+    v.val[0]                  = vreinterpretq_u8_s32(loAcc_s32);
+    v.val[1]                  = vreinterpretq_u8_s32(hiAcc_s32);
+    uint8x8_t const acc_u8    = vqtbl2_u8(v, vcreate_u8(0x18100800));
+#        else
+    int32x4_t const loAcc_s32 = vdotq_s32(vdupq_n_s32(0), lo_s8, weights_s8);
+    int32x4_t const hiAcc_s32 = vdotq_s32(vdupq_n_s32(0), hi_s8, weights_s8);
+    int32x4_t const acc_s32   = vpaddq_s32(loAcc_s32, hiAcc_s32);
+    uint8x8_t const tbl_u8    = vcreate_u8(0x0C080400);
+    uint8x8_t const acc_u8 = vqtbl1_u8(vreinterpretq_u8_s32(acc_s32), tbl_u8);
+#        endif
+    return vget_lane_u32(vreinterpret_u32_u8(acc_u8), 0);
+#    else
+    return ZL_Vec128_mask8(v.val[0]) | (ZL_Vec128_mask8(v.val[1]) << 16);
+#    endif
 }
 
 #else

--- a/tests/codecs/test_bitsplit_bf16.cpp
+++ b/tests/codecs/test_bitsplit_bf16.cpp
@@ -52,6 +52,18 @@ TEST_F(BitsplitBF16Test, BF16_RoundTrip)
     testBitsplitBF16RoundTrip(input);
 }
 
+TEST_F(BitsplitBF16Test, BF16_NegativeRoundTrip)
+{
+    // Sweep through a range of negative normal bf16 values
+    std::vector<uint16_t> input(1000);
+    for (size_t i = 0; i < input.size(); i++) {
+        // Range from small negative normals to larger ones
+        // bf16 exponent field starts at bit 7, normal range [0x0080..0x7F7F]
+        input[i] = static_cast<uint16_t>(0x8000 | (0x0080 + (i % 0x7F00)));
+    }
+    testBitsplitBF16RoundTrip(input);
+}
+
 TEST_F(BitsplitBF16Test, BF16_AllZero)
 {
     std::vector<uint16_t> input(1000, 0x0000);

--- a/tests/codecs/test_bitsplit_fp.cpp
+++ b/tests/codecs/test_bitsplit_fp.cpp
@@ -48,6 +48,15 @@ TEST_F(BitsplitFPTest, FP32_RoundTrip)
     testBitsplitFPRoundTrip(input);
 }
 
+TEST_F(BitsplitFPTest, FP32_NegativeRoundTrip)
+{
+    std::vector<float> input(1000);
+    for (size_t i = 0; i < input.size(); i++) {
+        input[i] = static_cast<float>(i) * -0.1f;
+    }
+    testBitsplitFPRoundTrip(input);
+}
+
 TEST_F(BitsplitFPTest, FP32_AllZero)
 {
     std::vector<float> input(1000, 0.0f);
@@ -119,6 +128,15 @@ TEST_F(BitsplitFPTest, FP64_RoundTrip)
     std::vector<double> input(1000);
     for (size_t i = 0; i < input.size(); i++) {
         input[i] = static_cast<double>(i) * 0.1;
+    }
+    testBitsplitFPRoundTrip(input);
+}
+
+TEST_F(BitsplitFPTest, FP64_NegativeRoundTrip)
+{
+    std::vector<double> input(1000);
+    for (size_t i = 0; i < input.size(); i++) {
+        input[i] = static_cast<double>(i) * -0.1;
     }
     testBitsplitFPRoundTrip(input);
 }
@@ -200,6 +218,18 @@ TEST_F(BitsplitFPTest, FP16_RoundTrip)
         // Range from small positive normals to larger ones
         // Exponent field [0x0400..0x7BFF] covers all normal fp16 values
         input[i] = static_cast<uint16_t>(0x0400 + (i % 0x7800));
+    }
+    testBitsplitFPRoundTrip(input);
+}
+
+TEST_F(BitsplitFPTest, FP16_NegativeRoundTrip)
+{
+    // Sweep through a range of negative normal fp16 values
+    std::vector<uint16_t> input(1000);
+    for (size_t i = 0; i < input.size(); i++) {
+        // Range from small negative normals to larger ones
+        // Exponent field [0x0400..0x7BFF] covers all normal fp16 values
+        input[i] = static_cast<uint16_t>(0x8000 | (0x0400 + (i % 0x7800)));
     }
     testBitsplitFPRoundTrip(input);
 }


### PR DESCRIPTION
## Summary

Optimize **AArch64** **Neon** support functions and add **Neon** accelerated bitSplit floating-point encode/decode paths.

This change:
- adds independent compile-time feature detection for **Neon**, **DotProd**, **I8MM**, **SVE**, **SVE2**, and **SVE2 BitPerm**;
- replaces the **SVE2 BitPerm**-based 128-bit mask extraction with native **Neon** implementations, using **I8MM** or **DotProd** when available and a baseline **Neon** fallback otherwise;
- adds a native 256-bit **Neon** SIMD wrapper backed by two 128-bit vectors;
- adds optimized **Neon** implementations for **bf16**, **fp16**, **fp32**, and **fp64** `bitSplit` encoders and decoders;
- preserves the existing scalar/reference implementations as fallbacks on non-Neon targets;
- adds negative-value round-trip tests for **bf16**, **fp16**, **fp32**, and **fp64** to verify correct sign-bit handling.

The optimized `bitSplit` paths show substantial speedups on several tested **AArch64** CPUs.

## Type of Change

Performance improvement

## Test Plan

Added round-trip coverage for negative **bf16**, **fp16**, **fp32**, and **fp64** values to verify that `bitSplit` encoding and decoding preserve the sign bit correctly.

Validated the optimized `bitSplit` encode/decode implementations against the existing reference behaviour.

Performance was benchmarked using the **enwik5** dataset on multiple **AArch64** CPU cores by `unitBench`. The **Neon** implementations were compared against the reference implementations using both Clang-22 and GCC-16 builds.

Decoder benchmarks showed improvements:
```
                       Neoverse V3        Neoverse V2
                      Clang-22  GCC-16   Clang-22  GCC-16
bitSplitDecode_bf16:   1.305x   1.361x    1.250x   1.450x
bitSplitDecode_fp16:   1.132x   1.147x    1.235x   1.192x
bitSplitDecode_fp32:   1.600x   1.937x    1.727x   2.425x
bitSplitDecode_fp64:   1.925x   1.894x    2.480x   2.304x

                         Cortex-X925        Cortex-A725
                      Clang-22  GCC-16   Clang-22  GCC-16
bitSplitDecode_bf16:   1.599x   1.509x    2.220x   2.519x
bitSplitDecode_fp16:   1.474x   1.493x    1.781x   1.662x
bitSplitDecode_fp32:   1.735x   2.573x    2.065x   3.515x
bitSplitDecode_fp64:   2.215x   2.461x    2.914x   3.601x
```

Encoder performance varies by CPU/compiler combination: Clang-22 emitted essentially the same instructions as the auto-vectorized implementation but scheduled them differently and replaced some of the hinted intrinsics, while GCC-16 generally performed better by preserving those hints and following the intrinsic-defined instruction ordering more closely:
```
                       Neoverse V3        Neoverse V2
                      Clang-22  GCC-16   Clang-22  GCC-16
bitSplitEncode_bf16:   0.963x   1.258x    0.926x   1.170x
bitSplitEncode_fp16:   0.929x   1.420x    0.999x   1.441x
bitSplitEncode_fp32:   1.717x   1.086x    1.548x   1.210x
bitSplitEncode_fp64:   1.186x   1.099x    1.255x   1.027x

                         Cortex-X925        Cortex-A725
                      Clang-22  GCC-16   Clang-22  GCC-16
bitSplitEncode_bf16:   1.000x   1.709x    1.001x   1.592x
bitSplitEncode_fp16:   1.000x   1.331x    0.998x   1.739x
bitSplitEncode_fp32:   1.008x   1.023x    1.689x   1.699x
bitSplitEncode_fp64:   1.331x   1.387x    2.408x   2.133x
```

### Test Configuration

- Compiler: Clang-22, GCC-16
- Build type: Release / benchmark build
- Platform(s): AArch64
