### PR TITLE
Add doubleFast strategy (#960)

### DIFF
--- a/cpp/include/openzl/cpp/codecs/Lz.hpp
+++ b/cpp/include/openzl/cpp/codecs/Lz.hpp
@@ -27,6 +27,18 @@ void addLzLocalParams(LocalParams& lp, const Parameters& params)
     if (params.windowLog.has_value()) {
         lp.addIntParam(ZL_LzParam_windowLog, params.windowLog.value());
     }
+    if (params.strategy.has_value()) {
+        lp.addIntParam(ZL_LzParam_strategy, params.strategy.value());
+    }
+    if (params.hashLog1.has_value()) {
+        lp.addIntParam(ZL_LzParam_hashLog1, params.hashLog1.value());
+    }
+    if (params.hashLog2.has_value()) {
+        lp.addIntParam(ZL_LzParam_hashLog2, params.hashLog2.value());
+    }
+    if (params.hashLength.has_value()) {
+        lp.addIntParam(ZL_LzParam_hashLength, params.hashLength.value());
+    }
 }
 } // namespace detail
 
@@ -55,6 +67,14 @@ struct Lz : public Node {
         poly::optional<int> acceleration;
         /// Optionally override the maximum lookback window log
         poly::optional<int> windowLog;
+        /// Optionally override the strategy
+        poly::optional<ZL_LzStrategy> strategy;
+        /// Optionally override hashLog1
+        poly::optional<int> hashLog1;
+        /// Optionally override hashLog2
+        poly::optional<int> hashLog2;
+        /// Optionally override hashLength
+        poly::optional<int> hashLength;
     };
 
     Lz() {}

--- a/cpp/tests/TestCodecs.cpp
+++ b/cpp/tests/TestCodecs.cpp
@@ -73,6 +73,10 @@ TEST_F(TestCodecs, lzParameters)
                                     .compressionLevel = -1,
                                     .acceleration     = 2,
                                     .windowLog        = 16,
+                                    .strategy         = ZL_LzStrategy_fast,
+                                    .hashLog1         = 15,
+                                    .hashLog2         = 17,
+                                    .hashLength       = 5,
                             },
                     .literalsGraph        = graphs::Store::graph,
                     .offsetsGraph         = graphs::Store::graph,
@@ -90,6 +94,10 @@ TEST_F(TestCodecs, lzParameters)
         { ZL_LzParam_compressionLevel, -1 },
         { ZL_LzParam_acceleration, 2 },
         { ZL_LzParam_windowLog, 16 },
+        { ZL_LzParam_strategy, ZL_LzStrategy_fast },
+        { ZL_LzParam_hashLog1, 15 },
+        { ZL_LzParam_hashLog2, 17 },
+        { ZL_LzParam_hashLength, 5 },
         { ZL_LzParam_literalsGraphIdx, 0 },
         { ZL_LzParam_offsetsGraphIdx, 1 },
         { ZL_LzParam_muxedBytesGraphIdx, 2 },
@@ -118,6 +126,10 @@ TEST_F(TestCodecs, lzNodeParameters)
                     .compressionLevel = 3,
                     .acceleration     = 4,
                     .windowLog        = 17,
+                    .strategy         = ZL_LzStrategy_doubleFast,
+                    .hashLog1         = 14,
+                    .hashLog2         = 16,
+                    .hashLength       = 6,
             });
 
     const auto nodeParameters = lz.parameters();
@@ -128,6 +140,10 @@ TEST_F(TestCodecs, lzNodeParameters)
         { ZL_LzParam_compressionLevel, 3 },
         { ZL_LzParam_acceleration, 4 },
         { ZL_LzParam_windowLog, 17 },
+        { ZL_LzParam_strategy, ZL_LzStrategy_doubleFast },
+        { ZL_LzParam_hashLog1, 14 },
+        { ZL_LzParam_hashLog2, 16 },
+        { ZL_LzParam_hashLength, 6 },
     };
     EXPECT_EQ(
             collectIntParams(*nodeParameters->localParams), expectedIntParams);

--- a/include/openzl/codecs/zl_lz.h
+++ b/include/openzl/codecs/zl_lz.h
@@ -34,8 +34,16 @@ extern "C" {
 /// - The match length is >= 2^16 and (ml % 2^16 < min_match_length)
 #define ZL_LZ_MIN_MATCH_LENGTH_METADATA_ID 77
 
+typedef enum {
+    ZL_LzStrategy_fast = 1,
+    ZL_LzStrategy_doubleFast,
+} ZL_LzStrategy;
+
 /**
  * Parameters that control the behavior of ZL_NODE_LZ and ZL_GRAPH_LZ.
+ *
+ * Parameters will be clamped to their min & max values where relevant (see
+ * below).
  */
 typedef enum {
     /**
@@ -45,6 +53,8 @@ typedef enum {
      * The compression level controls the default parameters and successor
      * graphs. If compression level has no effect on parameters or successor
      * graphs that are explicitly overridden.
+     *
+     * @note 0 means use the default value.
      */
     ZL_LzParam_compressionLevel = 1,
 
@@ -55,7 +65,7 @@ typedef enum {
      * from the compression level. If the compression level is >= 0,
      * then it defaults to 1. Otherwise it defaults to -compression_level.
      *
-     * @note This parameter is clamped to 1 if set to a lower value.
+     * @note 0 means use the default value of 1.
      */
     ZL_LzParam_acceleration = 100,
 
@@ -66,12 +76,46 @@ typedef enum {
      * The default value is set depending on the compression level and source
      * size, and is capped at the source size.
      *
+     * @note 0 means use the default value.
+     *
      * @note If the window size is <= 64K, then LZ will use 16-bit offsets
      * rather than 32-bit offsets.
-     * @note currently, this value will be clamped between 10 and 28, but this
-     * is subject to change.
      */
     ZL_LzParam_windowLog = 101,
+
+    /**
+     * The ZL_LzStrategy to use for compression.
+     *
+     * @note 0 means use the default value.
+     */
+    ZL_LzParam_strategy = 102,
+
+    /**
+     * The log2 of the primary hash table in LZ match finding. Higher values use
+     * more memory, but potentially improve compression.
+     *
+     * @note 0 means use the default value.
+     */
+    ZL_LzParam_hashLog1 = 103,
+
+    /**
+     * The log2 of the secondary hash table in LZ match finding. Higher values
+     * use more memory, but potentially improve compression.
+     *
+     * @note 0 means use the default value.
+     * @note This will be ignored if the strategy doesn't use the secondary
+     * table.
+     */
+    ZL_LzParam_hashLog2 = 104,
+
+    /**
+     * The number of bytes to hash in match finding hash tables. This is
+     * effectively the minimum match length that the match finder searches for
+     * (though it may find shorter matches by happenstance).
+     *
+     * @note 0 means use the default value.
+     */
+    ZL_LzParam_hashLength = 105,
 
     /**
      * If set, the customGraph at this index is used to compress the literals,
@@ -112,6 +156,27 @@ typedef enum {
      */
     ZL_LzParam_muxLengthsGraphIdx = 1004,
 } ZL_LzParam;
+
+#define ZL_LZPARAM_WINDOWLOG_MIN 10
+#define ZL_LZPARAM_WINDOWLOG_MAX 28
+
+#define ZL_LZPARAM_ACCELERATION_MIN 1
+#define ZL_LZPARAM_ACCELERATION_MAX 10000
+
+#define ZL_LZPARAM_HASHLOG1_MIN 10
+#define ZL_LZPARAM_HASHLOG1_MAX 23
+
+#define ZL_LZPARAM_HASHLOG2_MIN 10
+#define ZL_LZPARAM_HASHLOG2_MAX 23
+
+#define ZL_LZPARAM_STRATEGY_MIN ((int)ZL_LzStrategy_fast)
+#define ZL_LZPARAM_STRATEGY_MAX ((int)ZL_LzStrategy_doubleFast)
+
+#define ZL_LZPARAM_HASHLENGTH_MIN 4
+#define ZL_LZPARAM_HASHLENGTH_MAX 7
+
+#define ZL_LZPARAM_COMPRESSIONLEVEL_MIN (-ZL_LZPARAM_ACCELERATION_MAX)
+#define ZL_LZPARAM_COMPRESSIONLEVEL_MAX 4
 
 #if defined(__cplusplus)
 }

--- a/src/openzl/codecs/common/fast_table.h
+++ b/src/openzl/codecs/common/fast_table.h
@@ -88,6 +88,22 @@ ZL_FORCE_INLINE void ZS_FastTable_conditionalPutT(
     table->table[hash] = condition ? pos : table->table[hash];
 }
 
+/// Get the value at ptr. Replace the value with pos.
+/// Templated by minMatch.
+ZL_FORCE_INLINE uint32_t ZS_FastTable_getAndConditionalUpdateT(
+        ZS_FastTable* table,
+        uint8_t const* ptr,
+        uint32_t pos,
+        uint32_t const kMinMatch,
+        bool condition)
+{
+    ZL_ASSERT_EQ(kMinMatch, table->minMatch);
+    size_t const hash    = ZL_hashPtr(ptr, table->tableLog, kMinMatch);
+    uint32_t const match = table->table[hash];
+    table->table[hash]   = condition ? pos : table->table[hash];
+    return match;
+}
+
 /// Get the value at ptr.
 /// Templated by minMatch.
 ZL_FORCE_INLINE uint32_t

--- a/src/openzl/codecs/encoder_registry.c
+++ b/src/openzl/codecs/encoder_registry.c
@@ -136,7 +136,7 @@ const CNode ER_standardNodes[STANDARD_ENCODERS_NB] = {
     REGISTER_TRANSFORM(ZL_StandardNodeID_split_byrange, ZL_StandardTransformID_splitn_num, 24, 200, EI_SPLIT_BYRANGE),
     REGISTER_TRANSFORM(ZL_StandardNodeID_sentinel_byte, ZL_StandardTransformID_sentinel, 24, 200, EI_SENTINEL_BYTE),
     REGISTER_TRANSFORM(ZL_StandardNodeID_sentinel_num, ZL_StandardTransformID_sentinel, 24, 200, EI_SENTINEL),
-    REGISTER_TRANSFORM(ZL_StandardNodeID_lz, ZL_StandardTransformID_lz, 24, 200, EI_LZ),
+    REGISTER_TRANSFORM(ZL_StandardNodeID_lz, ZL_StandardTransformID_lz, 24, 204, EI_LZ),
     REGISTER_TRANSFORM(ZL_StandardNodeID_mux_lengths, ZL_StandardTransformID_mux_lengths, 24, 200, EI_MUX_LENGTHS),
     REGISTER_TRANSFORM(ZL_StandardNodeID_sparse_num, ZL_StandardTransformID_sparse_num, 26, 202, EI_SPARSE_NUM),
     REGISTER_TRANSFORM(ZL_StandardNodeID_sparse_num_auto, ZL_StandardTransformID_sparse_num, 26, 202, EI_SPARSE_NUM_AUTO),

--- a/src/openzl/codecs/lz/encode_lz_binding.c
+++ b/src/openzl/codecs/lz/encode_lz_binding.c
@@ -135,43 +135,62 @@ ZL_Report EI_fieldLz(ZL_Encoder* eictx, const ZL_Input* ins[], size_t nbIns)
     return ZL_returnValue(5);
 }
 
-static int getCompressionLevelEncoder(const ZL_Encoder* eictx)
+static ZL_LzParameters getLzParams(const ZL_Encoder* eictx, size_t srcSize)
 {
-    const ZL_IntParam compressionLevel =
-            ZL_Encoder_getLocalIntParam(eictx, ZL_LzParam_compressionLevel);
-    if (compressionLevel.paramId == ZL_LP_INVALID_PARAMID) {
-        return ZL_Encoder_getCParam(eictx, ZL_CParam_compressionLevel);
-    } else {
-        return compressionLevel.paramValue;
+    const ZL_LocalIntParams intParams = ZL_Encoder_getLocalIntParams(eictx);
+
+    int level                 = 0;
+    ZL_LzParameters overrides = { 0 };
+
+    for (size_t i = 0; i < intParams.nbIntParams; ++i) {
+        const int value = intParams.intParams[i].paramValue;
+        switch (intParams.intParams[i].paramId) {
+            case ZL_LzParam_compressionLevel:
+                level = value;
+                break;
+            case ZL_LzParam_acceleration:
+                overrides.acceleration = (uint32_t)value;
+                break;
+            case ZL_LzParam_windowLog:
+                overrides.windowLog = (uint32_t)value;
+                break;
+            case ZL_LzParam_strategy:
+                overrides.strategy = (ZL_LzStrategy)value;
+                break;
+            case ZL_LzParam_hashLog1:
+                overrides.hashLog1 = (uint32_t)value;
+                break;
+            case ZL_LzParam_hashLog2:
+                overrides.hashLog2 = (uint32_t)value;
+                break;
+            case ZL_LzParam_hashLength:
+                overrides.hashLength = (uint32_t)value;
+                break;
+            default:
+                continue;
+        }
     }
-}
-
-static int getAcceleration(const ZL_Encoder* eictx)
-{
-    const ZL_IntParam acceleration =
-            ZL_Encoder_getLocalIntParam(eictx, ZL_LzParam_acceleration);
-    if (acceleration.paramId == ZL_LP_INVALID_PARAMID) {
-        const int compressionLevel = getCompressionLevelEncoder(eictx);
-        return compressionLevel < 0 ? -compressionLevel : 1;
-    } else {
-        return ZL_MAX(acceleration.paramValue, 1);
-    }
-}
-
-static uint32_t getWindowLog(const ZL_Encoder* eictx, size_t srcSize)
-{
-    const ZL_IntParam windowLogParam =
-            ZL_Encoder_getLocalIntParam(eictx, ZL_LzParam_windowLog);
-
-    int windowLog = ZL_LZ_MAX_WINDOW_LOG;
-    if (windowLogParam.paramId != ZL_LP_INVALID_PARAMID) {
-        windowLog = windowLogParam.paramValue;
+    if (level == 0) {
+        level = ZL_Encoder_getCParam(eictx, ZL_CParam_compressionLevel);
     }
 
-    windowLog = ZL_MIN(windowLog, ZL_nextPow2(srcSize));
+    ZL_LzParameters params = ZL_LzParameters_default(level, srcSize);
+#define ZL_LZPARAMETERS_OVERRIDE(field)     \
+    do {                                    \
+        if (overrides.field != 0) {         \
+            params.field = overrides.field; \
+        }                                   \
+    } while (0)
+    ZL_LZPARAMETERS_OVERRIDE(strategy);
+    ZL_LZPARAMETERS_OVERRIDE(windowLog);
+    ZL_LZPARAMETERS_OVERRIDE(hashLog1);
+    ZL_LZPARAMETERS_OVERRIDE(hashLog2);
+    ZL_LZPARAMETERS_OVERRIDE(hashLength);
+    ZL_LZPARAMETERS_OVERRIDE(acceleration);
+#undef ZL_LZPARAMETERS_OVERRIDE
 
-    return (uint32_t)ZL_MAX(
-            ZL_LZ_MIN_WINDOW_LOG, ZL_MIN(windowLog, ZL_LZ_MAX_WINDOW_LOG));
+    ZL_LzParameters_adjust(&params, srcSize);
+    return params;
 }
 
 ZL_Report EI_lz(ZL_Encoder* eictx, const ZL_Input* ins[], size_t nbIns)
@@ -192,9 +211,9 @@ ZL_Report EI_lz(ZL_Encoder* eictx, const ZL_Input* ins[], size_t nbIns)
 
     size_t const maxNumSeq = ZL_Lz_maxNumSequences(srcSize);
     // Offsets are up to than 2^windowLog-1; use 32-bits when they won't fit u16
-    const uint32_t windowLog = getWindowLog(eictx, srcSize);
+    const ZL_LzParameters params = getLzParams(eictx, srcSize);
     const size_t offsetEltWidth =
-            (windowLog > 16) ? sizeof(uint32_t) : sizeof(uint16_t);
+            (params.windowLog > 16) ? sizeof(uint32_t) : sizeof(uint16_t);
 
     // Create output streams
     size_t const literalsCapacity = srcSize + ZL_LZ_LIT_OVER_LENGTH;
@@ -213,10 +232,9 @@ ZL_Report EI_lz(ZL_Encoder* eictx, const ZL_Input* ins[], size_t nbIns)
     ZL_ERR_IF_NULL(matchLengths, allocation);
 
     // Allocate hash table from scratch space
-    size_t const hashTableSize =
-            ZS_FastTable_tableSize(ZL_Lz_tableLog(windowLog));
-    void* hashTableMem = ZL_Encoder_getScratchSpace(eictx, hashTableSize);
-    ZL_ERR_IF_NULL(hashTableMem, allocation);
+    size_t const scratchSize = ZL_Lz_scratchBytes(&params);
+    void* scratchMem         = ZL_Encoder_getScratchSpace(eictx, scratchSize);
+    ZL_ERR_IF_NULL(scratchMem, allocation);
 
     ZL_Lz_OutSequences dst = {
         .literals         = (uint8_t*)ZL_Output_ptr(literals),
@@ -235,9 +253,8 @@ ZL_Report EI_lz(ZL_Encoder* eictx, const ZL_Input* ins[], size_t nbIns)
             &dst,
             (const uint8_t*)ZL_Input_ptr(in),
             srcSize,
-            hashTableMem,
-            windowLog,
-            getAcceleration(eictx));
+            scratchMem,
+            &params);
 
     // Write the original size as a varint codec header
     uint8_t header[ZL_VARINT_LENGTH_64];

--- a/src/openzl/codecs/lz/encode_lz_kernel.c
+++ b/src/openzl/codecs/lz/encode_lz_kernel.c
@@ -7,7 +7,7 @@
 #include "openzl/codecs/common/copy.h"
 #include "openzl/codecs/common/fast_table.h"
 #include "openzl/shared/mem.h"
-#include "openzl/shared/simd_wrapper.h"
+#include "openzl/shared/utils.h"
 
 // OpenZL uses uint16_t to emit literal lengths and match lengths so they cannot
 // be longer than UINT16_MAX. In fuzzing build modes, instead limit to a shorter
@@ -19,15 +19,70 @@
 #    define ZL_LZ_MAX_LENGTH UINT16_MAX
 #endif
 
-#define ZL_LZ_HASH_LEN 7
 #define ZL_LZ_DEFAULT_TABLE_LOG 14
 
 #define ZL_LZ_MATCH_OVER_LENGTH 16
 #define ZL_LZ_SEARCH_STRENGTH 8
 
-uint32_t ZL_Lz_tableLog(uint32_t windowLog)
+// clang-format off
+static const ZL_LzParameters kDefaultParams[5] = {
+    /* strategy,                 W, H1, H2, HL, A */
+    { ZL_LzStrategy_fast,       19, 13,  0,  7, 1 }, /* negative levels */
+    { ZL_LzStrategy_fast,       19, 14,  0,  7, 1 }, /* level 1 */
+    { ZL_LzStrategy_fast,       19, 16,  0,  6, 1 }, /* level 2 */
+    { ZL_LzStrategy_doubleFast, 21, 17, 16,  5, 1 }, /* level 3 */
+    { ZL_LzStrategy_doubleFast, 21, 18, 18,  5, 1 }, /* level 4 */
+};
+// clang-format on
+
+ZL_LzParameters ZL_LzParameters_default(int level, size_t srcSize)
 {
-    return ZL_MIN(windowLog + 1, ZL_LZ_DEFAULT_TABLE_LOG);
+    (void)srcSize; // Ignored for now
+
+    const int row = level == 0 ? 1 : ZL_CLAMP(level, 0, 4);
+
+    ZL_LzParameters params = kDefaultParams[row];
+    if (level < 0) {
+        params.acceleration = (uint32_t)-level;
+    }
+    return params;
+}
+
+void ZL_LzParameters_adjust(ZL_LzParameters* params, size_t srcSize)
+{
+#define ZL_LZPARAM_CLAMP(field, macro)          \
+    params->field = ZL_CLAMP(                   \
+            (uint32_t)params->field,            \
+            (uint32_t)ZL_LZPARAM_##macro##_MIN, \
+            (uint32_t)ZL_LZPARAM_##macro##_MAX)
+
+    ZL_LZPARAM_CLAMP(strategy, STRATEGY);
+    ZL_LZPARAM_CLAMP(windowLog, WINDOWLOG);
+    ZL_LZPARAM_CLAMP(hashLog1, HASHLOG1);
+    ZL_LZPARAM_CLAMP(hashLog2, HASHLOG2);
+    ZL_LZPARAM_CLAMP(hashLength, HASHLENGTH);
+    ZL_LZPARAM_CLAMP(acceleration, ACCELERATION);
+
+    // Adjust window log down if necessary
+    {
+        const uint32_t srcLog = (uint32_t)ZL_nextPow2(srcSize);
+        params->windowLog     = ZL_MIN(params->windowLog, srcLog);
+    }
+
+    // Adjust table sizes down if necessary
+    params->hashLog1 = ZL_MIN(params->windowLog + 1, params->hashLog1);
+    params->hashLog2 = ZL_MIN(params->windowLog + 1, params->hashLog2);
+
+    if (params->strategy == ZL_LzStrategy_fast) {
+        // Clear hashLog2 for fast, which doesn't use that table
+        params->hashLog2 = 0;
+    }
+}
+
+size_t ZL_Lz_scratchBytes(const ZL_LzParameters* params)
+{
+    return ZS_FastTable_tableSize(params->hashLog1)
+            + ZS_FastTable_tableSize(params->hashLog2);
 }
 
 // Returns the number of leading equal bytes (0..16) between the two 16-byte
@@ -120,19 +175,76 @@ static ptrdiff_t getMaxOffset(size_t offsetWidth, uint32_t windowLog)
     return ZL_MIN(maxOffset, (ptrdiff_t)(1u << windowLog));
 }
 
+ZL_FORCE_INLINE size_t storeSequence(
+        uint8_t* lits,
+        uint16_t* litLens,
+        uint16_t* matchLens,
+        void* offsets,
+        size_t seq,
+        const uint8_t* litStart,
+        ptrdiff_t ll,
+        ptrdiff_t ml,
+        ptrdiff_t off,
+        size_t offsetWidth)
+{
+    memcpy(lits, litStart, 16);
+    if (ZL_UNLIKELY(ll > 16)) {
+        assert(ZL_LZ_LIT_OVER_LENGTH >= ZS_WILDCOPY_OVERLENGTH);
+        ZS_wildcopy(lits, litStart, (ptrdiff_t)ll, ZS_wo_no_overlap);
+    }
+
+    // Store the sequence
+    if (ZL_LIKELY(ll <= ZL_LZ_MAX_LENGTH)) {
+        litLens[seq] = (uint16_t)ll;
+    } else {
+        // If the literal length is too large, split it into multiple
+        // sequences with match length 0 and offset 1.
+        while (ll > ZL_LZ_MAX_LENGTH) {
+            litLens[seq]   = ZL_LZ_MAX_LENGTH;
+            matchLens[seq] = 0;
+            storeOffset(offsets, offsetWidth, seq, 1);
+            ++seq;
+            ll -= ZL_LZ_MAX_LENGTH;
+        }
+        litLens[seq] = (uint16_t)ll;
+    }
+    if (ZL_LIKELY(ml <= ZL_LZ_MAX_LENGTH)) {
+        matchLens[seq] = (uint16_t)ml;
+        storeOffset(offsets, offsetWidth, seq, off);
+        ++seq;
+    } else {
+        // If the match length is too large, split it into multiple
+        // sequences. The final match length may be < ZL_LZ_MIN_MATCH
+        // but that is okay.
+        ptrdiff_t remainingMatchLength = ml;
+        while (remainingMatchLength > 0) {
+            ptrdiff_t const bounded =
+                    ZL_MIN(remainingMatchLength, ZL_LZ_MAX_LENGTH);
+            // litlens[seq] is already set
+            matchLens[seq] = (uint16_t)bounded;
+            storeOffset(offsets, offsetWidth, seq, off);
+            ++seq;
+
+            remainingMatchLength -= bounded;
+            litLens[seq] = 0;
+        }
+    }
+    return seq;
+}
+
 /**
  * Match finding algorithm that runs the equivalent of the ZSTD_fast strategy.
  *
  * NOTE: This kernel uses ptrdiff_t rather than pointers to avoid UB with
  * pointers, which are only valid within the buffer and one past the end.
  */
-void ZL_Lz_encode(
+ZL_FORCE_INLINE void ZL_Lz_encodeFastImpl(
         ZL_Lz_OutSequences* dst,
         const uint8_t* const src,
         size_t srcSize,
         void* hashTableMem,
-        uint32_t windowLog,
-        int acceleration)
+        const ZL_LzParameters* params,
+        const uint32_t kHashLen)
 {
     if (srcSize == 0) {
         dst->numLiterals  = 0;
@@ -145,9 +257,12 @@ void ZL_Lz_encode(
     assert(dst->offsetWidth == sizeof(uint16_t)
            || dst->offsetWidth == sizeof(uint32_t));
 
-    const uint32_t tableLog = ZL_Lz_tableLog(windowLog);
+    const uint32_t windowLog    = params->windowLog;
+    const uint32_t acceleration = params->acceleration;
+
+    const uint32_t tableLog = params->hashLog1;
     ZS_FastTable table      = { 0, 0, 0 };
-    ZS_FastTable_init(&table, hashTableMem, tableLog, ZL_LZ_HASH_LEN);
+    ZS_FastTable_init(&table, hashTableMem, tableLog, kHashLen);
 
     const ptrdiff_t kSrcOverLength =
             ZL_MAX(ZL_LZ_LIT_OVER_LENGTH, ZL_LZ_MATCH_OVER_LENGTH);
@@ -176,7 +291,7 @@ void ZL_Lz_encode(
     while (inPos <= inLimit) {
         const uint8_t* const inPtr = in + inPos;
         ptrdiff_t match            = ZS_FastTable_getAndUpdateT(
-                &table, inPtr, (uint32_t)inPos, ZL_LZ_HASH_LEN);
+                &table, inPtr, (uint32_t)inPos, kHashLen);
         const ptrdiff_t distance = inPos - match;
         if (ZL_read32(in + match) == ZL_read32(inPtr) && distance < maxOffset) {
             ptrdiff_t ml = 4 + matchLength(in, inPos + 4, match + 4, inEnd);
@@ -189,69 +304,33 @@ void ZL_Lz_encode(
                 ++ml;
             }
 
-            // Copy literals
-            size_t ll = (size_t)(inPos - inLitStart);
+            ptrdiff_t ll = (inPos - inLitStart);
             assert(inPos + ZL_LZ_LIT_OVER_LENGTH <= (ptrdiff_t)srcSize);
-            memcpy(lits, in + inLitStart, 16);
-            if (ZL_UNLIKELY(ll > 16)) {
-                assert(ZL_LZ_LIT_OVER_LENGTH >= ZS_WILDCOPY_OVERLENGTH);
-                ZS_wildcopy(
-                        lits, in + inLitStart, (ptrdiff_t)ll, ZS_wo_no_overlap);
-            }
+            seq = storeSequence(
+                    lits,
+                    litLens,
+                    matchLens,
+                    offsets,
+                    seq,
+                    in + inLitStart,
+                    ll,
+                    ml,
+                    distance,
+                    offsetWidth);
             lits += ll;
-
-            // Store the sequence
-            if (ZL_LIKELY(ll <= ZL_LZ_MAX_LENGTH)) {
-                litLens[seq] = (uint16_t)ll;
-            } else {
-                // If the literal length is too large, split it into multiple
-                // sequences with match length 0 and offset 1.
-                while (ll > ZL_LZ_MAX_LENGTH) {
-                    litLens[seq]   = ZL_LZ_MAX_LENGTH;
-                    matchLens[seq] = 0;
-                    storeOffset(offsets, offsetWidth, seq, 1);
-                    ++seq;
-                    ll -= ZL_LZ_MAX_LENGTH;
-                }
-                litLens[seq] = (uint16_t)ll;
-            }
-            if (ZL_LIKELY(ml <= ZL_LZ_MAX_LENGTH)) {
-                matchLens[seq] = (uint16_t)ml;
-                storeOffset(offsets, offsetWidth, seq, distance);
-                ++seq;
-            } else {
-                // If the match length is too large, split it into multiple
-                // sequences. The final match length may be < ZL_LZ_MIN_MATCH
-                // but that is okay.
-                ptrdiff_t remainingMatchLength = ml;
-                while (remainingMatchLength > 0) {
-                    ptrdiff_t const bounded =
-                            ZL_MIN(remainingMatchLength, ZL_LZ_MAX_LENGTH);
-                    // litlens[seq] is already set
-                    matchLens[seq] = (uint16_t)bounded;
-                    storeOffset(offsets, offsetWidth, seq, distance);
-                    ++seq;
-
-                    remainingMatchLength -= bounded;
-                    litLens[seq] = 0;
-                }
-            }
 
             // Update the hash table with positions at the start and end of the
             // match.
             // NOTE: Taken from zstd_fast.c
             ZS_FastTable_putT(
-                    &table,
-                    in + inPos + 2,
-                    (uint32_t)(inPos + 2),
-                    ZL_LZ_HASH_LEN);
+                    &table, in + inPos + 2, (uint32_t)(inPos + 2), kHashLen);
             inPos += ml;
             if (inPos <= inLimit) {
                 ZS_FastTable_putT(
                         &table,
                         in + inPos - 2,
                         (uint32_t)(inPos - 2),
-                        ZL_LZ_HASH_LEN);
+                        kHashLen);
             }
             inLitStart = inPos;
             step       = firstStep;
@@ -279,4 +358,263 @@ void ZL_Lz_encode(
 
     assert(dst->numLiterals + ZL_LZ_LIT_OVER_LENGTH <= dst->literalsCapacity);
     assert(dst->numSequences <= dst->sequencesCapacity);
+}
+
+#define ZL_LZ_ENCODE_DEFINITION(variant, kHashLen)                  \
+    ZL_FORCE_NOINLINE void ZL_Lz_encode##variant##kHashLen(         \
+            ZL_Lz_OutSequences* dst,                                \
+            const uint8_t* const src,                               \
+            size_t srcSize,                                         \
+            void* hashTableMem,                                     \
+            const ZL_LzParameters* params)                          \
+    {                                                               \
+        ZL_Lz_encode##variant##Impl(                                \
+                dst, src, srcSize, hashTableMem, params, kHashLen); \
+    }
+
+ZL_LZ_ENCODE_DEFINITION(Fast, 4)
+ZL_LZ_ENCODE_DEFINITION(Fast, 5)
+ZL_LZ_ENCODE_DEFINITION(Fast, 6)
+ZL_LZ_ENCODE_DEFINITION(Fast, 7)
+
+static void ZL_Lz_encodeFast(
+        ZL_Lz_OutSequences* dst,
+        const uint8_t* const src,
+        size_t srcSize,
+        void* hashTableMem,
+        const ZL_LzParameters* params)
+{
+    const uint32_t hashLen = params->hashLength;
+    if (hashLen <= 4) {
+        ZL_Lz_encodeFast4(dst, src, srcSize, hashTableMem, params);
+    } else if (hashLen == 5) {
+        ZL_Lz_encodeFast5(dst, src, srcSize, hashTableMem, params);
+    } else if (hashLen == 6) {
+        ZL_Lz_encodeFast6(dst, src, srcSize, hashTableMem, params);
+    } else {
+        ZL_Lz_encodeFast7(dst, src, srcSize, hashTableMem, params);
+    }
+}
+
+/**
+ * Match finding algorithm that runs the equivalent of the ZSTD_dfast
+ * strategy.
+ *
+ * NOTE: This kernel uses ptrdiff_t rather than pointers to avoid UB
+ * with pointers, which are only valid within the buffer and one past
+ * the end.
+ */
+ZL_FORCE_INLINE void ZL_Lz_encodeDoubleFastImpl(
+        ZL_Lz_OutSequences* dst,
+        const uint8_t* const src,
+        size_t srcSize,
+        void* hashTableMem,
+        const ZL_LzParameters* params,
+        const uint32_t kHashLen)
+{
+    if (srcSize == 0) {
+        dst->numLiterals  = 0;
+        dst->numSequences = 0;
+        return;
+    }
+
+    assert(dst->literalsCapacity >= srcSize + ZL_LZ_LIT_OVER_LENGTH);
+    assert(dst->sequencesCapacity >= ZL_Lz_maxNumSequences(srcSize));
+    assert(dst->offsetWidth == sizeof(uint16_t)
+           || dst->offsetWidth == sizeof(uint32_t));
+
+    const uint32_t windowLog    = params->windowLog;
+    const uint32_t acceleration = params->acceleration;
+
+    const uint32_t tableLogL = params->hashLog1;
+    ZS_FastTable tableL      = { 0, 0, 0 };
+    ZS_FastTable_init(&tableL, hashTableMem, tableLogL, 8);
+
+    const uint32_t tableLogS = params->hashLog2;
+    ZS_FastTable tableS      = { 0, 0, 0 };
+    ZS_FastTable_init(
+            &tableS,
+            (char*)hashTableMem + ZS_FastTable_tableSize(tableLogL),
+            tableLogS,
+            kHashLen);
+
+    const ptrdiff_t kSrcOverLength =
+            ZL_MAX(ZL_LZ_LIT_OVER_LENGTH, ZL_LZ_MATCH_OVER_LENGTH);
+
+    const uint8_t* const in = src;
+    const ptrdiff_t inEnd   = (ptrdiff_t)srcSize;
+    ptrdiff_t inLitStart    = 0;
+    ptrdiff_t inPos         = 1;
+    ptrdiff_t inLimit       = (ptrdiff_t)srcSize - kSrcOverLength;
+
+    // Cache output pointers locally to avoid reloading through dst
+    uint8_t* lits             = dst->literals;
+    uint16_t* const litLens   = dst->literalLengths;
+    uint16_t* const matchLens = dst->matchLengths;
+    void* const offsets       = dst->offsets;
+    const size_t offsetWidth  = dst->offsetWidth;
+    const ptrdiff_t maxOffset = getMaxOffset(offsetWidth, windowLog);
+
+    size_t seq = 0;
+
+    const ptrdiff_t kStepIncr = 1 << ZL_LZ_SEARCH_STRENGTH;
+    const ptrdiff_t firstStep = ZL_MAX(acceleration, 1);
+    ptrdiff_t step            = firstStep;
+    ptrdiff_t nextStep        = inPos + kStepIncr;
+
+    for (;;) {
+        ptrdiff_t distance;
+        ptrdiff_t match;
+        ptrdiff_t matchLen;
+        ptrdiff_t inPos1 = inPos + step;
+        while (inPos1 <= inLimit) {
+            const uint8_t* const inPtr = in + inPos;
+            const ptrdiff_t matchL     = ZS_FastTable_getAndUpdateT(
+                    &tableL, inPtr, (uint32_t)inPos, 8);
+            const ptrdiff_t matchS = ZS_FastTable_getAndUpdateT(
+                    &tableS, inPtr, (uint32_t)inPos, kHashLen);
+            const ptrdiff_t distanceL = inPos - matchL;
+            const ptrdiff_t distanceS = inPos - matchS;
+            if (ZL_read64(in + matchL) == ZL_read64(inPtr)
+                && distanceL < maxOffset) {
+                match    = matchL;
+                matchLen = 8 + matchLength(in, inPos + 8, matchL + 8, inEnd);
+                distance = distanceL;
+                break;
+            } else if (
+                    ZL_read32(in + matchS) == ZL_read32(inPtr)
+                    && distanceS < maxOffset) {
+                match    = matchS;
+                matchLen = 4 + matchLength(in, inPos + 4, matchS + 4, inEnd);
+                distance = distanceS;
+
+                // Check for longer match at inPos1
+                const uint8_t* const inPtr1 = in + inPos1;
+                // It is only safe to store this position when step < 4, as we
+                // are guaranteed to skip to at least inPos+4 with matchS.
+                const ptrdiff_t matchL1 = ZS_FastTable_getAndConditionalUpdateT(
+                        &tableL, inPtr1, (uint32_t)inPos1, 8, step < 4);
+                const ptrdiff_t distanceL1 = inPos1 - matchL1;
+                if (ZL_read64(in + matchL1) == ZL_read64(inPtr1)
+                    && distanceL1 < maxOffset) {
+                    const ptrdiff_t matchLenL1 =
+                            8 + matchLength(in, inPos1 + 8, matchL1 + 8, inEnd);
+                    if (matchLenL1 > matchLen) {
+                        // Use the long match instead
+                        inPos    = inPos1;
+                        match    = matchL1;
+                        matchLen = matchLenL1;
+                        distance = distanceL1;
+                    }
+                }
+                break;
+            } else {
+                inPos += step;
+                inPos1 = inPos + step;
+
+                // This logic helps skip over incompressible data quickly by
+                // progresssively speeding up every kStepIncr bytes and
+                // resetting when a match is found.
+                if (inPos >= nextStep) {
+                    ++step;
+                    nextStep += kStepIncr;
+                }
+            }
+        }
+
+        // The search loop only exits without a match when inPos1 passes
+        // inLimit, in which case match, matchLen, & distance are unset.
+        if (inPos1 > inLimit) {
+            break;
+        }
+
+        // Walk the match backwards
+        while (match > 0 && inPos > inLitStart
+               && in[match - 1] == in[inPos - 1]) {
+            --match;
+            --inPos;
+            ++matchLen;
+        }
+
+        ptrdiff_t ll = (inPos - inLitStart);
+        assert(inPos + ZL_LZ_LIT_OVER_LENGTH <= (ptrdiff_t)srcSize);
+        seq = storeSequence(
+                lits,
+                litLens,
+                matchLens,
+                offsets,
+                seq,
+                in + inLitStart,
+                ll,
+                matchLen,
+                distance,
+                offsetWidth);
+        lits += ll;
+
+        // Update the hash table with positions at the start and end of
+        // the match. NOTE: Taken from zstd_double_fast.c
+        ZS_FastTable_putT(&tableL, in + inPos + 2, (uint32_t)(inPos + 2), 8);
+        ZS_FastTable_putT(
+                &tableS, in + inPos + 2, (uint32_t)(inPos + 2), kHashLen);
+        inPos += matchLen;
+        if (inPos <= inLimit) {
+            ZS_FastTable_putT(
+                    &tableL, in + inPos - 2, (uint32_t)(inPos - 2), 8);
+            ZS_FastTable_putT(
+                    &tableS, in + inPos - 2, (uint32_t)(inPos - 2), kHashLen);
+        }
+        inLitStart = inPos;
+        step       = firstStep;
+        nextStep   = inPos + kStepIncr;
+    }
+
+    // Handle trailing literals
+    const size_t lastLits = srcSize - (size_t)inLitStart;
+    memcpy(lits, in + inLitStart, lastLits);
+    lits += lastLits;
+
+    dst->numLiterals  = (size_t)(lits - dst->literals);
+    dst->numSequences = seq;
+
+    assert(dst->numLiterals + ZL_LZ_LIT_OVER_LENGTH <= dst->literalsCapacity);
+    assert(dst->numSequences <= dst->sequencesCapacity);
+}
+
+ZL_LZ_ENCODE_DEFINITION(DoubleFast, 4)
+ZL_LZ_ENCODE_DEFINITION(DoubleFast, 5)
+ZL_LZ_ENCODE_DEFINITION(DoubleFast, 6)
+ZL_LZ_ENCODE_DEFINITION(DoubleFast, 7)
+
+static void ZL_Lz_encodeDoubleFast(
+        ZL_Lz_OutSequences* dst,
+        const uint8_t* const src,
+        size_t srcSize,
+        void* hashTableMem,
+        const ZL_LzParameters* params)
+{
+    const uint32_t hashLen = params->hashLength;
+    if (hashLen <= 4) {
+        ZL_Lz_encodeDoubleFast4(dst, src, srcSize, hashTableMem, params);
+    } else if (hashLen == 5) {
+        ZL_Lz_encodeDoubleFast5(dst, src, srcSize, hashTableMem, params);
+    } else if (hashLen == 6) {
+        ZL_Lz_encodeDoubleFast6(dst, src, srcSize, hashTableMem, params);
+    } else {
+        ZL_Lz_encodeDoubleFast7(dst, src, srcSize, hashTableMem, params);
+    }
+}
+
+void ZL_Lz_encode(
+        ZL_Lz_OutSequences* dst,
+        const uint8_t* const src,
+        size_t srcSize,
+        void* scratch,
+        const ZL_LzParameters* params)
+{
+    if (params->strategy == ZL_LzStrategy_fast) {
+        ZL_Lz_encodeFast(dst, src, srcSize, scratch, params);
+    } else {
+        assert(params->strategy == ZL_LzStrategy_doubleFast);
+        ZL_Lz_encodeDoubleFast(dst, src, srcSize, scratch, params);
+    }
 }

--- a/src/openzl/codecs/lz/encode_lz_kernel.h
+++ b/src/openzl/codecs/lz/encode_lz_kernel.h
@@ -7,6 +7,7 @@
 #include <stdint.h>
 
 #include "openzl/codecs/partition/common_partition.h"
+#include "openzl/codecs/zl_lz.h"
 
 #define ZL_LZ_LIT_OVER_LENGTH 32
 #define ZL_LZ_MIN_MATCH 4
@@ -27,14 +28,33 @@ typedef struct {
     size_t numSequences;
 } ZL_Lz_OutSequences;
 
+typedef struct {
+    ZL_LzStrategy strategy; //< Match finding algorithm to use
+    uint32_t windowLog;     //< Log size of the history window
+    uint32_t hashLog1;      //< Log size of the primary hash table
+    uint32_t hashLog2;      //< Log size of the secondary hash table
+    uint32_t hashLength;    //< Number of source bytes to hash in tables
+    uint32_t acceleration;  //< Only search one in acceleration positions
+} ZL_LzParameters;
+
+/// @returns The default parameters for the @p level and @p srcSize.
+ZL_LzParameters ZL_LzParameters_default(int level, size_t srcSize);
+
+/**
+ * Adjusts @p params to ensure that all parameters sized to compress data of
+ * size @p srcSize.
+ */
+void ZL_LzParameters_adjust(ZL_LzParameters* params, size_t srcSize);
+
 /**
  * Returns the maximum number of sequences that the encoder can produce
  * for an input of srcSize bytes.
  */
 size_t ZL_Lz_maxNumSequences(size_t srcSize);
 
-/// @returns The table log for the given window log.
-uint32_t ZL_Lz_tableLog(uint32_t windowLog);
+/// @returns The amount of scratch space the encoder needs.
+/// @note This memory must be at least 4-byte aligned.
+size_t ZL_Lz_scratchBytes(const ZL_LzParameters* params);
 
 /**
  * Encodes src[0..srcSize) into LZ sequences.
@@ -54,8 +74,7 @@ void ZL_Lz_encode(
         ZL_Lz_OutSequences* dst,
         const uint8_t* src,
         size_t srcSize,
-        void* hashTableMem,
-        uint32_t windowLog,
-        int acceleration);
+        void* scratch,
+        const ZL_LzParameters* params);
 
 #endif

--- a/src/openzl/compress/graph_registry.c
+++ b/src/openzl/compress/graph_registry.c
@@ -168,7 +168,7 @@ const InternalGraphDesc GR_standardGraphs[ZL_PrivateStandardGraphID_end] = {
     REGISTER_SELECTOR(ZL_StandardGraphID_bitpack, "!zl.bitpack", SI_selector_bitpack, ZL_Type_serial | ZL_Type_numeric, 200),
     REGISTER_STATIC_GRAPH(ZL_StandardGraphID_flatpack, "!zl.flatpack", ZL_Type_serial, ZL_PrivateStandardNodeID_flatpack, _2_SUCCESSORS(ZL_PrivateStandardGraphID_serial_store, ZL_PrivateStandardGraphID_serial_store), 200 ),
     REGISTER_DYNAMIC_GRAPH(ZL_StandardGraphID_field_lz, "!zl.field_lz", ZL_Type_struct | ZL_Type_numeric, EI_fieldLzDynGraph, 200),
-    REGISTER_DYNAMIC_GRAPH(ZL_StandardGraphID_lz, "!zl.lz", ZL_Type_serial, EI_lzDynGraph, 200),
+    REGISTER_DYNAMIC_GRAPH(ZL_StandardGraphID_lz, "!zl.lz", ZL_Type_serial, EI_lzDynGraph, 204),
     REGISTER_MIGRAPH(ZL_StandardGraphID_compress_generic, MIGRAPH_COMPRESS, 200),
     REGISTER_SELECTOR(ZL_StandardGraphID_select_generic_lz_backend, "!zl.select_generic_lz_backend", SI_selector_genericLZ, ZL_Type_serial, 200),
     REGISTER_SEGMENTER(ZL_StandardGraphID_segment_numeric, SEGM_NUMERIC_DESC, 200),

--- a/tests/registry/components/Lz.cpp
+++ b/tests/registry/components/Lz.cpp
@@ -24,11 +24,20 @@ class LzComponent : public OpenZLComponent {
     {
         std::vector<NodeID> nodes;
         nodes.push_back(ZL_NODE_LZ);
-        LocalParams params;
-        params.addIntParam(ZL_LzParam_compressionLevel, -2);
-        nodes.push_back(compressor.parameterizeNode(
-                ZL_NODE_LZ,
-                NodeParameters{ .localParams = std::move(params) }));
+        {
+            LocalParams params;
+            params.addIntParam(ZL_LzParam_compressionLevel, -2);
+            nodes.push_back(compressor.parameterizeNode(
+                    ZL_NODE_LZ,
+                    NodeParameters{ .localParams = std::move(params) }));
+        }
+        {
+            LocalParams params;
+            params.addIntParam(ZL_LzParam_compressionLevel, 3);
+            nodes.push_back(compressor.parameterizeNode(
+                    ZL_NODE_LZ,
+                    NodeParameters{ .localParams = std::move(params) }));
+        }
         return nodes;
     }
 
@@ -86,6 +95,15 @@ class LzComponent : public OpenZLComponent {
             maybeSetParam(params, gen, ZL_LzParam_compressionLevel, -10, 10);
             maybeSetParam(params, gen, ZL_LzParam_acceleration, -10, 100);
             maybeSetParam(params, gen, ZL_LzParam_windowLog, 10, 28);
+            maybeSetParam(
+                    params,
+                    gen,
+                    ZL_LzParam_strategy,
+                    ZL_LZPARAM_STRATEGY_MIN,
+                    ZL_LZPARAM_STRATEGY_MAX);
+            maybeSetParam(params, gen, ZL_LzParam_hashLog1, 10, 18);
+            maybeSetParam(params, gen, ZL_LzParam_hashLog2, 10, 18);
+            maybeSetParam(params, gen, ZL_LzParam_hashLength, 4, 7);
 
             maybeOverrideSuccessor(
                     params, successors, gen, ZL_LzParam_literalsGraphIdx);
@@ -168,10 +186,12 @@ class LzComponent : public OpenZLComponent {
             size_t numInputs;
             int compressionLevel;
         };
-        constexpr std::array<Param, 6> kParams = {
+        constexpr std::array<Param, 9> kParams = {
             Param{ 1000, 200, 1 },  Param{ 10000, 50, 1 },
             Param{ 100000, 10, 1 }, Param{ 1000, 200, -1 },
             Param{ 10000, 50, -1 }, Param{ 100000, 10, -1 },
+            Param{ 1000, 200, 3 },  Param{ 10000, 50, 3 },
+            Param{ 100000, 10, 3 },
         };
 
         std::vector<Benchmark> benchmarks;

--- a/tools/training/lz/lz_trainer.cpp
+++ b/tools/training/lz/lz_trainer.cpp
@@ -66,16 +66,19 @@ std::vector<std::string> findLzGraphs(const Compressor& compressor)
 /**
  * @returns The parameters to try for a single LZ backend graph.
  *
- * TODO: This is a placeholder. It sweeps the acceleration, which trades ratio
- * for compression speed, because that is the parameter with the clearest
- * tradeoff. It should also explore the window log and the successor graphs for
- * the literals, offsets and lengths streams. Note that sweeping the
- * compression level is not worthwhile on its own: every level >= 0 currently
- * produces identical output, and a level < 0 is just another way of setting
- * the acceleration.
+ * TODO: Switch to use a genetic algorithm rather than brute force.
+ * We're currently not searching hashLog1 and hashLog2 because it would
+ * expand the search space to be unreasonably large. This is expected to
+ * get the majority of the interesting search space, however.
  */
 std::vector<graphs::Lz::Parameters> candidateParameters()
 {
+    const std::vector<poly::optional<int>> levels = {
+        poly::nullopt, { 1 }, { 2 }, { 3 }, { 4 },
+    };
+    const std::vector<poly::optional<int>> hashLengths = {
+        poly::nullopt, { 4 }, { 5 }, { 6 }, { 7 },
+    };
     const std::vector<poly::optional<int>> accelerations = {
         poly::nullopt, { 2 }, { 3 }, { 5 }, { 7 },
     };
@@ -105,21 +108,29 @@ std::vector<graphs::Lz::Parameters> candidateParameters()
     };
 
     std::vector<graphs::Lz::Parameters> candidates;
-    for (auto acceleration : accelerations) {
-        for (auto windowLog : windowLogs) {
-            for (auto literalsGraph : literalsGraphs) {
-                for (auto offsetsGraph : offsetsGraphs) {
-                    for (auto muxedBytesGraph : muxedBytesGraphs) {
-                        for (auto overflowLengthsGraph :
-                             overflowLengthsGraphs) {
-                            graphs::Lz::Parameters params;
-                            params.nodeParams.acceleration = acceleration;
-                            params.nodeParams.windowLog    = windowLog;
-                            params.literalsGraph           = literalsGraph;
-                            params.offsetsGraph            = offsetsGraph;
-                            params.muxedBytesGraph         = muxedBytesGraph;
-                            params.overflowLengthsGraph = overflowLengthsGraph;
-                            candidates.push_back(std::move(params));
+    for (auto level : levels) {
+        for (auto acceleration : accelerations) {
+            for (auto windowLog : windowLogs) {
+                for (auto hashLength : hashLengths) {
+                    for (auto literalsGraph : literalsGraphs) {
+                        for (auto offsetsGraph : offsetsGraphs) {
+                            for (auto muxedBytesGraph : muxedBytesGraphs) {
+                                for (auto overflowLengthsGraph :
+                                     overflowLengthsGraphs) {
+                                    graphs::Lz::Parameters params;
+                                    params.nodeParams.compressionLevel = level;
+                                    params.nodeParams.acceleration =
+                                            acceleration;
+                                    params.nodeParams.windowLog  = windowLog;
+                                    params.nodeParams.hashLength = hashLength;
+                                    params.literalsGraph   = literalsGraph;
+                                    params.offsetsGraph    = offsetsGraph;
+                                    params.muxedBytesGraph = muxedBytesGraph;
+                                    params.overflowLengthsGraph =
+                                            overflowLengthsGraph;
+                                    candidates.push_back(std::move(params));
+                                }
+                            }
                         }
                     }
                 }


### PR DESCRIPTION
Summary:

* Add doubleFast strategy to match zstd's `ZSTD_dfast`
* Allow tuning more parameters via local int params
* Support compression levels up to 4

The implementation is simple, and I haven't spent time optimizing it. There should be room for improvement. E.g. you can see that OpenZL-LZ level 4 is slower to compress than ZSTD level 4, we can close that gap.

Reviewed By: kevinjzhang

Differential Revision: D116637541


