### PR TITLE
Fix sddl_compiler crash on non-ASCII bytes in source

### DIFF
--- a/tools/sddl/compiler/Logger.h
+++ b/tools/sddl/compiler/Logger.h
@@ -16,6 +16,13 @@ class Logger {
 
     std::ostream& operator()(int level) const;
 
+    /**
+     * Whether a message logged at the given verbosity @p level would be
+     * emitted (i.e. whether `operator()(level)` returns the real output
+     * stream rather than a no-op sink).
+     */
+    bool enabled(int level) const noexcept { return level <= verbosity_; }
+
    private:
     std::ostream& os_;
 

--- a/tools/sddl/compiler/Serializer.cpp
+++ b/tools/sddl/compiler/Serializer.cpp
@@ -2,6 +2,7 @@
 
 #include "tools/sddl/compiler/Serializer.h"
 
+#include <exception>
 #include <iomanip>
 
 #include "openzl/cpp/Compressor.hpp"
@@ -20,8 +21,19 @@ namespace {
 
 void log_json(std::ostream& log, const poly::string_view& ser)
 {
-    const auto json = Compressor::convertSerializedToJson(ser);
-    auto sv         = poly::string_view{ json };
+    std::string json;
+    try {
+        json = Compressor::convertSerializedToJson(ser);
+    } catch (const std::exception& ex) {
+        // The JSON rendering is debug-only output. A source containing
+        // non-ASCII bytes (e.g. in a comment) is embedded verbatim in the
+        // compiled output for error reporting, but cannot be represented as
+        // JSON; that must not abort compilation.
+        log << "<failed to render serialized CBOR as JSON: " << ex.what()
+            << ">" << std::endl;
+        return;
+    }
+    auto sv = poly::string_view{ json };
 
     log << "Serialized JSON:" << std::endl;
 
@@ -128,8 +140,15 @@ std::string Serializer::serialize(const ASTVec& ast, const Source& source) const
                 + A1C_ErrorType_getString(error.type));
     }
 
-    log_json(log_(2), ser);
-    log_serialized(log_(1), ser);
+    // The debug logs below are only produced at sufficiently high verbosity;
+    // don't run the (potentially failing) JSON rendering when they won't be
+    // emitted.
+    if (log_.enabled(2)) {
+        log_json(log_(2), ser);
+    }
+    if (log_.enabled(1)) {
+        log_serialized(log_(1), ser);
+    }
 
     return ser;
 }

--- a/tools/sddl/compiler/tests/CompilerTest.cpp
+++ b/tools/sddl/compiler/tests/CompilerTest.cpp
@@ -81,4 +81,24 @@ TEST_F(CompilerTest, UnaryNegation)
     expect_success(prog);
 }
 
+TEST_F(CompilerTest, NonAsciiByteInSourceDoesNotCrash)
+{
+    // A non-ASCII byte anywhere in the source (comments included) is embedded
+    // verbatim in the compiled output for debug info. Rendering that debug info
+    // as JSON used to throw and abort the compiler because the JSON encoder
+    // rejects bytes >= 0x80; compilation itself must succeed regardless of the
+    // requested verbosity.
+    const auto prog = std::string{ "# caf\xc3\xa9\n: Float32LE[_rem / 4]" };
+    expect_success(prog);
+}
+
+TEST_F(CompilerTest, NonAsciiByteInSourceAtDefaultVerbosityDoesNotCrash)
+{
+    // Same as above, but with the default verbosity (0), which is what the
+    // `sddl_compiler` CLI and the `zli --profile sddl` path use.
+    const auto prog = std::string{ "# caf\xc3\xa9\n: Float32LE[_rem / 4]" };
+    const Compiler compiler{};
+    EXPECT_NO_THROW(compiler.compile(prog, "[local_input]"));
+}
+
 } // namespace openzl::sddl::tests


### PR DESCRIPTION
## What

`sddl_compiler` aborts with SIGABRT (and `zli --profile sddl` exits 1 with a CBOR corruption error) whenever the SDDL1 description contains any non-ASCII byte -- including bytes only inside a `#` comment, and regardless of whether the byte forms valid UTF-8.

```
printf '# cafÃ©
: Float32LE[_rem / 4]
' | sddl_compiler   # rc=134
printf '# cafe
: Float32LE[_rem / 4]
'         | sddl_compiler   # rc=0
```

## Why

The serializer embeds the raw source (comments included) verbatim in the compiled output under the `src` key (`include_debug_info` defaults to true). After encoding, `Serializer::serialize` unconditionally rendered that CBOR as JSON for debug logging via `log_json()` even at the default verbosity (0). The A1CBOR JSON encoder rejects any string byte `>= 0x80` with `A1C_ErrorType_jsonUTF8Unsupported` (`src/openzl/shared/a1cbor.c:1698`). The resulting `openzl::Exception` is not a `CompilerException`, so `main.cpp` does not catch it and the process terminates.

## Fix

- Only run the debug logging when the requested verbosity actually enables it (new `Logger::enabled(int)`), so the default CLI path never performs the JSON rendering at all.
- If the JSON rendering still fails at high verbosity (e.g. `-v -v`), degrade to a one-line warning in the log instead of aborting compilation.

## Verification

- Traced the failing path in real code: `tools/sddl/compiler/Serializer.cpp` (unconditional `log_json`), `openzl/cpp/Compressor.cpp` (`convertSerializedToJson` -> `openzl::unwrap` throws), `src/openzl/common/a1cbor_helpers.c:185`, and `src/openzl/shared/a1cbor.c:1698` (`jsonUTF8Unsupported`).
- Added two regression tests in `tools/sddl/compiler/tests/CompilerTest.cpp`: one compiling a description with a non-ASCII comment at the default verbosity (the reported CLI path), and one at high verbosity (the debug-logging path).
- Full build not run here (Windows/MinGW environment); the changes are limited to the SDDL1 compiler and follow existing `CompilerTest` patterns.