### PR TITLE
Use pointer arithmetic instead of `std::string_view::end()` in `json_extract`

### DIFF
--- a/custom_transforms/json_extract/decode_json_extract.cpp
+++ b/custom_transforms/json_extract/decode_json_extract.cpp
@@ -140,13 +140,14 @@ ZL_Report replaceTokens(
         InStream& strs)
 {
     ZL_RESULT_DECLARE_SCOPE_REPORT(dictx);
-    size_t idx           = 0;
-    uint64_t mask        = bitmask[idx];
-    uint32_t skipped     = 0;
-    char const* tokenEnd = src.data();
+    size_t idx               = 0;
+    uint64_t mask            = bitmask[idx];
+    uint32_t skipped         = 0;
+    char const* tokenEnd     = src.data();
+    char const* const srcEnd = src.data() + src.size();
     char const* fastEnd;
     if (src.size() > 32) {
-        fastEnd = src.end() - 31;
+        fastEnd = srcEnd - 31;
     } else {
         fastEnd = src.data();
     }
@@ -156,8 +157,8 @@ ZL_Report replaceTokens(
             ++idx;
             if (idx == kBitmaskSize) {
                 // Copy the JSON suffix over
-                memcpy(out, tokenEnd, (src.end() - tokenEnd));
-                out += (src.end() - tokenEnd);
+                memcpy(out, tokenEnd, (srcEnd - tokenEnd));
+                out += (srcEnd - tokenEnd);
                 break;
             }
             mask    = bitmask[idx];

--- a/custom_transforms/json_extract/encode_json_extract.cpp
+++ b/custom_transforms/json_extract/encode_json_extract.cpp
@@ -368,14 +368,15 @@ ZL_FORCE_NOINLINE void extractTokens(
         std::string_view src,
         uint64_t const* bitmask)
 {
-    size_t idx           = 0;
-    int64_t mask         = (int64_t)bitmask[idx];
-    uint32_t skipped     = 0;
-    char const* tokenEnd = src.data();
-    Token prev           = Token(0);
+    size_t idx               = 0;
+    int64_t mask             = (int64_t)bitmask[idx];
+    uint32_t skipped         = 0;
+    char const* tokenEnd     = src.data();
+    char const* const srcEnd = src.data() + src.size();
+    Token prev               = Token(0);
     char const* fastEnd;
     if (src.size() > 32) {
-        fastEnd = src.end() - 31;
+        fastEnd = srcEnd - 31;
     } else {
         fastEnd = src.data();
     }
@@ -385,8 +386,7 @@ ZL_FORCE_NOINLINE void extractTokens(
             ++idx;
             if (idx == kBitmaskSize) {
                 // Push the final JSON
-                extracted.pushJson<false>(
-                        std::string_view{ tokenEnd, src.end() });
+                extracted.pushJson<false>(std::string_view{ tokenEnd, srcEnd });
                 goto end;
             }
             mask    = (int64_t)bitmask[idx];
@@ -411,7 +411,7 @@ ZL_FORCE_NOINLINE void extractTokens(
                 extracted.pushJson<false>(std::string_view{ tokenEnd, start });
                 // The token extends to the end of the input
                 dispatchToken<false>(
-                        extracted, std::string_view{ start, src.end() });
+                        extracted, std::string_view{ start, srcEnd });
                 goto end;
             }
             mask    = (int64_t)bitmask[idx];


### PR DESCRIPTION
Summary:
mirrors the change of D117315014 which fixed a build error with libc++:
```
error: assigning to 'const char *' from incompatible type '__wrap_iter<const char *>'
error: invalid operands to binary expression ('const_iterator' (aka '__wrap_iter<const char *>') and 'const char *')
error: no matching constructor for initialization of 'std::string_view'
```

Introduce a `char const* const srcEnd = src.data() + src.size();` local in `replaceTokens()` and `extractTokens()` and use it in place of `src.end()`. This keeps every end-of-input expression in the pointer domain the surrounding code already uses, so it is well-formed under both standard libraries and the generated code is unchanged.

Reviewed By: mmandina

Differential Revision: D118140835


