### PR TITLE
share the ACE training time budget across graphs

### DIFF
--- a/tools/training/ace/ace.cpp
+++ b/tools/training/ace/ace.cpp
@@ -1,6 +1,7 @@
 // Copyright (c) Meta Platforms, Inc. and affiliates.
 
 #include <algorithm>
+#include <chrono>
 #include <memory>
 #include <string_view>
 #include <vector>
@@ -189,18 +190,18 @@ std::vector<ACECompressor> selectAceCandidates(
 }
 
 /// @returns The ACE run configuration described by @p trainParams.
+/// @param maxTime Time budget for this run.
 AutomatedCompressorExplorer::Parameters aceParameters(
         const TrainParams& trainParams,
         uint32_t formatVersion,
-        int compressionLevel)
+        int compressionLevel,
+        poly::optional<std::chrono::seconds> maxTime)
 {
     AutomatedCompressorExplorer::Parameters params{
         .numThreads = trainParams.threads.value_or(
                 std::thread::hardware_concurrency() / 2),
     };
-    if (trainParams.maxTimeSecs.has_value()) {
-        params.maxTime = std::chrono::seconds(*trainParams.maxTimeSecs);
-    }
+    params.maxTime          = maxTime;
     params.formatVersion    = formatVersion;
     params.compressionLevel = compressionLevel;
     return params;
@@ -294,6 +295,14 @@ std::vector<SerializedCompressorInternal> ACETrainer::train(
     MergedParetoFrontier::BackendGraphMutationsMap candidates;
     std::vector<std::unique_ptr<BackendGraphMutation>> checkPointMutations;
 
+    // One budget for the whole phase: each graph builds its own explorer, so
+    // an unshared deadline is spent once per graph.
+    poly::optional<std::chrono::steady_clock::time_point> deadline;
+    if (trainParams.maxTimeSecs.has_value()) {
+        deadline = std::chrono::steady_clock::now()
+                + std::chrono::seconds(*trainParams.maxTimeSecs);
+    }
+
     size_t graphIdx        = 0;
     const size_t numGraphs = autoBackendGraphs.size();
     for (const auto& backendGraph : autoBackendGraphs) {
@@ -331,9 +340,34 @@ std::vector<SerializedCompressorInternal> ACETrainer::train(
             continue;
         }
 
+        // An equal share of what is left, so early graphs cannot drain the
+        // budget. Unused time rolls forward to the graphs after this one.
+        poly::optional<std::chrono::seconds> maxTime;
+        if (deadline.has_value() && !skipTraining_) {
+            // Rounded up: seconds granularity truncates a short remainder away.
+            const auto remaining = std::chrono::ceil<std::chrono::seconds>(
+                    *deadline - std::chrono::steady_clock::now());
+            if (remaining <= std::chrono::seconds(0)) {
+                Logger::log_c(
+                        INFO,
+                        "Stopping ACE training early at graph %zu / %zu. Exceeded max time of %zu s.",
+                        graphIdx,
+                        numGraphs,
+                        *trainParams.maxTimeSecs);
+                break;
+            }
+            const auto graphsLeft = numGraphs - graphIdx + 1;
+            maxTime               = std::chrono::seconds(
+                    std::max<int64_t>(
+                            1,
+                            (remaining.count() + int64_t(graphsLeft) - 1)
+                                    / int64_t(graphsLeft)));
+        }
+
         AutomatedCompressorExplorer ace(
                 flattened,
-                aceParameters(trainParams, formatVersion, compressionLevel));
+                aceParameters(
+                        trainParams, formatVersion, compressionLevel, maxTime));
         if (savedAceState.has_value()) {
             ace.loadPopulation(*savedAceState);
         }

--- a/tools/training/tests/test_ace.cpp
+++ b/tools/training/tests/test_ace.cpp
@@ -1,6 +1,8 @@
 // Copyright (c) Meta Platforms, Inc. and affiliates.
 
 #include <algorithm>
+#include <array>
+#include <chrono>
 #include <numeric>
 #include <random>
 #include <string>
@@ -10,6 +12,7 @@
 
 #include "openzl/cpp/CCtx.hpp"
 #include "openzl/cpp/codecs/ACE.hpp"
+#include "openzl/zl_compressor.h"
 #include "tools/training/ace/ace.h"
 #include "tools/training/ace/ace_compressor.h"
 #include "tools/training/ace/ace_compressors.h"
@@ -48,6 +51,59 @@ std::pair<std::string, std::vector<uint32_t>> tripleDeltaStringData()
         lengths.push_back(uint32_t(s.size()));
     }
     return { std::move(content), std::move(lengths) };
+}
+
+/// Trains @p numGraphs ACE graphs, one per field of a struct input, each graph
+/// seeing @p recordsPerGraph records, under a total budget of @p maxTimeSecs.
+/// @returns How long the whole training call took.
+std::chrono::milliseconds
+timeAceTraining(size_t numGraphs, size_t recordsPerGraph, size_t maxTimeSecs)
+{
+    std::vector<uint64_t> data(numGraphs * recordsPerGraph);
+    std::iota(data.begin(), data.end(), 0);
+    undelta(data);
+
+    std::vector<Input> inputsVec;
+    inputsVec.push_back(
+            Input::refSerial(data.data(), data.size() * sizeof(data[0])));
+    std::vector<MultiInput> multiInputs;
+    multiInputs.emplace_back(std::move(inputsVec));
+
+    auto compressorGenFunc = [](poly::string_view serialized,
+                                poly::string_view bundle = "") {
+        auto compressor = std::make_unique<Compressor>();
+        compressor->deserialize(serialized, bundle);
+        return compressor;
+    };
+
+    Compressor compressor;
+    std::vector<size_t> fieldSizes(numGraphs, sizeof(uint64_t));
+    std::vector<ZL_GraphID> fieldGraphs;
+    fieldGraphs.reserve(numGraphs);
+    for (size_t i = 0; i < numGraphs; ++i) {
+        fieldGraphs.push_back(graphs::ACE()(compressor));
+    }
+    compressor.selectStartingGraph(ZL_Compressor_registerSplitByStructGraph(
+            compressor.get(),
+            fieldSizes.data(),
+            fieldGraphs.data(),
+            fieldSizes.size()));
+    compressor.setParameter(CParam::FormatVersion, ZL_MAX_FORMAT_VERSION);
+
+    TrainParams trainParams = {
+        .compressorGenFunc = compressorGenFunc,
+        .threads           = 1,
+        .maxTimeSecs       = maxTimeSecs,
+    };
+
+    ACETrainer trainer;
+    const auto start = std::chrono::steady_clock::now();
+    auto results =
+            trainer.train(multiInputs, compressor.serialize(), trainParams);
+    const auto elapsed = std::chrono::duration_cast<std::chrono::milliseconds>(
+            std::chrono::steady_clock::now() - start);
+    EXPECT_FALSE(results.empty());
+    return elapsed;
 }
 } // namespace
 
@@ -360,6 +416,31 @@ TEST(ACETrainerTest, NoSaveAceStateProducesSmallerCompressor)
             << "Compressed data sizes should be identical since both come from "
                "the same training run: "
             << compressedWith.size() << " vs " << compressedWithout.size();
+}
+
+TEST(ACETrainerTest, MaxTimeSecsIsSharedAcrossAceGraphs)
+{
+    constexpr size_t kNumGraphs   = 8;
+    constexpr size_t kMaxTimeSecs = 2;
+    // Enough records that a single generation outlasts the budget, so an
+    // unshared budget costs a full generation per graph.
+    constexpr size_t kRecordsPerGraph = 16384;
+
+    // The budget only stops training between generations, and one generation
+    // can outrun it on a slow machine, so a wall-clock bound would flake.
+    // Compare against a one-graph run over the same records per graph instead:
+    // shared, the cost stays near the one-graph cost; unshared, it multiplies
+    // by the graph count.
+    const auto oneGraph = timeAceTraining(1, kRecordsPerGraph, kMaxTimeSecs);
+    const auto allGraphs =
+            timeAceTraining(kNumGraphs, kRecordsPerGraph, kMaxTimeSecs);
+
+    // Half of what an unshared budget would cost.
+    const auto budget = oneGraph * int64_t(kNumGraphs) / 2;
+    EXPECT_LT(allGraphs, budget)
+            << "ACE training over " << kNumGraphs << " graphs took "
+            << allGraphs.count() << "ms, against " << oneGraph.count()
+            << "ms for one graph, for a budget of " << kMaxTimeSecs << "s";
 }
 
 } // namespace tests


### PR DESCRIPTION
Fixes #930.

`--max-time-secs` is documented as "a duration limit to how long training will run for", but ACE applies it once per graph. `ACETrainer::train` constructs a new `AutomatedCompressorExplorer` inside the loop over ACE graphs, and `GeneticAlgorithm` sets its deadline in its constructor, so every graph starts the clock again. the csv profile builds 15 ACE graphs, so a 120 s budget buys 15 budgets rather than one.

this computes one deadline before the loop and gives each graph an equal share of what is left, `remaining / graphs_left`, rounded up so a short remainder is not truncated away. whatever a graph does not use rolls forward to the ones after it. if the deadline has already passed the remaining graphs are skipped with a log line, the same way graphs with no training samples are skipped today.

an earlier version of this gave each graph everything that was left instead of an equal share. it respected the budget but starved the later graphs, and the trained compressor came out 41% bigger, so that is not what is here.

measured on macOS arm64, 8 cores, three csv samples totalling 25 MB, `zli train --profile csv samples/ -o out.zlc --max-time-secs 120 -f`, three runs each:

| | wall | trained compressor on s1.csv |
| --- | --- | --- |
| main `74ec918` | 514 / 733 / 789 s | 470,748 / 470,667 / 472,512 B |
| this pr | 242 / 251 / 255 s | 486,270 / 498,166 / 489,237 B |

median 733 s to 251 s, output 3.5% larger. all six compressors round trip clean. the 3.5% is the cost of stopping when asked, main was buying it with roughly 3x the time the flag allows. the fixed runs are also stable at 242 to 255 s, where main ranges 514 to 789 s because its total is however long fifteen independent budgets happen to take.

what this does not fix: the run is still about 2x the budget. `train_cluster` is handed `maxTimeSecs` separately and starts its own clock, so one flag still funds two phases. that changes how the budget should be divided between clustering and ACE, which felt like your call rather than mine. happy to send a follow up if you want it.

test: `ACETrainerTest.MaxTimeSecsIsSharedAcrossAceGraphs` splits an input into 8 fields, each with its own ACE graph, and gives training a 2 s budget. on main it takes 16.4 s and fails, with this change it takes 2.2 s, and the bound is 8 s so neither side is close to flaking. it runs under `ctest` through `cmake-ci.yml`. worth knowing that `make gtests` does not build `tools/training/tests` at all, `TRAINING_TEST_CXXOBJS` is defined in the Makefile and never referenced, so `make test` will not pick it up.

`test_training` is 87/87 with this change. `ACETest.CompressesAtAllFormatVersions` and `ACETrainerTest.NoSaveAceStateProducesSmallerCompressor` also fail on unmodified main here, 3 failures across 6 baseline runs, so they are pre-existing flakes and not from this change. `cli_train_tests.py` ran 8, ok, 3 skipped for the missing `openzl.ext` module.
