### PR TITLE
Add --max-num-candidates flag to limit number of trained candidates

### DIFF
--- a/cli/args/TrainArgs.h
+++ b/cli/args/TrainArgs.h
@@ -133,6 +133,12 @@ class TrainArgs : public GlobalArgs, public ProfileArgs {
                 true,
                 "Target format version for training. If not provided, defaults "
                 "to the maximum supported format version.");
+        parser.addCommandFlag(
+                cmd(),
+                kMaxNumCandidates,
+                0,
+                true,
+                "Maximum number of trained candidates to produce when --pareto-frontier is set");
     }
 
     explicit TrainArgs(const arg::ParsedArgs& parsed)
@@ -220,6 +226,15 @@ class TrainArgs : public GlobalArgs, public ProfileArgs {
         if (parsed.cmdHasFlag(cmd(), kParetoFrontier)) {
             trainParams.paretoFrontier = true;
         }
+        auto maxNumCandidates = parsed.cmdFlag(cmd(), kMaxNumCandidates);
+        if (maxNumCandidates) {
+            trainParams.maxNumCandidates =
+                    util::checkedstoul(maxNumCandidates.value());
+            if (trainParams.maxNumCandidates < 10) {
+                throw InvalidArgsException(
+                        "Must set --max-num-candidates to at least 10");
+            }
+        }
 
         trainParams.noAceSuccessors =
                 parsed.cmdHasFlag(cmd(), kNoAceSuccessors);
@@ -280,18 +295,19 @@ class TrainArgs : public GlobalArgs, public ProfileArgs {
     inline static const std::string kDictBundleOutput = "dict-bundle-output";
 
     // Train Params
-    inline static const std::string kTrainer         = "trainer";
-    inline static const std::string kThreads         = "threads";
-    inline static const std::string kNumSamples      = "num-samples";
-    inline static const std::string kUseAllSamples   = "use-all-samples";
-    inline static const std::string kNoAceSuccessors = "no-ace-successors";
-    inline static const std::string kNoClustering    = "no-clustering";
-    inline static const std::string kMaxTimeSecs     = "max-time-secs";
-    inline static const std::string kMaxFileSizeMb   = "max-file-size-mb";
-    inline static const std::string kMaxTotalSizeMb  = "max-total-size-mb";
-    inline static const std::string kParetoFrontier  = "pareto-frontier";
-    inline static const std::string kSaveAceState    = "save-ace-state";
-    inline static const std::string kFormatVersion   = "format-version";
+    inline static const std::string kTrainer          = "trainer";
+    inline static const std::string kThreads          = "threads";
+    inline static const std::string kNumSamples       = "num-samples";
+    inline static const std::string kUseAllSamples    = "use-all-samples";
+    inline static const std::string kNoAceSuccessors  = "no-ace-successors";
+    inline static const std::string kNoClustering     = "no-clustering";
+    inline static const std::string kMaxTimeSecs      = "max-time-secs";
+    inline static const std::string kMaxFileSizeMb    = "max-file-size-mb";
+    inline static const std::string kMaxTotalSizeMb   = "max-total-size-mb";
+    inline static const std::string kParetoFrontier   = "pareto-frontier";
+    inline static const std::string kSaveAceState     = "save-ace-state";
+    inline static const std::string kFormatVersion    = "format-version";
+    inline static const std::string kMaxNumCandidates = "max-num-candidates";
 };
 
 } // namespace openzl::cli

--- a/tools/training/ace/ace.cpp
+++ b/tools/training/ace/ace.cpp
@@ -351,7 +351,7 @@ std::vector<SerializedCompressorInternal> ACETrainer::train(
             applyMutations(makeCompressor, checkPointMutations).serialize());
 
     MergedParetoFrontier frontier(
-            makeCompressor, std::move(candidates), inputs, trainParams.threads);
+            makeCompressor, std::move(candidates), inputs, trainParams);
     return frontier.paretoFrontier();
 }
 

--- a/tools/training/lz/lz_trainer.cpp
+++ b/tools/training/lz/lz_trainer.cpp
@@ -200,7 +200,7 @@ void LzTrainer::train(
             std::move(makeCompressor),
             std::move(candidates),
             inputs,
-            trainParams.threads);
+            trainParams);
 }
 
 std::vector<SerializedCompressorInternal> LzTrainer::paretoFrontier() const

--- a/tools/training/tests/test_pareto_combination.cpp
+++ b/tools/training/tests/test_pareto_combination.cpp
@@ -365,7 +365,7 @@ TEST_F(MergedParetoFrontierTest, KeepsOnlyParetoOptimalCandidates)
             [this] { return makeCompressor(); },
             makeCandidates({ 1, 19 }),
             inputs,
-            uint32_t(1));
+            TrainParams{ .threads = 1 });
 
     // A higher zstd level is smaller but slower, so at most both survive
     ASSERT_FALSE(frontier.selections().empty());
@@ -398,7 +398,7 @@ TEST_F(MergedParetoFrontierTest, BenchmarksCandidatesOnMultipleThreads)
             [this] { return makeCompressor(); },
             makeCandidates({ 1, 3, 6, 9, 12, 15, 19 }),
             inputs,
-            uint32_t(4));
+            TrainParams{ .threads = 4 });
 
     ASSERT_FALSE(frontier.selections().empty());
     auto compressors = frontier.paretoFrontier();
@@ -425,7 +425,7 @@ TEST_F(MergedParetoFrontierTest, BenchmarksTheReplacementGraph)
             [this] { return makeCompressor(); },
             std::move(candidates),
             inputs,
-            uint32_t(1));
+            TrainParams{ .threads = 1 });
 
     // Each candidate must be measured as the graph it installs, not as the
     // graph it replaces: storing and compressing cannot look alike.
@@ -442,7 +442,10 @@ TEST_F(MergedParetoFrontierTest, UnmutatedWhenThereAreNoCandidates)
     auto inputs     = makeInputs(data);
 
     MergedParetoFrontier frontier(
-            [this] { return makeCompressor(); }, {}, inputs, uint32_t(1));
+            [this] { return makeCompressor(); },
+            {},
+            inputs,
+            TrainParams{ .threads = 1 });
 
     ASSERT_EQ(frontier.selections().size(), 1u);
     EXPECT_TRUE(frontier.selections()[0].choices().empty());

--- a/tools/training/train_params.h
+++ b/tools/training/train_params.h
@@ -35,6 +35,10 @@ struct TrainParams {
     poly::optional<size_t> maxTotalSizeMb;
     bool paretoFrontier{ false };
     bool saveAceState{ false };
+    /// Prune down to to this number of candidates.
+    /// NOTE: This currently only prunes per-trainer, because we don't currently
+    /// have a final pareto-optimal filtering step for all candidates.
+    poly::optional<size_t> maxNumCandidates;
 };
 
 } // namespace openzl::training

--- a/tools/training/utils/BUCK
+++ b/tools/training/utils/BUCK
@@ -85,6 +85,7 @@ cpp_library(
     headers = relative_headers(["pareto_combination.h"]),
     header_namespace = "",
     exported_deps = [
+        "..:train_common",
         "../..:logger",
         "../../../cpp:openzl_cpp",
         "../sample_collection:sample_collection",

--- a/tools/training/utils/pareto_combination.cpp
+++ b/tools/training/utils/pareto_combination.cpp
@@ -19,10 +19,10 @@ namespace training {
 using namespace openzl::tools::logger;
 
 namespace {
+const size_t kDefaultNumFinalParetoCandidates = 100;
 
 // TODO: Make these hyperparameters training args
 const size_t kNumIntermediateFrontierCandidates = 1000;
-const size_t kNumFinalParetoCandidates          = 100;
 
 /**
  * Merges 2 vectors of candidates getting all combinations. Then filters out
@@ -186,21 +186,23 @@ MergedParetoFrontier::MergedParetoFrontier(
         std::function<Compressor()> makeCompressor,
         BackendGraphMutationsMap candidates,
         poly::span<const MultiInput> inputs,
-        poly::optional<uint32_t> threads)
+        const TrainParams& params)
         : makeCompressor_(std::move(makeCompressor)),
           candidates_(std::move(candidates))
 {
     ThreadPool threadPool(
             std::max<size_t>(
                     1,
-                    threads.value_or(std::thread::hardware_concurrency() / 2)));
+                    params.threads.value_or(
+                            std::thread::hardware_concurrency() / 2)));
 
     auto selections = getBackendGraphSelections(
             makeCompressor_, candidates_, inputs, threadPool);
 
-    auto frontier = combineCandidates(selections, threadPool);
-    paretoFrontier_ =
-            pruneCandidates(std::move(frontier), kNumFinalParetoCandidates);
+    auto frontier   = combineCandidates(selections, threadPool);
+    paretoFrontier_ = pruneCandidates(
+            std::move(frontier),
+            params.maxNumCandidates.value_or(kDefaultNumFinalParetoCandidates));
     std::sort(paretoFrontier_.begin(), paretoFrontier_.end());
     if (paretoFrontier_.empty()) {
         paretoFrontier_.emplace_back();

--- a/tools/training/utils/pareto_combination.h
+++ b/tools/training/utils/pareto_combination.h
@@ -13,6 +13,7 @@
 #include "openzl/cpp/poly/Optional.hpp"
 #include "openzl/cpp/poly/Span.hpp"
 
+#include "tools/training/train_params.h"
 #include "tools/training/utils/benchmark.h"
 #include "tools/training/utils/mutation.h"
 #include "tools/training/utils/serialized_compressor_internal.h"
@@ -129,14 +130,12 @@ class MergedParetoFrontier {
      * backend graph name.
      * @param inputs The samples to benchmark on. These are the inputs to the
      * whole compressor, not to the individual backend graphs.
-     * @param threads The number of threads to use, defaults to half the
-     * hardware concurrency.
      */
     MergedParetoFrontier(
             std::function<Compressor()> makeCompressor,
             BackendGraphMutationsMap candidates,
             poly::span<const MultiInput> inputs,
-            poly::optional<uint32_t> threads = poly::nullopt);
+            const TrainParams& params);
 
     std::vector<SerializedCompressorInternal> paretoFrontier() const;
 


### PR DESCRIPTION
Summary:
The trainer defaults to producing 100 candidates. This is too many to reason about. Add the `--max-num-candidates` flag to reduce that number of candidates.

This diff intentionally leaves the default at 100, so it is a no-op when the flag is not passed, so it can be safely grafted to prod.

Differential Revision: D118504854


