### PR TITLE
Use Transformer for high-level SAO compression (#994)

### DIFF
--- a/cli/args/ArgsUtils.cpp
+++ b/cli/args/ArgsUtils.cpp
@@ -43,6 +43,7 @@ std::unique_ptr<Compressor> createCompressorFromArgs(
                 "Both compressor profile and serialized compressor specified. Please provide only one.");
     }
 
+    std::unique_ptr<Compressor> compressor;
     if (profileArgs.name()) {
         if (profileArgs.chunkSize()) {
             const auto profileName = profileArgs.name().value();
@@ -55,18 +56,25 @@ std::unique_ptr<Compressor> createCompressorFromArgs(
                                 + "' does not support --chunk-size; ignoring the flag.");
             }
         }
-        return util::createCompressorFromProfile(profileArgs);
-    }
-
-    if (compressorPath) {
+        compressor = util::createCompressorFromProfile(profileArgs);
+    } else if (compressorPath) {
         auto compressorInput =
                 std::make_shared<tools::io::InputFile>(compressorPath.value());
-        return custom_parsers::createCompressorFromSerialized(
+        compressor = custom_parsers::createCompressorFromSerialized(
                 compressorInput->contents(), bundleData);
+    } else {
+        throw InvalidArgsException(
+                "No compressor profile or serialized compressor specified.");
     }
 
-    throw InvalidArgsException(
-            "No compressor profile or serialized compressor specified.");
+    /* Apply the command-line level after profile creation so it overrides the
+     * profile's compression level. */
+    if (profileArgs.requestedCompressionLevel()) {
+        compressor->setParameter(
+                CParam::CompressionLevel,
+                profileArgs.requestedCompressionLevel().value());
+    }
+    return compressor;
 }
 } // namespace cli
 } // namespace openzl

--- a/cli/args/BenchmarkArgs.h
+++ b/cli/args/BenchmarkArgs.h
@@ -72,6 +72,11 @@ struct BenchmarkArgs : public GlobalArgs, public ProfileArgs {
             tools::io::InputFile bundleInput(dictBundlePath.value());
             dictBundleData = bundleInput.contents();
         }
+        auto levelArg = parsed.cmdFlag(cmd(), kLevel);
+        if (levelArg) {
+            level = util::checkedstoiExact(levelArg.value());
+            setRequestedCompressionLevel(level.value());
+        }
         setCompressor(createCompressorFromArgs(
                 *this, parsed.cmdFlag(cmd(), kCompressor), dictBundleData));
         auto inputPath = parsed.cmdPositional(Cmd::BENCHMARK, kInput);
@@ -86,10 +91,6 @@ struct BenchmarkArgs : public GlobalArgs, public ProfileArgs {
         if (outputCsvPath) {
             outputCsv = std::make_unique<tools::io::OutputFile>(
                     std::move(outputCsvPath).value());
-        }
-        auto levelArg = parsed.cmdFlag(cmd(), kLevel);
-        if (levelArg) {
-            level = util::checkedstoiExact(levelArg.value());
         }
         auto numItersArg = parsed.cmdFlag(cmd(), kNumIters);
         if (numItersArg) {

--- a/cli/args/CompressArgs.h
+++ b/cli/args/CompressArgs.h
@@ -111,13 +111,13 @@ struct CompressArgs : public GlobalArgs, public ProfileArgs {
             dictBundleData = bundleInput.contents();
         }
         setVerbosityLevel(verbosity);
-        setCompressor(createCompressorFromArgs(
-                *this, parsed.cmdFlag(cmd(), kCompressor), dictBundleData));
-
         const auto levelArg = parsed.cmdFlag(cmd(), kLevel);
         if (levelArg) {
             compressionLevel = util::checkedstoiExact(levelArg.value());
+            setRequestedCompressionLevel(compressionLevel.value());
         }
+        setCompressor(createCompressorFromArgs(
+                *this, parsed.cmdFlag(cmd(), kCompressor), dictBundleData));
 
         // Get the input and output files
         auto inputPath = parsed.cmdPositional(cmd(), kInput);

--- a/cli/tests/BUCK
+++ b/cli/tests/BUCK
@@ -272,6 +272,20 @@ custom_unittest(
 )
 
 custom_unittest(
+    name = "sao_compression_level_test",
+    command = [
+        "$(location :integration_test_bin)",
+        "$(location ..:zli)",
+        "CompressionLevelTest.test_sao_compression_level",
+    ],
+    type = "simple",
+    deps = [
+        "..:zli",
+        ":integration_test_bin",
+    ],
+)
+
+custom_unittest(
     name = "serial_segmentation_default_test",
     command = [
         "$(location :integration_test_bin)",

--- a/cli/tests/cli_integration_tests.py
+++ b/cli/tests/cli_integration_tests.py
@@ -452,13 +452,15 @@ class CompressionLevelTest(unittest.TestCase):
         level: int,
         extra_args: str = "",
         output_suffix: str = "",
+        input_path: str | None = None,
     ) -> str:
+        source_path = input_path or self.input_path
         compressed_path = os.path.join(
             self.tmpdir, f"{profile}-level-{level}{output_suffix}.zl"
         )
         decompressed_path = compressed_path + ".rt"
         execute_compress(
-            file_to_compress_path=self.input_path,
+            file_to_compress_path=source_path,
             compressor_info=CompressorInfo(
                 compressor_str=profile,
                 compressor_type=CompressorType.PROFILE,
@@ -470,7 +472,7 @@ class CompressionLevelTest(unittest.TestCase):
             compressed_file_path=compressed_path,
             decompressed_file_path=decompressed_path,
         )
-        self.assertTrue(file_contents_match(self.input_path, decompressed_path))
+        self.assertTrue(file_contents_match(source_path, decompressed_path))
         return compressed_path
 
     def test_compression_level(self) -> None:
@@ -500,6 +502,49 @@ class CompressionLevelTest(unittest.TestCase):
             ),
             0,
         )
+
+    def _write_sao_file(self) -> str:
+        sao_path = os.path.join(self.tmpdir, "sao.bin")
+        with open(sao_path, "wb") as sao_file:
+            sao_file.write(bytes(28))
+            for i in range(16384):
+                sao_file.write(
+                    struct.pack(
+                        "<dd2shff",
+                        i / 8192.0,
+                        (i % 4096) / 2048.0 - 1.0,
+                        (b"G2", b"K1", b"M0")[i % 3],
+                        (i % 3000) - 1500,
+                        (i % 1024) / 1024.0,
+                        -((i % 2048) / 2048.0),
+                    )
+                )
+        return sao_path
+
+    @staticmethod
+    def _trace_uses_transformer(trace_path: str) -> bool:
+        with open(trace_path, "rb") as trace_file:
+            # CBOR text strings retain their UTF-8 representation in the trace.
+            return b"zl.private.transformer_" in trace_file.read()
+
+    def test_sao_compression_level(self) -> None:
+        sao_path = self._write_sao_file()
+        level_6_trace = os.path.join(self.tmpdir, "sao-level-6.trace")
+        level_7_trace = os.path.join(self.tmpdir, "sao-level-7.trace")
+        self._compress_and_round_trip(
+            "sao",
+            6,
+            extra_args=f"--trace {level_6_trace} --no-stream-preview",
+            input_path=sao_path,
+        )
+        self._compress_and_round_trip(
+            "sao",
+            7,
+            extra_args=f"--trace {level_7_trace} --no-stream-preview",
+            input_path=sao_path,
+        )
+        self.assertFalse(self._trace_uses_transformer(level_6_trace))
+        self.assertTrue(self._trace_uses_transformer(level_7_trace))
 
 
 class SerialSegmentationTest(unittest.TestCase):

--- a/cli/utils/compress_profiles.cpp
+++ b/cli/utils/compress_profiles.cpp
@@ -69,9 +69,58 @@ ProfileArgs::ProfileArgs(const arg::ParsedArgs& parsed)
 }
 
 namespace {
-ZL_GraphID saoProfile(Compressor& compressor)
+std::array<ZL_GraphID, 6> saoTransformerFieldGraphs(Compressor& compressor)
 {
-    compressor.setParameter(CParam::CompressionLevel, 1);
+    ZL_GraphID const numeric =
+            nodes::ConvertStructToNumLE()(compressor, ZL_GRAPH_NUMERIC);
+    /* Each field needs a distinct ACE wrapper so it can be trained
+     * independently, even though their initial graphs are identical. */
+    return {
+        graphs::ACE(numeric)(compressor), graphs::ACE(numeric)(compressor),
+        graphs::ACE(numeric)(compressor), graphs::ACE(numeric)(compressor),
+        graphs::ACE(numeric)(compressor), graphs::ACE(numeric)(compressor)
+    };
+}
+
+std::array<ZL_GraphID, 6> saoTunedFieldGraphs(Compressor& compressor)
+{
+    ZL_GraphID const sra0 = graphs::ACE(
+            nodes::ConvertStructToNumLE()(
+                    compressor,
+                    nodes::DeltaInt()(
+                            compressor, graphs::FieldLz()(compressor))))(
+            compressor);
+    ZL_GraphID const sdec0 = graphs::ACE(
+            nodes::TransposeSplit()(compressor, graphs::Zstd()(compressor)))(
+            compressor);
+    ZL_GraphID const tokenCompress = nodes::TokenizeStruct()(
+            compressor,
+            graphs::FieldLz()(compressor),
+            graphs::FieldLz()(compressor));
+    ZL_GraphID const numHuffman = nodes::ConvertStructToNumLE()(
+            compressor,
+            nodes::TokenizeNumeric(/* sort */ false)(
+                    compressor,
+                    graphs::Huffman()(compressor),
+                    graphs::Huffman()(compressor)));
+
+    ZL_GraphID const is   = graphs::ACE(numHuffman)(compressor);
+    ZL_GraphID const mag  = graphs::ACE(numHuffman)(compressor);
+    ZL_GraphID const xrpm = graphs::ACE(tokenCompress)(compressor);
+    ZL_GraphID const xdpm = graphs::ACE(tokenCompress)(compressor);
+    return { sra0, sdec0, is, mag, xrpm, xdpm };
+}
+
+ZL_GraphID saoProfile(Compressor& compressor, const ProfileArgs& args)
+{
+    /* This currently matches the Standard Numeric Selector rollout threshold,
+     * ensuring the high-level SAO branch reaches Transformer. Reevaluate the
+     * relationship if either rollout policy changes. */
+    constexpr int kTransformerMinCompressionLevel = 7;
+    /* Preserve SAO's historical level-1 default when no level was requested;
+     * an explicit CLI level remains authoritative. */
+    int const compressionLevel = args.requestedCompressionLevel().value_or(1);
+    compressor.setParameter(CParam::CompressionLevel, compressionLevel);
     /* The SAO format consists of a header,
      * which is 28 bytes for the dirSilesia/sao sample specifically,
      * followed by an array of structures, each one describing a star.
@@ -101,34 +150,11 @@ ZL_GraphID saoProfile(Compressor& compressor)
      * Real*4 XRPM      R.A. proper motion (radians per year)
      * Real*4 XDPM      Dec. proper motion (radians per year)
      */
-    ZL_GraphID sra0 = graphs::ACE(
-            nodes::ConvertStructToNumLE()(
-                    compressor,
-                    nodes::DeltaInt()(
-                            compressor, graphs::FieldLz()(compressor))))(
-            compressor);
-    ZL_GraphID sdec0 = graphs::ACE(
-            nodes::TransposeSplit()(compressor, graphs::Zstd()(compressor)))(
-            compressor);
-    ZL_GraphID token_compress = nodes::TokenizeStruct()(
-            compressor,
-            graphs::FieldLz()(compressor),
-            graphs::FieldLz()(compressor));
-    ZL_GraphID num_huffman = nodes::ConvertStructToNumLE()(
-            compressor,
-            nodes::TokenizeNumeric(/* sort */ false)(
-                    compressor,
-                    graphs::Huffman()(compressor),
-                    graphs::Huffman()(compressor)));
-
-    ZL_GraphID is   = graphs::ACE(num_huffman)(compressor);
-    ZL_GraphID mag  = graphs::ACE(num_huffman)(compressor);
-    ZL_GraphID xrpm = graphs::ACE(token_compress)(compressor);
-    ZL_GraphID xdpm = graphs::ACE(token_compress)(compressor);
-
-    const std::array<size_t, 6> fieldSizes      = { 8, 8, 2, 2, 4, 4 };
-    const std::array<ZL_GraphID, 6> fieldGraphs = { sra0, sdec0, is,
-                                                    mag,  xrpm,  xdpm };
+    std::array<size_t, 6> const fieldSizes = { 8, 8, 2, 2, 4, 4 };
+    std::array<ZL_GraphID, 6> const fieldGraphs =
+            compressionLevel >= kTransformerMinCompressionLevel
+            ? saoTransformerFieldGraphs(compressor)
+            : saoTunedFieldGraphs(compressor);
 
     ZL_GraphID splitStructure = ZL_Compressor_registerSplitByStructGraph(
             compressor.get(),
@@ -505,9 +531,9 @@ compressProfiles()
         mp[kSAOName]         = std::make_shared<CompressProfile>(
                 kSAOName,
                 "SAO format from the Silesia corpus",
-                [](ZL_Compressor* comp, void*, const ProfileArgs&) {
+                [](ZL_Compressor* comp, void*, const ProfileArgs& args) {
                     CompressorRef compressor(comp);
-                    return saoProfile(compressor);
+                    return saoProfile(compressor, args);
                 });
 
         std::string kGenericNumericName = "numeric-ml-selector-64";

--- a/cli/utils/compress_profiles.h
+++ b/cli/utils/compress_profiles.h
@@ -33,6 +33,16 @@ class ProfileArgs {
         return chunkSize_;
     }
 
+    const poly::optional<int>& requestedCompressionLevel() const
+    {
+        return requestedCompressionLevel_;
+    }
+
+    void setRequestedCompressionLevel(int compressionLevel)
+    {
+        requestedCompressionLevel_ = compressionLevel;
+    }
+
     const poly::optional<std::string>& name() const
     {
         return name_;
@@ -75,6 +85,7 @@ class ProfileArgs {
 
     poly::optional<std::string> name_;
     poly::optional<size_t> chunkSize_;
+    poly::optional<int> requestedCompressionLevel_;
     int verbosityLevel_{ 3 };
     // Arbitrary (K,V) arguments provided on the command line.
     std::map<std::string, std::string> argmap_;


### PR DESCRIPTION
Summary:

Make the requested CLI compression level available while constructing profiles, then apply it again after profile construction so explicit user settings win over profile defaults.

At levels below 7, the `sao` profile retains its existing hand-tuned ACE defaults. At level 7 and above, its six trained numeric fields use `ConvertStructToNumLE` followed by `ZL_GRAPH_NUMERIC` as their ACE defaults, allowing ordinary compression and inline training to exercise the Compression Transformer.

Differential Revision: D118906042
