### PR TITLE
Make the openzl `Logger` update line friendly to non-TTYs

### DIFF
--- a/tools/logger/CMakeLists.txt
+++ b/tools/logger/CMakeLists.txt
@@ -9,4 +9,16 @@ set_property(TARGET logger PROPERTY POSITION_INDEPENDENT_CODE ON)
 
 target_include_directories(logger PUBLIC ${PROJECT_SOURCE_DIR})
 apply_openzl_compile_options_to_target(logger)
+
+if (OPENZL_BUILD_TESTS)
+    add_executable(test_logger
+        ${CMAKE_CURRENT_LIST_DIR}/tests/LoggerTest.cpp)
+    target_link_libraries(test_logger
+        PRIVATE
+            logger
+            GTest::gtest_main
+    )
+    apply_openzl_compile_options_to_target(test_logger)
+    gtest_discover_tests(test_logger)
+endif()
 endif()

--- a/tools/logger/Logger.cpp
+++ b/tools/logger/Logger.cpp
@@ -3,15 +3,67 @@
 #include "Logger.h"
 #include <cstdlib>
 
+#if defined(_WIN32)
+#    include <io.h> // @manual
+#else
+#    include <unistd.h>
+#endif
+
 namespace openzl::tools::logger {
+
+bool Logger::stderrIsTTY()
+{
+#if defined(_WIN32)
+    return _isatty(_fileno(stderr)) != 0;
+#else
+    return isatty(fileno(stderr)) != 0;
+#endif
+}
 
 bool Logger::shouldLog(LogLevel level)
 {
     return static_cast<int>(level) <= instance().global_verbosity;
 }
 
+void Logger::updateLine(const std::string& message)
+{
+    auto& logger = instance();
+    if (logger.previous_update_message == message) {
+        return;
+    }
+    logger.previous_update_message = message;
+
+    if (logger.is_tty) {
+        // Return to the beginning of the line, overwrite it, then clear
+        // whatever the previous message left behind.
+        fprintf(stderr, "\r%s%s", message.c_str(), CLEAR_TO_EOL);
+    } else {
+        // Terminal control sequences are meaningless in a file or a pipe, so
+        // emit each distinct message as its own line instead.
+        fprintf(stderr, "%s\n", message.c_str());
+    }
+
+    fflush(stderr);
+}
+
+void Logger::finalizeUpdateLine()
+{
+    auto& logger = instance();
+    if (logger.is_tty) {
+        fprintf(stderr, "\n");
+    }
+    // Non-TTY update lines are already newline terminated.
+    logger.previous_update_message.reset();
+}
+
 void Logger::clearLine()
 {
+    auto& logger = instance();
+    if (!logger.is_tty) {
+        // The line cannot be taken back once written to a file or a pipe.
+        return;
+    }
+    logger.previous_update_message.reset();
     fprintf(stderr, "\r");
     for (int i = 0; i < PADDING_SIZE; ++i) {
         fprintf(stderr, " ");
@@ -34,12 +86,15 @@ void Logger::finalizeProgressIfActive()
 
 void Logger::reprintProgressIfActive()
 {
-    if (instance().progress_line_active
-        && shouldLog(instance().progress_level)) {
+    auto& logger = instance();
+    if (!logger.is_tty) {
+        // clearLine() left the progress line alone, so re-printing it would
+        // only duplicate it.
+        return;
+    }
+    if (logger.progress_line_active && shouldLog(logger.progress_level)) {
         // Re-print the stored progress message
-        update(instance().progress_level,
-               "%s",
-               instance().progress_message.c_str());
+        update(logger.progress_level, "%s", logger.progress_message.c_str());
     }
 }
 

--- a/tools/logger/Logger.h
+++ b/tools/logger/Logger.h
@@ -4,6 +4,7 @@
 
 #include <cstdio>
 #include <iostream>
+#include <optional>
 #include <ostream>
 #include <stdexcept>
 #include <string>
@@ -62,13 +63,28 @@ class Logger {
         return global_verbosity;
     }
 
+    /**
+     * Overrides the auto-detected TTY status of stderr. Exposed for tests, so
+     * that they can exercise both the TTY and the non-TTY code paths.
+     */
+    void setIsTTY(bool isTTY)
+    {
+        is_tty = isTTY;
+        previous_update_message.reset();
+    }
+    bool isTTY() const
+    {
+        return is_tty;
+    }
+
    private:
     Logger()
             : global_verbosity(INFO),
               progress_line_active(false),
               progress_level(INFO),
               progress_value(0.0),
-              progress_message("")
+              progress_message(""),
+              is_tty(stderrIsTTY())
     {
     }
     Logger(const Logger&)            = delete;
@@ -83,6 +99,31 @@ class Logger {
     static void log_inner(std::ostream& os, const Arg& arg, const Args&... args)
     {
         log_inner(os << arg, args...);
+    }
+
+    template <typename... Args>
+    static std::string formatToString(const char* format, const Args&... args)
+    {
+        if (format == nullptr || format[0] == '\0') {
+            return {};
+        }
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wformat-nonliteral"
+#pragma GCC diagnostic ignored "-Wformat-security"
+        const int required_size = snprintf(nullptr, 0, format, args...);
+        if (required_size <= 0) {
+            return {};
+        }
+        std::vector<char> buffer(required_size + 1); // +1 for null terminator
+        snprintf(buffer.data(), buffer.size(), format, args...);
+#pragma GCC diagnostic pop
+        return std::string(buffer.data(), (size_t)required_size);
+    }
+
+    // Number of '=' cells the bar shows for this progress value.
+    static constexpr int progressBarFilled(double progress)
+    {
+        return (int)(progress * progressBarWidth);
     }
 
    public:
@@ -107,11 +148,7 @@ class Logger {
 
         finalizeProgressIfActive();
 
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wformat-nonliteral"
-        fprintf(stderr, format, args...);
-        fprintf(stderr, "\n");
-#pragma GCC diagnostic pop
+        fprintf(stderr, "%s\n", formatToString(format, args...).c_str());
 
         reprintProgressIfActive();
     }
@@ -124,21 +161,7 @@ class Logger {
             return;
         }
 
-        // Move to beginning of line
-        // TODO remove control characters when printing to non-tty
-        fprintf(stderr, "\r");
-
-        // Print the formatted message
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wformat-nonliteral"
-        fprintf(stderr, format, args...);
-#pragma GCC diagnostic pop
-
-        // Clear to end of line to remove any remaining characters
-        // TODO remove control characters when printing to non-tty
-        fprintf(stderr, "%s", CLEAR_TO_EOL);
-
-        fflush(stderr);
+        updateLine(formatToString(format, args...));
     }
 
     template <typename... Args>
@@ -158,6 +181,15 @@ class Logger {
                     + std::to_string(progress) + ".");
         }
 
+        // On a non-TTY every redraw costs a whole new line, so wait until the
+        // bar gains or loses an '=' before spending one. A TTY redraws the
+        // line in place, so there it is not worth withholding an update.
+        const int filled = progressBarFilled(progress);
+        if (!instance().is_tty && instance().progress_line_active
+            && filled == progressBarFilled(instance().progress_value)) {
+            return;
+        }
+
         instance().progress_line_active = true;
 
         // Store current progress information for re-printing
@@ -165,22 +197,9 @@ class Logger {
         instance().progress_value = progress;
 
         // Build the user message part
-        std::string userMsg;
-        if (format && format[0] != '\0') {
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wformat-nonliteral"
-            int required_size = snprintf(nullptr, 0, format, args...);
-            if (required_size > 0) {
-                std::vector<char> buffer(
-                        required_size + 1); // +1 for null terminator
-                snprintf(buffer.data(), buffer.size(), format, args...);
-                userMsg = std::string(buffer.data());
-            }
-#pragma GCC diagnostic pop
-        }
+        const std::string userMsg = formatToString(format, args...);
 
         // Build the progress message
-        int filled = (int)(progress * progressBarWidth);
         char progressBar[progressBarWidth + 3]; // progressBarWidth + 2 for ends
                                                 // + 1 for null terminator
         progressBar[0] = '[';
@@ -202,8 +221,7 @@ class Logger {
             return;
         }
 
-        // Add newline
-        fprintf(stderr, "\n");
+        finalizeUpdateLine();
     }
 
     // Finalize an UPDATE line by adding a newline
@@ -211,6 +229,7 @@ class Logger {
     {
         finalizeUpdate(level);
         instance().progress_line_active = false;
+        instance().progress_value       = 0.0;
     }
 
    private:
@@ -219,7 +238,17 @@ class Logger {
 
     static constexpr int PADDING_SIZE = 80;
 
+    // The last message written by update(), or nullopt if the update line has
+    // since been cleared or finalized. Repeating a message is a no-op, which
+    // keeps non-TTY output free of duplicated progress lines.
+    std::optional<std::string> previous_update_message;
+    bool is_tty;
+
+    static bool stderrIsTTY();
+
     static bool shouldLog(LogLevel level);
+    static void updateLine(const std::string& message);
+    static void finalizeUpdateLine();
     static void clearLine();
     static void finalizeProgressIfActive();
     static void reprintProgressIfActive();

--- a/tools/logger/tests/BUCK
+++ b/tools/logger/tests/BUCK
@@ -1,0 +1,13 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+
+load("../../../defs.bzl", "zs_unittest")
+
+oncall("data_compression")
+
+zs_unittest(
+    name = "logger_test",
+    srcs = ["LoggerTest.cpp"],
+    deps = [
+        "../..:logger",
+    ],
+)

--- a/tools/logger/tests/LoggerTest.cpp
+++ b/tools/logger/tests/LoggerTest.cpp
@@ -1,0 +1,377 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#include <gtest/gtest.h>
+
+#include <algorithm>
+#include <string>
+
+#include "tools/logger/Logger.h"
+
+using namespace openzl::tools::logger;
+
+namespace {
+
+constexpr const char* kClearToEol = "\033[K";
+
+// Progress expressed in bar cells, so that these tests do not depend on the
+// value of progressBarWidth. Starting from 0.5 -- an exact cell boundary --
+// half a cell forward cannot change the bar, and one and a half cells forward
+// must advance it by exactly one.
+constexpr double kHalfCell = 0.5 / progressBarWidth;
+
+class LoggerTest : public ::testing::Test {
+   protected:
+    void SetUp() override
+    {
+        setIsTTY(false);
+        ::testing::internal::CaptureStderr();
+    }
+
+    void TearDown() override
+    {
+        // Leave nothing captured behind, even if the test failed early.
+        (void)::testing::internal::GetCapturedStderr();
+    }
+
+    void setIsTTY(bool isTTY)
+    {
+        auto& logger = Logger::instance();
+        logger.setGlobalLoggerVerbosity(INFO);
+        logger.progress_line_active = false;
+        logger.progress_value       = 0.0;
+        // Also resets the remembered update message.
+        logger.setIsTTY(isTTY);
+        isTTY_ = isTTY;
+    }
+
+    std::string captured()
+    {
+        std::string output = ::testing::internal::GetCapturedStderr();
+        ::testing::internal::CaptureStderr();
+        return output;
+    }
+
+    static size_t countBarCells(const std::string& output)
+    {
+        return (size_t)std::count(output.begin(), output.end(), '=');
+    }
+
+    // The bytes update() is expected to emit for a message it decides to print.
+    std::string updateOutput(const std::string& message) const
+    {
+        if (isTTY_) {
+            return "\r" + message + kClearToEol;
+        }
+        return message + "\n";
+    }
+
+    void checkUpdateWritesTheMessage()
+    {
+        Logger::update(INFO, "hello %d", 42);
+
+        EXPECT_EQ(captured(), updateOutput("hello 42"));
+    }
+
+    void checkRepeatedUpdateIsNotRewritten()
+    {
+        Logger::update(INFO, "same message");
+        EXPECT_EQ(captured(), updateOutput("same message"));
+
+        Logger::update(INFO, "same message");
+        EXPECT_EQ(captured(), "");
+    }
+
+    void checkRepeatedUpdateComparesTheFormattedMessage()
+    {
+        Logger::update(INFO, "progress: %d%%", 10);
+        EXPECT_EQ(captured(), updateOutput("progress: 10%"));
+
+        // Same format string, different result: must be written.
+        Logger::update(INFO, "progress: %d%%", 20);
+        EXPECT_EQ(captured(), updateOutput("progress: 20%"));
+
+        // Different format string, same result: must not be written.
+        Logger::update(INFO, "%s", "progress: 20%");
+        EXPECT_EQ(captured(), "");
+    }
+
+    void checkUpdateIsWrittenAgainAfterFinalize()
+    {
+        Logger::update(INFO, "message");
+        EXPECT_EQ(captured(), updateOutput("message"));
+
+        Logger::finalizeUpdate(INFO);
+        // A non-TTY update line is already newline terminated.
+        EXPECT_EQ(captured(), isTTY_ ? "\n" : "");
+
+        Logger::update(INFO, "message");
+        EXPECT_EQ(captured(), updateOutput("message"));
+    }
+
+   private:
+    bool isTTY_{ false };
+};
+
+TEST_F(LoggerTest, UpdateWritesTheMessageOnTTY)
+{
+    setIsTTY(true);
+    checkUpdateWritesTheMessage();
+}
+
+TEST_F(LoggerTest, UpdateWritesTheMessageOnNonTTY)
+{
+    setIsTTY(false);
+    checkUpdateWritesTheMessage();
+}
+
+TEST_F(LoggerTest, RepeatedUpdateIsNotRewrittenOnTTY)
+{
+    setIsTTY(true);
+    checkRepeatedUpdateIsNotRewritten();
+}
+
+TEST_F(LoggerTest, RepeatedUpdateIsNotRewrittenOnNonTTY)
+{
+    setIsTTY(false);
+    checkRepeatedUpdateIsNotRewritten();
+}
+
+TEST_F(LoggerTest, RepeatedUpdateComparesTheFormattedMessageOnTTY)
+{
+    setIsTTY(true);
+    checkRepeatedUpdateComparesTheFormattedMessage();
+}
+
+TEST_F(LoggerTest, RepeatedUpdateComparesTheFormattedMessageOnNonTTY)
+{
+    setIsTTY(false);
+    checkRepeatedUpdateComparesTheFormattedMessage();
+}
+
+TEST_F(LoggerTest, UpdateIsWrittenAgainAfterFinalizeOnTTY)
+{
+    setIsTTY(true);
+    checkUpdateIsWrittenAgainAfterFinalize();
+}
+
+TEST_F(LoggerTest, UpdateIsWrittenAgainAfterFinalizeOnNonTTY)
+{
+    setIsTTY(false);
+    checkUpdateIsWrittenAgainAfterFinalize();
+}
+
+TEST_F(LoggerTest, LogCWritesTheFormattedLine)
+{
+    Logger::log_c(INFO, "value %d and %s", 7, "text");
+
+    EXPECT_EQ(captured(), "value 7 and text\n");
+}
+
+TEST_F(LoggerTest, LogCWithEmptyFormatWritesOnlyANewline)
+{
+    Logger::log_c(INFO, "");
+
+    EXPECT_EQ(captured(), "\n");
+}
+
+TEST_F(LoggerTest, LogCBelowVerbosityWritesNothing)
+{
+    Logger::instance().setGlobalLoggerVerbosity(WARNINGS);
+
+    Logger::log_c(INFO, "invisible");
+
+    EXPECT_EQ(captured(), "");
+}
+
+TEST_F(LoggerTest, LogCRedrawsTheProgressLineOnTTY)
+{
+    setIsTTY(true);
+
+    Logger::logProgress(INFO, 0.5, "working");
+    const std::string progressMessage = Logger::instance().progress_message;
+    ASSERT_EQ(captured(), updateOutput(progressMessage));
+
+    Logger::log_c(INFO, "a %s line", "log");
+    const std::string output = captured();
+
+    EXPECT_NE(output.find("a log line\n"), std::string::npos);
+    EXPECT_NE(output.find(updateOutput(progressMessage)), std::string::npos);
+
+    Logger::finalizeProgress(INFO);
+}
+
+TEST_F(LoggerTest, UpdateBelowVerbosityWritesNothing)
+{
+    Logger::instance().setGlobalLoggerVerbosity(WARNINGS);
+
+    Logger::update(INFO, "invisible");
+
+    EXPECT_EQ(captured(), "");
+}
+
+// A log line wipes out the progress line on a TTY, so the progress line has to
+// be re-drawn even though its message is unchanged.
+TEST_F(LoggerTest, ProgressIsReprintedAfterLogClearsTheLineOnTTY)
+{
+    setIsTTY(true);
+
+    Logger::logProgress(INFO, 0.5, "working");
+    const std::string progressMessage = Logger::instance().progress_message;
+    ASSERT_EQ(captured(), updateOutput(progressMessage));
+
+    Logger::log(INFO, "a log line");
+    const std::string output = captured();
+
+    EXPECT_NE(output.find("a log line\n"), std::string::npos);
+    EXPECT_NE(output.find(updateOutput(progressMessage)), std::string::npos);
+
+    Logger::finalizeProgress(INFO);
+}
+
+// On a non-TTY the progress line was never wiped out, so re-printing it would
+// only duplicate it.
+TEST_F(LoggerTest, ProgressIsNotReprintedAfterLogOnNonTTY)
+{
+    setIsTTY(false);
+
+    Logger::logProgress(INFO, 0.5, "working");
+    const std::string progressMessage = Logger::instance().progress_message;
+    ASSERT_EQ(captured(), updateOutput(progressMessage));
+
+    Logger::log(INFO, "a log line");
+
+    EXPECT_EQ(captured(), "a log line\n");
+
+    Logger::finalizeProgress(INFO);
+}
+
+// Same as above, but with the remembered update message cleared in between, so
+// that the suppression cannot come from update()'s deduplication.
+TEST_F(LoggerTest, ProgressIsNotReprintedAfterLogOnNonTTYWhenNotDeduplicated)
+{
+    setIsTTY(false);
+
+    Logger::logProgress(INFO, 0.5, "working");
+    ASSERT_EQ(captured(), updateOutput(Logger::instance().progress_message));
+
+    // Forgets the previous message, but leaves the progress line active.
+    Logger::finalizeUpdate(INFO);
+    ASSERT_EQ(captured(), "");
+    ASSERT_TRUE(Logger::instance().progress_line_active);
+
+    Logger::log(INFO, "a log line");
+
+    EXPECT_EQ(captured(), "a log line\n");
+
+    Logger::finalizeProgress(INFO);
+}
+
+// The message differs on every call, so the only thing that can suppress the
+// middle write is the bar itself being unchanged -- which also means a message
+// change that does not move the bar is dropped along with it.
+TEST_F(LoggerTest, LogProgressSkipsRedrawWhileTheBarIsUnchangedOnNonTTY)
+{
+    setIsTTY(false);
+
+    Logger::logProgress(INFO, 0.5, "step %d", 1);
+    const std::string atBoundary = captured();
+    ASSERT_NE(atBoundary.find("step 1"), std::string::npos);
+
+    // Still inside the same cell, where a redraw would cost a whole new line.
+    Logger::logProgress(INFO, 0.5 + kHalfCell, "step %d", 2);
+    EXPECT_EQ(captured(), "");
+
+    // One cell further along: the bar gains an '=' and must be redrawn.
+    Logger::logProgress(INFO, 0.5 + 3 * kHalfCell, "step %d", 3);
+    const std::string nextCell = captured();
+    EXPECT_NE(nextCell.find("step 3"), std::string::npos);
+    EXPECT_EQ(countBarCells(nextCell), countBarCells(atBoundary) + 1);
+
+    Logger::finalizeProgress(INFO);
+}
+
+// A TTY redraws the line in place, so a new message is shown immediately even
+// though the bar has not moved.
+TEST_F(LoggerTest, LogProgressRedrawsWithinTheSameBarCellOnTTY)
+{
+    setIsTTY(true);
+
+    Logger::logProgress(INFO, 0.5, "step %d", 1);
+    const std::string atBoundary = captured();
+    ASSERT_NE(atBoundary.find("step 1"), std::string::npos);
+
+    Logger::logProgress(INFO, 0.5 + kHalfCell, "step %d", 2);
+    const std::string sameCell = captured();
+    EXPECT_NE(sameCell.find("step 2"), std::string::npos);
+    EXPECT_EQ(countBarCells(sameCell), countBarCells(atBoundary));
+
+    // An identical repeat is still suppressed, by update()'s deduplication.
+    Logger::logProgress(INFO, 0.5 + kHalfCell, "step %d", 2);
+    EXPECT_EQ(captured(), "");
+
+    Logger::finalizeProgress(INFO);
+}
+
+// The skip only applies while a progress line is active, so a new one starting
+// at the same value still draws.
+TEST_F(LoggerTest, LogProgressDrawsTheSameBarAgainAfterFinalize)
+{
+    setIsTTY(false);
+
+    Logger::logProgress(INFO, 0.5, "working");
+    const std::string first = captured();
+    ASSERT_FALSE(first.empty());
+
+    Logger::finalizeProgress(INFO);
+    ASSERT_EQ(captured(), "");
+
+    Logger::logProgress(INFO, 0.5, "working");
+
+    EXPECT_EQ(captured(), first);
+}
+
+// A finished progress line leaves no stale progress behind.
+TEST_F(LoggerTest, FinalizeProgressResetsTheProgressValue)
+{
+    Logger::logProgress(INFO, 0.5, "working");
+    ASSERT_DOUBLE_EQ(Logger::instance().progress_value, 0.5);
+    ASSERT_TRUE(Logger::instance().progress_line_active);
+
+    Logger::finalizeProgress(INFO);
+
+    EXPECT_DOUBLE_EQ(Logger::instance().progress_value, 0.0);
+    EXPECT_FALSE(Logger::instance().progress_line_active);
+}
+
+// The reset is unconditional, so a progress line that was never drawn because
+// of the verbosity level does not leave a value behind either.
+TEST_F(LoggerTest, FinalizeProgressResetsTheProgressValueBelowVerbosity)
+{
+    Logger::logProgress(INFO, 0.5, "working");
+    ASSERT_DOUBLE_EQ(Logger::instance().progress_value, 0.5);
+
+    Logger::instance().setGlobalLoggerVerbosity(WARNINGS);
+    Logger::finalizeProgress(INFO);
+
+    EXPECT_DOUBLE_EQ(Logger::instance().progress_value, 0.0);
+    EXPECT_FALSE(Logger::instance().progress_line_active);
+}
+
+// Non-TTY output must not contain carriage returns or ANSI escapes, including
+// the space padding used to clear the progress line.
+TEST_F(LoggerTest, NonTTYOutputHasNoTerminalControlSequences)
+{
+    setIsTTY(false);
+
+    Logger::logProgress(INFO, 0.25, "step %d", 1);
+    Logger::log(INFO, "a log line");
+    Logger::logProgress(INFO, 0.75, "step %d", 2);
+    Logger::finalizeProgress(INFO);
+    const std::string output = captured();
+
+    EXPECT_EQ(output.find('\r'), std::string::npos);
+    EXPECT_EQ(output.find('\033'), std::string::npos);
+    EXPECT_EQ(output.find("  "), std::string::npos);
+}
+
+} // namespace


### PR DESCRIPTION
Summary:
`Logger::update()` always wrote the ANSI sequences that redraw a progress line
in place: `\r` before the message, `ESC[K` after. In a file or a CI log those
are just noise, and repainting an unchanged progress bar duplicated the line.

`update()` now skips the write entirely when the formatted message matches the
previous one, and emits no control characters on a non-TTY — terminating each
message with a newline instead, so a piped log gets one line per distinct
message. `finalizeUpdate()` correspondingly suppresses its own newline there.

`logProgress()` throttles on the bar itself: on a non-TTY it skips the redraw
until the bar gains or loses an `=`, so a slow job costs one line per visible
step rather than one per call. A TTY redraws in place, so it is left alone.
`finalizeProgress()` also clears `progress_value`, leaving no stale progress
behind.

`clearLine()` and `reprintProgressIfActive()` are no-ops on a non-TTY too,
where a written line cannot be taken back and re-printing only duplicates it.

TTY status comes from `isatty(fileno(stderr))`, with an MSVC branch matching
the `_MSC_VER` handling in `portability.h`. `Logger::setIsTTY()` overrides it
so tests can drive both paths.

Deduplicating on the message meant `update()` had to build a `std::string`, so
the `snprintf`-twice formatting `logProgress()` open-coded became a shared
`formatToString()`. `log_c()` routes through it as well, leaving one place in
the file that handles a non-literal format string.

Differential Revision: D119233297


