### PR TITLE
Add the transformer as a backend in trainer

### DIFF
--- a/cpp/include/openzl/cpp/Codecs.hpp
+++ b/cpp/include/openzl/cpp/Codecs.hpp
@@ -38,6 +38,7 @@
 #include "openzl/cpp/codecs/SplitByStruct.hpp"    // IWYU pragma: export
 #include "openzl/cpp/codecs/Store.hpp"            // IWYU pragma: export
 #include "openzl/cpp/codecs/Tokenize.hpp"         // IWYU pragma: export
+#include "openzl/cpp/codecs/Transformer.hpp"      // IWYU pragma: export
 #include "openzl/cpp/codecs/Transpose.hpp"        // IWYU pragma: export
 #include "openzl/cpp/codecs/Zigzag.hpp"           // IWYU pragma: export
 #include "openzl/cpp/codecs/Zstd.hpp"             // IWYU pragma: export

--- a/cpp/include/openzl/cpp/codecs/Transformer.hpp
+++ b/cpp/include/openzl/cpp/codecs/Transformer.hpp
@@ -1,0 +1,26 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#pragma once
+
+#include "openzl/codecs/zl_transformer.h"
+#include "openzl/cpp/Compressor.hpp"
+#include "openzl/cpp/codecs/Graph.hpp"
+#include "openzl/cpp/codecs/Metadata.hpp"
+
+namespace openzl {
+namespace graphs {
+
+class TransformerNumeric : public SimpleGraph<TransformerNumeric> {
+   public:
+    static constexpr GraphID graph = ZL_GRAPH_TRANSFORMER_NUMERIC;
+
+    static constexpr GraphMetadata<1> metadata = {
+        .inputs = { InputMetadata{ .typeMask = TypeMask::Numeric } },
+        .lastInputIsVariable = true,
+        .description =
+                "Compress each numeric input by using a pretrained model to select the chain of transforms to apply",
+    };
+};
+
+} // namespace graphs
+} // namespace openzl

--- a/include/openzl/codecs/zl_transformer.h
+++ b/include/openzl/codecs/zl_transformer.h
@@ -1,0 +1,33 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#ifndef ZSTRONG_CODECS_TRANSFORMER_H
+#define ZSTRONG_CODECS_TRANSFORMER_H
+
+#include "openzl/zl_graphs.h"
+#include "openzl/zl_opaque_types.h"
+
+#if defined(__cplusplus)
+extern "C" {
+#endif
+
+/**
+ * Compresses numeric data by using a pretrained model to pick the next
+ * transform to apply. Each input is handled independently: the model builds a
+ * transform chain for it one decision at a time, re-consulting itself on the
+ * transform's outputs. When the model cannot be consulted, e.g. because the
+ * chain has grown too deep, a static heuristic selector takes over.
+ *
+ * Transforms that aren't available in the requested format version are skipped
+ * in favor of the best-scoring supported alternative, so this graph works with
+ * every supported format version.
+ *
+ * Inputs: One or more numeric streams of width 1, 2, 4, or 8.
+ */
+#define ZL_GRAPH_TRANSFORMER_NUMERIC \
+    ZL_MAKE_GRAPH_ID(ZL_StandardGraphID_transformer_numeric)
+
+#if defined(__cplusplus)
+}
+#endif
+
+#endif

--- a/include/openzl/zl_graphs.h
+++ b/include/openzl/zl_graphs.h
@@ -47,6 +47,8 @@ typedef enum {
 
     ZL_StandardGraphID_segment_serial,
 
+    ZL_StandardGraphID_transformer_numeric,
+
     ZL_StandardGraphID_public_end // last id, used to detect end of public
                                   // range
 } ZL_StandardGraphID;

--- a/include/openzl/zl_public_nodes.h
+++ b/include/openzl/zl_public_nodes.h
@@ -46,6 +46,7 @@
 #include "openzl/codecs/zl_split_by_struct.h"      // IWYU pragma: export
 #include "openzl/codecs/zl_store.h"                // IWYU pragma: export
 #include "openzl/codecs/zl_tokenize.h"             // IWYU pragma: export
+#include "openzl/codecs/zl_transformer.h"          // IWYU pragma: export
 #include "openzl/codecs/zl_transpose.h"            // IWYU pragma: export
 #include "openzl/codecs/zl_zigzag.h"               // IWYU pragma: export
 #include "openzl/codecs/zl_zstd.h"                 // IWYU pragma: export

--- a/src/openzl/compress/graph_registry.c
+++ b/src/openzl/compress/graph_registry.c
@@ -152,7 +152,7 @@
         },                                                                \
     }
 
-/* First library version recognizing the Transformer-specific private graphs. */
+/* First library version recognizing the Transformer graphs. */
 #define TRANSFORMER_NUMERIC_MIN_LIBRARY_VERSION 205
 
 // clang-format off
@@ -186,6 +186,7 @@ const InternalGraphDesc GR_standardGraphs[ZL_PrivateStandardGraphID_end] = {
     REGISTER_SEGMENTER(ZL_StandardGraphID_segment_num64_from_serial, SEGM_NUM_FROM_SERIAL_DESC(8, 64, ZL_PrivateStandardGraphID_interpret_num64_compress), 200),
     REGISTER_SEGMENTER(ZL_StandardGraphID_segment_serial, SEGM_SERIAL_DESC, 200),
     REGISTER_SELECTOR(ZL_StandardGraphID_select_numeric, "!zl.select_numeric", SI_selector_numeric, ZL_Type_numeric, 200),
+    REGISTER_MIGRAPH(ZL_StandardGraphID_transformer_numeric, MIGRAPH_TRANSFORMER_NUMERIC, TRANSFORMER_NUMERIC_MIN_LIBRARY_VERSION),
     REGISTER_MIGRAPH(ZL_StandardGraphID_clustering, MIGRAPH_CLUSTERING, 200),
     REGISTER_DYNAMIC_GRAPH(ZL_StandardGraphID_simple_data_description_language, "!zl.sddl", ZL_Type_serial, ZL_SDDL_dynGraph, 200),
     REGISTER_SEGMENTER(ZL_StandardGraphID_simple_data_description_language_v2, SEGM_SDDL2_DESC, 200),
@@ -251,12 +252,12 @@ const InternalGraphDesc GR_standardGraphs[ZL_PrivateStandardGraphID_end] = {
      * Each composition has its own ID because selectors return registered
      * graphs rather than parameterized graph descriptors.
      */
-    REGISTER_STATIC_GRAPH(ZL_PrivateStandardGraphID_transformer_delta_int, "!zl.private.transformer_delta_int", ZL_Type_numeric, ZL_StandardNodeID_delta_int, _1_SUCCESSOR(ZL_PrivateStandardGraphID_transformer_numeric), TRANSFORMER_NUMERIC_MIN_LIBRARY_VERSION),
-    REGISTER_STATIC_GRAPH(ZL_PrivateStandardGraphID_transformer_range_pack, "!zl.private.transformer_range_pack", ZL_Type_numeric, ZL_StandardNodeID_range_pack, _1_SUCCESSOR(ZL_PrivateStandardGraphID_transformer_numeric), TRANSFORMER_NUMERIC_MIN_LIBRARY_VERSION),
-    REGISTER_STATIC_GRAPH(ZL_PrivateStandardGraphID_transformer_divide_by_gcd, "!zl.private.transformer_divide_by_gcd", ZL_Type_numeric, ZL_StandardNodeID_divide_by, _1_SUCCESSOR(ZL_PrivateStandardGraphID_transformer_numeric), TRANSFORMER_NUMERIC_MIN_LIBRARY_VERSION),
-    REGISTER_STATIC_GRAPH(ZL_PrivateStandardGraphID_transformer_tokenize_numeric, "!zl.private.transformer_tokenize_numeric", ZL_Type_numeric, ZL_StandardNodeID_tokenize_numeric, _2_SUCCESSORS(ZL_PrivateStandardGraphID_transformer_numeric, ZL_PrivateStandardGraphID_transformer_numeric), TRANSFORMER_NUMERIC_MIN_LIBRARY_VERSION),
-    REGISTER_STATIC_GRAPH(ZL_PrivateStandardGraphID_transformer_tokenize_numeric_sorted, "!zl.private.transformer_tokenize_numeric_sorted", ZL_Type_numeric, ZL_PrivateStandardNodeID_tokenize_sorted, _2_SUCCESSORS(ZL_PrivateStandardGraphID_transformer_numeric, ZL_PrivateStandardGraphID_transformer_numeric), TRANSFORMER_NUMERIC_MIN_LIBRARY_VERSION),
-    REGISTER_STATIC_GRAPH(ZL_PrivateStandardGraphID_transformer_sparse_num, "!zl.private.transformer_sparse_num", ZL_Type_numeric, ZL_StandardNodeID_sparse_num, _2_SUCCESSORS(ZL_PrivateStandardGraphID_transformer_numeric, ZL_PrivateStandardGraphID_transformer_numeric), TRANSFORMER_NUMERIC_MIN_LIBRARY_VERSION),
+    REGISTER_STATIC_GRAPH(ZL_PrivateStandardGraphID_transformer_delta_int, "!zl.private.transformer_delta_int", ZL_Type_numeric, ZL_StandardNodeID_delta_int, _1_SUCCESSOR(ZL_PrivateStandardGraphID_transformer_numeric1), TRANSFORMER_NUMERIC_MIN_LIBRARY_VERSION),
+    REGISTER_STATIC_GRAPH(ZL_PrivateStandardGraphID_transformer_range_pack, "!zl.private.transformer_range_pack", ZL_Type_numeric, ZL_StandardNodeID_range_pack, _1_SUCCESSOR(ZL_PrivateStandardGraphID_transformer_numeric1), TRANSFORMER_NUMERIC_MIN_LIBRARY_VERSION),
+    REGISTER_STATIC_GRAPH(ZL_PrivateStandardGraphID_transformer_divide_by_gcd, "!zl.private.transformer_divide_by_gcd", ZL_Type_numeric, ZL_StandardNodeID_divide_by, _1_SUCCESSOR(ZL_PrivateStandardGraphID_transformer_numeric1), TRANSFORMER_NUMERIC_MIN_LIBRARY_VERSION),
+    REGISTER_STATIC_GRAPH(ZL_PrivateStandardGraphID_transformer_tokenize_numeric, "!zl.private.transformer_tokenize_numeric", ZL_Type_numeric, ZL_StandardNodeID_tokenize_numeric, _2_SUCCESSORS(ZL_PrivateStandardGraphID_transformer_numeric1, ZL_PrivateStandardGraphID_transformer_numeric1), TRANSFORMER_NUMERIC_MIN_LIBRARY_VERSION),
+    REGISTER_STATIC_GRAPH(ZL_PrivateStandardGraphID_transformer_tokenize_numeric_sorted, "!zl.private.transformer_tokenize_numeric_sorted", ZL_Type_numeric, ZL_PrivateStandardNodeID_tokenize_sorted, _2_SUCCESSORS(ZL_PrivateStandardGraphID_transformer_numeric1, ZL_PrivateStandardGraphID_transformer_numeric1), TRANSFORMER_NUMERIC_MIN_LIBRARY_VERSION),
+    REGISTER_STATIC_GRAPH(ZL_PrivateStandardGraphID_transformer_sparse_num, "!zl.private.transformer_sparse_num", ZL_Type_numeric, ZL_StandardNodeID_sparse_num, _2_SUCCESSORS(ZL_PrivateStandardGraphID_transformer_numeric1, ZL_PrivateStandardGraphID_transformer_numeric1), TRANSFORMER_NUMERIC_MIN_LIBRARY_VERSION),
 
     REGISTER_SELECTOR(ZL_PrivateStandardGraphID_transformer_static_core, "!zl.private.transformer_static_core", SI_transformer_static_core_select, ZL_Type_numeric, TRANSFORMER_NUMERIC_MIN_LIBRARY_VERSION),
     REGISTER_STATIC_GRAPH(ZL_PrivateStandardGraphID_transformer_static_delta, "!zl.private.transformer_static_delta", ZL_Type_numeric, ZL_StandardNodeID_delta_int, _1_SUCCESSOR(ZL_PrivateStandardGraphID_transformer_static_core), TRANSFORMER_NUMERIC_MIN_LIBRARY_VERSION),
@@ -272,7 +273,7 @@ const InternalGraphDesc GR_standardGraphs[ZL_PrivateStandardGraphID_end] = {
     REGISTER_STATIC_GRAPH(ZL_PrivateStandardGraphID_transformer_static_tok_mono_lz, "!zl.private.transformer_static_tok_mono_lz", ZL_Type_numeric, ZL_PrivateStandardNodeID_tokenize_sorted, _2_SUCCESSORS(ZL_StandardGraphID_zstd, ZL_StandardGraphID_zstd), TRANSFORMER_NUMERIC_MIN_LIBRARY_VERSION),
     REGISTER_STATIC_GRAPH(ZL_PrivateStandardGraphID_transformer_static_delta_tok_mono_lz, "!zl.private.transformer_static_delta_tok_mono_lz", ZL_Type_numeric, ZL_StandardNodeID_delta_int, _1_SUCCESSOR(ZL_PrivateStandardGraphID_transformer_static_tok_mono_lz), TRANSFORMER_NUMERIC_MIN_LIBRARY_VERSION),
     REGISTER_SELECTOR(ZL_PrivateStandardGraphID_transformer_static_fallback, "!zl.private.transformer_static_fallback", SI_transformer_static_fallback_select, ZL_Type_numeric, TRANSFORMER_NUMERIC_MIN_LIBRARY_VERSION),
-    REGISTER_SELECTOR(ZL_PrivateStandardGraphID_transformer_numeric, "!zl.private.transformer_numeric", SI_transformer_numeric_select, ZL_Type_numeric, TRANSFORMER_NUMERIC_MIN_LIBRARY_VERSION),
+    REGISTER_SELECTOR(ZL_PrivateStandardGraphID_transformer_numeric1, "!zl.private.transformer_numeric1", SI_transformer_numeric_select, ZL_Type_numeric, TRANSFORMER_NUMERIC_MIN_LIBRARY_VERSION),
 };
 // clang-format on
 

--- a/src/openzl/compress/private_nodes.h
+++ b/src/openzl/compress/private_nodes.h
@@ -246,7 +246,7 @@ typedef enum {
     ZL_PrivateStandardGraphID_transformer_static_tok_mono_lz,
     ZL_PrivateStandardGraphID_transformer_static_delta_tok_mono_lz,
     ZL_PrivateStandardGraphID_transformer_static_fallback,
-    ZL_PrivateStandardGraphID_transformer_numeric,
+    ZL_PrivateStandardGraphID_transformer_numeric1,
 
     ZL_PrivateStandardGraphID_end // last id, used to detect out-of-bound enum
                                   // values
@@ -409,8 +409,11 @@ typedef enum {
             ZL_PrivateStandardGraphID_transformer_static_delta_tok_mono_lz)
 #define ZL_GRAPH_TRANSFORMER_STATIC_FALLBACK \
     ZL_MAKE_GRAPH_ID(ZL_PrivateStandardGraphID_transformer_static_fallback)
-#define ZL_GRAPH_TRANSFORMER_NUMERIC \
-    ZL_MAKE_GRAPH_ID(ZL_PrivateStandardGraphID_transformer_numeric)
+
+/* Single-Input Transformer selector.
+ * ZL_GRAPH_TRANSFORMER_NUMERIC is the Multi-Input graph on top of it. */
+#define ZL_GRAPH_TRANSFORMER_NUMERIC1 \
+    ZL_MAKE_GRAPH_ID(ZL_PrivateStandardGraphID_transformer_numeric1)
 
 // clang-format on
 

--- a/src/openzl/compress/selectors/selector_numeric.c
+++ b/src/openzl/compress/selectors/selector_numeric.c
@@ -334,6 +334,19 @@ ZL_GraphID SI_transformer_numeric_select(
             &decision.core, TRS_score_num64_operation_ids, supportedOperations);
 }
 
+ZL_Report MultiInputGraph_transformerNumeric(
+        ZL_Graph* gctx,
+        ZL_Edge* inputs[],
+        size_t nbInputs)
+{
+    ZL_RESULT_DECLARE_SCOPE_REPORT(gctx);
+    for (size_t n = 0; n < nbInputs; n++) {
+        ZL_ERR_IF_ERR(ZL_Edge_setDestination(
+                inputs[n], ZL_GRAPH_TRANSFORMER_NUMERIC1));
+    }
+    return ZL_returnSuccess();
+}
+
 ZL_GraphID SI_selector_numeric(
         const ZL_Selector* selCtx,
         const ZL_Input* inputStream,
@@ -349,5 +362,5 @@ ZL_GraphID SI_selector_numeric(
     if (compressionLevel < TRANSFORMER_MIN_COMPRESSION_LEVEL) {
         return ZL_GRAPH_STRUCT_COMPRESS;
     }
-    return ZL_GRAPH_TRANSFORMER_NUMERIC;
+    return ZL_GRAPH_TRANSFORMER_NUMERIC1;
 }

--- a/src/openzl/compress/selectors/selector_numeric.h
+++ b/src/openzl/compress/selectors/selector_numeric.h
@@ -5,6 +5,7 @@
 
 #include "openzl/compress/selectors/transformer/generic_numeric_ops.h"
 #include "openzl/shared/portability.h"
+#include "openzl/zl_graph_api.h"
 #include "openzl/zl_selector.h"
 
 ZL_BEGIN_C_DECLS
@@ -48,6 +49,22 @@ ZL_GraphID SI_transformer_numeric_select(
         const ZL_Input* inputStream,
         const ZL_GraphID* customGraphs,
         size_t nbCustomGraphs);
+
+// Multi-Input version of the pretrained numeric Transformer.
+// Dispatches each Input to its own Transformer selector.
+ZL_Report MultiInputGraph_transformerNumeric(
+        ZL_Graph* gctx,
+        ZL_Edge* inputs[],
+        size_t nbInputs);
+
+#define MIGRAPH_TRANSFORMER_NUMERIC                                  \
+    {                                                                \
+        .name                = "!zl.transformer_numeric",            \
+        .graph_f             = MultiInputGraph_transformerNumeric,   \
+        .inputTypeMasks      = (const ZL_Type[]){ ZL_Type_numeric }, \
+        .nbInputs            = 1,                                    \
+        .lastInputIsVariable = 1,                                    \
+    }
 
 // .selector_f   = SI_selector_numeric,
 // .inStreamType = ZL_Type_numeric

--- a/tests/registry/OpenZLComponents.h
+++ b/tests/registry/OpenZLComponents.h
@@ -92,6 +92,7 @@ enum class OpenZLComponentID {
     SparseNum,
     PivCoHuffman,
     PivCoHuffmanGraph,
+    TransformerNumeric,
     // Must be last enum value
     NumComponents,
 };
@@ -170,6 +171,7 @@ std::unique_ptr<OpenZLComponent> makeMuxLengthsComponent();
 std::unique_ptr<OpenZLComponent> makeSparseNumComponent();
 std::unique_ptr<OpenZLComponent> makePivCoHuffmanComponent();
 std::unique_ptr<OpenZLComponent> makePivCoHuffmanGraphComponent();
+std::unique_ptr<OpenZLComponent> makeTransformerNumericComponent();
 
 } // namespace components
 
@@ -311,6 +313,8 @@ inline std::unique_ptr<OpenZLComponent> makeOpenZLComponent(
             return components::makePivCoHuffmanComponent();
         case OpenZLComponentID::PivCoHuffmanGraph:
             return components::makePivCoHuffmanGraphComponent();
+        case OpenZLComponentID::TransformerNumeric:
+            return components::makeTransformerNumericComponent();
         case OpenZLComponentID::NumComponents:
         default:
             throw std::runtime_error("Invalid component");

--- a/tests/registry/components/Transformer.cpp
+++ b/tests/registry/components/Transformer.cpp
@@ -1,0 +1,208 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+#include <array>
+
+#include "openzl/cpp/codecs/Transformer.hpp"
+#include "tests/registry/OpenZLComponents.h"
+#include "tests/registry/OpenZLInput.h"
+
+namespace openzl::tests::components {
+namespace {
+
+/// Builds a numeric input of @p eltWidth bytes from @p values, truncating each
+/// value to the width so one generator can feed all four widths.
+std::unique_ptr<OpenZLInput> makeInputOfWidth(
+        size_t eltWidth,
+        const std::vector<uint64_t>& values)
+{
+    switch (eltWidth) {
+        case 1: {
+            std::vector<uint8_t> elts(values.begin(), values.end());
+            return U8OpenZLInput::make(std::move(elts));
+        }
+        case 2: {
+            std::vector<uint16_t> elts(values.begin(), values.end());
+            return U16OpenZLInput::make(std::move(elts));
+        }
+        case 4: {
+            std::vector<uint32_t> elts(values.begin(), values.end());
+            return U32OpenZLInput::make(std::move(elts));
+        }
+        default: {
+            return U64OpenZLInput::make(values);
+        }
+    }
+}
+
+/// The Transformer model routes on the shape of the data, so cover the shapes
+/// that map onto each transform it can pick: constant, monotonic (delta),
+/// GCD-divisible, narrow range, low cardinality (tokenize) and mostly-zero
+/// (sparse).
+std::vector<std::vector<uint64_t>> interestingValueSequences()
+{
+    std::vector<std::vector<uint64_t>> sequences;
+    sequences.push_back({});
+    sequences.push_back({ 0 });
+    sequences.push_back({ 42 });
+    // Constant
+    sequences.push_back(std::vector<uint64_t>(200, 7));
+    // Monotonically increasing with a constant stride
+    {
+        std::vector<uint64_t> values(200);
+        for (size_t i = 0; i < values.size(); ++i) {
+            values[i] = i * 3;
+        }
+        sequences.push_back(std::move(values));
+    }
+    // All values share a large common divisor
+    {
+        std::vector<uint64_t> values(200);
+        for (size_t i = 0; i < values.size(); ++i) {
+            values[i] = (i % 17) * 1000;
+        }
+        sequences.push_back(std::move(values));
+    }
+    // Narrow range far from zero
+    {
+        std::vector<uint64_t> values(200);
+        for (size_t i = 0; i < values.size(); ++i) {
+            values[i] = 100000 + (i % 5);
+        }
+        sequences.push_back(std::move(values));
+    }
+    // Low cardinality, unsorted
+    {
+        std::vector<uint64_t> values(200);
+        for (size_t i = 0; i < values.size(); ++i) {
+            values[i] = (i * 37) % 6;
+        }
+        sequences.push_back(std::move(values));
+    }
+    // Mostly zeroes with sparse literals
+    {
+        std::vector<uint64_t> values(200, 0);
+        for (size_t i = 0; i < values.size(); i += 23) {
+            values[i] = i + 1;
+        }
+        sequences.push_back(std::move(values));
+    }
+    return sequences;
+}
+
+std::unique_ptr<OpenZLInput> generateNumericInput(
+        datagen::DataGen& gen,
+        size_t maxInputSize)
+{
+    switch (gen.usize_range("width", 0, 3)) {
+        case 0:
+            return U8OpenZLInput::make(gen.randVector<uint8_t>(
+                    "values", 0, UINT8_MAX, maxInputSize / sizeof(uint8_t)));
+        case 1:
+            return U16OpenZLInput::make(gen.randVector<uint16_t>(
+                    "values", 0, UINT16_MAX, maxInputSize / sizeof(uint16_t)));
+        case 2:
+            return U32OpenZLInput::make(gen.randVector<uint32_t>(
+                    "values", 0, UINT32_MAX, maxInputSize / sizeof(uint32_t)));
+        default:
+            return U64OpenZLInput::make(gen.randVector<uint64_t>(
+                    "values", 0, UINT64_MAX, maxInputSize / sizeof(uint64_t)));
+    }
+}
+
+class TransformerNumericComponent : public OpenZLComponent {
+   public:
+    std::string name() const override
+    {
+        return "TransformerNumeric";
+    }
+
+    /// Frames with more than one input require format version 15.
+    int minFormatVersion() const override
+    {
+        return 15;
+    }
+
+    std::vector<GraphID> predefinedGraphs(Compressor& compressor) const override
+    {
+        auto graph = graphs::TransformerNumeric{}.parameterize(compressor);
+        compressor.selectStartingGraph(graph);
+        return { graph };
+    }
+
+    std::vector<std::unique_ptr<OpenZLInput>> predefinedInputs() const override
+    {
+        std::vector<std::unique_ptr<OpenZLInput>> inputs;
+        for (const auto& values : interestingValueSequences()) {
+            for (const size_t eltWidth : std::array<size_t, 4>{ 1, 2, 4, 8 }) {
+                inputs.push_back(makeInputOfWidth(eltWidth, values));
+            }
+        }
+        // Full-width extremes, which the feature extractors treat specially.
+        inputs.push_back(
+                U8OpenZLInput::make(std::vector<uint8_t>{ 0, UINT8_MAX }));
+        inputs.push_back(
+                U16OpenZLInput::make(std::vector<uint16_t>{ 0, UINT16_MAX }));
+        inputs.push_back(
+                U32OpenZLInput::make(std::vector<uint32_t>{ 0, UINT32_MAX }));
+        inputs.push_back(
+                U64OpenZLInput::make(std::vector<uint64_t>{ 0, UINT64_MAX }));
+        // Widths mixed within a single frame, since each input is routed
+        // through the model independently.
+        {
+            std::vector<std::unique_ptr<OpenZLInput>> inner;
+            inner.push_back(U8OpenZLInput::make(std::vector<uint8_t>{ 1, 2 }));
+            inner.push_back(
+                    U32OpenZLInput::make(std::vector<uint32_t>{ 3, 4 }));
+            inputs.push_back(MultiOpenZLInput::make(std::move(inner)));
+        }
+        // An empty input alongside a non-empty one.
+        {
+            std::vector<std::unique_ptr<OpenZLInput>> inner;
+            inner.push_back(U64OpenZLInput::make(std::vector<uint64_t>{}));
+            inner.push_back(
+                    U64OpenZLInput::make(std::vector<uint64_t>{ 7, 7, 7 }));
+            inputs.push_back(MultiOpenZLInput::make(std::move(inner)));
+        }
+        // One input per interesting shape, all at the same width.
+        {
+            std::vector<std::unique_ptr<OpenZLInput>> inner;
+            for (const auto& values : interestingValueSequences()) {
+                inner.push_back(makeInputOfWidth(4, values));
+            }
+            inputs.push_back(MultiOpenZLInput::make(std::move(inner)));
+        }
+        return inputs;
+    }
+
+    std::vector<std::unique_ptr<OpenZLInput>> generateInputs(
+            datagen::DataGen& gen,
+            size_t num,
+            size_t maxInputSize,
+            const Compressor&,
+            GraphID) const override
+    {
+        std::vector<std::unique_ptr<OpenZLInput>> inputs;
+        inputs.reserve(num);
+        for (size_t i = 0; i < num; ++i) {
+            auto numInner = gen.usize_range("num_inputs", 1, 8);
+            auto innerMaxSize =
+                    std::max<size_t>(maxInputSize / numInner, sizeof(uint64_t));
+            std::vector<std::unique_ptr<OpenZLInput>> inner;
+            inner.reserve(numInner);
+            for (size_t j = 0; j < numInner; ++j) {
+                inner.push_back(generateNumericInput(gen, innerMaxSize));
+            }
+            inputs.push_back(MultiOpenZLInput::make(std::move(inner)));
+        }
+        return inputs;
+    }
+};
+
+} // namespace
+
+std::unique_ptr<OpenZLComponent> makeTransformerNumericComponent()
+{
+    return std::make_unique<TransformerNumericComponent>();
+}
+
+} // namespace openzl::tests::components

--- a/tools/training/lz/lz_trainer.cpp
+++ b/tools/training/lz/lz_trainer.cpp
@@ -112,17 +112,32 @@ std::vector<graphs::Lz::Parameters> candidateParameters()
         for (auto acceleration : accelerations) {
             for (auto windowLog : windowLogs) {
                 for (auto hashLength : hashLengths) {
+                    nodes::Lz::Parameters nodeParams;
+                    nodeParams.compressionLevel = level;
+                    nodeParams.acceleration     = acceleration;
+                    nodeParams.windowLog        = windowLog;
+                    nodeParams.hashLength       = hashLength;
+
+                    // Add the transformer as an option.
+                    for (auto muxLengthsGraph :
+                         { poly::optional<GraphID>{},
+                           poly::optional<GraphID>{
+                                   ZL_GRAPH_TRANSFORMER_NUMERIC } }) {
+                        graphs::Lz::Parameters params;
+                        params.nodeParams      = nodeParams;
+                        params.muxLengthsGraph = muxLengthsGraph;
+                        params.offsetsGraph    = ZL_GRAPH_TRANSFORMER_NUMERIC;
+                        params.overflowLengthsGraph =
+                                ZL_GRAPH_TRANSFORMER_NUMERIC;
+                        candidates.push_back(std::move(params));
+                    }
                     for (auto literalsGraph : literalsGraphs) {
                         for (auto offsetsGraph : offsetsGraphs) {
                             for (auto muxedBytesGraph : muxedBytesGraphs) {
                                 for (auto overflowLengthsGraph :
                                      overflowLengthsGraphs) {
                                     graphs::Lz::Parameters params;
-                                    params.nodeParams.compressionLevel = level;
-                                    params.nodeParams.acceleration =
-                                            acceleration;
-                                    params.nodeParams.windowLog  = windowLog;
-                                    params.nodeParams.hashLength = hashLength;
+                                    params.nodeParams      = nodeParams;
                                     params.literalsGraph   = literalsGraph;
                                     params.offsetsGraph    = offsetsGraph;
                                     params.muxedBytesGraph = muxedBytesGraph;


### PR DESCRIPTION
Summary:
Adds the transformer as a possible backend for the numeric streams in LZ.

This diff adds it in a limited way, in order to not significantly regress training time. A future diff will refactor LZ training to allow for searching a larger parameter space via a heuristic, rather than brute force.

Differential Revision: D119406723


