### PR TITLE
Allow overriding entropy backend hueristics (#1009)

### DIFF
--- a/cpp/include/openzl/cpp/codecs/Lz.hpp
+++ b/cpp/include/openzl/cpp/codecs/Lz.hpp
@@ -151,6 +151,12 @@ class Lz : public Graph {
         poly::optional<GraphID> overflowLengthsGraph;
         /// Optionally override the backend mux lengths graph
         poly::optional<GraphID> muxLengthsGraph;
+        /// Optionally override the minimum bytes saved needed to invoke an
+        /// entropy backend graph
+        poly::optional<int> minGainForEntropyBytes;
+        /// Optionally override the minimum percent saved needed to invoke an
+        /// entropy backend graph
+        poly::optional<int> minGainForEntropyPct;
     };
 
     Lz() {}
@@ -189,6 +195,17 @@ class Lz : public Graph {
                 ZL_LzParam_overflowLengthsGraphIdx,
                 params_->overflowLengthsGraph);
         addGraph(ZL_LzParam_muxLengthsGraphIdx, params_->muxLengthsGraph);
+
+        auto addParam = [&](int key, poly::optional<int> value) {
+            if (value.has_value()) {
+                lp.addIntParam(key, *value);
+            }
+        };
+        addParam(
+                ZL_LzParam_minGainForEntropyBytes,
+                params_->minGainForEntropyBytes);
+        addParam(
+                ZL_LzParam_minGainForEntropyPct, params_->minGainForEntropyPct);
 
         return GraphParameters{
             .customGraphs = std::move(graphs),

--- a/cpp/tests/TestCodecs.cpp
+++ b/cpp/tests/TestCodecs.cpp
@@ -78,11 +78,13 @@ TEST_F(TestCodecs, lzParameters)
                                     .hashLog2         = 17,
                                     .hashLength       = 5,
                             },
-                    .literalsGraph        = graphs::Store::graph,
-                    .offsetsGraph         = graphs::Store::graph,
-                    .muxedBytesGraph      = graphs::Store::graph,
-                    .overflowLengthsGraph = graphs::Store::graph,
-                    .muxLengthsGraph      = muxLengthsGraph,
+                    .literalsGraph          = graphs::Store::graph,
+                    .offsetsGraph           = graphs::Store::graph,
+                    .muxedBytesGraph        = graphs::Store::graph,
+                    .overflowLengthsGraph   = graphs::Store::graph,
+                    .muxLengthsGraph        = muxLengthsGraph,
+                    .minGainForEntropyBytes = 42,
+                    .minGainForEntropyPct   = 43,
             });
 
     const auto graphParameters = lz.parameters();
@@ -103,6 +105,8 @@ TEST_F(TestCodecs, lzParameters)
         { ZL_LzParam_muxedBytesGraphIdx, 2 },
         { ZL_LzParam_overflowLengthsGraphIdx, 3 },
         { ZL_LzParam_muxLengthsGraphIdx, 4 },
+        { ZL_LzParam_minGainForEntropyBytes, 42 },
+        { ZL_LzParam_minGainForEntropyPct, 43 },
     };
     EXPECT_EQ(
             collectIntParams(*graphParameters->localParams), expectedIntParams);

--- a/include/openzl/codecs/zl_lz.h
+++ b/include/openzl/codecs/zl_lz.h
@@ -155,6 +155,25 @@ typedef enum {
      * @note Must be a multi-input graph that accepts two 16-bit numeric inputs.
      */
     ZL_LzParam_muxLengthsGraphIdx = 1004,
+
+    /**
+     * Entropy backend graphs will only be invoked if they can save this many
+     * bytes. This overrides the default value which is 0.5% of the input size
+     * + 50 bytes.
+     *
+     * Increasing this value will speed up decompression at the cost of
+     * compressed size.
+     */
+    ZL_LzParam_minGainForEntropyBytes = 10000,
+
+    /**
+     * Entropy backend graphs will only be invoked if they can save this percent
+     * of their input size. This overrides the default value, which is 1%.
+     *
+     * Increasing this value will speed up decompression at the cost of
+     * compressed size.
+     */
+    ZL_LzParam_minGainForEntropyPct = 10001,
 } ZL_LzParam;
 
 #define ZL_LZPARAM_WINDOWLOG_MIN 10

--- a/src/openzl/codecs/lz/encode_lz_binding.c
+++ b/src/openzl/codecs/lz/encode_lz_binding.c
@@ -504,7 +504,8 @@ static ZL_Report setEntropyDestinationOrOverride(
         ZL_GraphIDList customGraphs,
         int overrideParam,
         ZL_GraphID entropyGraph,
-        int minGainForHuffmanBytes)
+        int minGainForHuffmanBytes,
+        int minGainForHuffmanPct)
 {
     ZL_RESULT_DECLARE_SCOPE_REPORT(edge);
 
@@ -514,16 +515,34 @@ static ZL_Report setEntropyDestinationOrOverride(
         entropyGraph = override;
     }
     ZL_ERR_IF_ERR(ZL_Edge_setEntropyDestination(
-            edge, entropyGraph, minGainForHuffmanBytes, -1));
+            edge, entropyGraph, minGainForHuffmanBytes, minGainForHuffmanPct));
     return ZL_returnSuccess();
+}
+
+static int getIntParamOrDefault(const ZL_Graph* gctx, int key, int dflt)
+{
+    const ZL_IntParam param = ZL_Graph_getLocalIntParam(gctx, key);
+    if (param.paramId == ZL_LP_INVALID_PARAMID) {
+        return dflt;
+    } else {
+        return param.paramValue;
+    }
 }
 
 /**
  * Rough estimate of the compressed size of muxed lengths for fast compression
  * levels.
  */
-static size_t guessMuxedEntropySize(size_t numSequences)
+static size_t guessMuxedEntropySize(
+        size_t numSequences,
+        int minGainForHuffmanBytes,
+        int minGainForHuffmanPct)
 {
+    size_t add =
+            minGainForHuffmanBytes > 0 ? (size_t)minGainForHuffmanBytes : 0;
+    if (minGainForHuffmanPct > 0) {
+        add = ZL_MAX(add, (numSequences * (size_t)minGainForHuffmanPct) / 100);
+    }
     // Estimate the encoded size optimistically at 60% compressibility.
     // This is lower than the typical encoded size for muxed lengths.
     const size_t encodedSize = (6 * numSequences) / 10;
@@ -531,7 +550,7 @@ static size_t guessMuxedEntropySize(size_t numSequences)
     // skipping Huffman more aggressively on smaller inputs, and attempting it
     // more on larger inputs.
     const size_t headerSize = 75;
-    return headerSize + encodedSize;
+    return headerSize + encodedSize + add;
 }
 
 ZL_Report EI_lzDynGraph(ZL_Graph* gctx, ZL_Edge* inputs[], size_t nbIns)
@@ -544,7 +563,12 @@ ZL_Report EI_lzDynGraph(ZL_Graph* gctx, ZL_Edge* inputs[], size_t nbIns)
     // The combination of a small percent of the source size and a fixed
     // component strongly discourages Huffman for small inputs where the speed
     // penalty is large, and has little impact on large inputs.
-    const int minGainForHuffmanBytes = (int)(inputSize / 200) + 50;
+    const int minGainForHuffmanBytes = getIntParamOrDefault(
+            gctx,
+            ZL_LzParam_minGainForEntropyBytes,
+            (int)(inputSize / 200) + 50);
+    const int minGainForHuffmanPct =
+            getIntParamOrDefault(gctx, ZL_LzParam_minGainForEntropyPct, -1);
 
     const ZL_LocalParams* localParams = GCTX_getAllLocalParams(gctx);
 
@@ -587,7 +611,8 @@ ZL_Report EI_lzDynGraph(ZL_Graph* gctx, ZL_Edge* inputs[], size_t nbIns)
             customGraphs,
             ZL_LzParam_literalsGraphIdx,
             huffOrStore,
-            minGainForHuffmanBytes));
+            minGainForHuffmanBytes,
+            minGainForHuffmanPct));
     ZL_ERR_IF_ERR(ZL_Edge_setDestination(offsets, offsetsGraph));
 
     ZL_Edge* muxInputs[2] = { literalLengths, matchLengths };
@@ -605,7 +630,8 @@ ZL_Report EI_lzDynGraph(ZL_Graph* gctx, ZL_Edge* inputs[], size_t nbIns)
 
         const size_t muxedStoreSize =
                 ZL_Input_contentSize(ZL_Edge_getData(muxStreams.edges[0]));
-        const size_t muxedSizeGuess = guessMuxedEntropySize(muxedStoreSize);
+        size_t muxedSizeGuess = guessMuxedEntropySize(
+                muxedStoreSize, minGainForHuffmanBytes, minGainForHuffmanPct);
         // Guess the compressibility of the muxed lengths. When Huffman is
         // likely to not provide enough benefit, don't even try it. This is
         // mainly important for small inputs, where the cost of evaluating
@@ -616,10 +642,9 @@ ZL_Report EI_lzDynGraph(ZL_Graph* gctx, ZL_Edge* inputs[], size_t nbIns)
                 muxStreams.edges[0],
                 customGraphs,
                 ZL_LzParam_muxedBytesGraphIdx,
-                muxedSizeGuess + (size_t)minGainForHuffmanBytes < muxedStoreSize
-                        ? huffOrStore
-                        : ZL_GRAPH_STORE,
-                minGainForHuffmanBytes));
+                muxedSizeGuess < muxedStoreSize ? huffOrStore : ZL_GRAPH_STORE,
+                minGainForHuffmanBytes,
+                minGainForHuffmanPct));
 
         ZL_ERR_IF_ERR(setEntropyDestinationOrOverride(
                 gctx,
@@ -627,7 +652,8 @@ ZL_Report EI_lzDynGraph(ZL_Graph* gctx, ZL_Edge* inputs[], size_t nbIns)
                 customGraphs,
                 ZL_LzParam_overflowLengthsGraphIdx,
                 ZL_GRAPH_COMPRESS_SMALL_LENGTHS,
-                minGainForHuffmanBytes));
+                minGainForHuffmanBytes,
+                minGainForHuffmanPct));
     }
 
     return ZL_returnSuccess();

--- a/tests/registry/components/Lz.cpp
+++ b/tests/registry/components/Lz.cpp
@@ -118,6 +118,11 @@ class LzComponent : public OpenZLComponent {
                     ZL_LzParam_overflowLengthsGraphIdx);
             maybeOverrideSuccessor(
                     params, successors, gen, ZL_LzParam_muxLengthsGraphIdx);
+
+            maybeSetParam(
+                    params, gen, ZL_LzParam_minGainForEntropyBytes, 0, 100);
+            maybeSetParam(params, gen, ZL_LzParam_minGainForEntropyPct, 0, 10);
+
             graphs.push_back(compressor.parameterizeGraph(
                     ZL_GRAPH_LZ,
                     GraphParameters{


### PR DESCRIPTION
Summary:

Allows overriding the LZ's graphs heuristics for when to invoke Huffman to allow users & the trainer to tune size vs. speed tradeoffs. The current heuristics favor speed, and I need to be able to favor size in a new use case I have in mind.

NOTE: This does not change any behavior, as I want to be able to safely graft this onto prod.

Differential Revision: D119698278


